### PR TITLE
Adding path discovery tools to SDK.  Change name to mxc-sdk.

### DIFF
--- a/cli/ARCHITECTURE.md
+++ b/cli/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# WXC CLI Architecture
+# MXC CLI Architecture
 
 ## Overview
 
-The WXC CLI is a TypeScript-based Node.js wrapper for the Restricted Codex Executor (WXC). It provides both a command-line interface and a programmatic API for invoking WXC with type-safe configuration.
+The MXC CLI is a TypeScript-based Node.js wrapper for the Microsoft eXecution Containers (MXC) restricted container environment. It provides both a command-line interface and a programmatic API for invoking MXC with type-safe configuration.
 
 ## Project Structure
 
@@ -27,7 +27,7 @@ cli/
 
 The command-line interface built with Commander.js provides three main commands:
 
-- **run**: Execute scruot code with WXC
+- **run**: Execute script code with WXC
   - Accepts config file path or base64-encoded config
   - Supports --config-base64 and --debug flags
   - Allows custom WXC executable path

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
-# WXC CLI
+# MXC CLI
 
-TypeScript-based Node.js CLI for invoking the WXC (Windows eXecution Container).
+TypeScript-based Node.js CLI for invoking the MXC (Microsoft eXecution Container).
 
 ## Features
 

--- a/cli/example-sdk-usage.ts
+++ b/cli/example-sdk-usage.ts
@@ -1,5 +1,5 @@
 /**
- * Example: Using the WXC SDK from the CLI package
+ * Example: Using the MXC SDK from the CLI package
  *
  * This demonstrates how to use the SDK exports from the CLI package
  * for both interactive and non-interactive sandboxed process spawning.
@@ -19,7 +19,7 @@ import {  // Platform detection
   spawnSandboxAsync,
   // Types
   SandboxPolicy
-} from '@shschaefer/wxc-sdk';
+} from '@microsoft/mxc-sdk';
 
 /**
  * Example 1: Platform Detection

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "wxc-cli",
+  "name": "mxc-cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wxc-cli",
+      "name": "mxc-cli",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@shschaefer/wxc-sdk": "file:../sdk",
+        "@microsoft/mxc-sdk": "file:../sdk",
         "commander": "^11.1.0"
       },
       "bin": {
@@ -29,8 +29,8 @@
       }
     },
     "../sdk": {
-      "name": "@shschaefer/wxc-sdk",
-      "version": "0.1.4",
+      "name": "@microsoft/mxc-sdk",
+      "version": "0.1.5",
       "license": "MIT",
       "os": [
         "win32"
@@ -360,6 +360,10 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@microsoft/mxc-sdk": {
+      "resolved": "../sdk",
+      "link": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -370,10 +374,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@shschaefer/wxc-sdk": {
-      "resolved": "../sdk",
-      "link": true
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
@@ -423,6 +423,7 @@
       "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -462,6 +463,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -666,6 +668,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -926,6 +929,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -1639,6 +1643,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1964,6 +1969,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "wxc-cli",
+  "name": "mxc-cli",
   "version": "0.1.0",
-  "description": "TypeScript CLI for invoking the WXC (Windows eXecution Container)",
+  "description": "TypeScript CLI for invoking the MXC (Microsoft eXecution Containers) SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
@@ -39,7 +39,7 @@
     "typescript-eslint": "^8.54.0"
   },
   "dependencies": {
-    "@shschaefer/wxc-sdk": "file:../sdk",
+    "@microsoft/mxc-sdk": "file:../sdk",
     "commander": "^11.1.0"
   }
 }

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -5,12 +5,13 @@ import { WxcExecutor } from './wxc-executor';
 import {
   spawnSandbox,
   getPlatformSupport,
-  SandboxPolicy
-} from '@shschaefer/wxc-sdk';
+  SandboxPolicy,
+  getAvailableToolsPolicy
+} from '@microsoft/mxc-sdk';
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { WxcConfiguration } from '@shschaefer/wxc-sdk/dist/types';
+import { WxcConfiguration } from '@microsoft/mxc-sdk/dist/types';
 
 const program = new Command();
 
@@ -142,6 +143,27 @@ program
             clearPolicyOnExit: config.filesystem?.clearPolicyOnExit ?? true,
         } : undefined,
       };
+
+      // Discover tool paths from the current environment and merge them
+      const toolsPolicy = getAvailableToolsPolicy(process.env);
+      if (toolsPolicy.readonlyPaths.length > 0) {
+        if (!policy.filesystem) {
+          policy.filesystem = {};
+        }
+        policy.filesystem.readonlyPaths = [
+          ...(policy.filesystem.readonlyPaths ?? []),
+          ...toolsPolicy.readonlyPaths,
+        ];
+      }
+      if (toolsPolicy.readwritePaths.length > 0) {
+        if (!policy.filesystem) {
+          policy.filesystem = {};
+        }
+        policy.filesystem.readwritePaths = [
+          ...(policy.filesystem.readwritePaths ?? []),
+          ...toolsPolicy.readwritePaths,
+        ];
+      }
 
       console.log('Spawning sandboxed process using SDK...');
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,4 +1,4 @@
-import { WxcConfiguration } from '@shschaefer/wxc-sdk/dist/types';
+import { WxcConfiguration } from '@microsoft/mxc-sdk/dist/types';
 
 /**
  * Helper function to create a minimal valid configuration

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -19,7 +19,7 @@ The WXC SDK provides a Node.js interface for running processes in sandboxed envi
 The WXC SDK is currently published to a private registry hosted with NPM.  To use this registry, you must have an access token with permission to read from this scope and will need to explicitly install the SDK into your local node modules.
 
 ```bash
-npm install --save @shschaefer/wxc-sdk
+npm install --save @microsoft/mxc-sdk
 ```
 
 **Requirements**:
@@ -43,7 +43,7 @@ npm install --save @shschaefer/wxc-sdk
 ## Quick Start
 
 ```typescript
-import { spawnSandbox, SandboxConfig, getPlatformSupport } from '@shschaefer/wxc-sdk';
+import { spawnSandbox, SandboxConfig, getPlatformSupport } from '@microsoft/mxc-sdk';
 
 // Check platform support
 if (!getPlatformSupport().supported) {
@@ -82,7 +82,7 @@ pty.onExit((event: { exitCode: number }) => {
 Returns detailed platform support information including available sandboxing methods and the reason for any unsupported status.
 
 ```typescript
-import { getPlatformSupport } from '@shschaefer/wxc-sdk';
+import { getPlatformSupport } from '@microsoft/mxc-sdk';
 
 const support = getPlatformSupport();
 console.log('Platform:', support.platform);
@@ -136,7 +136,7 @@ Spawns a sandboxed process and returns a node-pty `IPty` object for interactive 
 **Throws**: Error if platform is not supported or wxc-exec is not found
 
 ```typescript
-import { spawnSandbox, SandboxConfig } from '@shschaefer/wxc-sdk';
+import { spawnSandbox, SandboxConfig } from '@microsoft/mxc-sdk';
 
 const config: SandboxConfig = {
   script: 'python -c "print(\'Hello!\')"',
@@ -160,7 +160,7 @@ pty.onExit((e) => console.log('Exit code:', e.exitCode));
 Spawns a sandboxed process and returns a promise that resolves with the output. This is a convenience wrapper for non-interactive use cases.
 
 ```typescript
-import { spawnSandboxAsync, SandboxConfig } from '@shschaefer/wxc-sdk';
+import { spawnSandboxAsync, SandboxConfig } from '@microsoft/mxc-sdk';
 
 async function runSandboxed() {
   const config: SandboxConfig = {
@@ -224,7 +224,7 @@ interface SandboxConfig {
 Creates a minimal valid configuration with just a script command.
 
 ```typescript
-import { createMinimalConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { createMinimalConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config = createMinimalConfig('python -c "print(\'Hello\')"');
 const pty = spawnSandbox(config);
@@ -234,7 +234,7 @@ const pty = spawnSandbox(config);
 Creates a configuration with network restrictions (blocks all except allowed hosts).
 
 ```typescript
-import { createNetworkRestrictedConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { createNetworkRestrictedConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config = createNetworkRestrictedConfig(
   'python -c "import requests; print(requests.get(\'https://api.github.com\').status_code)"',
@@ -248,7 +248,7 @@ const pty = spawnSandbox(config);
 Creates a configuration with filesystem restrictions.
 
 ```typescript
-import { createFilesystemRestrictedConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { createFilesystemRestrictedConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config = createFilesystemRestrictedConfig(
   'python script.py',
@@ -264,7 +264,7 @@ const pty = spawnSandbox(config);
 ### Minimal Configuration
 
 ```typescript
-import { createMinimalConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { createMinimalConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config = createMinimalConfig('python -c "print(\'Hello World\')"');
 const pty = spawnSandbox(config);
@@ -276,7 +276,7 @@ pty.onExit((e) => console.log('Done!'));
 ### Network Restrictions
 
 ```typescript
-import { SandboxConfig, spawnSandboxAsync } from '@shschaefer/wxc-sdk';
+import { SandboxConfig, spawnSandboxAsync } from '@microsoft/mxc-sdk';
 
 const config: SandboxConfig = {
   script: 'python -c "import urllib.request; print(urllib.request.urlopen(\'https://api.github.com\').read())"',
@@ -293,7 +293,7 @@ console.log(result.stdout);
 ### Filesystem Restrictions
 
 ```typescript
-import { SandboxConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { SandboxConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config: SandboxConfig = {
   script: 'python script.py',
@@ -311,7 +311,7 @@ const pty = spawnSandbox(config);
 ### Advanced Configuration
 
 ```typescript
-import { SandboxConfig, spawnSandbox } from '@shschaefer/wxc-sdk';
+import { SandboxConfig, spawnSandbox } from '@microsoft/mxc-sdk';
 
 const config: SandboxConfig = {
   script: 'node app.js',
@@ -391,7 +391,7 @@ import {
   PlatformSupport,
   SandboxingMethod,
   SandboxSpawnOptions
-} from '@shschaefer/wxc-sdk';
+} from '@microsoft/mxc-sdk';
 ```
 
 ## Development

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@shschaefer/wxc-sdk",
-  "version": "0.1.4",
+  "name": "@microsoft/mxc-sdk",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@shschaefer/wxc-sdk",
-      "version": "0.1.4",
+      "name": "@microsoft/mxc-sdk",
+      "version": "0.1.5",
       "license": "MIT",
       "os": [
         "win32"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@shschaefer/wxc-sdk",
-  "version": "0.1.4",
-  "description": "TypeScript SDK for WXC (Windows eXecution Container) - spawn sandboxed processes on Windows",
+  "name": "@microsoft/mxc-sdk",
+  "version": "0.1.5",
+  "description": "TypeScript SDK for MXC (Micfosoft eXecution Containers)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [ "bin/", "dist/" ],

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { spawnSandbox, SandboxConfig, getPlatformSupport } from '@shschaefer/wxc-sdk';
+ * import { spawnSandbox, SandboxConfig, getPlatformSupport } from '@microsoft/mxc-sdk';
  *
  * if (getPlatformSupport().isSupported) {
  *   const config: SandboxConfig = {
@@ -44,3 +44,12 @@ export {
   spawnSandboxAsync,
   SandboxSpawnOptions
 } from './sandbox';
+
+// Export policy discovery functions
+export {
+  getAvailableToolsPolicy,
+  getUserProfilePolicy,
+  getTemporaryFilesPolicy,
+  FilesystemPolicyResult,
+  ToolsPolicyOptions,
+} from './policy';

--- a/sdk/src/policy.ts
+++ b/sdk/src/policy.ts
@@ -1,0 +1,307 @@
+/**
+ * Policy discovery APIs for building sandbox filesystem policy.
+ *
+ * These functions enumerate the host environment to discover tool paths,
+ * user profile locations, and temporary storage — returning policy fragments
+ * that callers can merge into a {@link SandboxPolicy}.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { randomBytes } from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A composable fragment of filesystem policy.
+ * Callers merge one or more fragments into {@link SandboxPolicy.filesystem}.
+ */
+export interface FilesystemPolicyResult {
+    /** Paths that should be granted read-only access inside the container */
+    readonlyPaths: string[];
+    /** Paths that should be granted read-write access inside the container */
+    readwritePaths: string[];
+}
+
+/**
+ * Options for {@link getAvailableToolsPolicy}.
+ */
+export interface ToolsPolicyOptions {
+    /**
+     * When set to `'appcontainer'`, directories whose ACLs already grant
+     * access to ALL_APPLICATION_PACKAGES are excluded from the result
+     * because AppContainer processes can already see them implicitly.
+     */
+    containerType?: 'appcontainer';
+}
+
+// ---------------------------------------------------------------------------
+// Known environment variable registry
+// ---------------------------------------------------------------------------
+
+type PathExtractor = (value: string) => string[];
+
+interface KnownEnvVar {
+    /** Environment variable name */
+    name: string;
+    /** Extracts zero or more directory paths from the variable's value */
+    extractPaths: PathExtractor;
+}
+
+/** Split a semicolon-delimited path list (PATH, PYTHONPATH, …). */
+function splitPathList(value: string): string[] {
+    return value.split(';').filter(p => p.length > 0);
+}
+
+/** Treat the entire value as a single directory path. */
+function singlePath(value: string): string[] {
+    return value.trim() ? [value.trim()] : [];
+}
+
+/**
+ * Registry of well-known environment variables that point to tool
+ * installations, SDK roots, or language-specific resource directories.
+ * Each entry defines how to extract filesystem paths from the variable.
+ */
+const KNOWN_ENV_VARS: KnownEnvVar[] = [
+    // Python
+    { name: 'PYTHONPATH', extractPaths: splitPathList },
+    { name: 'PYTHONHOME', extractPaths: singlePath },
+
+    // Visual Studio / MSVC
+    { name: 'VCINSTALLDIR', extractPaths: singlePath },
+    { name: 'VSINSTALLDIR', extractPaths: singlePath },
+
+    // PowerShell modules
+    { name: 'PSModulePath', extractPaths: splitPathList },
+
+    // vcpkg
+    { name: 'VCPKG_ROOT', extractPaths: singlePath },
+
+    // Go
+    { name: 'GOPATH', extractPaths: singlePath },
+    { name: 'GOROOT', extractPaths: singlePath },
+
+    // Rust
+    { name: 'CARGO_HOME', extractPaths: singlePath },
+    { name: 'RUSTUP_HOME', extractPaths: singlePath },
+
+    // Java
+    { name: 'JAVA_HOME', extractPaths: singlePath },
+
+    // Node.js
+    { name: 'NVM_HOME', extractPaths: singlePath },
+    { name: 'NVM_SYMLINK', extractPaths: singlePath },
+    { name: 'NODE_PATH', extractPaths: splitPathList },
+
+    // .NET
+    { name: 'DOTNET_ROOT', extractPaths: singlePath },
+
+    // Conda / Anaconda
+    { name: 'CONDA_PREFIX', extractPaths: singlePath },
+];
+
+// ---------------------------------------------------------------------------
+// Filtering helpers
+// ---------------------------------------------------------------------------
+
+function getWindowsDirectory(): string {
+    return process.env['WINDIR'] || process.env['windir'] || 'C:\\Windows';
+}
+
+/**
+ * Returns `true` if the path resides under the Windows directory
+ * (e.g. C:\Windows, C:\Windows\System32) or other system-critical locations.
+ */
+function isSystemCriticalPath(dirPath: string): boolean {
+    const winDir = getWindowsDirectory().toLowerCase();
+    const normalized = path.resolve(dirPath).toLowerCase();
+
+    return normalized === winDir || normalized.startsWith(winDir + '\\');
+}
+
+/**
+ * Checks whether the directory ACL already grants access to the
+ * ALL_APPLICATION_PACKAGES well-known SID (S-1-15-2-1).
+ */
+function hasAllApplicationPackagesAccess(dirPath: string): boolean {
+    try {
+        const output = execSync(`icacls "${dirPath}"`, {
+            encoding: 'utf-8',
+            stdio: 'pipe',
+            timeout: 5000,
+        });
+        return output.includes('ALL APPLICATION PACKAGES') || output.includes('S-1-15-2-1');
+    } catch {
+        // If the check fails (access denied, timeout, etc.) assume the
+        // directory is NOT already accessible — safer to include it.
+        return false;
+    }
+}
+
+function directoryExists(dirPath: string): boolean {
+    try {
+        return fs.statSync(dirPath).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Deduplicates an array of paths using case-insensitive comparison
+ * (Windows filesystem semantics). Paths are resolved to absolute form.
+ */
+function deduplicatePaths(paths: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const p of paths) {
+        const resolved = path.resolve(p);
+        const key = resolved.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            result.push(resolved);
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover tool and SDK directories from the environment and return them as
+ * read-only policy paths.
+ *
+ * Reads the `PATH` variable and a set of well-known tool / SDK environment
+ * variables, enumerates the directories they reference, then applies filters:
+ *
+ * 1. Directories that do not exist on disk are removed.
+ * 2. System-critical directories (under `%WINDIR%`) are removed.
+ * 3. When `options.containerType` is `'appcontainer'`, directories whose ACLs
+ *    already grant access to `ALL_APPLICATION_PACKAGES` are removed because
+ *    AppContainer processes can see them without explicit brokering.
+ *
+ * @param env - Environment variable map. Defaults to `process.env`.
+ * @param options - Filtering options.
+ * @returns A policy fragment with discovered paths in `readonlyPaths`.
+ */
+export function getAvailableToolsPolicy(
+    env?: { [key: string]: string | undefined },
+    options?: ToolsPolicyOptions,
+): FilesystemPolicyResult {
+    const environment = env ?? process.env;
+    const collected: string[] = [];
+
+    // PATH directories
+    const pathValue = environment['PATH'] || environment['Path'] || '';
+    collected.push(...splitPathList(pathValue));
+
+    // Known environment variables
+    for (const knownVar of KNOWN_ENV_VARS) {
+        const value = environment[knownVar.name];
+        if (value) {
+            collected.push(...knownVar.extractPaths(value));
+        }
+    }
+
+    const unique = deduplicatePaths(collected);
+
+    // Filter out non-existent paths, system-critical paths, and (optionally)
+    // paths already accessible to containers.
+    const filtered = unique.filter(dirPath => {
+        if (!directoryExists(dirPath)) {
+            return false;
+        }
+        if (isSystemCriticalPath(dirPath)) {
+            return false;
+        }
+        if (options?.containerType === 'appcontainer' && hasAllApplicationPackagesAccess(dirPath)) {
+            return false;
+        }
+        return true;
+    });
+
+    return {
+        readonlyPaths: filtered,
+        readwritePaths: [],
+    };
+}
+
+/**
+ * Build read-only policy for standard user profile application data locations.
+ *
+ * Enumerates immediate subdirectories of `%LOCALAPPDATA%\Programs`
+ * (per-user installed developer tools) as additional read-only paths.
+ *
+ * @returns A policy fragment with user profile paths in `readonlyPaths`.
+ */
+export function getUserProfilePolicy(): FilesystemPolicyResult {
+    const readonlyPaths: string[] = [];
+
+    /*  TODO: Need to think through the implications of granting access
+        to folders within APPDATA versus LOCALAPPDATA.
+    const appData = process.env['APPDATA'];
+    if (appData && directoryExists(appData)) {
+        readonlyPaths.push(path.resolve(appData));
+    }*/
+
+    const localAppData = process.env['LOCALAPPDATA'];
+    if (localAppData && directoryExists(localAppData)) {
+        // Enumerate per-user program installations
+        const programsDir = path.join(localAppData, 'Programs');
+        if (directoryExists(programsDir)) {
+            try {
+                const entries = fs.readdirSync(programsDir, { withFileTypes: true });
+                for (const entry of entries) {
+                    if (entry.isDirectory()) {
+                        readonlyPaths.push(path.join(programsDir, entry.name));
+                    }
+                }
+            } catch {
+                // Ignore enumeration errors (e.g. permission denied)
+            }
+        }
+    }
+
+    return {
+        readonlyPaths,
+        readwritePaths: [],
+    };
+}
+
+/**
+ * Generate a dedicated temporary directory for a container and return it as
+ * read-write policy.
+ *
+ * If the provided environment contains a `TEMP` (or `TMP`) variable, a
+ * uniquely-named subdirectory is created beneath that path and returned in
+ * `tempDirectory` and `readwritePaths`. If neither variable is set the
+ * container is assumed to manage its own temp directory, so the returned
+ * policy is empty.
+ *
+ * @param env - Environment variable map. Defaults to `process.env`.
+ * @returns Policy fragment with the temp directory in both `tempDirectory`
+ *          and `readwritePaths`, or empty values when no TEMP path is found.
+ */
+export function getTemporaryFilesPolicy(
+    env?: { [key: string]: string | undefined },
+): FilesystemPolicyResult {
+    const environment = env ?? process.env;
+    const tempRoot = environment['TEMP'] || environment['TMP'];
+
+    if (!tempRoot || !directoryExists(tempRoot)) {
+        return {
+            readonlyPaths: [],
+            readwritePaths: [],
+        };
+    }
+
+    return {
+        readonlyPaths: [],
+        readwritePaths: [tempRoot],
+    };
+}


### PR DESCRIPTION
Adding path discovery tools to SDK to help clients manage policies.

Start changing names to mxc-sdk.