### PR TITLE
Fix bfscfg argument quoting for paths with spaces

### DIFF
--- a/wxc_common/FileSystemBfsManager.cpp
+++ b/wxc_common/FileSystemBfsManager.cpp
@@ -150,12 +150,21 @@ std::wstring FileSystemBfsManager::RunBfsCfg(std::span<std::wstring_view> args, 
 
     PROCESS_INFORMATION pi = {};
 
-    // Create std::wstring command line from args
+    // Create std::wstring command line from args, quoting any that contain spaces
     std::wstring commandLine{BfsCfgExe};
     for (const auto& arg : args)
     {
         commandLine += L" ";
-        commandLine += arg;
+        if (arg.find(L' ') != std::wstring_view::npos)
+        {
+            commandLine += L"\"";
+            commandLine += arg;
+            commandLine += L"\"";
+        }
+        else
+        {
+            commandLine += arg;
+        }
     }
 
     std::vector<wchar_t> commandLineBuffer(commandLine.begin(), commandLine.end());


### PR DESCRIPTION
## Summary

Fixes #24 — filesystem paths containing spaces are not quoted when passed to `bfscfg.exe`, causing the path to be split into multiple arguments and the policy to silently fail.

## What changed

**`wxc_common/FileSystemBfsManager.cpp`** — `RunBfsCfg()`

Arguments containing spaces are now wrapped in double quotes before being appended to the command line string.

**Before:** `bfscfg.exe --addpolicy --policybroker --filename C:\...\Session Storage --appid Clippy`
**After:** `bfscfg.exe --addpolicy --policybroker --filename "C:\...\Session Storage" --appid Clippy`

## Testing

With a policy containing a path with spaces (e.g. `Session Storage`):

- **Before:** `bfscfg.exe exited with code 87` / `Unknown option: Storage`
- **After:** `bfscfg process created successfully` — policy applied correctly