### PR TITLE
Publish @microsoft/mxc-sdk to this repo's own private package feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Build C++ solution
         run: msbuild wxc.sln /p:Configuration=Release /p:Platform=x64 /t:Rebuild /m /verbosity:minimal
 
+      - name: Set SDK build version
+        working-directory: sdk
+        run: |
+          $timestamp = Get-Date -Format "yyyyMMdd.HHmmss"
+          npm version "$(node -p "require('./package.json').version")-build.$timestamp" --no-git-tag-version
+
       - name: Install and build SDK
         working-directory: sdk
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ on:
     branches: [ main ]
   workflow_call:
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build:
     runs-on: windows-latest
@@ -64,7 +60,3 @@ jobs:
           path: |
             sdk/*.tgz
             cli/*.tgz
-
-  publish:
-    needs: build
-    uses: ./.github/workflows/publish.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_call:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: windows-latest
@@ -60,3 +64,7 @@ jobs:
           path: |
             sdk/*.tgz
             cli/*.tgz
+
+  publish:
+    needs: build
+    uses: ./.github/workflows/publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,18 +27,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@microsoft'
 
-      - name: Set build version
-        run: |
-          $tgz = Get-Item sdk/*.tgz
-          $extractDir = "sdk-package"
-          mkdir $extractDir
-          tar -xzf $tgz.FullName -C $extractDir
-          $pkg = Get-Content "$extractDir/package/package.json" | ConvertFrom-Json
-          $pkg.version = "$($pkg.version)-build.${{ github.run_number }}"
-          $pkg | ConvertTo-Json -Depth 10 | Set-Content "$extractDir/package/package.json"
-          tar -czf $tgz.FullName -C $extractDir package
-          echo "Publishing version $($pkg.version)"
-
       - name: Publish SDK
         run: npm publish sdk/*.tgz
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish SDK to GPR
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@microsoft'
+
+      - name: Install and publish SDK
+        working-directory: sdk
+        run: |
+          npm install
+          npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,18 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@microsoft'
 
+      - name: Set build version
+        run: |
+          $tgz = Get-Item sdk/*.tgz
+          $extractDir = "sdk-package"
+          mkdir $extractDir
+          tar -xzf $tgz.FullName -C $extractDir
+          $pkg = Get-Content "$extractDir/package/package.json" | ConvertFrom-Json
+          $pkg.version = "$($pkg.version)-build.${{ github.run_number }}"
+          $pkg | ConvertTo-Json -Depth 10 | Set-Content "$extractDir/package/package.json"
+          tar -czf $tgz.FullName -C $extractDir package
+          echo "Publishing version $($pkg.version)"
+
       - name: Publish SDK
         run: npm publish sdk/*.tgz
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,20 @@
 name: Publish SDK to GPR
 
 on:
-  workflow_call:
+  release:
+    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
   publish:
+    needs: build
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,19 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@microsoft'
 
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Install vcpkg dependencies
+        run: |
+          vcpkg integrate install
+          vcpkg install --triplet x64-windows
+        env:
+          VCPKG_ROOT: C:\vcpkg
+
+      - name: Build native executable
+        run: msbuild wxc.sln /p:Configuration=Release /p:Platform=x64 /t:Rebuild /m /verbosity:minimal
+
       - name: Install and publish SDK
         working-directory: sdk
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
           scope: '@microsoft'
 
       - name: Publish SDK
-        run: npm publish sdk/*.tgz
+        run: |
+          $tgz = (Get-Item sdk\*.tgz).FullName
+          echo "Publishing $tgz"
+          npm publish $tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,16 @@ permissions:
   packages: write
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
   publish:
+    needs: build
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
 
       - uses: actions/setup-node@v4
         with:
@@ -21,23 +27,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@microsoft'
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Install vcpkg dependencies
-        run: |
-          vcpkg integrate install
-          vcpkg install --triplet x64-windows
-        env:
-          VCPKG_ROOT: C:\vcpkg
-
-      - name: Build native executable
-        run: msbuild wxc.sln /p:Configuration=Release /p:Platform=x64 /t:Rebuild /m /verbosity:minimal
-
-      - name: Install and publish SDK
-        working-directory: sdk
-        run: |
-          npm install
-          npm publish
+      - name: Publish SDK
+        run: npm publish sdk/*.tgz
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,20 +1,14 @@
 name: Publish SDK to GPR
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read
   packages: write
 
 jobs:
-  build:
-    uses: ./.github/workflows/build.yml
-
   publish:
-    needs: build
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -32,5 +32,8 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "os": ["win32"]
+  "os": ["win32"],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }


### PR DESCRIPTION
## Summary

Adds GHPR (GitHub Package Registry) publishing support for `@microsoft/mxc-sdk`.

## Access control

GHPR defaults access to "same as the repo". So, installing this NPM package will require:

 * Creating a GitHub PAT with `read:packages` scope
 * Adding to `~/.npmrc`: `//npm.pkg.github.com/:_authToken=<PAT>`
 * Running: `npm install @microsoft/mxc-sdk --registry=https://npm.pkg.github.com`

... and the user will need to have access to this repository for that PAT to be valid.
