### PR TITLE
Update to windows-rs 0.62, add arch-specific builds, and bundle wxc-exec in SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  # Check formatting and linting for the WXC Rust code
+  # Check formatting and linting for the Rust code
   wxc-exec-lint:
     name: WXC Exec Lint
     runs-on: windows-latest
@@ -39,9 +39,9 @@ jobs:
         run: exit 1
 
 
-  # Build and run Rust tests on x64 and ARM64
-  wxc-exec-test:
-    name: WXC Exec Rust tests
+  # Build and test Rust on x64 and ARM64, upload binaries
+  wxc-exec-build:
+    name: WXC Exec Build (${{ matrix.target }})
     strategy:
       matrix:
         include:
@@ -64,13 +64,22 @@ jobs:
           rustup update stable
           rustup target add ${{ matrix.target }}
 
+      - name: Build release
+        run: cargo build --release --target ${{ matrix.target }}
+
       - name: Run tests
-        run: cargo test --workspace --target ${{ matrix.target }}
+        run: cargo test --release --target ${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wxc-exec-${{ matrix.target }}
+          path: src/target/${{ matrix.target }}/release/wxc-exec.exe
 
 
-  # Build and package the TypeScript SDK
+  # Build and package the TypeScript SDK with bundled wxc-exec binaries
   wxc-typescript-sdk:
     name: WXC TypeScript SDK
+    needs: wxc-exec-build
     runs-on: windows-latest
 
     defaults:
@@ -84,6 +93,23 @@ jobs:
         with:
           node-version: 20
 
+      - name: Download wxc-exec (x64)
+        uses: actions/download-artifact@v4
+        with:
+          name: wxc-exec-x86_64-pc-windows-msvc
+          path: sdk/bin/x86_64-pc-windows-msvc
+
+      - name: Download wxc-exec (arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: wxc-exec-aarch64-pc-windows-msvc
+          path: sdk/bin/aarch64-pc-windows-msvc
+
+      - name: Set build version
+        run: |
+          $timestamp = Get-Date -Format "yyyyMMdd.HHmmss"
+          npm version "$(node -p "require('./package.json').version")-build.$timestamp" --no-git-tag-version
+
       - name: Install dependencies
         run: npm ci
 
@@ -95,15 +121,19 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: sdk-npm-package
+          name: npm-packages
           path: sdk/*.tgz
 
 
-# Build and package the TypeScript CLI (needs SDK built first)
+  # Build and package the TypeScript CLI
   wxc-typescript-cli:
     name: WXC TypeScript CLI
     needs: wxc-typescript-sdk
     runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: cli
 
     steps:
       - uses: actions/checkout@v4
@@ -115,39 +145,19 @@ jobs:
       - name: Download SDK package
         uses: actions/download-artifact@v4
         with:
-          name: sdk-npm-package
-          path: sdk-artifact
+          name: npm-packages
+          path: sdk-pkg
 
-      - name: Build Rust workspace
-        working-directory: src
-        run: cargo build --release
-
-      - name: Run Rust tests
-        working-directory: src
-        run: cargo test --release
-
-      - name: Set SDK build version
-        working-directory: sdk
+      - name: Install CLI dependencies using SDK artifact
         run: |
-          $timestamp = Get-Date -Format "yyyyMMdd.HHmmss"
-          npm version "$(node -p "require('./package.json').version")-build.$timestamp" --no-git-tag-version
-
-      - name: Install and build SDK
-        working-directory: sdk
-        run: |
+          $sdkTgz = (Get-Item ..\sdk-pkg\*.tgz).FullName
           npm ci
-          npm run build
-
-      - name: Install CLI dependencies
-        working-directory: cli
-        run: npm ci
+          npm install $sdkTgz
 
       - name: Build CLI
-        working-directory: cli
         run: npm run build
 
       - name: Pack npm package
-        working-directory: cli
         run: npm pack
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: npm-packages
+          path: packages
 
       - uses: actions/setup-node@v4
         with:
@@ -29,7 +30,7 @@ jobs:
 
       - name: Publish SDK
         run: |
-          $tgz = (Get-Item sdk\*.tgz).FullName
+          $tgz = (Get-Item packages\*.tgz).FullName
           echo "Publishing $tgz"
           npm publish $tgz
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ vcpkg_installed/
 # build artifacts
 output
 **/target/
+
+# Copilot
+.copilot/

--- a/Readme.md
+++ b/Readme.md
@@ -23,23 +23,55 @@ You will also need Node.js 20.10+ and must ensure that the node dependencies are
 
 A copy of Python 3.x is needed for executing test scripts.
 
+### Project Structure
+
+```
+src/            Rust workspace (wxc-exec native binary + wxc_common library)
+sdk/            TypeScript SDK (@microsoft/mxc-sdk npm package)
+cli/            TypeScript CLI (mxc-cli npm package, depends on SDK)
+docs/           Schema and configuration documentation
+examples/       Example configurations
+test_configs/   Test JSON configurations
+test_scripts/   Test scripts for exercising WXC
+```
+
 ### Building WXC
 
-From the `src` directory, build the Rust workspace with Cargo:
+The easiest way to build everything is with `build.bat` from the repo root:
+
+```bash
+build.bat              # Release build for your machine's architecture
+build.bat --debug      # Debug build for your machine's architecture
+build.bat --all        # Release build for both x64 and ARM64
+build.bat --help       # Show all options
+```
+
+This will:
+1. Build the Rust `wxc-exec.exe` binary for the selected architecture(s)
+2. Copy the binary into `sdk/bin/<target-triple>/` so it is bundled with the SDK package
+3. Build the TypeScript SDK
+
+#### Building components individually
+
+To build just the Rust workspace:
 
 ```bash
 cd src
-cargo build --release
+cargo build --release --target x86_64-pc-windows-msvc    # x64
+cargo build --release --target aarch64-pc-windows-msvc   # ARM64
 ```
 
-This will produce the `wxc-exec.exe` binary and the `wxc_test_driver.exe` test program in `src/target/release/`.
+This produces `wxc-exec.exe` in `src/target/<target-triple>/release/`.
 
-For the SDK npm library, go into the SDK folder and build:
+For the SDK npm library:
 
 ```bash
 cd sdk
 npm install && npm run build
 ```
+
+> **Note:** If building the SDK separately, you must first copy `wxc-exec.exe` into
+> `sdk/bin/<target-triple>/` for it to be included in the npm package.
 
 ## Usage
 

--- a/build.bat
+++ b/build.bat
@@ -1,13 +1,93 @@
 @echo off
+setlocal enabledelayedexpansion
 
+:: Defaults
+set "BUILD_CONFIG=release"
+set "BUILD_ARCH="
+set "BUILD_ALL=0"
+
+:: Parse arguments
+:parse_args
+if "%~1"=="" goto :args_done
+if /i "%~1"=="--debug"   ( set "BUILD_CONFIG=debug"   & shift & goto :parse_args )
+if /i "%~1"=="--release" ( set "BUILD_CONFIG=release"  & shift & goto :parse_args )
+if /i "%~1"=="--x64"     ( set "BUILD_ARCH=x86_64-pc-windows-msvc"   & shift & goto :parse_args )
+if /i "%~1"=="--arm64"   ( set "BUILD_ARCH=aarch64-pc-windows-msvc"  & shift & goto :parse_args )
+if /i "%~1"=="--all"     ( set "BUILD_ALL=1"           & shift & goto :parse_args )
+if /i "%~1"=="--help"    ( goto :usage )
+if /i "%~1"=="-h"        ( goto :usage )
+echo Unknown argument: %~1
+goto :usage
+:args_done
+
+:: Detect native architecture if not specified and not --all
+if "%BUILD_ALL%"=="0" if "%BUILD_ARCH%"=="" (
+    if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+        set "BUILD_ARCH=aarch64-pc-windows-msvc"
+    ) else (
+        set "BUILD_ARCH=x86_64-pc-windows-msvc"
+    )
+)
+
+:: Build flags
+set "CARGO_FLAGS=--target"
+if "%BUILD_CONFIG%"=="release" set "CARGO_FLAGS=--release --target"
+
+:: Build Rust
 echo.
-echo Building WXC (Rust)...
+echo Building WXC (Rust) [%BUILD_CONFIG%]...
 pushd src
-cargo build --release
+if "%BUILD_ALL%"=="1" (
+    echo   Target: x86_64-pc-windows-msvc
+    cargo build %CARGO_FLAGS% x86_64-pc-windows-msvc || goto :error
+    echo   Target: aarch64-pc-windows-msvc
+    cargo build %CARGO_FLAGS% aarch64-pc-windows-msvc || goto :error
+) else (
+    echo   Target: %BUILD_ARCH%
+    cargo build %CARGO_FLAGS% %BUILD_ARCH% || goto :error
+)
 popd
 
+:: Copy wxc-exec binaries into SDK package
+echo.
+echo Copying wxc-exec binaries into SDK package...
+for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
+    set "SRC_EXE=src\target\%%T\%BUILD_CONFIG%\wxc-exec.exe"
+    if exist "!SRC_EXE!" (
+        if not exist "sdk\bin\%%T" mkdir "sdk\bin\%%T"
+        copy /Y "!SRC_EXE!" "sdk\bin\%%T\wxc-exec.exe" >nul
+        echo   Copied %%T\wxc-exec.exe
+    )
+)
+
+:: Build npm packages
 echo.
 echo Building npm SDK package...
 pushd sdk
 call npm install & call npm run build
 popd
+
+echo.
+echo Build complete.
+exit /b 0
+
+:error
+popd
+echo.
+echo Build failed.
+exit /b 1
+
+:usage
+echo.
+echo Usage: build.bat [options]
+echo.
+echo Options:
+echo   --debug     Build debug configuration (default: release)
+echo   --release   Build release configuration
+echo   --x64       Build for x64 only
+echo   --arm64     Build for ARM64 only
+echo   --all       Build for both x64 and ARM64
+echo   -h, --help  Show this help
+echo.
+echo Default: builds release for the current machine architecture.
+exit /b 0

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -113,16 +113,41 @@ export function getPlatformSupport(): PlatformSupport {
 }
 
 /**
+ * Get the Rust target triple for the current machine architecture.
+ * @returns The Rust target triple string
+ */
+function getRustTargetTriple(): string {
+  const arch = os.arch();
+  switch (arch) {
+    case 'arm64':
+      return 'aarch64-pc-windows-msvc';
+    case 'x64':
+    default:
+      return 'x86_64-pc-windows-msvc';
+  }
+}
+
+/**
  * Find the wxc-exec executable
- * Searches in common locations relative to the SDK package
+ * Searches in common locations relative to the SDK package,
+ * selecting the build matching the current machine architecture.
  * @returns Path to wxc-exec.exe if found, null otherwise
  */
 export function findWxcExecutable(): string | null {
+  const targetTriple = getRustTargetTriple();
+  const targetDir = path.join(__dirname, '..', '..', 'src', 'target');
+
   const possiblePaths = [
-    // Rust release build output
-    path.join(__dirname, '..', '..', 'src', 'target', 'release', 'wxc-exec.exe'),
-    // Rust debug build output
-    path.join(__dirname, '..', '..', 'src', 'target', 'debug', 'wxc-exec.exe'),
+    // Bundled in the SDK package (e.g. when installed via npm)
+    path.join(__dirname, '..', 'bin', targetTriple, 'wxc-exec.exe'),
+    // Architecture-specific release build output (monorepo dev)
+    path.join(targetDir, targetTriple, 'release', 'wxc-exec.exe'),
+    // Architecture-specific debug build output (monorepo dev)
+    path.join(targetDir, targetTriple, 'debug', 'wxc-exec.exe'),
+    // Fallback: default Cargo release build output (no explicit --target)
+    path.join(targetDir, 'release', 'wxc-exec.exe'),
+    // Fallback: default Cargo debug build output (no explicit --target)
+    path.join(targetDir, 'debug', 'wxc-exec.exe'),
   ];
 
   for (const wxcPath of possiblePaths) {

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -474,32 +474,54 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.58.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.58.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -508,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.58.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -524,22 +546,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.2.0"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -552,68 +583,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-threading"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
 members = ["wxc", "wxc_common", "wxc_test_driver"]
-resolver = "2"
+resolver = "3"
 
 [workspace.dependencies]
-windows = { version = "0.58", features = [
+windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Com",
@@ -19,11 +19,13 @@ windows = { version = "0.58", features = [
     "Win32_System_Memory",
     "Win32_System_Diagnostics_Debug",
     "Win32_Security_Isolation",
+    "Win32_System_Variant",
 ] }
-windows-core = "0.58"
+windows-core = "0.62"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
+wxc_common = { path = "wxc_common" }

--- a/src/wxc/Cargo.toml
+++ b/src/wxc/Cargo.toml
@@ -8,7 +8,7 @@ name = "wxc-exec"
 path = "src/main.rs"
 
 [dependencies]
-wxc_common = { path = "../wxc_common" }
+wxc_common.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 windows.workspace = true

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -66,8 +66,7 @@ fn delete_app_container_profile(name: &str, logger: &mut Logger) -> bool {
 
     // Delete the AppContainer profile
     let wide_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
-    let hstring =
-        windows::core::HSTRING::from_wide(&wide_name[..wide_name.len() - 1]).unwrap_or_default();
+    let hstring = windows::core::HSTRING::from_wide(&wide_name[..wide_name.len() - 1]);
     match unsafe { DeleteAppContainerProfile(&hstring) } {
         Ok(()) => {
             logger.log_line(&format!("Deleted AppContainer profile: {}", name));

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -67,7 +67,7 @@ impl Drop for CapabilitySidGuard {
     fn drop(&mut self) {
         for &sid in &self.0 {
             unsafe {
-                let _ = LocalFree(HLOCAL(sid));
+                let _ = LocalFree(Some(HLOCAL(sid)));
             }
         }
     }
@@ -226,22 +226,20 @@ impl AppContainerScriptRunner {
 
         // First call to get the required buffer size.
         unsafe {
-            let _ = InitializeProcThreadAttributeList(
-                LPPROC_THREAD_ATTRIBUTE_LIST(ptr::null_mut()),
-                attr_count,
-                0,
-                &mut attr_list_size,
-            );
+            let _ = InitializeProcThreadAttributeList(None, attr_count, None, &mut attr_list_size);
         }
 
         let mut attr_list_buf: Vec<u8> = vec![0u8; attr_list_size];
         let attr_list = LPPROC_THREAD_ATTRIBUTE_LIST(attr_list_buf.as_mut_ptr() as *mut _);
 
         unsafe {
-            InitializeProcThreadAttributeList(attr_list, attr_count, 0, &mut attr_list_size)
-                .map_err(|e| {
-                    WxcError::Process(format!("InitializeProcThreadAttributeList: {}", e))
-                })?;
+            InitializeProcThreadAttributeList(
+                Some(attr_list),
+                attr_count,
+                None,
+                &mut attr_list_size,
+            )
+            .map_err(|e| WxcError::Process(format!("InitializeProcThreadAttributeList: {}", e)))?;
         }
 
         // RAII guard to call DeleteProcThreadAttributeList on exit.
@@ -350,14 +348,14 @@ impl AppContainerScriptRunner {
         unsafe {
             CreateProcessW(
                 PCWSTR::null(),
-                PWSTR(cmd_line_wide.as_mut_ptr()),
+                Some(PWSTR(cmd_line_wide.as_mut_ptr())),
                 None,
                 None,
                 true,
                 EXTENDED_STARTUPINFO_PRESENT,
                 None,
                 working_dir_pcwstr,
-                &si_ex.StartupInfo,
+                &si_ex.StartupInfo as *const STARTUPINFOW,
                 &mut pi,
             )
             .map_err(|e| WxcError::Process(format!("CreateProcessW failed: {}", e)))?;

--- a/src/wxc_common/src/network_firewall.rs
+++ b/src/wxc_common/src/network_firewall.rs
@@ -4,7 +4,6 @@
 use std::net::{IpAddr, ToSocketAddrs};
 
 use windows::core::BSTR;
-use windows::core::VARIANT;
 use windows::Win32::Foundation::VARIANT_BOOL;
 use windows::Win32::NetworkManagement::WindowsFirewall::{
     INetFwPolicy2, INetFwRule3, NetFwPolicy2, NetFwRule, NET_FW_ACTION, NET_FW_ACTION_ALLOW,
@@ -15,6 +14,7 @@ use windows::Win32::System::Com::{
     CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_INPROC_SERVER,
     COINIT_APARTMENTTHREADED,
 };
+use windows::Win32::System::Variant::VARIANT;
 use windows_core::Interface;
 
 use crate::error::WxcError;

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -5,12 +5,12 @@ use crate::error::WxcError;
 use crate::string_util;
 
 use windows::Win32::Foundation::{
-    CloseHandle, LocalFree, SetHandleInformation, BOOL, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT,
-    HLOCAL,
+    CloseHandle, LocalFree, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, HLOCAL,
 };
 use windows::Win32::Security::{DeriveCapabilitySidsFromName, PSID, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::ReadFile;
 use windows::Win32::System::Pipes::CreatePipe;
+use windows_core::BOOL;
 use windows_core::PCWSTR;
 
 const BUFFER_SIZE: u32 = 4096;
@@ -164,17 +164,19 @@ pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void
             &mut capability_sids,
             &mut capability_sid_count,
         )
-        .map_err(|_| WxcError::Process(format!("DeriveCapabilitySidsFromName({}) failed", name)))?;
+        .map_err(|e| {
+            WxcError::Process(format!("DeriveCapabilitySidsFromName({name}) failed: {e}"))
+        })?;
 
         // Free group SIDs
         for i in 0..group_sid_count {
             let sid = *group_sids.add(i as usize);
-            let _ = LocalFree(HLOCAL(sid.0));
+            let _ = LocalFree(Some(HLOCAL(sid.0)));
         }
-        let _ = LocalFree(HLOCAL(group_sids as *mut _));
+        let _ = LocalFree(Some(HLOCAL(group_sids as *mut _)));
 
         if capability_sid_count == 0 {
-            let _ = LocalFree(HLOCAL(capability_sids as *mut _));
+            let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
             return Err(WxcError::Process(format!(
                 "No capability SID returned for {}",
                 name
@@ -187,9 +189,9 @@ pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void
         // Free remaining capability SIDs (index 1+)
         for i in 1..capability_sid_count {
             let sid = *capability_sids.add(i as usize);
-            let _ = LocalFree(HLOCAL(sid.0));
+            let _ = LocalFree(Some(HLOCAL(sid.0)));
         }
-        let _ = LocalFree(HLOCAL(capability_sids as *mut _));
+        let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
 
         Ok(result_sid)
     }

--- a/src/wxc_common/src/string_util.rs
+++ b/src/wxc_common/src/string_util.rs
@@ -27,6 +27,10 @@ pub fn from_wide(wide: &[u16]) -> String {
 /// # Safety
 /// The caller must ensure `sid` points to a valid SID structure.
 pub unsafe fn sid_to_string(sid: *mut std::ffi::c_void, default_value: &str) -> String {
+    if sid.is_null() {
+        return default_value.to_string();
+    }
+
     let mut string_sid = windows_core::PWSTR::null();
     let psid = PSID(sid);
 
@@ -38,7 +42,7 @@ pub unsafe fn sid_to_string(sid: *mut std::ffi::c_void, default_value: &str) -> 
     let result = unsafe { string_sid.to_string() }.unwrap_or_else(|_| default_value.to_string());
 
     unsafe {
-        let _ = LocalFree(HLOCAL(string_sid.0 as *mut std::ffi::c_void));
+        let _ = LocalFree(Some(HLOCAL(string_sid.0 as *mut std::ffi::c_void)));
     }
 
     result


### PR DESCRIPTION
Rust (windows crate 0.58 -> 0.62):
  - VARIANT moved to Win32::System::Variant, BOOL to windows_core
  - LocalFree takes Option<HLOCAL>, CreateProcessW/InitializeProcThreadAttributeList
    signature updates, HSTRING::from_wide no longer returns Result
  - Add wxc_common workspace dependency, Win32_System_Variant feature, resolver 3
  - Set edition = 2021 on wxc crate

  Build (build.bat):
  - Add --debug, --release, --x64, --arm64, --all flags (default: release
    for native arch via PROCESSOR_ARCHITECTURE)
  - Copy wxc-exec.exe into sdk/bin/<triple>/ post-build so npm pack bundles it

  CI (build.yml + publish.yml):
  - Restructure into separate jobs: lint, build (x64+arm64 matrix), SDK, CLI
  - wxc-exec-build runs release build + tests on native runners, uploads
    per-arch binaries as artifacts
  - wxc-typescript-sdk downloads both binaries into sdk/bin/ before packing
  - wxc-typescript-cli installs SDK from .tgz artifact instead of rebuilding
  - publish.yml downloads SDK artifact into packages/ subdirectory

  SDK (platform.ts):
  - Add getRustTargetTriple() to select x64/arm64 based on os.arch()
  - findWxcExecutable() checks sdk/bin/<triple>/ first (npm package), then
    Cargo target dirs (monorepo dev), with generic fallbacks

  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>