### PR TITLE
Add CI lint/test matrix and apply rustfmt/clippy fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,20 +8,115 @@ on:
   workflow_call:
 
 jobs:
-  build:
+
+  # Check formatting and linting for the WXC Rust code
+  wxc-exec-lint:
+    name: WXC Exec Lint
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: src
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        run: |
+          rustup update stable
+          rustup component add rustfmt clippy
+
+      - name: Check formatting
+        id: fmt
+        continue-on-error: true
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Fail if formatting check failed
+        if: steps.fmt.outcome == 'failure'
+        run: exit 1
+
+
+  # Build and run Rust tests on x64 and ARM64
+  wxc-exec-test:
+    name: WXC Exec Rust tests
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+            runner: windows-2025
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    defaults:
+      run:
+        working-directory: src
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        run: |
+          rustup update stable
+          rustup target add ${{ matrix.target }}
+
+      - name: Run tests
+        run: cargo test --workspace --target ${{ matrix.target }}
+
+
+  # Build and package the TypeScript SDK
+  wxc-typescript-sdk:
+    name: WXC TypeScript SDK
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: sdk
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack npm package
+        run: npm pack
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdk-npm-package
+          path: sdk/*.tgz
+
+
+# Build and package the TypeScript CLI (needs SDK built first)
+  wxc-typescript-cli:
+    name: WXC TypeScript CLI
+    needs: wxc-typescript-sdk
     runs-on: windows-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
 
-      - name: Setup Rust toolchain
-        run: rustup default stable
+      - name: Download SDK package
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-npm-package
+          path: sdk-artifact
 
       - name: Build Rust workspace
         working-directory: src
@@ -40,21 +135,22 @@ jobs:
       - name: Install and build SDK
         working-directory: sdk
         run: |
-          npm install
+          npm ci
           npm run build
-          npm pack
 
-      - name: Install and build CLI
+      - name: Install CLI dependencies
         working-directory: cli
-        run: |
-          npm install
-          npm run build
-          npm pack
+        run: npm ci
 
-      - name: Upload npm packages
-        uses: actions/upload-artifact@v4
+      - name: Build CLI
+        working-directory: cli
+        run: npm run build
+
+      - name: Pack npm package
+        working-directory: cli
+        run: npm pack
+
+      - uses: actions/upload-artifact@v4
         with:
-          name: npm-packages
-          path: |
-            sdk/*.tgz
-            cli/*.tgz
+          name: cli-npm-package
+          path: cli/*.tgz

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -4,24 +4,22 @@
 use std::ptr;
 use std::thread;
 
-use windows::Win32::Foundation::{HLOCAL, LocalFree, WAIT_OBJECT_0};
+use windows::Win32::Foundation::{LocalFree, HLOCAL, WAIT_OBJECT_0};
 use windows::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
 use windows::Win32::Security::PSID;
 use windows::Win32::System::Threading::{
     CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
-    InitializeProcThreadAttributeList, UpdateProcThreadAttribute, LPPROC_THREAD_ATTRIBUTE_LIST,
-    PROCESS_CREATION_FLAGS, PROCESS_INFORMATION, STARTF_USESTDHANDLES, STARTUPINFOEXW,
-    STARTUPINFOW, TerminateProcess, WaitForSingleObject,
+    InitializeProcThreadAttributeList, TerminateProcess, UpdateProcThreadAttribute,
+    WaitForSingleObject, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW, STARTUPINFOW,
 };
 use windows_core::{PCWSTR, PWSTR};
 
 use crate::error::WxcError;
 use crate::logger::Logger;
-use crate::models::{
-    CodexRequest, NetworkEnforcementMode, NetworkPolicy, ScriptResponse,
-};
+use crate::models::{CodexRequest, NetworkEnforcementMode, NetworkPolicy, ScriptResponse};
 use crate::process_util::{
     create_std_pipes, get_capability_sid_from_name, read_from_pipe, suppress_python_location_error,
     OwnedHandle, SendOwnedHandle,
@@ -109,9 +107,8 @@ impl AppContainerScriptRunner {
         let desc = string_util::to_wide("Profile for agentic script execution");
         let pcwstr_desc = PCWSTR(desc.as_ptr());
 
-        let result = unsafe {
-            CreateAppContainerProfile(pcwstr_name, pcwstr_display, pcwstr_desc, None)
-        };
+        let result =
+            unsafe { CreateAppContainerProfile(pcwstr_name, pcwstr_display, pcwstr_desc, None) };
 
         match result {
             Ok(sid) => Ok(sid),
@@ -170,10 +167,9 @@ impl AppContainerScriptRunner {
         );
         if use_capabilities_for_network
             && request.policy.default_network_policy == NetworkPolicy::Allow
+            && !capabilities_to_add.iter().any(|c| c == "internetClient")
         {
-            if !capabilities_to_add.iter().any(|c| c == "internetClient") {
-                capabilities_to_add.push("internetClient".to_string());
-            }
+            capabilities_to_add.push("internetClient".to_string());
         }
 
         // --- Derive SIDs for each capability ---
@@ -213,10 +209,10 @@ impl AppContainerScriptRunner {
         // --- Create pipes ---
         let (stdin_read, stdin_write) =
             create_std_pipes(false).map_err(|e| WxcError::Process(format!("stdin pipe: {}", e)))?;
-        let (mut stdout_read, stdout_write) = create_std_pipes(true)
-            .map_err(|e| WxcError::Process(format!("stdout pipe: {}", e)))?;
-        let (mut stderr_read, stderr_write) = create_std_pipes(true)
-            .map_err(|e| WxcError::Process(format!("stderr pipe: {}", e)))?;
+        let (mut stdout_read, stdout_write) =
+            create_std_pipes(true).map_err(|e| WxcError::Process(format!("stdout pipe: {}", e)))?;
+        let (mut stderr_read, stderr_write) =
+            create_std_pipes(true).map_err(|e| WxcError::Process(format!("stderr pipe: {}", e)))?;
 
         let inherit_handles = [stdin_read.get(), stdout_write.get(), stderr_write.get()];
 
@@ -239,8 +235,7 @@ impl AppContainerScriptRunner {
         }
 
         let mut attr_list_buf: Vec<u8> = vec![0u8; attr_list_size];
-        let attr_list =
-            LPPROC_THREAD_ATTRIBUTE_LIST(attr_list_buf.as_mut_ptr() as *mut _);
+        let attr_list = LPPROC_THREAD_ATTRIBUTE_LIST(attr_list_buf.as_mut_ptr() as *mut _);
 
         unsafe {
             InitializeProcThreadAttributeList(attr_list, attr_count, 0, &mut attr_list_size)
@@ -336,7 +331,11 @@ impl AppContainerScriptRunner {
         };
 
         // --- Build command line ---
-        let mut cmd_line_wide: Vec<u16> = request.script_code.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut cmd_line_wide: Vec<u16> = request
+            .script_code
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
 
         let working_dir_wide = string_util::to_wide(&request.working_directory);
         let working_dir_pcwstr = if request.working_directory.is_empty() {

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -320,7 +320,10 @@ mod tests {
         assert_eq!(req.script_timeout, 3000);
         assert_eq!(req.policy.app_container_name, "TestProfile");
         assert!(req.policy.least_privilege_mode);
-        assert!(req.policy.capabilities.contains(&"internetClient".to_string()));
+        assert!(req
+            .policy
+            .capabilities
+            .contains(&"internetClient".to_string()));
         assert_eq!(req.policy.readwrite_paths, vec!["C:\\rw"]);
         assert_eq!(req.policy.readonly_paths, vec!["C:\\ro"]);
         assert_eq!(req.policy.denied_paths, vec!["C:\\denied"]);
@@ -491,8 +494,7 @@ mod tests {
 
     #[test]
     fn network_enforcement_mode_capabilities() {
-        let json =
-            r#"{"script": "print('test')", "network": {"enforcementMode": "capabilities"}}"#;
+        let json = r#"{"script": "print('test')", "network": {"enforcementMode": "capabilities"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 

--- a/src/wxc_common/src/filesystem_bfs.rs
+++ b/src/wxc_common/src/filesystem_bfs.rs
@@ -59,10 +59,8 @@ impl FileSystemBfsManager {
     }
 
     pub fn remove_configuration(&mut self, logger: &mut Logger) -> bool {
-        if self.configured {
-            if self.remove_configuration_inner(logger).is_ok() {
-                self.configured = false;
-            }
+        if self.configured && self.remove_configuration_inner(logger).is_ok() {
+            self.configured = false;
         }
         !self.configured
     }
@@ -76,12 +74,7 @@ impl FileSystemBfsManager {
         self.execute_bfscfg_operation(&args, &description, logger)
     }
 
-    fn add_bfs_path(
-        &self,
-        path: &str,
-        inherit: bool,
-        logger: &mut Logger,
-    ) -> Result<(), WxcError> {
+    fn add_bfs_path(&self, path: &str, inherit: bool, logger: &mut Logger) -> Result<(), WxcError> {
         let mut args = vec![
             "--addpolicy",
             "--policybroker",

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -3,31 +3,21 @@
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkPolicy {
+    #[default]
     Allow,
     Block,
 }
 
-impl Default for NetworkPolicy {
-    fn default() -> Self {
-        NetworkPolicy::Allow
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkEnforcementMode {
+    #[default]
     Capabilities,
     Firewall,
     Both,
-}
-
-impl Default for NetworkEnforcementMode {
-    fn default() -> Self {
-        NetworkEnforcementMode::Capabilities
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,24 +56,13 @@ impl Default for ContainerPolicy {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct CodexRequest {
     pub script_code: String,
     pub working_directory: String,
     pub script_timeout: u32,
     pub policy: ContainerPolicy,
-}
-
-impl Default for CodexRequest {
-    fn default() -> Self {
-        Self {
-            script_code: String::new(),
-            working_directory: String::new(),
-            script_timeout: 0,
-            policy: ContainerPolicy::default(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/wxc_common/src/network_firewall.rs
+++ b/src/wxc_common/src/network_firewall.rs
@@ -100,7 +100,13 @@ impl NetworkFirewallManager {
 
         if default_policy == DefaultPolicy::Block {
             let block_all_name = format!("{}_BlockAll", rule_prefix);
-            if !self.create_rule(&block_all_name, principal_id, NET_FW_ACTION_BLOCK, "", logger)? {
+            if !self.create_rule(
+                &block_all_name,
+                principal_id,
+                NET_FW_ACTION_BLOCK,
+                "",
+                logger,
+            )? {
                 return Ok(false);
             }
             self.created_rule_names.push(block_all_name);
@@ -186,9 +192,8 @@ impl NetworkFirewallManager {
             }
         };
 
-        let rules = unsafe { fw_policy.Rules() }.map_err(|e| {
-            WxcError::Firewall(format!("Failed to get firewall rules: {}", e))
-        })?;
+        let rules = unsafe { fw_policy.Rules() }
+            .map_err(|e| WxcError::Firewall(format!("Failed to get firewall rules: {}", e)))?;
 
         let mut all_success = true;
         for rule_name in &self.created_rule_names {
@@ -290,14 +295,12 @@ impl NetworkFirewallManager {
             .as_ref()
             .ok_or_else(|| WxcError::Firewall("Firewall policy not initialized".into()))?;
 
-        let rules = unsafe { fw_policy.Rules() }.map_err(|e| {
-            WxcError::Firewall(format!("Failed to get firewall rules: {}", e))
-        })?;
+        let rules = unsafe { fw_policy.Rules() }
+            .map_err(|e| WxcError::Firewall(format!("Failed to get firewall rules: {}", e)))?;
 
         let rule: windows::Win32::NetworkManagement::WindowsFirewall::INetFwRule =
-            unsafe { CoCreateInstance(&NetFwRule, None, CLSCTX_INPROC_SERVER) }.map_err(|e| {
-                WxcError::Firewall(format!("Failed to create NetFwRule: {}", e))
-            })?;
+            unsafe { CoCreateInstance(&NetFwRule, None, CLSCTX_INPROC_SERVER) }
+                .map_err(|e| WxcError::Firewall(format!("Failed to create NetFwRule: {}", e)))?;
 
         let rule3: INetFwRule3 = rule.cast().map_err(|e| {
             WxcError::Firewall(format!("Failed to get INetFwRule3 interface: {}", e))
@@ -312,9 +315,7 @@ impl NetworkFirewallManager {
 
             rule3
                 .SetLocalAppPackageId(&BSTR::from(principal_id))
-                .map_err(|e| {
-                    WxcError::Firewall(format!("put_LocalAppPackageId failed: {}", e))
-                })?;
+                .map_err(|e| WxcError::Firewall(format!("put_LocalAppPackageId failed: {}", e)))?;
 
             rule.SetDirection(NET_FW_RULE_DIR_OUT)
                 .map_err(|e| WxcError::Firewall(format!("put_Direction failed: {}", e)))?;
@@ -339,7 +340,10 @@ impl NetworkFirewallManager {
             match rules.Add(&rule) {
                 Ok(()) => Ok(true),
                 Err(e) => {
-                    _logger.log_line(&format!("Failed to add firewall rule '{}': {}", rule_name, e));
+                    _logger.log_line(&format!(
+                        "Failed to add firewall rule '{}': {}",
+                        rule_name, e
+                    ));
                     Ok(false)
                 }
             }
@@ -366,9 +370,7 @@ pub fn resolve_hostname(hostname: &str) -> Result<String, WxcError> {
         .to_socket_addrs()
         .map_err(|e| WxcError::Firewall(format!("Failed to resolve '{}': {}", hostname, e)))?
         .next()
-        .ok_or_else(|| {
-            WxcError::Firewall(format!("No addresses found for '{}'", hostname))
-        })?;
+        .ok_or_else(|| WxcError::Firewall(format!("No addresses found for '{}'", hostname)))?;
 
     Ok(addr.ip().to_string())
 }
@@ -440,7 +442,8 @@ mod tests {
             default_network_policy: NetworkPolicy::Block,
             ..Default::default()
         };
-        let (default_policy, use_fw) = NetworkFirewallManager::initialize_policy(&policy, &mut logger);
+        let (default_policy, use_fw) =
+            NetworkFirewallManager::initialize_policy(&policy, &mut logger);
         assert!(use_fw);
         assert_eq!(default_policy, DefaultPolicy::Block);
     }
@@ -452,7 +455,8 @@ mod tests {
             network_enforcement_mode: NetworkEnforcementMode::Capabilities,
             ..Default::default()
         };
-        let (default_policy, use_fw) = NetworkFirewallManager::initialize_policy(&policy, &mut logger);
+        let (default_policy, use_fw) =
+            NetworkFirewallManager::initialize_policy(&policy, &mut logger);
         assert!(!use_fw);
         assert_eq!(default_policy, DefaultPolicy::Allow);
     }
@@ -466,7 +470,8 @@ mod tests {
             allowed_hosts: vec!["example.com".to_string()],
             ..Default::default()
         };
-        let (default_policy, use_fw) = NetworkFirewallManager::initialize_policy(&policy, &mut logger);
+        let (default_policy, use_fw) =
+            NetworkFirewallManager::initialize_policy(&policy, &mut logger);
         assert!(use_fw);
         assert_eq!(default_policy, DefaultPolicy::Allow);
     }

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -5,13 +5,11 @@ use crate::error::WxcError;
 use crate::string_util;
 
 use windows::Win32::Foundation::{
-    CloseHandle, BOOL, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, HLOCAL, LocalFree,
-    SetHandleInformation,
+    CloseHandle, LocalFree, SetHandleInformation, BOOL, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT,
+    HLOCAL,
 };
-use windows::Win32::Security::{
-    DeriveCapabilitySidsFromName, PSID, SECURITY_ATTRIBUTES,
-};
-use windows::Win32::Storage::FileSystem::{ReadFile};
+use windows::Win32::Security::{DeriveCapabilitySidsFromName, PSID, SECURITY_ATTRIBUTES};
+use windows::Win32::Storage::FileSystem::ReadFile;
 use windows::Win32::System::Pipes::CreatePipe;
 use windows_core::PCWSTR;
 
@@ -112,7 +110,7 @@ pub fn read_from_pipe(pipe: HANDLE) -> String {
 /// If `no_inherit_read` is true, the read end is made non-inheritable;
 /// otherwise the write end is made non-inheritable.
 pub fn create_std_pipes(no_inherit_read: bool) -> Result<(OwnedHandle, OwnedHandle), WxcError> {
-    let mut sa = SECURITY_ATTRIBUTES {
+    let sa = SECURITY_ATTRIBUTES {
         nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
         bInheritHandle: BOOL::from(true),
         lpSecurityDescriptor: std::ptr::null_mut(),
@@ -121,16 +119,15 @@ pub fn create_std_pipes(no_inherit_read: bool) -> Result<(OwnedHandle, OwnedHand
     let mut h_write = HANDLE::default();
 
     unsafe {
-        CreatePipe(&mut h_read, &mut h_write, Some(&mut sa), 0)
+        CreatePipe(&mut h_read, &mut h_write, Some(&sa), 0)
             .map_err(|_| WxcError::Process("Failed to create pipe".into()))?;
 
         let h_dup = if no_inherit_read { h_read } else { h_write };
-        SetHandleInformation(h_dup, HANDLE_FLAG_INHERIT.0, HANDLE_FLAGS(0))
-            .map_err(|_| {
-                let _ = CloseHandle(h_read);
-                let _ = CloseHandle(h_write);
-                WxcError::Process("Failed to set handle information on pipe".into())
-            })?;
+        SetHandleInformation(h_dup, HANDLE_FLAG_INHERIT.0, HANDLE_FLAGS(0)).map_err(|_| {
+            let _ = CloseHandle(h_read);
+            let _ = CloseHandle(h_write);
+            WxcError::Process("Failed to set handle information on pipe".into())
+        })?;
     }
 
     Ok((OwnedHandle::new(h_read), OwnedHandle::new(h_write)))
@@ -150,9 +147,7 @@ pub fn suppress_python_location_error(stderr: &mut String) {
 
 /// Derive the capability SID for a given capability name.
 /// Returns the raw SID pointer. The caller is responsible for freeing it with `LocalFree`.
-pub fn get_capability_sid_from_name(
-    name: &str,
-) -> Result<*mut core::ffi::c_void, WxcError> {
+pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void, WxcError> {
     let wide_name = string_util::to_wide(name);
     let pcwstr = PCWSTR(wide_name.as_ptr());
 
@@ -169,12 +164,7 @@ pub fn get_capability_sid_from_name(
             &mut capability_sids,
             &mut capability_sid_count,
         )
-        .map_err(|_| {
-            WxcError::Process(format!(
-                "DeriveCapabilitySidsFromName({}) failed",
-                name
-            ))
-        })?;
+        .map_err(|_| WxcError::Process(format!("DeriveCapabilitySidsFromName({}) failed", name)))?;
 
         // Free group SIDs
         for i in 0..group_sid_count {

--- a/src/wxc_common/src/script_runner.rs
+++ b/src/wxc_common/src/script_runner.rs
@@ -34,8 +34,7 @@ pub trait ScriptRunner {
 
         let principal_id = self.get_principal_id();
 
-        let mut bfs_manager =
-            FileSystemBfsManager::new(request.policy.app_container_name.clone());
+        let mut bfs_manager = FileSystemBfsManager::new(request.policy.app_container_name.clone());
         if let Err(e) = bfs_manager.configure(&request.policy, logger) {
             return ScriptResponse::error(&e.to_string());
         }
@@ -71,7 +70,11 @@ pub trait ScriptRunner {
 
 /// Convert a timeout value to milliseconds, treating 0 as infinite (INFINITE = `u32::MAX`).
 pub fn get_timeout_milliseconds(timeout: u32) -> u32 {
-    if timeout == 0 { u32::MAX } else { timeout }
+    if timeout == 0 {
+        u32::MAX
+    } else {
+        timeout
+    }
 }
 
 #[cfg(test)]

--- a/src/wxc_common/src/string_util.rs
+++ b/src/wxc_common/src/string_util.rs
@@ -4,7 +4,7 @@
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
-use windows::Win32::Foundation::{HLOCAL, LocalFree};
+use windows::Win32::Foundation::{LocalFree, HLOCAL};
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::PSID;
 
@@ -101,10 +101,7 @@ mod tests {
 
     #[test]
     fn base64_decode_valid() {
-        assert_eq!(
-            base64_decode("SGVsbG8gV29ybGQ=").unwrap(),
-            b"Hello World"
-        );
+        assert_eq!(base64_decode("SGVsbG8gV29ybGQ=").unwrap(), b"Hello World");
     }
 
     #[test]
@@ -251,10 +248,7 @@ mod tests {
 
     #[test]
     fn from_wide_emoji() {
-        let wide: Vec<u16> = "Test 😀"
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let wide: Vec<u16> = "Test 😀".encode_utf16().chain(std::iter::once(0)).collect();
         assert_eq!(from_wide(&wide), "Test 😀");
     }
 
@@ -274,10 +268,7 @@ mod tests {
     #[test]
     fn from_wide_large_string() {
         let original = "A".repeat(10_000);
-        let wide: Vec<u16> = original
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let wide: Vec<u16> = original.encode_utf16().chain(std::iter::once(0)).collect();
         assert_eq!(from_wide(&wide), original);
     }
 
@@ -337,5 +328,4 @@ mod tests {
         let result = unsafe { sid_to_string(std::ptr::null_mut(), "") };
         assert_eq!(result, "");
     }
-
 }

--- a/src/wxc_test_driver/src/main.rs
+++ b/src/wxc_test_driver/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     for entry in fs::read_dir(config_dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().map_or(false, |e| e == "json") {
+        if path.extension().is_some_and(|e| e == "json") {
             let output = Command::new(&wxc_path).arg(&path).output()?;
             let exit_code = output.status.code().unwrap_or(-1);
 


### PR DESCRIPTION
Restructure build.yml into separate lint and test jobs:
- wxc-exec-lint: formatting check and clippy warnings
- wxc-exec-test: build and test on x64 and ARM64 runners

Apply rustfmt formatting and clippy suggestions across wxc_common:
- Reorder imports, flatten nested ifs, use #[default] on enums
- Replace map_or(false, ...) with is_some_and(...)
- Derive Default instead of manual impls where possible
- Minor formatting and whitespace cleanup