### PR TITLE
Add network proxy support to wxc for appcontainers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: wxc-exec-${{ matrix.target }}
-          path: src/target/${{ matrix.target }}/release/wxc-exec.exe
+          path: |
+            src/target/${{ matrix.target }}/release/wxc-exec.exe
+            src/target/${{ matrix.target }}/release/winhttp-proxy-shim.exe
 
 
   # Build and package the TypeScript SDK with bundled wxc-exec binaries

--- a/build.bat
+++ b/build.bat
@@ -65,6 +65,10 @@ for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
             copy /Y "!BIN_DIR!\wxc-sandbox-daemon.exe" "sdk\bin\%%T\" >nul
             echo   Copied %%T\wxc-sandbox-daemon.exe
         )
+        if exist "!BIN_DIR!\winhttp-proxy-shim.exe" (
+            copy /Y "!BIN_DIR!\winhttp-proxy-shim.exe" "sdk\bin\%%T\" >nul
+            echo   Copied %%T\winhttp-proxy-shim.exe
+        )
     )
 )
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -42,3 +42,24 @@ For a more comprehensive list of examples, look in the examples\ directory.
   }
 }
 ```
+
+### Network Proxy
+
+Route AppContainer traffic through an already-running localhost proxy. The
+proxy is responsible for application-layer filtering such as domain allow/deny
+lists, request inspection, and logging. Supported with the `appcontainer`
+containment backend only.
+
+```json
+{
+  "script": "python -c \"import urllib.request; print(urllib.request.urlopen('https://api.github.com').status)\"",
+  "timeout": 30000,
+  "appContainer": {
+    "name": "CLI-Proxy",
+    "capabilities": ["internetClient"]
+  },
+  "network": {
+    "proxy": { "localhost": 8080 }
+  }
+}
+```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -36,7 +36,10 @@ WXC uses a JSON configuration file with the following structure:
         "140.82.121.0/24"
       ],
       "blockedHosts": [],                  // Blocked hostnames
-      "removeRulesOnExit": true            // Remove firewall rules after execution
+      "removeRulesOnExit": true,           // Remove firewall rules after execution
+      "proxy": {
+        "localhost": 8080                  // Port of already-running localhost proxy
+      }
     }
 }
 ```

--- a/examples/09_network_proxy_appcontainer.json
+++ b/examples/09_network_proxy_appcontainer.json
@@ -1,0 +1,14 @@
+{
+  "script": "python -c \"import urllib.request\n\nprint('Test 1: Requesting api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Test 2: Requesting httpbin.org...')\ntry:\n    response = urllib.request.urlopen('https://httpbin.org/get', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Done.')\"",
+  "timeout": 45000,
+  "appContainer": {
+    "name": "CLI-Proxy-Example",
+    "capabilities": ["internetClient"],
+    "learningMode": true
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "allowedHosts": ["api.github.com"],
+    "proxy": { "localhost": 8080 }
+  }
+}

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +216,87 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "id-arena"
@@ -326,6 +428,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "prettyplease"
@@ -549,6 +657,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +689,15 @@ dependencies = [
  "getrandom",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -938,6 +1061,22 @@ name = "wxc_test_driver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "wxc_winhttp_proxy_shim"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "windows",
+ "windows-core",
+ "wxc_common",
 ]
 
 [[package]]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
-members = ["wxc", "wxc_common", "wxc_test_driver", "wxc_sandbox_agent", "wxc_sandbox_daemon"]
+members = ["wxc", "wxc_common", "wxc_test_driver", "wxc_sandbox_agent", "wxc_sandbox_daemon", "wxc_winhttp_proxy_shim"]
 resolver = "3"
+
+[workspace.package]
+edition = "2021"
 
 [workspace.dependencies]
 windows = { version = "0.62", features = [
@@ -21,6 +24,9 @@ windows = { version = "0.62", features = [
     "Win32_System_Diagnostics_Debug",
     "Win32_Security_Isolation",
     "Win32_System_Variant",
+    "Win32_System_LibraryLoader",
+    "Win32_UI_Shell",
+    "Win32_System_Registry",
 ] }
 windows-core = "0.62"
 serde = { version = "1", features = ["derive"] }

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -90,6 +90,7 @@ struct SecurityCapabilities {
 pub struct AppContainerScriptRunner {
     app_container_name: String,
     app_container_sid: PSID,
+    proxy_port: u16,
 }
 
 impl AppContainerScriptRunner {
@@ -97,6 +98,7 @@ impl AppContainerScriptRunner {
         Self {
             app_container_name: String::new(),
             app_container_sid: PSID(ptr::null_mut()),
+            proxy_port: 0,
         }
     }
 
@@ -346,10 +348,28 @@ impl AppContainerScriptRunner {
             PCWSTR(working_dir_wide.as_ptr())
         };
 
+        // When proxy is active, temporarily set proxy env vars in our process
+        // so the child inherits them. Restore originals right after CreateProcessW.
+        let proxy_vars = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY"];
+        let proxy_backup: Option<Vec<(String, Option<String>)>> = if self.proxy_port > 0 {
+            let proxy_url = format!("http://127.0.0.1:{}", self.proxy_port);
+            let backup: Vec<_> = proxy_vars
+                .iter()
+                .map(|name| (name.to_string(), std::env::var(name).ok()))
+                .collect();
+            std::env::set_var("HTTP_PROXY", &proxy_url);
+            std::env::set_var("HTTPS_PROXY", &proxy_url);
+            std::env::remove_var("NO_PROXY");
+            std::env::remove_var("ALL_PROXY");
+            Some(backup)
+        } else {
+            None
+        };
+
         // --- Create process ---
         let mut pi = PROCESS_INFORMATION::default();
 
-        unsafe {
+        let create_result = unsafe {
             CreateProcessW(
                 PCWSTR::null(),
                 Some(PWSTR(cmd_line_wide.as_mut_ptr())),
@@ -362,8 +382,21 @@ impl AppContainerScriptRunner {
                 &si_ex.StartupInfo as *const STARTUPINFOW,
                 &mut pi,
             )
-            .map_err(|e| WxcError::Process(format!("CreateProcessW failed: {}", e)))?;
+        };
+
+        // Restore original env vars immediately.
+        if let Some(backup) = proxy_backup {
+            for (name, original) in backup {
+                if let Some(value) = original {
+                    std::env::set_var(&name, value);
+                } else {
+                    std::env::remove_var(&name);
+                }
+            }
         }
+
+        create_result
+            .map_err(|err| WxcError::Process(format!("CreateProcessW failed: {}", err)))?;
 
         logger.log_line(&format!(
             "Process created successfully (PID: {})",
@@ -499,10 +532,10 @@ impl Default for AppContainerScriptRunner {
 }
 
 impl ScriptRunner for AppContainerScriptRunner {
-    /// Template method: validate → initialize → configure FS → configure network → run → cleanup.
     fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         use crate::filesystem_bfs::FileSystemBfsManager;
         use crate::network_firewall::NetworkFirewallManager;
+        use crate::network_proxy::NetworkProxyManager;
         use crate::validator::validate_request;
 
         if let Err(e) = validate_request(request) {
@@ -519,13 +552,32 @@ impl ScriptRunner for AppContainerScriptRunner {
             return ScriptResponse::error(&e.to_string());
         }
 
+        let mut network_proxy_manager = NetworkProxyManager::new();
+        if request.policy.network_proxy.is_enabled() {
+            match network_proxy_manager.start(
+                &request.policy,
+                &principal_id,
+                self.app_container_sid,
+                logger,
+            ) {
+                Ok(()) => {
+                    self.proxy_port = network_proxy_manager.proxy_port();
+                }
+                Err(err) => {
+                    return ScriptResponse::error(&err.to_string());
+                }
+            }
+        }
+
         let mut fw_manager = NetworkFirewallManager::new();
         match fw_manager.apply_firewall_rules(&principal_id, &request.policy, logger) {
             Ok(true) => {}
             Ok(false) => {
+                network_proxy_manager.stop(logger);
                 return ScriptResponse::error("Failed to apply network firewall rules.");
             }
             Err(e) => {
+                network_proxy_manager.stop(logger);
                 return ScriptResponse::error(&e.to_string());
             }
         }
@@ -539,6 +591,9 @@ impl ScriptRunner for AppContainerScriptRunner {
 
         if fw_manager.rules_applied() && request.policy.remove_firewall_rules_on_exit {
             let _ = fw_manager.remove_firewall_rules(logger);
+        }
+        if network_proxy_manager.is_active() {
+            network_proxy_manager.stop(logger);
         }
         if bfs_manager.configured() && request.policy.clear_policy_on_exit {
             bfs_manager.remove_configuration(logger);

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -53,8 +53,8 @@ const PROXY_VAR_NAMES: &[&str] = &["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL
 /// Copies the current process environment, strips any existing proxy vars
 /// (case-insensitive), injects HTTP_PROXY/HTTPS_PROXY pointing to the
 /// localhost proxy, and returns a double-null-terminated UTF-16 block.
-fn build_proxy_env_block(proxy_port: u16) -> Vec<u16> {
-    let proxy_url = format!("http://127.0.0.1:{}", proxy_port);
+fn build_proxy_env_block(address: &crate::models::ProxyAddress) -> Vec<u16> {
+    let proxy_url = address.to_url();
     let mut entries: Vec<(String, String)> = Vec::new();
 
     for (key, value) in std::env::vars_os() {
@@ -132,7 +132,7 @@ struct SecurityCapabilities {
 pub struct AppContainerScriptRunner {
     app_container_name: String,
     app_container_sid: PSID,
-    proxy_port: u16,
+    proxy_address: Option<crate::models::ProxyAddress>,
 }
 
 impl AppContainerScriptRunner {
@@ -140,7 +140,7 @@ impl AppContainerScriptRunner {
         Self {
             app_container_name: String::new(),
             app_container_sid: PSID(ptr::null_mut()),
-            proxy_port: 0,
+            proxy_address: None,
         }
     }
 
@@ -392,11 +392,7 @@ impl AppContainerScriptRunner {
 
         // Build an explicit environment block when proxy is active.
         // This avoids mutating process-global env vars (which isn't thread-safe).
-        let env_block: Option<Vec<u16>> = if self.proxy_port > 0 {
-            Some(build_proxy_env_block(self.proxy_port))
-        } else {
-            None
-        };
+        let env_block: Option<Vec<u16>> = self.proxy_address.as_ref().map(build_proxy_env_block);
 
         let env_ptr = env_block
             .as_ref()
@@ -590,7 +586,7 @@ impl ScriptRunner for AppContainerScriptRunner {
                 logger,
             ) {
                 Ok(()) => {
-                    self.proxy_port = network_proxy_manager.proxy_port();
+                    self.proxy_address = network_proxy_manager.address().cloned();
                 }
                 Err(err) => {
                     return ScriptResponse::error(&err.to_string());

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -37,12 +37,54 @@ const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x0002_0002;
 const PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY: usize = 0x0002_000F;
 const PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT: u32 = 1;
 const EXTENDED_STARTUPINFO_PRESENT: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(0x0008_0000);
+const CREATE_UNICODE_ENVIRONMENT: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(0x0000_0400);
 
 /// SE_GROUP_ENABLED attribute value for SID_AND_ATTRIBUTES.
 const SE_GROUP_ENABLED: u32 = 0x0000_0004;
 
 /// HRESULT value for ERROR_ALREADY_EXISTS (183 / 0xB7).
 const HRESULT_ERROR_ALREADY_EXISTS: i32 = 0x8007_00B7u32 as i32;
+
+/// Proxy-related env var names to strip/override when building the child env block.
+const PROXY_VAR_NAMES: &[&str] = &["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY"];
+
+/// Build a Unicode environment block for CreateProcessW with proxy env vars injected.
+///
+/// Copies the current process environment, strips any existing proxy vars
+/// (case-insensitive), injects HTTP_PROXY/HTTPS_PROXY pointing to the
+/// localhost proxy, and returns a double-null-terminated UTF-16 block.
+fn build_proxy_env_block(proxy_port: u16) -> Vec<u16> {
+    let proxy_url = format!("http://127.0.0.1:{}", proxy_port);
+    let mut entries: Vec<(String, String)> = Vec::new();
+
+    for (key, value) in std::env::vars_os() {
+        let key_str = key.to_string_lossy();
+        let is_proxy_var = PROXY_VAR_NAMES
+            .iter()
+            .any(|name| key_str.eq_ignore_ascii_case(name));
+        if !is_proxy_var {
+            entries.push((key_str.into_owned(), value.to_string_lossy().into_owned()));
+        }
+    }
+
+    entries.push(("HTTP_PROXY".to_string(), proxy_url.clone()));
+    entries.push(("HTTPS_PROXY".to_string(), proxy_url));
+
+    // Sort case-insensitively by key (required by CreateProcessW).
+    entries.sort_by(|(key_a, _), (key_b, _)| {
+        key_a.to_ascii_uppercase().cmp(&key_b.to_ascii_uppercase())
+    });
+
+    let mut block = Vec::new();
+    for (key, value) in &entries {
+        for ch in format!("{}={}", key, value).encode_utf16() {
+            block.push(ch);
+        }
+        block.push(0);
+    }
+    block.push(0);
+    block
+}
 
 /// A `SID_AND_ATTRIBUTES`-compatible struct used to build the capabilities array.
 /// Using a manual struct avoids issues with conditional availability of
@@ -348,55 +390,42 @@ impl AppContainerScriptRunner {
             PCWSTR(working_dir_wide.as_ptr())
         };
 
-        // When proxy is active, temporarily set proxy env vars in our process
-        // so the child inherits them. Restore originals right after CreateProcessW.
-        let proxy_vars = ["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY"];
-        let proxy_backup: Option<Vec<(String, Option<String>)>> = if self.proxy_port > 0 {
-            let proxy_url = format!("http://127.0.0.1:{}", self.proxy_port);
-            let backup: Vec<_> = proxy_vars
-                .iter()
-                .map(|name| (name.to_string(), std::env::var(name).ok()))
-                .collect();
-            std::env::set_var("HTTP_PROXY", &proxy_url);
-            std::env::set_var("HTTPS_PROXY", &proxy_url);
-            std::env::remove_var("NO_PROXY");
-            std::env::remove_var("ALL_PROXY");
-            Some(backup)
+        // Build an explicit environment block when proxy is active.
+        // This avoids mutating process-global env vars (which isn't thread-safe).
+        let env_block: Option<Vec<u16>> = if self.proxy_port > 0 {
+            Some(build_proxy_env_block(self.proxy_port))
         } else {
             None
+        };
+
+        let env_ptr = env_block
+            .as_ref()
+            .map(|block| block.as_ptr() as *const core::ffi::c_void);
+
+        let creation_flags = if env_block.is_some() {
+            PROCESS_CREATION_FLAGS(EXTENDED_STARTUPINFO_PRESENT.0 | CREATE_UNICODE_ENVIRONMENT.0)
+        } else {
+            EXTENDED_STARTUPINFO_PRESENT
         };
 
         // --- Create process ---
         let mut pi = PROCESS_INFORMATION::default();
 
-        let create_result = unsafe {
+        unsafe {
             CreateProcessW(
                 PCWSTR::null(),
                 Some(PWSTR(cmd_line_wide.as_mut_ptr())),
                 None,
                 None,
                 true,
-                EXTENDED_STARTUPINFO_PRESENT,
-                None,
+                creation_flags,
+                env_ptr,
                 working_dir_pcwstr,
                 &si_ex.StartupInfo as *const STARTUPINFOW,
                 &mut pi,
             )
-        };
-
-        // Restore original env vars immediately.
-        if let Some(backup) = proxy_backup {
-            for (name, original) in backup {
-                if let Some(value) = original {
-                    std::env::set_var(&name, value);
-                } else {
-                    std::env::remove_var(&name);
-                }
-            }
         }
-
-        create_result
-            .map_err(|err| WxcError::Process(format!("CreateProcessW failed: {}", err)))?;
+        .map_err(|err| WxcError::Process(format!("CreateProcessW failed: {}", err)))?;
 
         logger.log_line(&format!(
             "Process created successfully (PID: {})",

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -10,7 +10,7 @@ use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
     CodexRequest, ContainerPolicy, ContainmentBackend, NetworkEnforcementMode, NetworkPolicy,
-    SandboxConfig,
+    ProxyConfig, SandboxConfig,
 };
 use crate::string_util::base64_decode;
 
@@ -53,6 +53,7 @@ struct RawNetwork {
     blocked_hosts: Option<Vec<String>>,
     #[serde(rename = "removeRulesOnExit")]
     remove_rules_on_exit: Option<bool>,
+    proxy: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize, Default)]
@@ -80,6 +81,32 @@ struct RawConfig {
 }
 
 // ---------- Public API ----------
+
+/// Parse the `proxy` field: `{ "localhost": <port> }`.
+fn parse_proxy_config(value: &serde_json::Value) -> Result<ProxyConfig, WxcError> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| WxcError::ConfigParse("network.proxy must be an object".to_string()))?;
+
+    let port_value = obj
+        .get("localhost")
+        .and_then(|val| val.as_u64())
+        .ok_or_else(|| {
+            WxcError::ConfigParse(
+                "network.proxy requires a 'localhost' field with a port number".to_string(),
+            )
+        })?;
+
+    if port_value == 0 || port_value > 65535 {
+        return Err(WxcError::ConfigParse(
+            "network.proxy.localhost must be a port between 1 and 65535".to_string(),
+        ));
+    }
+
+    Ok(ProxyConfig {
+        localhost: port_value as u16,
+    })
+}
 
 /// Loads and parses a JSON-based code execution request.
 ///
@@ -233,6 +260,17 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
 
     // Network section
     if let Some(net) = raw.network {
+        if let Some(proxy_value) = net.proxy {
+            let proxy_config = parse_proxy_config(&proxy_value)?;
+            if proxy_config.is_enabled() && containment != ContainmentBackend::AppContainer {
+                let msg =
+                    "Network proxy is only supported with the 'appcontainer' containment backend";
+                logger.log_line(msg);
+                return Err(WxcError::ConfigParse(msg.to_string()));
+            }
+            policy.network_proxy = proxy_config;
+        }
+
         if let Some(p) = net.default_policy {
             policy.default_network_policy = match p.as_str() {
                 "allow" => NetworkPolicy::Allow,
@@ -750,5 +788,92 @@ mod tests {
         assert_eq!(req.containment, ContainmentBackend::Sandbox);
         assert_eq!(req.sandbox_config.idle_timeout_ms, 60000);
         assert_eq!(req.sandbox_config.daemon_pipe_name, "my-custom-pipe");
+    }
+
+    // ====== Network proxy configuration tests ======
+
+    #[test]
+    fn no_proxy_leaves_default() {
+        let json = r#"{"script": "echo test", "network": {"defaultPolicy": "block"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.policy.network_proxy.is_enabled());
+    }
+
+    #[test]
+    fn proxy_localhost_port() {
+        let json = r#"{
+            "script": "echo test",
+            "network": {
+                "proxy": { "localhost": 8080 }
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.is_enabled());
+        assert_eq!(req.policy.network_proxy.localhost, 8080);
+    }
+
+    #[test]
+    fn proxy_with_firewall_fields() {
+        let json = r#"{
+            "script": "echo test",
+            "network": {
+                "defaultPolicy": "block",
+                "allowedHosts": ["api.github.com"],
+                "proxy": { "localhost": 9090 }
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.policy.network_proxy.localhost, 9090);
+        assert_eq!(req.policy.default_network_policy, NetworkPolicy::Block);
+    }
+
+    #[test]
+    fn proxy_rejected_with_sandbox() {
+        let json =
+            r#"{"script":"x","containment":"sandbox","network":{"proxy":{"localhost":8080}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_rejects_port_zero() {
+        let json = r#"{"script":"x","network":{"proxy":{"localhost":0}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_rejects_missing_localhost() {
+        let json = r#"{"script":"x","network":{"proxy":{}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_rejects_non_object() {
+        let json = r#"{"script":"x","network":{"proxy":true}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
     }
 }

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -10,7 +10,7 @@ use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
     CodexRequest, ContainerPolicy, ContainmentBackend, NetworkEnforcementMode, NetworkPolicy,
-    ProxyConfig, SandboxConfig,
+    ProxyAddress, ProxyConfig, SandboxConfig,
 };
 use crate::string_util::base64_decode;
 
@@ -93,7 +93,8 @@ fn parse_proxy_config(value: &serde_json::Value) -> Result<ProxyConfig, WxcError
         .and_then(|val| val.as_u64())
         .ok_or_else(|| {
             WxcError::ConfigParse(
-                "network.proxy requires a 'localhost' field with a port number".to_string(),
+                "network.proxy requires a 'localhost' port (only localhost is currently supported)"
+                    .to_string(),
             )
         })?;
 
@@ -104,7 +105,7 @@ fn parse_proxy_config(value: &serde_json::Value) -> Result<ProxyConfig, WxcError
     }
 
     Ok(ProxyConfig {
-        localhost: port_value as u16,
+        address: Some(ProxyAddress::Localhost(port_value as u16)),
     })
 }
 
@@ -815,7 +816,10 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(req.policy.network_proxy.is_enabled());
-        assert_eq!(req.policy.network_proxy.localhost, 8080);
+        assert_eq!(
+            req.policy.network_proxy.address.as_ref().unwrap().port(),
+            8080
+        );
     }
 
     #[test]
@@ -832,7 +836,10 @@ mod tests {
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.policy.network_proxy.localhost, 9090);
+        assert_eq!(
+            req.policy.network_proxy.address.as_ref().unwrap().port(),
+            9090
+        );
         assert_eq!(req.policy.default_network_policy, NetworkPolicy::Block);
     }
 

--- a/src/wxc_common/src/error.rs
+++ b/src/wxc_common/src/error.rs
@@ -26,6 +26,9 @@ pub enum WxcError {
     #[error("Initialization error: {0}")]
     Initialization(String),
 
+    #[error("Network proxy error: {0}")]
+    NetworkProxy(String),
+
     #[error("String conversion error: {0}")]
     StringConversion(String),
 }

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod filesystem_bfs;
 pub mod logger;
 pub mod models;
 pub mod network_firewall;
+pub mod network_proxy;
 pub mod process_util;
 pub mod sandbox_protocol;
 pub mod sandbox_runner;

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -51,21 +51,43 @@ pub enum NetworkEnforcementMode {
     Both,
 }
 
+/// Proxy address — currently only localhost is supported.
+#[derive(Debug, Clone)]
+pub enum ProxyAddress {
+    Localhost(u16),
+    // Custom(String, u16) — future: user-specified host:port
+}
+
+impl ProxyAddress {
+    pub fn host(&self) -> &str {
+        match self {
+            ProxyAddress::Localhost(_) => "127.0.0.1",
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        match self {
+            ProxyAddress::Localhost(port) => *port,
+        }
+    }
+
+    pub fn to_url(&self) -> String {
+        format!("http://{}:{}", self.host(), self.port())
+    }
+}
+
 /// Proxy configuration for the network section.
 ///
-/// When present with a non-zero port, wxc routes AppContainer traffic through
-/// an already-running proxy at `127.0.0.1:<port>`. The proxy is responsible
-/// for any domain filtering.
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[serde(default)]
+/// When enabled, wxc routes AppContainer traffic through an already-running
+/// proxy. The proxy is responsible for any application-layer filtering.
+#[derive(Debug, Default, Clone)]
 pub struct ProxyConfig {
-    /// Port of the already-running localhost proxy.
-    pub localhost: u16,
+    pub address: Option<ProxyAddress>,
 }
 
 impl ProxyConfig {
     pub fn is_enabled(&self) -> bool {
-        self.localhost > 0
+        self.address.is_some()
     }
 }
 
@@ -84,6 +106,7 @@ pub struct ContainerPolicy {
     pub allowed_hosts: Vec<String>,
     pub blocked_hosts: Vec<String>,
     pub remove_firewall_rules_on_exit: bool,
+    #[serde(skip)]
     pub network_proxy: ProxyConfig,
 }
 

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -51,6 +51,24 @@ pub enum NetworkEnforcementMode {
     Both,
 }
 
+/// Proxy configuration for the network section.
+///
+/// When present with a non-zero port, wxc routes AppContainer traffic through
+/// an already-running proxy at `127.0.0.1:<port>`. The proxy is responsible
+/// for any domain filtering.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProxyConfig {
+    /// Port of the already-running localhost proxy.
+    pub localhost: u16,
+}
+
+impl ProxyConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.localhost > 0
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ContainerPolicy {
@@ -66,6 +84,7 @@ pub struct ContainerPolicy {
     pub allowed_hosts: Vec<String>,
     pub blocked_hosts: Vec<String>,
     pub remove_firewall_rules_on_exit: bool,
+    pub network_proxy: ProxyConfig,
 }
 
 impl Default for ContainerPolicy {
@@ -83,6 +102,7 @@ impl Default for ContainerPolicy {
             allowed_hosts: Vec::new(),
             blocked_hosts: Vec::new(),
             remove_firewall_rules_on_exit: true,
+            network_proxy: ProxyConfig::default(),
         }
     }
 }

--- a/src/wxc_common/src/network_proxy.rs
+++ b/src/wxc_common/src/network_proxy.rs
@@ -7,7 +7,7 @@ use std::ptr;
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::WAIT_OBJECT_0;
 use windows::Win32::Security::PSID;
-use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+use windows::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject};
 use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
 
@@ -36,19 +36,18 @@ fn remove_loopback_exemption(container_name: &str) {
         .status();
 }
 
-/// Enable loopback network access for one or more AppContainers.
+/// Enable loopback network access for a single AppContainer.
 ///
 /// Preserves existing exemptions by reading the current list first.
-fn enable_loopback_for_containers(container_sids: &[PSID]) -> Result<(), WxcError> {
+fn enable_loopback(container_sid: PSID) -> Result<(), WxcError> {
     type FnGetConfig =
         unsafe extern "system" fn(count: *mut u32, entries: *mut *mut SidAndAttributes) -> u32;
     type FnSetConfig =
         unsafe extern "system" fn(count: u32, entries: *const SidAndAttributes) -> u32;
 
     let dll_name = string_util::to_wide("FirewallAPI.dll");
-    let module = unsafe { LoadLibraryW(PCWSTR(dll_name.as_ptr())) }.map_err(|err| {
-        WxcError::NetworkProxy(format!("Failed to load FirewallAPI.dll: {}", err))
-    })?;
+    let module = unsafe { GetModuleHandleW(PCWSTR(dll_name.as_ptr())) }
+        .map_err(|err| WxcError::NetworkProxy(format!("FirewallAPI.dll not loaded: {}", err)))?;
 
     let get_proc = unsafe {
         GetProcAddress(
@@ -68,7 +67,7 @@ fn enable_loopback_for_containers(container_sids: &[PSID]) -> Result<(), WxcErro
         ));
     };
 
-    unsafe {
+    let result = unsafe {
         let get_fn: FnGetConfig =
             std::mem::transmute::<unsafe extern "system" fn() -> isize, FnGetConfig>(get_proc);
         let set_fn: FnSetConfig =
@@ -93,16 +92,13 @@ fn enable_loopback_for_containers(container_sids: &[PSID]) -> Result<(), WxcErro
                 });
             }
         }
-        for sid in container_sids {
-            combined.push(SidAndAttributes {
-                sid: *sid,
-                attributes: 0,
-            });
-        }
+        combined.push(SidAndAttributes {
+            sid: container_sid,
+            attributes: 0,
+        });
 
         let set_result = set_fn(combined.len() as u32, combined.as_ptr());
 
-        // Free the buffer allocated by NetworkIsolationGetAppContainerConfig.
         if !existing_entries.is_null() {
             if let Ok(heap) = windows::Win32::System::Memory::GetProcessHeap() {
                 let _ = windows::Win32::System::Memory::HeapFree(
@@ -113,12 +109,14 @@ fn enable_loopback_for_containers(container_sids: &[PSID]) -> Result<(), WxcErro
             }
         }
 
-        if set_result != 0 {
-            return Err(WxcError::NetworkProxy(format!(
-                "Failed to set loopback exemption: 0x{:08x}",
-                set_result
-            )));
-        }
+        set_result
+    };
+
+    if result != 0 {
+        return Err(WxcError::NetworkProxy(format!(
+            "Failed to set loopback exemption: 0x{:08x}",
+            result
+        )));
     }
 
     Ok(())
@@ -286,7 +284,7 @@ impl NetworkProxyManager {
 
         self.proxy_port = proxy_config.localhost;
 
-        if let Err(err) = enable_loopback_for_containers(&[script_sid]) {
+        if let Err(err) = enable_loopback(script_sid) {
             self.cleanup_on_failure(logger);
             return Err(err);
         }

--- a/src/wxc_common/src/network_proxy.rs
+++ b/src/wxc_common/src/network_proxy.rs
@@ -234,7 +234,7 @@ fn poll_for_ready_file(
 /// `winhttp-proxy-shim` process launched via UAC, which binds the script's
 /// AppContainer SID to the proxy's address and port.
 pub struct NetworkProxyManager {
-    proxy_port: u16,
+    proxy_address: Option<crate::models::ProxyAddress>,
     shim_process_handle: Option<OwnedHandle>,
     cleanup_event_handle: Option<OwnedHandle>,
     ready_file_path: Option<PathBuf>,
@@ -244,7 +244,7 @@ pub struct NetworkProxyManager {
 impl NetworkProxyManager {
     pub fn new() -> Self {
         Self {
-            proxy_port: 0,
+            proxy_address: None,
             shim_process_handle: None,
             cleanup_event_handle: None,
             ready_file_path: None,
@@ -254,12 +254,12 @@ impl NetworkProxyManager {
 
     /// `true` if the proxy is active.
     pub fn is_active(&self) -> bool {
-        self.proxy_port > 0
+        self.proxy_address.is_some()
     }
 
-    /// Returns the proxy port (0 if not active).
-    pub fn proxy_port(&self) -> u16 {
-        self.proxy_port
+    /// Returns the proxy address (if active).
+    pub fn address(&self) -> Option<&crate::models::ProxyAddress> {
+        self.proxy_address.as_ref()
     }
 
     /// Set the WinHTTP proxy policy for the AppContainer and configure
@@ -278,11 +278,13 @@ impl NetworkProxyManager {
         }
 
         let proxy_config = &policy.network_proxy;
-        if !proxy_config.is_enabled() {
+        let address = if let Some(ref addr) = proxy_config.address {
+            addr.clone()
+        } else {
             return Ok(());
-        }
+        };
 
-        self.proxy_port = proxy_config.localhost;
+        self.proxy_address = Some(address.clone());
 
         if let Err(err) = enable_loopback(script_sid) {
             self.cleanup_on_failure(logger);
@@ -296,8 +298,9 @@ impl NetworkProxyManager {
         }
 
         logger.log_line(&format!(
-            "Proxy policy active for SID {} -> 127.0.0.1:{}",
-            principal_id, self.proxy_port,
+            "Proxy policy active for SID {} -> {}",
+            principal_id,
+            self.proxy_address.as_ref().unwrap().to_url(),
         ));
 
         Ok(())
@@ -321,19 +324,22 @@ impl NetworkProxyManager {
         self.ready_file_path = Some(ready_file_path.clone());
 
         let shim_path = find_sibling_exe("winhttp-proxy-shim.exe")?;
+        let addr = self.proxy_address.as_ref().unwrap();
         let shim_args = format!(
-            "--sid {} --proxy-address 127.0.0.1 --proxy-port {} \
+            "--sid {} --proxy-address {} --proxy-port {} \
              --ready-file \"{}\" --cleanup-event \"{}\" --parent-pid {}",
             principal_id,
-            self.proxy_port,
+            addr.host(),
+            addr.port(),
             ready_file_path.display(),
             event_name,
             std::process::id(),
         );
 
         logger.log_line(&format!(
-            "Launching winhttp-proxy-shim elevated: SID {} -> 127.0.0.1:{}",
-            principal_id, self.proxy_port
+            "Launching winhttp-proxy-shim elevated: SID {} -> {}",
+            principal_id,
+            addr.to_url()
         ));
 
         let shim_handle = launch_elevated(&shim_path, &shim_args, logger)?;
@@ -389,7 +395,7 @@ impl NetworkProxyManager {
     fn release_resources(&mut self) {
         self.cleanup_event_handle = None;
         self.shim_process_handle = None;
-        self.proxy_port = 0;
+        self.proxy_address = None;
 
         if let Some(path) = self.ready_file_path.take() {
             let _ = std::fs::remove_file(&path);

--- a/src/wxc_common/src/network_proxy.rs
+++ b/src/wxc_common/src/network_proxy.rs
@@ -1,0 +1,466 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::path::{Path, PathBuf};
+use std::ptr;
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::WAIT_OBJECT_0;
+use windows::Win32::Security::PSID;
+use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+use windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject};
+use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW};
+
+use crate::error::WxcError;
+use crate::logger::Logger;
+use crate::models::ContainerPolicy;
+use crate::process_util::OwnedHandle;
+use crate::string_util;
+
+#[repr(C)]
+struct SidAndAttributes {
+    sid: PSID,
+    attributes: u32,
+}
+
+/// Remove an AppContainer from the loopback exemption list.
+fn remove_loopback_exemption(container_name: &str) {
+    let _ = std::process::Command::new("CheckNetIsolation.exe")
+        .args([
+            "LoopbackExempt",
+            "-d",
+            &format!("-n={}", container_name.to_lowercase()),
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Enable loopback network access for one or more AppContainers.
+///
+/// Preserves existing exemptions by reading the current list first.
+fn enable_loopback_for_containers(container_sids: &[PSID]) -> Result<(), WxcError> {
+    type FnGetConfig =
+        unsafe extern "system" fn(count: *mut u32, entries: *mut *mut SidAndAttributes) -> u32;
+    type FnSetConfig =
+        unsafe extern "system" fn(count: u32, entries: *const SidAndAttributes) -> u32;
+
+    let dll_name = string_util::to_wide("FirewallAPI.dll");
+    let module = unsafe { LoadLibraryW(PCWSTR(dll_name.as_ptr())) }.map_err(|err| {
+        WxcError::NetworkProxy(format!("Failed to load FirewallAPI.dll: {}", err))
+    })?;
+
+    let get_proc = unsafe {
+        GetProcAddress(
+            module,
+            windows::core::s!("NetworkIsolationGetAppContainerConfig"),
+        )
+    };
+    let set_proc = unsafe {
+        GetProcAddress(
+            module,
+            windows::core::s!("NetworkIsolationSetAppContainerConfig"),
+        )
+    };
+    let (Some(get_proc), Some(set_proc)) = (get_proc, set_proc) else {
+        return Err(WxcError::NetworkProxy(
+            "NetworkIsolation APIs not found in FirewallAPI.dll".into(),
+        ));
+    };
+
+    unsafe {
+        let get_fn: FnGetConfig =
+            std::mem::transmute::<unsafe extern "system" fn() -> isize, FnGetConfig>(get_proc);
+        let set_fn: FnSetConfig =
+            std::mem::transmute::<unsafe extern "system" fn() -> isize, FnSetConfig>(set_proc);
+
+        let mut existing_count: u32 = 0;
+        let mut existing_entries: *mut SidAndAttributes = ptr::null_mut();
+        let get_result = get_fn(&mut existing_count, &mut existing_entries);
+
+        if get_result != 0 {
+            existing_count = 0;
+            existing_entries = ptr::null_mut();
+        }
+
+        let mut combined: Vec<SidAndAttributes> = Vec::new();
+        if !existing_entries.is_null() {
+            for index in 0..existing_count as usize {
+                let entry = &*existing_entries.add(index);
+                combined.push(SidAndAttributes {
+                    sid: entry.sid,
+                    attributes: entry.attributes,
+                });
+            }
+        }
+        for sid in container_sids {
+            combined.push(SidAndAttributes {
+                sid: *sid,
+                attributes: 0,
+            });
+        }
+
+        let set_result = set_fn(combined.len() as u32, combined.as_ptr());
+
+        // Free the buffer allocated by NetworkIsolationGetAppContainerConfig.
+        if !existing_entries.is_null() {
+            if let Ok(heap) = windows::Win32::System::Memory::GetProcessHeap() {
+                let _ = windows::Win32::System::Memory::HeapFree(
+                    heap,
+                    windows::Win32::System::Memory::HEAP_FLAGS(0),
+                    Some(existing_entries as *const core::ffi::c_void),
+                );
+            }
+        }
+
+        if set_result != 0 {
+            return Err(WxcError::NetworkProxy(format!(
+                "Failed to set loopback exemption: 0x{:08x}",
+                set_result
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Find a sibling executable next to the current exe.
+fn find_sibling_exe(name: &str) -> Result<String, WxcError> {
+    let exe_dir = std::env::current_exe()
+        .map_err(|err| WxcError::NetworkProxy(format!("Failed to get current exe path: {}", err)))?
+        .parent()
+        .ok_or_else(|| WxcError::NetworkProxy("Failed to get exe directory".into()))?
+        .to_path_buf();
+
+    let path = exe_dir.join(name);
+    if !path.exists() {
+        return Err(WxcError::NetworkProxy(format!(
+            "{} not found at {}",
+            name,
+            path.display()
+        )));
+    }
+
+    Ok(path.to_string_lossy().to_string())
+}
+
+/// Generate a unique identifier for event and file naming.
+fn generate_unique_id() -> String {
+    let pid = std::process::id();
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{}", pid, timestamp)
+}
+
+/// Launch an executable elevated via UAC prompt using `ShellExecuteExW("runas")`.
+///
+/// Returns an owned process handle of the elevated child.
+fn launch_elevated(
+    exe_path: &str,
+    args: &str,
+    logger: &mut Logger,
+) -> Result<OwnedHandle, WxcError> {
+    let verb_wide = string_util::to_wide("runas");
+    let exe_wide = string_util::to_wide(exe_path);
+    let args_wide = string_util::to_wide(args);
+
+    let mut shell_info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
+    shell_info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
+    shell_info.fMask = SEE_MASK_NOCLOSEPROCESS;
+    shell_info.lpVerb = PCWSTR(verb_wide.as_ptr());
+    shell_info.lpFile = PCWSTR(exe_wide.as_ptr());
+    shell_info.lpParameters = PCWSTR(args_wide.as_ptr());
+    shell_info.nShow = 0; // SW_HIDE
+
+    logger.log_line("Requesting administrator privileges (UAC prompt)...");
+
+    unsafe { ShellExecuteExW(&mut shell_info) }.map_err(|err| {
+        WxcError::NetworkProxy(format!(
+            "Failed to launch elevated winhttp-proxy-shim (user may have denied UAC): {}",
+            err
+        ))
+    })?;
+
+    if shell_info.hProcess.is_invalid() {
+        return Err(WxcError::NetworkProxy(
+            "ShellExecuteExW succeeded but returned no process handle".to_string(),
+        ));
+    }
+
+    Ok(OwnedHandle::new(shell_info.hProcess))
+}
+
+/// Poll for the ready file that the shim writes after setting the proxy policy.
+///
+/// Also checks whether the shim process exited prematurely (e.g. access denied).
+fn poll_for_ready_file(
+    ready_path: &Path,
+    shim_handle: &OwnedHandle,
+    timeout_seconds: u32,
+    logger: &mut Logger,
+) -> Result<(), WxcError> {
+    let start = std::time::Instant::now();
+    let timeout = std::time::Duration::from_secs(timeout_seconds as u64);
+
+    loop {
+        if ready_path.exists() {
+            logger.log_line("winhttp-proxy-shim reported ready.");
+            return Ok(());
+        }
+
+        if start.elapsed() > timeout {
+            return Err(WxcError::NetworkProxy(
+                "Timed out waiting for winhttp-proxy-shim to set proxy policy".to_string(),
+            ));
+        }
+
+        // Check if the shim exited before writing the ready file.
+        let wait_result = unsafe { WaitForSingleObject(shim_handle.get(), 0) };
+        if wait_result == WAIT_OBJECT_0 {
+            return Err(WxcError::NetworkProxy(
+                "winhttp-proxy-shim exited before setting proxy policy — check for elevation errors"
+                    .to_string(),
+            ));
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+/// Manages the network proxy policy for sandboxed AppContainer workloads.
+///
+/// Routes AppContainer traffic through an already-running localhost proxy
+/// specified by port number. WinHTTP proxy policy is set by an elevated
+/// `winhttp-proxy-shim` process launched via UAC, which binds the script's
+/// AppContainer SID to the proxy's address and port.
+pub struct NetworkProxyManager {
+    proxy_port: u16,
+    shim_process_handle: Option<OwnedHandle>,
+    cleanup_event_handle: Option<OwnedHandle>,
+    ready_file_path: Option<PathBuf>,
+    loopback_container_name: Option<String>,
+}
+
+impl NetworkProxyManager {
+    pub fn new() -> Self {
+        Self {
+            proxy_port: 0,
+            shim_process_handle: None,
+            cleanup_event_handle: None,
+            ready_file_path: None,
+            loopback_container_name: None,
+        }
+    }
+
+    /// `true` if the proxy is active.
+    pub fn is_active(&self) -> bool {
+        self.proxy_port > 0
+    }
+
+    /// Returns the proxy port (0 if not active).
+    pub fn proxy_port(&self) -> u16 {
+        self.proxy_port
+    }
+
+    /// Set the WinHTTP proxy policy for the AppContainer and configure
+    /// loopback access so the script can reach the localhost proxy.
+    pub fn start(
+        &mut self,
+        policy: &ContainerPolicy,
+        principal_id: &str,
+        script_sid: PSID,
+        logger: &mut Logger,
+    ) -> Result<(), WxcError> {
+        if self.is_active() {
+            return Err(WxcError::NetworkProxy(
+                "Network proxy is already active".into(),
+            ));
+        }
+
+        let proxy_config = &policy.network_proxy;
+        if !proxy_config.is_enabled() {
+            return Ok(());
+        }
+
+        self.proxy_port = proxy_config.localhost;
+
+        if let Err(err) = enable_loopback_for_containers(&[script_sid]) {
+            self.cleanup_on_failure(logger);
+            return Err(err);
+        }
+        self.loopback_container_name = Some(policy.app_container_name.clone());
+
+        if let Err(err) = self.launch_shim(principal_id, logger) {
+            self.cleanup_on_failure(logger);
+            return Err(err);
+        }
+
+        logger.log_line(&format!(
+            "Proxy policy active for SID {} -> 127.0.0.1:{}",
+            principal_id, self.proxy_port,
+        ));
+
+        Ok(())
+    }
+
+    /// Launch the elevated winhttp-proxy-shim to set the per-AppContainer
+    /// WinHTTP proxy policy.
+    fn launch_shim(&mut self, principal_id: &str, logger: &mut Logger) -> Result<(), WxcError> {
+        let unique_id = generate_unique_id();
+        let ready_file_path =
+            std::env::temp_dir().join(format!("wxc-shim-ready-{}.tmp", unique_id));
+        let event_name = format!("Local\\wxc-shim-{}", unique_id);
+        let event_name_wide = string_util::to_wide(&event_name);
+
+        let event_handle =
+            unsafe { CreateEventW(None, true, false, PCWSTR(event_name_wide.as_ptr())) }.map_err(
+                |err| WxcError::NetworkProxy(format!("Failed to create cleanup event: {}", err)),
+            )?;
+
+        self.cleanup_event_handle = Some(OwnedHandle::new(event_handle));
+        self.ready_file_path = Some(ready_file_path.clone());
+
+        let shim_path = find_sibling_exe("winhttp-proxy-shim.exe")?;
+        let shim_args = format!(
+            "--sid {} --proxy-address 127.0.0.1 --proxy-port {} \
+             --ready-file \"{}\" --cleanup-event \"{}\" --parent-pid {}",
+            principal_id,
+            self.proxy_port,
+            ready_file_path.display(),
+            event_name,
+            std::process::id(),
+        );
+
+        logger.log_line(&format!(
+            "Launching winhttp-proxy-shim elevated: SID {} -> 127.0.0.1:{}",
+            principal_id, self.proxy_port
+        ));
+
+        let shim_handle = launch_elevated(&shim_path, &shim_args, logger)?;
+        self.shim_process_handle = Some(shim_handle);
+
+        poll_for_ready_file(
+            &ready_file_path,
+            self.shim_process_handle.as_ref().unwrap(),
+            30,
+            logger,
+        )
+    }
+
+    /// Clean up any partially-initialized resources when start() fails.
+    fn cleanup_on_failure(&mut self, logger: &mut Logger) {
+        self.stop(logger);
+    }
+
+    /// Stop the proxy: signal shim cleanup, remove loopback exemption.
+    pub fn stop(&mut self, logger: &mut Logger) {
+        self.signal_shim_cleanup(logger);
+        self.release_resources();
+    }
+
+    /// Signal the winhttp-proxy-shim to delete the proxy policy and wait for it.
+    fn signal_shim_cleanup(&self, logger: &mut Logger) {
+        let event_handle = if let Some(ref handle) = self.cleanup_event_handle {
+            handle
+        } else {
+            return;
+        };
+
+        logger.log_line("Signaling winhttp-proxy-shim to clean up...");
+        unsafe {
+            let _ = SetEvent(event_handle.get());
+        }
+
+        if let Some(ref shim_handle) = self.shim_process_handle {
+            let wait_result = unsafe { WaitForSingleObject(shim_handle.get(), 5000) };
+            if wait_result == WAIT_OBJECT_0 {
+                logger.log_line("winhttp-proxy-shim exited.");
+            } else {
+                logger.log_line(
+                    "Warning: winhttp-proxy-shim did not exit within 5 seconds \
+                     — proxy policy may still be set",
+                );
+            }
+        }
+    }
+
+    /// Release all owned resources (handles, files, loopback exemption).
+    /// Shared by both stop() and Drop.
+    fn release_resources(&mut self) {
+        self.cleanup_event_handle = None;
+        self.shim_process_handle = None;
+        self.proxy_port = 0;
+
+        if let Some(path) = self.ready_file_path.take() {
+            let _ = std::fs::remove_file(&path);
+        }
+        if let Some(container_name) = self.loopback_container_name.take() {
+            remove_loopback_exemption(&container_name);
+        }
+    }
+}
+
+impl Default for NetworkProxyManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for NetworkProxyManager {
+    fn drop(&mut self) {
+        // Signal shim without logger (best-effort during drop).
+        if let Some(ref event_handle) = self.cleanup_event_handle {
+            unsafe {
+                let _ = SetEvent(event_handle.get());
+            }
+            if let Some(ref shim_handle) = self.shim_process_handle {
+                let _ = unsafe { WaitForSingleObject(shim_handle.get(), 5000) };
+            }
+        }
+        self.release_resources();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_manager() {
+        let mgr = NetworkProxyManager::new();
+        assert!(!mgr.is_active());
+    }
+
+    #[test]
+    fn test_default_manager() {
+        let mgr = NetworkProxyManager::default();
+        assert!(!mgr.is_active());
+    }
+
+    #[test]
+    fn test_stop_when_not_active() {
+        let mut mgr = NetworkProxyManager::new();
+        let mut logger = Logger::new(crate::logger::Mode::Buffer);
+        mgr.stop(&mut logger);
+        assert!(!mgr.is_active());
+    }
+
+    #[test]
+    fn test_generate_unique_id() {
+        let id = generate_unique_id();
+        assert!(!id.is_empty());
+        // Format: <pid>-<timestamp_nanos>
+        let parts: Vec<&str> = id.split('-').collect();
+        assert_eq!(parts.len(), 2, "ID should be in format 'pid-timestamp'");
+        assert!(
+            parts[0].parse::<u32>().is_ok(),
+            "First part should be a valid PID"
+        );
+        assert!(
+            parts[1].parse::<u128>().is_ok(),
+            "Second part should be a valid timestamp"
+        );
+    }
+}

--- a/src/wxc_test_driver/Cargo.toml
+++ b/src/wxc_test_driver/Cargo.toml
@@ -9,3 +9,10 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+tokio.workspace = true
+serde_json.workspace = true
+hyper = { version = "1", features = ["server", "client", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+bytes = "1"
+

--- a/src/wxc_test_driver/src/main.rs
+++ b/src/wxc_test_driver/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod test_proxy;
+
 use std::env;
 use std::fs;
 use std::process::Command;
@@ -9,15 +11,33 @@ const RED: &str = "\x1b[31m";
 const GREEN: &str = "\x1b[32m";
 const RESET: &str = "\x1b[0m";
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: wxc-test-driver <config_path_dir>");
+        eprintln!("Usage: wxc-test-driver <config_path|config_dir> [--debug] [--proxy]");
         std::process::exit(1);
     }
-    let config_dir = &args[1];
+    let config_path = std::path::Path::new(&args[1]);
+    let debug = args.iter().any(|arg| arg == "--debug");
+    let use_proxy = args.iter().any(|arg| arg == "--proxy");
 
-    // Find wxc-exec.exe next to this executable
+    let proxy_port = if use_proxy {
+        let port = test_proxy::start().await;
+        println!("Test proxy started on 127.0.0.1:{}", port);
+        Some(port)
+    } else {
+        None
+    };
+
+    run_configs(config_path, debug, proxy_port)
+}
+
+fn run_configs(
+    config_path: &std::path::Path,
+    debug: bool,
+    proxy_port: Option<u16>,
+) -> anyhow::Result<()> {
     let exe_dir = env::current_exe()?
         .parent()
         .expect("Failed to get executable directory")
@@ -29,34 +49,73 @@ fn main() -> anyhow::Result<()> {
         std::process::exit(1);
     }
 
-    for entry in fs::read_dir(config_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().is_some_and(|e| e == "json") {
-            let output = Command::new(&wxc_path).arg(&path).output()?;
-            let exit_code = output.status.code().unwrap_or(-1);
+    let configs: Vec<std::path::PathBuf> = if config_path.is_file() {
+        vec![config_path.to_path_buf()]
+    } else {
+        let mut entries: Vec<_> = fs::read_dir(config_path)?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect();
+        entries.sort();
+        entries
+    };
 
-            if exit_code != 0 {
-                println!(
-                    "{RED}wxc-exec failed for config: {} with exit code: 0x{:x}{RESET}",
-                    path.display(),
-                    exit_code
-                );
-            } else {
-                println!(
-                    "{GREEN}wxc-exec succeeded for config: {}{RESET}",
-                    path.display()
-                );
-            }
+    for path in &configs {
+        // When --proxy is used, patch the config's proxy.localhost with the actual port.
+        let config_arg = if let Some(port) = proxy_port {
+            let content = fs::read_to_string(path)?;
+            let patched = patch_proxy_port(&content, port);
+            let temp = env::temp_dir().join("wxc-test-patched.json");
+            fs::write(&temp, &patched)?;
+            temp
+        } else {
+            path.clone()
+        };
 
-            if !output.stdout.is_empty() {
-                println!("STDOUT:\n{}", String::from_utf8_lossy(&output.stdout));
-            }
-            if !output.stderr.is_empty() {
-                println!("STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
-            }
+        let mut cmd = Command::new(&wxc_path);
+        cmd.arg(&config_arg);
+        if debug {
+            cmd.arg("--debug");
+        }
+
+        let output = cmd.output()?;
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        if exit_code != 0 {
+            println!(
+                "{RED}wxc-exec failed for config: {} with exit code: 0x{:x}{RESET}",
+                path.display(),
+                exit_code
+            );
+        } else {
+            println!(
+                "{GREEN}wxc-exec succeeded for config: {}{RESET}",
+                path.display()
+            );
+        }
+
+        if !output.stdout.is_empty() {
+            println!("STDOUT:\n{}", String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            println!("STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
         }
     }
 
     Ok(())
+}
+
+/// Patch a JSON config string to set network.proxy.localhost to the given port.
+fn patch_proxy_port(json_str: &str, port: u16) -> String {
+    if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json_str) {
+        if let Some(network) = value.get_mut("network") {
+            network["proxy"] = serde_json::json!({ "localhost": port });
+        } else {
+            value["network"] = serde_json::json!({ "proxy": { "localhost": port } });
+        }
+        serde_json::to_string_pretty(&value).unwrap_or_else(|_| json_str.to_string())
+    } else {
+        json_str.to_string()
+    }
 }

--- a/src/wxc_test_driver/src/main.rs
+++ b/src/wxc_test_driver/src/main.rs
@@ -61,12 +61,13 @@ fn run_configs(
         entries
     };
 
-    for path in &configs {
+    for (index, path) in configs.iter().enumerate() {
         // When --proxy is used, patch the config's proxy.localhost with the actual port.
         let config_arg = if let Some(port) = proxy_port {
             let content = fs::read_to_string(path)?;
             let patched = patch_proxy_port(&content, port);
-            let temp = env::temp_dir().join("wxc-test-patched.json");
+            let temp =
+                env::temp_dir().join(format!("wxc-test-{}-{}.json", std::process::id(), index));
             fs::write(&temp, &patched)?;
             temp
         } else {
@@ -101,6 +102,11 @@ fn run_configs(
         if !output.stderr.is_empty() {
             println!("STDERR:\n{}", String::from_utf8_lossy(&output.stderr));
         }
+
+        // Clean up patched temp config.
+        if proxy_port.is_some() {
+            let _ = fs::remove_file(&config_arg);
+        }
     }
 
     Ok(())
@@ -109,10 +115,11 @@ fn run_configs(
 /// Patch a JSON config string to set network.proxy.localhost to the given port.
 fn patch_proxy_port(json_str: &str, port: u16) -> String {
     if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json_str) {
-        if let Some(network) = value.get_mut("network") {
-            network["proxy"] = serde_json::json!({ "localhost": port });
+        let proxy = serde_json::json!({ "localhost": port });
+        if let Some(network) = value.get_mut("network").and_then(|val| val.as_object_mut()) {
+            network.insert("proxy".to_string(), proxy);
         } else {
-            value["network"] = serde_json::json!({ "proxy": { "localhost": port } });
+            value["network"] = serde_json::json!({ "proxy": proxy });
         }
         serde_json::to_string_pretty(&value).unwrap_or_else(|_| json_str.to_string())
     } else {

--- a/src/wxc_test_driver/src/main.rs
+++ b/src/wxc_test_driver/src/main.rs
@@ -114,15 +114,18 @@ fn run_configs(
 
 /// Patch a JSON config string to set network.proxy.localhost to the given port.
 fn patch_proxy_port(json_str: &str, port: u16) -> String {
-    if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(json_str) {
-        let proxy = serde_json::json!({ "localhost": port });
-        if let Some(network) = value.get_mut("network").and_then(|val| val.as_object_mut()) {
-            network.insert("proxy".to_string(), proxy);
-        } else {
-            value["network"] = serde_json::json!({ "proxy": proxy });
-        }
-        serde_json::to_string_pretty(&value).unwrap_or_else(|_| json_str.to_string())
-    } else {
-        json_str.to_string()
+    let mut value = match serde_json::from_str::<serde_json::Value>(json_str) {
+        Ok(val) => val,
+        Err(_) => return json_str.to_string(),
+    };
+
+    let proxy = serde_json::json!({ "localhost": port });
+
+    if let Some(network) = value.get_mut("network").and_then(|val| val.as_object_mut()) {
+        network.insert("proxy".to_string(), proxy);
+    } else if let Some(root) = value.as_object_mut() {
+        root.insert("network".to_string(), serde_json::json!({ "proxy": proxy }));
     }
+
+    serde_json::to_string_pretty(&value).unwrap_or_else(|_| json_str.to_string())
 }

--- a/src/wxc_test_driver/src/test_proxy.rs
+++ b/src/wxc_test_driver/src/test_proxy.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Minimal HTTP CONNECT proxy for testing.
+
+use http_body_util::Empty;
+use hyper::body::Incoming;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, TcpStream};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+type ProxyResponse = Response<Empty<bytes::Bytes>>;
+
+fn empty_response(status: StatusCode) -> ProxyResponse {
+    let mut resp = Response::new(Empty::new());
+    *resp.status_mut() = status;
+    resp
+}
+
+/// Start the test proxy. Binds to port 0 (OS-assigned) and returns the actual port.
+pub async fn start() -> u16 {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .unwrap_or_else(|err| {
+            eprintln!("Test proxy failed to bind: {}", err);
+            std::process::exit(1);
+        });
+
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        loop {
+            if let Ok((stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let _ = http1::Builder::new()
+                        .preserve_header_case(true)
+                        .title_case_headers(true)
+                        .serve_connection(io, service_fn(handle_request))
+                        .with_upgrades()
+                        .await;
+                });
+            }
+        }
+    });
+
+    port
+}
+
+async fn handle_request(req: Request<Incoming>) -> Result<ProxyResponse, BoxError> {
+    if req.method() != Method::CONNECT {
+        eprintln!(
+            "[test-proxy] rejected non-CONNECT: {} {}",
+            req.method(),
+            req.uri()
+        );
+        return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
+    }
+
+    let authority = req
+        .uri()
+        .authority()
+        .ok_or("CONNECT missing authority")?
+        .to_string();
+
+    eprintln!("[test-proxy] CONNECT {}", authority);
+
+    let server = TcpStream::connect(&authority).await.map_err(|err| {
+        eprintln!("[test-proxy] connect error for {}: {}", authority, err);
+        err
+    })?;
+
+    let target = authority.clone();
+    tokio::spawn(async move {
+        let upgraded = match hyper::upgrade::on(req).await {
+            Ok(upgraded) => upgraded,
+            Err(err) => {
+                eprintln!("[test-proxy] upgrade failed for {}: {}", target, err);
+                return;
+            }
+        };
+
+        let mut client = TokioIo::new(upgraded);
+        let mut server = server;
+        if let Ok((from_client, from_server)) =
+            tokio::io::copy_bidirectional(&mut client, &mut server).await
+        {
+            eprintln!(
+                "[test-proxy] tunnel closed {} (client: {} bytes, server: {} bytes)",
+                target, from_client, from_server
+            );
+        }
+    });
+
+    Ok(empty_response(StatusCode::OK))
+}

--- a/src/wxc_winhttp_proxy_shim/Cargo.toml
+++ b/src/wxc_winhttp_proxy_shim/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wxc_winhttp_proxy_shim"
+version = "0.1.0"
+edition.workspace = true
+
+[[bin]]
+name = "winhttp-proxy-shim"
+path = "src/main.rs"
+
+[dependencies]
+wxc_common.workspace = true
+clap.workspace = true
+windows.workspace = true
+windows-core.workspace = true

--- a/src/wxc_winhttp_proxy_shim/README.md
+++ b/src/wxc_winhttp_proxy_shim/README.md
@@ -1,0 +1,11 @@
+# winhttp-proxy-shim
+
+Temporary elevated helper that sets per-AppContainer WinHTTP proxy policy.
+
+This binary will be removed once `CreateProcess` supports associating an
+AppContainer with a localhost proxy at creation time. Until then, the
+undocumented `WinHttpConnectionSetPolicyEntries` and
+`WinHttpConnectionSetProxyInfo` APIs require elevation, so this shim is
+launched with a UAC prompt to perform the binding.
+
+Requires administrator privileges (UAC prompt) each time the proxy is started.

--- a/src/wxc_winhttp_proxy_shim/src/bindings.rs
+++ b/src/wxc_winhttp_proxy_shim/src/bindings.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! C-compatible struct and constant definitions for undocumented WinHTTP
+//! connection policy APIs. These are not in the public Windows SDK headers
+//! and are not exposed by the windows-rs crate.
+
+use windows_core::PWSTR;
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum WinHttpConnectionPolicyTag {
+    /// Safe tag for per-AppContainer proxy policy. Does not interfere with
+    /// WCM's own policies.
+    Wwwpt = 2,
+}
+
+#[repr(C)]
+pub struct WinHttpConnectionPolicyEntry {
+    pub pwsz_host: *const u16,
+    pub pwsz_app_id: *const u16,
+    pub cb_app_sid: u32,
+    pub pb_app_sid: *const u8,
+    pub n_connections: u32,
+    pub ppwsz_connections: *const *const u16,
+    pub dw_policy_entry_flags: u32,
+}
+
+#[repr(C)]
+pub struct WinHttpConnectionPolicyEntryList {
+    pub p_policy_entries: *mut WinHttpConnectionPolicyEntry,
+    pub n_entries: u32,
+}
+
+pub const WINHTTP_CONNECTION_PROXY_INFO_CURRENT_VERSION: u32 = 1;
+pub const WINHTTP_CONNECTION_PROXY_TYPE_HTTP: u32 = 0;
+
+#[repr(u32)]
+#[derive(Debug, Clone, Copy)]
+pub enum WinHttpConnectionProxyInfoSwitch {
+    Config = 0,
+}
+
+#[repr(C)]
+pub struct WinHttpConnectionProxyInfoConfig {
+    pub pwsz_server: PWSTR,
+    pub pwsz_username: PWSTR,
+    pub pwsz_password: PWSTR,
+    pub pwsz_exception: PWSTR,
+    pub pwsz_extra_info: PWSTR,
+    pub port: u16,
+}
+
+#[repr(C)]
+pub struct WinHttpConnectionProxyInfo {
+    pub version: u32,
+    pub pwsz_friendly_name: PWSTR,
+    pub flags: u32,
+    pub switch: WinHttpConnectionProxyInfoSwitch,
+    pub config: WinHttpConnectionProxyInfoConfig,
+}
+
+pub type FnWinHttpConnectionSetPolicyEntries = unsafe extern "system" fn(
+    h_session: *mut core::ffi::c_void,
+    tag: WinHttpConnectionPolicyTag,
+    policy_list: *mut WinHttpConnectionPolicyEntryList,
+) -> u32;
+
+pub type FnWinHttpConnectionDeletePolicyEntries = unsafe extern "system" fn(
+    h_session: *mut core::ffi::c_void,
+    tag: WinHttpConnectionPolicyTag,
+) -> u32;
+
+pub type FnWinHttpConnectionSetProxyInfo = unsafe extern "system" fn(
+    connection_name: *const u16,
+    proxy_type: u32,
+    proxy_info: *mut WinHttpConnectionProxyInfo,
+) -> u32;
+
+pub type FnWinHttpConnectionDeleteProxyInfo =
+    unsafe extern "system" fn(connection_name: *const u16, proxy_type: u32) -> u32;

--- a/src/wxc_winhttp_proxy_shim/src/main.rs
+++ b/src/wxc_winhttp_proxy_shim/src/main.rs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Elevated WinHTTP proxy policy shim.
+//!
+//! This binary is launched with UAC elevation by `wxc-exec` to set
+//! per-AppContainer WinHTTP proxy policies. The WCM proxy policy APIs
+//! require administrator privileges, so this shim runs elevated while
+//! the rest of the pipeline stays non-elevated.
+//!
+//! Lifecycle:
+//!   1. Parse CLI args (SID, proxy address/port, ready file, cleanup event, parent PID).
+//!   2. Set the per-AppContainer proxy policy via `ActiveProxyPolicy::set()`.
+//!   3. Write "READY" to the ready file so the launcher knows the policy is active.
+//!   4. Wait for the cleanup event to be signaled or the parent process to exit.
+//!   5. Delete the proxy policy and exit.
+
+use clap::Parser;
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::Threading::{
+    OpenEventW, OpenProcess, WaitForMultipleObjects, EVENT_ALL_ACCESS, PROCESS_SYNCHRONIZE,
+};
+
+use wxc_common::logger::{Logger, Mode};
+use wxc_common::string_util;
+mod bindings;
+mod proxy_policy;
+
+use proxy_policy::ActiveProxyPolicy;
+
+#[derive(Parser)]
+#[command(
+    name = "winhttp-proxy-shim",
+    about = "Elevated WinHTTP proxy policy shim for AppContainer sandboxing"
+)]
+struct Cli {
+    /// AppContainer SID string (e.g. "S-1-15-2-...")
+    #[arg(long)]
+    sid: String,
+
+    /// Proxy server address (e.g. "127.0.0.1")
+    #[arg(long)]
+    proxy_address: String,
+
+    /// Proxy server port
+    #[arg(long)]
+    proxy_port: u16,
+
+    /// Path to the ready file — written when the policy is active
+    #[arg(long)]
+    ready_file: String,
+
+    /// Name of the cleanup event created by the launcher
+    #[arg(long)]
+    cleanup_event: String,
+
+    /// PID of the parent process — monitored for crash recovery
+    #[arg(long)]
+    parent_pid: u32,
+}
+
+/// Open the named cleanup event created by the parent process.
+fn open_cleanup_event(event_name: &str) -> Result<HANDLE, String> {
+    let event_name_wide = string_util::to_wide(event_name);
+    unsafe {
+        OpenEventW(EVENT_ALL_ACCESS, false, PCWSTR(event_name_wide.as_ptr()))
+            .map_err(|err| format!("OpenEventW failed for '{}': {}", event_name, err))
+    }
+}
+
+/// Open a handle to the parent process for crash-recovery monitoring.
+fn open_parent_process(parent_pid: u32) -> Result<HANDLE, String> {
+    unsafe {
+        OpenProcess(PROCESS_SYNCHRONIZE, false, parent_pid)
+            .map_err(|err| format!("OpenProcess failed for PID {}: {}", parent_pid, err))
+    }
+}
+
+/// Block until the cleanup event is signaled or the parent process exits.
+fn wait_for_cleanup_signal(event_handle: HANDLE, parent_handle: HANDLE) {
+    let handles = [event_handle, parent_handle];
+    unsafe {
+        // Returns when *either* handle is signaled (bWaitAll = false).
+        let _ = WaitForMultipleObjects(&handles, false, u32::MAX);
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut logger = Logger::new(Mode::Console);
+
+    // Open handles before setting the policy so failures are caught early.
+    let event_handle = match open_cleanup_event(&cli.cleanup_event) {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("[winhttp-proxy-shim] {}", err);
+            std::process::exit(1);
+        }
+    };
+
+    let parent_handle = match open_parent_process(cli.parent_pid) {
+        Ok(handle) => handle,
+        Err(err) => {
+            eprintln!("[winhttp-proxy-shim] {}", err);
+            unsafe {
+                let _ = CloseHandle(event_handle);
+            }
+            std::process::exit(1);
+        }
+    };
+
+    // Set the per-AppContainer proxy policy (requires elevation).
+    let policy =
+        match ActiveProxyPolicy::set(&cli.sid, &cli.proxy_address, cli.proxy_port, &mut logger) {
+            Ok(policy) => policy,
+            Err(err) => {
+                eprintln!("[winhttp-proxy-shim] Failed to set proxy policy: {}", err);
+                unsafe {
+                    let _ = CloseHandle(event_handle);
+                    let _ = CloseHandle(parent_handle);
+                }
+                std::process::exit(1);
+            }
+        };
+
+    // Signal readiness to the launcher.
+    if let Err(err) = std::fs::write(&cli.ready_file, "READY") {
+        eprintln!("[winhttp-proxy-shim] Failed to write ready file: {}", err);
+        policy.delete(&mut logger);
+        unsafe {
+            let _ = CloseHandle(event_handle);
+            let _ = CloseHandle(parent_handle);
+        }
+        std::process::exit(1);
+    }
+
+    eprintln!("[winhttp-proxy-shim] Proxy policy active — waiting for cleanup signal.");
+
+    // Block until the launcher signals cleanup or the parent process exits.
+    wait_for_cleanup_signal(event_handle, parent_handle);
+
+    // Clean up the proxy policy before exiting.
+    eprintln!("[winhttp-proxy-shim] Cleaning up proxy policy...");
+    policy.delete(&mut logger);
+
+    unsafe {
+        let _ = CloseHandle(event_handle);
+        let _ = CloseHandle(parent_handle);
+    }
+
+    eprintln!("[winhttp-proxy-shim] Done.");
+}

--- a/src/wxc_winhttp_proxy_shim/src/main.rs
+++ b/src/wxc_winhttp_proxy_shim/src/main.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 use windows::core::PCWSTR;
-use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::Foundation::{CloseHandle, HANDLE, WAIT_FAILED};
 use windows::Win32::System::Threading::{
     OpenEventW, OpenProcess, WaitForMultipleObjects, EVENT_ALL_ACCESS, PROCESS_SYNCHRONIZE,
 };
@@ -80,9 +80,12 @@ fn open_parent_process(parent_pid: u32) -> Result<HANDLE, String> {
 /// Block until the cleanup event is signaled or the parent process exits.
 fn wait_for_cleanup_signal(event_handle: HANDLE, parent_handle: HANDLE) {
     let handles = [event_handle, parent_handle];
-    unsafe {
-        // Returns when *either* handle is signaled (bWaitAll = false).
-        let _ = WaitForMultipleObjects(&handles, false, u32::MAX);
+    let result = unsafe { WaitForMultipleObjects(&handles, false, u32::MAX) };
+    if result == WAIT_FAILED {
+        eprintln!(
+            "[winhttp-proxy-shim] WaitForMultipleObjects failed: {}",
+            std::io::Error::last_os_error()
+        );
     }
 }
 

--- a/src/wxc_winhttp_proxy_shim/src/proxy_policy.rs
+++ b/src/wxc_winhttp_proxy_shim/src/proxy_policy.rs
@@ -220,19 +220,6 @@ fn free_sid(psid: PSID) {
     }
 }
 
-fn clear_stale_entries(
-    session: &WinHttpSession,
-    functions: &WinHttpProxyFunctions,
-    logger: &mut Logger,
-) {
-    // Policies are permanent (not tied to session handle). Delete all entries
-    // for our tag to clear stale state from previous runs or crashes.
-    unsafe {
-        (functions.delete_policy)(session.as_ptr(), WinHttpConnectionPolicyTag::Wwwpt);
-    }
-    logger.log_line("Cleared stale policy entries.");
-}
-
 fn set_policy_entries(
     session: &WinHttpSession,
     functions: &WinHttpProxyFunctions,
@@ -374,8 +361,6 @@ impl ActiveProxyPolicy {
 
         let (psid, sid_len) = sid_string_to_raw(principal_id)?;
         let proxy_url = format!("http://{}:{}", proxy_address, proxy_port);
-
-        clear_stale_entries(&session, &functions, logger);
 
         if let Err(err) = set_policy_entries(
             &session,

--- a/src/wxc_winhttp_proxy_shim/src/proxy_policy.rs
+++ b/src/wxc_winhttp_proxy_shim/src/proxy_policy.rs
@@ -1,0 +1,447 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This crate is temporary — transmute annotations are verbose for FFI casts
+// where the target types are already defined as type aliases.
+#![allow(clippy::missing_transmute_annotations)]
+
+//! Safe wrappers around the WinHTTP per-AppContainer proxy policy APIs.
+//!
+//! These APIs (`WinHttpConnectionSetPolicyEntries`, `WinHttpConnectionSetProxyInfo`)
+//! are not in the public SDK or windows-rs. They are loaded at runtime from
+//! winhttp.dll via `GetProcAddress`.
+
+use std::ptr;
+
+use windows::core::PCWSTR;
+use windows::Win32::Security::Authorization::ConvertStringSidToSidW;
+use windows::Win32::Security::{GetLengthSid, PSID};
+use windows::Win32::System::Com::CoCreateGuid;
+use windows::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryW};
+use windows_core::PWSTR;
+
+use wxc_common::error::WxcError;
+use wxc_common::logger::Logger;
+use wxc_common::string_util;
+
+use crate::bindings::*;
+
+// Standard WinHTTP API function pointer types (public SDK, but loaded dynamically)
+const WINHTTP_ACCESS_TYPE_NO_PROXY: u32 = 1;
+
+type FnWinHttpOpen = unsafe extern "system" fn(
+    user_agent: *const u16,
+    access_type: u32,
+    proxy_name: *const u16,
+    proxy_bypass: *const u16,
+    flags: u32,
+) -> *mut core::ffi::c_void;
+
+type FnWinHttpCloseHandle = unsafe extern "system" fn(handle: *mut core::ffi::c_void) -> i32;
+
+/// Holds a WinHTTP session handle and ensures it is closed on drop.
+struct WinHttpSession {
+    handle: *mut core::ffi::c_void,
+    close_fn: FnWinHttpCloseHandle,
+}
+
+impl WinHttpSession {
+    fn open(module: windows::Win32::Foundation::HMODULE) -> Result<Self, WxcError> {
+        let open_fn: FnWinHttpOpen = unsafe {
+            let proc =
+                GetProcAddress(module, windows::core::s!("WinHttpOpen")).ok_or_else(|| {
+                    WxcError::NetworkProxy("WinHttpOpen not found in winhttp.dll".to_string())
+                })?;
+            std::mem::transmute(proc)
+        };
+
+        let close_fn: FnWinHttpCloseHandle = unsafe {
+            let proc = GetProcAddress(module, windows::core::s!("WinHttpCloseHandle")).ok_or_else(
+                || {
+                    WxcError::NetworkProxy(
+                        "WinHttpCloseHandle not found in winhttp.dll".to_string(),
+                    )
+                },
+            )?;
+            std::mem::transmute(proc)
+        };
+
+        let user_agent = string_util::to_wide("WXC-NetworkProxy/1.0");
+        let handle = unsafe {
+            open_fn(
+                user_agent.as_ptr(),
+                WINHTTP_ACCESS_TYPE_NO_PROXY,
+                ptr::null(),
+                ptr::null(),
+                0,
+            )
+        };
+
+        if handle.is_null() {
+            return Err(WxcError::NetworkProxy(
+                "WinHttpOpen returned null".to_string(),
+            ));
+        }
+
+        Ok(Self { handle, close_fn })
+    }
+
+    fn as_ptr(&self) -> *mut core::ffi::c_void {
+        self.handle
+    }
+}
+
+impl Drop for WinHttpSession {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                (self.close_fn)(self.handle);
+            }
+        }
+    }
+}
+
+/// Resolved function pointers for the undocumented WinHTTP APIs.
+struct WinHttpProxyFunctions {
+    set_policy: FnWinHttpConnectionSetPolicyEntries,
+    delete_policy: FnWinHttpConnectionDeletePolicyEntries,
+    set_proxy: FnWinHttpConnectionSetProxyInfo,
+    delete_proxy: FnWinHttpConnectionDeleteProxyInfo,
+}
+
+impl WinHttpProxyFunctions {
+    fn load(module: windows::Win32::Foundation::HMODULE) -> Result<Self, WxcError> {
+        unsafe {
+            let set_policy = GetProcAddress(
+                module,
+                windows::core::s!("WinHttpConnectionSetPolicyEntries"),
+            )
+            .ok_or_else(|| {
+                WxcError::NetworkProxy(
+                    "WinHttpConnectionSetPolicyEntries not found in winhttp.dll".to_string(),
+                )
+            })?;
+
+            let delete_policy = GetProcAddress(
+                module,
+                windows::core::s!("WinHttpConnectionDeletePolicyEntries"),
+            )
+            .ok_or_else(|| {
+                WxcError::NetworkProxy(
+                    "WinHttpConnectionDeletePolicyEntries not found in winhttp.dll".to_string(),
+                )
+            })?;
+
+            let set_proxy =
+                GetProcAddress(module, windows::core::s!("WinHttpConnectionSetProxyInfo"))
+                    .ok_or_else(|| {
+                        WxcError::NetworkProxy(
+                            "WinHttpConnectionSetProxyInfo not found in winhttp.dll".to_string(),
+                        )
+                    })?;
+
+            let delete_proxy = GetProcAddress(
+                module,
+                windows::core::s!("WinHttpConnectionDeleteProxyInfo"),
+            )
+            .ok_or_else(|| {
+                WxcError::NetworkProxy(
+                    "WinHttpConnectionDeleteProxyInfo not found in winhttp.dll".to_string(),
+                )
+            })?;
+
+            Ok(Self {
+                set_policy: std::mem::transmute::<
+                    unsafe extern "system" fn() -> isize,
+                    FnWinHttpConnectionSetPolicyEntries,
+                >(set_policy),
+                delete_policy: std::mem::transmute::<
+                    unsafe extern "system" fn() -> isize,
+                    FnWinHttpConnectionDeletePolicyEntries,
+                >(delete_policy),
+                set_proxy: std::mem::transmute::<
+                    unsafe extern "system" fn() -> isize,
+                    FnWinHttpConnectionSetProxyInfo,
+                >(set_proxy),
+                delete_proxy: std::mem::transmute::<
+                    unsafe extern "system" fn() -> isize,
+                    FnWinHttpConnectionDeleteProxyInfo,
+                >(delete_proxy),
+            })
+        }
+    }
+}
+
+/// Generate a GUID string in the format `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}`.
+fn generate_guid_string() -> Result<String, WxcError> {
+    let guid = unsafe {
+        CoCreateGuid()
+            .map_err(|err| WxcError::NetworkProxy(format!("CoCreateGuid failed: {}", err)))?
+    };
+
+    Ok(format!(
+        "{{{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}}}",
+        guid.data1,
+        guid.data2,
+        guid.data3,
+        guid.data4[0],
+        guid.data4[1],
+        guid.data4[2],
+        guid.data4[3],
+        guid.data4[4],
+        guid.data4[5],
+        guid.data4[6],
+        guid.data4[7],
+    ))
+}
+
+/// Convert a SID string (e.g. "S-1-15-2-...") to raw SID bytes.
+fn sid_string_to_raw(sid_string: &str) -> Result<(PSID, u32), WxcError> {
+    let wide_sid = string_util::to_wide(sid_string);
+    let mut psid = PSID(ptr::null_mut());
+
+    unsafe {
+        ConvertStringSidToSidW(PCWSTR(wide_sid.as_ptr()), &mut psid).map_err(|err| {
+            WxcError::NetworkProxy(format!(
+                "ConvertStringSidToSidW failed for '{}': {}",
+                sid_string, err
+            ))
+        })?;
+
+        let sid_len = GetLengthSid(psid);
+        Ok((psid, sid_len))
+    }
+}
+
+fn free_sid(psid: PSID) {
+    unsafe {
+        let _ =
+            windows::Win32::Foundation::LocalFree(Some(windows::Win32::Foundation::HLOCAL(psid.0)));
+    }
+}
+
+fn clear_stale_entries(
+    session: &WinHttpSession,
+    functions: &WinHttpProxyFunctions,
+    logger: &mut Logger,
+) {
+    // Policies are permanent (not tied to session handle). Delete all entries
+    // for our tag to clear stale state from previous runs or crashes.
+    unsafe {
+        (functions.delete_policy)(session.as_ptr(), WinHttpConnectionPolicyTag::Wwwpt);
+    }
+    logger.log_line("Cleared stale policy entries.");
+}
+
+fn set_policy_entries(
+    session: &WinHttpSession,
+    functions: &WinHttpProxyFunctions,
+    psid: PSID,
+    sid_len: u32,
+    connection_guid: &str,
+    logger: &mut Logger,
+) -> Result<(), WxcError> {
+    let host_wide = string_util::to_wide("*");
+    let connection_guid_wide = string_util::to_wide(connection_guid);
+    let connection_ptr: *const u16 = connection_guid_wide.as_ptr();
+
+    let mut policy_entry = WinHttpConnectionPolicyEntry {
+        pwsz_host: host_wide.as_ptr(),
+        pwsz_app_id: ptr::null(),
+        cb_app_sid: sid_len,
+        pb_app_sid: psid.0 as *const u8,
+        n_connections: 1,
+        ppwsz_connections: &connection_ptr,
+        dw_policy_entry_flags: 0,
+    };
+
+    let mut policy_list = WinHttpConnectionPolicyEntryList {
+        p_policy_entries: &mut policy_entry,
+        n_entries: 1,
+    };
+
+    let result = unsafe {
+        (functions.set_policy)(
+            session.as_ptr(),
+            WinHttpConnectionPolicyTag::Wwwpt,
+            &mut policy_list,
+        )
+    };
+
+    if result != 0 {
+        if result == 5 {
+            return Err(WxcError::NetworkProxy(
+                "WinHttpConnectionSetPolicyEntries failed: access denied. \
+                 Network proxy requires administrator privileges. Run wxc-exec as administrator."
+                    .to_string(),
+            ));
+        }
+        return Err(WxcError::NetworkProxy(format!(
+            "WinHttpConnectionSetPolicyEntries failed (error {})",
+            result
+        )));
+    }
+
+    logger.log_line("Policy entry set successfully.");
+    Ok(())
+}
+
+fn set_proxy_info(
+    functions: &WinHttpProxyFunctions,
+    connection_guid: &str,
+    proxy_url: &str,
+    proxy_port: u16,
+    logger: &mut Logger,
+) -> Result<(), WxcError> {
+    let mut proxy_url_wide = string_util::to_wide(proxy_url);
+    let connection_guid_wide = string_util::to_wide(connection_guid);
+
+    let mut proxy_info = WinHttpConnectionProxyInfo {
+        version: WINHTTP_CONNECTION_PROXY_INFO_CURRENT_VERSION,
+        pwsz_friendly_name: PWSTR::null(),
+        flags: 0,
+        switch: WinHttpConnectionProxyInfoSwitch::Config,
+        config: WinHttpConnectionProxyInfoConfig {
+            pwsz_server: PWSTR(proxy_url_wide.as_mut_ptr()),
+            pwsz_username: PWSTR::null(),   // not used
+            pwsz_password: PWSTR::null(),   // not used
+            pwsz_exception: PWSTR::null(),  // not used
+            pwsz_extra_info: PWSTR::null(), // not used
+            port: proxy_port,
+        },
+    };
+
+    logger.log_line(&format!(
+        "Setting proxy info: {} (port {})",
+        proxy_url, proxy_port
+    ));
+
+    let result = unsafe {
+        (functions.set_proxy)(
+            connection_guid_wide.as_ptr(),
+            WINHTTP_CONNECTION_PROXY_TYPE_HTTP,
+            &mut proxy_info,
+        )
+    };
+
+    if result != 0 {
+        return Err(WxcError::NetworkProxy(format!(
+            "WinHttpConnectionSetProxyInfo failed (error {})",
+            result
+        )));
+    }
+
+    Ok(())
+}
+
+/// Active proxy policy state — tracks what was set so it can be cleaned up.
+///
+/// **Requires elevation.** The WinHTTP proxy policy APIs return
+/// `ERROR_ACCESS_DENIED` without administrator privileges. This is a POC
+/// constraint — in production the OS will manage proxy policy on behalf of
+/// the AppContainer, removing the need for elevation.
+pub struct ActiveProxyPolicy {
+    session: WinHttpSession,
+    connection_guid: String,
+    functions: WinHttpProxyFunctions,
+}
+
+impl ActiveProxyPolicy {
+    /// Set a per-AppContainer proxy policy.
+    ///
+    /// This binds the AppContainer SID to a connection GUID, then binds that
+    /// GUID to a proxy server address and port. Mirrors the Orchestrator
+    /// pattern from the networkingtest repo.
+    pub fn set(
+        principal_id: &str,
+        proxy_address: &str,
+        proxy_port: u16,
+        logger: &mut Logger,
+    ) -> Result<Self, WxcError> {
+        let dll_name = string_util::to_wide("winhttp.dll");
+        let module = unsafe { LoadLibraryW(PCWSTR(dll_name.as_ptr())) }.map_err(|err| {
+            WxcError::NetworkProxy(format!("Failed to load winhttp.dll: {}", err))
+        })?;
+
+        let functions = WinHttpProxyFunctions::load(module)?;
+        let session = WinHttpSession::open(module)?;
+        let connection_guid = generate_guid_string()?;
+
+        logger.log_line(&format!(
+            "Setting per-AppContainer proxy policy (connection GUID: {})",
+            connection_guid
+        ));
+
+        let (psid, sid_len) = sid_string_to_raw(principal_id)?;
+        let proxy_url = format!("http://{}:{}", proxy_address, proxy_port);
+
+        clear_stale_entries(&session, &functions, logger);
+
+        if let Err(err) = set_policy_entries(
+            &session,
+            &functions,
+            psid,
+            sid_len,
+            &connection_guid,
+            logger,
+        ) {
+            free_sid(psid);
+            return Err(err);
+        }
+
+        free_sid(psid);
+
+        if let Err(err) =
+            set_proxy_info(&functions, &connection_guid, &proxy_url, proxy_port, logger)
+        {
+            unsafe {
+                (functions.delete_policy)(session.as_ptr(), WinHttpConnectionPolicyTag::Wwwpt);
+            }
+            return Err(err);
+        }
+
+        logger.log_line(&format!(
+            "Proxy policy active: {}:{} for SID {}",
+            proxy_address, proxy_port, principal_id
+        ));
+
+        Ok(Self {
+            session,
+            connection_guid,
+            functions,
+        })
+    }
+
+    /// Remove the per-AppContainer proxy policy.
+    pub fn delete(self, logger: &mut Logger) {
+        let connection_guid_wide = string_util::to_wide(&self.connection_guid);
+
+        unsafe {
+            let result = (self.functions.delete_proxy)(
+                connection_guid_wide.as_ptr(),
+                WINHTTP_CONNECTION_PROXY_TYPE_HTTP,
+            );
+            if result == 0 {
+                logger.log_line("Proxy info deleted.");
+            } else {
+                logger.log_line(&format!(
+                    "Warning: WinHttpConnectionDeleteProxyInfo failed (error {})",
+                    result
+                ));
+            }
+
+            let result = (self.functions.delete_policy)(
+                self.session.as_ptr(),
+                WinHttpConnectionPolicyTag::Wwwpt,
+            );
+            if result == 0 {
+                logger.log_line("Policy entries deleted.");
+            } else {
+                logger.log_line(&format!(
+                    "Warning: WinHttpConnectionDeletePolicyEntries failed (error {})",
+                    result
+                ));
+            }
+        }
+    }
+}

--- a/test_configs/proxy_localhost_test.json
+++ b/test_configs/proxy_localhost_test.json
@@ -1,0 +1,12 @@
+{
+  "script": "python -c \"import urllib.request\n\nprint('Test 1: Requesting api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  Status: {response.status}')\nexcept Exception as err:\n    print(f'  Error: {err}')\n\nprint()\nprint('Done.')\"",
+  "timeout": 30000,
+  "appContainer": {
+    "name": "CLI-Proxy-Default-Test",
+    "capabilities": ["internetClient"],
+    "learningMode": true
+  },
+  "network": {
+    "proxy": { "localhost": 8080 }
+  }
+}

--- a/test_scripts/run_appcontainer_proxy_tests.ps1
+++ b/test_scripts/run_appcontainer_proxy_tests.ps1
@@ -1,0 +1,53 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Run network proxy test configs through wxc-test-driver.
+# The test driver starts its own built-in test proxy via --proxy.
+
+param(
+    [switch]$Release
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$TestDriverCrate = Join-Path $RepoRoot "src\wxc_test_driver"
+$TestConfigs = Join-Path $RepoRoot "test_configs"
+
+# Build once
+if ($Release) {
+    Write-Host "Building in release mode..." -ForegroundColor Yellow
+    Push-Location (Join-Path $RepoRoot "src")
+    cargo build --release
+    Pop-Location
+} else {
+    Write-Host "Building in debug mode..." -ForegroundColor Yellow
+    Push-Location (Join-Path $RepoRoot "src")
+    cargo build
+    Pop-Location
+}
+
+$ProxyConfigs = @(
+    "proxy_localhost_test.json"
+)
+
+foreach ($configFile in $ProxyConfigs) {
+    $configPath = Join-Path $TestConfigs $configFile
+    if (-not (Test-Path $configPath)) {
+        Write-Host "SKIPPED (not found): $configPath" -ForegroundColor Yellow
+        continue
+    }
+
+    Write-Host "`nRunning: $configFile" -ForegroundColor Cyan
+    $cargoArgs = @("run")
+    if ($Release) { $cargoArgs += "--release" }
+    $cargoArgs += @("--", $configPath, "--debug", "--proxy")
+
+    Push-Location $TestDriverCrate
+    try {
+        cargo @cargoArgs
+    } finally {
+        Pop-Location
+    }
+}
+
+Write-Host "`nProxy tests complete." -ForegroundColor Green


### PR DESCRIPTION
## Add network proxy support for AppContainer workloads

Route AppContainer traffic through a user-provided localhost proxy. wxc configures WinHTTP proxy policy and injects `HTTP_PROXY`/`HTTPS_PROXY` env vars so sandboxed scripts transparently use the proxy without code changes.

### Architecture

```mermaid
sequenceDiagram
    participant user as User Proxy
    participant wxc as wxc-exec
    participant shim as winhttp-proxy-shim
    participant script as Script (AppContainer)
    participant internet as Internet

    Note over user: Already running on localhost
    wxc->>shim: Launch elevated (UAC prompt)
    shim->>shim: Set WinHTTP proxy policy (SID -> port)
    shim-->>wxc: READY (rendezvous file)
    wxc->>script: CreateProcessW (HTTP_PROXY/HTTPS_PROXY set)

    script->>user: CONNECT api.github.com:443
    user->>internet: Tunnel bytes
    internet-->>user: Response
    user-->>script: 200 OK + tunneled data

    wxc->>shim: Signal cleanup event
    shim->>shim: Delete WinHTTP proxy policy
```

### New crate

| Crate | Binary | Purpose |
|-------|--------|---------|
| `wxc_winhttp_proxy_shim` | `winhttp-proxy-shim.exe` | Elevated helper that sets per-AppContainer WinHTTP proxy policy. Launched via UAC, sets the policy, waits for cleanup signal, then exits. Will be removed when the OS supports this natively. |

### How it works

- **Config**: `"proxy": { "localhost": 8080 }` in the network config points to an already-running proxy
- **Env vars**: `HTTP_PROXY`/`HTTPS_PROXY` injected into the child process; `NO_PROXY`/`ALL_PROXY` stripped to prevent bypass
- **WinHTTP policy**: The elevated shim binds the AppContainer SID to the proxy address so WinHTTP-based apps also route through it
- **Loopback**: `NetworkIsolationSetAppContainerConfig` enables the AppContainer to reach `127.0.0.1`
- **Cleanup**: On exit, the shim deletes the proxy policy and the loopback exemption is removed
- **Domain filtering**: The proxy is responsible for its own filtering -- wxc does not inspect traffic

### Config example

```json
{
  "script": "python -c \"import urllib.request; print(urllib.request.urlopen('https://api.github.com').status)\"",
  "appContainer": { "name": "my-container", "capabilities": ["internetClient"] },
  "network": {
    "proxy": { "localhost": 8080 }
  }
}
```

### Testing

The test driver includes a built-in CONNECT proxy (`--proxy` flag) for integration testing:

```
wxc-test-driver test_configs/proxy_localhost_test.json --debug --proxy
```

### Changes

- **New**: `wxc_winhttp_proxy_shim` crate (elevated WinHTTP proxy policy helper)
- **New**: `network_proxy.rs` in wxc_common (proxy lifecycle: loopback, shim launch, cleanup)
- **New**: `test_proxy.rs` in wxc_test_driver (built-in CONNECT proxy for testing)
- **Modified**: `appcontainer.rs` (proxy integration in `ScriptRunner::run()`, env var injection)
- **Modified**: `config_parser.rs` (proxy config parsing + validation)
- **Modified**: `models.rs` (`ProxyConfig` struct)
- **Modified**: `test_driver/main.rs` (`--proxy` flag, config port patching)
- **Modified**: `build.yml` (upload shim binary)
- **Modified**: `build.bat` (copy shim binary to SDK)
- **Docs**: Updated `schema.md`, `examples.md` with proxy examples
