### PR TITLE
Update node-pty

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -12,7 +12,7 @@
         "win32"
       ],
       "dependencies": {
-        "node-pty": "^1.0.0"
+        "node-pty": "^1.2.0-beta.12"
       },
       "devDependencies": {
         "@types/node": "^20.10.0",
@@ -117,9 +117,9 @@
       "license": "MIT"
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -27,7 +27,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "node-pty": "^1.0.0"
+    "node-pty": "^1.2.0-beta.12"
   },
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
1.2.0-beta.12 fixes the issue with conpty that made it hang when running under a debugger.