### PR TITLE
[Config json format consolidation] #3 Add lifecycle section, wslc config alias, and update TypeScript SDK types

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -5,10 +5,34 @@
 
 
 /**
+ * Process execution settings
+ */
+export interface WxcProcessConfig {
+  /** Complete command line to execute (e.g., "python -c \"print('hello')\"") */
+  commandLine: string;
+  /** Working directory for the process */
+  cwd?: string;
+  /** Environment variables as KEY=VALUE strings */
+  env?: string[];
+  /** Execution timeout in milliseconds (default: 0 = no timeout) */
+  timeout?: number;
+}
+
+/**
+ * Container lifecycle settings shared across all backends
+ */
+export interface WxcLifecycleConfig {
+  /** Destroy the container after execution completes (default: true) */
+  destroyOnExit?: boolean;
+  /** Retain filesystem and network policies after execution (default: false) */
+  preservePolicy?: boolean;
+}
+
+/**
  * AppContainer configuration for Windows sandbox
  */
 export interface WxcAppContainerConfig {
-  /** AppContainer profile name (default: "CLI") */
+  /** AppContainer profile name (default: "CLI"). Deprecated: use containerId instead. */
   name?: string;
   /** Use least privilege mode with PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT (default: false) */
   leastPrivilege?: boolean;
@@ -48,24 +72,44 @@ export interface WxcNetworkConfig {
   allowedHosts?: string[];
   /** Hostnames or IP addresses to block (firewall mode only) */
   blockedHosts?: string[];
-  /** Automatically remove firewall rules after execution (default: true) */
+  /** Automatically remove firewall rules after execution (default: true). Deprecated: use lifecycle.preservePolicy. */
   removeRulesOnExit?: boolean;
+}
+
+/**
+ * WSLC SDK configuration for Linux containers from Windows
+ */
+export interface WxcWslcConfig {
+  /** OCI container image name (default: "alpine:latest") */
+  image?: string;
+  /** Storage path for WSLC session image store */
+  storagePath?: string;
 }
 
 /**
  * Main WXC configuration
  */
 export interface WxcConfiguration {
-  /** Complete command line to execute (e.g., "python -c \"print('hello')\"") */
-  script: string;
-  /** Optional working directory for the script */
+  /** MXC config schema version (current: "1") */
+  version?: string;
+  /** Externally assigned container identifier */
+  containerId?: string;
+  /** Containment backend */
+  containment?: 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
+  /** Container lifecycle settings */
+  lifecycle?: WxcLifecycleConfig;
+  /** Process execution settings */
+  process?: WxcProcessConfig;
+  /** Complete command line to execute. Deprecated: use process.commandLine instead. */
+  script?: string;
+  /** Working directory. Deprecated: use process.cwd instead. */
   workingDirectory?: string;
-  /** Script execution timeout in milliseconds (default: 0 = no timeout) */
+  /** Timeout in ms. Deprecated: use process.timeout instead. */
   timeout?: number;
-  /** Containment backend: "appcontainer" (Windows), "sandbox" (Windows), or "lxc" (Linux) */
-  containment?: 'appcontainer' | 'sandbox' | 'lxc';
   /** AppContainer configuration */
   appContainer?: WxcAppContainerConfig;
+  /** WSLC SDK configuration */
+  wslc?: WxcWslcConfig;
   /** LXC container configuration (Linux only) */
   lxc?: WxcLxcConfig;
   /** Filesystem access configuration */
@@ -116,7 +160,7 @@ export interface WxcLxcConfig {
 /**
  * Sandboxing methods available on the platform
  */
-export type SandboxingMethod = 'appcontainer' | 'lxc';
+export type SandboxingMethod = 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
 
 /**
  * Platform support information

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -10,7 +10,7 @@ use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
-    CodexRequest, ContainerConfig, ContainerPolicy, ContainmentBackend, LxcConfig,
+    CodexRequest, ContainerConfig, ContainerPolicy, ContainmentBackend, LifecycleConfig, LxcConfig,
     NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SandboxConfig,
 };
 
@@ -117,12 +117,22 @@ struct RawProcess {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
+struct RawLifecycle {
+    #[serde(rename = "destroyOnExit")]
+    destroy_on_exit: Option<bool>,
+    #[serde(rename = "preservePolicy")]
+    preserve_policy: Option<bool>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct RawConfig {
     version: Option<String>,
     #[serde(rename = "containerId")]
     container_id: Option<String>,
     platform: Option<String>,
     process: Option<RawProcess>,
+    lifecycle: Option<RawLifecycle>,
     script: Option<String>,
     containment: Option<String>,
     #[serde(rename = "workingDirectory")]
@@ -131,6 +141,7 @@ struct RawConfig {
     #[serde(rename = "appContainer")]
     app_container: Option<RawAppContainer>,
     sandbox: Option<RawSandbox>,
+    wslc: Option<RawContainerConfig>,
     container: Option<RawContainerConfig>,
     lxc: Option<RawLxc>,
     filesystem: Option<RawFilesystem>,
@@ -353,7 +364,8 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
     }
 
-    // LXC configuration
+    // LXC configuration — save destroy_on_exit for lifecycle fallback before consuming
+    let lxc_legacy_destroy_on_exit = raw.lxc.as_ref().and_then(|l| l.destroy_on_exit);
     let mut lxc_config = {
         let raw_lxc = raw.lxc.unwrap_or_default();
         LxcConfig {
@@ -480,9 +492,9 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
     }
 
-    // Container configuration (WSLC SDK)
+    // Container configuration (WSLC SDK) — "wslc" key takes precedence over "container"
     let mut container_config = ContainerConfig::default();
-    if let Some(cc) = raw.container {
+    if let Some(cc) = raw.wslc.or(raw.container) {
         if let Some(os) = cc.target_os {
             container_config.target_os = os;
         }
@@ -507,6 +519,29 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
     }
 
+    // Lifecycle section with dual-read fallback from legacy fields
+    let lifecycle = {
+        let lc = raw.lifecycle.unwrap_or_default();
+        let destroy_on_exit = lc
+            .destroy_on_exit
+            .or(lxc_legacy_destroy_on_exit)
+            .unwrap_or(true);
+        let preserve_policy = lc.preserve_policy.unwrap_or(false);
+
+        // Sync back to legacy fields so existing runners keep working.
+        // Only override legacy values when lifecycle.preservePolicy was explicitly set.
+        if lc.preserve_policy.is_some() {
+            policy.clear_policy_on_exit = !preserve_policy;
+            policy.remove_firewall_rules_on_exit = !preserve_policy;
+        }
+        lxc_config.destroy_on_exit = destroy_on_exit;
+
+        LifecycleConfig {
+            destroy_on_exit,
+            preserve_policy,
+        }
+    };
+
     // containerId takes precedence over backend-specific container names
     if !container_id.is_empty() {
         policy.app_container_name = container_id.clone();
@@ -525,6 +560,7 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         working_directory,
         script_timeout,
         containment,
+        lifecycle,
         policy,
         sandbox_config,
         container_config,
@@ -1379,5 +1415,125 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.policy.app_container_name, "old-name");
+    }
+
+    #[test]
+    fn lifecycle_destroy_on_exit_parsed() {
+        let json = r#"{"script": "echo hi", "lifecycle": {"destroyOnExit": false}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.lifecycle.destroy_on_exit);
+        assert!(!req.lxc_config.destroy_on_exit);
+    }
+
+    #[test]
+    fn lifecycle_preserve_policy_parsed() {
+        let json = r#"{"script": "echo hi", "lifecycle": {"preservePolicy": true}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.lifecycle.preserve_policy);
+        assert!(!req.policy.clear_policy_on_exit);
+        assert!(!req.policy.remove_firewall_rules_on_exit);
+    }
+
+    #[test]
+    fn lifecycle_fallback_from_lxc_destroy_on_exit() {
+        let json =
+            r#"{"script": "echo hi", "containment": "lxc", "lxc": {"destroyOnExit": false}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.lifecycle.destroy_on_exit);
+        assert!(!req.lxc_config.destroy_on_exit);
+    }
+
+    #[test]
+    fn lifecycle_defaults_when_absent() {
+        let json = r#"{"script": "echo hi"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.lifecycle.destroy_on_exit);
+        assert!(!req.lifecycle.preserve_policy);
+    }
+
+    #[test]
+    fn lifecycle_overrides_lxc_destroy_on_exit() {
+        let json = r#"{"script": "echo hi", "lifecycle": {"destroyOnExit": true}, "lxc": {"destroyOnExit": false}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.lifecycle.destroy_on_exit);
+    }
+
+    #[test]
+    fn lifecycle_preserve_policy_overrides_legacy_fields() {
+        let json = r#"{
+            "script": "echo hi",
+            "filesystem": {"clearPolicyOnExit": true},
+            "network": {"removeRulesOnExit": true},
+            "lifecycle": {"preservePolicy": true}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.lifecycle.preserve_policy);
+        assert!(!req.policy.clear_policy_on_exit);
+        assert!(!req.policy.remove_firewall_rules_on_exit);
+    }
+
+    #[test]
+    fn legacy_policy_fields_preserved_when_lifecycle_absent() {
+        let json = r#"{
+            "script": "echo hi",
+            "filesystem": {"clearPolicyOnExit": false},
+            "network": {"removeRulesOnExit": false}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.lifecycle.preserve_policy);
+        assert!(!req.policy.clear_policy_on_exit);
+        assert!(!req.policy.remove_firewall_rules_on_exit);
+    }
+
+    #[test]
+    fn wslc_section_parsed() {
+        let json =
+            r#"{"script": "echo hi", "containment": "wslc", "wslc": {"image": "python:3.12"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.container_config.image, "python:3.12");
+    }
+
+    #[test]
+    fn wslc_falls_back_to_container_section() {
+        let json = r#"{"script": "echo hi", "containment": "wslc", "container": {"image": "ubuntu:22.04"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.container_config.image, "ubuntu:22.04");
+    }
+
+    #[test]
+    fn wslc_section_overrides_container_section() {
+        let json = r#"{"script": "echo hi", "containment": "wslc", "wslc": {"image": "python:3.12"}, "container": {"image": "ubuntu:22.04"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.container_config.image, "python:3.12");
     }
 }

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -218,6 +218,25 @@ impl Default for ContainerConfig {
     }
 }
 
+/// Container lifecycle settings shared across all backends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LifecycleConfig {
+    /// Destroy the container after execution completes. Default: true.
+    pub destroy_on_exit: bool,
+    /// If true, retain filesystem and network policies after execution. Default: false.
+    pub preserve_policy: bool,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            destroy_on_exit: true,
+            preserve_policy: false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct CodexRequest {
@@ -234,6 +253,8 @@ pub struct CodexRequest {
     pub script_timeout: u32,
     /// Which containment backend to use. Default: AppContainer.
     pub containment: ContainmentBackend,
+    /// Shared lifecycle settings.
+    pub lifecycle: LifecycleConfig,
     /// AppContainer-specific policy (used when containment == AppContainer).
     pub policy: ContainerPolicy,
     /// Sandbox-specific configuration (used when containment == Sandbox).
@@ -255,6 +276,7 @@ impl Default for CodexRequest {
             working_directory: String::new(),
             script_timeout: 0,
             containment: ContainmentBackend::default(),
+            lifecycle: LifecycleConfig::default(),
             policy: ContainerPolicy::default(),
             sandbox_config: SandboxConfig::default(),
             container_config: ContainerConfig::default(),


### PR DESCRIPTION
Step 3 of multi-step consolidation process.

Adds LifecycleConfig with destroyOnExit and preservePolicy fields, parsed with dual-read fallback from legacy lxc.destroyOnExit, clearPolicyOnExit, and removeRulesOnExit. Lifecycle only overrides legacy fields when explicitly set. Adds wslc as the primary JSON key for WSLC config with container as fallback alias. Updates TypeScript SDK with WxcProcessConfig, WxcLifecycleConfig, WxcWslcConfig interfaces and expands SandboxingMethod and WxcConfiguration to cover all backends.

----------------------------------------------
**PR 1** ✅ Merged
   - `version`, `containerId`, `process` section with dual-read fallback. `Vm`/`MicroVm` enum variants.
   Manual `Default` for `CodexRequest`.

   **PR 2** 🔄 In review
   - `schemas/mxc-config.v1.schema.json`. Schema version validation. `idleTimeoutMs` dual-read. `containerId` →
  `app_container_name` mapping. Migrate 15 examples + 16 test configs. Update `docs/schema.md`.

   **PR 3** 🔄 In review -> This PR
   - Add `LifecycleConfig` struct. Parse `lifecycle.destroyOnExit`/`preservePolicy` with dual-read from legacy
  fields. `wslc` alias for `container` key. Update `sdk/src/types.ts`, `cli/README.md`, `cli/ARCHITECTURE.md`,
  `sdk/README.md`.

   **PR 4**
   - Drop `script`, `workingDirectory`, top-level `timeout`, `container` alias, `appContainer.name`,
  `lxc.containerName`, `lxc.destroyOnExit`, `clearPolicyOnExit`, `removeRulesOnExit` from parser. Bump
  `SUPPORTED_MAJOR_VERSION` to 2.
----------------------------------------------