### PR TITLE
Fix CLI build typescript build

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -69,13 +69,14 @@ program
       const policy: WxcConfiguration = JSON.parse(content);
 
       // Basic validation
-      if (!policy.script) {
-        console.error('Invalid configuration: missing script.code');
+      const commandLine = policy.process?.commandLine;
+      if (!commandLine) {
+        console.error('Invalid configuration: missing process.commandLine');
         process.exit(1);
       }
 
       console.log('Configuration is valid');
-      console.log('Script code length:', policy.script.length, 'characters');
+      console.log('Command line length:', commandLine.length, 'characters');
 
       if (policy.appContainer) {
         console.log('AppContainer:', policy.appContainer.name || 'WXC');
@@ -179,11 +180,19 @@ program
          containerName = (config as any).appContainer?.name;
        }
 
+      const commandLine = config.process?.commandLine;
+      if (!commandLine) {
+        console.error('Invalid configuration: missing process.commandLine');
+        process.exit(1);
+      }
+
+      const workingDirectory = config.process?.cwd;
+
       // Spawn the process
       // NOTE: For now, we will force winpty.
-      const pty = spawnSandbox(config.script, policy, {
+      const pty = spawnSandbox(commandLine, policy, {
         debug: options.debug ?? false
-      }, config.workingDirectory, containerName);
+      }, workingDirectory, containerName);
 
       // Handle output
       pty.onData((data: string) => {

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -5,7 +5,7 @@ import { WxcConfiguration } from '@microsoft/mxc-sdk/dist/types';
  */
 export function createMinimalConfig(code: string): WxcConfiguration {
   return {
-    script: code
+    process: { commandLine: code }
   };
 }
 
@@ -17,7 +17,7 @@ export function createNetworkRestrictedConfig(
   allow: string[]
 ): WxcConfiguration {
   return {
-    script: code,
+    process: { commandLine: code },
     network: {
       defaultPolicy: 'block',
       enforcementMode: 'capabilities'
@@ -35,7 +35,7 @@ export function createFilesystemRestrictedConfig(
   deniedPaths: string[] = []
 ): WxcConfiguration {
   return {
-    script: code,
+    process: { commandLine: code },
     filesystem: {
       readonlyPaths: readonlyPaths,
       readwritePaths: readwritePaths,

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -10,7 +10,7 @@ you add `"$schema": "./schemas/mxc-config.v1.schema.json"` to your config file.
 
 ```json
 {
-    "version": "0.3.0-alpha",               // Schema version (current: "0.3.0-alpha")
+    "version": "1",               // Schema version (current: "1")
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "appcontainer",         // Backend (see table below)
 

--- a/examples/02_filesystem_access.json
+++ b/examples/02_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/04_combined_restrictions.json
+++ b/examples/04_combined_restrictions.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Combined-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/05_custom_python.json
+++ b/examples/05_custom_python.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-CustomPython",
   "containment": "appcontainer",
   "process": {

--- a/examples/06_network_capabilities_only.json
+++ b/examples/06_network_capabilities_only.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Network-Capabilities",
   "containment": "appcontainer",
   "process": {

--- a/examples/07_test_delete.json
+++ b/examples/07_test_delete.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/08_pwsh.json
+++ b/examples/08_pwsh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Pwsh",
   "containment": "appcontainer",
   "process": {

--- a/examples/09_sandbox_hello_world.json
+++ b/examples/09_sandbox_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/examples/10_sandbox_network_isolated.json
+++ b/examples/10_sandbox_network_isolated.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Sandbox-Network-Isolated",
   "containment": "sandbox",
   "process": {

--- a/examples/11_localhost_proxy_appcontainer.json
+++ b/examples/11_localhost_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Proxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/11_lxc_hello_world.json
+++ b/examples/11_lxc_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/12_builtin_test_proxy_appcontainer.json
+++ b/examples/12_builtin_test_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-BuiltinProxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/12_lxc_filesystem_access.json
+++ b/examples/12_lxc_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-FilesystemAccess",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/13_lxc_network_restricted.json
+++ b/examples/13_lxc_network_restricted.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-NetworkRestricted",
   "containment": "lxc",
   "platform": "linux",

--- a/schemas/mxc-config.v1.schema.json
+++ b/schemas/mxc-config.v1.schema.json
@@ -10,7 +10,7 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version. Current: '0.3.0-alpha.",
+      "description": "MXC config schema version. Current: '1.",
       "examples": ["0.1.0"]
     },
     "containerId": {

--- a/test_configs/basic_appcontainer.json
+++ b/test_configs/basic_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-BasicAppContainer-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_lpac.json
+++ b/test_configs/basic_lpac.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LPAC-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_lxc.json
+++ b/test_configs/basic_lxc.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/basic_permissive.json
+++ b/test_configs/basic_permissive.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Permissive-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_sandbox.json
+++ b/test_configs/basic_sandbox.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/test_configs/filesystem_bfs_readonly_test.json
+++ b/test_configs/filesystem_bfs_readonly_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-BFSReadOnly-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/filesystem_bfs_test.json
+++ b/test_configs/filesystem_bfs_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-BFS-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/lxc_filesystem_test.json
+++ b/test_configs/lxc_filesystem_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/lxc_network_test.json
+++ b/test_configs/lxc_network_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/network_both_test.json
+++ b/test_configs/network_both_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Network-Both-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_capabilities_test.json
+++ b/test_configs/network_capabilities_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Network-Capabilities-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_default_test.json
+++ b/test_configs/network_default_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Network-Default-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_firewall_test.json
+++ b/test_configs/network_firewall_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Network-Firewall-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/proxy_builtin_test.json
+++ b/test_configs/proxy_builtin_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Proxy-Builtin-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/pwsh_setlocation.json
+++ b/test_configs/pwsh_setlocation.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Pwsh-SetLocation-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/sandbox_custom_timeout.json
+++ b/test_configs/sandbox_custom_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Sandbox-Timeout",
   "containment": "sandbox",
   "process": {

--- a/test_configs/with_capabilities.json
+++ b/test_configs/with_capabilities.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "1",
   "containerId": "CLI-Cap-Test",
   "containment": "appcontainer",
   "process": {


### PR DESCRIPTION
PR fixes the CLI build. Basically, it just needed to use the new way of passing in the script stuff that Soham added. I'll add a GitHub issue on myself so the test scripts can also be ran on in the pipelines too so we catch this eariler.  

Another issue it fixes is that our parser will only accept version 1 in the json. So as a quick fix, since I know that will be updated in the future, I've updated all the example and test script json files to use version 1 so they can be ran locally without the version error.