### PR TITLE
[Config json format consolidation] #4 Remove deprecated config fallbacks and bump schema to v2

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,15 +2,15 @@
 ## Configuration Schema
 
 MXC uses a JSON configuration file. The formal schema is at
-[`schemas/mxc-config.v2.schema.json`](../schemas/mxc-config.v2.schema.json) —
+[`schemas/mxc-config.schema.json`](../schemas/mxc-config.schema.json) —
 editors that support JSON Schema will provide autocomplete and validation when
-you add `"$schema": "./schemas/mxc-config.v2.schema.json"` to your config file.
+you add `"$schema": "./schemas/mxc-config.schema.json"` to your config file.
 
 ### Full Schema
 
 ```json
 {
-    "version": "2",                            // Schema version (current: "2")
+    "version": "0.4.0-alpha",              // Schema version (semver, current: "0.4.0-alpha")
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "appcontainer",         // Backend (see table below)
 
@@ -66,50 +66,45 @@ other backend sections are ignored.
 
 ### Schema Versioning
 
-MXC config files include an optional `version` field that declares the schema
-version. The parser uses this to detect incompatible configs and provide clear
-upgrade guidance.
+MXC config files include an optional `version` field using
+[Semantic Versioning](https://semver.org/) (MAJOR.MINOR.PATCH). The parser uses
+this to detect incompatible configs and provide clear upgrade guidance. If
+`version` is absent, the config is assumed compatible with the current version.
 
-The parser declares a `SUPPORTED_MAJOR_VERSION` constant. At parse time:
+The parser compares the config's major.minor against its supported version:
 
 | Config `version` | Parser supports | Result |
 |---|---|---|
-| absent | any | Accepted (assumed compatible) |
-| `"1"` | 2 | Accepted (1 ≤ 2) |
-| `"2"` | 2 | Accepted (2 ≤ 2) |
-| `"3"` | 2 | **Rejected** — "upgrade wxc-exec" |
-| `"0"` or non-numeric | any | **Rejected** — invalid format |
-
-Version must be a positive integer (e.g., `"1"`, `"2"`). Minor versions
-(e.g., `"2.1"`) are parsed by major only — `"2.1"` is treated as major `2`.
+| absent | 0.4.0-alpha | Accepted (assumed compatible) |
+| `"0.3.0-alpha"` | 0.4.0-alpha | Accepted (0.3 ≤ 0.4) |
+| `"0.4.0-alpha"` | 0.4.0-alpha | Accepted (0.4 ≤ 0.4) |
+| `"0.5.0"` | 0.4.0-alpha | **Rejected** — "upgrade wxc-exec" |
+| `"1.0.0"` | 0.4.0-alpha | **Rejected** — "upgrade wxc-exec" |
 
 #### When to bump
 
 | Change type | Version bump | Example |
 |---|---|---|
-| Add new optional field | **None** | Adding `resources` section |
-| Add new enum value | **None** | Adding `"seatbelt"` to containment |
-| Change a default value | **None** | Default timeout change |
-| Remove a field | **Major** | Dropping `script` top-level field |
-| Rename a field without fallback | **Major** | `workingDirectory` → `process.cwd` |
-| Change a field's type | **Major** | `gpu: bool` → `gpu: { type: "..." }` |
-| Make an optional field required | **Major** | `process` becoming required |
+| Add new optional field | **Patch** (0.4.0 → 0.4.1) | Adding `resources` section |
+| Add backward-compatible functionality | **Minor** (0.4.0 → 0.5.0) | New containment backend |
+| Remove a field / breaking change | **Major** (0.x → 1.0.0) | Dropping legacy fields |
 
-**Rule of thumb:** If an existing valid config would stop parsing, bump the
-major version. Otherwise, don't.
+**Rule of thumb:** Follow [semver](https://semver.org/). While in `0.x`,
+minor bumps may include breaking changes. Once `1.0.0` is reached, breaking
+changes require a major bump.
 
 #### Migration process for breaking changes
 
-1. **PR N:** Add new field with dual-read fallback from old field. No version bump.
+1. **PR N:** Add new field with dual-read fallback from old field. Patch bump.
 2. **PR N+1:** Update all configs, examples, SDK types, and docs to new format.
-3. **PR N+2:** Remove fallback code. Bump `SUPPORTED_MAJOR_VERSION`. Old configs
+3. **PR N+2:** Remove fallback code. Minor bump (or major if post-1.0). Old configs
    no longer parse.
 
 #### Version history
 
 | Version | Changes |
 |---|---|
-| 1 | Initial versioned schema. Added `process`, `lifecycle`, `containerId`, `wslc` alias. All additive with dual-read fallbacks. |
-| 2 | Removed legacy fields (`script`, `workingDirectory`, `appContainer.name`, etc.). `process` section now required. |
+| 0.3.0-alpha | Initial versioned schema. Added `process`, `lifecycle`, `containerId`, `wslc` alias. Dual-read fallbacks for legacy fields. |
+| 0.4.0-alpha | Removed legacy fields (`script`, `workingDirectory`, `appContainer.name`, etc.). `process` section now required. |
 
 See the `examples/` directory for complete configuration examples.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,9 +2,9 @@
 ## Configuration Schema
 
 MXC uses a JSON configuration file. The formal schema is at
-[`schemas/mxc-config.v1.schema.json`](../schemas/mxc-config.v1.schema.json) —
+[`schemas/mxc-config.v2.schema.json`](../schemas/mxc-config.v2.schema.json) —
 editors that support JSON Schema will provide autocomplete and validation when
-you add `"$schema": "./schemas/mxc-config.v1.schema.json"` to your config file.
+you add `"$schema": "./schemas/mxc-config.v2.schema.json"` to your config file.
 
 ### Full Schema
 
@@ -66,15 +66,50 @@ other backend sections are ignored.
 
 ### Schema Versioning
 
-The `version` field uses major-version compatibility: configs with a version
-higher than the binary supports are rejected with an error suggesting to upgrade
-`wxc-exec`. Missing `version` is accepted (treated as version 1). Additive
-changes (new optional fields) do not require a version bump.
+MXC config files include an optional `version` field that declares the schema
+version. The parser uses this to detect incompatible configs and provide clear
+upgrade guidance.
 
-### Legacy Fields
+The parser declares a `SUPPORTED_MAJOR_VERSION` constant. At parse time:
 
-The parser also accepts legacy top-level fields (`script`, `workingDirectory`,
-`timeout`) as fallbacks for `process.commandLine`, `process.cwd`, and
-`process.timeout` respectively. These will be removed in a future schema version.
+| Config `version` | Parser supports | Result |
+|---|---|---|
+| absent | any | Accepted (assumed compatible) |
+| `"1"` | 2 | Accepted (1 ≤ 2) |
+| `"2"` | 2 | Accepted (2 ≤ 2) |
+| `"3"` | 2 | **Rejected** — "upgrade wxc-exec" |
+| `"0"` or non-numeric | any | **Rejected** — invalid format |
+
+Version must be a positive integer (e.g., `"1"`, `"2"`). Minor versions
+(e.g., `"2.1"`) are parsed by major only — `"2.1"` is treated as major `2`.
+
+#### When to bump
+
+| Change type | Version bump | Example |
+|---|---|---|
+| Add new optional field | **None** | Adding `resources` section |
+| Add new enum value | **None** | Adding `"seatbelt"` to containment |
+| Change a default value | **None** | Default timeout change |
+| Remove a field | **Major** | Dropping `script` top-level field |
+| Rename a field without fallback | **Major** | `workingDirectory` → `process.cwd` |
+| Change a field's type | **Major** | `gpu: bool` → `gpu: { type: "..." }` |
+| Make an optional field required | **Major** | `process` becoming required |
+
+**Rule of thumb:** If an existing valid config would stop parsing, bump the
+major version. Otherwise, don't.
+
+#### Migration process for breaking changes
+
+1. **PR N:** Add new field with dual-read fallback from old field. No version bump.
+2. **PR N+1:** Update all configs, examples, SDK types, and docs to new format.
+3. **PR N+2:** Remove fallback code. Bump `SUPPORTED_MAJOR_VERSION`. Old configs
+   no longer parse.
+
+#### Version history
+
+| Version | Changes |
+|---|---|
+| 1 | Initial versioned schema. Added `process`, `lifecycle`, `containerId`, `wslc` alias. All additive with dual-read fallbacks. |
+| 2 | Removed legacy fields (`script`, `workingDirectory`, `appContainer.name`, etc.). `process` section now required. |
 
 See the `examples/` directory for complete configuration examples.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -10,7 +10,7 @@ you add `"$schema": "./schemas/mxc-config.v2.schema.json"` to your config file.
 
 ```json
 {
-    "version": "0.3.0-alpha",               // Schema version (current: "0.3.0-alpha")
+    "version": "2",                            // Schema version (current: "2")
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "appcontainer",         // Backend (see table below)
 

--- a/examples/01_hello_world.json
+++ b/examples/01_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-HelloWorld",
   "containment": "appcontainer",
   "process": {

--- a/examples/01_hello_world.json
+++ b/examples/01_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-HelloWorld",
   "containment": "appcontainer",
   "process": {

--- a/examples/02_filesystem_access.json
+++ b/examples/02_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/02_filesystem_access.json
+++ b/examples/02_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/03_network_restricted.json
+++ b/examples/03_network_restricted.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/03_network_restricted.json
+++ b/examples/03_network_restricted.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/04_combined_restrictions.json
+++ b/examples/04_combined_restrictions.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Combined-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/04_combined_restrictions.json
+++ b/examples/04_combined_restrictions.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Combined-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/05_custom_python.json
+++ b/examples/05_custom_python.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-CustomPython",
   "containment": "appcontainer",
   "process": {

--- a/examples/05_custom_python.json
+++ b/examples/05_custom_python.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-CustomPython",
   "containment": "appcontainer",
   "process": {

--- a/examples/05_custom_python.json
+++ b/examples/05_custom_python.json
@@ -10,7 +10,6 @@
     "capabilities": [ "registryRead" ]
   },
   "fileSystem": {
-    "executablePath": "C:\\Users\\AdminUser\\AppData\\Local\\anaconda3\\python.exe",
-    "workingDirectory": "C:\\Users\\AdminUser\\AppData\\Local\\anaconda3"
+    "executablePath": "C:\\Users\\AdminUser\\AppData\\Local\\anaconda3\\python.exe"
   }
 }

--- a/examples/06_network_capabilities_only.json
+++ b/examples/06_network_capabilities_only.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Capabilities",
   "containment": "appcontainer",
   "process": {

--- a/examples/06_network_capabilities_only.json
+++ b/examples/06_network_capabilities_only.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Capabilities",
   "containment": "appcontainer",
   "process": {

--- a/examples/07_test_delete.json
+++ b/examples/07_test_delete.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/07_test_delete.json
+++ b/examples/07_test_delete.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Filesystem-Test",
   "containment": "appcontainer",
   "process": {

--- a/examples/08_pwsh.json
+++ b/examples/08_pwsh.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Pwsh",
   "containment": "appcontainer",
   "process": {

--- a/examples/08_pwsh.json
+++ b/examples/08_pwsh.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Pwsh",
   "containment": "appcontainer",
   "process": {

--- a/examples/09_sandbox_hello_world.json
+++ b/examples/09_sandbox_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/examples/09_sandbox_hello_world.json
+++ b/examples/09_sandbox_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/examples/10_sandbox_network_isolated.json
+++ b/examples/10_sandbox_network_isolated.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Sandbox-Network-Isolated",
   "containment": "sandbox",
   "process": {

--- a/examples/10_sandbox_network_isolated.json
+++ b/examples/10_sandbox_network_isolated.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Sandbox-Network-Isolated",
   "containment": "sandbox",
   "process": {

--- a/examples/11_localhost_proxy_appcontainer.json
+++ b/examples/11_localhost_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Proxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/11_localhost_proxy_appcontainer.json
+++ b/examples/11_localhost_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Proxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/11_lxc_hello_world.json
+++ b/examples/11_lxc_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/11_lxc_hello_world.json
+++ b/examples/11_lxc_hello_world.json
@@ -6,9 +6,11 @@
   "process": {
     "commandLine": "echo 'Hello from LXC container!'"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   }
 }

--- a/examples/11_lxc_hello_world.json
+++ b/examples/11_lxc_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/12_builtin_test_proxy_appcontainer.json
+++ b/examples/12_builtin_test_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-BuiltinProxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/12_builtin_test_proxy_appcontainer.json
+++ b/examples/12_builtin_test_proxy_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-BuiltinProxy-Example",
   "containment": "appcontainer",
   "process": {

--- a/examples/12_lxc_filesystem_access.json
+++ b/examples/12_lxc_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-FilesystemAccess",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/12_lxc_filesystem_access.json
+++ b/examples/12_lxc_filesystem_access.json
@@ -6,10 +6,12 @@
   "process": {
     "commandLine": "ls -la /mnt/shared && echo 'test' > /mnt/output/result.txt && cat /mnt/output/result.txt"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   },
   "filesystem": {
     "readonlyPaths": ["/mnt/shared"],

--- a/examples/12_lxc_filesystem_access.json
+++ b/examples/12_lxc_filesystem_access.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-FilesystemAccess",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/13_lxc_network_restricted.json
+++ b/examples/13_lxc_network_restricted.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-NetworkRestricted",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/13_lxc_network_restricted.json
+++ b/examples/13_lxc_network_restricted.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-NetworkRestricted",
   "containment": "lxc",
   "platform": "linux",

--- a/examples/13_lxc_network_restricted.json
+++ b/examples/13_lxc_network_restricted.json
@@ -6,10 +6,12 @@
   "process": {
     "commandLine": "wget -qO- https://api.github.com/zen || echo 'Network blocked as expected'"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   },
   "network": {
     "defaultPolicy": "block",

--- a/schemas/mxc-config.schema.json
+++ b/schemas/mxc-config.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/microsoft/mxc/schemas/mxc-config.v2.schema.json",
+  "$id": "https://github.com/microsoft/mxc/schemas/mxc-config.schema.json",
   "title": "MXC Configuration",
-  "description": "Configuration schema for MXC container execution engine (v2). Defines the canonical config format with no legacy field support.",
+  "description": "Configuration schema for MXC container execution engine. Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
   "type": "object",
 
   "required": ["process"],
@@ -10,8 +10,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version. Current: '2'.",
-      "examples": ["2"]
+      "description": "MXC config schema version (semver). Current: '0.4.0-alpha'.",
+      "examples": ["0.4.0-alpha"]
     },
     "containerId": {
       "type": "string",

--- a/schemas/mxc-config.v2.schema.json
+++ b/schemas/mxc-config.v2.schema.json
@@ -10,8 +10,8 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version. Current: '0.3.0-alpha.",
-      "examples": ["0.1.0"]
+      "description": "MXC config schema version. Current: '2'.",
+      "examples": ["2"]
     },
     "containerId": {
       "type": "string",

--- a/schemas/mxc-config.v2.schema.json
+++ b/schemas/mxc-config.v2.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/microsoft/mxc/schemas/mxc-config.v1.schema.json",
+  "$id": "https://github.com/microsoft/mxc/schemas/mxc-config.v2.schema.json",
   "title": "MXC Configuration",
-  "description": "Configuration schema for MXC container execution engine (v1). Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
+  "description": "Configuration schema for MXC container execution engine (v2). Defines the canonical config format with no legacy field support.",
   "type": "object",
 
   "required": ["process"],

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -44,11 +44,7 @@ fn log_request(request: &CodexRequest, logger: &mut Logger) {
     let _ = writeln!(logger, "Script code length: {}", request.script_code.len());
     let _ = writeln!(logger, "Working directory: {}", request.working_directory);
     let _ = writeln!(logger, "Script timeout: {}", request.script_timeout);
-    let _ = writeln!(
-        logger,
-        "Container name: {}",
-        request.lxc_config.container_name
-    );
+    let _ = writeln!(logger, "Container name: {}", request.container_id);
 }
 
 fn display_script_results(response: &ScriptResponse, logger: &mut Logger) {
@@ -135,7 +131,11 @@ fn main() {
     }
 
     // Run script in LXC container
-    let mut runner = LxcScriptRunner::new(&request.lxc_config);
+    let mut runner = LxcScriptRunner::new(
+        &request.lxc_config,
+        &request.container_id,
+        &request.lifecycle,
+    );
     let response = runner.run(&request, &mut logger);
     display_script_results(&response, &mut logger);
 

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -8,7 +8,7 @@
 use std::fmt::Write;
 
 use wxc_common::logger::Logger;
-use wxc_common::models::{CodexRequest, LxcConfig, ScriptResponse};
+use wxc_common::models::{CodexRequest, LifecycleConfig, LxcConfig, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
 use wxc_common::validator::validate_request;
 
@@ -19,21 +19,27 @@ use crate::network_iptables::NetworkIptablesManager;
 /// Script runner that executes commands inside an LXC container.
 pub struct LxcScriptRunner {
     config: LxcConfig,
+    container_id: String,
+    destroy_on_exit: bool,
+    cleanup_policy: bool,
 }
 
 impl LxcScriptRunner {
-    pub fn new(config: &LxcConfig) -> Self {
+    pub fn new(config: &LxcConfig, container_id: &str, lifecycle: &LifecycleConfig) -> Self {
         Self {
             config: config.clone(),
+            container_id: container_id.to_string(),
+            destroy_on_exit: lifecycle.destroy_on_exit,
+            cleanup_policy: !lifecycle.preserve_policy,
         }
     }
 
     /// Generate a container name if one wasn't provided.
     fn resolve_container_name(&self) -> String {
-        if self.config.container_name.is_empty() {
+        if self.container_id.is_empty() {
             format!("mxc-{}", uuid_simple())
         } else {
-            self.config.container_name.clone()
+            self.container_id.clone()
         }
     }
 
@@ -67,7 +73,7 @@ impl LxcScriptRunner {
         if let Err(e) =
             filesystem_mounts::configure_filesystem_mounts(&container, &request.policy, logger)
         {
-            if self.config.destroy_on_exit || container_created {
+            if self.destroy_on_exit || container_created {
                 let _ = container.destroy();
             }
             return ScriptResponse::error(&format!("Failed to configure filesystem: {}", e));
@@ -97,13 +103,13 @@ impl LxcScriptRunner {
         match fw_manager.apply_firewall_rules(&request.policy, logger) {
             Ok(true) => {}
             Ok(false) => {
-                if self.config.destroy_on_exit || container_created {
+                if self.destroy_on_exit || container_created {
                     let _ = container.destroy();
                 }
                 return ScriptResponse::error("Failed to apply network firewall rules.");
             }
             Err(e) => {
-                if self.config.destroy_on_exit || container_created {
+                if self.destroy_on_exit || container_created {
                     let _ = container.destroy();
                 }
                 return ScriptResponse::error(&format!("Network policy error: {}", e));
@@ -129,12 +135,12 @@ impl LxcScriptRunner {
         };
 
         // Cleanup: remove network rules
-        if fw_manager.rules_applied() && request.policy.remove_firewall_rules_on_exit {
+        if fw_manager.rules_applied() && self.cleanup_policy {
             let _ = fw_manager.remove_firewall_rules(logger);
         }
 
         // Cleanup: destroy container if configured
-        if self.config.destroy_on_exit {
+        if self.destroy_on_exit {
             let _ = writeln!(logger, "Destroying container...");
             if let Err(e) = container.destroy() {
                 let _ = writeln!(logger, "Warning: failed to destroy container: {}", e);
@@ -185,18 +191,17 @@ mod tests {
 
     #[test]
     fn resolve_container_name_uses_config() {
-        let config = LxcConfig {
-            container_name: "my-test".to_string(),
-            ..Default::default()
-        };
-        let runner = LxcScriptRunner::new(&config);
+        let config = LxcConfig::default();
+        let lifecycle = LifecycleConfig::default();
+        let runner = LxcScriptRunner::new(&config, "my-test", &lifecycle);
         assert_eq!(runner.resolve_container_name(), "my-test");
     }
 
     #[test]
     fn resolve_container_name_generates_when_empty() {
         let config = LxcConfig::default();
-        let runner = LxcScriptRunner::new(&config);
+        let lifecycle = LifecycleConfig::default();
+        let runner = LxcScriptRunner::new(&config, "", &lifecycle);
         let name = runner.resolve_container_name();
         assert!(name.starts_with("mxc-"));
     }

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -53,7 +53,11 @@ fn log_request(request: &CodexRequest, logger: &mut Logger) {
     let _ = writeln!(
         logger,
         "Container name: {}",
-        request.policy.app_container_name
+        if request.container_id.is_empty() {
+            "CLI"
+        } else {
+            &request.container_id
+        }
     );
 }
 

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -527,9 +527,13 @@ impl AppContainerScriptRunner {
 
     /// Create the AppContainer SID for the given request.
     fn initialize(&mut self, request: &CodexRequest) -> Result<(), WxcError> {
-        self.app_container_sid =
-            Self::create_app_container_sid(&request.policy.app_container_name)?;
-        self.app_container_name = request.policy.app_container_name.clone();
+        let container_name = if request.container_id.is_empty() {
+            "CLI".to_string()
+        } else {
+            request.container_id.clone()
+        };
+        self.app_container_sid = Self::create_app_container_sid(&container_name)?;
+        self.app_container_name = container_name;
         Ok(())
     }
 
@@ -571,7 +575,7 @@ impl ScriptRunner for AppContainerScriptRunner {
 
         let principal_id = self.get_principal_id();
 
-        let mut bfs_manager = FileSystemBfsManager::new(request.policy.app_container_name.clone());
+        let mut bfs_manager = FileSystemBfsManager::new(self.app_container_name.clone());
         if let Err(e) = bfs_manager.configure(&request.policy, logger) {
             return ScriptResponse::error(&e.to_string());
         }
@@ -579,6 +583,7 @@ impl ScriptRunner for AppContainerScriptRunner {
         let mut network_manager = NetworkManager::new();
         match network_manager.start(
             &principal_id,
+            &self.app_container_name,
             &request.policy,
             self.app_container_sid,
             logger,
@@ -598,8 +603,8 @@ impl ScriptRunner for AppContainerScriptRunner {
             Err(_) => ScriptResponse::error("Unknown error during script execution."),
         };
 
-        network_manager.stop_all(&request.policy, logger);
-        if bfs_manager.configured() && request.policy.clear_policy_on_exit {
+        network_manager.stop_all(!request.lifecycle.preserve_policy, logger);
+        if bfs_manager.configured() && !request.lifecycle.preserve_policy {
             bfs_manager.remove_configuration(logger);
         }
 

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -19,7 +19,6 @@ use crate::models::{
 #[derive(Deserialize, Default)]
 #[serde(default)]
 struct RawAppContainer {
-    name: Option<String>,
     #[serde(rename = "leastPrivilege")]
     least_privilege: Option<bool>,
     #[serde(rename = "learningMode")]
@@ -36,8 +35,6 @@ struct RawFilesystem {
     readonly_paths: Option<Vec<String>>,
     #[serde(rename = "deniedPaths")]
     denied_paths: Option<Vec<String>>,
-    #[serde(rename = "clearPolicyOnExit")]
-    clear_policy_on_exit: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]
@@ -51,8 +48,6 @@ struct RawNetwork {
     allowed_hosts: Option<Vec<String>>,
     #[serde(rename = "blockedHosts")]
     blocked_hosts: Option<Vec<String>>,
-    #[serde(rename = "removeRulesOnExit")]
-    remove_rules_on_exit: Option<bool>,
     proxy: Option<serde_json::Value>,
 }
 
@@ -97,12 +92,8 @@ struct RawContainerConfig {
 #[derive(Deserialize, Default)]
 #[serde(default)]
 struct RawLxc {
-    #[serde(rename = "containerName")]
-    container_name: Option<String>,
     distribution: Option<String>,
     release: Option<String>,
-    #[serde(rename = "destroyOnExit")]
-    destroy_on_exit: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]
@@ -133,16 +124,11 @@ struct RawConfig {
     platform: Option<String>,
     process: Option<RawProcess>,
     lifecycle: Option<RawLifecycle>,
-    script: Option<String>,
     containment: Option<String>,
-    #[serde(rename = "workingDirectory")]
-    working_directory: Option<String>,
-    timeout: Option<u32>,
     #[serde(rename = "appContainer")]
     app_container: Option<RawAppContainer>,
     sandbox: Option<RawSandbox>,
     wslc: Option<RawContainerConfig>,
-    container: Option<RawContainerConfig>,
     lxc: Option<RawLxc>,
     filesystem: Option<RawFilesystem>,
     network: Option<RawNetwork>,
@@ -254,7 +240,7 @@ pub fn load_request(
 // ---------- Cross-field validation ----------
 
 /// Maximum supported schema major version.
-const SUPPORTED_MAJOR_VERSION: u32 = 1;
+const SUPPORTED_MAJOR_VERSION: u32 = 2;
 
 /// Validate that the schema version is supported by this binary.
 fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), WxcError> {
@@ -300,40 +286,30 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
     let container_id = raw.container_id.unwrap_or_default();
     let platform = raw.platform.unwrap_or_else(|| "windows".to_string());
 
-    // Process section with dual-read fallback(new location wins, old is fallback)
-    let (process_script, process_cwd, process_timeout, env) = if let Some(ref p) = raw.process {
-        (
-            p.command_line.clone().or(raw.script.clone()),
-            p.cwd.clone().or(raw.working_directory.clone()),
-            p.timeout.or(raw.timeout),
-            p.env.clone().unwrap_or_default(),
-        )
-    } else {
-        (
-            raw.script.clone(),
-            raw.working_directory.clone(),
-            raw.timeout,
-            vec![],
-        )
-    };
+    // Process section is required
+    let process = raw
+        .process
+        .ok_or_else(|| WxcError::ConfigParse("'process' section is required".into()))?;
 
-    // Script is required and must be non-empty
-    let script_code = match process_script {
+    let script_code = match process.command_line {
         Some(s) if !s.is_empty() => s,
         Some(_) => {
-            logger.log_line("script cannot be empty");
-            return Err(WxcError::ConfigParse("script cannot be empty".to_string()));
+            logger.log_line("process.commandLine cannot be empty");
+            return Err(WxcError::ConfigParse(
+                "process.commandLine cannot be empty".to_string(),
+            ));
         }
         None => {
-            logger.log_line("Missing required script execution fields");
+            logger.log_line("Missing required field: process.commandLine");
             return Err(WxcError::ConfigParse(
-                "Missing required script execution fields".to_string(),
+                "Missing required field: process.commandLine".to_string(),
             ));
         }
     };
 
-    let working_directory = process_cwd.unwrap_or_default();
-    let script_timeout = process_timeout.unwrap_or(0);
+    let working_directory = process.cwd.unwrap_or_default();
+    let script_timeout = process.timeout.unwrap_or(0);
+    let env = process.env.unwrap_or_default();
 
     // Containment backend selection
     let containment = match raw.containment.as_deref() {
@@ -364,15 +340,12 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
     }
 
-    // LXC configuration — save destroy_on_exit for lifecycle fallback before consuming
-    let lxc_legacy_destroy_on_exit = raw.lxc.as_ref().and_then(|l| l.destroy_on_exit);
-    let mut lxc_config = {
+    // LXC configuration
+    let lxc_config = {
         let raw_lxc = raw.lxc.unwrap_or_default();
         LxcConfig {
-            container_name: raw_lxc.container_name.unwrap_or_default(),
             distribution: raw_lxc.distribution.unwrap_or_else(|| "alpine".to_string()),
             release: raw_lxc.release.unwrap_or_else(|| "3.19".to_string()),
-            destroy_on_exit: raw_lxc.destroy_on_exit.unwrap_or(true),
         }
     };
 
@@ -380,9 +353,6 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
 
     // AppContainer section
     if let Some(ac) = raw.app_container {
-        if let Some(name) = ac.name {
-            policy.app_container_name = name;
-        }
         if let Some(lp) = ac.least_privilege {
             policy.least_privilege_mode = lp;
         }
@@ -431,9 +401,6 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
         if let Some(v) = fscfg.readonly_paths {
             policy.readonly_paths = v;
-        }
-        if let Some(b) = fscfg.clear_policy_on_exit {
-            policy.clear_policy_on_exit = b;
         }
     }
 
@@ -487,14 +454,11 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         if let Some(v) = net.blocked_hosts {
             policy.blocked_hosts = v;
         }
-        if let Some(b) = net.remove_rules_on_exit {
-            policy.remove_firewall_rules_on_exit = b;
-        }
     }
 
-    // Container configuration (WSLC SDK) — "wslc" key takes precedence over "container"
+    // Container configuration (WSLC SDK)
     let mut container_config = ContainerConfig::default();
-    if let Some(cc) = raw.wslc.or(raw.container) {
+    if let Some(cc) = raw.wslc {
         if let Some(os) = cc.target_os {
             container_config.target_os = os;
         }
@@ -519,34 +483,17 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         }
     }
 
-    // Lifecycle section with dual-read fallback from legacy fields
+    // Lifecycle section
     let lifecycle = {
         let lc = raw.lifecycle.unwrap_or_default();
-        let destroy_on_exit = lc
-            .destroy_on_exit
-            .or(lxc_legacy_destroy_on_exit)
-            .unwrap_or(true);
+        let destroy_on_exit = lc.destroy_on_exit.unwrap_or(true);
         let preserve_policy = lc.preserve_policy.unwrap_or(false);
-
-        // Sync back to legacy fields so existing runners keep working.
-        // Only override legacy values when lifecycle.preservePolicy was explicitly set.
-        if lc.preserve_policy.is_some() {
-            policy.clear_policy_on_exit = !preserve_policy;
-            policy.remove_firewall_rules_on_exit = !preserve_policy;
-        }
-        lxc_config.destroy_on_exit = destroy_on_exit;
 
         LifecycleConfig {
             destroy_on_exit,
             preserve_policy,
         }
     };
-
-    // containerId takes precedence over backend-specific container names
-    if !container_id.is_empty() {
-        policy.app_container_name = container_id.clone();
-        lxc_config.container_name = container_id.clone();
-    }
 
     // Schema version check
     validate_schema_version(&schema_version, logger)?;
@@ -580,7 +527,7 @@ mod tests {
 
     #[test]
     fn minimal_config() {
-        let json = r#"{"script": "echo hello"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -591,8 +538,8 @@ mod tests {
     }
 
     #[test]
-    fn missing_script_field() {
-        let json = r#"{"timeout": 5000}"#;
+    fn missing_process_section() {
+        let json = r#"{"containment": "appcontainer"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -601,8 +548,18 @@ mod tests {
     }
 
     #[test]
-    fn empty_script_field() {
-        let json = r#"{"script": ""}"#;
+    fn missing_command_line() {
+        let json = r#"{"process": {"cwd": "/tmp"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty_command_line() {
+        let json = r#"{"process": {"commandLine": ""}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -613,26 +570,26 @@ mod tests {
     #[test]
     fn full_config() {
         let json = r#"{
-            "script": "dir",
-            "workingDirectory": "C:\\temp",
-            "timeout": 3000,
+            "containerId": "TestProfile",
+            "process": {
+                "commandLine": "dir",
+                "cwd": "C:\\temp",
+                "timeout": 3000
+            },
             "appContainer": {
-                "name": "TestProfile",
                 "leastPrivilege": true,
                 "capabilities": ["internetClient"]
             },
             "filesystem": {
                 "readwritePaths": ["C:\\rw"],
                 "readonlyPaths": ["C:\\ro"],
-                "deniedPaths": ["C:\\denied"],
-                "clearPolicyOnExit": false
+                "deniedPaths": ["C:\\denied"]
             },
             "network": {
                 "defaultPolicy": "block",
                 "enforcementMode": "firewall",
                 "allowedHosts": ["example.com"],
-                "blockedHosts": ["evil.com"],
-                "removeRulesOnExit": false
+                "blockedHosts": ["evil.com"]
             }
         }"#;
         let encoded = base64_encode(json.as_bytes());
@@ -642,7 +599,7 @@ mod tests {
         assert_eq!(req.script_code, "dir");
         assert_eq!(req.working_directory, "C:\\temp");
         assert_eq!(req.script_timeout, 3000);
-        assert_eq!(req.policy.app_container_name, "TestProfile");
+        assert_eq!(req.container_id, "TestProfile");
         assert!(req.policy.least_privilege_mode);
         assert!(req
             .policy
@@ -651,7 +608,6 @@ mod tests {
         assert_eq!(req.policy.readwrite_paths, vec!["C:\\rw"]);
         assert_eq!(req.policy.readonly_paths, vec!["C:\\ro"]);
         assert_eq!(req.policy.denied_paths, vec!["C:\\denied"]);
-        assert!(!req.policy.clear_policy_on_exit);
         assert_eq!(req.policy.default_network_policy, NetworkPolicy::Block);
         assert_eq!(
             req.policy.network_enforcement_mode,
@@ -659,12 +615,12 @@ mod tests {
         );
         assert_eq!(req.policy.allowed_hosts, vec!["example.com"]);
         assert_eq!(req.policy.blocked_hosts, vec!["evil.com"]);
-        assert!(!req.policy.remove_firewall_rules_on_exit);
     }
 
     #[test]
     fn invalid_network_policy() {
-        let json = r#"{"script": "echo x", "network": {"defaultPolicy": "invalid"}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo x"}, "network": {"defaultPolicy": "invalid"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -674,7 +630,8 @@ mod tests {
 
     #[test]
     fn invalid_enforcement_mode() {
-        let json = r#"{"script": "echo x", "network": {"enforcementMode": "invalid"}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo x"}, "network": {"enforcementMode": "invalid"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -686,7 +643,7 @@ mod tests {
     fn load_from_file() {
         let dir = tempfile::tempdir().unwrap();
         let file_path = dir.path().join("config.json");
-        std::fs::write(&file_path, r#"{"script": "whoami"}"#).unwrap();
+        std::fs::write(&file_path, r#"{"process": {"commandLine": "whoami"}}"#).unwrap();
 
         let mut logger = test_logger();
         let req = load_request(file_path.to_str().unwrap(), &mut logger, false).unwrap();
@@ -718,7 +675,8 @@ mod tests {
     #[cfg(debug_assertions)]
     #[test]
     fn learning_mode_adds_capability_in_debug() {
-        let json = r#"{"script": "echo x", "appContainer": {"learningMode": true}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo x"}, "appContainer": {"learningMode": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -733,8 +691,7 @@ mod tests {
     #[cfg(not(debug_assertions))]
     #[test]
     fn learning_mode_stripped_in_release() {
-        let json =
-            r#"{"script": "echo x", "appContainer": {"capabilities": ["permissiveLearningMode"]}}"#;
+        let json = r#"{"process": {"commandLine": "echo x"}, "appContainer": {"capabilities": ["permissiveLearningMode"]}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -750,7 +707,8 @@ mod tests {
 
     #[test]
     fn script_with_timeout() {
-        let json = r#"{"script": "import sys\nprint(sys.version)", "timeout": 60000}"#;
+        let json =
+            r#"{"process": {"commandLine": "import sys\nprint(sys.version)", "timeout": 60000}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -759,19 +717,9 @@ mod tests {
     }
 
     #[test]
-    fn app_container_name_standalone() {
-        let json = r#"{"script": "print('test')", "appContainer": {"name": "CustomAppContainer"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.policy.app_container_name, "CustomAppContainer");
-    }
-
-    #[test]
     fn app_container_capabilities() {
         let json = r#"{
-            "script": "print('test')",
+            "process": {"commandLine": "print('test')"},
             "appContainer": {
                 "capabilities": ["internetClient", "privateNetworkClientServer", "documentsLibrary"]
             }
@@ -788,7 +736,7 @@ mod tests {
 
     #[test]
     fn least_privilege_mode() {
-        let json = r#"{"script": "print('test')", "appContainer": {"leastPrivilege": true}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "appContainer": {"leastPrivilege": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -798,7 +746,7 @@ mod tests {
 
     #[test]
     fn network_default_policy_allow() {
-        let json = r#"{"script": "print('test')", "network": {"defaultPolicy": "allow"}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "network": {"defaultPolicy": "allow"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -808,7 +756,7 @@ mod tests {
 
     #[test]
     fn network_default_policy_block() {
-        let json = r#"{"script": "print('test')", "network": {"defaultPolicy": "block"}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "network": {"defaultPolicy": "block"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -818,7 +766,7 @@ mod tests {
 
     #[test]
     fn network_enforcement_mode_capabilities() {
-        let json = r#"{"script": "print('test')", "network": {"enforcementMode": "capabilities"}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "network": {"enforcementMode": "capabilities"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -831,7 +779,7 @@ mod tests {
 
     #[test]
     fn network_enforcement_mode_firewall() {
-        let json = r#"{"script": "print('test')", "network": {"enforcementMode": "firewall"}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "network": {"enforcementMode": "firewall"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -844,7 +792,7 @@ mod tests {
 
     #[test]
     fn network_enforcement_mode_both() {
-        let json = r#"{"script": "print('test')", "network": {"enforcementMode": "both"}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "network": {"enforcementMode": "both"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -858,7 +806,7 @@ mod tests {
     #[test]
     fn network_hosts() {
         let json = r#"{
-            "script": "print('test')",
+            "process": {"commandLine": "print('test')"},
             "network": {
                 "allowedHosts": ["example.com", "api.trusted.com"],
                 "blockedHosts": ["malicious.com", "tracker.net"]
@@ -879,7 +827,7 @@ mod tests {
     #[test]
     fn filesystem_paths() {
         let json = r#"{
-            "script": "print('test')",
+            "process": {"commandLine": "print('test')"},
             "filesystem": {
                 "readwritePaths": ["C:\\Users\\Public", "C:\\Temp\\Data"],
                 "deniedPaths": ["C:\\Windows\\System32", "C:\\Program Files"]
@@ -898,25 +846,14 @@ mod tests {
     }
 
     #[test]
-    fn filesystem_clear_policy_on_exit_false() {
-        let json = r#"{
-            "script": "print('test')",
-            "filesystem": {"clearPolicyOnExit": false}
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(!req.policy.clear_policy_on_exit);
-    }
-
-    #[test]
     fn base64_complex_config() {
         let json = r#"{
-            "script": "import sys\nprint(sys.version)",
-            "timeout": 10000,
+            "containerId": "TestContainer",
+            "process": {
+                "commandLine": "import sys\nprint(sys.version)",
+                "timeout": 10000
+            },
             "appContainer": {
-                "name": "TestContainer",
                 "capabilities": ["internetClient", "privateNetworkClientServer"]
             }
         }"#;
@@ -926,26 +863,13 @@ mod tests {
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.script_code, "import sys\nprint(sys.version)");
         assert_eq!(req.script_timeout, 10000);
-        assert_eq!(req.policy.app_container_name, "TestContainer");
+        assert_eq!(req.container_id, "TestContainer");
         assert_eq!(req.policy.capabilities.len(), 2);
     }
 
     #[test]
-    fn network_remove_rules_on_exit() {
-        let json = r#"{
-            "script": "print('test')",
-            "network": {"removeRulesOnExit": true}
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.policy.remove_firewall_rules_on_exit);
-    }
-
-    #[test]
     fn invalid_json_syntax() {
-        let json = r#"{"script": "print('test')", INVALID_JSON}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, INVALID_JSON}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -955,7 +879,7 @@ mod tests {
 
     #[test]
     fn default_timeout_is_zero() {
-        let json = r#"{"script": "echo hello"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -967,7 +891,7 @@ mod tests {
 
     #[test]
     fn default_containment_is_appcontainer() {
-        let json = r#"{"script": "echo hello"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -977,7 +901,7 @@ mod tests {
 
     #[test]
     fn explicit_appcontainer_containment() {
-        let json = r#"{"script": "echo hello", "containment": "appcontainer"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "appcontainer"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -987,7 +911,7 @@ mod tests {
 
     #[test]
     fn sandbox_containment() {
-        let json = r#"{"script": "echo hello", "containment": "sandbox"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "sandbox"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -997,7 +921,7 @@ mod tests {
 
     #[test]
     fn invalid_containment_value() {
-        let json = r#"{"script": "echo hello", "containment": "docker"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "docker"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1007,7 +931,7 @@ mod tests {
 
     #[test]
     fn sandbox_config_defaults() {
-        let json = r#"{"script": "echo hello", "containment": "sandbox"}"#;
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "sandbox"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1019,7 +943,7 @@ mod tests {
     #[test]
     fn sandbox_config_custom_values() {
         let json = r#"{
-            "script": "echo hello",
+            "process": {"commandLine": "echo hello"},
             "containment": "sandbox",
             "sandbox": {
                 "idleTimeout": 60000,
@@ -1039,7 +963,8 @@ mod tests {
 
     #[test]
     fn no_proxy_leaves_default() {
-        let json = r#"{"script": "echo test", "network": {"defaultPolicy": "block"}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo test"}, "network": {"defaultPolicy": "block"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1050,7 +975,7 @@ mod tests {
     #[test]
     fn proxy_localhost_port() {
         let json = r#"{
-            "script": "echo test",
+            "process": {"commandLine": "echo test"},
             "network": {
                 "proxy": { "localhost": 8080 }
             }
@@ -1069,7 +994,7 @@ mod tests {
     #[test]
     fn proxy_with_firewall_fields() {
         let json = r#"{
-            "script": "echo test",
+            "process": {"commandLine": "echo test"},
             "network": {
                 "defaultPolicy": "block",
                 "allowedHosts": ["api.github.com"],
@@ -1089,8 +1014,7 @@ mod tests {
 
     #[test]
     fn proxy_rejected_with_sandbox() {
-        let json =
-            r#"{"script":"x","containment":"sandbox","network":{"proxy":{"localhost":8080}}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"containment":"sandbox","network":{"proxy":{"localhost":8080}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1100,7 +1024,7 @@ mod tests {
 
     #[test]
     fn proxy_rejects_port_zero() {
-        let json = r#"{"script":"x","network":{"proxy":{"localhost":0}}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"network":{"proxy":{"localhost":0}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1110,7 +1034,7 @@ mod tests {
 
     #[test]
     fn proxy_rejects_missing_localhost() {
-        let json = r#"{"script":"x","network":{"proxy":{}}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"network":{"proxy":{}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1120,7 +1044,7 @@ mod tests {
 
     #[test]
     fn proxy_rejects_non_object() {
-        let json = r#"{"script":"x","network":{"proxy":true}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"network":{"proxy":true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1131,7 +1055,7 @@ mod tests {
     #[test]
     fn proxy_builtin_test_server() {
         let json = r#"{
-            "script": "echo test",
+            "process": {"commandLine": "echo test"},
             "network": {
                 "proxy": { "builtinTestServer": true }
             }
@@ -1147,8 +1071,7 @@ mod tests {
 
     #[test]
     fn proxy_builtin_test_server_rejects_extra_keys() {
-        let json =
-            r#"{"script":"x","network":{"proxy":{"builtinTestServer":true,"localhost":8080}}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"network":{"proxy":{"builtinTestServer":true,"localhost":8080}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1158,7 +1081,8 @@ mod tests {
 
     #[test]
     fn proxy_builtin_test_server_rejects_false() {
-        let json = r#"{"script":"x","network":{"proxy":{"builtinTestServer":false}}}"#;
+        let json =
+            r#"{"process":{"commandLine":"x"},"network":{"proxy":{"builtinTestServer":false}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1168,7 +1092,7 @@ mod tests {
 
     #[test]
     fn proxy_builtin_test_server_rejected_with_sandbox() {
-        let json = r#"{"script":"x","containment":"sandbox","network":{"proxy":{"builtinTestServer":true}}}"#;
+        let json = r#"{"process":{"commandLine":"x"},"containment":"sandbox","network":{"proxy":{"builtinTestServer":true}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1178,19 +1102,19 @@ mod tests {
 
     #[test]
     fn new_toplevel_fields_parsed() {
-        let json = r#"{"version": "1", "containerId": "abc-123", "platform": "linux", "containment": "lxc", "script": "echo hi"}"#;
+        let json = r#"{"version": "2", "containerId": "abc-123", "platform": "linux", "containment": "lxc", "process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.schema_version, "1");
+        assert_eq!(req.schema_version, "2");
         assert_eq!(req.container_id, "abc-123");
         assert_eq!(req.platform, "linux");
     }
 
     #[test]
     fn new_toplevel_fields_default_when_absent() {
-        let json = r#"{"script": "echo hi"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1198,47 +1122,6 @@ mod tests {
         assert_eq!(req.schema_version, "");
         assert_eq!(req.container_id, "");
         assert_eq!(req.platform, "windows");
-    }
-
-    #[test]
-    fn process_section_overrides_toplevel() {
-        let json = r#"{
-            "script": "old command",
-            "process": { "commandLine": "new command" }
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.script_code, "new command");
-    }
-
-    #[test]
-    fn process_section_cwd_overrides_working_directory() {
-        let json = r#"{
-            "script": "echo hi",
-            "workingDirectory": "C:\\old",
-            "process": { "cwd": "/new" }
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.working_directory, "/new");
-    }
-
-    #[test]
-    fn process_section_timeout_overrides_toplevel() {
-        let json = r#"{
-            "script": "echo hi",
-            "timeout": 5000,
-            "process": { "timeout": 9000 }
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.script_timeout, 9000);
     }
 
     #[test]
@@ -1257,39 +1140,38 @@ mod tests {
     }
 
     #[test]
-    fn toplevel_fallback_when_no_process_section() {
+    fn process_section_cwd_parsed() {
         let json = r#"{
-            "script": "echo hello",
-            "workingDirectory": "C:\\temp",
-            "timeout": 3000
+            "process": {
+                "commandLine": "echo hi",
+                "cwd": "/workspace"
+            }
         }"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.script_code, "echo hello");
-        assert_eq!(req.working_directory, "C:\\temp");
-        assert_eq!(req.script_timeout, 3000);
-        assert!(req.env.is_empty());
-    }
-
-    #[test]
-    fn process_section_falls_back_to_toplevel_script() {
-        let json = r#"{
-            "script": "echo fallback",
-            "process": { "cwd": "/workspace" }
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.script_code, "echo fallback");
         assert_eq!(req.working_directory, "/workspace");
     }
 
     #[test]
+    fn process_section_timeout_parsed() {
+        let json = r#"{
+            "process": {
+                "commandLine": "echo hi",
+                "timeout": 9000
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.script_timeout, 9000);
+    }
+
+    #[test]
     fn containment_vm_accepted() {
-        let json = r#"{"script": "echo hi", "containment": "vm"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "vm"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1299,7 +1181,7 @@ mod tests {
 
     #[test]
     fn containment_microvm_accepted() {
-        let json = r#"{"script": "echo hi", "containment": "microvm"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "microvm"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1309,7 +1191,7 @@ mod tests {
 
     #[test]
     fn schema_version_too_new_rejected() {
-        let json = r#"{"script": "echo hi", "version": "2"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "3"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1319,7 +1201,17 @@ mod tests {
 
     #[test]
     fn schema_version_current_accepted() {
-        let json = r#"{"script": "echo hi", "version": "1"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "2"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.schema_version, "2");
+    }
+
+    #[test]
+    fn schema_version_v1_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "1"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1329,7 +1221,7 @@ mod tests {
 
     #[test]
     fn schema_version_absent_accepted() {
-        let json = r#"{"script": "echo hi"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1339,7 +1231,7 @@ mod tests {
 
     #[test]
     fn schema_version_non_numeric_rejected() {
-        let json = r#"{"script": "echo hi", "version": "x"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "x"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1349,7 +1241,7 @@ mod tests {
 
     #[test]
     fn schema_version_zero_rejected() {
-        let json = r#"{"script": "echo hi", "version": "0"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1359,7 +1251,7 @@ mod tests {
 
     #[test]
     fn schema_version_beta_suffix_rejected() {
-        let json = r#"{"script": "echo hi", "version": "2-beta"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "3-beta"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1369,7 +1261,7 @@ mod tests {
 
     #[test]
     fn sandbox_idle_timeout_ms_accepted() {
-        let json = r#"{"script": "echo hi", "containment": "sandbox", "sandbox": {"idleTimeoutMs": 60000}}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "sandbox", "sandbox": {"idleTimeoutMs": 60000}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1379,7 +1271,7 @@ mod tests {
 
     #[test]
     fn sandbox_idle_timeout_ms_overrides_idle_timeout() {
-        let json = r#"{"script": "echo hi", "containment": "sandbox", "sandbox": {"idleTimeout": 10000, "idleTimeoutMs": 60000}}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "sandbox", "sandbox": {"idleTimeout": 10000, "idleTimeoutMs": 60000}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1388,148 +1280,51 @@ mod tests {
     }
 
     #[test]
-    fn container_id_overrides_app_container_name() {
-        let json = r#"{"script": "echo hi", "containerId": "my-container", "appContainer": {"name": "old-name"}}"#;
+    fn container_id_parsed() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containerId": "my-container"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.policy.app_container_name, "my-container");
-    }
-
-    #[test]
-    fn container_id_overrides_lxc_container_name() {
-        let json = r#"{"script": "echo hi", "containment": "lxc", "platform": "linux", "containerId": "my-lxc", "lxc": {"containerName": "old-name"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.lxc_config.container_name, "my-lxc");
-    }
-
-    #[test]
-    fn container_id_fallback_to_app_container_name() {
-        let json = r#"{"script": "echo hi", "appContainer": {"name": "old-name"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.policy.app_container_name, "old-name");
+        assert_eq!(req.container_id, "my-container");
     }
 
     #[test]
     fn lifecycle_destroy_on_exit_parsed() {
-        let json = r#"{"script": "echo hi", "lifecycle": {"destroyOnExit": false}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo hi"}, "lifecycle": {"destroyOnExit": false}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(!req.lifecycle.destroy_on_exit);
-        assert!(!req.lxc_config.destroy_on_exit);
     }
 
     #[test]
     fn lifecycle_preserve_policy_parsed() {
-        let json = r#"{"script": "echo hi", "lifecycle": {"preservePolicy": true}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo hi"}, "lifecycle": {"preservePolicy": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(req.lifecycle.preserve_policy);
-        assert!(!req.policy.clear_policy_on_exit);
-        assert!(!req.policy.remove_firewall_rules_on_exit);
-    }
-
-    #[test]
-    fn lifecycle_fallback_from_lxc_destroy_on_exit() {
-        let json =
-            r#"{"script": "echo hi", "containment": "lxc", "lxc": {"destroyOnExit": false}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(!req.lifecycle.destroy_on_exit);
-        assert!(!req.lxc_config.destroy_on_exit);
     }
 
     #[test]
     fn lifecycle_defaults_when_absent() {
-        let json = r#"{"script": "echo hi"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(req.lifecycle.destroy_on_exit);
         assert!(!req.lifecycle.preserve_policy);
-    }
-
-    #[test]
-    fn lifecycle_overrides_lxc_destroy_on_exit() {
-        let json = r#"{"script": "echo hi", "lifecycle": {"destroyOnExit": true}, "lxc": {"destroyOnExit": false}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.lifecycle.destroy_on_exit);
-    }
-
-    #[test]
-    fn lifecycle_preserve_policy_overrides_legacy_fields() {
-        let json = r#"{
-            "script": "echo hi",
-            "filesystem": {"clearPolicyOnExit": true},
-            "network": {"removeRulesOnExit": true},
-            "lifecycle": {"preservePolicy": true}
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.lifecycle.preserve_policy);
-        assert!(!req.policy.clear_policy_on_exit);
-        assert!(!req.policy.remove_firewall_rules_on_exit);
-    }
-
-    #[test]
-    fn legacy_policy_fields_preserved_when_lifecycle_absent() {
-        let json = r#"{
-            "script": "echo hi",
-            "filesystem": {"clearPolicyOnExit": false},
-            "network": {"removeRulesOnExit": false}
-        }"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(!req.lifecycle.preserve_policy);
-        assert!(!req.policy.clear_policy_on_exit);
-        assert!(!req.policy.remove_firewall_rules_on_exit);
     }
 
     #[test]
     fn wslc_section_parsed() {
-        let json =
-            r#"{"script": "echo hi", "containment": "wslc", "wslc": {"image": "python:3.12"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.container_config.image, "python:3.12");
-    }
-
-    #[test]
-    fn wslc_falls_back_to_container_section() {
-        let json = r#"{"script": "echo hi", "containment": "wslc", "container": {"image": "ubuntu:22.04"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.container_config.image, "ubuntu:22.04");
-    }
-
-    #[test]
-    fn wslc_section_overrides_container_section() {
-        let json = r#"{"script": "echo hi", "containment": "wslc", "wslc": {"image": "python:3.12"}, "container": {"image": "ubuntu:22.04"}}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "wslc": {"image": "python:3.12"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -239,38 +239,52 @@ pub fn load_request(
 
 // ---------- Cross-field validation ----------
 
-/// Maximum supported schema major version.
-const SUPPORTED_MAJOR_VERSION: u32 = 2;
+/// Supported schema version (semver). Configs with a higher major.minor are rejected.
+const SUPPORTED_VERSION: (u32, u32) = (0, 4); // 0.4.x
 
-/// Validate that the schema version is supported by this binary.
+/// Validate that the schema version (semver) is supported by this binary.
+/// Compares major.minor only — patch and pre-release labels are ignored.
 fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), WxcError> {
     if version.is_empty() {
         return Ok(());
     }
-    let major_str = version.split('.').next().unwrap_or("");
-    let major: u32 = match major_str.parse() {
-        Ok(0) => {
-            let msg = format!(
-                "Invalid schema version '{}': major version must be >= 1",
-                version
-            );
-            logger.log_line(&msg);
-            return Err(WxcError::ConfigParse(msg));
-        }
-        Ok(v) => v,
-        Err(_) => {
-            let msg = format!(
-                "Invalid schema version '{}': must start with a positive integer (e.g., '1' or '1.0')",
-                version
-            );
-            logger.log_line(&msg);
-            return Err(WxcError::ConfigParse(msg));
-        }
-    };
-    if major > SUPPORTED_MAJOR_VERSION {
+
+    // Strip pre-release suffix (e.g., "0.4.0-alpha" → "0.4.0")
+    let version_core = version.split('-').next().unwrap_or(version);
+    let parts: Vec<&str> = version_core.split('.').collect();
+
+    if parts.len() < 2 {
         let msg = format!(
-            "Config schema version '{}' is newer than supported (max: {}.x). Upgrade wxc-exec.",
-            version, SUPPORTED_MAJOR_VERSION
+            "Invalid schema version '{}': must be semver (e.g., '0.4.0' or '0.4.0-alpha')",
+            version
+        );
+        logger.log_line(&msg);
+        return Err(WxcError::ConfigParse(msg));
+    }
+
+    let major: u32 = parts[0].parse().map_err(|_| {
+        let msg = format!(
+            "Invalid schema version '{}': major version must be a non-negative integer",
+            version
+        );
+        logger.log_line(&msg);
+        WxcError::ConfigParse(msg)
+    })?;
+
+    let minor: u32 = parts[1].parse().map_err(|_| {
+        let msg = format!(
+            "Invalid schema version '{}': minor version must be a non-negative integer",
+            version
+        );
+        logger.log_line(&msg);
+        WxcError::ConfigParse(msg)
+    })?;
+
+    let (sup_major, sup_minor) = SUPPORTED_VERSION;
+    if major > sup_major || (major == sup_major && minor > sup_minor) {
+        let msg = format!(
+            "Config schema version '{}' is newer than supported (max: {}.{}.x). Upgrade wxc-exec.",
+            version, sup_major, sup_minor
         );
         logger.log_line(&msg);
         return Err(WxcError::ConfigParse(msg));
@@ -1102,12 +1116,12 @@ mod tests {
 
     #[test]
     fn new_toplevel_fields_parsed() {
-        let json = r#"{"version": "2", "containerId": "abc-123", "platform": "linux", "containment": "lxc", "process": {"commandLine": "echo hi"}}"#;
+        let json = r#"{"version": "0.4.0-alpha", "containerId": "abc-123", "platform": "linux", "containment": "lxc", "process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.schema_version, "2");
+        assert_eq!(req.schema_version, "0.4.0-alpha");
         assert_eq!(req.container_id, "abc-123");
         assert_eq!(req.platform, "linux");
     }
@@ -1191,7 +1205,7 @@ mod tests {
 
     #[test]
     fn schema_version_too_new_rejected() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "3"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.5.0"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1201,22 +1215,22 @@ mod tests {
 
     #[test]
     fn schema_version_current_accepted() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "2"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.4.0-alpha"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.schema_version, "2");
+        assert_eq!(req.schema_version, "0.4.0-alpha");
     }
 
     #[test]
-    fn schema_version_v1_accepted() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "1"}"#;
+    fn schema_version_older_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.3.0-alpha"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.schema_version, "1");
+        assert_eq!(req.schema_version, "0.3.0-alpha");
     }
 
     #[test]
@@ -1230,7 +1244,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_non_numeric_rejected() {
+    fn schema_version_non_semver_rejected() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "version": "x"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
@@ -1240,8 +1254,8 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_zero_rejected() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0"}"#;
+    fn schema_version_major_only_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "2"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1250,8 +1264,8 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_beta_suffix_rejected() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "3-beta"}"#;
+    fn schema_version_future_major_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "1.0.0"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -47,23 +47,17 @@ impl Default for SandboxConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LxcConfig {
-    /// Container name. Default: auto-generated.
-    pub container_name: String,
     /// Linux distribution for the container rootfs (e.g., "alpine", "ubuntu").
     pub distribution: String,
     /// Distribution release version (e.g., "3.19", "24.04").
     pub release: String,
-    /// Whether to destroy the container after execution. Default: true.
-    pub destroy_on_exit: bool,
 }
 
 impl Default for LxcConfig {
     fn default() -> Self {
         Self {
-            container_name: String::new(),
             distribution: "alpine".to_string(),
             release: "3.19".to_string(),
-            destroy_on_exit: true,
         }
     }
 }
@@ -133,43 +127,20 @@ impl ProxyConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ContainerPolicy {
-    pub app_container_name: String,
     pub least_privilege_mode: bool,
     pub capabilities: Vec<String>,
     pub readwrite_paths: Vec<String>,
     pub readonly_paths: Vec<String>,
     pub denied_paths: Vec<String>,
-    pub clear_policy_on_exit: bool,
     pub default_network_policy: NetworkPolicy,
     pub network_enforcement_mode: NetworkEnforcementMode,
     pub allowed_hosts: Vec<String>,
     pub blocked_hosts: Vec<String>,
-    pub remove_firewall_rules_on_exit: bool,
     #[serde(skip)]
     pub network_proxy: ProxyConfig,
-}
-
-impl Default for ContainerPolicy {
-    fn default() -> Self {
-        Self {
-            app_container_name: "CLI".to_string(),
-            least_privilege_mode: false,
-            capabilities: Vec::new(),
-            readwrite_paths: Vec::new(),
-            readonly_paths: Vec::new(),
-            denied_paths: Vec::new(),
-            clear_policy_on_exit: true,
-            default_network_policy: NetworkPolicy::default(),
-            network_enforcement_mode: NetworkEnforcementMode::default(),
-            allowed_hosts: Vec::new(),
-            blocked_hosts: Vec::new(),
-            remove_firewall_rules_on_exit: true,
-            network_proxy: ProxyConfig::default(),
-        }
-    }
 }
 
 /// Port mapping for host↔container port forwarding.

--- a/src/wxc_common/src/network_manager.rs
+++ b/src/wxc_common/src/network_manager.rs
@@ -200,6 +200,7 @@ impl NetworkManager {
     pub fn start(
         &mut self,
         principal_id: &str,
+        container_name: &str,
         policy: &ContainerPolicy,
         script_sid: windows::Win32::Security::PSID,
         logger: &mut Logger,
@@ -207,7 +208,7 @@ impl NetworkManager {
         if policy.network_proxy.is_enabled() {
             self.proxy_coordinator.start(
                 &policy.network_proxy,
-                &policy.app_container_name,
+                container_name,
                 principal_id,
                 script_sid,
                 logger,
@@ -225,8 +226,8 @@ impl NetworkManager {
     }
 
     /// Stop all network resources: firewall rules, proxy policy, test proxy.
-    pub fn stop_all(&mut self, policy: &ContainerPolicy, logger: &mut Logger) {
-        if self.rules_applied() && policy.remove_firewall_rules_on_exit {
+    pub fn stop_all(&mut self, cleanup_policy: bool, logger: &mut Logger) {
+        if self.rules_applied() && cleanup_policy {
             let _ = self.remove_firewall_rules(logger);
         }
         if self.proxy_coordinator.is_active() {

--- a/src/wxc_common/src/validator.rs
+++ b/src/wxc_common/src/validator.rs
@@ -16,7 +16,6 @@ pub fn validate_request(request: &CodexRequest) -> Result<(), WxcError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::ContainerPolicy;
 
     #[test]
     fn validate_request_with_valid_script() {
@@ -42,10 +41,7 @@ mod tests {
             script_code: "print('test')".to_string(),
             working_directory: "C:\\temp".to_string(),
             script_timeout: 5000,
-            policy: ContainerPolicy {
-                app_container_name: "Test".to_string(),
-                ..Default::default()
-            },
+            container_id: "Test".to_string(),
             ..Default::default()
         };
         assert!(validate_request(&req).is_ok());

--- a/test_configs/basic_appcontainer.json
+++ b/test_configs/basic_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-BasicAppContainer-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_appcontainer.json
+++ b/test_configs/basic_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-BasicAppContainer-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_lpac.json
+++ b/test_configs/basic_lpac.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LPAC-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_lpac.json
+++ b/test_configs/basic_lpac.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LPAC-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_lxc.json
+++ b/test_configs/basic_lxc.json
@@ -6,9 +6,11 @@
   "process": {
     "commandLine": "echo 'Hello from LXC' && uname -a"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   }
 }

--- a/test_configs/basic_lxc.json
+++ b/test_configs/basic_lxc.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/basic_lxc.json
+++ b/test_configs/basic_lxc.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/basic_permissive.json
+++ b/test_configs/basic_permissive.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Permissive-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_permissive.json
+++ b/test_configs/basic_permissive.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Permissive-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/basic_sandbox.json
+++ b/test_configs/basic_sandbox.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/test_configs/basic_sandbox.json
+++ b/test_configs/basic_sandbox.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Sandbox-Hello-World",
   "containment": "sandbox",
   "process": {

--- a/test_configs/filesystem_bfs_readonly_test.json
+++ b/test_configs/filesystem_bfs_readonly_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-BFSReadOnly-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/filesystem_bfs_readonly_test.json
+++ b/test_configs/filesystem_bfs_readonly_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-BFSReadOnly-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/filesystem_bfs_test.json
+++ b/test_configs/filesystem_bfs_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-BFS-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/filesystem_bfs_test.json
+++ b/test_configs/filesystem_bfs_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-BFS-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/lxc_filesystem_test.json
+++ b/test_configs/lxc_filesystem_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/lxc_filesystem_test.json
+++ b/test_configs/lxc_filesystem_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/lxc_filesystem_test.json
+++ b/test_configs/lxc_filesystem_test.json
@@ -6,10 +6,12 @@
   "process": {
     "commandLine": "cat /mnt/readonly/test.txt && echo 'write test' > /mnt/readwrite/output.txt"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   },
   "filesystem": {
     "readonlyPaths": ["/mnt/readonly"],

--- a/test_configs/lxc_network_test.json
+++ b/test_configs/lxc_network_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/lxc_network_test.json
+++ b/test_configs/lxc_network_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
   "platform": "linux",

--- a/test_configs/lxc_network_test.json
+++ b/test_configs/lxc_network_test.json
@@ -6,10 +6,12 @@
   "process": {
     "commandLine": "wget -qO- https://api.github.com/zen"
   },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
   "lxc": {
     "distribution": "alpine",
-    "release": "3.19",
-    "destroyOnExit": true
+    "release": "3.19"
   },
   "network": {
     "defaultPolicy": "block",

--- a/test_configs/network_both_test.json
+++ b/test_configs/network_both_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Both-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_both_test.json
+++ b/test_configs/network_both_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Both-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_both_test.json
+++ b/test_configs/network_both_test.json
@@ -16,7 +16,6 @@
     "defaultPolicy": "block",
     "enforcementMode": "both",
     "allowedHosts": ["api.github.com"],
-    "blockedHosts": [],
-    "removeRulesOnExit": true
+    "blockedHosts": []
   }
 }

--- a/test_configs/network_capabilities_test.json
+++ b/test_configs/network_capabilities_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Capabilities-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_capabilities_test.json
+++ b/test_configs/network_capabilities_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Capabilities-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_capabilities_test.json
+++ b/test_configs/network_capabilities_test.json
@@ -16,7 +16,6 @@
     "defaultPolicy": "block",
     "enforcementMode": "capabilities",
     "allowedHosts": ["api.github.com"],
-    "blockedHosts": [],
-    "removeRulesOnExit": true
+    "blockedHosts": []
   }
 }

--- a/test_configs/network_default_test.json
+++ b/test_configs/network_default_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Default-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_default_test.json
+++ b/test_configs/network_default_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Default-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_default_test.json
+++ b/test_configs/network_default_test.json
@@ -15,7 +15,6 @@
   "network": {
     "defaultPolicy": "block",
     "allowedHosts": ["api.github.com"],
-    "blockedHosts": [],
-    "removeRulesOnExit": true
+    "blockedHosts": []
   }
 }

--- a/test_configs/network_firewall_test.json
+++ b/test_configs/network_firewall_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Network-Firewall-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/network_firewall_test.json
+++ b/test_configs/network_firewall_test.json
@@ -16,7 +16,6 @@
     "defaultPolicy": "block",
     "enforcementMode": "firewall",
     "allowedHosts": [ "api.github.com" ],
-    "blockedHosts": [],
-    "removeRulesOnExit": true
+    "blockedHosts": []
   }
 }

--- a/test_configs/network_firewall_test.json
+++ b/test_configs/network_firewall_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Firewall-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/proxy_builtin_test.json
+++ b/test_configs/proxy_builtin_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Proxy-Builtin-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/proxy_builtin_test.json
+++ b/test_configs/proxy_builtin_test.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Proxy-Builtin-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/pwsh_setlocation.json
+++ b/test_configs/pwsh_setlocation.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Pwsh-SetLocation-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/pwsh_setlocation.json
+++ b/test_configs/pwsh_setlocation.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Pwsh-SetLocation-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/sandbox_custom_timeout.json
+++ b/test_configs/sandbox_custom_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Sandbox-Timeout",
   "containment": "sandbox",
   "process": {

--- a/test_configs/sandbox_custom_timeout.json
+++ b/test_configs/sandbox_custom_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Sandbox-Timeout",
   "containment": "sandbox",
   "process": {

--- a/test_configs/with_capabilities.json
+++ b/test_configs/with_capabilities.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0-alpha",
+  "version": "2",
   "containerId": "CLI-Cap-Test",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/with_capabilities.json
+++ b/test_configs/with_capabilities.json
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "0.4.0-alpha",
   "containerId": "CLI-Cap-Test",
   "containment": "appcontainer",
   "process": {


### PR DESCRIPTION
Step 4 of multi-step consolidation process.

Removes all dual-read fallback code for legacy config fields (script, workingDirectory, top-level timeout, appContainer.name, lxc.containerName, lxc.destroyOnExit, clearPolicyOnExit, removeRulesOnExit, container alias). Process section is now required. Runners read from container_id and lifecycle instead of removed ContainerPolicy/LxcConfig fields. Bumps SUPPORTED_MAJOR_VERSION to 2. Schema renamed to v2.

----------------------------------------------
**PR 1** ✅ Merged
   - `version`, `containerId`, `process` section with dual-read fallback. `Vm`/`MicroVm` enum variants.
   Manual `Default` for `CodexRequest`.

   **PR 2** ✅ Merged
   - `schemas/mxc-config.v1.schema.json`. Schema version validation. `idleTimeoutMs` dual-read. `containerId` →
  `app_container_name` mapping. Migrate 15 examples + 16 test configs. Update `docs/schema.md`.

   **PR 3** ✅ Merged
   - Add `LifecycleConfig` struct. Parse `lifecycle.destroyOnExit`/`preservePolicy` with dual-read from legacy
  fields. `wslc` alias for `container` key. Update `sdk/src/types.ts`, `cli/README.md`, `cli/ARCHITECTURE.md`,
  `sdk/README.md`.

   **PR 4** 🔄 In review -> This PR
   - Drop `script`, `workingDirectory`, top-level `timeout`, `container` alias, `appContainer.name`,
  `lxc.containerName`, `lxc.destroyOnExit`, `clearPolicyOnExit`, `removeRulesOnExit` from parser. Bump
  `SUPPORTED_MAJOR_VERSION` to 2.
----------------------------------------------

