### PR TITLE
App container bfs fix for file paths with spaces

### DIFF
--- a/src/wxc_common/src/filesystem_bfs.rs
+++ b/src/wxc_common/src/filesystem_bfs.rs
@@ -139,12 +139,7 @@ impl FileSystemBfsManager {
     }
 
     fn run_bfscfg(&self, args: &[&str]) -> Result<String, WxcError> {
-        // Build a command line: "bfscfg.exe arg1 arg2 ..."
-        let mut cmd_line = BFSCFG_EXE.to_string();
-        for arg in args {
-            cmd_line.push(' ');
-            cmd_line.push_str(arg);
-        }
+        let cmd_line = build_bfscfg_cmd_line(args);
 
         let output = process_util::run_process_with_captured_output(&cmd_line, BFSCFG_TIMEOUT_MS)?;
 
@@ -172,6 +167,17 @@ fn test_for_root_path(path: &str) -> bool {
     path != "C:\\"
 }
 
+// We control the arguments and ensure they are properly quoted, so this simple implementation
+// is sufficient for our needs. The only time we expect spaces in our arguments is for the user
+// provided path argument and user provided container name, both of which are properly quoted here.
+fn build_bfscfg_cmd_line(args: &[&str]) -> String {
+    let mut cmd_line = BFSCFG_EXE.to_string();
+    for arg in args {
+        cmd_line.push_str(&format!(" \"{arg}\""));
+    }
+    cmd_line
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -192,5 +198,20 @@ mod tests {
     fn test_new_manager() {
         let mgr = FileSystemBfsManager::new("test_container".to_string());
         assert!(!mgr.configured());
+    }
+
+    #[test]
+    fn test_build_cmd_line_quotes_args_with_spaces() {
+        let cmd = build_bfscfg_cmd_line(&[
+            "--addpolicy",
+            "--filename",
+            r"C:\Program Files\PowerShell\7",
+            "--appid",
+            "test_container",
+        ]);
+        assert_eq!(
+            cmd,
+            r#"bfscfg.exe "--addpolicy" "--filename" "C:\Program Files\PowerShell\7" "--appid" "test_container""#
+        );
     }
 }

--- a/test_configs/filesystem_bfs_spaces_test.json
+++ b/test_configs/filesystem_bfs_spaces_test.json
@@ -3,7 +3,7 @@
   "containerId": "CLI-BFS-Spaces-Test",
   "containment": "appcontainer",
   "process": {
-    "commandLine": "python -c \"import os, sys\nallowed_dir = 'C:\\\\Users\\\\Public\\\\wxc bfs test'\nallowed_path = os.path.join(allowed_dir, 'test_output.txt')\ndenied_path = 'C:\\\\temp\\\\wxc_test_denied\\\\forbidden.txt'\nprint('Testing BFS with spaces in path...')\nf = open(allowed_path, 'w')\nf.write('SUCCESS')\nf.close()\nprint(f'Wrote to: {allowed_path}')\ntry:\n    f2 = open(denied_path, 'w')\n    f2.write('should fail')\n    f2.close()\n    print('ERROR: Write to denied path should have failed!')\n    sys.exit(1)\nexcept PermissionError:\n    print('SUCCESS: Access denied on path outside BFS policy')\"",
+    "commandLine": "cmd.exe /c echo SUCCESS > \"C:\\Users\\Public\\wxc bfs test\\test_output.txt\" && type \"C:\\Users\\Public\\wxc bfs test\\test_output.txt\"",
     "timeout": 30000
   },
   "filesystem": {

--- a/test_configs/filesystem_bfs_spaces_test.json
+++ b/test_configs/filesystem_bfs_spaces_test.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-BFS-Spaces-Test",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "python -c \"import os, sys\nallowed_dir = 'C:\\\\Users\\\\Public\\\\wxc bfs test'\nallowed_path = os.path.join(allowed_dir, 'test_output.txt')\ndenied_path = 'C:\\\\temp\\\\wxc_test_denied\\\\forbidden.txt'\nprint('Testing BFS with spaces in path...')\nf = open(allowed_path, 'w')\nf.write('SUCCESS')\nf.close()\nprint(f'Wrote to: {allowed_path}')\ntry:\n    f2 = open(denied_path, 'w')\n    f2.write('should fail')\n    f2.close()\n    print('ERROR: Write to denied path should have failed!')\n    sys.exit(1)\nexcept PermissionError:\n    print('SUCCESS: Access denied on path outside BFS policy')\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [ "C:\\Users\\Public\\wxc bfs test" ]
+  }
+}

--- a/test_scripts/run_filesystem_bfs_spaces_test.ps1
+++ b/test_scripts/run_filesystem_bfs_spaces_test.ps1
@@ -1,0 +1,47 @@
+# Tests that BFS paths with spaces (e.g. "C:\Users\Public\wxc bfs test") are
+# quoted correctly when passed to bfscfg.exe.
+
+param(
+    [ValidateSet(
+        "x86_64-pc-windows-msvc",
+        "aarch64-pc-windows-msvc",
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu")
+    ]
+    [System.String]
+    $Target = "x86_64-pc-windows-msvc",
+
+    [ValidateSet('debug', 'release')]
+    [System.String]
+    $Config = "release"
+)
+
+$ErrorActionPreference = 'Stop'
+$wxcExe = Join-Path $PSScriptRoot "..\src\target\$Target\$Config\wxc-exec.exe"
+$testConfig = Join-Path $PSScriptRoot "..\test_configs\filesystem_bfs_spaces_test.json"
+$testDir = "C:\Users\Public\wxc bfs test"
+
+if (-not (Test-Path $wxcExe)) {
+    Write-Host "ERROR: wxc-exec.exe not found at $wxcExe" -ForegroundColor Red
+    Write-Host "Run 'build.bat --debug' from the repo root first." -ForegroundColor Yellow
+    exit 1
+}
+
+try {
+    New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+    Write-Host "Running BFS spaces-in-path test..."
+    & $wxcExe --debug $testConfig
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -ne 0) {
+        Write-Host "FAILED: wxc-exec exited with code $exitCode" -ForegroundColor Red
+        exit $exitCode
+    }
+
+    Write-Host "PASSED: BFS path with spaces handled correctly" -ForegroundColor Green
+} finally {
+    if (Test-Path $testDir) {
+        Remove-Item -Recurse -Force $testDir
+    }
+}


### PR DESCRIPTION
### Why is this change needed?
We don't account for the spaces that might appear in the file path so `Bfscfg.exe` errors with something like:
```
Output from bfscfg.exe:
Unknown option: test
```
For a file path like `"C:\Users\Public\Documents\new test"` when using something like this in the `filesystem` json
```json
  "filesystem": {
    "readwritePaths": [ "C:\\Users\\Public\\Documents\\new test" ]
  }
```

Note: We create the arguments we pass to `Bfscfg.exe` ourselves in the code and only add in 2 user provided arguments (filename and appid).

### What changed?
- updated the arguments we pass to bfscfg.exe to be contained within quotes.  

### How was this tested?
- Added new test_config and test script. I confirmed we no longer get the error. However when looking into this error I realized another issue. We don't handle all bfscfg failures see: #67
- Also added unit test as well.

fixes:#65 

