### PR TITLE
﻿Refactor build pipelines into reusable templates and use Central Feed Services

### DIFF
--- a/.azure-pipelines/.cargo/config.toml
+++ b/.azure-pipelines/.cargo/config.toml
@@ -1,0 +1,15 @@
+
+# Instruct Cargo to use the Azure Artifacts feed instead of crates.io for pulling public crates
+# in ADO pipelines. This file is copied to the `<repo-root>/src` folder during rust pipeline builds.
+# See: https://eng.ms/docs/more/languages-at-microsoft/rust/articles/gettingstarted/install/installcicd
+# See: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust
+
+[registries]
+Mxc-Azure-Feed = { index = "sparse+https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/Cargo/index/" }
+
+[source.crates-io]
+replace-with = "Mxc-Azure-Feed"
+
+# Add linker for arm64 on linux for cross-compilation
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.azure-pipelines/.npm/.npmrc
+++ b/.azure-pipelines/.npm/.npmrc
@@ -1,0 +1,6 @@
+; Used in azure pipelines to point to our azure artifacts feed for npm packages.
+; See README.md in <repo-root>/.azure-pipelines/ for more details on Central Feeds Services.
+; This file is copied to the '<repo-root>/sdk' folder during npm pipeline builds.
+registry=https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/npm/registry/ 
+                 
+always-auth=true

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -3,6 +3,7 @@
 
 trigger: none
 name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -12,6 +13,14 @@ resources:
 
 # Parameters for ESRP signing info will be passed from the ADO UI.
 parameters:
+  - name: officialBuild
+    displayName: Build Official or Unofficial
+    type: string
+    default: Official
+    values:
+      - Official
+      - Unofficial
+
   - name: ESRPInfo
     type: object
     default:
@@ -22,287 +31,65 @@ parameters:
       signCertName: ''
       clientId: ''
 
+variables:
+  # Prevents failure when no Rust tests are found; pipeline runs will still fail if present
+  # tests do not pass.
+  NEXTEST_NO_TESTS: pass
+
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/1ES.${{parameters.officialBuild}}.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       image: windows-2022
       os: windows
+
     customBuildTags:
     - ES365AIMigrationTooling
+
     stages:
     - stage: Build_Binaries
       displayName: 'Build Executables'
       jobs:
-        - job: build_wxc
-          displayName: Build WXC using toolchain
-          pool:
-            name: Azure-Pipelines-1ESPT-ExDShared
-            image: windows-2022
-            os: windows
-          templateContext:
-            rust:
-              rustToolchain:
-                toolchainFeed: https://pkgs.dev.azure.com/microsoft/_packaging/RustTools/nuget/v3/index.json
-                cratesIoFeed: sparse+https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/Cargo/index/
-              workingDirectory: src
-          strategy:
+
+        # Build Binaries for all targets in parallel
+        - template: .azure-pipelines/templates/Rust.Build.Job.yml@self
+          parameters:
+            isOfficialBuild: ${{ eq(parameters.officialBuild, 'Official') }}
             matrix:
-              x64_windows:
-                triplet: x86_64-pc-windows-msvc
-              arm64_windows:
-                triplet: aarch64-pc-windows-msvc
-          variables:
-            # This is the temp directory that Cargo will use for compiling Rust crates.
-            # We use c:\t\target to avoid interference from the container host.
-            CARGO_TARGET_DIR: c:\t\target
-            targetTriple: $(triplet)
-            targetTripleDir: $(CARGO_TARGET_DIR)\$(targetTriple)\release
-            outputDirectory: $(Build.SourcesDirectory)\out
-            artifactBaseName: wxc-binaries-$(targetTriple)
+              - name: windows_x64
+                os: windows
+                arch: x64
+                component: WXC
+              - name: windows_arm64
+                os: windows
+                arch: arm64
+                component: WXC
+              - name: linux_x64
+                os: linux
+                arch: x64
+                component: LXC
+              - name: linux_arm64
+                os: linux
+                arch: arm64
+                component: LXC
 
-          steps:
-            - checkout: self
-            - task: 1ES.Build.Rust.Setup@1
-            - task: 1ES.Build.Rust.Restore@1
+            ESRPInfo: ${{ parameters.ESRPInfo }}
 
-            # Build Windows WXC crates without building LXC
-            - task: 1ES.Build.Rust.Run@1
-              displayName: Build Windows crates
-              condition: contains(variables['triplet'], 'windows')
-              inputs:
-                command: build
-                profile: release
-                target: $(triplet)
-                buildExtraArgs: '--exclude lxc --exclude lxc_common'
-                enableTest: true
-                enableClippy: true
-
-            # Sign binaries in build folder
-            - task: EsrpCodeSigning@5
-              displayName: Code Sign ESRP
-              inputs:
-                ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
-                AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
-                AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }} 
-                AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
-                AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
-                AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
-                FolderPath: $(targetTripleDir)
-                Pattern: |
-                  wxc-exec.exe
-                  winhttp-proxy-shim.exe
-                  wxc-sandbox-daemon.exe
-                  wxc-sandbox-agent.exe
-                  wxc-test-proxy.exe
-                UseMinimatch: true
-                signConfigType: inlineSignParams
-                inlineOperation: |
-                  [
-                    {
-                      "keyCode": "CP-230012",
-                      "operationCode": "SigntoolSign",
-                      "parameters": {
-                        "OpusName": "Microsoft eXecution Container",
-                        "OpusInfo": "https://github.com/microsoft/mxc",
-                        "FileDigest": "/fd \"SHA256\"",
-                        "PageHash": "/NPH",
-                        "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      },
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                    },
-                    {
-                      "keyCode": "CP-230012",
-                      "operationCode": "SigntoolVerify",
-                      "parameters": {},
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                    }
-                  ]
-            
-            - task: CopyFiles@2
-              displayName: Copy Release Binaries
-              inputs:
-                sourceFolder: $(targetTripleDir)
-                contents: |
-                  wxc-exec.exe
-                  winhttp-proxy-shim.exe
-                  wxc-sandbox-daemon.exe
-                  wxc-sandbox-agent.exe
-                  wxc-test-proxy.exe
-                targetFolder: $(outputDirectory)/$(targetTriple)
-
-            - task: 1ES.PublishPipelineArtifact@1
-              displayName: Upload binaries as pipeline artifact
-              inputs:
-                path: '$(outputDirectory)/$(targetTriple)'
-                artifactName: $(artifactBaseName)
-
-        - job: build_lxc
-          displayName: Build LXC using toolchain
-          dependsOn: build_wxc
-          pool:
-            name: Azure-Pipelines-1ESPT-ExDShared
-            image: ubuntu-latest
-            os: linux
-          templateContext:
-            rust:
-              rustToolchain:
-                toolchainFeed: https://pkgs.dev.azure.com/microsoft/_packaging/RustTools/nuget/v3/index.json
-                cratesIoFeed: sparse+https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/Cargo/index/
-              workingDirectory: src
-          strategy:
-            matrix:
-              x64_linux:
-                triplet: x86_64-unknown-linux-gnu
-                workingDirectory: $(Build.SourcesDirectory)/src/lxc
-              arm64_linux:
-                triplet: aarch64-unknown-linux-gnu
-                workingDirectory: $(Build.SourcesDirectory)/src/lxc
-          variables:
-            # This is the temp directory that Cargo will use for compiling Rust crates.
-            # We use /tmp/target to avoid interference from the container host.
-            CARGO_TARGET_DIR: /tmp/target
-            targetTriple: $(triplet)
-            targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
-            outputDirectory: $(Build.SourcesDirectory)/out
-            artifactBaseName: lxc-binaries-$(targetTriple)
-
-          steps:
-            - checkout: self
-            - task: 1ES.Build.Rust.Setup@1
-            - task: 1ES.Build.Rust.Restore@1
-
-            # Build Linux LXC crates without building WXC
-            - task: 1ES.Build.Rust.Run@1
-              displayName: Build Linux crates
-              condition: contains(variables['triplet'], 'linux')
-              inputs:
-                command: build
-                workingDirectory: $(workingDirectory)
-                profile: release
-                target: $(triplet)
-                enableTest: true
-                enableClippy: true
-
-            # Sign binaries in build folder
-            - task: EsrpCodeSigning@5
-              displayName: Code Sign ESRP
-              inputs:
-                ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
-                AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
-                AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }} 
-                AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
-                AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
-                AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
-                FolderPath: $(targetTripleDir)
-                Pattern: |
-                  lxc-exec.exe
-                UseMinimatch: true
-                signConfigType: inlineSignParams
-                inlineOperation: |
-                  [
-                    {
-                      "keyCode": "CP-230012",
-                      "operationCode": "SigntoolSign",
-                      "parameters": {
-                        "OpusName": "Microsoft eXecution Container",
-                        "OpusInfo": "https://github.com/microsoft/mxc",
-                        "FileDigest": "/fd \"SHA256\"",
-                        "PageHash": "/NPH",
-                        "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      },
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                    },
-                    {
-                      "keyCode": "CP-230012",
-                      "operationCode": "SigntoolVerify",
-                      "parameters": {},
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                    }
-                  ]
-            
-            - task: CopyFiles@2
-              displayName: Copy Release Binaries
-              inputs:
-                sourceFolder: $(targetTripleDir)
-                contents: |
-                  lxc-exec.exe
-                targetFolder: $(outputDirectory)/$(targetTriple)
-
-            - task: 1ES.PublishPipelineArtifact@1
-              displayName: Upload binaries as pipeline artifact
-              inputs:
-                path: '$(outputDirectory)/$(targetTriple)'
-                artifactName: $(artifactBaseName)      
-
-    - stage: Package_MXC_SDK
-      displayName: 'Package MXC SDK'
+    - stage: Package_MXC_NPM_SDK
+      displayName: 'Package Npm Sdk'
       dependsOn: Build_Binaries
-      jobs:    
-        - job: package_mxc_sdk
-          displayName: Package MXC SDK
-          pool:
-            type: windows
-          variables:
-            outputDirectory: $(Build.SourcesDirectory)\out
-            sdkDirectory: $(Build.SourcesDirectory)\sdk
-            artifactBaseName: mxc-sdk-package
-          steps:
-            - task: DownloadPipelineArtifact@2
-              displayName: Download wxc x64 binary
-              inputs:
-                artifact: wxc-binaries-x86_64-pc-windows-msvc
-                path: $(sdkDirectory)/bin/x86_64-pc-windows-msvc
+      jobs:
+      - template: .azure-pipelines/templates/Package.NpmSdk.Job.yml@self
+        parameters:
+          targets:
+            - artifact: wxc-binaries-x86_64-pc-windows-msvc
+              path: x86_64-pc-windows-msvc
+            - artifact: wxc-binaries-aarch64-pc-windows-msvc
+              path: aarch64-pc-windows-msvc
+            - artifact: lxc-binaries-x86_64-unknown-linux-gnu
+              path: x86_64-unknown-linux-gnu
+            - artifact: lxc-binaries-aarch64-unknown-linux-gnu
+              path: aarch64-unknown-linux-gnu
 
-            - task: DownloadPipelineArtifact@2
-              displayName: Download wxc arm64 binary
-              inputs:
-                artifact: wxc-binaries-aarch64-pc-windows-msvc
-                path: $(sdkDirectory)/bin/aarch64-pc-windows-msvc
-            
-            - task: DownloadPipelineArtifact@2
-              displayName: Download lxc x64 binary
-              inputs:
-                artifact: lxc-binaries-x86_64-unknown-linux-gnu
-                path: $(sdkDirectory)/bin/x86_64-unknown-linux-gnu
-
-            - task: DownloadPipelineArtifact@2
-              displayName: Download lxc arm64 binary
-              inputs:
-                artifact: lxc-binaries-aarch64-unknown-linux-gnu
-                path: $(sdkDirectory)/bin/aarch64-unknown-linux-gnu
-                      
-            - task: NpmAuthenticate@0
-              displayName: NPM Authenticate
-              inputs:
-                workingFile: '$(Build.SourcesDirectory)/.npmrc'
-
-            - script: npm clean install
-              workingDirectory: $(sdkDirectory)
-              displayName: npm ci
-            - script: npm build
-              workingDirectory: $(sdkDirectory)
-              displayName: npm run build
-
-            - script:  Pack npm package
-              workingDirectory: $(sdkDirectory)
-              displayName: npm pack
-
-            - task: CopyFiles@2
-              displayName: Copy Release Binaries
-              inputs:
-                sourceFolder: $(sdkDirectory)
-                contents: |
-                  *.tgz
-                targetFolder: '$(outputDirectory)/packages'
-              
-            - task: 1ES.PublishPipelineArtifact@1
-              displayName: Upload SDK as pipeline artifact
-              inputs:
-                path: '$(outputDirectory)/packages'
-                artifactName: $(artifactBaseName)
+          ESRPInfo: ${{ parameters.ESRPInfo }}

--- a/.azure-pipelines/1ES.Release.yml
+++ b/.azure-pipelines/1ES.Release.yml
@@ -18,6 +18,7 @@ parameters:
       serviceName: ''
       tenantId: ''
       azureKeyVaultName: ''
+      authCertName: ''
       signCertName: ''
       clientId: ''
       ApproversEmail: ''
@@ -53,7 +54,7 @@ extends:
           inputs:
           - input: pipelineArtifact
             targetPath: '$(Pipeline.Workspace)/packages'
-            artifactName: mxc-sdk-package
+            artifactName: mxc-npm-sdk-package
 
         displayName: Publish to NPM
         pool:
@@ -63,14 +64,19 @@ extends:
           displayName: 'Publish to NPM'
           inputs:
             connectedservicename: ${{ parameters.ESRPInfo.serviceName }}
-            usemanagedidentity: true 
+            usemanagedidentity: true
             keyvaultname: ${{ parameters.ESRPInfo.azureKeyVaultName }}
+            authcertname: ${{ parameters.ESRPInfo.authCertName }}
             signcertname: ${{ parameters.ESRPInfo.signCertName }}
             clientid: ${{ parameters.ESRPInfo.clientId }}
+            intent: 'PackageDistribution'
             contenttype: npm
+            contentsource: 'Folder'
             folderlocation: '$(Pipeline.Workspace)/packages'
             owners: ${{ parameters.ESRPInfo.OwnersEmail }}
             approvers: ${{ parameters.ESRPInfo.ApproversEmail }}
+            waitforreleasecompletion: true
+            serviceendpointurl: 'https://api.esrp.microsoft.com'
             mainpublisher: ESRPRELPACMAN
             domaintenantid: ${{ parameters.ESRPInfo.tenantId }} 
 

--- a/.azure-pipelines/README.md
+++ b/.azure-pipelines/README.md
@@ -1,0 +1,20 @@
+# Configuration Strategy
+
+## For Developers
+
+Developers should to use public registries like `crates.io`
+and `npmjs` directly so they can iterate quickly.
+
+## For CI/Pipelines
+
+### Central Feed Services
+Production CI pipelines use an Azure Artifacts feed (CFS) to source dependencies
+from crates.io and npmjs, helping ensure secure and vetted consumption of third‑party packages.
+For Microsoft folks see: [Central Feed Services](https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/central-feed-services-cfs/central-feed-services-cfs).
+
+### Production Build and Release pipelines
+- We use Azure pipelines for official builds with signing and public releases.
+
+### PR Pipelines
+- We use github actions but will be consolidated to use the azure pipelines which
+  contain governance tasks, like binary scanning etc in the future.

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: Targets
+  type: object
+  default: []   # list of { artifact, path }
+- name: ESRPInfo
+  type: object
+  default: {}
+
+jobs:
+- job: package_mxc_npm_sdk
+  displayName: Package Mxc Npm Sdk
+  pool:
+    name: Azure-Pipelines-1ESPT-ExDShared
+    image: windows-latest
+    os: windows
+  variables:
+    outputDirectory: $(Build.SourcesDirectory)\out
+    sdkDirectory: $(Build.SourcesDirectory)\sdk
+    artifactBaseName: mxc-npm-sdk-package
+
+  steps:
+    - checkout: self
+
+    # Download all artifacts dynamically
+    - ${{ each target in parameters.targets }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download ${{ target.artifact }}
+        inputs:
+          artifact: ${{ target.artifact }}
+          path: $(sdkDirectory)/bin/${{ target.path }}
+
+    # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
+    - task: CopyFiles@2
+      displayName: Copy .npmrc to SDK
+      inputs:
+        SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
+        Contents: '.npmrc'
+        TargetFolder: '$(sdkDirectory)'
+
+    - task: NpmAuthenticate@0
+      displayName: NPM Authenticate
+      inputs:
+        workingFile: '$(sdkDirectory)/.npmrc'
+
+    - script: npm ci
+      workingDirectory: $(sdkDirectory)
+      displayName: npm ci
+
+    - script: npm run build
+      workingDirectory: $(sdkDirectory)
+      displayName: npm run build
+
+    - script: npm pack
+      workingDirectory: $(sdkDirectory)
+      displayName: npm pack
+
+    - task: CopyFiles@2
+      displayName: Copy npm package
+      inputs:
+        sourceFolder: $(sdkDirectory)
+        contents: |
+          *.tgz
+        targetFolder: '$(outputDirectory)/packages'
+
+    - task: 1ES.PublishPipelineArtifact@1
+      displayName: Upload SDK as pipeline artifact
+      inputs:
+        path: '$(outputDirectory)/packages'
+        artifactName: $(artifactBaseName)

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -1,0 +1,167 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: isOfficialBuild
+  type: boolean
+  default: false
+- name: matrix
+  type: object
+  default: {}
+- name: ESRPInfo
+  type: object
+  default: {}
+
+jobs:
+- ${{ each item in parameters.matrix }}:
+  - job: 'build_${{ item.arch }}_${{ item.component }}'
+    displayName: 'Build (${{ item.arch }} ${{ item.component }})'
+
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      ${{ if eq(item.os, 'windows') }}:
+        image: windows-latest #x64 host
+        os: windows
+      ${{ if eq(item.os, 'linux') }}:
+        image: ubuntu-latest #x64 host
+        os: linux
+
+    variables:
+
+      # Triplet
+      ${{ if and(eq(item.os, 'windows'), eq(item.arch, 'x64')) }}:
+        triplet: x86_64-pc-windows-msvc
+      ${{ if and(eq(item.os, 'windows'), eq(item.arch, 'arm64')) }}:
+        triplet: aarch64-pc-windows-msvc
+      ${{ if and(eq(item.os, 'linux'), eq(item.arch, 'x64')) }}:
+        triplet: x86_64-unknown-linux-gnu
+      ${{ if and(eq(item.os, 'linux'), eq(item.arch, 'arm64')) }}:
+        triplet: aarch64-unknown-linux-gnu
+
+      # Windows specific variables
+      ${{ if eq(item.os, 'windows') }}:
+        CARGO_TARGET_DIR: c:/t/target
+        artifactPrefix: wxc-binaries
+        workingDirectory: src
+        buildExtraArgs: '--workspace --exclude lxc --exclude lxc_common'
+        signPattern: |
+            wxc-exec.exe
+            winhttp-proxy-shim.exe
+            wxc-sandbox-daemon.exe
+            wxc-sandbox-agent.exe
+            wxc-test-proxy.exe
+
+      # Linux specific variables
+      ${{ if eq(item.os, 'linux') }}:
+        CARGO_TARGET_DIR: /tmp/target
+        artifactPrefix: lxc-binaries
+        workingDirectory: $(Build.SourcesDirectory)/src/lxc
+        buildExtraArgs: ''
+        signPattern: |
+          lxc-exec
+
+      ${{ if eq(item.arch, 'x64') }}:
+        isX64: true
+        
+      ${{ if eq(item.arch, 'arm64') }}:
+        isX64: false
+      
+      # Paths
+      targetTriple: $(triplet)
+      targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
+      outputDirectory: $(Build.SourcesDirectory)/out
+      artifactBaseName: $(artifactPrefix)-$(targetTriple)
+
+    templateContext:
+      rust:
+        rustToolchain:
+          toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
+          version: 'ms-prod-1.93'
+          additionalTargets: $(triplet)
+        workingDirectory: $(workingDirectory)
+
+    steps:
+      - checkout: self
+
+      # Install Linux ARM64 toolchain for arm64 linux builds
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+        displayName: Install ARM64 toolchain
+        condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
+
+      - task: CopyFiles@2
+        displayName: Setup Cargo Config
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.cargo'
+          Contents: 'config.toml'
+          TargetFolder: '$(Build.SourcesDirectory)/.cargo'
+
+      - task: 1ES.Build.Rust.Setup@1
+      - task: 1ES.Build.Rust.Restore@1
+
+      - task: 1ES.Build.Rust.Run@1
+        displayName: Build
+        inputs:
+          command: build
+          profile: release
+          target: $(triplet)
+          testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
+          enableTests: $(isX64)
+          publishTestResults: $(isX64)
+          enableClippy: $(isX64)
+          useNextest: $(isX64)
+          testAllTargets: false
+          buildAllTargets: false
+
+      - task: EsrpCodeSigning@5
+        displayName: Code Sign
+        condition: and(eq(${{ parameters.isOfficialBuild }}, true), eq('${{ item.os }}', 'windows'))
+        inputs:
+          ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
+          AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
+          AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }}
+          AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
+          AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
+          AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
+          FolderPath: $(targetTripleDir)
+          Pattern: |
+            $(signPattern)
+          UseMinimatch: true
+          inlineOperation: >-
+            [
+              {
+                "KeyCode": "CP-230012",
+                "OperationCode": "SigntoolSign",
+                "ToolName": "sign",
+                "ToolVersion": "1.0",
+                "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                }
+              },
+              {
+                "KeyCode": "CP-230012",
+                "OperationCode": "SigntoolVerify",
+                "ToolName": "sign",
+                "ToolVersion": "1.0",
+                "Parameters": {}
+              }
+            ]
+
+      - task: CopyFiles@2
+        displayName: Copy binaries
+        inputs:
+          sourceFolder: $(targetTripleDir)
+          contents: |
+            $(signPattern)
+          targetFolder: $(outputDirectory)/$(targetTriple)
+
+      - task: 1ES.PublishPipelineArtifact@1
+        displayName: Publish
+        inputs:
+          path: '$(outputDirectory)/$(targetTriple)'
+          artifactName: $(artifactBaseName)


### PR DESCRIPTION
### Summary

﻿Continuation of #52. Refactors the 1ES build pipeline by extracting inline job definitions into reusable YAML
templates and integrates Central Feed Services for secure dependency consumption in the ADO pipelines.

Tested and confirmed working via pipeline builds: https://microsoft.visualstudio.com/Dart/_build?definitionId=190018

### Changes
﻿- **Templatized build jobs**: Refactored the Rust build/sign/artifact publish steps with a parameterized 
`Rust.Build.Job.yml` template driven by a matrix of OS/arch/component targets.
 - **Templatized SDK packaging**: Extracted NPM SDK packaging into `Package.NpmSdk.Job.yml` with dynamic artifact 
download.
 - **Central Feed Services**: Added `.cargo/config.toml` and `.npm/.npmrc` to route CI builds through Azure Artifacts 
feeds, keeping developer workflows on public registries.
 - **Official/Unofficial builds** — Added officialBuild parameter to toggle between 1ES.Official and 1ES.Unofficial 
pipeline templates.
 - **Release pipeline fixes** : Added missing ESRP fields (`authCertName`, `intent`, `serviceendpointurl`) and updated 
artifact name to `mxc-npm-sdk-package`.
 - Added `.azure-pipelines/README.md` documenting CI feed strategy.