### PR TITLE
[SDK/CLI] Fix SDK payload format, add SandboxPolicy versioning, and test infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Pack npm package
         run: npm pack
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,7 @@
     "watch": "tsc --watch",
     "start": "node dist/cli.js",
     "dev": "ts-node src/cli.ts",
-    "test": "jest",
+    "test": "node --test dist/cli.test.js",
     "lint": "eslint src --ext .ts",
     "clean": "rimraf dist"
   },

--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const cliPath = path.join(__dirname, '..', 'dist', 'cli.js');
+
+function runCli(args: string): string {
+  try {
+    return execSync(`node ${cliPath} ${args}`, {
+      encoding: 'utf-8',
+      timeout: 60000,
+      cwd: path.join(__dirname, '..'),
+    });
+  } catch (error: any) {
+    const stderr = error.stderr?.toString() ?? '';
+    const stdout = error.stdout?.toString() ?? '';
+    throw new Error(`CLI failed (exit ${error.status}):\nstdout: ${stdout}\nstderr: ${stderr}`);
+  }
+}
+
+describe('SDK end-to-end', () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  function createTempDir(): string {
+    tempDir = path.join(os.tmpdir(), `mxc-test-${Date.now()}`);
+    fs.mkdirSync(tempDir);
+    return tempDir;
+  }
+
+  function writeTempPolicy(dir: string, policy: object): string {
+    const filePath = path.join(dir, 'policy.json');
+    fs.writeFileSync(filePath, JSON.stringify(policy));
+    return filePath;
+  }
+
+  it('cmd.exe: should execute in appcontainer', () => {
+    const dir = createTempDir();
+    const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
+    const output = runCli(`run-sdk --script "cmd.exe /c echo Container test successful" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('Container test successful'));
+    assert.ok(output.includes('Process exited with code 0'));
+  });
+
+  it('powershell 5.1: should execute in appcontainer', () => {
+    const dir = createTempDir();
+    const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
+    const output = runCli(`run-sdk --script "powershell.exe -NoProfile -Command Write-Output 'PowerShell test successful'" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('PowerShell test successful'));
+    assert.ok(output.includes('Process exited with code 0'));
+  });
+
+  it('python: should execute in appcontainer', () => {
+    const dir = createTempDir();
+    const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
+    const output = runCli(`run-sdk --script "python -c \\"print('Python test successful')\\"" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('Python test successful'));
+    assert.ok(output.includes('Process exited with code 0'));
+  });
+
+  it('readwritePaths: should allow writing to brokered path', () => {
+    const dir = createTempDir();
+    const testFile = path.join(dir, 'output.txt');
+    const scriptFile = path.join(dir, 'write_test.py');
+    fs.writeFileSync(scriptFile, `f = open(r'${testFile}', 'w')\nf.write('hello')\nf.close()\nprint('WRITE_OK')\n`);
+    const policyFile = writeTempPolicy(dir, {
+      version: '0.4.0-alpha',
+      filesystem: { readwritePaths: [dir] },
+    });
+    const output = runCli(`run-sdk --script "python ${scriptFile}" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('WRITE_OK'));
+    assert.ok(output.includes('Process exited with code 0'));
+    assert.ok(fs.existsSync(testFile), 'File should have been written to readwrite path');
+  });
+
+  it('readonlyPaths: should allow reading from brokered path', () => {
+    const dir = createTempDir();
+    fs.writeFileSync(path.join(dir, 'input.txt'), 'readonly test data');
+    const inputFile = path.join(dir, 'input.txt');
+    const policyFile = writeTempPolicy(dir, {
+      version: '0.4.0-alpha',
+      filesystem: { readonlyPaths: [dir] },
+    });
+    const output = runCli(`run-sdk --script "cmd.exe /c type ${inputFile}" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('readonly test data'));
+    assert.ok(output.includes('Process exited with code 0'));
+  });
+});

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,37 +1,50 @@
-#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 
 import { Command } from 'commander';
-import { WxcExecutor } from './wxc-executor';
+import { ContainerExecutor } from './wxc-executor';
 import {
   spawnSandbox,
   getPlatformSupport,
   SandboxPolicy,
-  getAvailableToolsPolicy
 } from '@microsoft/mxc-sdk';
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { WxcConfiguration } from '@microsoft/mxc-sdk/dist/types';
+import { ContainerConfig } from '@microsoft/mxc-sdk/dist/types';
 
 const program = new Command();
 
 program
   .name('wxc-cli')
-  .description('CLI for invoking the WXC (Windows eXecution Container)')
+  .description('CLI test driver for the MXC SDK and container backends')
   .version('0.1.0');
 
 program
   .command('run')
-  .description('Run Python code with WXC sandbox')
-  .argument('<config>', 'Path to JSON configuration file or base64-encoded config')
+  .description('Run a config for a specific container backend')
+  .argument('<config>', 'Path to ContainerConfig JSON file or base64-encoded config')
   .option('--config-base64', 'Treat config argument as base64-encoded JSON')
   .option('--debug', 'Enable debug output')
-  .option('--wxc-path <path>', 'Path to wxc-exec.exe executable', path.join(__dirname, '..', '..', 'src', 'target', 'debug', 'wxc-exec.exe'))
-  .action(async (config: string, options: { base64?: boolean; debug?: boolean; wxcPath: string }) => {
+  .action(async (config: string, options: { configBase64?: boolean; debug?: boolean }) => {
     try {
-      const executor = new WxcExecutor(options.wxcPath);
+      const platform = require('os').platform();
+      let execPath: string | null;
+      if (platform === 'linux') {
+        const { findLxcExecutable } = require('@microsoft/mxc-sdk');
+        execPath = findLxcExecutable();
+      } else {
+        const { findWxcExecutable } = require('@microsoft/mxc-sdk');
+        execPath = findWxcExecutable();
+      }
+      if (!execPath) {
+        console.error('Error: Executable not found. Ensure wxc-exec or lxc-exec is built.');
+        process.exit(1);
+      }
+      const executor = new ContainerExecutor(execPath);
       const result = await executor.run(config, {
-        isBase64: options.base64 ?? false,
+        isBase64: options.configBase64 ?? false,
         debug: options.debug ?? false
       });
 
@@ -66,16 +79,17 @@ program
       }
 
       const content = fs.readFileSync(configPath, 'utf-8');
-      const policy: WxcConfiguration = JSON.parse(content);
+      const policy: ContainerConfig = JSON.parse(content);
 
       // Basic validation
-      if (!policy.script) {
-        console.error('Invalid configuration: missing script.code');
+      if (!policy.process?.commandLine) {
+        console.error('Invalid configuration: missing process.commandLine');
         process.exit(1);
       }
 
+      const scriptLength = policy.process.commandLine.length;
       console.log('Configuration is valid');
-      console.log('Script code length:', policy.script.length, 'characters');
+      console.log('Script code length:', scriptLength, 'characters');
 
       if (policy.appContainer) {
         console.log('AppContainer:', policy.appContainer.name || 'WXC');
@@ -110,97 +124,56 @@ program
     }
   });
 
-// SDK-based commands
 program
   .command('run-sdk')
-  .description('Run code with WXC sandbox using SDK (interactive mode with node-pty)')
-  .argument('<config>', 'Path to JSON configuration file')
+  .description('Simulate SDK usage: build a sandbox payload from a SandboxPolicy and spawn it')
+  .option('--script <command>', 'Command line to execute')
+  .option('--script-file <path>', 'Path to a script file (contents are read and passed as the command)')
+  // Policy JSON should match the SandboxPolicy type defined in sdk/src/types.ts
+  .option('--policy <json>', 'SandboxPolicy as a JSON string')
+  .option('--policy-file <path>', 'Path to a SandboxPolicy JSON file')
   .option('--debug', 'Enable debug output')
-  .action(async (configPath: string, options: { debug?: boolean; wxcPath?: string }) => {
+  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; debug?: boolean }) => {
     try {
-      // Check platform support
-      const platformInfo = getPlatformSupport();
-      if (!platformInfo.isSupported) {
-        console.error(`Error: MXC is not supported on this platform: ${platformInfo.reason}`);
+      let scriptCommand: string;
+      if (options.script) {
+        scriptCommand = options.script;
+      } else if (options.scriptFile) {
+        if (!fs.existsSync(options.scriptFile)) {
+          console.error(`Script file not found: ${options.scriptFile}`);
+          process.exit(1);
+        }
+        scriptCommand = fs.readFileSync(path.resolve(options.scriptFile), 'utf-8').trim();
+      } else {
+        console.error('Error: Provide --script <command> or --script-file <path>');
         process.exit(1);
       }
 
-      // Read configuration
-      if (!fs.existsSync(configPath)) {
-        console.error(`Configuration file not found: ${configPath}`);
+      let policy: SandboxPolicy;
+      if (options.policy) {
+        policy = JSON.parse(options.policy);
+      } else if (options.policyFile) {
+        if (!fs.existsSync(options.policyFile)) {
+          console.error(`Policy file not found: ${options.policyFile}`);
+          process.exit(1);
+        }
+        policy = JSON.parse(fs.readFileSync(options.policyFile, 'utf-8'));
+      } else {
+        console.error('Error: Provide --policy <json> or --policy-file <path>');
         process.exit(1);
-      }
-
-      // NOTE: This is a lossy conversion since WxcConfiguration is not exactly
-      //  the same as SandboxPolicy, but for demo purposes we will just extract
-      //  the relevant parts.
-      const content = fs.readFileSync(configPath, 'utf-8');
-      const config: WxcConfiguration = JSON.parse(content);
-      const policy: SandboxPolicy = {
-        filesystem: config.filesystem ? {
-            readwritePaths: config.filesystem?.readwritePaths,
-            readonlyPaths: config.filesystem?.readonlyPaths,
-            deniedPaths: config.filesystem?.deniedPaths,
-            clearPolicyOnExit: config.filesystem?.clearPolicyOnExit ?? true,
-        } : undefined,
-      };
-
-      // Discover tool paths from the current environment and merge them
-      const toolsPolicy = getAvailableToolsPolicy(process.env);
-      if (toolsPolicy.readonlyPaths.length > 0) {
-        if (!policy.filesystem) {
-          policy.filesystem = {};
-        }
-        policy.filesystem.readonlyPaths = [
-          ...(policy.filesystem.readonlyPaths ?? []),
-          ...toolsPolicy.readonlyPaths,
-        ];
-      }
-      if (toolsPolicy.readwritePaths.length > 0) {
-        if (!policy.filesystem) {
-          policy.filesystem = {};
-        }
-        policy.filesystem.readwritePaths = [
-          ...(policy.filesystem.readwritePaths ?? []),
-          ...toolsPolicy.readwritePaths,
-        ];
       }
 
       console.log('Spawning sandboxed process using SDK...');
 
-      // Resolve command line from new or legacy fields
-      const commandLine = config.process?.commandLine ?? config.script;
-      if (!commandLine) {
-        console.error('Error: No command specified. Use process.commandLine or script.');
-        process.exit(1);
-      }
+      const ptyProcess = spawnSandbox(scriptCommand, policy, {
+        debug: options.debug ?? false,
+      });
 
-      const workingDirectory = config.process?.cwd ?? config.workingDirectory;
-
-      // Determine container name based on containment configuration.
-      // TODO: Rationalize these together in the schema.
-      let containerName: string | undefined;
-      if (config.containerId) {
-        containerName = config.containerId;
-      } else if ((config as any).containment === 'lxc') {
-        containerName = (config as any).lxc?.containerName;
-      } else {
-        containerName = (config as any).appContainer?.name;
-      }
-
-      // Spawn the process
-      // NOTE: For now, we will force winpty.
-      const pty = spawnSandbox(commandLine, policy, {
-        debug: options.debug ?? false
-      }, workingDirectory, containerName);
-
-      // Handle output
-      pty.onData((data: string) => {
+      ptyProcess.onData((data: string) => {
         process.stdout.write(data);
       });
 
-      // Handle exit
-      pty.onExit((event: { exitCode: number; signal?: number }) => {
+      ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
         console.log(`\nProcess exited with code ${event.exitCode}`);
         process.exit(event.exitCode);
       });

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -2,8 +2,8 @@
  * WXC CLI - TypeScript wrapper for the Windows eXecution Container
  */
 
-// Legacy WxcExecutor (original implementation)
-export { WxcExecutor, WxcExecutionOptions, WxcExecutionResult } from './wxc-executor';
+// Legacy ContainerExecutor (original implementation)
+export { ContainerExecutor, ContainerExecutionOptions, ContainerExecutionResult } from './wxc-executor';
 
 export {
   createMinimalConfig,

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -1,11 +1,16 @@
-import { WxcConfiguration } from '@microsoft/mxc-sdk/dist/types';
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ContainerConfig } from '@microsoft/mxc-sdk/dist/types';
 
 /**
  * Helper function to create a minimal valid configuration
  */
-export function createMinimalConfig(code: string): WxcConfiguration {
+export function createMinimalConfig(code: string): ContainerConfig {
   return {
-    script: code
+    process: {
+      commandLine: code,
+    },
   };
 }
 
@@ -15,12 +20,14 @@ export function createMinimalConfig(code: string): WxcConfiguration {
 export function createNetworkRestrictedConfig(
   code: string,
   allow: string[]
-): WxcConfiguration {
+): ContainerConfig {
   return {
-    script: code,
+    process: {
+      commandLine: code,
+    },
     network: {
       defaultPolicy: 'block',
-      enforcementMode: 'capabilities'
+      enforcementMode: 'capabilities',
     }
   };
 }
@@ -33,9 +40,11 @@ export function createFilesystemRestrictedConfig(
   readonlyPaths: string[],
   readwritePaths: string[],
   deniedPaths: string[] = []
-): WxcConfiguration {
+): ContainerConfig {
   return {
-    script: code,
+    process: {
+      commandLine: code,
+    },
     filesystem: {
       readonlyPaths: readonlyPaths,
       readwritePaths: readwritePaths,

--- a/cli/src/wxc-executor.ts
+++ b/cli/src/wxc-executor.ts
@@ -1,51 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { spawn } from 'child_process';
 import * as fs from 'fs';
 
-export interface WxcExecutionOptions {
+export interface ContainerExecutionOptions {
   isBase64?: boolean;
   debug?: boolean;
 }
 
-export interface WxcExecutionResult {
+export interface ContainerExecutionResult {
   success: boolean;
   exitCode: number;
   stdout: string;
   stderr: string;
 }
 
-export class WxcExecutor {
-  private wxcPath: string;
+export class ContainerExecutor {
+  private executablePath: string;
 
-  constructor(wxcPath: string) {
-    if (!fs.existsSync(wxcPath)) {
-      throw new Error(`WXC executable not found at: ${wxcPath}`);
+  constructor(executablePath: string) {
+    if (!fs.existsSync(executablePath)) {
+      throw new Error(`Container executable not found at: ${executablePath}`);
     }
-    this.wxcPath = wxcPath;
+    this.executablePath = executablePath;
   }
 
-  async run(config: string, options: WxcExecutionOptions = {}): Promise<WxcExecutionResult> {
+  async run(config: string, options: ContainerExecutionOptions = {}): Promise<ContainerExecutionResult> {
     return new Promise((resolve, reject) => {
       const args: string[] = [];
 
-      // Add config argument (file path or base64 string)
-      args.push(config);
-
-      // Add base64 flag if needed
       if (options.isBase64) {
-        args.push('--config-base64');
+        args.push('--config-base64', config);
+      } else {
+        args.push(config);
       }
 
-      // Add debug flag if needed
       if (options.debug) {
         args.push('--debug');
       }
 
-      const wxc = spawn(this.wxcPath, args);
+      const child = spawn(this.executablePath, args);
 
       let stdout = '';
       let stderr = '';
 
-      wxc.stdout.on('data', (data: Buffer) => {
+      child.stdout.on('data', (data: Buffer) => {
         const text = data.toString();
         stdout += text;
         if (options.debug) {
@@ -53,7 +53,7 @@ export class WxcExecutor {
         }
       });
 
-      wxc.stderr.on('data', (data: Buffer) => {
+      child.stderr.on('data', (data: Buffer) => {
         const text = data.toString();
         stderr += text;
         if (options.debug) {
@@ -61,11 +61,11 @@ export class WxcExecutor {
         }
       });
 
-      wxc.on('error', (error: Error) => {
-        reject(new Error(`Failed to spawn WXC process: ${error.message}`));
+      child.on('error', (error: Error) => {
+        reject(new Error(`Failed to spawn container process: ${error.message}`));
       });
 
-      wxc.on('close', (code: number | null) => {
+      child.on('close', (code: number | null) => {
         const exitCode = code ?? 1;
         resolve({
           success: exitCode === 0,
@@ -77,7 +77,7 @@ export class WxcExecutor {
     });
   }
 
-  getWxcPath(): string {
-    return this.wxcPath;
+  getExecutablePath(): string {
+    return this.executablePath;
   }
 }

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -13,10 +13,12 @@
         "linux"
       ],
       "dependencies": {
-        "node-pty": "^1.2.0-beta.12"
+        "node-pty": "^1.2.0-beta.12",
+        "semver": "^7.7.4"
       },
       "devDependencies": {
         "@types/node": "^20.10.0",
+        "@types/semver": "^7.7.1",
         "rimraf": "^6.1.3",
         "typescript": "^5.3.3"
       },
@@ -33,6 +35,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.3",
@@ -169,6 +178,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typescript": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -4,11 +4,15 @@
   "description": "TypeScript SDK for MXC (Microsoft eXecution Containers)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": [ "bin/", "dist/" ],
+  "files": [
+    "bin/",
+    "dist/"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
     "clean": "rimraf dist",
+    "test": "node --test dist/sandbox.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -23,16 +27,21 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^20.10.0",
+    "@types/semver": "^7.7.1",
     "rimraf": "^6.1.3",
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "node-pty": "^1.2.0-beta.12"
+    "node-pty": "^1.2.0-beta.12",
+    "semver": "^7.7.4"
   },
   "engines": {
     "node": ">=16.0.0"
   },
-  "os": ["win32", "linux"],
+  "os": [
+    "win32",
+    "linux"
+  ],
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,5 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
- * WXC SDK - TypeScript SDK for execution containers
+ * MXC SDK - TypeScript SDK for execution containers
  *
  * This package provides a Node.js interface for spawning sandboxed processes
  * on Windows using the WXC system.
@@ -36,6 +39,7 @@ export {
 // Export platform detection functions
 export {
   getPlatformSupport,
+  findWxcExecutable,
   findLxcExecutable,
 } from './platform';
 

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { buildSandboxPayload } from './sandbox';
+import { SandboxPolicy } from './types';
+
+describe('buildSandboxPayload', () => {
+  const defaultPolicy: SandboxPolicy = { version: '0.4.0-alpha' };
+
+  describe('Windows', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
+
+    const mockWindows = () => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    };
+
+    const restore = () => {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    };
+
+    it('should set process.commandLine from script parameter', () => {
+      mockWindows();
+      try {
+        const payload = buildSandboxPayload('echo hello', defaultPolicy);
+        assert.strictEqual(payload.process!.commandLine, 'echo hello');
+      } finally {
+        restore();
+      }
+    });
+
+    it('should map network policy to appcontainer capabilities', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true, allowLocalNetwork: true },
+        };
+        const payload = buildSandboxPayload('echo hi', policy);
+        assert.ok(payload.appContainer!.capabilities!.includes('internetClient'));
+        assert.ok(payload.appContainer!.capabilities!.includes('privateNetworkClientServer'));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should pass filesystem policy through', () => {
+      const policy: SandboxPolicy = {
+        version: '0.4.0-alpha',
+        filesystem: {
+          readwritePaths: ['C:\\temp'],
+          readonlyPaths: ['C:\\data'],
+        },
+      };
+      const payload = buildSandboxPayload('echo hi', policy);
+      assert.deepStrictEqual(payload.filesystem!.readwritePaths![0], 'C:\\temp');
+      assert.deepStrictEqual(payload.filesystem!.readonlyPaths, ['C:\\data']);
+    });
+
+    it('should accept a compatible version', () => {
+      mockWindows();
+      try {
+        assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.4.0-alpha' }));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should accept a newer minor version within same major', () => {
+      mockWindows();
+      try {
+        assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.99.0' }));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject a different major version', () => {
+      mockWindows();
+      try {
+        assert.throws(
+          () => buildSandboxPayload('echo hi', { version: '1.0.0' }),
+          { message: /incompatible/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject an invalid semver string', () => {
+      mockWindows();
+      try {
+        assert.throws(
+          () => buildSandboxPayload('echo hi', { version: 'not-a-version' }),
+          { message: /Invalid policy version/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('Linux', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
+
+    const mockLinux = () => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    };
+
+    const restore = () => {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    };
+
+    it('should default to lxc on Linux', () => {
+      mockLinux();
+      try {
+        const payload = buildSandboxPayload('echo hi', defaultPolicy);
+        assert.strictEqual(payload.containment, 'lxc');
+        assert.strictEqual(payload.lxc!.destroyOnExit, true);
+      } finally {
+        restore();
+      }
+    });
+  });
+});

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -1,10 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as pty from 'node-pty';
-import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
 import { randomBytes } from "crypto";
-import { SandboxPolicy, WxcConfiguration } from './types';
+import { parse as semverParse } from 'semver';
+import { SandboxPolicy, ContainerConfig } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
+
+const SUPPORTED_VERSION = '0.4.0-alpha';
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -13,8 +17,27 @@ function generateRandomContainerName(): string {
     return randomBytes(4).toString("hex");
 }
 
+function validatePolicyVersion(version: string): void {
+    if (!version) {
+        throw new Error('Policy version is required');
+    }
+
+    const parsed = semverParse(version);
+    if (!parsed) {
+        throw new Error(`Invalid policy version '${version}': must be valid semver (e.g., '0.4.0' or '0.4.0-alpha')`);
+    }
+
+    const supported = semverParse(SUPPORTED_VERSION);
+    if (parsed.major !== supported!.major) {
+        throw new Error(
+            `Policy version '${version}' is incompatible (major version ${parsed.major} != ${supported!.major}). ` +
+            `This SDK supports major version ${supported!.major}.`
+        );
+    }
+}
+
 /**
- * Builds a sandbox payload JSON object from the sandbox configuration.
+ * Builds a sandbox payload JSON object from the sandbox policy.
  * @param script The command line script to execute
  * @param policy The sandbox policy configuration
  * @param workingDirectory Optional working directory path
@@ -26,28 +49,36 @@ export function buildSandboxPayload(
     policy: SandboxPolicy,
     workingDirectory?: string,
     containerName?: string,
-): WxcConfiguration {
+): ContainerConfig {
+    validatePolicyVersion(policy.version);
+
     const platform = os.platform();
+    const name = containerName ?? generateRandomContainerName();
+
+    const config: ContainerConfig = {
+        process: {
+            commandLine: script,
+            cwd: workingDirectory,
+        },
+        containerId: name,
+        filesystem: {
+            readwritePaths: policy.filesystem?.readwritePaths,
+            readonlyPaths: policy.filesystem?.readonlyPaths,
+            deniedPaths: policy.filesystem?.deniedPaths,
+            clearPolicyOnExit: true,
+        },
+    };
 
     if (platform === 'linux') {
-        // Build LXC payload
-        const config: WxcConfiguration = {
-            script,
-            containment: 'lxc',
-            workingDirectory,
-            lxc: {
-                containerName: containerName ?? generateRandomContainerName(),
-                destroyOnExit: true,
-            },
-            filesystem: {
-                readwritePaths: policy.filesystem?.readwritePaths,
-                readonlyPaths: policy.filesystem?.readonlyPaths,
-                deniedPaths: policy.filesystem?.deniedPaths,
-                clearPolicyOnExit: true,
-            },
+        config.containment = 'lxc';
+        config.lxc = {
+            containerName: name,
+            // Default Linux distro since SandboxPolicy doesn't expose this
+            distribution: 'alpine',
+            release: '3.23',
+            destroyOnExit: true,
         };
 
-        // Add network config if specified
         if (policy.network) {
             config.network = {
                 defaultPolicy: policy.network.allowOutbound ? 'allow' : 'block',
@@ -58,31 +89,19 @@ export function buildSandboxPayload(
         return config;
     }
 
-    // Existing Windows payload
+    // Windows / AppContainer
     const capabilities: string[] = [];
-
     if (policy.network?.allowOutbound) {
         capabilities.push("internetClient");
     }
-
     if (policy.network?.allowLocalNetwork) {
         capabilities.push("privateNetworkClientServer");
     }
 
-    const config: WxcConfiguration = {
-        script,
-        workingDirectory,
-        appContainer: {
-            name: containerName ?? generateRandomContainerName(),
-            leastPrivilege: false,
-            capabilities,
-        },
-        filesystem: {
-            readwritePaths: policy.filesystem?.readwritePaths,
-            readonlyPaths: policy.filesystem?.readonlyPaths,
-            deniedPaths: policy.filesystem?.deniedPaths,
-            clearPolicyOnExit: true,
-        },
+    config.appContainer = {
+        name: name,
+        leastPrivilege: false,
+        capabilities,
     };
 
     return config;
@@ -161,23 +180,10 @@ export function spawnSandbox(
   // Build config
   const config = buildSandboxPayload(script, policy, workingDirectory, containerName);
 
-  // Prepare arguments
   const args: string[] = [];
-  const useBase64 = options.debug ?? true;
-
-  if (useBase64) {
-    const configJson = JSON.stringify(config);
-    const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
-    args.push('--config-base64', configBase64);
-  } else {
-    const tempDir = os.tmpdir();
-    const tempFile = path.join(
-      tempDir,
-      `mxc-config-${Date.now()}-${Math.random().toString(36).substring(7)}.json`
-    );
-    fs.writeFileSync(tempFile, JSON.stringify(config, null, 2), 'utf-8');
-    args.push('--config', tempFile);
-  }
+  const configJson = JSON.stringify(config);
+  const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
+  args.push('--config-base64', configBase64);
 
   if (options.debug) {
     args.push('--debug');

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,5 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 /**
- * WXC SDK Types
+ * MXC SDK Types
  * These types match the wxc-exec JSON configuration schema
  */
 
@@ -7,7 +10,7 @@
 /**
  * Process execution settings
  */
-export interface WxcProcessConfig {
+export interface ProcessConfig {
   /** Complete command line to execute (e.g., "python -c \"print('hello')\"") */
   commandLine: string;
   /** Working directory for the process */
@@ -21,7 +24,7 @@ export interface WxcProcessConfig {
 /**
  * Container lifecycle settings shared across all backends
  */
-export interface WxcLifecycleConfig {
+export interface LifecycleConfig {
   /** Destroy the container after execution completes (default: true) */
   destroyOnExit?: boolean;
   /** Retain filesystem and network policies after execution (default: false) */
@@ -31,7 +34,7 @@ export interface WxcLifecycleConfig {
 /**
  * AppContainer configuration for Windows sandbox
  */
-export interface WxcAppContainerConfig {
+export interface AppContainerConfig {
   /** AppContainer profile name (default: "CLI"). Deprecated: use containerId instead. */
   name?: string;
   /** Use least privilege mode with PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT (default: false) */
@@ -43,7 +46,7 @@ export interface WxcAppContainerConfig {
 /**
  * Filesystem access configuration
  */
-export interface WxcFilesystemConfig {
+export interface FilesystemConfig {
   /** Paths the script can read and write */
   readwritePaths?: string[];
   /** Paths the script can read but not write */
@@ -57,7 +60,7 @@ export interface WxcFilesystemConfig {
 /**
  * Network access configuration
  */
-export interface WxcNetworkConfig {
+export interface NetworkConfig {
   /**
    * Network enforcement mode:
    * - "capabilities": Use AppContainer capabilities only (no admin required)
@@ -72,6 +75,8 @@ export interface WxcNetworkConfig {
   allowedHosts?: string[];
   /** Hostnames or IP addresses to block (firewall mode only) */
   blockedHosts?: string[];
+  /** Proxy configuration (currently appcontainer only, requires elevation) */
+  proxy?: { builtinTestServer: true } | { localhost: number };
   /** Automatically remove firewall rules after execution (default: true). Deprecated: use lifecycle.preservePolicy. */
   removeRulesOnExit?: boolean;
 }
@@ -79,7 +84,7 @@ export interface WxcNetworkConfig {
 /**
  * WSLC SDK configuration for Linux containers from Windows
  */
-export interface WxcWslcConfig {
+export interface WslcConfig {
   /** OCI container image name (default: "alpine:latest") */
   image?: string;
   /** Storage path for WSLC session image store */
@@ -89,33 +94,27 @@ export interface WxcWslcConfig {
 /**
  * Main WXC configuration
  */
-export interface WxcConfiguration {
-  /** MXC config schema version (current: "1") */
+export interface ContainerConfig {
+  /** MXC config schema version (current: "0.4.0-alpha") */
   version?: string;
   /** Externally assigned container identifier */
   containerId?: string;
   /** Containment backend */
   containment?: 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
   /** Container lifecycle settings */
-  lifecycle?: WxcLifecycleConfig;
-  /** Process execution settings */
-  process?: WxcProcessConfig;
-  /** Complete command line to execute. Deprecated: use process.commandLine instead. */
-  script?: string;
-  /** Working directory. Deprecated: use process.cwd instead. */
-  workingDirectory?: string;
-  /** Timeout in ms. Deprecated: use process.timeout instead. */
-  timeout?: number;
+  lifecycle?: LifecycleConfig;
+  /** Process execution settings (required) */
+  process?: ProcessConfig;
   /** AppContainer configuration */
-  appContainer?: WxcAppContainerConfig;
+  appContainer?: AppContainerConfig;
   /** WSLC SDK configuration */
-  wslc?: WxcWslcConfig;
+  wslc?: WslcConfig;
   /** LXC container configuration (Linux only) */
-  lxc?: WxcLxcConfig;
+  lxc?: LxcConfig;
   /** Filesystem access configuration */
-  filesystem?: WxcFilesystemConfig;
+  filesystem?: FilesystemConfig;
   /** Network access configuration */
-  network?: WxcNetworkConfig;
+  network?: NetworkConfig;
 }
 
 /**
@@ -123,6 +122,8 @@ export interface WxcConfiguration {
  * to define sandboxed execution environments.
  */
 export type SandboxPolicy = {
+  /** Policy version (semver). */
+  version: string;
   /** Filesystem access restrictions */
   filesystem?: {
       /** Paths that are granted read and write access */
@@ -146,7 +147,7 @@ export type SandboxPolicy = {
 /**
  * LXC container configuration for Linux sandbox
  */
-export interface WxcLxcConfig {
+export interface LxcConfig {
   /** Container name (default: auto-generated) */
   containerName?: string;
   /** Linux distribution for container rootfs (default: "alpine") */


### PR DESCRIPTION
### Why is this change needed?

The SDK's `buildSandboxPayload()` still emitted the deprecated `script` field, but schema 0.4.0-alpha requires `process.commandLine`. Every `spawnSandbox()` call failed with "Request error". Additionally, `SandboxPolicy` had no version field and there were no tests.

### What changed

**SDK**
- Renamed types: `WxcConfiguration` -> `ContainerConfig`, dropped `Container` prefix from sub-types
- `buildSandboxPayload()` emits `process.commandLine` instead of `script`
- Removed deprecated fields (`script`, `workingDirectory`, `timeout`) from `ContainerConfig`
- Added required `version` field to `SandboxPolicy` with semver validation via the `semver` package
- Exported `findWxcExecutable` (was missing from index.ts)
- Added 8 unit tests using `node:test`

**CLI**
- `run-sdk` rewritten to take `<script>` + `--policy`/`--policy-file` (mirrors `spawnSandbox(script, policy)` API)
- `run` auto-discovers wxc-exec/lxc-exec, removed `--wxc-path`
- Fixed `--config-base64` flag mismatch and base64 arg passing
- Added 3 integration test for app container usage

**CI**
- Added `npm test` for SDK (unit tests only since the CLI integration tests wxc integration and wxc requires a specific version of windows)

### How was it tested?

- 8 SDK unit tests: payload format, capabilities mapping, version validation
- 3 CLI integration tests (local): AppContainer command execution
- Manual: filesystem, proxy, and direct SDK `spawnSandbox()` calls