### PR TITLE
Add policy for issueOpened

### DIFF
--- a/.github/workflows/policies/labelManagement.issueOpened.yml
+++ b/.github/workflows/policies/labelManagement.issueOpened.yml
@@ -1,0 +1,27 @@
+id: labelManagement.issueOpened
+name: GitOps.PullRequestIssueManagement
+description: Handlers for when an issue is first opened
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Add CodeFlow link to new PRs
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Opened
+        then:
+          - addCodeFlowLink
+      - description: Add Needs-Triage to new issues
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+        then:
+          - addLabel:
+              label: Needs-Triage
+onFailure:
+onSuccess:


### PR DESCRIPTION
Policy Bot helps with GitHub issues.

This will add the "CodeFlow link to new PRs" and "the `Needs-Triage` label to new issues.