### PR TITLE
[NanVix] Adding initial NanVix support

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -59,7 +59,7 @@ you add `"$schema": "./schemas/dev/mxc-config.schema.json"` to your config file.
 | `"wslc"` | Linux containers via the WSL Container SDK |
 | `"lxc"` | Native LXC container isolation |
 | `"vm"` | VM-based isolation (not yet implemented) |
-| `"microvm"` | MicroVM-based isolation (not yet implemented) |
+| `"nanvix"` | NanVix microkernel VM isolation via WHP |
 
 Only the backend section matching the selected `containment` value is used;
 other backend sections are ignored.

--- a/schemas/dev/mxc-config.schema.json
+++ b/schemas/dev/mxc-config.schema.json
@@ -19,7 +19,7 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["appcontainer", "lxc"],
+      "enum": ["appcontainer", "lxc", "microvm"],
       "default": "appcontainer",
       "description": "Containment backend to use for execution."
     },

--- a/schemas/dev/mxc-config.schema.json
+++ b/schemas/dev/mxc-config.schema.json
@@ -19,7 +19,7 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["appcontainer", "lxc", "microvm"],
+      "enum": ["appcontainer", "lxc", "nanvix"],
       "default": "appcontainer",
       "description": "Containment backend to use for execution."
     },

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -100,7 +100,7 @@ export interface ContainerConfig {
   /** Externally assigned container identifier */
   containerId?: string;
   /** Containment backend */
-  containment?: 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
+  containment?: 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'nanvix';
   /** Container lifecycle settings */
   lifecycle?: LifecycleConfig;
   /** Process execution settings (required) */
@@ -161,7 +161,7 @@ export interface LxcConfig {
 /**
  * Sandboxing methods available on the platform
  */
-export type SandboxingMethod = 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
+export type SandboxingMethod = 'appcontainer' | 'sandbox' | 'wslc' | 'lxc' | 'vm' | 'nanvix';
 
 /**
  * Platform support information

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -11,6 +11,7 @@ use wxc_common::config_parser::load_request;
 use wxc_common::filesystem_bfs::FileSystemBfsManager;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
+use wxc_common::nanvix_runner::NanVixScriptRunner;
 use wxc_common::sandbox_runner::SandboxScriptRunner;
 use wxc_common::script_runner::ScriptRunner;
 
@@ -155,10 +156,7 @@ fn main() {
             eprintln!("Error: VM backend not yet implemented");
             process::exit(1);
         }
-        ContainmentBackend::MicroVm => {
-            eprintln!("Error: MicroVM backend not yet implemented");
-            process::exit(1);
-        }
+        ContainmentBackend::NanVix => Box::new(NanVixScriptRunner::new()),
     };
     let response = runner.run(&request, &mut logger);
     display_script_results(&response, &mut logger);

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -332,10 +332,10 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         Some("wslc") => ContainmentBackend::Wslc,
         Some("lxc") => ContainmentBackend::Lxc,
         Some("vm") => ContainmentBackend::Vm,
-        Some("microvm") => ContainmentBackend::MicroVm,
+        Some("nanvix") => ContainmentBackend::NanVix,
         Some(other) => {
             let msg = format!(
-                "Invalid containment value '{}' (must be 'appcontainer', 'sandbox', 'wslc', 'lxc', 'vm', or 'microvm')",
+                "Invalid containment value '{}' (must be 'appcontainer', 'sandbox', 'wslc', 'lxc', 'vm', or 'nanvix')",
                 other
             );
             logger.log_line(&msg);
@@ -1194,13 +1194,13 @@ mod tests {
     }
 
     #[test]
-    fn containment_microvm_accepted() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "microvm"}"#;
+    fn containment_nanvix_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "nanvix"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.containment, ContainmentBackend::MicroVm);
+        assert_eq!(req.containment, ContainmentBackend::NanVix);
     }
 
     #[test]

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod encoding;
 pub mod error;
 pub mod logger;
 pub mod models;
+pub mod nanvix_runner;
 pub mod script_runner;
 pub mod validator;
 

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -18,9 +18,9 @@ pub enum ContainmentBackend {
     Lxc,
     /// VM-based isolation.
     Vm,
-    /// MicroVM-based isolation.
-    #[serde(rename = "microvm")]
-    MicroVm,
+    /// NanVix — microkernel VM isolation via WHP.
+    #[serde(rename = "nanvix")]
+    NanVix,
 }
 
 /// Configuration specific to the Windows Sandbox backend.

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -9,8 +9,14 @@
 //! ## I/O model
 //!
 //! - **stdin**: runner writes script code, then closes (EOF triggers `exec()`)
-//! - **stdout**: relayed directly to parent process (not captured)
-//! - **stderr**: relayed directly to parent process (kernel traces)
+//! - **stdout**: relayed directly to parent process via `Stdio::inherit()` (not captured)
+//! - **stderr**: relayed directly to parent process via `Stdio::inherit()` (kernel traces)
+//!
+//! **Note for SDK consumers:** Because stdout/stderr are inherited (not captured),
+//! `ScriptResponse.standard_out` and `standard_err` are always empty strings for
+//! the NanVix backend. Output is streamed directly to the parent's console/pipes.
+//! Programmatic consumers that need captured output should redirect wxc-exec's
+//! stdout/stderr at the process level.
 //!
 //! ## Exit codes
 //!
@@ -149,6 +155,8 @@ impl NanVixScriptRunner {
 impl ScriptRunner for NanVixScriptRunner {
     fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         // -- Policy validation ---------------------------------------------------
+        // Reject unsupported policies — NanVix provides its own isolation model.
+        // Fail-closed: any policy setting not meaningful for NanVix is rejected.
         if !request.policy.readwrite_paths.is_empty()
             || !request.policy.readonly_paths.is_empty()
             || !request.policy.denied_paths.is_empty()
@@ -171,12 +179,32 @@ impl ScriptRunner for NanVixScriptRunner {
             )
             .to_response();
         }
+        if request.policy.network_proxy.is_enabled() {
+            return NanVixError::Preflight(
+                "network proxy is not supported by the NanVix backend \
+                 — NanVix has no network stack"
+                    .to_string(),
+            )
+            .to_response();
+        }
         if !request.working_directory.is_empty() {
             return NanVixError::Preflight(
                 "workingDirectory is not supported by the NanVix backend \
                  -- guest has its own filesystem namespace"
                     .to_string(),
             )
+            .to_response();
+        }
+
+        // Validate PYTHON_HOME doesn't contain NanVix delimiters that could
+        // corrupt the guest argument string (';' separates argv from env vars,
+        // spaces separate argv entries).
+        if PYTHON_HOME.contains(';') || PYTHON_HOME.contains(' ') {
+            return NanVixError::Preflight(format!(
+                "PYTHON_HOME '{}' contains invalid characters (';' or space) \
+                 — these are NanVix argument delimiters",
+                PYTHON_HOME
+            ))
             .to_response();
         }
 
@@ -285,17 +313,29 @@ impl ScriptRunner for NanVixScriptRunner {
                 let result = cvar.wait_timeout(cancelled, duration).unwrap();
                 cancelled = result.0;
 
+                // Always close the duplicated handle to avoid leaks.
+                let close_handle = |handle_raw: usize| {
+                    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+                    let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
+                    let _ = unsafe { CloseHandle(handle) };
+                };
+
                 if *cancelled {
+                    // Process already exited — close the handle and return.
+                    if let Some(handle_raw) = process_handle_raw {
+                        close_handle(handle_raw);
+                    }
                     return;
                 }
 
+                // Timeout elapsed and process is still running — kill it.
                 if let Some(handle_raw) = process_handle_raw {
-                    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+                    use windows::Win32::Foundation::HANDLE;
                     use windows::Win32::System::Threading::TerminateProcess;
 
                     let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
                     let kill_result = unsafe { TerminateProcess(handle, 1) };
-                    let _ = unsafe { CloseHandle(handle) };
+                    close_handle(handle_raw);
 
                     if kill_result.is_ok() {
                         timed_out_clone.store(true, Ordering::SeqCst);
@@ -489,5 +529,47 @@ mod tests {
             !resp.error_message.contains("workingDirectory"),
             "default request should not trigger workingDirectory rejection"
         );
+    }
+
+    #[test]
+    fn policy_rejects_network_proxy() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                network_proxy: crate::models::ProxyConfig {
+                    address: Some(crate::models::ProxyAddress::new(
+                        "127.0.0.1".to_string(),
+                        8080,
+                        true,
+                    )),
+                    builtin_test_server: false,
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("network proxy"));
+    }
+
+    #[test]
+    fn python_home_constant_has_no_delimiters() {
+        // PYTHON_HOME must not contain ';' or spaces — these are NanVix
+        // argument delimiters that would corrupt the guest arg string.
+        assert!(!PYTHON_HOME.contains(';'), "PYTHON_HOME contains ';'");
+        assert!(!PYTHON_HOME.contains(' '), "PYTHON_HOME contains space");
+    }
+
+    #[test]
+    fn guest_args_format_is_correct() {
+        let expected = "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME=/sysroot";
+        let actual = format!(
+            "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
+            PYTHON_HOME
+        );
+        assert_eq!(actual, expected);
+        assert!(!"exec(__import__('sys').stdin.read())".contains(' '));
     }
 }

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -30,10 +30,11 @@
 use std::fmt::Write;
 use std::io::Write as IoWrite;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use crate::logger::Logger;
@@ -54,6 +55,13 @@ const RAMFS_IMAGE: &str = "cpython-ramfs.img";
 const BOOT_TIMEOUT_MS: u64 = 60_000;
 /// Generic error exit code returned to host callers.
 const ERROR_EXIT_CODE: i32 = -1;
+const ERR_FILESYSTEM_POLICY: &str =
+    "filesystem policy is not supported by the NanVix backend -- guest has a read-only ramfs";
+const ERR_NETWORK_POLICY: &str =
+    "network policy is not supported by the NanVix backend -- NanVix has no network stack";
+const ERR_PROXY_POLICY: &str =
+    "network proxy is not supported by the NanVix backend -- NanVix has no network stack";
+const ERR_WORKDIR: &str = "workingDirectory is not supported by the NanVix backend -- guest has its own filesystem namespace";
 
 // -- NanVix error classification ---------------------------------------------
 
@@ -109,6 +117,62 @@ fn exe_dir() -> Result<PathBuf, NanVixError> {
     exe.parent()
         .map(Path::to_path_buf)
         .ok_or_else(|| NanVixError::Preflight("exe has no parent directory".to_string()))
+}
+
+/// Watchdog thread: waits for timeout or cancellation, then terminates the process.
+fn watchdog_thread_fn(
+    process_handle_raw: usize,
+    duration: Duration,
+    cancel_pair: Arc<(Mutex<bool>, Condvar)>,
+    timed_out: Arc<AtomicBool>,
+) {
+    let (lock, cvar) = &*cancel_pair;
+    let mut cancelled = lock.lock().unwrap_or_else(|e| e.into_inner());
+    let start = Instant::now();
+    let mut remaining = duration;
+    loop {
+        let result = cvar
+            .wait_timeout(cancelled, remaining)
+            .unwrap_or_else(|e| e.into_inner());
+        cancelled = result.0;
+        if *cancelled || result.1.timed_out() {
+            break;
+        }
+        let elapsed = start.elapsed();
+        if elapsed >= duration {
+            break;
+        }
+        remaining = duration.saturating_sub(elapsed);
+    }
+
+    // Always close the duplicated handle to avoid leaks.
+    let close_handle = |handle_raw: usize| {
+        use windows::Win32::Foundation::{CloseHandle, HANDLE};
+        let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
+        // SAFETY: `handle` was returned by `DuplicateHandle` in this
+        // process and is closed exactly once by this watchdog thread.
+        let _ = unsafe { CloseHandle(handle) };
+    };
+
+    if *cancelled {
+        // Process already exited — close the handle and return.
+        close_handle(process_handle_raw);
+        return;
+    }
+
+    // Timeout elapsed and process is still running — kill it.
+    // Set the timed_out flag BEFORE terminating so the main thread
+    // always sees it as true after child.wait() returns from a kill.
+    timed_out.store(true, Ordering::SeqCst);
+
+    use windows::Win32::Foundation::HANDLE;
+    use windows::Win32::System::Threading::TerminateProcess;
+
+    let handle = HANDLE(process_handle_raw as *mut std::ffi::c_void);
+    // SAFETY: `handle` is a valid duplicated process handle owned by
+    // this thread, and passing exit code 1 is valid for termination.
+    let _ = unsafe { TerminateProcess(handle, 1) };
+    close_handle(process_handle_raw);
 }
 
 // -- NanVixScriptRunner ------------------------------------------------------
@@ -180,41 +244,36 @@ impl NanVixScriptRunner {
             || !request.policy.readonly_paths.is_empty()
             || !request.policy.denied_paths.is_empty()
         {
-            return Err(NanVixError::Preflight(
-                "filesystem policy is not supported by the NanVix backend \
-                 -- guest has a read-only ramfs"
-                    .to_string(),
-            ));
+            return Err(NanVixError::Preflight(ERR_FILESYSTEM_POLICY.to_string()));
         }
         if !request.policy.allowed_hosts.is_empty()
             || !request.policy.blocked_hosts.is_empty()
             || request.policy.default_network_policy != NetworkPolicy::Allow
         {
-            return Err(NanVixError::Preflight(
-                "network policy is not supported by the NanVix backend \
-                 -- NanVix has no network stack"
-                    .to_string(),
-            ));
+            return Err(NanVixError::Preflight(ERR_NETWORK_POLICY.to_string()));
         }
         if request.policy.network_proxy.is_enabled() {
-            return Err(NanVixError::Preflight(
-                "network proxy is not supported by the NanVix backend \
-                 — NanVix has no network stack"
-                    .to_string(),
-            ));
+            return Err(NanVixError::Preflight(ERR_PROXY_POLICY.to_string()));
         }
         if !request.working_directory.is_empty() {
-            return Err(NanVixError::Preflight(
-                "workingDirectory is not supported by the NanVix backend \
-                 -- guest has its own filesystem namespace"
-                    .to_string(),
-            ));
+            return Err(NanVixError::Preflight(ERR_WORKDIR.to_string()));
         }
 
         Ok(())
     }
 
     fn build_guest_args() -> String {
+        // Build the NanVix guest argument string.
+        // Format: "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME=/sysroot"
+        //
+        // ';' is NanVix's separator between argv and environment variables.
+        // Everything before ';' is split on spaces into argv entries.
+        // Everything after ';' is set as environment variables.
+        //
+        // -S: skip site.py  -B: no .pyc writing
+        // -c exec(...): reads all of stdin and executes it (no interactive >>> prompts)
+        // Note: exec(__import__('sys').stdin.read()) has NO spaces, so it survives
+        //       NanVix's space-splitting in build_string_table().
         format!(
             "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
             PYTHON_HOME
@@ -254,169 +313,136 @@ impl NanVixScriptRunner {
 
         Ok(child)
     }
-}
 
-impl ScriptRunner for NanVixScriptRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        // -- Policy validation ---------------------------------------------------
-        // Reject unsupported policies — NanVix provides its own isolation model.
-        // Fail-closed: any policy setting not meaningful for NanVix is rejected.
-        if let Err(e) = Self::validate_policies(request) {
-            return e.to_response();
+    fn start_watchdog(
+        child: &std::process::Child,
+        timeout_ms: u64,
+        cancel_pair: Arc<(Mutex<bool>, Condvar)>,
+        timed_out: Arc<AtomicBool>,
+    ) -> Option<thread::JoinHandle<()>> {
+        if timeout_ms == u64::MAX {
+            return None;
         }
 
-        // -- Path resolution -----------------------------------------------------
-        let (nanvixd_path, bin_dir, ramfs_path, python_path) = match self.resolve_paths() {
-            Ok(paths) => paths,
-            Err(e) => return e.to_response(),
+        let duration = Duration::from_millis(timeout_ms);
+
+        // Duplicate the process handle at spawn time (safe against PID reuse).
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
+        use windows::Win32::System::Threading::GetCurrentProcess;
+
+        let raw = child.as_raw_handle();
+        let mut dup_handle = HANDLE::default();
+        let dup_ok = unsafe {
+            // SAFETY: `raw` is the live process HANDLE from `std::process::Child`.
+            // We duplicate it into the current process with same access rights so
+            // the watchdog thread can safely terminate/close it independently.
+            DuplicateHandle(
+                GetCurrentProcess(),
+                HANDLE(raw),
+                GetCurrentProcess(),
+                &mut dup_handle,
+                0,
+                false,
+                DUPLICATE_SAME_ACCESS,
+            )
         };
+        if dup_ok.is_err() {
+            return None;
+        }
+        let process_handle_raw = dup_handle.0 as usize;
 
-        let _ = writeln!(logger, "NanVix: nanvixd={:?}", nanvixd_path);
-        let _ = writeln!(logger, "NanVix: bin_dir={:?}", bin_dir);
-        let _ = writeln!(logger, "NanVix: ramfs={:?}", ramfs_path);
-        let _ = writeln!(logger, "NanVix: python={:?}", python_path);
+        Some(thread::spawn(move || {
+            watchdog_thread_fn(process_handle_raw, duration, cancel_pair, timed_out);
+        }))
+    }
 
-        // Build the guest argument string.
-        // The ';' is NanVix's separator between argv and environment variables:
-        //   everything before ';' -> kernel splits on spaces -> argv[]
-        //   everything after ';'  -> kernel sets as env vars
-        // -S: skip site.py, -B: no .pyc writing
-        // -c exec(...): reads all of stdin and executes it (no interactive >>> prompts)
-        // Note: exec(__import__('sys').stdin.read()) has NO spaces, so it survives
-        //       NanVix's space-splitting in build_string_table().
-        let guest_args = Self::build_guest_args();
-
-        // -- Spawn nanvixd -------------------------------------------------------
-        // stdout/stderr are inherited (relayed directly to parent process).
-        // Only stdin is piped so we can write the script and send EOF.
-        let mut child = match Self::spawn_nanvixd(
-            (&nanvixd_path, &bin_dir, &ramfs_path, &python_path),
-            &guest_args,
-            &request.script_code,
-        ) {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = writeln!(logger, "{}", e);
-                return e.to_response();
-            }
-        };
-
-        // -- Watchdog ------------------------------------------------------------
-        // Condvar-based watchdog with duplicated HANDLE for safe termination.
-        let timeout_ms = Self::total_timeout_ms(request.script_timeout);
+    fn setup_watchdog(
+        child: &mut std::process::Child,
+        timeout_ms: u64,
+        logger: &mut Logger,
+    ) -> Result<
+        (
+            Option<JoinHandle<()>>,
+            Arc<(Mutex<bool>, Condvar)>,
+            Arc<AtomicBool>,
+        ),
+        ScriptResponse,
+    > {
         let timed_out = Arc::new(AtomicBool::new(false));
         let cancel_pair = Arc::new((Mutex::new(false), Condvar::new()));
 
         let watchdog = if timeout_ms < u64::MAX {
-            let timed_out_clone = Arc::clone(&timed_out);
-            let cancel_pair_clone = Arc::clone(&cancel_pair);
-            let duration = Duration::from_millis(timeout_ms);
-
-            // Duplicate the process handle at spawn time (safe against PID reuse).
-            use std::os::windows::io::AsRawHandle;
-            use windows::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
-            use windows::Win32::System::Threading::GetCurrentProcess;
-
-            let raw = child.as_raw_handle();
-            let mut dup_handle = HANDLE::default();
-            let dup_ok = unsafe {
-                // SAFETY: `raw` is the live process HANDLE from `std::process::Child`.
-                // We duplicate it into the current process with same access rights so
-                // the watchdog thread can safely terminate/close it independently.
-                DuplicateHandle(
-                    GetCurrentProcess(),
-                    HANDLE(raw),
-                    GetCurrentProcess(),
-                    &mut dup_handle,
-                    0,
-                    false,
-                    DUPLICATE_SAME_ACCESS,
-                )
-            };
-            if let Err(e) = dup_ok {
-                let err = NanVixError::Platform(format!(
-                    "failed to duplicate {} process handle: {}",
-                    NANVIXD_BINARY, e
-                ));
-                let _ = writeln!(logger, "{}", err);
-                let _ = child.kill();
-                let _ = child.wait();
-                return err.to_response();
+            match Self::start_watchdog(
+                child,
+                timeout_ms,
+                Arc::clone(&cancel_pair),
+                Arc::clone(&timed_out),
+            ) {
+                Some(handle) => Some(handle),
+                None => {
+                    let err = NanVixError::Platform(format!(
+                        "failed to duplicate {} process handle",
+                        NANVIXD_BINARY
+                    ));
+                    let _ = writeln!(logger, "{}", err);
+                    if let Err(e) = child.kill() {
+                        let _ = writeln!(
+                            logger,
+                            "NanVix: failed to kill child after handle dup failure: {}",
+                            e
+                        );
+                    }
+                    if let Err(e) = child.wait() {
+                        let _ = writeln!(
+                            logger,
+                            "NanVix: failed to wait for child after handle dup failure: {}",
+                            e
+                        );
+                    }
+                    return Err(err.to_response());
+                }
             }
-            let process_handle_raw = dup_handle.0 as usize;
-
-            Some(thread::spawn(move || {
-                let (lock, cvar) = &*cancel_pair_clone;
-                let mut cancelled = lock.lock().unwrap_or_else(|e| e.into_inner());
-                let start = Instant::now();
-                let mut remaining = duration;
-                loop {
-                    let result = cvar
-                        .wait_timeout(cancelled, remaining)
-                        .unwrap_or_else(|e| e.into_inner());
-                    cancelled = result.0;
-                    if *cancelled || result.1.timed_out() {
-                        break;
-                    }
-                    let elapsed = start.elapsed();
-                    if elapsed >= duration {
-                        break;
-                    }
-                    remaining = duration.saturating_sub(elapsed);
-                }
-
-                // Always close the duplicated handle to avoid leaks.
-                let close_handle = |handle_raw: usize| {
-                    use windows::Win32::Foundation::{CloseHandle, HANDLE};
-                    let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
-                    // SAFETY: `handle` was returned by `DuplicateHandle` in this
-                    // process and is closed exactly once by this watchdog thread.
-                    let _ = unsafe { CloseHandle(handle) };
-                };
-
-                if *cancelled {
-                    // Process already exited — close the handle and return.
-                    close_handle(process_handle_raw);
-                    return;
-                }
-
-                // Timeout elapsed and process is still running — kill it.
-                // Set the timed_out flag BEFORE terminating so the main thread
-                // always sees it as true after child.wait() returns from a kill.
-                timed_out_clone.store(true, Ordering::SeqCst);
-
-                use windows::Win32::Foundation::HANDLE;
-                use windows::Win32::System::Threading::TerminateProcess;
-
-                let handle = HANDLE(process_handle_raw as *mut std::ffi::c_void);
-                // SAFETY: `handle` is a valid duplicated process handle owned by
-                // this thread, and passing exit code 1 is valid for termination.
-                let _ = unsafe { TerminateProcess(handle, 1) };
-                close_handle(process_handle_raw);
-            }))
         } else {
             None
         };
 
-        // -- Wait + cleanup ------------------------------------------------------
+        Ok((watchdog, cancel_pair, timed_out))
+    }
+
+    fn log_resolved_paths(logger: &mut Logger, nanvixd: &Path, bin_dir: &Path, ramfs: &Path, python: &Path) {
+        let _ = writeln!(logger, "NanVix: nanvixd={:?}", nanvixd);
+        let _ = writeln!(logger, "NanVix: bin_dir={:?}", bin_dir);
+        let _ = writeln!(logger, "NanVix: ramfs={:?}", ramfs);
+        let _ = writeln!(logger, "NanVix: python={:?}", python);
+    }
+
+    fn wait_and_respond(
+        child: &mut Child,
+        watchdog: Option<JoinHandle<()>>,
+        cancel_pair: &Arc<(Mutex<bool>, Condvar)>,
+        timed_out: &AtomicBool,
+        timeout_ms: u64,
+        script_timeout: u32,
+        logger: &mut Logger,
+    ) -> ScriptResponse {
         let exit_status = child.wait();
 
-        // Signal watchdog to stop
         {
-            let (lock, cvar) = &*cancel_pair;
+            let (lock, cvar) = &**cancel_pair;
             let mut cancelled = lock.lock().unwrap_or_else(|e| e.into_inner());
             *cancelled = true;
             cvar.notify_one();
         }
-        if let Some(t) = watchdog {
-            let _ = t.join();
+
+        if let Some(handle) = watchdog {
+            let _ = handle.join();
         }
 
-        let was_timed_out = timed_out.load(Ordering::SeqCst);
-
-        if was_timed_out {
+        if timed_out.load(Ordering::SeqCst) {
+            let _ = child.kill();
             let err = NanVixError::Timeout {
-                script_timeout_ms: request.script_timeout,
+                script_timeout_ms: script_timeout,
                 total_ms: timeout_ms,
             };
             let _ = writeln!(logger, "{}", err);
@@ -439,6 +465,50 @@ impl ScriptRunner for NanVixScriptRunner {
                 err.to_response()
             }
         }
+    }
+}
+
+impl ScriptRunner for NanVixScriptRunner {
+    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+        if let Err(e) = Self::validate_policies(request) {
+            return e.to_response();
+        }
+
+        let (nanvixd_path, bin_dir, ramfs_path, python_path) = match self.resolve_paths() {
+            Ok(paths) => paths,
+            Err(e) => return e.to_response(),
+        };
+
+        Self::log_resolved_paths(logger, &nanvixd_path, &bin_dir, &ramfs_path, &python_path);
+        let guest_args = Self::build_guest_args();
+
+        let mut child = match Self::spawn_nanvixd(
+            (&nanvixd_path, &bin_dir, &ramfs_path, &python_path),
+            &guest_args,
+            &request.script_code,
+        ) {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = writeln!(logger, "{}", e);
+                return e.to_response();
+            }
+        };
+
+        let timeout_ms = Self::total_timeout_ms(request.script_timeout);
+        let (watchdog, cancel_pair, timed_out) = match Self::setup_watchdog(&mut child, timeout_ms, logger) {
+            Ok(v) => v,
+            Err(resp) => return resp,
+        };
+
+        Self::wait_and_respond(
+            &mut child,
+            watchdog,
+            &cancel_pair,
+            timed_out.as_ref(),
+            timeout_ms,
+            request.script_timeout,
+            logger,
+        )
     }
 }
 
@@ -478,7 +548,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("filesystem policy"));
+        assert!(resp.error_message.contains(ERR_FILESYSTEM_POLICY));
     }
 
     #[test]
@@ -494,7 +564,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("filesystem policy"));
+        assert!(resp.error_message.contains(ERR_FILESYSTEM_POLICY));
     }
 
     #[test]
@@ -510,7 +580,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("network policy"));
+        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
     }
 
     #[test]
@@ -526,7 +596,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("network policy"));
+        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
     }
 
     #[test]
@@ -542,7 +612,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("network policy"));
+        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
     }
 
     #[test]
@@ -555,7 +625,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("workingDirectory"));
+        assert!(resp.error_message.contains(ERR_WORKDIR));
     }
 
     #[test]
@@ -568,15 +638,15 @@ mod tests {
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(
-            !resp.error_message.contains("filesystem policy"),
+            !resp.error_message.contains(ERR_FILESYSTEM_POLICY),
             "default request should not trigger filesystem policy rejection"
         );
         assert!(
-            !resp.error_message.contains("network policy"),
+            !resp.error_message.contains(ERR_NETWORK_POLICY),
             "default request should not trigger network policy rejection"
         );
         assert!(
-            !resp.error_message.contains("workingDirectory"),
+            !resp.error_message.contains(ERR_WORKDIR),
             "default request should not trigger workingDirectory rejection"
         );
     }
@@ -601,7 +671,7 @@ mod tests {
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains("network proxy"));
+        assert!(resp.error_message.contains(ERR_PROXY_POLICY));
     }
 
     #[test]

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -1,0 +1,493 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `NanVixScriptRunner` -- executes code inside a NanVix micro-VM.
+//!
+//! The initial runtime is CPython 3.12 with a trimmed FAT32 stdlib filesystem.
+//! The architecture supports additional runtimes (QuickJS, C, C++, Rust binaries).
+//!
+//! ## I/O model
+//!
+//! - **stdin**: runner writes script code, then closes (EOF triggers `exec()`)
+//! - **stdout**: relayed directly to parent process (not captured)
+//! - **stderr**: relayed directly to parent process (kernel traces)
+//!
+//! ## Exit codes
+//!
+//! `nanvixd` propagates the guest process exit code directly.
+//!
+//! ## Auto-discovery
+//!
+//! All required binaries (`nanvixd.exe`, `python.elf`, `cpython-ramfs.img`)
+//! are discovered next to the running executable. No configuration is needed.
+
+use std::fmt::Write;
+use std::io::Write as IoWrite;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crate::logger::Logger;
+use crate::models::{CodexRequest, NetworkPolicy, ScriptResponse};
+use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
+
+const PYTHON_BINARY: &str = "python.elf";
+const PYTHON_HOME: &str = "/sysroot";
+const BOOT_TIMEOUT_MS: u64 = 60_000;
+
+// -- NanVix error classification ---------------------------------------------
+
+/// Classifies NanVix runner errors for structured error handling.
+#[derive(Debug)]
+enum NanVixError {
+    /// Missing binaries, invalid paths, unsupported policies.
+    Preflight(String),
+    /// WHP unavailable, spawn failure.
+    Platform(String),
+    /// Stdin broken pipe, VM crash.
+    Runtime(String),
+    /// Watchdog killed the process.
+    Timeout {
+        script_timeout_ms: u32,
+        total_ms: u64,
+    },
+}
+
+impl std::fmt::Display for NanVixError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NanVixError::Preflight(msg) => write!(f, "NanVix preflight error: {}", msg),
+            NanVixError::Platform(msg) => write!(f, "NanVix platform error: {}", msg),
+            NanVixError::Runtime(msg) => write!(f, "NanVix runtime error: {}", msg),
+            NanVixError::Timeout {
+                script_timeout_ms,
+                total_ms,
+            } => write!(
+                f,
+                "NanVix execution timed out after {}ms \
+                 (boot_timeout={}ms, script_timeout={}ms)",
+                total_ms, BOOT_TIMEOUT_MS, script_timeout_ms
+            ),
+        }
+    }
+}
+
+impl NanVixError {
+    fn to_response(&self) -> ScriptResponse {
+        ScriptResponse {
+            exit_code: -1,
+            error_message: self.to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+/// Returns the directory containing the current executable.
+fn exe_dir() -> Result<PathBuf, NanVixError> {
+    let exe = std::env::current_exe()
+        .map_err(|e| NanVixError::Preflight(format!("cannot determine exe path: {}", e)))?;
+    exe.parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| NanVixError::Preflight("exe has no parent directory".to_string()))
+}
+
+// -- NanVixScriptRunner ------------------------------------------------------
+
+/// Script runner that executes Python code inside a NanVix microkernel VM.
+///
+/// All binaries are auto-discovered next to the running executable.
+pub struct NanVixScriptRunner {
+    _private: (),
+}
+
+impl NanVixScriptRunner {
+    pub fn new() -> Self {
+        Self { _private: () }
+    }
+
+    /// Resolve and validate all required paths next to the running executable.
+    fn resolve_paths(&self) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf), NanVixError> {
+        let dir = exe_dir()?;
+
+        let nanvixd = dir.join("nanvixd.exe");
+        if !nanvixd.exists() {
+            return Err(NanVixError::Preflight(format!(
+                "nanvixd.exe not found in {:?}",
+                dir
+            )));
+        }
+
+        let ramfs = dir.join("cpython-ramfs.img");
+        if !ramfs.exists() {
+            return Err(NanVixError::Preflight(format!(
+                "cpython-ramfs.img not found in {:?}",
+                dir
+            )));
+        }
+
+        let python = dir.join(PYTHON_BINARY);
+        if !python.exists() {
+            return Err(NanVixError::Preflight(format!(
+                "{} not found in {:?}",
+                PYTHON_BINARY, dir
+            )));
+        }
+
+        Ok((nanvixd, dir, ramfs, python))
+    }
+
+    /// Compute total timeout: boot grace + script timeout.
+    fn total_timeout_ms(script_timeout: u32) -> u64 {
+        let script_ms = get_timeout_milliseconds(script_timeout) as u64;
+        BOOT_TIMEOUT_MS.saturating_add(script_ms)
+    }
+}
+
+impl ScriptRunner for NanVixScriptRunner {
+    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+        // -- Policy validation ---------------------------------------------------
+        if !request.policy.readwrite_paths.is_empty()
+            || !request.policy.readonly_paths.is_empty()
+            || !request.policy.denied_paths.is_empty()
+        {
+            return NanVixError::Preflight(
+                "filesystem policy is not supported by the NanVix backend \
+                 -- guest has a read-only ramfs"
+                    .to_string(),
+            )
+            .to_response();
+        }
+        if !request.policy.allowed_hosts.is_empty()
+            || !request.policy.blocked_hosts.is_empty()
+            || request.policy.default_network_policy != NetworkPolicy::Allow
+        {
+            return NanVixError::Preflight(
+                "network policy is not supported by the NanVix backend \
+                 -- NanVix has no network stack"
+                    .to_string(),
+            )
+            .to_response();
+        }
+        if !request.working_directory.is_empty() {
+            return NanVixError::Preflight(
+                "workingDirectory is not supported by the NanVix backend \
+                 -- guest has its own filesystem namespace"
+                    .to_string(),
+            )
+            .to_response();
+        }
+
+        // -- Path resolution -----------------------------------------------------
+        let (nanvixd_path, bin_dir, ramfs_path, python_path) = match self.resolve_paths() {
+            Ok(paths) => paths,
+            Err(e) => return e.to_response(),
+        };
+
+        let _ = writeln!(logger, "NanVix: nanvixd={:?}", nanvixd_path);
+        let _ = writeln!(logger, "NanVix: bin_dir={:?}", bin_dir);
+        let _ = writeln!(logger, "NanVix: ramfs={:?}", ramfs_path);
+        let _ = writeln!(logger, "NanVix: python={:?}", python_path);
+
+        // Build the guest argument string.
+        // The ';' is NanVix's separator between argv and environment variables:
+        //   everything before ';' -> kernel splits on spaces -> argv[]
+        //   everything after ';'  -> kernel sets as env vars
+        // -S: skip site.py, -B: no .pyc writing
+        // -c exec(...): reads all of stdin and executes it (no interactive >>> prompts)
+        // Note: exec(__import__('sys').stdin.read()) has NO spaces, so it survives
+        //       NanVix's space-splitting in build_string_table().
+        let guest_args = format!(
+            "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
+            PYTHON_HOME
+        );
+
+        // -- Spawn nanvixd -------------------------------------------------------
+        // stdout/stderr are inherited (relayed directly to parent process).
+        // Only stdin is piped so we can write the script and send EOF.
+        let mut child = match Command::new(&nanvixd_path)
+            .arg("-bin-dir")
+            .arg(&bin_dir)
+            .arg("-ramfs")
+            .arg(&ramfs_path)
+            .arg("--")
+            .arg(&python_path)
+            .arg(&guest_args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let err = NanVixError::Platform(format!("failed to spawn nanvixd: {}", e));
+                let _ = writeln!(logger, "{}", err);
+                return err.to_response();
+            }
+        };
+
+        // Write script to stdin, then close (EOF triggers exec() in guest Python).
+        // With inherited stdout/stderr there is no pipe buffer deadlock risk.
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(request.script_code.as_bytes()) {
+                let err = NanVixError::Runtime(format!(
+                    "failed to write script to nanvixd stdin: {}",
+                    e
+                ));
+                let _ = writeln!(logger, "{}", err);
+                let _ = child.kill();
+                let _ = child.wait();
+                return err.to_response();
+            }
+            // stdin dropped here -- sends EOF to nanvixd
+        }
+
+        // -- Watchdog ------------------------------------------------------------
+        // Condvar-based watchdog with duplicated HANDLE for safe termination.
+        let timeout_ms = Self::total_timeout_ms(request.script_timeout);
+        let timed_out = Arc::new(AtomicBool::new(false));
+        let cancel_pair = Arc::new((Mutex::new(false), Condvar::new()));
+
+        let watchdog = if timeout_ms < u32::MAX as u64 {
+            let timed_out_clone = Arc::clone(&timed_out);
+            let cancel_pair_clone = Arc::clone(&cancel_pair);
+            let duration = Duration::from_millis(timeout_ms);
+
+            // Duplicate the process handle at spawn time (safe against PID reuse).
+            use std::os::windows::io::AsRawHandle;
+            use windows::Win32::Foundation::{DuplicateHandle, HANDLE, DUPLICATE_SAME_ACCESS};
+            use windows::Win32::System::Threading::GetCurrentProcess;
+
+            let raw = child.as_raw_handle();
+            let mut dup_handle = HANDLE::default();
+            let dup_ok = unsafe {
+                DuplicateHandle(
+                    GetCurrentProcess(),
+                    HANDLE(raw),
+                    GetCurrentProcess(),
+                    &mut dup_handle,
+                    0,
+                    false,
+                    DUPLICATE_SAME_ACCESS,
+                )
+            };
+            let process_handle_raw: Option<usize> = if dup_ok.is_ok() {
+                Some(dup_handle.0 as usize)
+            } else {
+                None
+            };
+
+            Some(thread::spawn(move || {
+                let (lock, cvar) = &*cancel_pair_clone;
+                let mut cancelled = lock.lock().unwrap();
+                let result = cvar.wait_timeout(cancelled, duration).unwrap();
+                cancelled = result.0;
+
+                if *cancelled {
+                    return;
+                }
+
+                if let Some(handle_raw) = process_handle_raw {
+                    use windows::Win32::Foundation::{CloseHandle, HANDLE};
+                    use windows::Win32::System::Threading::TerminateProcess;
+
+                    let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
+                    let kill_result = unsafe { TerminateProcess(handle, 1) };
+                    let _ = unsafe { CloseHandle(handle) };
+
+                    if kill_result.is_ok() {
+                        timed_out_clone.store(true, Ordering::SeqCst);
+                    }
+                }
+            }))
+        } else {
+            None
+        };
+
+        // -- Wait + cleanup ------------------------------------------------------
+        let exit_status = child.wait();
+
+        // Signal watchdog to stop
+        {
+            let (lock, cvar) = &*cancel_pair;
+            let mut cancelled = lock.lock().unwrap();
+            *cancelled = true;
+            cvar.notify_one();
+        }
+        if let Some(t) = watchdog {
+            let _ = t.join();
+        }
+
+        let was_timed_out = timed_out.load(Ordering::SeqCst);
+
+        if was_timed_out {
+            let err = NanVixError::Timeout {
+                script_timeout_ms: request.script_timeout,
+                total_ms: timeout_ms,
+            };
+            let _ = writeln!(logger, "{}", err);
+            return err.to_response();
+        }
+
+        match exit_status {
+            Ok(status) => {
+                let exit_code = status.code().unwrap_or(-1);
+                let _ = writeln!(logger, "NanVix: process exited with code {}", exit_code);
+                ScriptResponse {
+                    exit_code,
+                    ..Default::default()
+                }
+            }
+            Err(e) => {
+                let err = NanVixError::Runtime(format!("failed to wait for nanvixd: {}", e));
+                let _ = writeln!(logger, "{}", err);
+                err.to_response()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logger::{Logger, Mode};
+    use crate::models::{ContainerPolicy, NetworkPolicy};
+
+    #[test]
+    fn total_timeout_adds_boot_and_script() {
+        // script_timeout=0 -> u32::MAX (infinite), so total saturates
+        assert_eq!(
+            NanVixScriptRunner::total_timeout_ms(0),
+            u32::MAX as u64 + BOOT_TIMEOUT_MS
+        );
+        // script_timeout=30000 -> 30s + 60s boot = 90s
+        assert_eq!(NanVixScriptRunner::total_timeout_ms(30_000), 90_000);
+    }
+
+    #[test]
+    fn resolve_paths_fails_when_exe_dir_has_no_binaries() {
+        let runner = NanVixScriptRunner::new();
+        let err = runner.resolve_paths().unwrap_err();
+        assert!(err.to_string().contains("not found"), "got: {}", err);
+    }
+
+    // -- Policy validation tests -------------------------------------------------
+
+    #[test]
+    fn policy_rejects_filesystem_paths() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                readwrite_paths: vec!["/tmp".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("filesystem policy"));
+    }
+
+    #[test]
+    fn policy_rejects_readonly_paths() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                readonly_paths: vec!["/data".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("filesystem policy"));
+    }
+
+    #[test]
+    fn policy_rejects_network_hosts() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                allowed_hosts: vec!["example.com".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("network policy"));
+    }
+
+    #[test]
+    fn policy_rejects_blocked_network_hosts() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                blocked_hosts: vec!["evil.com".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("network policy"));
+    }
+
+    #[test]
+    fn policy_rejects_network_block_policy() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            policy: ContainerPolicy {
+                default_network_policy: NetworkPolicy::Block,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("network policy"));
+    }
+
+    #[test]
+    fn policy_rejects_working_directory() {
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest {
+            working_directory: "/home/user".to_string(),
+            ..Default::default()
+        };
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error_message.contains("workingDirectory"));
+    }
+
+    #[test]
+    fn policy_allows_defaults() {
+        // A request with all-default policies should pass validation and
+        // fail later on path resolution (nanvixd not found), NOT on policy.
+        let mut runner = NanVixScriptRunner::new();
+        let request = CodexRequest::default();
+        let mut logger = Logger::new(Mode::Buffer);
+        let resp = runner.run(&request, &mut logger);
+        assert_eq!(resp.exit_code, -1);
+        assert!(
+            !resp.error_message.contains("filesystem policy"),
+            "default request should not trigger filesystem policy rejection"
+        );
+        assert!(
+            !resp.error_message.contains("network policy"),
+            "default request should not trigger network policy rejection"
+        );
+        assert!(
+            !resp.error_message.contains("workingDirectory"),
+            "default request should not trigger workingDirectory rejection"
+        );
+    }
+}

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -109,6 +109,12 @@ pub struct NanVixScriptRunner {
     _private: (),
 }
 
+impl Default for NanVixScriptRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NanVixScriptRunner {
     pub fn new() -> Self {
         Self { _private: () }

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -34,24 +34,35 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::logger::Logger;
 use crate::models::{CodexRequest, NetworkPolicy, ScriptResponse};
-use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
+use crate::script_runner::ScriptRunner;
 
+/// CPython guest binary loaded by NanVix.
 const PYTHON_BINARY: &str = "python.elf";
+/// Guest PYTHONHOME value used by CPython inside NanVix.
+/// Must NOT contain ';' or spaces — these are NanVix argument delimiters
+/// that would corrupt the guest cmdline string.
 const PYTHON_HOME: &str = "/sysroot";
+/// NanVix daemon binary launched by the host runner.
+const NANVIXD_BINARY: &str = "nanvixd.exe";
+/// CPython stdlib ramfs image mounted by NanVix.
+const RAMFS_IMAGE: &str = "cpython-ramfs.img";
+/// Boot grace period that is always enforced.
 const BOOT_TIMEOUT_MS: u64 = 60_000;
+/// Generic error exit code returned to host callers.
+const ERROR_EXIT_CODE: i32 = -1;
 
 // -- NanVix error classification ---------------------------------------------
 
 /// Classifies NanVix runner errors for structured error handling.
 #[derive(Debug)]
 enum NanVixError {
-    /// Missing binaries, invalid paths, unsupported policies.
+    /// Pre-spawn validation failures (missing artifacts, invalid config, unsupported policy).
     Preflight(String),
-    /// WHP unavailable, spawn failure.
+    /// OS/platform failures while spawning/managing the NanVix process (WHP/spawn/handles).
     Platform(String),
     /// Stdin broken pipe, VM crash.
     Runtime(String),
@@ -84,7 +95,7 @@ impl std::fmt::Display for NanVixError {
 impl NanVixError {
     fn to_response(&self) -> ScriptResponse {
         ScriptResponse {
-            exit_code: -1,
+            exit_code: ERROR_EXIT_CODE,
             error_message: self.to_string(),
             ..Default::default()
         }
@@ -123,20 +134,23 @@ impl NanVixScriptRunner {
     /// Resolve and validate all required paths next to the running executable.
     fn resolve_paths(&self) -> Result<(PathBuf, PathBuf, PathBuf, PathBuf), NanVixError> {
         let dir = exe_dir()?;
+        // NanVix runtime artifacts (nanvixd.exe, kernel.elf, python.elf, cpython-ramfs.img)
+        // are distributed via GitHub releases from nanvix/nanvix and nanvix/cpython.
+        // They are placed next to wxc-exec.exe by setup scripts.
 
-        let nanvixd = dir.join("nanvixd.exe");
+        let nanvixd = dir.join(NANVIXD_BINARY);
         if !nanvixd.exists() {
             return Err(NanVixError::Preflight(format!(
-                "nanvixd.exe not found in {:?}",
-                dir
+                "{} not found in {:?}",
+                NANVIXD_BINARY, dir
             )));
         }
 
-        let ramfs = dir.join("cpython-ramfs.img");
+        let ramfs = dir.join(RAMFS_IMAGE);
         if !ramfs.exists() {
             return Err(NanVixError::Preflight(format!(
-                "cpython-ramfs.img not found in {:?}",
-                dir
+                "{} not found in {:?}",
+                RAMFS_IMAGE, dir
             )));
         }
 
@@ -153,8 +167,92 @@ impl NanVixScriptRunner {
 
     /// Compute total timeout: boot grace + script timeout.
     fn total_timeout_ms(script_timeout: u32) -> u64 {
-        let script_ms = get_timeout_milliseconds(script_timeout) as u64;
-        BOOT_TIMEOUT_MS.saturating_add(script_ms)
+        if script_timeout == 0 {
+            // Infinite script timeout — still enforce boot timeout.
+            u64::MAX
+        } else {
+            BOOT_TIMEOUT_MS.saturating_add(script_timeout as u64)
+        }
+    }
+
+    fn validate_policies(request: &CodexRequest) -> Result<(), NanVixError> {
+        if !request.policy.readwrite_paths.is_empty()
+            || !request.policy.readonly_paths.is_empty()
+            || !request.policy.denied_paths.is_empty()
+        {
+            return Err(NanVixError::Preflight(
+                "filesystem policy is not supported by the NanVix backend \
+                 -- guest has a read-only ramfs"
+                    .to_string(),
+            ));
+        }
+        if !request.policy.allowed_hosts.is_empty()
+            || !request.policy.blocked_hosts.is_empty()
+            || request.policy.default_network_policy != NetworkPolicy::Allow
+        {
+            return Err(NanVixError::Preflight(
+                "network policy is not supported by the NanVix backend \
+                 -- NanVix has no network stack"
+                    .to_string(),
+            ));
+        }
+        if request.policy.network_proxy.is_enabled() {
+            return Err(NanVixError::Preflight(
+                "network proxy is not supported by the NanVix backend \
+                 — NanVix has no network stack"
+                    .to_string(),
+            ));
+        }
+        if !request.working_directory.is_empty() {
+            return Err(NanVixError::Preflight(
+                "workingDirectory is not supported by the NanVix backend \
+                 -- guest has its own filesystem namespace"
+                    .to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn build_guest_args() -> String {
+        format!(
+            "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
+            PYTHON_HOME
+        )
+    }
+
+    fn spawn_nanvixd(
+        paths: (&Path, &Path, &Path, &Path),
+        guest_args: &str,
+        script: &str,
+    ) -> Result<std::process::Child, NanVixError> {
+        let (nanvixd_path, bin_dir, ramfs_path, python_path) = paths;
+        let mut child = Command::new(nanvixd_path)
+            .arg("-bin-dir")
+            .arg(bin_dir)
+            .arg("-ramfs")
+            .arg(ramfs_path)
+            .arg("--")
+            .arg(python_path)
+            .arg(guest_args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| NanVixError::Platform(format!("failed to spawn {}: {}", NANVIXD_BINARY, e)))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(script.as_bytes()) {
+                let err =
+                    NanVixError::Runtime(format!("failed to write script to {} stdin: {}", NANVIXD_BINARY, e));
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(err);
+            }
+            drop(stdin);
+        }
+
+        Ok(child)
     }
 }
 
@@ -163,55 +261,8 @@ impl ScriptRunner for NanVixScriptRunner {
         // -- Policy validation ---------------------------------------------------
         // Reject unsupported policies — NanVix provides its own isolation model.
         // Fail-closed: any policy setting not meaningful for NanVix is rejected.
-        if !request.policy.readwrite_paths.is_empty()
-            || !request.policy.readonly_paths.is_empty()
-            || !request.policy.denied_paths.is_empty()
-        {
-            return NanVixError::Preflight(
-                "filesystem policy is not supported by the NanVix backend \
-                 -- guest has a read-only ramfs"
-                    .to_string(),
-            )
-            .to_response();
-        }
-        if !request.policy.allowed_hosts.is_empty()
-            || !request.policy.blocked_hosts.is_empty()
-            || request.policy.default_network_policy != NetworkPolicy::Allow
-        {
-            return NanVixError::Preflight(
-                "network policy is not supported by the NanVix backend \
-                 -- NanVix has no network stack"
-                    .to_string(),
-            )
-            .to_response();
-        }
-        if request.policy.network_proxy.is_enabled() {
-            return NanVixError::Preflight(
-                "network proxy is not supported by the NanVix backend \
-                 — NanVix has no network stack"
-                    .to_string(),
-            )
-            .to_response();
-        }
-        if !request.working_directory.is_empty() {
-            return NanVixError::Preflight(
-                "workingDirectory is not supported by the NanVix backend \
-                 -- guest has its own filesystem namespace"
-                    .to_string(),
-            )
-            .to_response();
-        }
-
-        // Validate PYTHON_HOME doesn't contain NanVix delimiters that could
-        // corrupt the guest argument string (';' separates argv from env vars,
-        // spaces separate argv entries).
-        if PYTHON_HOME.contains(';') || PYTHON_HOME.contains(' ') {
-            return NanVixError::Preflight(format!(
-                "PYTHON_HOME '{}' contains invalid characters (';' or space) \
-                 — these are NanVix argument delimiters",
-                PYTHON_HOME
-            ))
-            .to_response();
+        if let Err(e) = Self::validate_policies(request) {
+            return e.to_response();
         }
 
         // -- Path resolution -----------------------------------------------------
@@ -233,48 +284,22 @@ impl ScriptRunner for NanVixScriptRunner {
         // -c exec(...): reads all of stdin and executes it (no interactive >>> prompts)
         // Note: exec(__import__('sys').stdin.read()) has NO spaces, so it survives
         //       NanVix's space-splitting in build_string_table().
-        let guest_args = format!(
-            "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
-            PYTHON_HOME
-        );
+        let guest_args = Self::build_guest_args();
 
         // -- Spawn nanvixd -------------------------------------------------------
         // stdout/stderr are inherited (relayed directly to parent process).
         // Only stdin is piped so we can write the script and send EOF.
-        let mut child = match Command::new(&nanvixd_path)
-            .arg("-bin-dir")
-            .arg(&bin_dir)
-            .arg("-ramfs")
-            .arg(&ramfs_path)
-            .arg("--")
-            .arg(&python_path)
-            .arg(&guest_args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::inherit())
-            .stderr(Stdio::inherit())
-            .spawn()
-        {
+        let mut child = match Self::spawn_nanvixd(
+            (&nanvixd_path, &bin_dir, &ramfs_path, &python_path),
+            &guest_args,
+            &request.script_code,
+        ) {
             Ok(c) => c,
             Err(e) => {
-                let err = NanVixError::Platform(format!("failed to spawn nanvixd: {}", e));
-                let _ = writeln!(logger, "{}", err);
-                return err.to_response();
+                let _ = writeln!(logger, "{}", e);
+                return e.to_response();
             }
         };
-
-        // Write script to stdin, then close (EOF triggers exec() in guest Python).
-        // With inherited stdout/stderr there is no pipe buffer deadlock risk.
-        if let Some(mut stdin) = child.stdin.take() {
-            if let Err(e) = stdin.write_all(request.script_code.as_bytes()) {
-                let err =
-                    NanVixError::Runtime(format!("failed to write script to nanvixd stdin: {}", e));
-                let _ = writeln!(logger, "{}", err);
-                let _ = child.kill();
-                let _ = child.wait();
-                return err.to_response();
-            }
-            // stdin dropped here -- sends EOF to nanvixd
-        }
 
         // -- Watchdog ------------------------------------------------------------
         // Condvar-based watchdog with duplicated HANDLE for safe termination.
@@ -282,7 +307,7 @@ impl ScriptRunner for NanVixScriptRunner {
         let timed_out = Arc::new(AtomicBool::new(false));
         let cancel_pair = Arc::new((Mutex::new(false), Condvar::new()));
 
-        let watchdog = if timeout_ms < u32::MAX as u64 {
+        let watchdog = if timeout_ms < u64::MAX {
             let timed_out_clone = Arc::clone(&timed_out);
             let cancel_pair_clone = Arc::clone(&cancel_pair);
             let duration = Duration::from_millis(timeout_ms);
@@ -295,6 +320,9 @@ impl ScriptRunner for NanVixScriptRunner {
             let raw = child.as_raw_handle();
             let mut dup_handle = HANDLE::default();
             let dup_ok = unsafe {
+                // SAFETY: `raw` is the live process HANDLE from `std::process::Child`.
+                // We duplicate it into the current process with same access rights so
+                // the watchdog thread can safely terminate/close it independently.
                 DuplicateHandle(
                     GetCurrentProcess(),
                     HANDLE(raw),
@@ -305,46 +333,66 @@ impl ScriptRunner for NanVixScriptRunner {
                     DUPLICATE_SAME_ACCESS,
                 )
             };
-            let process_handle_raw: Option<usize> = if dup_ok.is_ok() {
-                Some(dup_handle.0 as usize)
-            } else {
-                None
-            };
+            if let Err(e) = dup_ok {
+                let err = NanVixError::Platform(format!(
+                    "failed to duplicate {} process handle: {}",
+                    NANVIXD_BINARY, e
+                ));
+                let _ = writeln!(logger, "{}", err);
+                let _ = child.kill();
+                let _ = child.wait();
+                return err.to_response();
+            }
+            let process_handle_raw = dup_handle.0 as usize;
 
             Some(thread::spawn(move || {
                 let (lock, cvar) = &*cancel_pair_clone;
-                let mut cancelled = lock.lock().unwrap();
-                let result = cvar.wait_timeout(cancelled, duration).unwrap();
-                cancelled = result.0;
+                let mut cancelled = lock.lock().unwrap_or_else(|e| e.into_inner());
+                let start = Instant::now();
+                let mut remaining = duration;
+                loop {
+                    let result = cvar
+                        .wait_timeout(cancelled, remaining)
+                        .unwrap_or_else(|e| e.into_inner());
+                    cancelled = result.0;
+                    if *cancelled || result.1.timed_out() {
+                        break;
+                    }
+                    let elapsed = start.elapsed();
+                    if elapsed >= duration {
+                        break;
+                    }
+                    remaining = duration.saturating_sub(elapsed);
+                }
 
                 // Always close the duplicated handle to avoid leaks.
                 let close_handle = |handle_raw: usize| {
                     use windows::Win32::Foundation::{CloseHandle, HANDLE};
                     let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
+                    // SAFETY: `handle` was returned by `DuplicateHandle` in this
+                    // process and is closed exactly once by this watchdog thread.
                     let _ = unsafe { CloseHandle(handle) };
                 };
 
                 if *cancelled {
                     // Process already exited — close the handle and return.
-                    if let Some(handle_raw) = process_handle_raw {
-                        close_handle(handle_raw);
-                    }
+                    close_handle(process_handle_raw);
                     return;
                 }
 
                 // Timeout elapsed and process is still running — kill it.
-                if let Some(handle_raw) = process_handle_raw {
-                    use windows::Win32::Foundation::HANDLE;
-                    use windows::Win32::System::Threading::TerminateProcess;
+                // Set the timed_out flag BEFORE terminating so the main thread
+                // always sees it as true after child.wait() returns from a kill.
+                timed_out_clone.store(true, Ordering::SeqCst);
 
-                    let handle = HANDLE(handle_raw as *mut std::ffi::c_void);
-                    let kill_result = unsafe { TerminateProcess(handle, 1) };
-                    close_handle(handle_raw);
+                use windows::Win32::Foundation::HANDLE;
+                use windows::Win32::System::Threading::TerminateProcess;
 
-                    if kill_result.is_ok() {
-                        timed_out_clone.store(true, Ordering::SeqCst);
-                    }
-                }
+                let handle = HANDLE(process_handle_raw as *mut std::ffi::c_void);
+                // SAFETY: `handle` is a valid duplicated process handle owned by
+                // this thread, and passing exit code 1 is valid for termination.
+                let _ = unsafe { TerminateProcess(handle, 1) };
+                close_handle(process_handle_raw);
             }))
         } else {
             None
@@ -356,7 +404,7 @@ impl ScriptRunner for NanVixScriptRunner {
         // Signal watchdog to stop
         {
             let (lock, cvar) = &*cancel_pair;
-            let mut cancelled = lock.lock().unwrap();
+            let mut cancelled = lock.lock().unwrap_or_else(|e| e.into_inner());
             *cancelled = true;
             cvar.notify_one();
         }
@@ -377,7 +425,7 @@ impl ScriptRunner for NanVixScriptRunner {
 
         match exit_status {
             Ok(status) => {
-                let exit_code = status.code().unwrap_or(-1);
+                let exit_code = status.code().unwrap_or(ERROR_EXIT_CODE);
                 let _ = writeln!(logger, "NanVix: process exited with code {}", exit_code);
                 ScriptResponse {
                     exit_code,
@@ -385,7 +433,8 @@ impl ScriptRunner for NanVixScriptRunner {
                 }
             }
             Err(e) => {
-                let err = NanVixError::Runtime(format!("failed to wait for nanvixd: {}", e));
+                let err =
+                    NanVixError::Runtime(format!("failed to wait for {}: {}", NANVIXD_BINARY, e));
                 let _ = writeln!(logger, "{}", err);
                 err.to_response()
             }
@@ -401,11 +450,8 @@ mod tests {
 
     #[test]
     fn total_timeout_adds_boot_and_script() {
-        // script_timeout=0 -> u32::MAX (infinite), so total saturates
-        assert_eq!(
-            NanVixScriptRunner::total_timeout_ms(0),
-            u32::MAX as u64 + BOOT_TIMEOUT_MS
-        );
+        // script_timeout=0 => infinite script timeout sentinel.
+        assert_eq!(NanVixScriptRunner::total_timeout_ms(0), u64::MAX);
         // script_timeout=30000 -> 30s + 60s boot = 90s
         assert_eq!(NanVixScriptRunner::total_timeout_ms(30_000), 90_000);
     }
@@ -431,7 +477,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("filesystem policy"));
     }
 
@@ -447,7 +493,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("filesystem policy"));
     }
 
@@ -463,7 +509,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("network policy"));
     }
 
@@ -479,7 +525,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("network policy"));
     }
 
@@ -495,7 +541,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("network policy"));
     }
 
@@ -508,7 +554,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("workingDirectory"));
     }
 
@@ -520,7 +566,7 @@ mod tests {
         let request = CodexRequest::default();
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(
             !resp.error_message.contains("filesystem policy"),
             "default request should not trigger filesystem policy rejection"
@@ -554,7 +600,7 @@ mod tests {
         };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(resp.error_message.contains("network proxy"));
     }
 
@@ -569,10 +615,7 @@ mod tests {
     #[test]
     fn guest_args_format_is_correct() {
         let expected = "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME=/sysroot";
-        let actual = format!(
-            "-S -B -c exec(__import__('sys').stdin.read());PYTHONHOME={}",
-            PYTHON_HOME
-        );
+        let actual = NanVixScriptRunner::build_guest_args();
         assert_eq!(actual, expected);
         assert!(!"exec(__import__('sys').stdin.read())".contains(' '));
     }

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -266,10 +266,8 @@ impl ScriptRunner for NanVixScriptRunner {
         // With inherited stdout/stderr there is no pipe buffer deadlock risk.
         if let Some(mut stdin) = child.stdin.take() {
             if let Err(e) = stdin.write_all(request.script_code.as_bytes()) {
-                let err = NanVixError::Runtime(format!(
-                    "failed to write script to nanvixd stdin: {}",
-                    e
-                ));
+                let err =
+                    NanVixError::Runtime(format!("failed to write script to nanvixd stdin: {}", e));
                 let _ = writeln!(logger, "{}", err);
                 let _ = child.kill();
                 let _ = child.wait();
@@ -291,7 +289,7 @@ impl ScriptRunner for NanVixScriptRunner {
 
             // Duplicate the process handle at spawn time (safe against PID reuse).
             use std::os::windows::io::AsRawHandle;
-            use windows::Win32::Foundation::{DuplicateHandle, HANDLE, DUPLICATE_SAME_ACCESS};
+            use windows::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
             use windows::Win32::System::Threading::GetCurrentProcess;
 
             let raw = child.as_raw_handle();

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -175,6 +175,15 @@ fn watchdog_thread_fn(
     close_handle(process_handle_raw);
 }
 
+/// Components returned by [`NanVixScriptRunner::setup_watchdog`]: the watchdog
+/// thread handle (if a finite timeout was requested), the cancellation pair
+/// used to signal early completion, and the `timed_out` flag.
+type WatchdogState = (
+    Option<JoinHandle<()>>,
+    Arc<(Mutex<bool>, Condvar)>,
+    Arc<AtomicBool>,
+);
+
 // -- NanVixScriptRunner ------------------------------------------------------
 
 /// Script runner that executes Python code inside a NanVix microkernel VM.
@@ -298,12 +307,16 @@ impl NanVixScriptRunner {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|e| NanVixError::Platform(format!("failed to spawn {}: {}", NANVIXD_BINARY, e)))?;
+            .map_err(|e| {
+                NanVixError::Platform(format!("failed to spawn {}: {}", NANVIXD_BINARY, e))
+            })?;
 
         if let Some(mut stdin) = child.stdin.take() {
             if let Err(e) = stdin.write_all(script.as_bytes()) {
-                let err =
-                    NanVixError::Runtime(format!("failed to write script to {} stdin: {}", NANVIXD_BINARY, e));
+                let err = NanVixError::Runtime(format!(
+                    "failed to write script to {} stdin: {}",
+                    NANVIXD_BINARY, e
+                ));
                 let _ = child.kill();
                 let _ = child.wait();
                 return Err(err);
@@ -361,14 +374,7 @@ impl NanVixScriptRunner {
         child: &mut std::process::Child,
         timeout_ms: u64,
         logger: &mut Logger,
-    ) -> Result<
-        (
-            Option<JoinHandle<()>>,
-            Arc<(Mutex<bool>, Condvar)>,
-            Arc<AtomicBool>,
-        ),
-        ScriptResponse,
-    > {
+    ) -> Result<WatchdogState, ScriptResponse> {
         let timed_out = Arc::new(AtomicBool::new(false));
         let cancel_pair = Arc::new((Mutex::new(false), Condvar::new()));
 
@@ -410,7 +416,13 @@ impl NanVixScriptRunner {
         Ok((watchdog, cancel_pair, timed_out))
     }
 
-    fn log_resolved_paths(logger: &mut Logger, nanvixd: &Path, bin_dir: &Path, ramfs: &Path, python: &Path) {
+    fn log_resolved_paths(
+        logger: &mut Logger,
+        nanvixd: &Path,
+        bin_dir: &Path,
+        ramfs: &Path,
+        python: &Path,
+    ) {
         let _ = writeln!(logger, "NanVix: nanvixd={:?}", nanvixd);
         let _ = writeln!(logger, "NanVix: bin_dir={:?}", bin_dir);
         let _ = writeln!(logger, "NanVix: ramfs={:?}", ramfs);
@@ -495,10 +507,11 @@ impl ScriptRunner for NanVixScriptRunner {
         };
 
         let timeout_ms = Self::total_timeout_ms(request.script_timeout);
-        let (watchdog, cancel_pair, timed_out) = match Self::setup_watchdog(&mut child, timeout_ms, logger) {
-            Ok(v) => v,
-            Err(resp) => return resp,
-        };
+        let (watchdog, cancel_pair, timed_out) =
+            match Self::setup_watchdog(&mut child, timeout_ms, logger) {
+                Ok(v) => v,
+                Err(resp) => return resp,
+            };
 
         Self::wait_and_respond(
             &mut child,

--- a/test_configs/nanvix_hello.json
+++ b/test_configs/nanvix_hello.json
@@ -1,5 +1,7 @@
 {
-    "script": "x = 42\ny = 58\nprint('Hello from NanVix! sum=%d' % (x + y))",
-    "containment": "nanvix",
-    "timeout": 30000
+    "process": {
+        "commandLine": "x = 42\ny = 58\nprint('Hello from NanVix! sum=%d' % (x + y))",
+        "timeout": 30000
+    },
+    "containment": "nanvix"
 }

--- a/test_configs/nanvix_hello.json
+++ b/test_configs/nanvix_hello.json
@@ -1,0 +1,5 @@
+{
+    "script": "x = 42\ny = 58\nprint('Hello from NanVix! sum=%d' % (x + y))",
+    "containment": "nanvix",
+    "timeout": 30000
+}


### PR DESCRIPTION
## NanVix Backend for MXC

Adds NanVix as a containment backend in wxc-exec.exe. When the JSON config specifies `"containment": "nanvix"`, the binary routes to a new `NanVixScriptRunner` that spawns `nanvixd.exe` (the NanVix microkernel VM daemon), pipes the script via stdin, and relays stdout/stderr directly to the parent process.

### What Changed

- `models.rs` Added `NanVix` variant to `ContainmentBackend` enum (replaces `MicroVm`)
- `config_parser.rs` Added `"nanvix"` containment parsing
- `nanvix_runner.rs` **NEW** `NanVixScriptRunner` implementing `ScriptRunner` trait
- `lib.rs` Added `pub mod nanvix_runner` (Windows-gated with `#[cfg(windows)]`)
- `main.rs` Added `ContainmentBackend::NanVix` dispatch arm
- `types.ts` Updated SDK types: `microvm` â†’ `nanvix`
- `schema.md` / `schema.json` Updated docs and JSON schema
- `nanvix_hello.json` Example test configuration

### NanVix Runner Design

- **I/O model**: stdin piped (script code), stdout/stderr inherited (relayed to parent)
- **Auto-discovery**: `nanvixd.exe`, `kernel.elf`, `python.elf`, `cpython-ramfs.img` discovered next to the running executable
- **Error handling**: Internal `NanVixError` enum with 4 variants (Preflight, Platform, Runtime, Timeout)
- **Watchdog**: Condvar-based timer thread with duplicated Windows HANDLE for safe process termination (avoids PID reuse)
- **Policy validation**: Rejects filesystem paths, network policies, proxy, and working directory (NanVix has its own isolation)
- **Handle leak fix**: Duplicated process HANDLE is closed on both normal-exit and timeout paths via shared closure

### Commits

1. **First Implementation** (`e380f3f`) Core NanVix backend: runner, config parsing, models, SDK types, schema updates
2. **Close Handle Fix** (`a9f39a5`) P0 fix: handle leak on normal-exit path, P1 proxy policy check, P2 python_home delimiter validation, 4 new tests
3. **Fix clippy lint** (`203cc52`) Add `Default` impl for `NanVixScriptRunner`, fix test config JSON format

### Tests

167 workspace tests pass. Zero clippy warnings. E2E test verified with actual NanVix VM producing correct output (`Hello from NanVix! sum=100`).
