### PR TITLE
[LXC] Fix DNS resolution failure in LXC

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for shell scripts (prevents CRLF issues in WSL/Linux)
+*.sh text eol=lf

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -10,7 +10,9 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use wxc_common::logger::Logger;
-use wxc_common::models::{CodexRequest, LifecycleConfig, LxcConfig, NetworkEnforcementMode, ScriptResponse};
+use wxc_common::models::{
+    CodexRequest, LifecycleConfig, LxcConfig, NetworkEnforcementMode, ScriptResponse,
+};
 use wxc_common::script_runner::ScriptRunner;
 use wxc_common::validator::validate_request;
 

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -51,7 +51,7 @@ impl LxcScriptRunner {
     /// Polls `lxc-info` until the container has an IP address or the timeout is reached.
     fn wait_for_network(container_name: &str, timeout: Duration, logger: &mut Logger) -> bool {
         let start = Instant::now();
-        let poll_interval = Duration::from_millis(250);
+        let poll_interval = Duration::from_millis(500);
 
         let _ = writeln!(logger, "Waiting for container network to initialize...");
 

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -6,9 +6,11 @@
 //! Implements the `ScriptRunner` trait for LXC-based containment on Linux.
 
 use std::fmt::Write;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use wxc_common::logger::Logger;
-use wxc_common::models::{CodexRequest, LifecycleConfig, LxcConfig, ScriptResponse};
+use wxc_common::models::{CodexRequest, LifecycleConfig, LxcConfig, NetworkEnforcementMode, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
 use wxc_common::validator::validate_request;
 
@@ -41,6 +43,46 @@ impl LxcScriptRunner {
         } else {
             self.container_id.clone()
         }
+    }
+
+    /// Wait for the container's network stack to initialize.
+    /// Polls `lxc-info` until the container has an IP address or the timeout is reached.
+    fn wait_for_network(container_name: &str, timeout: Duration, logger: &mut Logger) -> bool {
+        let start = Instant::now();
+        let poll_interval = Duration::from_millis(250);
+
+        let _ = writeln!(logger, "Waiting for container network to initialize...");
+
+        while start.elapsed() < timeout {
+            let output = std::process::Command::new("lxc-info")
+                .arg("-n")
+                .arg(container_name)
+                .arg("-iH")
+                .output();
+
+            if let Ok(out) = output {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let ip = stdout.trim();
+                if !ip.is_empty() {
+                    let _ = writeln!(
+                        logger,
+                        "Container network ready (IP: {}, waited {:.1}s)",
+                        ip,
+                        start.elapsed().as_secs_f64()
+                    );
+                    return true;
+                }
+            }
+
+            thread::sleep(poll_interval);
+        }
+
+        let _ = writeln!(
+            logger,
+            "Warning: container network not ready after {:.1}s",
+            timeout.as_secs_f64()
+        );
+        false
     }
 
     /// Core execution logic.
@@ -97,6 +139,18 @@ impl LxcScriptRunner {
             let _ = writeln!(logger, "Container started successfully.");
         } else {
             let _ = writeln!(logger, "Container already running.");
+        }
+
+        // Wait for network only when the config uses network features (firewall rules
+        // or allowed/blocked hosts).
+        let needs_network = matches!(
+            request.policy.network_enforcement_mode,
+            NetworkEnforcementMode::Firewall | NetworkEnforcementMode::Both
+        ) || !request.policy.allowed_hosts.is_empty()
+            || !request.policy.blocked_hosts.is_empty();
+
+        if needs_network {
+            Self::wait_for_network(&container_name, Duration::from_secs(10), logger);
         }
 
         // Configure network rules


### PR DESCRIPTION
Fixes #76 . 

When defaultPolicy: "block" with allowedHosts set, DNS resolution failed inside the container because the script executed before the container's network stack (DHCP/DNS) had fully initialized. After lxc-start, the container's DHCP lease and /etc/resolv.conf take ~3-4 seconds to initialize. The runner was executing the script immediately, causing wget: bad address errors even though iptables rules correctly allowed DNS (port 53).

Fix
Added wait_for_network() which polls lxc-info -iH every 250ms until the container reports an IP address (up to 10s timeout). Only runs when network features are in use (firewall enforcement mode or allowed/blocked hosts configured), so
non-networked containers have zero overhead.