### PR TITLE
Add experimental feature guide and update versioning doc

### DIFF
--- a/docs/add-a-new-experimental-feature.md
+++ b/docs/add-a-new-experimental-feature.md
@@ -157,18 +157,37 @@ Add tests to verify:
 - Missing optional fields use defaults
 - Unknown fields under `experimental` are ignored (forward compatibility)
 
+Also ensure that `convert_raw_config()` populates `CodexRequest.experimental`:
+
+```rust
+Ok(CodexRequest {
+    // ... existing fields ...
+    experimental,   // ← include the parsed experimental config
+})
+```
+
 ## Step 4: Implement the feature in the runner
 
 > The `--experimental` CLI flag and `experimental_enabled` field on
 > `CodexRequest` already exist from when `compartments` was added. No changes
 > needed in `main.rs`.
 
+The full flow is:
+
+```
+main.rs: cli.experimental → request.experimental_enabled = true
+main.rs: runner.run(&request, &mut logger)
+  → runner checks request.experimental_enabled
+    → reads request.experimental.gpu_isolation
+      → applies the feature
+```
+
 In the appropriate runner (`appcontainer.rs`, `lxc_runner.rs`, etc.), guard
 your feature behind `experimental_enabled`:
 
 ```rust
 fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-    // ... normal execution ...
+    // ... normal execution (filesystem, network, etc.) ...
 
     if request.experimental_enabled {
         // existing experimental feature
@@ -182,7 +201,7 @@ fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse
         }
     }
 
-    // ... continue normal execution ...
+    // ... execute the script ...
 }
 ```
 
@@ -220,6 +239,14 @@ wxc-exec.exe test_configs/experimental_gpu_isolation.json --experimental --debug
 # Without flag — experimental section silently ignored, normal execution
 wxc-exec.exe test_configs/experimental_gpu_isolation.json --debug
 ```
+
+Verify three things:
+1. **With `--experimental`:** debug output shows your feature was applied
+   (e.g., "Applying GPU isolation: device 0, 1024MB limit")
+2. **Without `--experimental`:** no trace of your feature in the output,
+   process executes normally
+3. **Stable features unaffected:** filesystem, network, and other policies
+   still work exactly as before in both modes
 
 ## Step 6: Update the SDK (if needed)
 

--- a/docs/add-a-new-experimental-feature.md
+++ b/docs/add-a-new-experimental-feature.md
@@ -72,7 +72,8 @@ feature with its own typed schema:
           "default": false,
           "description": "Allow CUDA runtime access inside the container."
         }
-      }
+      },
+      "required": ["deviceIndex", "memoryLimitMb"]
     }
   }
 }
@@ -130,24 +131,33 @@ struct RawGpuIsolation {
 }
 ```
 
-In `convert_raw_config()`, map it directly — no name matching needed:
+In `convert_raw_config()`, map it directly — no name matching needed. Each
+feature should own its parsing via a constructor:
 
 ```rust
 let mut experimental = ExperimentalConfig::default();
 
 if let Some(raw_exp) = raw.experimental {
     if let Some(c) = raw_exp.compartments {
-        experimental.compartments = Some(CompartmentsConfig {
-            namespace: c.namespace,
-            isolation_level: c.isolation_level,
-        });
+        experimental.compartments = Some(CompartmentsConfig::from_raw(c)?);
     }
     if let Some(g) = raw_exp.gpu_isolation {
-        experimental.gpu_isolation = Some(GpuIsolationConfig {
-            device_index: g.device_index,
-            memory_limit_mb: g.memory_limit_mb,
-            allow_cuda: g.allow_cuda.unwrap_or(false),
-        });
+        experimental.gpu_isolation = Some(GpuIsolationConfig::from_raw(g)?);
+    }
+}
+```
+
+Each feature implements its own `from_raw()` constructor to keep
+`convert_raw_config()` clean:
+
+```rust
+impl GpuIsolationConfig {
+    fn from_raw(raw: RawGpuIsolation) -> Result<Self, String> {
+        Ok(Self {
+            device_index: raw.device_index,
+            memory_limit_mb: raw.memory_limit_mb,
+            allow_cuda: raw.allow_cuda.unwrap_or(false),
+        })
     }
 }
 ```
@@ -251,10 +261,10 @@ Verify three things:
 ## Step 6: Update the SDK (if needed)
 
 If your feature should be accessible from the TypeScript SDK, add
-`experimental` to the `SpawnOptions` interface in `sdk/src/types.ts`:
+`experimental` to the `SandboxSpawnOptions` interface in `sdk/src/sandbox.ts`:
 
 ```typescript
-export interface SpawnOptions {
+export interface SandboxSpawnOptions {
   debug?: boolean;
   experimental?: boolean;
 }
@@ -273,7 +283,10 @@ When your experimental feature is ready to ship:
 4. Remove the `if request.experimental_enabled` guard
 5. Bump the minor version
 6. Add a parser error for configs still referencing the feature under
-   `experimental`: `"gpuIsolation has moved to the stable section"`
+   `experimental`: `"gpuIsolation has moved to the stable section"`.
+   This error should persist for at least one release cycle so users have
+   time to migrate, then it can be relaxed to the standard "unknown field"
+   behavior.
 
 ## Checklist
 

--- a/docs/add-a-new-experimental-feature.md
+++ b/docs/add-a-new-experimental-feature.md
@@ -1,0 +1,260 @@
+# Adding a New Experimental Feature
+
+> **Do not modify stable schemas.** Files in `schemas/stable/` are immutable
+> release artifacts. All experimental work happens in `schemas/dev/` only.
+> Stable schemas are updated solely during the promotion process when an
+> experimental feature ships.
+
+This guide walks MXC developers through adding a new experimental feature
+end-to-end. We assume an experimental feature `compartments` already exists in
+the codebase, and we are adding a second experimental feature called
+`gpuIsolation`.
+
+## Prerequisites
+
+Read the [Versioning Design](versioning.md) doc for context on how experimental
+features fit into the MXC schema and shipping model.
+
+## Overview
+
+Adding an experimental feature touches these files:
+
+| File | What to change |
+|------|----------------|
+| `schemas/dev/mxc-config.schema.json` | Add `gpuIsolation` as a feature under `experimental` |
+| `src/wxc_common/src/models.rs` | Add `GpuIsolationConfig` struct, add field to `ExperimentalConfig` |
+| `src/wxc_common/src/config_parser.rs` | Add `gpuIsolation` field to `RawExperimental` |
+| Runner (`appcontainer.rs` or `lxc_runner.rs`) | Feature logic, guarded behind `experimental_enabled` |
+| `test_configs/` | Test config exercising your feature |
+
+## Step 1: Update the schema
+
+In `schemas/dev/mxc-config.schema.json`, the `experimental` section already
+exists with `compartments` as a feature. Add `gpuIsolation` as a new
+feature with its own typed schema:
+
+```json
+"experimental": {
+  "type": "object",
+  "description": "Experimental features. Only active when --experimental is passed.",
+  "properties": {
+    "compartments": {
+      "type": "object",
+      "description": "Network compartment isolation (experimental).",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Compartment namespace identifier."
+        },
+        "isolationLevel": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Isolation level (1 = shared network, 2 = separate stack, 3 = full isolation)."
+        }
+      }
+    },
+    "gpuIsolation": {
+      "type": "object",
+      "description": "GPU device isolation (experimental).",
+      "properties": {
+        "deviceIndex": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "GPU device index to assign to the container."
+        },
+        "memoryLimitMb": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "GPU memory limit in megabytes. 0 = no limit."
+        },
+        "allowCuda": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow CUDA runtime access inside the container."
+        }
+      }
+    }
+  }
+}
+```
+
+Each experimental feature is its own typed property under `experimental` —
+the same pattern as stable features (`filesystem`, `network`) under the
+top-level config. This gives editors full autocomplete and validation.
+
+## Step 2: Add the model struct
+
+In `src/wxc_common/src/models.rs`, `ExperimentalConfig` already exists with
+`compartments`. Add your `GpuIsolationConfig` struct and a field for it:
+
+```rust
+/// GPU isolation settings (experimental).
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct GpuIsolationConfig {
+    pub device_index: u32,
+    pub memory_limit_mb: u32,
+    pub allow_cuda: bool,
+}
+```
+
+Add it to the existing `ExperimentalConfig`:
+
+```rust
+pub struct ExperimentalConfig {
+    pub compartments: Option<CompartmentsConfig>,
+    pub gpu_isolation: Option<GpuIsolationConfig>,   // ← add this
+}
+```
+
+## Step 3: Parse the experimental section
+
+In `src/wxc_common/src/config_parser.rs`, the `RawExperimental` struct already
+exists with `compartments`. Add `gpu_isolation`:
+
+```rust
+#[derive(Deserialize, Default)]
+struct RawExperimental {
+    compartments: Option<RawCompartments>,          // existing
+    #[serde(rename = "gpuIsolation")]
+    gpu_isolation: Option<RawGpuIsolation>,         // ← add this
+}
+
+#[derive(Deserialize)]
+struct RawGpuIsolation {
+    #[serde(rename = "deviceIndex")]
+    device_index: u32,
+    #[serde(rename = "memoryLimitMb")]
+    memory_limit_mb: u32,
+    #[serde(rename = "allowCuda")]
+    allow_cuda: Option<bool>,
+}
+```
+
+In `convert_raw_config()`, map it directly — no name matching needed:
+
+```rust
+let mut experimental = ExperimentalConfig::default();
+
+if let Some(raw_exp) = raw.experimental {
+    if let Some(c) = raw_exp.compartments {
+        experimental.compartments = Some(CompartmentsConfig {
+            namespace: c.namespace,
+            isolation_level: c.isolation_level,
+        });
+    }
+    if let Some(g) = raw_exp.gpu_isolation {
+        experimental.gpu_isolation = Some(GpuIsolationConfig {
+            device_index: g.device_index,
+            memory_limit_mb: g.memory_limit_mb,
+            allow_cuda: g.allow_cuda.unwrap_or(false),
+        });
+    }
+}
+```
+
+Add tests to verify:
+- `gpuIsolation` config parses correctly
+- Missing optional fields use defaults
+- Unknown fields under `experimental` are ignored (forward compatibility)
+
+## Step 4: Implement the feature in the runner
+
+> The `--experimental` CLI flag and `experimental_enabled` field on
+> `CodexRequest` already exist from when `compartments` was added. No changes
+> needed in `main.rs`.
+
+In the appropriate runner (`appcontainer.rs`, `lxc_runner.rs`, etc.), guard
+your feature behind `experimental_enabled`:
+
+```rust
+fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+    // ... normal execution ...
+
+    if request.experimental_enabled {
+        // existing experimental feature
+        if let Some(ref compartments) = request.experimental.compartments {
+            self.apply_compartments(compartments, logger)?;
+        }
+
+        // new experimental feature
+        if let Some(ref gpu) = request.experimental.gpu_isolation {
+            self.apply_gpu_isolation(gpu, logger)?;
+        }
+    }
+
+    // ... continue normal execution ...
+}
+```
+
+**Important:** Your experimental code must not break the stable code path. When
+`experimental_enabled` is false, behavior must be identical to before your
+change.
+
+## Step 5: Add a test config
+
+Create a test config that exercises your feature:
+
+```json
+{
+  "version": "0.4.0-alpha",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "cmd.exe /c echo gpu isolation test"
+  },
+  "experimental": {
+    "gpuIsolation": {
+      "deviceIndex": 0,
+      "memoryLimitMb": 1024,
+      "allowCuda": true
+    }
+  }
+}
+```
+
+Run it with and without the flag to verify:
+
+```bash
+# With flag — experimental feature is active
+wxc-exec.exe test_configs/experimental_gpu_isolation.json --experimental --debug
+
+# Without flag — experimental section silently ignored, normal execution
+wxc-exec.exe test_configs/experimental_gpu_isolation.json --debug
+```
+
+## Step 6: Update the SDK (if needed)
+
+If your feature should be accessible from the TypeScript SDK, add
+`experimental` to the `SpawnOptions` interface in `sdk/src/types.ts`:
+
+```typescript
+export interface SpawnOptions {
+  debug?: boolean;
+  experimental?: boolean;
+}
+```
+
+The SDK passes `--experimental` to the underlying binary when this is set.
+
+## Promoting to Stable
+
+When your experimental feature is ready to ship:
+
+1. Move the property from `experimental` to a top-level property in the schema
+   (e.g., `experimental.gpuIsolation` → `gpuIsolation`)
+2. Move the struct from `ExperimentalConfig` to `CodexRequest`
+3. Move the field from `RawExperimental` to `RawConfig`
+4. Remove the `if request.experimental_enabled` guard
+5. Bump the minor version
+6. Add a parser error for configs still referencing the feature under
+   `experimental`: `"gpuIsolation has moved to the stable section"`
+
+## Checklist
+
+- [ ] Schema updated in `schemas/dev/mxc-config.schema.json`
+- [ ] Model struct added to `models.rs`
+- [ ] Parsing added to `config_parser.rs` with unit tests
+- [ ] `--experimental` flag wired through (if not already)
+- [ ] Feature logic guarded behind `experimental_enabled` in the runner
+- [ ] Test config created and verified with and without `--experimental`
+- [ ] Stable code path is unaffected (all existing tests pass)
+- [ ] SDK updated if feature is SDK-accessible

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -71,36 +71,35 @@ The current config schema has two sections:
   "appContainer": { ... },
   "lxc": { ... },
 
-  "experimental": [
-    {
-      "name": "compartments",
-      "config": { ... }
+  "experimental": {
+    "compartments": {
+      "namespace": "test-ns",
+      "isolationLevel": 2
     },
-    {
-      "name": "gpu-isolation",
-      "config": { ... }
+    "gpuIsolation": {
+      "deviceIndex": 0,
+      "memoryLimitMb": 1024,
+      "allowCuda": true
     }
-  ]
+  }
 }
 ```
 
-Each experimental feature has a `name` (used for identification and future
-per-feature gating — see Open Questions) and a freeform `config` object that
-the feature developer defines. The `name` must be unique across all experimental
-features. Today, the `--experimental` flag is a global toggle that enables all
+Each experimental feature is a typed property under `experimental` — the same
+pattern as stable features (`filesystem`, `network`) under the top-level
+config. This gives editors full autocomplete and validation for experimental
+configs. Today, the `--experimental` flag is a global toggle that enables all
 experimental features; per-feature gating (e.g., `--experimental compartments`)
 is under consideration.
 
 **Rules:**
-- **Generic section** (top) — shipped, stable, supported. Always executed.
-- **Experimental section** (bottom) — an array of named features, only executed
-  when the experimental flag is enabled (see below). Developers can put any
-  keys or nested keys they want inside a feature's `config` and are responsible
-  for adding the parsing code for their
-  experimental feature. As long as their experimental code doesn't break what
-  is shipped, they are free to iterate as much as they want.
+- **Stable section** (top) — shipped, stable, supported. Always executed.
+- **Experimental section** — an object containing experimental features as
+  typed properties, only applied when the experimental flag is enabled (see
+  below). Each feature defines its own schema. As long as experimental code
+  doesn't break what is shipped, developers are free to iterate.
 - **Promotion:** When an experimental feature is ready to ship, move it from
-  `experimental` to the generic section and bump the minor version.
+  `experimental` to the top-level section and bump the minor version.
 
 ### Experimental Flag
 
@@ -132,7 +131,8 @@ The SDK passes `--experimental` to the underlying binary when this option is set
 
 ### Forking Code for Experimental Features
 
-Developers adding experimental features follow this pattern:
+Developers adding experimental features follow this pattern. For a detailed
+step-by-step guide, see [Adding a New Experimental Feature](add-a-new-experimental-feature.md).
 
 **In `config_parser.rs`:**
 ```rust
@@ -143,13 +143,19 @@ struct RawConfig {
 
 struct RawExperimental {
     compartments: Option<RawCompartments>,
+    #[serde(rename = "gpuIsolation")]
     gpu_isolation: Option<RawGpuIsolation>,
-    // ... add new experimental fields here ...
+    // ... add new experimental features here ...
 }
 ```
 
-**In `CodexRequest` (models.rs):**
+**In `models.rs`:**
 ```rust
+pub struct ExperimentalConfig {
+    pub compartments: Option<CompartmentsConfig>,
+    pub gpu_isolation: Option<GpuIsolationConfig>,
+}
+
 pub struct CodexRequest {
     // ... stable fields ...
     pub experimental_enabled: bool,  // set by --experimental flag
@@ -164,20 +170,25 @@ fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse
 
     // Experimental features only applied when flag is set
     if request.experimental_enabled {
-        if let Some(compartments) = &request.experimental.compartments {
+        if let Some(ref compartments) = request.experimental.compartments {
             self.apply_compartments(compartments, logger);
+        }
+        if let Some(ref gpu) = request.experimental.gpu_isolation {
+            self.apply_gpu_isolation(gpu, logger);
         }
     }
 }
 ```
 
 **Promotion process:** When an experimental feature is ready to ship:
-1. Move the field from `RawExperimental` to the stable section of `RawConfig`
-2. Move the field from `ExperimentalConfig` to `CodexRequest`
-3. Remove the `if request.experimental_enabled` guard — the feature now always
-   applies
-4. Update the schema: move from `experimental` section to generic section
+1. Move the property from `experimental` to a top-level property in the schema
+   (e.g., `experimental.gpuIsolation` → `gpuIsolation`)
+2. Move the struct from `ExperimentalConfig` to `CodexRequest`
+3. Move the field from `RawExperimental` to `RawConfig`
+4. Remove the `if request.experimental_enabled` guard
 5. Bump the minor version
+6. Add a parser error for configs still referencing the feature under
+   `experimental`: `"<feature> has moved to the stable section"`
 
 ## Data Flow
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -188,7 +188,10 @@ fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse
 4. Remove the `if request.experimental_enabled` guard
 5. Bump the minor version
 6. Add a parser error for configs still referencing the feature under
-   `experimental`: `"<feature> has moved to the stable section"`
+   `experimental`: `"<feature> has moved to the stable section"`.
+   This error should persist for at least one release cycle so users have
+   time to migrate, then it can be relaxed to the standard "unknown field"
+   behavior.
 
 ## Data Flow
 


### PR DESCRIPTION
Adds a step-by-step developer guide for adding experimental features to MXC, and updates versioning.md to use the new object-based experimental section design.