### PR TITLE
Remove labesl when issue or PR is closed

### DIFF
--- a/.github/policies/labelManagement.issueClosed.yml
+++ b/.github/policies/labelManagement.issueClosed.yml
@@ -1,0 +1,34 @@
+id: labelManagement.issueClosed
+name: GitOps.PullRequestIssueManagement
+description: Handlers when an issue gets closed
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove labels when an issue is closed
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Closed
+        then:
+          - removeLabel:
+              label: Needs-Triage
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+      - description: Remove labels when a pull request is closed
+        if:
+          - payloadType: Pull_Request
+          - isAction:
+              action: Closed
+        then:
+          - removeLabel:
+              label: Needs-Attention
+          - removeLabel:
+              label: Needs-Author-Feedback
+onFailure:
+onSuccess:


### PR DESCRIPTION
Removes labels when Issue or PR is closed:

From Issues
* Needs-Triage
* Needs-Attention
* Needs-Author-Feedback

From PRs
* Needs-Attention
* Needs-Author-Feedback

Resolves #98 
* #98

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/103)