### PR TITLE
[SDK/CLI] Remove export of findWxcExecutable and findLxcExecutable functions from SDK 

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -22,52 +22,6 @@ program
   .version('0.1.0');
 
 program
-  .command('run')
-  .description('Run a config for a specific container backend')
-  .argument('<config>', 'Path to ContainerConfig JSON file or base64-encoded config')
-  .option('--config-base64', 'Treat config argument as base64-encoded JSON')
-  .option('--debug', 'Enable debug output')
-  .action(async (config: string, options: { configBase64?: boolean; debug?: boolean }) => {
-    try {
-      const platform = require('os').platform();
-      let execPath: string | null;
-      if (platform === 'linux') {
-        const { findLxcExecutable } = require('@microsoft/mxc-sdk');
-        execPath = findLxcExecutable();
-      } else {
-        const { findWxcExecutable } = require('@microsoft/mxc-sdk');
-        execPath = findWxcExecutable();
-      }
-      if (!execPath) {
-        console.error('Error: Executable not found. Ensure wxc-exec or lxc-exec is built.');
-        process.exit(1);
-      }
-      const executor = new ContainerExecutor(execPath);
-      const result = await executor.run(config, {
-        isBase64: options.configBase64 ?? false,
-        debug: options.debug ?? false
-      });
-
-      if (result.success) {
-        console.log('Execution successful');
-        if (result.stdout) {
-          console.log('Output:', result.stdout);
-        }
-        process.exit(result.exitCode);
-      } else {
-        console.error('Execution failed');
-        if (result.stderr) {
-          console.error('Error:', result.stderr);
-        }
-        process.exit(result.exitCode);
-      }
-    } catch (error) {
-      console.error('Error:', error instanceof Error ? error.message : String(error));
-      process.exit(1);
-    }
-  });
-
-program
   .command('validate')
   .description('Validate a configuration file')
   .argument('<config>', 'Path to JSON configuration file')

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -39,8 +39,6 @@ export {
 // Export platform detection functions
 export {
   getPlatformSupport,
-  findWxcExecutable,
-  findLxcExecutable,
 } from './platform';
 
 // Export sandbox spawning functions


### PR DESCRIPTION
Addresses part of #105.

SDK consumers should interact through `spawnSandbox()` which handles executable discovery internally. The `findWxcExecutable` and `findLxcExecutable` functions are implementation details that should not be part of the public API surface.

Changes

 - SDK: Remove `findWxcExecutable` and `findLxcExecutable` from `sdk/src/index.ts` exports (functions remain available internally for sandbox.ts)
 - CLI: Delete the legacy run command which was the only external consumer of these functions. Functional tests use the `run-sdk` command which goes through the public `spawnSandbox()` function of the SDK. This was only used to test passing wxc-exec configs directly to wxc-exec, which is not needed as `run-sdk` uses public sdk functions we eventually do this under the hood. 
 - See `run-sdk` here: https://github.com/microsoft/mxc/blob/93ccc2a420ce8b92a5aa62d098a8676b89b83db8/cli/src/cli.ts#L127

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/107)