### PR TITLE
Build experimental infra for new features

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -90,7 +90,8 @@ program
   .option('--cwd <path>', 'Working directory for the sandboxed process')
   .option('--container-name <name>', 'Name for the sandbox container')
   .option('--debug', 'Enable debug output')
-  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; debug?: boolean }) => {
+  .option('--experimental', 'Enable experimental features')
+  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; debug?: boolean; experimental?: boolean }) => {
     try {
       let scriptCommand: string;
       if (options.script) {
@@ -145,6 +146,7 @@ program
 
       const ptyProcess = spawnSandbox(scriptCommand, policy, {
         debug: options.debug ?? false,
+        experimental: options.experimental ?? false,
       }, options.cwd, options.containerName);
 
       ptyProcess.onData((data: string) => {

--- a/docs/authoring-a-new-feature.md
+++ b/docs/authoring-a-new-feature.md
@@ -21,7 +21,7 @@ Adding an experimental feature touches these files:
 
 | File | What to change |
 |------|----------------|
-| `schemas/dev/mxc-config.schema.json` | Add `gpuIsolation` as a feature under `experimental` |
+| `schemas/dev/mxc-config.schema.0.5.0-dev.json` | Add `gpuIsolation` as a feature under `experimental` |
 | `src/wxc_common/src/models.rs` | Add `GpuIsolationConfig` struct, add field to `ExperimentalConfig` |
 | `src/wxc_common/src/config_parser.rs` | Add `gpuIsolation` field to `RawExperimental` |
 | Runner (`appcontainer.rs` or `lxc_runner.rs`) | Feature logic, guarded behind `experimental_enabled` |
@@ -29,7 +29,7 @@ Adding an experimental feature touches these files:
 
 ## Step 1: Update the schema
 
-In `schemas/dev/mxc-config.schema.json`, the `experimental` section already
+In `schemas/dev/mxc-config.schema.0.5.0-dev.json`, the `experimental` section already
 exists with `compartments` as a feature. Add `gpuIsolation` as a new
 feature with its own typed schema:
 
@@ -219,6 +219,13 @@ fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse
 `experimental_enabled` is false, behavior must be identical to before your
 change.
 
+**Validation:** Schema validation for your feature should happen in the feature
+component (e.g., `apply_gpu_isolation()`), not in `config_parser.rs`. The parser
+only deserializes the JSON into structs — the feature component owns validating
+that the config values are correct, compatible, and make sense for the current
+backend. This keeps `config_parser.rs` lean and lets each feature evolve its
+validation independently.
+
 ## Step 5: Add a test config
 
 Create a test config that exercises your feature:
@@ -290,7 +297,7 @@ When your experimental feature is ready to ship:
 
 ## Checklist
 
-- [ ] Schema updated in `schemas/dev/mxc-config.schema.json`
+- [ ] Schema updated in `schemas/dev/mxc-config.schema.X.Y.Z-dev.json`
 - [ ] Model struct added to `models.rs`
 - [ ] Parsing added to `config_parser.rs` with unit tests
 - [ ] `--experimental` flag wired through (if not already)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,12 +1,23 @@
 
 ## Configuration Schema
 
-MXC uses a JSON configuration file. The formal schema is at
-[`schemas/dev/mxc-config.schema.0.5.0-dev.json`](../schemas/dev/mxc-config.schema.0.5.0-dev.json) —
-editors that support JSON Schema will provide autocomplete and validation when
-you add `"$schema": "./schemas/dev/mxc-config.schema.0.5.0-dev.json"` to your config file.
-This `$schema` value is for editor validation only; the config file's runtime
-`"version"` should remain `"0.4.0-alpha"` until the parser/SDK support `0.5.x`.
+MXC uses a JSON configuration file. The current stable schema is at
+[`schemas/stable/mxc-config.schema.0.4.0-alpha.json`](../schemas/stable/mxc-config.schema.0.4.0-alpha.json).
+For development, the dev schema at
+[`schemas/dev/mxc-config.schema.0.5.0-dev.json`](../schemas/dev/mxc-config.schema.0.5.0-dev.json)
+includes experimental features and may change without notice.
+
+Editors that support JSON Schema will provide autocomplete and validation when
+you add a `"$schema"` reference to your config file. Use the stable schema for
+production configs and the dev schema when working on experimental features:
+
+```json
+// Production
+"$schema": "./schemas/stable/mxc-config.schema.0.4.0-alpha.json"
+
+// Development (experimental features)
+"$schema": "./schemas/dev/mxc-config.schema.0.5.0-dev.json"
+```
 
 ### Full Schema
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -5,6 +5,8 @@ MXC uses a JSON configuration file. The formal schema is at
 [`schemas/dev/mxc-config.schema.0.5.0-dev.json`](../schemas/dev/mxc-config.schema.0.5.0-dev.json) —
 editors that support JSON Schema will provide autocomplete and validation when
 you add `"$schema": "./schemas/dev/mxc-config.schema.0.5.0-dev.json"` to your config file.
+This `$schema` value is for editor validation only; the config file's runtime
+`"version"` should remain `"0.4.0-alpha"` until the parser/SDK support `0.5.x`.
 
 ### Full Schema
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -2,9 +2,9 @@
 ## Configuration Schema
 
 MXC uses a JSON configuration file. The formal schema is at
-[`schemas/dev/mxc-config.schema.json`](../schemas/dev/mxc-config.schema.json) —
+[`schemas/dev/mxc-config.schema.0.5.0-dev.json`](../schemas/dev/mxc-config.schema.0.5.0-dev.json) —
 editors that support JSON Schema will provide autocomplete and validation when
-you add `"$schema": "./schemas/dev/mxc-config.schema.json"` to your config file.
+you add `"$schema": "./schemas/dev/mxc-config.schema.0.5.0-dev.json"` to your config file.
 
 ### Full Schema
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -49,12 +49,12 @@ Per [semver.org](https://semver.org/):
 mxc/schemas/
 ├── stable/
 │   ├── schema.0.3.0-alpha.json      (shipped — historical)
-│   └── schema.0.4.0-alpha.json      (shipped — current stable)
+│   └── mxc-config.schema.0.4.0-alpha.json  (shipped — current stable)
 └── dev/
-    └── mxc-config.schema.json       (current — includes experimental section definition)
+    └── mxc-config.schema.0.5.0-dev.json   (current — includes experimental section definition)
 ```
 
-The dev schema file (`mxc-config.schema.json`) must define the `experimental`
+The dev schema file (`mxc-config.schema.X.Y.Z-dev.json`) must define the `experimental`
 section structure so that editors can validate experimental configs. Stable
 schemas in `stable/` do not include the experimental section.
 
@@ -132,7 +132,7 @@ The SDK passes `--experimental` to the underlying binary when this option is set
 ### Forking Code for Experimental Features
 
 Developers adding experimental features follow this pattern. For a detailed
-step-by-step guide, see [Adding a New Experimental Feature](add-a-new-experimental-feature.md).
+step-by-step guide, see [Authoring a New Feature](authoring-a-new-feature.md).
 
 **In `config_parser.rs`:**
 ```rust

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -48,7 +48,6 @@ Per [semver.org](https://semver.org/):
 ```
 mxc/schemas/
 ├── stable/
-│   ├── schema.0.3.0-alpha.json      (shipped — historical)
 │   └── mxc-config.schema.0.4.0-alpha.json  (shipped — current stable)
 └── dev/
     └── mxc-config.schema.0.5.0-dev.json   (current — includes experimental section definition)

--- a/schemas/dev/mxc-config.schema.0.5.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.5.0-dev.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/microsoft/mxc/schemas/dev/mxc-config.schema.json",
+  "$id": "https://github.com/microsoft/mxc/schemas/dev/mxc-config.schema.0.5.0-dev.json",
   "title": "MXC Configuration",
   "description": "Configuration schema for MXC container execution engine. Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
   "type": "object",

--- a/schemas/dev/mxc-config.schema.0.5.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.5.0-dev.json
@@ -10,7 +10,7 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version (semver). Current: '0.4.0-alpha'.",
+      "description": "MXC config schema version (semver). Current stable: '0.4.0-alpha'. The dev schema filename (0.5.0-dev) reflects the next version in development — configs should continue using '0.4.0-alpha' until the parser is updated to support 0.5.x.",
       "examples": ["0.4.0-alpha"]
     },
     "containerId": {

--- a/schemas/dev/mxc-config.schema.json
+++ b/schemas/dev/mxc-config.schema.json
@@ -185,6 +185,23 @@
           "description": "Distribution release version (e.g., '3.20', '24.04'). Required."
         }
       }
+    },
+
+    "experimental": {
+      "type": "object",
+      "description": "Experimental features. Only active when --experimental is passed.",
+      "properties": {
+        "test": {
+          "type": "object",
+          "description": "Placeholder feature for testing experimental infrastructure.",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Message to log when the feature is applied."
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/schemas/stable/mxc-config.schema.0.4.0-alpha.json
+++ b/schemas/stable/mxc-config.schema.0.4.0-alpha.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/microsoft/mxc/schemas/mxc-config.schema.json",
+  "$id": "https://github.com/microsoft/mxc/schemas/stable/mxc-config.schema.0.4.0-alpha.json",
   "title": "MXC Configuration",
   "description": "Configuration schema for MXC container execution engine. Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
   "type": "object",

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -128,6 +128,11 @@ export interface SandboxSpawnOptions {
   debug?: boolean;
 
   /**
+   * Enable experimental features
+   */
+  experimental?: boolean;
+
+  /**
    * PTY options to pass to node-pty
    */
   ptyOptions?: pty.IPtyForkOptions;
@@ -198,6 +203,10 @@ export function spawnSandbox(
 
   if (options.debug) {
     args.push('--debug');
+  }
+
+  if (options.experimental) {
+    args.push('--experimental');
   }
 
   const ptyOpts: pty.IPtyForkOptions = {

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -38,6 +38,10 @@ struct Cli {
     /// Container name (required with --delete)
     #[arg(long = "containername")]
     containername: Option<String>,
+
+    /// Enable experimental features
+    #[arg(long)]
+    experimental: bool,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -114,13 +118,15 @@ fn main() {
     }
 
     // Load request
-    let request = match load_request(&config_data, &mut logger, is_base64) {
+    let mut request = match load_request(&config_data, &mut logger, is_base64) {
         Ok(r) => r,
         Err(_) => {
             eprint!("Request error\n{}", logger.get_buffer());
             process::exit(1);
         }
     };
+
+    request.experimental_enabled = cli.experimental;
 
     log_request(&request, &mut logger);
 

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -105,6 +105,17 @@ impl LxcScriptRunner {
             self.config.distribution, self.config.release
         );
 
+        // Apply experimental features when flag is set
+        if request.experimental_enabled {
+            if let Some(ref test) = request.experimental.test {
+                let _ = writeln!(
+                    logger,
+                    "Experimental feature 'test' applied: {}",
+                    test.message
+                );
+            }
+        }
+
         // Create container handle
         let container = LxcContainer::new(&container_name, None);
         let mut container_created = false;

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -41,6 +41,10 @@ struct Cli {
     /// Container name (required with --delete)
     #[arg(long = "containername")]
     containername: Option<String>,
+
+    /// Enable experimental features
+    #[arg(long)]
+    experimental: bool,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -130,13 +134,15 @@ fn main() {
     }
 
     // Load request
-    let request = match load_request(&config_data, &mut logger, is_base64) {
+    let mut request = match load_request(&config_data, &mut logger, is_base64) {
         Ok(r) => r,
         Err(_) => {
             eprint!("Request error\n{}", logger.get_buffer());
             process::exit(1);
         }
     };
+
+    request.experimental_enabled = cli.experimental;
 
     log_request(&request, &mut logger);
 

--- a/src/wxc_common/src/appcontainer.rs
+++ b/src/wxc_common/src/appcontainer.rs
@@ -515,6 +515,17 @@ impl ScriptRunner for AppContainerScriptRunner {
         if let Err(e) = validate_request(request) {
             return ScriptResponse::error(&e.to_string());
         }
+
+        // Apply experimental features when flag is set
+        if request.experimental_enabled {
+            if let Some(ref test) = request.experimental.test {
+                logger.log_line(&format!(
+                    "Experimental feature 'test' applied: {}",
+                    test.message
+                ));
+            }
+        }
+
         if let Err(e) = self.initialize(request) {
             return ScriptResponse::error(&e.to_string());
         }

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -10,8 +10,9 @@ use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
-    CodexRequest, ContainerConfig, ContainerPolicy, ContainmentBackend, LifecycleConfig, LxcConfig,
-    NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SandboxConfig,
+    CodexRequest, ContainerConfig, ContainerPolicy, ContainmentBackend, ExperimentalConfig,
+    LifecycleConfig, LxcConfig, NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress,
+    ProxyConfig, SandboxConfig, TestFeatureConfig,
 };
 
 // ---------- Intermediate serde structs matching the JSON schema ----------
@@ -117,6 +118,18 @@ struct RawLifecycle {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
+struct RawTestFeature {
+    message: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct RawExperimental {
+    test: Option<RawTestFeature>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct RawConfig {
     version: Option<String>,
     #[serde(rename = "containerId")]
@@ -132,6 +145,7 @@ struct RawConfig {
     lxc: Option<RawLxc>,
     filesystem: Option<RawFilesystem>,
     network: Option<RawNetwork>,
+    experimental: Option<RawExperimental>,
 }
 
 // ---------- Public API ----------
@@ -512,6 +526,14 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
     // Schema version check
     validate_schema_version(&schema_version, logger)?;
 
+    // Experimental section (parsed but only applied when --experimental flag is set)
+    let experimental = if let Some(raw_exp) = raw.experimental {
+        let test = raw_exp.test.map(|t| TestFeatureConfig::from_raw(t.message));
+        ExperimentalConfig { test }
+    } else {
+        ExperimentalConfig::default()
+    };
+
     Ok(CodexRequest {
         schema_version,
         container_id,
@@ -526,6 +548,8 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         sandbox_config,
         container_config,
         lxc_config,
+        experimental_enabled: false,
+        experimental,
     })
 }
 
@@ -1344,5 +1368,70 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.container_config.image, "python:3.12");
+    }
+
+    // ---------- Experimental feature tests ----------
+
+    #[test]
+    fn experimental_section_parsed_when_present() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"test": {"message": "world"}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.experimental.test.is_some());
+        assert_eq!(req.experimental.test.unwrap().message, "world");
+    }
+
+    #[test]
+    fn experimental_section_absent_is_ok() {
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.experimental.test.is_none());
+    }
+
+    #[test]
+    fn experimental_enabled_defaults_to_false() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"test": {"message": "check"}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.experimental_enabled);
+    }
+
+    #[test]
+    fn unknown_experimental_fields_ignored() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"futureFeature": {"x": 1}, "test": {"message": "hi"}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.experimental.test.is_some());
+    }
+
+    #[test]
+    fn experimental_test_message_parsed() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"test": {"message": "greetings"}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let test = req.experimental.test.unwrap();
+        assert_eq!(test.message, "greetings");
+    }
+
+    #[test]
+    fn experimental_test_default_message() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"test": {}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let test = req.experimental.test.unwrap();
+        assert!(test.message.is_empty());
     }
 }

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -199,6 +199,30 @@ impl Default for LifecycleConfig {
     }
 }
 
+/// Placeholder experimental feature for testing the experimental infrastructure.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TestFeatureConfig {
+    /// Message to log when the feature is applied.
+    pub message: String,
+}
+
+impl TestFeatureConfig {
+    pub fn from_raw(message: Option<String>) -> Self {
+        Self {
+            message: message.unwrap_or_default(),
+        }
+    }
+}
+
+/// Container for all experimental feature configs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExperimentalConfig {
+    /// Placeholder feature for testing experimental infrastructure.
+    pub test: Option<TestFeatureConfig>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct CodexRequest {
@@ -225,6 +249,10 @@ pub struct CodexRequest {
     pub container_config: ContainerConfig,
     /// LXC-specific configuration (used when containment == Lxc).
     pub lxc_config: LxcConfig,
+    /// Whether the --experimental flag was passed.
+    pub experimental_enabled: bool,
+    /// Experimental feature configs (only applied when experimental_enabled is true).
+    pub experimental: ExperimentalConfig,
 }
 
 impl Default for CodexRequest {
@@ -243,6 +271,8 @@ impl Default for CodexRequest {
             sandbox_config: SandboxConfig::default(),
             container_config: ContainerConfig::default(),
             lxc_config: LxcConfig::default(),
+            experimental_enabled: false,
+            experimental: ExperimentalConfig::default(),
         }
     }
 }

--- a/test_configs/experimental_hello_appcontainer.json
+++ b/test_configs/experimental_hello_appcontainer.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-Experimental-Hello",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "cmd.exe /c echo experimental hello test"
+  },
+  "experimental": {
+    "test": {
+      "message": "Test feature from AppContainer experimental!"
+    }
+  }
+}

--- a/test_configs/experimental_hello_lxc.json
+++ b/test_configs/experimental_hello_lxc.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-Experimental-Hello-LXC",
+  "containment": "lxc",
+  "process": {
+    "commandLine": "echo 'Hello from LXC experimental!'"
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "lxc": {
+    "distribution": "alpine",
+    "release": "3.20"
+  },
+  "experimental": {
+    "test": {
+      "message": "Test feature from LXC experimental!"
+    }
+  }
+}


### PR DESCRIPTION
Adds the --experimental CLI flag across the full stack, with a placeholder test feature that confirms that the plumbing works end-to-end in both AppContainer and LXC runners.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/108)