### PR TITLE
[SDK Tests] Update functional tests to use `getAvailableToolsPolicy` to find read only tool paths 

### DIFF
--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -49,7 +49,7 @@ describe('SDK end-to-end', () => {
   it('cmd.exe: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
-    const output = runCli(`run-sdk --script "cmd.exe /c echo Container test successful" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "cmd.exe /c echo Container test successful" --cwd "${dir}" --container-name "test-1" --policy-file "${policyFile}"`);
     assert.ok(output.includes('Container test successful'));
     assert.ok(output.includes('Process exited with code 0'));
   });
@@ -57,7 +57,7 @@ describe('SDK end-to-end', () => {
   it('powershell 5.1: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
-    const output = runCli(`run-sdk --script "powershell.exe -NoProfile -Command Write-Output 'PowerShell test successful'" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "powershell.exe -NoProfile -Command Write-Output 'PowerShell test successful'" --cwd "${dir}" --container-name "test-2" --policy-file "${policyFile}"`);
     assert.ok(output.includes('PowerShell test successful'));
     assert.ok(output.includes('Process exited with code 0'));
   });
@@ -65,7 +65,7 @@ describe('SDK end-to-end', () => {
   it('python: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
-    const output = runCli(`run-sdk --script "python -c \\"print('Python test successful')\\"" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "python -c \\"print('Python test successful')\\"" --cwd "${dir}" --container-name "test-3" --policy-file "${policyFile}"`);
     assert.ok(output.includes('Python test successful'));
     assert.ok(output.includes('Process exited with code 0'));
   });
@@ -79,7 +79,7 @@ describe('SDK end-to-end', () => {
       version: '0.4.0-alpha',
       filesystem: { readwritePaths: [dir] },
     });
-    const output = runCli(`run-sdk --script "python ${scriptFile}" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "python ${scriptFile}" --cwd "${dir}" --container-name "test-4" --policy-file "${policyFile}"`);
     assert.ok(output.includes('WRITE_OK'));
     assert.ok(output.includes('Process exited with code 0'));
     assert.ok(fs.existsSync(testFile), 'File should have been written to readwrite path');
@@ -93,7 +93,7 @@ describe('SDK end-to-end', () => {
       version: '0.4.0-alpha',
       filesystem: { readonlyPaths: [dir] },
     });
-    const output = runCli(`run-sdk --script "cmd.exe /c type ${inputFile}" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "cmd.exe /c type ${inputFile}" --cwd "${dir}" --container-name "test-5" --policy-file "${policyFile}"`);
     assert.ok(output.includes('readonly test data'));
     assert.ok(output.includes('Process exited with code 0'));
   });

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -8,6 +8,7 @@ import {
   spawnSandbox,
   getPlatformSupport,
   SandboxPolicy,
+  getAvailableToolsPolicy,
 } from '@microsoft/mxc-sdk';
 
 import * as fs from 'fs';
@@ -132,8 +133,10 @@ program
   // Policy JSON should match the SandboxPolicy type defined in sdk/src/types.ts
   .option('--policy <json>', 'SandboxPolicy as a JSON string')
   .option('--policy-file <path>', 'Path to a SandboxPolicy JSON file')
+  .option('--cwd <path>', 'Working directory for the sandboxed process')
+  .option('--container-name <name>', 'Name for the sandbox container')
   .option('--debug', 'Enable debug output')
-  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; debug?: boolean }) => {
+  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; debug?: boolean }) => {
     try {
       let scriptCommand: string;
       if (options.script) {
@@ -163,11 +166,32 @@ program
         process.exit(1);
       }
 
+      // Discover tool paths from the current environment and merge them
+      const toolsPolicy = getAvailableToolsPolicy(process.env);
+      if (toolsPolicy.readonlyPaths.length > 0) {
+        if (!policy.filesystem) {
+          policy.filesystem = {};
+        }
+        policy.filesystem.readonlyPaths = [
+          ...(policy.filesystem.readonlyPaths ?? []),
+          ...toolsPolicy.readonlyPaths,
+        ];
+      }
+      if (toolsPolicy.readwritePaths.length > 0) {
+        if (!policy.filesystem) {
+          policy.filesystem = {};
+        }
+        policy.filesystem.readwritePaths = [
+          ...(policy.filesystem.readwritePaths ?? []),
+          ...toolsPolicy.readwritePaths,
+        ];
+      }
+
       console.log('Spawning sandboxed process using SDK...');
 
       const ptyProcess = spawnSandbox(scriptCommand, policy, {
         debug: options.debug ?? false,
-      });
+      }, options.cwd, options.containerName);
 
       ptyProcess.onData((data: string) => {
         process.stdout.write(data);


### PR DESCRIPTION
- We need to make sure we call `getAvailableToolsPolicy()` in the tests to update the readonly/read-write locations in the policy. This will allow the container to be aware of the location of these tool paths.  like python, node etc. 
    - This now makes the behavior the same as it use to be for the cli before my previous change.
-  PR also now allows the container name and current working directory to be passed in the test.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/109)