### PR TITLE
[SDK] Plumb proxy through network SandboxPolicy and add proxy integration tests

### DIFF
--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -3,18 +3,19 @@
 
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { execSync } from 'child_process';
+import { execSync, ChildProcess } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
+import { startTestProxy } from './test-helpers';
 
 const cliPath = path.join(__dirname, '..', 'dist', 'cli.js');
 
-function runCli(args: string): string {
+function runCli(args: string, timeoutMs: number = 60000): string {
   try {
     return execSync(`node ${cliPath} ${args}`, {
       encoding: 'utf-8',
-      timeout: 60000,
+      timeout: timeoutMs,
       cwd: path.join(__dirname, '..'),
     });
   } catch (error: any) {
@@ -22,6 +23,18 @@ function runCli(args: string): string {
     const stdout = error.stdout?.toString() ?? '';
     throw new Error(`CLI failed (exit ${error.status}):\nstdout: ${stdout}\nstderr: ${stderr}`);
   }
+}
+
+function createTempDir(prefix: string = 'mxc-test'): string {
+  const dir = path.join(os.tmpdir(), `${prefix}-${Date.now()}`);
+  fs.mkdirSync(dir);
+  return dir;
+}
+
+function writeTempPolicy(dir: string, policy: object): string {
+  const filePath = path.join(dir, 'policy.json');
+  fs.writeFileSync(filePath, JSON.stringify(policy));
+  return filePath;
 }
 
 describe('SDK end-to-end', () => {
@@ -33,18 +46,6 @@ describe('SDK end-to-end', () => {
       tempDir = '';
     }
   });
-
-  function createTempDir(): string {
-    tempDir = path.join(os.tmpdir(), `mxc-test-${Date.now()}`);
-    fs.mkdirSync(tempDir);
-    return tempDir;
-  }
-
-  function writeTempPolicy(dir: string, policy: object): string {
-    const filePath = path.join(dir, 'policy.json');
-    fs.writeFileSync(filePath, JSON.stringify(policy));
-    return filePath;
-  }
 
   it('cmd.exe: should execute in appcontainer', () => {
     const dir = createTempDir();
@@ -71,30 +72,93 @@ describe('SDK end-to-end', () => {
   });
 
   it('readwritePaths: should allow writing to brokered path', () => {
-    const dir = createTempDir();
-    const testFile = path.join(dir, 'output.txt');
-    const scriptFile = path.join(dir, 'write_test.py');
+    tempDir = createTempDir();
+    const testFile = path.join(tempDir, 'output.txt');
+    const scriptFile = path.join(tempDir, 'write_test.py');
     fs.writeFileSync(scriptFile, `f = open(r'${testFile}', 'w')\nf.write('hello')\nf.close()\nprint('WRITE_OK')\n`);
-    const policyFile = writeTempPolicy(dir, {
+    const policyFile = writeTempPolicy(tempDir, {
       version: '0.4.0-alpha',
-      filesystem: { readwritePaths: [dir] },
+      filesystem: { readwritePaths: [tempDir] },
     });
-    const output = runCli(`run-sdk --script "python ${scriptFile}" --cwd "${dir}" --container-name "test-4" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "python ${scriptFile}" --cwd "${tempDir}" --container-name "test-4" --policy-file "${policyFile}"`);
     assert.ok(output.includes('WRITE_OK'));
     assert.ok(output.includes('Process exited with code 0'));
     assert.ok(fs.existsSync(testFile), 'File should have been written to readwrite path');
   });
 
   it('readonlyPaths: should allow reading from brokered path', () => {
-    const dir = createTempDir();
-    fs.writeFileSync(path.join(dir, 'input.txt'), 'readonly test data');
-    const inputFile = path.join(dir, 'input.txt');
-    const policyFile = writeTempPolicy(dir, {
+    tempDir = createTempDir();
+    fs.writeFileSync(path.join(tempDir, 'input.txt'), 'readonly test data');
+    const inputFile = path.join(tempDir, 'input.txt');
+    const policyFile = writeTempPolicy(tempDir, {
       version: '0.4.0-alpha',
-      filesystem: { readonlyPaths: [dir] },
+      filesystem: { readonlyPaths: [tempDir] },
     });
-    const output = runCli(`run-sdk --script "cmd.exe /c type ${inputFile}" --cwd "${dir}" --container-name "test-5" --policy-file "${policyFile}"`);
+    const output = runCli(`run-sdk --script "cmd.exe /c type ${inputFile}" --cwd "${tempDir}" --container-name "test-5" --policy-file "${policyFile}"`);
     assert.ok(output.includes('readonly test data'));
     assert.ok(output.includes('Process exited with code 0'));
+  });
+});
+
+describe('SDK proxy end-to-end', () => {
+  let tempDir = '';
+  let proxyProcess: ChildProcess | null = null;
+
+  afterEach(() => {
+    if (proxyProcess) {
+      proxyProcess.kill();
+      proxyProcess = null;
+    }
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('builtinTestServer proxy: should route traffic through built-in proxy', () => {
+    tempDir = createTempDir('mxc-proxy-test');
+    const scriptFile = path.join(tempDir, 'proxy_cmd.txt');
+    fs.writeFileSync(scriptFile, `python -c "import urllib.request; r = urllib.request.urlopen('https://api.github.com/zen', timeout=15); print('PROXY_RESPONSE: ' + r.read().decode())"`);
+    const policyFile = writeTempPolicy(tempDir, {
+      version: '0.4.0-alpha',
+      network: {
+        allowOutbound: true,
+        proxy: { builtinTestServer: true },
+      },
+      filesystem: { readonlyPaths: [tempDir] },
+    });
+
+    const output = runCli(
+      `run-sdk --script-file "${scriptFile}" --policy-file "${policyFile}" --debug`,
+      90000,
+    );
+    assert.ok(output.includes('PROXY_RESPONSE:'), 'Expected a response through the proxy');
+    assert.ok(output.includes('Process exited with code 0'));
+    assert.ok(output.includes('Proxy policy active'), 'Expected proxy policy to be set up');
+  });
+
+  it('localhost proxy: should route traffic through external proxy', () => {
+    tempDir = createTempDir('mxc-proxy-test');
+    const { port, proxyProcess: proc } = startTestProxy(tempDir);
+    proxyProcess = proc;
+
+    const scriptFile = path.join(tempDir, 'proxy_cmd.txt');
+    fs.writeFileSync(scriptFile, `python -c "import urllib.request; r = urllib.request.urlopen('https://api.github.com/zen', timeout=15); print('PROXY_RESPONSE: ' + r.read().decode())"`);
+    const policyFile = writeTempPolicy(tempDir, {
+      version: '0.4.0-alpha',
+      network: {
+        allowOutbound: true,
+        proxy: { localhost: port },
+      },
+      filesystem: { readonlyPaths: [tempDir] },
+    });
+
+    const output = runCli(
+      `run-sdk --script-file "${scriptFile}" --policy-file "${policyFile}" --debug`,
+      90000,
+    );
+    assert.ok(output.includes('PROXY_RESPONSE:'), 'Expected a response through the proxy');
+    assert.ok(output.includes('Process exited with code 0'));
+    assert.ok(output.includes('Proxy policy active'), 'Expected proxy policy to be set up');
   });
 });

--- a/cli/src/test-helpers.ts
+++ b/cli/src/test-helpers.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawn, ChildProcess } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+export function findTestProxyBinary(): string {
+  const triple = os.arch() === 'arm64' ? 'aarch64-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
+  const sdkBinPath = path.join(require.resolve('@microsoft/mxc-sdk'), '..', '..', 'bin', triple, 'wxc-test-proxy.exe');
+  if (fs.existsSync(sdkBinPath)) {
+    return sdkBinPath;
+  }
+  // Fallback: check Rust build output directly (dev environment without build.bat)
+  const targetDir = path.join(__dirname, '..', '..', 'src', 'target');
+  const fallbacks = [
+    path.join(targetDir, triple, 'release', 'wxc-test-proxy.exe'),
+    path.join(targetDir, triple, 'debug', 'wxc-test-proxy.exe'),
+  ];
+  for (const candidate of fallbacks) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error(`wxc-test-proxy.exe not found. Checked SDK bin and build output.`);
+}
+
+/**
+ * Start wxc-test-proxy.exe in a child process.
+ * It binds to an OS-assigned port and writes it to a ready file.
+ * Uses --parent-pid so the proxy exits when tests finish.
+ */
+export function startTestProxy(dir: string): { port: number; proxyProcess: ChildProcess } {
+  const proxyPath = findTestProxyBinary();
+  const readyFile = path.join(dir, 'proxy-ready.txt');
+  const eventName = `Local\\mxc-cli-test-${process.pid}-${Date.now()}`;
+
+  const proxyProcess = spawn(proxyPath, [
+    '--ready-file', readyFile,
+    '--cleanup-event', eventName,
+    '--parent-pid', process.pid.toString(),
+  ], { stdio: 'ignore' });
+
+  // Poll for the ready file (up to 15 seconds)
+  const deadline = Date.now() + 15000;
+  while (!fs.existsSync(readyFile) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+
+  if (!fs.existsSync(readyFile)) {
+    proxyProcess.kill();
+    throw new Error('wxc-test-proxy did not write ready file within 15 seconds');
+  }
+
+  const portStr = fs.readFileSync(readyFile, 'utf-8').trim();
+  const port = parseInt(portStr, 10);
+  if (isNaN(port) || port <= 0) {
+    proxyProcess.kill();
+    throw new Error(`Invalid port in ready file: ${portStr}`);
+  }
+
+  return { port, proxyProcess };
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -2,27 +2,23 @@
 // Licensed under the MIT License.
 
 /**
- * MXC SDK - TypeScript SDK for execution containers
+ * MXC SDK - TypeScript SDK for Microsoft eXecution Containers
  *
- * This package provides a Node.js interface for spawning sandboxed processes
- * on Windows using the WXC system.
+ * This package provides a Node.js interface for spawning sandboxed containers.
  *
  * @example
  * ```typescript
- * import { spawnSandbox, SandboxConfig, getPlatformSupport } from '@microsoft/mxc-sdk';
+ * import { spawnSandbox, SandboxPolicy, getPlatformSupport } from '@microsoft/mxc-sdk';
  *
  * if (getPlatformSupport().isSupported) {
- *   const config: SandboxConfig = {
- *     script: 'python -c "print(\'Hello from sandbox\')"',
- *     appContainer: {
- *       name: 'MyApp',
- *       learningMode: true
- *     }
+ *   const policy: SandboxPolicy = {
+ *     version: '0.4.0-alpha',
+ *     network: { allowOutbound: true },
  *   };
  *
- *   const pty = spawnSandbox(config);
- *   pty.onData((data) => console.log(data));
- *   pty.onExit((e) => console.log('Exit code:', e.exitCode));
+ *   const ptyProcess = spawnSandbox('python -c "print(\'Hello from sandbox\')"', policy);
+ *   ptyProcess.onData((data) => console.log(data));
+ *   ptyProcess.onExit((event) => console.log('Exit code:', event.exitCode));
  * }
  * ```
  *

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -102,6 +102,48 @@ describe('buildSandboxPayload', () => {
         restore();
       }
     });
+
+    it('should pass builtinTestServer proxy through to network config', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true, proxy: { builtinTestServer: true } },
+        };
+        const payload = buildSandboxPayload('echo hi', policy);
+        assert.deepStrictEqual(payload.network!.proxy, { builtinTestServer: true });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should pass localhost proxy through to network config', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true, proxy: { localhost: 8080 } },
+        };
+        const payload = buildSandboxPayload('echo hi', policy);
+        assert.deepStrictEqual(payload.network!.proxy, { localhost: 8080 });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should not set network.proxy when proxy is not specified', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true },
+        };
+        const payload = buildSandboxPayload('echo hi', policy);
+        assert.strictEqual(payload.network?.proxy, undefined);
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe('Linux', () => {
@@ -124,6 +166,22 @@ describe('buildSandboxPayload', () => {
         const payload = buildSandboxPayload('echo hi', defaultPolicy);
         assert.strictEqual(payload.containment, 'lxc');
         assert.strictEqual(payload.lxc!.destroyOnExit, true);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject proxy configuration on Linux', () => {
+      mockLinux();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true, proxy: { builtinTestServer: true } },
+        };
+        assert.throws(
+          () => buildSandboxPayload('echo hi', policy),
+          { message: /not supported on Linux/ },
+        );
       } finally {
         restore();
       }

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -79,6 +79,10 @@ export function buildSandboxPayload(
             destroyOnExit: true,
         };
 
+        if (policy.network?.proxy) {
+            throw new Error('Proxy configuration is not supported on Linux');
+        }
+
         if (policy.network) {
             config.network = {
                 defaultPolicy: policy.network.allowOutbound ? 'allow' : 'block',
@@ -103,6 +107,13 @@ export function buildSandboxPayload(
         leastPrivilege: false,
         capabilities,
     };
+
+    if (policy.network?.proxy) {
+        if (!config.network) {
+            config.network = {};
+        }
+        config.network.proxy = policy.network.proxy;
+    }
 
     return config;
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -141,6 +141,13 @@ export type SandboxPolicy = {
       allowOutbound?: boolean;
       /** Whether to allow connections to local networks. (default: false) */
       allowLocalNetwork?: boolean;
+      /**
+       * Proxy configuration for the container (temporarily Windows only, temporarily requires elevation).
+       * Only one option may be specified:
+       * - `builtinTestServer`: Use the built-in test proxy server
+       * - `localhost`: Forward traffic through a proxy on the specified localhost port
+       */
+      proxy?: { builtinTestServer: true } | { localhost: number }
   };
 }
 


### PR DESCRIPTION
- Add proxy to SandboxPolicy.network
- Pass proxy through to ContainerConfig.network in buildSandboxPayload
- Add SDK unit tests for proxy plumbing
- Add CLI integration tests for builtinTestServer and localhost proxy

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/112)