### PR TITLE
[SDK] Fix: propagate SandboxPolicy.version to ContainerConfig output in SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
 
 
   # Build and package the TypeScript SDK with bundled wxc-exec binaries
-  wxc-typescript-sdk:
-    name: WXC TypeScript SDK
+  mxc-typescript-sdk:
+    name: MXC TypeScript SDK
     needs: wxc-exec-build
     runs-on: windows-latest
 
@@ -131,10 +131,10 @@ jobs:
           path: sdk/*.tgz
 
 
-  # Build and package the TypeScript CLI
-  wxc-typescript-cli:
-    name: WXC TypeScript CLI
-    needs: wxc-typescript-sdk
+  # Build and package the TypeScript Test CLI
+  mxc-typescript-test-cli:
+    name: MXC TypeScript Test CLI
+    needs: mxc-typescript-sdk
     runs-on: windows-latest
 
     defaults:
@@ -162,6 +162,9 @@ jobs:
 
       - name: Build CLI
         run: npm run build
+
+      - name: Run tests
+        run: npm test
 
       - name: Pack npm package
         run: npm pack

--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -47,7 +47,8 @@ describe('SDK end-to-end', () => {
     }
   });
 
-  it('cmd.exe: should execute in appcontainer', () => {
+  // Skipped: AppContainer can't find executables on GitHub workflow runners, run locally until then
+  it.skip('cmd.exe: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
     const output = runCli(`run-sdk --script "cmd.exe /c echo Container test successful" --cwd "${dir}" --container-name "test-1" --policy-file "${policyFile}"`);
@@ -55,7 +56,8 @@ describe('SDK end-to-end', () => {
     assert.ok(output.includes('Process exited with code 0'));
   });
 
-  it('powershell 5.1: should execute in appcontainer', () => {
+  // Skipped: AppContainer can't find executables on GitHub workflow runners, run locally until then
+  it.skip('powershell 5.1: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
     const output = runCli(`run-sdk --script "powershell.exe -NoProfile -Command Write-Output 'PowerShell test successful'" --cwd "${dir}" --container-name "test-2" --policy-file "${policyFile}"`);
@@ -63,7 +65,8 @@ describe('SDK end-to-end', () => {
     assert.ok(output.includes('Process exited with code 0'));
   });
 
-  it('python: should execute in appcontainer', () => {
+  // Skipped: bfscfg.exe doesn't exist on workflow machines currently, run locally until then
+  it.skip('python: should execute in appcontainer', () => {
     const dir = createTempDir();
     const policyFile = writeTempPolicy(dir, { version: '0.4.0-alpha' });
     const output = runCli(`run-sdk --script "python -c \\"print('Python test successful')\\"" --cwd "${dir}" --container-name "test-3" --policy-file "${policyFile}"`);
@@ -71,7 +74,8 @@ describe('SDK end-to-end', () => {
     assert.ok(output.includes('Process exited with code 0'));
   });
 
-  it('readwritePaths: should allow writing to brokered path', () => {
+  // Skipped: bfscfg.exe doesn't exist on workflow machines currently, run locally until then
+  it.skip('readwritePaths: should allow writing to brokered path', () => {
     tempDir = createTempDir();
     const testFile = path.join(tempDir, 'output.txt');
     const scriptFile = path.join(tempDir, 'write_test.py');
@@ -86,7 +90,8 @@ describe('SDK end-to-end', () => {
     assert.ok(fs.existsSync(testFile), 'File should have been written to readwrite path');
   });
 
-  it('readonlyPaths: should allow reading from brokered path', () => {
+  // Skipped: bfscfg.exe doesn't exist on workflow machines currently, run locally until then
+  it.skip('readonlyPaths: should allow reading from brokered path', () => {
     tempDir = createTempDir();
     fs.writeFileSync(path.join(tempDir, 'input.txt'), 'readonly test data');
     const inputFile = path.join(tempDir, 'input.txt');
@@ -98,9 +103,37 @@ describe('SDK end-to-end', () => {
     assert.ok(output.includes('readonly test data'));
     assert.ok(output.includes('Process exited with code 0'));
   });
+
+  it('should reject policy with missing version', () => {
+    tempDir = createTempDir();
+    const policyFile = writeTempPolicy(tempDir, {});
+    assert.throws(
+      () => runCli(`run-sdk --script "cmd.exe /c echo hi" --cwd "${tempDir}" --container-name "test-no-ver" --policy-file "${policyFile}"`),
+      { message: /version is required/ },
+    );
+  });
+
+  it('should reject policy with invalid version', () => {
+    tempDir = createTempDir();
+    const policyFile = writeTempPolicy(tempDir, { version: '99.0.0' });
+    assert.throws(
+      () => runCli(`run-sdk --script "cmd.exe /c echo hi" --cwd "${tempDir}" --container-name "test-bad-ver" --policy-file "${policyFile}"`),
+      { message: /incompatible/ },
+    );
+  });
+
+  // Skipped: AppContainer can't find executables on GitHub workflow runners, run locally until then
+  it.skip('should launch basic appcontainer with valid version', () => {
+    tempDir = createTempDir();
+    const policyFile = writeTempPolicy(tempDir, { version: '0.4.0-alpha' });
+    const output = runCli(`run-sdk --script "cmd.exe /c echo version ok" --container-name "test-ver" --policy-file "${policyFile}"`);
+    assert.ok(output.includes('version ok'));
+    assert.ok(output.includes('Process exited with code 0'));
+  });
 });
 
-describe('SDK proxy end-to-end', () => {
+// Skipped: requires admin currently and not runnable in pipelines, run locally until then
+describe.skip('SDK proxy end-to-end', () => {
   let tempDir = '';
   let proxyProcess: ChildProcess | null = null;
 

--- a/cli/src/cli.test.ts
+++ b/cli/src/cli.test.ts
@@ -118,7 +118,7 @@ describe('SDK end-to-end', () => {
     const policyFile = writeTempPolicy(tempDir, { version: '99.0.0' });
     assert.throws(
       () => runCli(`run-sdk --script "cmd.exe /c echo hi" --cwd "${tempDir}" --container-name "test-bad-ver" --policy-file "${policyFile}"`),
-      { message: /incompatible/ },
+      { message: /newer than supported/ },
     );
   });
 

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -6,8 +6,9 @@ import { ContainerConfig } from '@microsoft/mxc-sdk/dist/types';
 /**
  * Helper function to create a minimal valid configuration
  */
-export function createMinimalConfig(code: string): ContainerConfig {
+export function createMinimalConfig(code: string, version: string = '0.4.0-alpha'): ContainerConfig {
   return {
+    version,
     process: {
       commandLine: code,
     },
@@ -19,9 +20,11 @@ export function createMinimalConfig(code: string): ContainerConfig {
  */
 export function createNetworkRestrictedConfig(
   code: string,
-  allow: string[]
+  allow: string[],
+  version: string = '0.4.0-alpha'
 ): ContainerConfig {
   return {
+    version,
     process: {
       commandLine: code,
     },
@@ -39,9 +42,11 @@ export function createFilesystemRestrictedConfig(
   code: string,
   readonlyPaths: string[],
   readwritePaths: string[],
-  deniedPaths: string[] = []
+  deniedPaths: string[] = [],
+  version: string = '0.4.0-alpha'
 ): ContainerConfig {
   return {
+    version,
     process: {
       commandLine: code,
     },

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -80,10 +80,13 @@ describe('buildSandboxPayload', () => {
       }
     });
 
-    it('should accept a newer minor version within same major', () => {
+    it('should reject a newer minor version within same major', () => {
       mockWindows();
       try {
-        assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.99.0' }));
+        assert.throws(
+          () => buildSandboxPayload('echo hi', { version: '0.99.0' }),
+          { message: /newer than supported/ },
+        );
       } finally {
         restore();
       }
@@ -94,7 +97,7 @@ describe('buildSandboxPayload', () => {
       try {
         assert.throws(
           () => buildSandboxPayload('echo hi', { version: '1.0.0' }),
-          { message: /incompatible/ },
+          { message: /newer than supported/ },
         );
       } finally {
         restore();

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -61,6 +61,16 @@ describe('buildSandboxPayload', () => {
       assert.deepStrictEqual(payload.filesystem!.readonlyPaths, ['C:\\data']);
     });
 
+    it('should set ContainerConfig.version to match SandboxPolicy.version', () => {
+      mockWindows();
+      try {
+        const payload = buildSandboxPayload('echo hi', { version: '0.4.0-alpha' });
+        assert.strictEqual(payload.version, '0.4.0-alpha');
+      } finally {
+        restore();
+      }
+    });
+
     it('should accept a compatible version', () => {
       mockWindows();
       try {
@@ -97,6 +107,18 @@ describe('buildSandboxPayload', () => {
         assert.throws(
           () => buildSandboxPayload('echo hi', { version: 'not-a-version' }),
           { message: /Invalid policy version/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject an empty version string', () => {
+      mockWindows();
+      try {
+        assert.throws(
+          () => buildSandboxPayload('echo hi', { version: '' }),
+          { message: /version is required/ },
         );
       } finally {
         restore();

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -56,6 +56,7 @@ export function buildSandboxPayload(
     const name = containerName ?? generateRandomContainerName();
 
     const config: ContainerConfig = {
+        version: policy.version,
         process: {
             commandLine: script,
             cwd: workingDirectory,

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -24,14 +24,22 @@ function validatePolicyVersion(version: string): void {
 
     const parsed = semverParse(version);
     if (!parsed) {
-        throw new Error(`Invalid policy version '${version}': must be valid semver (e.g., '0.4.0' or '0.4.0-alpha')`);
+        throw new Error(
+            `Invalid policy version '${version}': must be valid semver` +
+            ` (e.g., '0.4.0' or '0.4.0-alpha')`
+        );
     }
 
     const supported = semverParse(SUPPORTED_VERSION);
-    if (parsed.major !== supported!.major) {
+    if (
+        parsed.major > supported!.major ||
+        (parsed.major === supported!.major &&
+            parsed.minor > supported!.minor)
+    ) {
         throw new Error(
-            `Policy version '${version}' is incompatible (major version ${parsed.major} != ${supported!.major}). ` +
-            `This SDK supports major version ${supported!.major}.`
+            `Policy version '${version}' is newer than supported` +
+            ` (max: ${supported!.major}.${supported!.minor}.x).` +
+            ` Upgrade the SDK.`
         );
     }
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -95,8 +95,8 @@ export interface WslcConfig {
  * Main WXC configuration
  */
 export interface ContainerConfig {
-  /** MXC config schema version (current: "0.4.0-alpha") */
-  version?: string;
+  /** MXC config schema version. Required. */
+  version: string;
   /** Externally assigned container identifier */
   containerId?: string;
   /** Containment backend */


### PR DESCRIPTION
buildSandboxPayload validated policy.version but never set it on the returned ContainerConfig, causing MXC to receive a versionless config.

- Added version: `policy.version` to the config object in `buildSandboxPayload`
- Made `ContainerConfig.version` a required field (compile-time guard)
- Added unit test for version propagation and empty version rejection
- Added integration tests for missing version, invalid version, and basic appcontainer launch with valid version
- Added npm test step to CLI job in build workflow. NOTE: unfortunately some tests are skipped because they can't run in the pipeline e.g no bfscfg.exe, appcontainer seemly not being able to register the PATH variable :(. But there are some that do run, which is still helpful to confirming sdk functionality is works. 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/125)