### PR TITLE
[MicroVM] Add SDK & CLI support

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 
-import { Command, InvalidArgumentError } from 'commander';
+import { Command } from 'commander';
 import {
   spawnSandbox,
-  spawnSandboxWithPty,
+  spawnSandboxWithoutPty,
   getPlatformSupport,
   SandboxPolicy,
   ContainmentType,
@@ -90,14 +90,7 @@ program
   .option('--policy-file <path>', 'Path to a SandboxPolicy JSON file')
   .option('--cwd <path>', 'Working directory for the sandboxed process')
   .option('--container-name <name>', 'Name for the sandbox container')
-  .option('--containment <backend>', 'Override containment backend',
-    (value: string) => {
-      const valid = ['microvm'];
-      if (!valid.includes(value)) {
-        throw new InvalidArgumentError(`Must be one of: ${valid.join(', ')}`);
-      }
-      return value;
-    })
+  .option('--containment <backend>', 'Override containment backend')
   .option('--no-pty', 'Use child_process.spawn instead of node-pty (reliable exit codes)')
   .option('--debug', 'Enable debug output')
   .option('--experimental', 'Enable experimental features')
@@ -160,12 +153,12 @@ program
       };
 
       if (options.pty === false) {
-        // Non-PTY mode using spawnSandbox() (child_process.spawn).
+        // Non-PTY mode using spawnSandboxWithoutPty() (child_process.spawn).
         // This provides reliable exit code propagation and separate stdout/stderr
         // streams. Use this for CI, automation, or any scenario where correct exit
         // codes matter. The default PTY mode (node-pty/ConPTY) returns exit code -1
         // for all processes on Windows due to a known ConPTY limitation.
-        const child = spawnSandbox(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
+        const child = spawnSandboxWithoutPty(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
 
         child.stdout?.on('data', (data: Buffer) => {
           process.stdout.write(data);
@@ -183,7 +176,7 @@ program
       } else {
         // PTY mode: interactive terminal with colors/input
         console.log('Spawning sandboxed process using SDK...');
-        const ptyProcess = spawnSandboxWithPty(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
+        const ptyProcess = spawnSandbox(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
 
         ptyProcess.onData((data: string) => {
           process.stdout.write(data);

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 
-import { Command } from 'commander';
-import { ContainerExecutor } from './wxc-executor';
+import { Command, InvalidArgumentError } from 'commander';
 import {
   spawnSandbox,
+  spawnSandboxWithPty,
   getPlatformSupport,
   SandboxPolicy,
+  ContainmentType,
   getAvailableToolsPolicy,
 } from '@microsoft/mxc-sdk';
 
@@ -81,7 +82,7 @@ program
 
 program
   .command('run-sdk')
-  .description('Simulate SDK usage: build a sandbox payload from a SandboxPolicy and spawn it')
+  .description('Run a workload in a sandbox using the MXC SDK')
   .option('--script <command>', 'Command line to execute')
   .option('--script-file <path>', 'Path to a script file (contents are read and passed as the command)')
   // Policy JSON should match the SandboxPolicy type defined in sdk/src/types.ts
@@ -89,9 +90,18 @@ program
   .option('--policy-file <path>', 'Path to a SandboxPolicy JSON file')
   .option('--cwd <path>', 'Working directory for the sandboxed process')
   .option('--container-name <name>', 'Name for the sandbox container')
+  .option('--containment <backend>', 'Override containment backend',
+    (value: string) => {
+      const valid = ['microvm'];
+      if (!valid.includes(value)) {
+        throw new InvalidArgumentError(`Must be one of: ${valid.join(', ')}`);
+      }
+      return value;
+    })
+  .option('--no-pty', 'Use child_process.spawn instead of node-pty (reliable exit codes)')
   .option('--debug', 'Enable debug output')
   .option('--experimental', 'Enable experimental features')
-  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; debug?: boolean; experimental?: boolean }) => {
+  .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; containment?: string; pty?: boolean; debug?: boolean; experimental?: boolean }) => {
     try {
       let scriptCommand: string;
       if (options.script) {
@@ -142,21 +152,48 @@ program
         ];
       }
 
-      console.log('Spawning sandboxed process using SDK...');
+      const containment = options.containment as ContainmentType | undefined;
 
-      const ptyProcess = spawnSandbox(scriptCommand, policy, {
+      const spawnOptions = {
         debug: options.debug ?? false,
         experimental: options.experimental ?? false,
-      }, options.cwd, options.containerName);
+      };
 
-      ptyProcess.onData((data: string) => {
-        process.stdout.write(data);
-      });
+      if (options.pty === false) {
+        // Non-PTY mode using spawnSandbox() (child_process.spawn).
+        // This provides reliable exit code propagation and separate stdout/stderr
+        // streams. Use this for CI, automation, or any scenario where correct exit
+        // codes matter. The default PTY mode (node-pty/ConPTY) returns exit code -1
+        // for all processes on Windows due to a known ConPTY limitation.
+        const child = spawnSandbox(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
 
-      ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
-        console.log(`\nProcess exited with code ${event.exitCode}`);
-        process.exit(event.exitCode);
-      });
+        child.stdout?.on('data', (data: Buffer) => {
+          process.stdout.write(data);
+        });
+        child.stderr?.on('data', (data: Buffer) => {
+          process.stderr.write(data);
+        });
+        child.on('close', (code: number | null) => {
+          process.exit(code ?? 1);
+        });
+        child.on('error', (err: Error) => {
+          console.error('Error:', err.message);
+          process.exit(1);
+        });
+      } else {
+        // PTY mode: interactive terminal with colors/input
+        console.log('Spawning sandboxed process using SDK...');
+        const ptyProcess = spawnSandboxWithPty(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
+
+        ptyProcess.onData((data: string) => {
+          process.stdout.write(data);
+        });
+
+        ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
+          console.log(`\nProcess exited with code ${event.exitCode}`);
+          process.exit(event.exitCode);
+        });
+      }
     } catch (error) {
       console.error('Error:', error instanceof Error ? error.message : String(error));
       process.exit(1);

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -44,6 +44,7 @@ export {
 export {
   createConfigFromPolicy,
   spawnSandbox,
+  spawnSandboxAsync,
   spawnSandboxWithoutPty,
   spawnSandboxFromConfig,
   buildSandboxPayload,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,7 +38,6 @@ export {
 // Export platform detection functions
 export {
   getPlatformSupport,
-  findWxcExecutable,
 } from './platform';
 
 // Export sandbox spawning functions

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -8,7 +8,7 @@
  *
  * @example
  * ```typescript
- * import { spawnSandbox, SandboxPolicy, getPlatformSupport } from '@microsoft/mxc-sdk';
+ * import { spawnSandbox, spawnSandboxWithPty, SandboxPolicy, getPlatformSupport } from '@microsoft/mxc-sdk';
  *
  * if (getPlatformSupport().isSupported) {
  *   const policy: SandboxPolicy = {
@@ -16,7 +16,7 @@
  *     network: { allowOutbound: true },
  *   };
  *
- *   const ptyProcess = spawnSandbox('python -c "print(\'Hello from sandbox\')"', policy);
+ *   const ptyProcess = spawnSandboxWithPty('python -c "print(\'Hello from sandbox\')"', policy);
  *   ptyProcess.onData((data) => console.log(data));
  *   ptyProcess.onExit((event) => console.log('Exit code:', event.exitCode));
  * }
@@ -29,6 +29,7 @@
 export {
   SandboxPolicy,
   SandboxingMethod,
+  ContainmentType,
   ContainerConfig,
   PlatformSupport,
 } from './types';
@@ -36,15 +37,17 @@ export {
 // Export platform detection functions
 export {
   getPlatformSupport,
+  findWxcExecutable,
 } from './platform';
 
 // Export sandbox spawning functions
 export {
   createConfigFromPolicy,
   spawnSandbox,
+  spawnSandboxWithPty,
   spawnSandboxFromConfig,
-  spawnSandboxAsync,
-  SandboxSpawnOptions
+  buildSandboxPayload,
+  SandboxSpawnOptions,
 } from './sandbox';
 
 // Export policy discovery functions

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -30,6 +30,7 @@ export {
   SandboxPolicy,
   SandboxingMethod,
   ContainmentType,
+  ExperimentalBackends,
   ContainerConfig,
   PlatformSupport,
 } from './types';
@@ -44,7 +45,7 @@ export {
 export {
   createConfigFromPolicy,
   spawnSandbox,
-  spawnSandboxWithPty,
+  spawnSandboxWithoutPty,
   spawnSandboxFromConfig,
   buildSandboxPayload,
   SandboxSpawnOptions,

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -233,6 +233,134 @@ describe('buildSandboxPayload', () => {
       }
     });
   });
+
+  describe('Containment override', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
+
+    const mockWindows = () => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+    };
+
+    const restore = () => {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    };
+
+    it('should return minimal config for microvm without filesystem', () => {
+      mockWindows();
+      try {
+        const payload = buildSandboxPayload('print(42)', defaultPolicy, undefined, undefined, 'microvm');
+        assert.strictEqual(payload.containment, 'microvm');
+        assert.strictEqual(payload.filesystem, undefined);
+        assert.strictEqual(payload.appContainer, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should include filesystem with clearPolicyOnExit for microvm when policy has paths', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          filesystem: { readwritePaths: ['/tmp'] },
+        };
+        const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
+        assert.strictEqual(payload.containment, 'microvm');
+        assert.deepStrictEqual(payload.filesystem!.readwritePaths, ['/tmp']);
+        assert.strictEqual(payload.filesystem!.clearPolicyOnExit, true);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should honor clearPolicyOnExit false for microvm', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          filesystem: { readwritePaths: ['/tmp'], clearPolicyOnExit: false },
+        };
+        const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
+        assert.strictEqual(payload.filesystem!.clearPolicyOnExit, false);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should build appcontainer config on Windows with default process containment', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true },
+        };
+        const payload = buildSandboxPayload('echo hi', policy);
+        assert.ok(payload.appContainer, 'appContainer section should be present');
+        assert.ok(payload.appContainer!.capabilities!.includes('internetClient'));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject network policies for microvm', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { allowOutbound: true },
+        };
+        assert.throws(
+          () => buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm'),
+          { message: /does not support network policy/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject microvm on non-Windows platforms', () => {
+      const orig = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      try {
+        assert.throws(
+          () => buildSandboxPayload('print(42)', defaultPolicy, undefined, undefined, 'microvm'),
+          { message: /only supported on Windows/ },
+        );
+      } finally {
+        if (orig) Object.defineProperty(process, 'platform', orig);
+      }
+    });
+
+    it('should preserve lifecycle config for microvm', () => {
+      mockWindows();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          filesystem: { clearPolicyOnExit: false },
+        };
+        const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
+        assert.strictEqual(payload.lifecycle!.destroyOnExit, true);
+        assert.strictEqual(payload.lifecycle!.preservePolicy, true);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should set process commandLine and containerId for microvm', () => {
+      mockWindows();
+      try {
+        const payload = buildSandboxPayload('print(42)', defaultPolicy, undefined, 'my-container', 'microvm');
+        assert.strictEqual(payload.process!.commandLine, 'print(42)');
+        assert.strictEqual(payload.containerId, 'my-container');
+      } finally {
+        restore();
+      }
+    });
+
+  });
 });
 
 describe('createConfigFromPolicy', () => {

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -3,10 +3,11 @@
 
 import * as pty from 'node-pty';
 import * as os from 'os';
+import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, ContainerConfig, ContainmentType } from './types';
+import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
@@ -167,11 +168,37 @@ export function createConfigFromPolicy(
             commandLine: '',
             timeout: policy.timeoutMs ?? 0,
         },
-        filesystem: {
-            readwritePaths: [...(policy.filesystem?.readwritePaths ?? [])],
-            readonlyPaths: [...(policy.filesystem?.readonlyPaths ?? [])],
-            deniedPaths: [...(policy.filesystem?.deniedPaths ?? [])],
-        },
+    };
+
+    // Microvm: minimal config with early return — no UI/network mapping needed
+    if (containment === 'microvm') {
+        if (os.platform() !== 'win32') {
+            throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
+        }
+        if (policy.network) {
+            throw new Error(
+                'The microvm backend does not support network policy enforcement. ' +
+                'Remove policy.network or use a different containment backend.'
+            );
+        }
+        if (policy.filesystem?.readwritePaths?.length ||
+            policy.filesystem?.readonlyPaths?.length ||
+            policy.filesystem?.deniedPaths?.length) {
+            config.filesystem = {
+                readwritePaths: policy.filesystem?.readwritePaths,
+                readonlyPaths: policy.filesystem?.readonlyPaths,
+                deniedPaths: policy.filesystem?.deniedPaths,
+                clearPolicyOnExit: policy.filesystem?.clearPolicyOnExit ?? true,
+            };
+        }
+        config.containment = containment;
+        return config;
+    }
+
+    config.filesystem = {
+        readwritePaths: [...(policy.filesystem?.readwritePaths ?? [])],
+        readonlyPaths: [...(policy.filesystem?.readonlyPaths ?? [])],
+        deniedPaths: [...(policy.filesystem?.deniedPaths ?? [])],
     };
 
     // UI mapping (cross-platform)
@@ -220,6 +247,7 @@ export function createConfigFromPolicy(
  * @param policy The sandbox policy configuration
  * @param workingDirectory Optional working directory path
  * @param containerName Optional container name; if not provided, a random name will be generated
+ * @param containment Optional containment backend type
  * @returns The sandbox payload object
  */
 export function buildSandboxPayload(
@@ -227,8 +255,9 @@ export function buildSandboxPayload(
     policy: SandboxPolicy,
     workingDirectory?: string,
     containerName?: string,
+    containment?: ContainmentType,
 ): ContainerConfig {
-    const config = createConfigFromPolicy(policy, "process", containerName);
+    const config = createConfigFromPolicy(policy, containment ?? "process", containerName);
 
     config.process!.commandLine = script;
     config.process!.cwd = workingDirectory;
@@ -259,20 +288,19 @@ export interface SandboxSpawnOptions {
   executablePath?: string;
 
   /**
-   * PTY options to pass to node-pty
+   * PTY options to pass to node-pty (only used by spawnSandboxWithPty)
    */
   ptyOptions?: pty.IPtyForkOptions;
 }
 
 /**
- * Internal helper: resolves the executor binary path and spawns a PTY process.
+ * Resolves the executable path and builds CLI arguments for a sandbox invocation.
+ * Shared setup used by both PTY and non-PTY spawn paths.
  */
-function spawnWithConfig(
+function resolveExecutableAndArgs(
   config: ContainerConfig,
-  options: SandboxSpawnOptions,
-  workingDirectory?: string,
-  env?: { [key: string]: string | undefined },
-): pty.IPty {
+  options: SandboxSpawnOptions = {},
+): { executablePath: string; args: string[] } {
   if (!config.process?.commandLine) {
     throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
   }
@@ -282,14 +310,27 @@ function spawnWithConfig(
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
 
+  // Validate containment against platform
+  if (config.containment) {
+    if (config.containment === 'microvm' && os.platform() !== 'win32') {
+      throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
+    }
+    const experimentalBackends: string[] = ['microvm'];
+    if (!experimentalBackends.includes(config.containment) &&
+        !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
+      throw new Error(
+        `Containment backend '${config.containment}' is not available on this platform. ` +
+        `Available methods: ${platformSupport.availableMethods.join(', ')}`
+      );
+    }
+  }
+
   const platform = os.platform();
   let executablePath: string | null;
 
   if (options.executablePath) {
     if (!fs.existsSync(options.executablePath)) {
-      throw new Error(
-        `File not found: ${options.executablePath}`
-      );
+      throw new Error(`File not found: ${options.executablePath}`);
     }
     executablePath = options.executablePath;
   } else if (platform === 'linux') {
@@ -317,38 +358,99 @@ function spawnWithConfig(
     args.push('--debug');
   }
 
-  if (options.experimental) {
+  if (options.experimental || config.containment === 'microvm') {
     args.push('--experimental');
   }
+
+  return { executablePath, args };
+}
+
+/**
+ * Internal helper: resolves the executor binary path and spawns a PTY process.
+ */
+function spawnWithConfig(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions,
+  workingDirectory?: string,
+  env?: { [key: string]: string | undefined },
+): pty.IPty {
+  const { executablePath, args } = resolveExecutableAndArgs(config, options);
 
   const ptyOpts: pty.IPtyForkOptions = {
     name: "xterm-color",
     cols: 120,
     rows: 80,
-    cwd: workingDirectory || process.cwd(),
-    env: env
+    ...options.ptyOptions,
+    cwd: workingDirectory || options.ptyOptions?.cwd || process.cwd(),
+    env: env ?? options.ptyOptions?.env,
   };
 
   return pty.spawn(executablePath, args, ptyOpts);
 }
 
 /**
- * Spawn a sandboxed process from a SandboxPolicy.
+ * Spawn a sandboxed process using wxc-exec with a PTY (node-pty) for
+ * interactive terminal I/O (colors, input forwarding).
  *
  * @param script The command line script to execute
  * @param policy The sandbox policy
  * @param options - Spawn options
  * @param workingDirectory Optional working directory path
  * @param containerName Optional container name; if not provided, a random name will be generated
+ * @param env Optional environment variables
+ * @param containment Optional containment backend
  * @returns IPty object for interacting with the sandboxed process
+ * @throws Error if platform is not supported or wxc-exec is not found
  *
  * @example
  * ```typescript
- * const policy: SandboxPolicy = {
- *   version: '0.4.0-alpha',
- *   network: { allowOutbound: true },
- * };
- * const ptyProcess = spawnSandbox('echo hello', policy);
+ * const script = 'python -c "import sys; print(sys.version)"';
+ * const policy: SandboxPolicy = { version: '0.4.0-alpha' };
+ *
+ * const ptyProcess = spawnSandboxWithPty(script, policy);
+ * ptyProcess.onData((data) => console.log(data));
+ * ptyProcess.onExit((e) => console.log('Exit code:', e.exitCode));
+ * ```
+ */
+export function spawnSandboxWithPty(
+  script: string,
+  policy: SandboxPolicy,
+  options: SandboxSpawnOptions = {},
+  workingDirectory?: string,
+  containerName?: string,
+  env?: { [key: string]: string | undefined },
+  containment?: ContainmentType,
+): pty.IPty {
+  const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
+  return spawnWithConfig(config, options, workingDirectory, env);
+}
+
+/**
+ * Spawn a sandboxed process using child_process.spawn (non-PTY).
+ *
+ * Returns the `ChildProcess` directly so the caller can manage stdout, stderr,
+ * and exit events. Use this for CI/automation where reliable exit codes and
+ * separate output streams are required.
+ *
+ * @param script The command line script to execute
+ * @param policy The sandbox policy
+ * @param options - Spawn options
+ * @param workingDirectory Optional working directory path
+ * @param containerName Optional container name
+ * @param env Optional environment variables
+ * @param containment Optional containment backend
+ *
+ * @returns The spawned ChildProcess
+ *
+ * @example
+ * ```typescript
+ * const child = spawnSandbox(
+ *   "print('Hello from sandbox!')",
+ *   { version: '0.4.0-alpha' },
+ *   { experimental: true }
+ * );
+ * child.stdout?.on('data', (data) => console.log(data.toString()));
+ * child.on('close', (code) => console.log('Exit code:', code));
  * ```
  */
 export function spawnSandbox(
@@ -357,10 +459,20 @@ export function spawnSandbox(
   options: SandboxSpawnOptions = {},
   workingDirectory?: string,
   containerName?: string,
-  env?: { [key: string]: string | undefined }
-): pty.IPty {
-  const config = buildSandboxPayload(script, policy, workingDirectory, containerName);
-  return spawnWithConfig(config, options, workingDirectory, env);
+  env?: { [key: string]: string | undefined },
+  containment?: ContainmentType,
+): ChildProcess {
+  if (options.ptyOptions) {
+    console.warn('Warning: ptyOptions are ignored by spawnSandbox (non-PTY). Use spawnSandboxWithPty for PTY support.');
+  }
+  const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
+  const { executablePath, args } = resolveExecutableAndArgs(config, options);
+
+  return spawn(executablePath, args, {
+    cwd: workingDirectory || process.cwd(),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
+  });
 }
 
 /**
@@ -390,59 +502,4 @@ export function spawnSandboxFromConfig(
   env?: { [key: string]: string | undefined }
 ): pty.IPty {
   return spawnWithConfig(config, options, workingDirectory, env);
-}
-
-/**
- * Spawn a sandboxed process and return a promise that resolves with output.
- * Convenience wrapper around spawnSandbox for non-interactive use cases.
- *
- * @param script The command line script to execute
- * @param policy The sandbox policy
- * @param options - Spawn options
- * @param workingDirectory Optional working directory path
- * @param containerName Optional container name; if not provided, a random name will be generated
- * 
- * @returns Promise that resolves with stdout/stderr and exit code
- *
- * @example
- * ```typescript
- * const policy: SandboxPolicy = {
- *   version: '0.4.0-alpha',
- *   filesystem: { readwritePaths: ['/workspace'] },
- * };
- *
- * const result = await spawnSandboxAsync('echo hello', policy);
- * console.log('Output:', result.stdout);
- * console.log('Exit code:', result.exitCode);
- * ```
- */
-export function spawnSandboxAsync(
-  script: string,
-  policy: SandboxPolicy,
-  options: SandboxSpawnOptions = {},
-  workingDirectory?: string,
-  containerName?: string,
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return new Promise((resolve, reject) => {
-    try {
-      const ptyProcess = spawnSandbox(script, policy, options, workingDirectory, containerName);
-      let output = '';
-
-      ptyProcess.onData((data: string) => {
-        output += data;
-      });
-
-      ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
-        // Note: wxc-exec doesn't separate stdout/stderr when using PTY
-        // All output is combined
-        resolve({
-          stdout: output,
-          stderr: '',
-          exitCode: event.exitCode
-        });
-      });
-    } catch (error) {
-      reject(error);
-    }
-  });
 }

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -369,7 +369,13 @@ function resolveExecutableAndArgs(
     args.push('--debug');
   }
 
-  if (options.experimental || ExperimentalBackends.includes(config.containment as ContainmentType)) {
+  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
+    throw new Error(
+      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
+    );
+  }
+
+  if (options.experimental) {
     args.push('--experimental');
   }
 

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -519,3 +519,58 @@ export function spawnSandboxFromConfig(
 ): pty.IPty {
   return spawnWithConfig(config, options, workingDirectory, env);
 }
+
+/**
+ * Spawn a sandboxed process and return a promise that resolves with output.
+ * Convenience wrapper around spawnSandbox for non-interactive use cases.
+ *
+ * @param script The command line script to execute
+ * @param policy The sandbox policy
+ * @param options - Spawn options
+ * @param workingDirectory Optional working directory path
+ * @param containerName Optional container name; if not provided, a random name will be generated
+ *
+ * @returns Promise that resolves with stdout/stderr and exit code
+ *
+ * @example
+ * ```typescript
+ * const policy: SandboxPolicy = {
+ *   version: '0.4.0-alpha',
+ *   filesystem: { readwritePaths: ['/workspace'] },
+ * };
+ *
+ * const result = await spawnSandboxAsync('echo hello', policy);
+ * console.log('Output:', result.stdout);
+ * console.log('Exit code:', result.exitCode);
+ * ```
+ */
+export function spawnSandboxAsync(
+  script: string,
+  policy: SandboxPolicy,
+  options: SandboxSpawnOptions = {},
+  workingDirectory?: string,
+  containerName?: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    try {
+      const ptyProcess = spawnSandbox(script, policy, options, workingDirectory, containerName);
+      let output = '';
+
+      ptyProcess.onData((data: string) => {
+        output += data;
+      });
+
+      ptyProcess.onExit((event: { exitCode: number; signal?: number }) => {
+        // Note: wxc-exec doesn't separate stdout/stderr when using PTY
+        // All output is combined
+        resolve({
+          stdout: output,
+          stderr: '',
+          exitCode: event.exitCode
+        });
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -326,8 +326,7 @@ function resolveExecutableAndArgs(
     if (config.containment === 'microvm' && os.platform() !== 'win32') {
       throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
     }
-    const experimentalList: readonly string[] = ExperimentalBackends;
-    if (!experimentalList.includes(config.containment) &&
+    if (!(ExperimentalBackends as readonly string[]).includes(config.containment) &&
         !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
       throw new Error(
         `Containment backend '${config.containment}' is not available on this platform. ` +
@@ -398,7 +397,7 @@ function spawnWithConfig(
     cols: 120,
     rows: 80,
     ...options.ptyOptions,
-    cwd: workingDirectory || options.ptyOptions?.cwd || process.cwd(),
+    cwd: workingDirectory || process.cwd(),
     env: env ?? options.ptyOptions?.env,
   };
 

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -7,7 +7,7 @@ import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType } from './types';
+import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
@@ -119,6 +119,37 @@ function buildProcessBaseContainerConfig(
 }
 
 /**
+ * Builds the MicroVM (NanVix) portion of a ContainerConfig.
+ * MicroVM is Windows-only and does not support network or UI policies.
+ */
+function buildMicroVmConfig(
+    config: ContainerConfig,
+    policy: SandboxPolicy,
+): ContainerConfig {
+    if (os.platform() !== 'win32') {
+        throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
+    }
+    if (policy.network) {
+        throw new Error(
+            'The microvm backend does not support network policy enforcement. ' +
+            'Remove policy.network or use a different containment backend.'
+        );
+    }
+    if (policy.filesystem?.readwritePaths?.length ||
+        policy.filesystem?.readonlyPaths?.length ||
+        policy.filesystem?.deniedPaths?.length) {
+        config.filesystem = {
+            readwritePaths: policy.filesystem?.readwritePaths,
+            readonlyPaths: policy.filesystem?.readonlyPaths,
+            deniedPaths: policy.filesystem?.deniedPaths,
+            clearPolicyOnExit: policy.filesystem?.clearPolicyOnExit ?? true,
+        };
+    }
+    config.containment = 'microvm';
+    return config;
+}
+
+/**
  * Creates a ContainerConfig from a SandboxPolicy and optional containment type.
  *
  * This is the primary API for translating user-facing security intent (SandboxPolicy)
@@ -170,29 +201,9 @@ export function createConfigFromPolicy(
         },
     };
 
-    // Microvm: minimal config with early return — no UI/network mapping needed
+    // Microvm: delegate to dedicated builder
     if (containment === 'microvm') {
-        if (os.platform() !== 'win32') {
-            throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
-        }
-        if (policy.network) {
-            throw new Error(
-                'The microvm backend does not support network policy enforcement. ' +
-                'Remove policy.network or use a different containment backend.'
-            );
-        }
-        if (policy.filesystem?.readwritePaths?.length ||
-            policy.filesystem?.readonlyPaths?.length ||
-            policy.filesystem?.deniedPaths?.length) {
-            config.filesystem = {
-                readwritePaths: policy.filesystem?.readwritePaths,
-                readonlyPaths: policy.filesystem?.readonlyPaths,
-                deniedPaths: policy.filesystem?.deniedPaths,
-                clearPolicyOnExit: policy.filesystem?.clearPolicyOnExit ?? true,
-            };
-        }
-        config.containment = containment;
-        return config;
+        return buildMicroVmConfig(config, policy);
     }
 
     config.filesystem = {
@@ -255,9 +266,9 @@ export function buildSandboxPayload(
     policy: SandboxPolicy,
     workingDirectory?: string,
     containerName?: string,
-    containment?: ContainmentType,
+    containment: ContainmentType = "process",
 ): ContainerConfig {
-    const config = createConfigFromPolicy(policy, containment ?? "process", containerName);
+    const config = createConfigFromPolicy(policy, containment, containerName);
 
     config.process!.commandLine = script;
     config.process!.cwd = workingDirectory;
@@ -288,7 +299,7 @@ export interface SandboxSpawnOptions {
   executablePath?: string;
 
   /**
-   * PTY options to pass to node-pty (only used by spawnSandboxWithPty)
+   * PTY options to pass to node-pty (only used by spawnSandbox)
    */
   ptyOptions?: pty.IPtyForkOptions;
 }
@@ -315,8 +326,8 @@ function resolveExecutableAndArgs(
     if (config.containment === 'microvm' && os.platform() !== 'win32') {
       throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
     }
-    const experimentalBackends: string[] = ['microvm'];
-    if (!experimentalBackends.includes(config.containment) &&
+    const experimentalList: readonly string[] = ExperimentalBackends;
+    if (!experimentalList.includes(config.containment) &&
         !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
       throw new Error(
         `Containment backend '${config.containment}' is not available on this platform. ` +
@@ -358,7 +369,7 @@ function resolveExecutableAndArgs(
     args.push('--debug');
   }
 
-  if (options.experimental || config.containment === 'microvm') {
+  if (options.experimental || ExperimentalBackends.includes(config.containment as ContainmentType)) {
     args.push('--experimental');
   }
 
@@ -407,12 +418,12 @@ function spawnWithConfig(
  * const script = 'python -c "import sys; print(sys.version)"';
  * const policy: SandboxPolicy = { version: '0.4.0-alpha' };
  *
- * const ptyProcess = spawnSandboxWithPty(script, policy);
+ * const ptyProcess = spawnSandbox(script, policy);
  * ptyProcess.onData((data) => console.log(data));
  * ptyProcess.onExit((e) => console.log('Exit code:', e.exitCode));
  * ```
  */
-export function spawnSandboxWithPty(
+export function spawnSandbox(
   script: string,
   policy: SandboxPolicy,
   options: SandboxSpawnOptions = {},
@@ -444,7 +455,7 @@ export function spawnSandboxWithPty(
  *
  * @example
  * ```typescript
- * const child = spawnSandbox(
+ * const child = spawnSandboxWithoutPty(
  *   "print('Hello from sandbox!')",
  *   { version: '0.4.0-alpha' },
  *   { experimental: true }
@@ -453,7 +464,7 @@ export function spawnSandboxWithPty(
  * child.on('close', (code) => console.log('Exit code:', code));
  * ```
  */
-export function spawnSandbox(
+export function spawnSandboxWithoutPty(
   script: string,
   policy: SandboxPolicy,
   options: SandboxSpawnOptions = {},
@@ -463,7 +474,7 @@ export function spawnSandbox(
   containment?: ContainmentType,
 ): ChildProcess {
   if (options.ptyOptions) {
-    console.warn('Warning: ptyOptions are ignored by spawnSandbox (non-PTY). Use spawnSandboxWithPty for PTY support.');
+    console.warn('Warning: ptyOptions are ignored by spawnSandboxWithoutPty (non-PTY). Use spawnSandbox for PTY support.');
   }
   const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
   const { executablePath, args } = resolveExecutableAndArgs(config, options);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -40,6 +40,11 @@ export interface LifecycleConfig {
 export type ContainmentType = "process" | "microvm";
 
 /**
+ * Containment backends that require the --experimental flag.
+ */
+export const ExperimentalBackends: readonly ContainmentType[] = ['microvm'];
+
+/**
  * Clipboard access policy levels
  */
 export type ClipboardPolicy = "none" | "read" | "write" | "all";

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -35,8 +35,9 @@ export interface LifecycleConfig {
  * Containment type abstraction for createConfigFromPolicy.
  * Maps to platform-specific backends:
  * - "process": BaseProcessContainer (Windows) / LXC (Linux)
+ * - "microvm": MicroVM/Nanvix backend (Windows only, experimental)
  */
-export type ContainmentType = "process";
+export type ContainmentType = "process" | "microvm";
 
 /**
  * Clipboard access policy levels


### PR DESCRIPTION
Adds SDK/CLI support needed to invoke experimental containment backends (notably MicroVM), including a non-PTY execution path intended for CI/automation where accurate exit codes and separated stdout/stderr are required.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/134)