### PR TITLE
refactor: move SidAndAttributes to process_util for shared use

### DIFF
--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -21,7 +21,7 @@ use windows_core::{PCWSTR, PWSTR};
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{CodexRequest, NetworkEnforcementMode, NetworkPolicy, ScriptResponse};
-use crate::process_util::{get_capability_sid_from_name, OwnedHandle};
+use crate::process_util::{get_capability_sid_from_name, OwnedHandle, SidAndAttributes};
 use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
 use crate::string_util;
 
@@ -77,15 +77,6 @@ fn build_proxy_env_block(address: &crate::models::ProxyAddress) -> Vec<u16> {
     }
     block.push(0);
     block
-}
-
-/// A `SID_AND_ATTRIBUTES`-compatible struct used to build the capabilities array.
-/// Using a manual struct avoids issues with conditional availability of
-/// `windows::Win32::Security::SID_AND_ATTRIBUTES`.
-#[repr(C)]
-struct SidAndAttributes {
-    sid: PSID,
-    attributes: u32,
 }
 
 /// RAII guard that frees capability SID pointers via `LocalFree` on drop.

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -337,6 +337,17 @@ pub fn run_process_with_captured_output(
 
 // ── Capability SID helpers ────────────────────────────────────────────────
 
+/// A `SID_AND_ATTRIBUTES`-compatible struct for building capability arrays
+/// and loopback exemption lists.
+///
+/// Using a manual struct avoids issues with conditional availability of
+/// `windows::Win32::Security::SID_AND_ATTRIBUTES`.
+#[repr(C)]
+pub struct SidAndAttributes {
+    pub sid: PSID,
+    pub attributes: u32,
+}
+
 /// Derive the capability SID for a given capability name.
 /// Returns the raw SID pointer. The caller is responsible for freeing it with `LocalFree`.
 pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void, WxcError> {

--- a/src/wxc_common/src/proxy_coordinator.rs
+++ b/src/wxc_common/src/proxy_coordinator.rs
@@ -16,14 +16,8 @@ use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLE
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{ProxyAddress, ProxyConfig};
-use crate::process_util::OwnedHandle;
+use crate::process_util::{OwnedHandle, SidAndAttributes};
 use crate::string_util;
-
-#[repr(C)]
-struct SidAndAttributes {
-    sid: PSID,
-    attributes: u32,
-}
 
 /// Remove an AppContainer from the loopback exemption list.
 fn remove_loopback_exemption(container_name: &str) {


### PR DESCRIPTION
Consolidate the duplicate SidAndAttributes struct definitions from appcontainer.rs and proxy_coordinator.rs into a single public definition in process_util.rs. Both modules now import from one place.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/135)