### PR TITLE
refactor: extract resolve_sibling_binary() into process_util

### DIFF
--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -112,11 +112,7 @@ impl NanVixError {
 
 /// Returns the directory containing the current executable.
 fn exe_dir() -> Result<PathBuf, NanVixError> {
-    let exe = std::env::current_exe()
-        .map_err(|e| NanVixError::Preflight(format!("cannot determine exe path: {}", e)))?;
-    exe.parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| NanVixError::Preflight("exe has no parent directory".to_string()))
+    crate::process_util::exe_dir().map_err(|e| NanVixError::Preflight(e.to_string()))
 }
 
 /// Watchdog thread: waits for timeout or cancellation, then terminates the process.

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::path::PathBuf;
+
 use crate::error::WxcError;
 use crate::string_util;
 
@@ -394,6 +396,35 @@ pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void
         let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
 
         Ok(result_sid)
+    }
+}
+
+// ── Sibling binary resolution ─────────────────────────────────────────────
+
+/// Return the directory containing the current executable.
+pub fn exe_dir() -> Result<PathBuf, WxcError> {
+    let exe = std::env::current_exe()
+        .map_err(|e| WxcError::Process(format!("cannot determine exe path: {}", e)))?;
+    exe.parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| WxcError::Process("exe has no parent directory".to_string()))
+}
+
+/// Locate a sibling executable next to the current exe.
+///
+/// Returns the full path if the binary exists, or an error describing
+/// where it was expected.
+pub fn resolve_sibling_binary(name: &str) -> Result<PathBuf, WxcError> {
+    let dir = exe_dir()?;
+    let path = dir.join(name);
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(WxcError::Process(format!(
+            "{} not found at {}",
+            name,
+            path.display()
+        )))
     }
 }
 

--- a/src/wxc_common/src/proxy_coordinator.rs
+++ b/src/wxc_common/src/proxy_coordinator.rs
@@ -16,7 +16,7 @@ use windows::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOCLOSEPROCESS, SHELLE
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{ProxyAddress, ProxyConfig};
-use crate::process_util::{OwnedHandle, SidAndAttributes};
+use crate::process_util::{resolve_sibling_binary, OwnedHandle, SidAndAttributes};
 use crate::string_util;
 
 /// Remove an AppContainer from the loopback exemption list.
@@ -116,26 +116,6 @@ fn enable_loopback(container_sid: PSID) -> Result<(), WxcError> {
     }
 
     Ok(())
-}
-
-/// Find a sibling executable next to the current exe.
-fn find_sibling_exe(name: &str) -> Result<PathBuf, WxcError> {
-    let exe_dir = std::env::current_exe()
-        .map_err(|err| WxcError::NetworkProxy(format!("Failed to get current exe path: {}", err)))?
-        .parent()
-        .ok_or_else(|| WxcError::NetworkProxy("Failed to get exe directory".into()))?
-        .to_path_buf();
-
-    let path = exe_dir.join(name);
-    if !path.exists() {
-        return Err(WxcError::NetworkProxy(format!(
-            "{} not found at {}",
-            name,
-            path.display()
-        )));
-    }
-
-    Ok(path)
 }
 
 /// Generate a unique identifier for event and file naming.
@@ -371,7 +351,7 @@ impl ProxyCoordinator {
         self.test_proxy_cleanup_event = Some(OwnedHandle::new(event_handle));
         self.test_proxy_ready_file_path = Some(ready_file_path.clone());
 
-        let proxy_exe = find_sibling_exe("wxc-test-proxy.exe")?;
+        let proxy_exe = resolve_sibling_binary("wxc-test-proxy.exe")?;
 
         let mut child = std::process::Command::new(&proxy_exe)
             .arg("--ready-file")
@@ -441,7 +421,7 @@ impl ProxyCoordinator {
         self.shim_cleanup_event = Some(OwnedHandle::new(event_handle));
         self.shim_ready_file_path = Some(ready_file_path.clone());
 
-        let shim_path = find_sibling_exe("winhttp-proxy-shim.exe")?;
+        let shim_path = resolve_sibling_binary("winhttp-proxy-shim.exe")?;
         let addr = self.proxy_address.as_ref().unwrap();
         let shim_args = format!(
             "--sid {} --proxy-address {} --proxy-port {} \

--- a/src/wxc_common/src/windows_sandbox_runner.rs
+++ b/src/wxc_common/src/windows_sandbox_runner.rs
@@ -6,11 +6,11 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpStream;
-use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::logger::Logger;
 use crate::models::{CodexRequest, ScriptResponse, WindowsSandboxConfig};
+use crate::process_util::resolve_sibling_binary;
 use crate::sandbox_protocol::DaemonResult;
 use crate::script_runner::ScriptRunner;
 
@@ -48,15 +48,8 @@ impl WindowsSandboxScriptRunner {
     }
 
     /// Locate the daemon executable next to wxc-exec.
-    fn daemon_exe_path() -> Result<PathBuf, String> {
-        let exe = std::env::current_exe().map_err(|e| format!("current_exe: {}", e))?;
-        let dir = exe.parent().ok_or("exe has no parent dir")?;
-        let daemon = dir.join("wxc-windows-sandbox-daemon.exe");
-        if daemon.exists() {
-            Ok(daemon)
-        } else {
-            Err(format!("daemon binary not found at {:?}", daemon))
-        }
+    fn daemon_exe_path() -> Result<std::path::PathBuf, String> {
+        resolve_sibling_binary("wxc-windows-sandbox-daemon.exe").map_err(|e| e.to_string())
     }
 
     /// Launch the daemon process if it's not already running.


### PR DESCRIPTION
Consolidate the duplicated 'find binary next to exe' pattern from sandbox_runner, proxy_coordinator, and nanvix_runner into shared process_util::exe_dir() and process_util::resolve_sibling_binary() functions. All three modules now delegate to the shared helpers.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/136)