### PR TITLE
refactor: standardize wide-string conversion via string_util::to_wide

### DIFF
--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -341,11 +341,7 @@ impl AppContainerScriptRunner {
         };
 
         // --- Build command line ---
-        let mut cmd_line_wide: Vec<u16> = request
-            .script_code
-            .encode_utf16()
-            .chain(std::iter::once(0))
-            .collect();
+        let mut cmd_line_wide = string_util::to_wide(&request.script_code);
 
         let working_dir_wide = string_util::to_wide(&request.working_directory);
         let working_dir_pcwstr = if request.working_directory.is_empty() {

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -265,10 +265,7 @@ pub fn run_process_with_captured_output(
         ..Default::default()
     };
 
-    let mut cmd_wide: Vec<u16> = command_line
-        .encode_utf16()
-        .chain(std::iter::once(0))
-        .collect();
+    let mut cmd_wide = string_util::to_wide(command_line);
     let mut pi = PROCESS_INFORMATION::default();
 
     unsafe {
@@ -643,7 +640,7 @@ mod tests {
             ..Default::default()
         };
         let mut pi = PROCESS_INFORMATION::default();
-        let mut cmd_wide: Vec<u16> = cmd.encode_utf16().chain(std::iter::once(0)).collect();
+        let mut cmd_wide = string_util::to_wide(cmd);
 
         unsafe {
             CreateProcessW(


### PR DESCRIPTION
Replace manual encode_utf16().chain(once(0)).collect() patterns in appcontainer.rs and process_util.rs with calls to the existing string_util::to_wide() helper for consistency and reduced duplication.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/137)