### PR TITLE
Use widestring crate for UTF-16 conversions in string_util

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -901,6 +901,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1136,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "widestring",
  "windows",
  "windows-core",
 ]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -43,3 +43,4 @@ nix = { version = "0.29", features = ["mount", "sched", "signal", "net", "proces
 lxc_common = { path = "lxc_common" }
 flatbuffers = "25"
 sandbox_spec = { path = "generated/base_container_specification" }
+widestring = "1"

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -14,6 +14,7 @@ windows = { workspace = true }
 windows-core = { workspace = true }
 flatbuffers = { workspace = true }
 sandbox_spec = { workspace = true }
+widestring = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/wxc_common/src/string_util.rs
+++ b/src/wxc_common/src/string_util.rs
@@ -2,23 +2,20 @@
 // Licensed under the MIT License.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use std::ffi::OsString;
-use std::os::windows::ffi::OsStringExt;
+use widestring::{U16CString, U16Str};
 use windows::Win32::Foundation::{LocalFree, HLOCAL};
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::PSID;
 
 /// Convert a UTF-8 string to a null-terminated UTF-16 wide string.
 pub fn to_wide(s: &str) -> Vec<u16> {
-    s.encode_utf16().chain(std::iter::once(0)).collect()
+    U16CString::from_str_truncate(s).into_vec_with_nul()
 }
 
 /// Convert a UTF-16 slice to a UTF-8 String, stopping at the first null terminator if present.
 pub fn from_wide(wide: &[u16]) -> String {
     let len = wide.iter().position(|&c| c == 0).unwrap_or(wide.len());
-    OsString::from_wide(&wide[..len])
-        .to_string_lossy()
-        .into_owned()
+    U16Str::from_slice(&wide[..len]).to_string_lossy()
 }
 
 /// Convert a SID pointer to its string representation (e.g. "S-1-5-...").


### PR DESCRIPTION
Replace manual UTF-16 encoding/decoding in to_wide() and from_wide() with the widestring crate's U16CString and U16Str types. This removes the dependency on std::ffi::OsString and OsStringExt while keeping the same public API.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/140)