### PR TITLE
Add Copilot instructions, Rust conventions, and LSP config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,6 @@
 
 - [ ] I have signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs).
 - [ ] This pull request is related to an issue.
+- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 
 -----

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,170 @@
+# MXC (Microsoft eXecution Container) — Copilot Instructions
+
+## Prerequisites
+
+LSP servers are configured in `.github/lsp.json` for Rust and TypeScript. Install them before use:
+
+```
+rustup component add rust-analyzer
+npm install -g typescript-language-server typescript
+```
+
+## Build Commands
+
+### Full build (Windows)
+
+```
+build.bat                  # Release build for current architecture
+build.bat --debug          # Debug build
+build.bat --all            # Release build for both x64 and ARM64
+build.bat --with-microvm   # Include NanVix micro-VM binaries
+```
+
+### Full build (Linux)
+
+```
+./build.sh                 # Release build
+./build.sh --debug         # Debug build
+./build.sh --rust-only     # Only Rust binaries, skip SDK/CLI
+```
+
+### Individual components
+
+```
+# Rust workspace (from src/)
+cargo build --release --target x86_64-pc-windows-msvc
+cargo build --release --target aarch64-pc-windows-msvc
+cargo build --release -p lxc          # Linux only — builds lxc-exec
+
+# SDK (from sdk/)
+npm install && npm run build
+
+# CLI (from cli/)
+npm install && npm run build
+```
+
+### Lint and format
+
+```
+# Rust (from src/)
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+
+# CLI (from cli/)
+npx eslint src --ext .ts
+```
+
+### Tests
+
+```
+# Rust unit tests (from src/)
+cargo test --workspace
+cargo test -p wxc_common                    # Single crate
+cargo test -p wxc_common -- config_parser   # Filter by test name
+
+# SDK (from sdk/) — requires build first
+node --test dist/sandbox.test.js
+
+# CLI (from cli/) — requires build first
+node --test dist/cli.test.js
+
+# Integration tests — run from repo root, requires built wxc-exec.exe
+test_scripts\run_test_configs.bat           # All test configs via wxc_test_driver
+test_scripts\run_basicac_test.bat           # Single AppContainer test
+test_scripts\run_lxc_all_tests.sh           # All LXC tests (Linux)
+```
+
+## Architecture
+
+MXC is a **sandboxed code execution system** with a Rust core and TypeScript SDK/CLI layer.
+
+### Containment backends
+
+The Rust workspace (`src/`) implements multiple sandboxing backends behind the `ScriptRunner` trait (`wxc_common/src/script_runner.rs`):
+
+| Backend | Binary | Platform | Module |
+|---------|--------|----------|--------|
+| AppContainer | `wxc-exec.exe` | Windows | `appcontainer_runner.rs` |
+| BaseContainer (OS sandbox API) | `wxc-exec.exe` | Windows | `base_container_runner.rs` — calls `Experimental_CreateProcessInSandbox` via FlatBuffer |
+| Windows Sandbox | `wxc-exec.exe` | Windows | `windows_sandbox_runner.rs` |
+| MicroVM (NanVix) | `wxc-exec.exe` | Windows | `nanvix_runner.rs` — feature-gated behind `microvm` |
+| LXC | `lxc-exec` | Linux | `lxc/src/main.rs` + `lxc_common/` |
+
+### Config flow
+
+1. User provides JSON config (file or base64) → `config_parser.rs` deserializes into intermediate `Raw*` structs → validates and maps to `CodexRequest` (the internal execution model in `models.rs`)
+2. `CodexRequest` includes the containment backend selection, process config, filesystem/network policies, and optional experimental features
+3. The appropriate `ScriptRunner` implementation executes the process and returns `ScriptResponse`
+
+### TypeScript layers
+
+- **SDK** (`sdk/`, `@microsoft/mxc-sdk`) — the public API. `spawnSandbox()` builds a `ContainerConfig` from a `SandboxPolicy`, serializes to base64, and spawns the correct native binary (`wxc-exec.exe` or `lxc-exec`) via `node-pty`. Platform detection is in `platform.ts`.
+- **CLI** (`cli/`, `mxc-cli`) — thin Commander.js wrapper around the SDK. Depends on `@microsoft/mxc-sdk` via `file:../sdk`.
+
+The SDK auto-discovers native binaries by checking `sdk/bin/<target-triple>/` (npm-packaged) and `src/target/<target-triple>/{release,debug}/` (local dev). The `build.bat`/`build.sh` scripts copy binaries into the SDK bin directory.
+
+### Schema system
+
+- **Stable schema**: `schemas/stable/mxc-config.schema.0.4.0-alpha.json` — immutable after release
+- **Dev schema**: `schemas/dev/mxc-config.schema.0.5.0-dev.json` — includes `experimental` section
+- Current schema version: `0.4.0-alpha`
+- Config files can reference schemas via `"$schema"` for editor validation
+
+### Key documentation (`docs/`)
+
+- `docs/schema.md` — full JSON configuration schema reference
+- `docs/versioning.md` — schema versioning design, experimental feature lifecycle, and promotion process
+- `docs/authoring-a-new-feature.md` — step-by-step guide for adding experimental features (which files to touch, in what order)
+- `docs/lxc-backend.md` — LXC container backend details
+- `docs/windows-sandbox.md` / `docs/windows-sandbox-reference.md` — Windows Sandbox backend
+- `docs/examples.md` — annotated configuration examples (see also `examples/` and `test_configs/`)
+
+## Key Conventions
+
+### Experimental features
+
+New features go under the `experimental` JSON section and are only active when `--experimental` is passed. See `docs/authoring-a-new-feature.md` for the full checklist. The pattern:
+
+1. Add the property schema to `schemas/dev/` under `experimental`
+2. Add Rust structs to `models.rs` (`ExperimentalConfig`) and `config_parser.rs` (`RawExperimental`)
+3. Guard execution behind `if request.experimental_enabled` in the runner
+4. Never modify files in `schemas/stable/` — those are immutable release artifacts
+
+### Rust workspace structure
+
+- `wxc_common` is the shared library — all config parsing, models, error types, and runner implementations live here
+- `wxc` and `lxc` are thin binary crates that wire up CLI args (`clap`) and dispatch to `wxc_common`
+- Platform-specific modules in `wxc_common` use `#[cfg(target_os = "windows")]` / `#[cfg(target_os = "linux")]`
+- Workspace edition is 2021; shared dependencies are declared in the root `Cargo.toml` `[workspace.dependencies]`
+
+### Config parser pattern
+
+The parser uses two layers of structs: `Raw*` structs (matching JSON with `#[serde(rename)]`) that deserialize permissively, then map to validated domain structs in `models.rs`. This keeps serde attributes separate from the internal model.
+
+### TypeScript conventions
+
+- Target ES2020, CommonJS modules, strict mode
+- SDK and CLI each have their own `tsconfig.json` with `declaration: true`
+- Tests use Node.js built-in test runner (`node --test`)
+- CLI uses flat ESLint config (`eslint.config.js`) with `typescript-eslint`
+
+### Binary naming
+
+- Windows: `wxc-exec.exe` (AppContainer / Windows Sandbox / MicroVM)
+- Linux: `lxc-exec` (LXC containers)
+- Target triples: `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`
+
+### Keeping docs up to date
+
+When changing behavior covered by existing documentation, update the relevant docs in the same change:
+
+- **Schema changes** (adding/removing/renaming config fields) → update `docs/schema.md` and the appropriate JSON schema in `schemas/dev/` or `schemas/stable/`
+- **New experimental features** → follow `docs/authoring-a-new-feature.md`, which includes schema, Rust, and test config steps
+- **SDK API changes** (new exports, changed signatures, new options) → update `sdk/README.md` and the JSDoc in `sdk/src/index.ts`
+- **CLI command changes** → update `cli/README.md` and `cli/ARCHITECTURE.md`
+- **New containment backends or major backend changes** → update the relevant doc in `docs/` (e.g., `lxc-backend.md`, `windows-sandbox.md`)
+- **Versioning or promotion changes** → update `docs/versioning.md`
+
+### Policy versioning
+
+The `SandboxPolicy.version` in the SDK must match the JSON schema version (currently `0.4.0-alpha`). The SDK validates this in `sandbox.ts` — if the policy version is newer than `SUPPORTED_VERSION`, it throws. See `docs/versioning.md` for the full design.

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,135 @@
+---
+description: 'Rust programming language coding conventions and best practices'
+applyTo: '**/*.rs'
+---
+
+# Rust Coding Conventions and Best Practices
+
+Follow idiomatic Rust practices and community standards when writing Rust code. 
+
+These instructions are based on [The Rust Book](https://doc.rust-lang.org/book/), [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/), [RFC 430 naming conventions](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md), and the broader Rust community at [users.rust-lang.org](https://users.rust-lang.org).
+
+## General Instructions
+
+- Always prioritize readability, safety, and maintainability.
+- Use strong typing and leverage Rust's ownership system for memory safety.
+- Break down complex functions into smaller, more manageable functions.
+- For algorithm-related code, include explanations of the approach used.
+- Write code with good maintainability practices, including comments on why certain design decisions were made.
+- Handle errors gracefully using `Result<T, E>` and provide meaningful error messages.
+- For external dependencies, mention their usage and purpose in documentation.
+- Use consistent naming conventions following [RFC 430](https://github.com/rust-lang/rfcs/blob/master/text/0430-finalizing-naming-conventions.md).
+- Write idiomatic, safe, and efficient Rust code that follows the borrow checker's rules.
+- Ensure code compiles without warnings.
+
+## Patterns to Follow
+
+- Use modules (`mod`) and public interfaces (`pub`) to encapsulate logic.
+- Handle errors properly using `?`, `match`, or `if let`.
+- Use `serde` for serialization and `thiserror` or `anyhow` for custom errors.
+- Implement traits to abstract services or external dependencies.
+- Structure async code using `async/await` and `tokio` or `async-std`.
+- Prefer enums over flags and states for type safety.
+- Use builders for complex object creation.
+- Split binary and library code (`main.rs` vs `lib.rs`) for testability and reuse.
+- Use `rayon` for data parallelism and CPU-bound tasks.
+- Use iterators instead of index-based loops as they're often faster and safer.
+- Use `&str` instead of `String` for function parameters when you don't need ownership.
+- Prefer borrowing and zero-copy operations to avoid unnecessary allocations.
+
+### Ownership, Borrowing, and Lifetimes
+
+- Prefer borrowing (`&T`) over cloning unless ownership transfer is necessary.
+- Use `&mut T` when you need to modify borrowed data.
+- Explicitly annotate lifetimes when the compiler cannot infer them.
+- Use `Rc<T>` for single-threaded reference counting and `Arc<T>` for thread-safe reference counting.
+- Use `RefCell<T>` for interior mutability in single-threaded contexts and `Mutex<T>` or `RwLock<T>` for multi-threaded contexts.
+
+## Patterns to Avoid
+
+- Don't use `unwrap()` or `expect()` unless absolutely necessary—prefer proper error handling.
+- Avoid panics in library code—return `Result` instead.
+- Don't rely on global mutable state—use dependency injection or thread-safe containers.
+- Avoid deeply nested logic—refactor with functions or combinators.
+- Don't ignore warnings—treat them as errors during CI.
+- Avoid `unsafe` unless required and fully documented.
+- Don't overuse `clone()`, use borrowing instead of cloning unless ownership transfer is needed.
+- Avoid premature `collect()`, keep iterators lazy until you actually need the collection.
+- Avoid unnecessary allocations—prefer borrowing and zero-copy operations.
+
+## Code Style and Formatting
+
+- Follow the Rust Style Guide and use `rustfmt` for automatic formatting.
+- Keep lines under 100 characters when possible.
+- Place function and struct documentation immediately before the item using `///`.
+- Use `cargo clippy` to catch common mistakes and enforce best practices.
+
+## Error Handling
+
+- Use `Result<T, E>` for recoverable errors and `panic!` only for unrecoverable errors.
+- Prefer `?` operator over `unwrap()` or `expect()` for error propagation.
+- Create custom error types using `thiserror` or implement `std::error::Error`.
+- Use `Option<T>` for values that may or may not exist.
+- Provide meaningful error messages and context.
+- Error types should be meaningful and well-behaved (implement standard traits).
+- Validate function arguments and return appropriate errors for invalid input.
+
+## API Design Guidelines
+
+### Common Traits Implementation
+Eagerly implement common traits where appropriate:
+- `Copy`, `Clone`, `Eq`, `PartialEq`, `Ord`, `PartialOrd`, `Hash`, `Debug`, `Display`, `Default`
+- Use standard conversion traits: `From`, `AsRef`, `AsMut`
+- Collections should implement `FromIterator` and `Extend`
+- Note: `Send` and `Sync` are auto-implemented by the compiler when safe; avoid manual implementation unless using `unsafe` code
+
+### Type Safety and Predictability
+- Use newtypes to provide static distinctions
+- Arguments should convey meaning through types; prefer specific types over generic `bool` parameters
+- Use `Option<T>` appropriately for truly optional values
+- Functions with a clear receiver should be methods
+- Only smart pointers should implement `Deref` and `DerefMut`
+
+### Future Proofing
+- Use sealed traits to protect against downstream implementations
+- Structs should have private fields
+- Functions should validate their arguments
+- All public types must implement `Debug`
+
+## Testing and Documentation
+
+- Write comprehensive unit tests using `#[cfg(test)]` modules and `#[test]` annotations.
+- Use test modules alongside the code they test (`mod tests { ... }`).
+- Write integration tests in `tests/` directory with descriptive filenames.
+- Write clear and concise comments for each function, struct, enum, and complex logic.
+- Ensure functions have descriptive names and include comprehensive documentation.
+- Document all public APIs with rustdoc (`///` comments) following the [API Guidelines](https://rust-lang.github.io/api-guidelines/).
+- Use `#[doc(hidden)]` to hide implementation details from public documentation.
+- Document error conditions, panic scenarios, and safety considerations.
+- Examples should use `?` operator, not `unwrap()` or deprecated `try!` macro.
+
+## Project Organization
+
+- Use semantic versioning in `Cargo.toml`.
+- Include comprehensive metadata: `description`, `license`, `repository`, `keywords`, `categories`.
+- Use feature flags for optional functionality.
+- Organize code into modules using `mod.rs` or named files.
+- Keep `main.rs` or `lib.rs` minimal - move logic to modules.
+
+## Quality Checklist
+
+Before publishing or reviewing Rust code, ensure:
+
+### Core Requirements
+- [ ] **Naming**: Follows RFC 430 naming conventions
+- [ ] **Traits**: Implements `Debug`, `Clone`, `PartialEq` where appropriate
+- [ ] **Error Handling**: Uses `Result<T, E>` and provides meaningful error types
+- [ ] **Documentation**: All public items have rustdoc comments with examples
+- [ ] **Testing**: Comprehensive test coverage including edge cases
+
+### Safety and Quality
+- [ ] **Safety**: No unnecessary `unsafe` code, proper error handling
+- [ ] **Performance**: Efficient use of iterators, minimal allocations
+- [ ] **API Design**: Functions are predictable, flexible, and type-safe
+- [ ] **Future Proofing**: Private fields in structs, sealed traits where appropriate
+- [ ] **Tooling**: Code passes `cargo fmt`, `cargo clippy`, and `cargo test`

--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,19 @@
+{
+  "lspServers": {
+    "rust": {
+      "command": "rust-analyzer",
+      "args": [],
+      "fileExtensions": {
+        ".rs": "rust"
+      }
+    },
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "fileExtensions": {
+        ".ts": "typescript",
+        ".tsx": "typescriptreact"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds three files to help Copilot (and other AI assistants) work effectively in this repo:

- **.github/copilot-instructions.md** - Build/test/lint commands, architecture overview (containment backends, config flow, SDK/CLI layers), key conventions (experimental features, config parser pattern, schema system), doc maintenance rules, and LSP prerequisites.
- **.github/instructions/rust.instructions.md** - Rust coding best practices scoped to *.rs files via applyTo frontmatter. Sourced from [github/awesome-copilot](https://github.com/github/awesome-copilot).
- **.github/lsp.json** - LSP server definitions for rust-analyzer and typescript-language-server.