### PR TITLE
use x64/arm64 instead of Rust target triples for SDK bin layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,13 +100,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wxc-exec-x86_64-pc-windows-msvc
-          path: sdk/bin/x86_64-pc-windows-msvc
+          path: sdk/bin/x64
 
       - name: Download wxc-exec (arm64)
         uses: actions/download-artifact@v4
         with:
           name: wxc-exec-aarch64-pc-windows-msvc
-          path: sdk/bin/aarch64-pc-windows-msvc
+          path: sdk/bin/arm64
 
       - name: Set build version
         run: |

--- a/build.bat
+++ b/build.bat
@@ -60,31 +60,32 @@ echo.
 echo Copying binaries into SDK package...
 for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
     set "BIN_DIR=src\target\%%T\%BUILD_CONFIG%"
+    if "%%T"=="x86_64-pc-windows-msvc" (set "SDK_ARCH=x64") else (set "SDK_ARCH=arm64")
     if exist "!BIN_DIR!\wxc-exec.exe" (
-        if not exist "sdk\bin\%%T" mkdir "sdk\bin\%%T"
-        copy /Y "!BIN_DIR!\wxc-exec.exe" "sdk\bin\%%T\" >nul
-        echo   Copied %%T\wxc-exec.exe
+        if not exist "sdk\bin\!SDK_ARCH!" mkdir "sdk\bin\!SDK_ARCH!"
+        copy /Y "!BIN_DIR!\wxc-exec.exe" "sdk\bin\!SDK_ARCH!\" >nul
+        echo   Copied !SDK_ARCH!\wxc-exec.exe
         if exist "!BIN_DIR!\wxc-windows-sandbox-guest.exe" (
-            copy /Y "!BIN_DIR!\wxc-windows-sandbox-guest.exe" "sdk\bin\%%T\" >nul
-            echo   Copied %%T\wxc-windows-sandbox-guest.exe
+            copy /Y "!BIN_DIR!\wxc-windows-sandbox-guest.exe" "sdk\bin\!SDK_ARCH!\" >nul
+            echo   Copied !SDK_ARCH!\wxc-windows-sandbox-guest.exe
         )
         if exist "!BIN_DIR!\wxc-windows-sandbox-daemon.exe" (
-            copy /Y "!BIN_DIR!\wxc-windows-sandbox-daemon.exe" "sdk\bin\%%T\" >nul
-            echo   Copied %%T\wxc-windows-sandbox-daemon.exe
+            copy /Y "!BIN_DIR!\wxc-windows-sandbox-daemon.exe" "sdk\bin\!SDK_ARCH!\" >nul
+            echo   Copied !SDK_ARCH!\wxc-windows-sandbox-daemon.exe
         )
         if exist "!BIN_DIR!\winhttp-proxy-shim.exe" (
-            copy /Y "!BIN_DIR!\winhttp-proxy-shim.exe" "sdk\bin\%%T\" >nul
-            echo   Copied %%T\winhttp-proxy-shim.exe
+            copy /Y "!BIN_DIR!\winhttp-proxy-shim.exe" "sdk\bin\!SDK_ARCH!\" >nul
+            echo   Copied !SDK_ARCH!\winhttp-proxy-shim.exe
         )
         if exist "!BIN_DIR!\wxc-test-proxy.exe" (
-            copy /Y "!BIN_DIR!\wxc-test-proxy.exe" "sdk\bin\%%T\" >nul
-            echo   Copied %%T\wxc-test-proxy.exe
+            copy /Y "!BIN_DIR!\wxc-test-proxy.exe" "sdk\bin\!SDK_ARCH!\" >nul
+            echo   Copied !SDK_ARCH!\wxc-test-proxy.exe
         )
         if "%WITH_NANVIX%"=="1" (
             for %%B in (nanvixd.exe kernel.elf python.elf cpython-ramfs.img) do (
                 if exist "!BIN_DIR!\%%B" (
-                    copy /Y "!BIN_DIR!\%%B" "sdk\bin\%%T\" >nul
-                    echo   Copied %%T\%%B
+                    copy /Y "!BIN_DIR!\%%B" "sdk\bin\!SDK_ARCH!\" >nul
+                    echo   Copied !SDK_ARCH!\%%B
                 )
             )
         )

--- a/build.sh
+++ b/build.sh
@@ -70,18 +70,21 @@ ARCH=$(uname -m)
 case $ARCH in
     x86_64)
         TARGET_TRIPLE="x86_64-unknown-linux-gnu"
+        SDK_ARCH="x64"
         ;;
     aarch64)
         TARGET_TRIPLE="aarch64-unknown-linux-gnu"
+        SDK_ARCH="arm64"
         ;;
     *)
         echo "Warning: Unknown architecture $ARCH, skipping binary copy to SDK"
         TARGET_TRIPLE=""
+        SDK_ARCH=""
         ;;
 esac
 
 if [ -n "$TARGET_TRIPLE" ]; then
-    BIN_DIR="$SDK_DIR/bin/$TARGET_TRIPLE"
+    BIN_DIR="$SDK_DIR/bin/$SDK_ARCH"
     mkdir -p "$BIN_DIR"
 
     if [ "$BUILD_TYPE" = "release" ]; then

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -129,6 +129,14 @@ function isLxcAvailable(): boolean {
 }
 
 /**
+ * Get the simplified architecture name used for SDK bin directory layout.
+ * @returns 'arm64' or 'x64'
+ */
+function getSdkArch(): string {
+  return os.arch() === 'arm64' ? 'arm64' : 'x64';
+}
+
+/**
  * Get the Rust target triple for the current machine architecture.
  * @returns The Rust target triple string
  */
@@ -168,7 +176,7 @@ export function findWxcExecutable(): string | null {
 
   const possiblePaths = [
     // Bundled in the SDK package (e.g. when installed via npm)
-    path.join(__dirname, '..', 'bin', targetTriple, 'wxc-exec.exe'),
+    path.join(__dirname, '..', 'bin', getSdkArch(), 'wxc-exec.exe'),
     // Architecture-specific release build output (monorepo dev)
     path.join(targetDir, targetTriple, 'release', 'wxc-exec.exe'),
     // Architecture-specific debug build output (monorepo dev)
@@ -221,7 +229,7 @@ export function findLxcExecutable(): string | null {
 
   const possiblePaths = [
     // Bundled in the SDK package
-    path.join(__dirname, '..', 'bin', targetTriple, 'lxc-exec'),
+    path.join(__dirname, '..', 'bin', getSdkArch(), 'lxc-exec'),
     // Architecture-specific release build
     path.join(targetDir, targetTriple, 'release', 'lxc-exec'),
     // Architecture-specific debug build


### PR DESCRIPTION
Replace the full Rust target triple directory names (e.g.
x86_64-pc-windows-msvc, aarch64-unknown-linux-gnu) with shorter,
platform-agnostic names (x64, arm64) in the sdk/bin/ directory structure.

- build.bat: derive SDK_ARCH (x64/arm64) from the Cargo target triple and use it
  for all sdk\bin\ destination paths, keeping the full triple for Cargo source
  paths
- build.sh: similarly introduce SDK_ARCH alongside TARGET_TRIPLE and use it for
  BIN_DIR
- sdk/src/platform.ts: add getSdkArch() returning 'x64'/'arm64' and use it for
  the bundled SDK bin path in findWxcExecutable() and findLxcExecutable();
  monorepo dev fallback paths continue to use the full Rust target triple
- .github/workflows/build.yml: update download artifact paths

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/149)