### PR TITLE
Add PowerShell directory discovery to SDK getAvailableToolsPolicy

### DIFF
--- a/sdk/src/policy.test.ts
+++ b/sdk/src/policy.test.ts
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { getAvailableToolsPolicy } from './policy';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+describe('getAvailableToolsPolicy - PowerShell discovery', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
+    let tmpDir: string | undefined;
+
+    const mockWindows = () => {
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+    };
+
+    const mockLinux = () => {
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'linux' });
+    };
+
+    /** Create a temp directory containing a fake pwsh.exe and return its path. */
+    const createFakePwshDir = (): string => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mxc-test-'));
+        fs.writeFileSync(path.join(tmpDir, 'pwsh.exe'), '');
+        return tmpDir;
+    };
+
+    afterEach(() => {
+        if (originalPlatform) {
+            Object.defineProperty(process, 'platform', originalPlatform);
+            originalPlatform = undefined;
+        }
+        if (tmpDir) {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+            tmpDir = undefined;
+        }
+    });
+
+    it('should add system root to readonlyPaths when pwsh.exe is on PATH', () => {
+        mockWindows();
+        const pwshDir = createFakePwshDir();
+        const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
+        const result = getAvailableToolsPolicy(env);
+        assert.ok(
+            result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
+            'System root (e.g. C:\\) should be in readonlyPaths when pwsh.exe is on PATH',
+        );
+    });
+
+    it('should add PSReadLine dir to readwritePaths when pwsh.exe is on PATH', () => {
+        mockWindows();
+        const pwshDir = createFakePwshDir();
+        const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
+        const result = getAvailableToolsPolicy(env);
+        const expected = path.join(
+            'C:\\Users\\TestUser', 'AppData', 'Roaming', 'Microsoft', 'Windows', 'PowerShell', 'PSReadLine',
+        );
+        assert.ok(
+            result.readwritePaths.some(p => p.toLowerCase() === expected.toLowerCase()),
+            'PSReadLine directory should be in readwritePaths',
+        );
+    });
+
+    it('should not add PowerShell paths when pwsh.exe is not on PATH', () => {
+        mockWindows();
+        const env = { PATH: 'C:\\Windows\\System32', USERPROFILE: 'C:\\Users\\TestUser' };
+        const result = getAvailableToolsPolicy(env);
+        assert.ok(
+            !result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
+            'System root should not be in readonlyPaths when pwsh.exe is not on PATH',
+        );
+        assert.strictEqual(result.readwritePaths.length, 0,
+            'readwritePaths should be empty when pwsh.exe is not on PATH',
+        );
+    });
+
+    it('should not add PowerShell paths on non-Windows platforms', () => {
+        mockLinux();
+        const pwshDir = createFakePwshDir();
+        const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
+        const result = getAvailableToolsPolicy(env);
+        assert.ok(
+            !result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
+            'System root should not be added on Linux',
+        );
+        assert.strictEqual(result.readwritePaths.length, 0,
+            'readwritePaths should be empty on Linux',
+        );
+    });
+
+    it('should not add PSReadLine path when USERPROFILE is not set', () => {
+        mockWindows();
+        const pwshDir = createFakePwshDir();
+        const env = { PATH: pwshDir };
+        const result = getAvailableToolsPolicy(env);
+        assert.ok(
+            result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
+            'System root should still be in readonlyPaths',
+        );
+        assert.strictEqual(result.readwritePaths.length, 0,
+            'readwritePaths should be empty without USERPROFILE',
+        );
+    });
+});

--- a/sdk/src/policy.ts
+++ b/sdk/src/policy.ts
@@ -186,12 +186,67 @@ function deduplicatePaths(paths: string[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// PowerShell discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether PowerShell (pwsh.exe) is available on the machine by scanning
+ * the supplied PATH directories for a `pwsh.exe` binary.
+ *
+ * When PowerShell is found, return a policy fragment with:
+ * - `C:\` in `readonlyPaths` — pwsh.exe enumerates the drive root on startup.
+ * - The PSReadLine history directory in `readwritePaths` so the PSReadLine
+ *   module can persist command history.
+ *
+ * On non-Windows platforms or when pwsh.exe is not found on PATH, returns an
+ * empty policy.
+ *
+ * @param pathDirs - The list of PATH directories already collected by the caller.
+ * @param env - Environment variable map (used to resolve `%USERPROFILE%`).
+ */
+function getPowerShellPolicy(
+    pathDirs: string[],
+    env: { [key: string]: string | undefined },
+): FilesystemPolicyResult {
+    if (os.platform() !== 'win32') {
+        return { readonlyPaths: [], readwritePaths: [] };
+    }
+
+    const pwshFound = pathDirs.some(dir => {
+        try {
+            return fs.existsSync(path.join(dir, 'pwsh.exe'));
+        } catch {
+            return false;
+        }
+    });
+
+    if (!pwshFound) {
+        return { readonlyPaths: [], readwritePaths: [] };
+    }
+
+    const systemDrive = process.env["SystemDrive"] || 'C:';
+    const systemRoot = systemDrive + "\\";
+    const readonlyPaths: string[] = [systemRoot];
+    const readwritePaths: string[] = [];
+
+    const userProfile = env['USERPROFILE'];
+    if (userProfile) {
+        const psReadLineDir = path.join(
+            userProfile, 'AppData', 'Roaming', 'Microsoft', 'Windows', 'PowerShell', 'PSReadLine',
+        );
+        readwritePaths.push(psReadLineDir);
+    }
+
+    return { readonlyPaths, readwritePaths };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Discover tool and SDK directories from the environment and return them as
- * read-only policy paths.
+ * policy paths.
  *
  * Reads the `PATH` variable and a set of well-known tool / SDK environment
  * variables, enumerates the directories they reference, then applies filters:
@@ -202,9 +257,14 @@ function deduplicatePaths(paths: string[]): string[] {
  *    already grant access to `ALL_APPLICATION_PACKAGES` are removed because
  *    AppContainer processes can see them without explicit brokering.
  *
+ * Additionally, if PowerShell (`pwsh.exe`) is found on PATH, the drive root
+ * (`C:\`) is added to `readonlyPaths` and the PSReadLine history directory
+ * is added to `readwritePaths` so that interactive PowerShell sessions work
+ * correctly inside the container.
+ *
  * @param env - Environment variable map. Defaults to `process.env`.
  * @param options - Filtering options.
- * @returns A policy fragment with discovered paths in `readonlyPaths`.
+ * @returns A policy fragment with discovered paths.
  */
 export function getAvailableToolsPolicy(
     env?: { [key: string]: string | undefined },
@@ -215,7 +275,8 @@ export function getAvailableToolsPolicy(
 
     // PATH directories
     const pathValue = environment['PATH'] || environment['Path'] || '';
-    collected.push(...splitPathList(pathValue));
+    const pathDirs = splitPathList(pathValue);
+    collected.push(...pathDirs);
 
     // Known environment variables
     for (const knownVar of KNOWN_ENV_VARS) {
@@ -242,9 +303,12 @@ export function getAvailableToolsPolicy(
         return true;
     });
 
+    // Merge PowerShell-specific paths when pwsh.exe is available
+    const pwshPolicy = getPowerShellPolicy(pathDirs, environment);
+
     return {
-        readonlyPaths: filtered,
-        readwritePaths: [],
+        readonlyPaths: deduplicatePaths([...filtered, ...pwshPolicy.readonlyPaths]),
+        readwritePaths: deduplicatePaths([...pwshPolicy.readwritePaths]),
     };
 }
 


### PR DESCRIPTION
When PowerShell (pwsh.exe) is detected on PATH, getAvailableToolsPolicy()
now includes the extra filesystem paths that PowerShell needs to function
inside a sandboxed container:

- C:\ added to readonlyPaths so pwsh.exe can enumerate the drive root
  during startup.
- %USERPROFILE%\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadLine
  added to readwritePaths so the PSReadLine module can persist command
  history.

This is implemented as a private getPowerShellPolicy() helper in
sdk/src/policy.ts that is called by getAvailableToolsPolicy(). Detection
checks whether any PATH directory contains pwsh.exe (machine-level
discovery, not command-line-level). Windows-only; returns empty policy on
other platforms.

Includes five SDK tests covering:
- C:\ and PSReadLine path injection when pwsh.exe is on PATH
- No injection when pwsh.exe is absent from PATH
- No injection on non-Windows platforms
- No PSReadLine path when USERPROFILE is unset

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>