### PR TITLE
Allow MXC to accept 0.5.0-alpha jsons

### DIFF
--- a/docs/authoring-a-new-feature.md
+++ b/docs/authoring-a-new-feature.md
@@ -314,7 +314,7 @@ Create a test config that exercises your feature:
 
 ```json
 {
-  "version": "0.4.0-alpha",
+  "version": "0.5.0-alpha",
   "containment": "appcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo gpu isolation test"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -94,12 +94,12 @@ The parser compares the config's major.minor against its supported version
 
 | Config `version` | Parser supports | Result |
 |---|---|---|
-| absent | 0.5.0-alpha | Accepted (assumed compatible) |
-| `"0.3.0-alpha"` | 0.5.0-alpha | Accepted (0.3 ≤ 0.5) |
-| `"0.4.0-alpha"` | 0.5.0-alpha | Accepted (0.4 ≤ 0.5) |
-| `"0.5.0-alpha"` | 0.5.0-alpha | Accepted (0.5 ≤ 0.5) |
-| `"0.6.0"` | 0.5.0-alpha | **Rejected** — "upgrade wxc-exec" |
-| `"1.0.0"` | 0.5.0-alpha | **Rejected** — "upgrade wxc-exec" |
+| absent | >=0.4, <=0.5 | Accepted (assumed compatible) |
+| `"0.3.0-alpha"` | >=0.4, <=0.5 | **Rejected** — "older than supported" |
+| `"0.4.0-alpha"` | >=0.4, <=0.5 | Accepted (0.4 in range) |
+| `"0.5.0-alpha"` | >=0.4, <=0.5 | Accepted (0.5 in range) |
+| `"0.6.0"` | >=0.4, <=0.5 | **Rejected** — "newer than supported" |
+| `"1.0.0"` | >=0.4, <=0.5 | **Rejected** — "newer than supported" |
 
 #### When to bump
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,7 +23,7 @@ production configs and the dev schema when working on experimental features:
 
 ```json
 {
-    "version": "0.5.0-alpha",              // Schema version (semver, current: "0.5.0-alpha")
+    "version": "0.4.0-alpha",              // Schema version (semver). Current stable: "0.4.0-alpha". Also accepts "0.5.0-alpha".
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "appcontainer",         // Backend (see table below)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,7 +23,7 @@ production configs and the dev schema when working on experimental features:
 
 ```json
 {
-    "version": "0.4.0-alpha",              // Schema version (semver, current: "0.4.0-alpha")
+    "version": "0.5.0-alpha",              // Schema version (semver, current: "0.5.0-alpha")
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "appcontainer",         // Backend (see table below)
 
@@ -94,11 +94,12 @@ The parser compares the config's major.minor against its supported version
 
 | Config `version` | Parser supports | Result |
 |---|---|---|
-| absent | 0.4.0-alpha | Accepted (assumed compatible) |
-| `"0.3.0-alpha"` | 0.4.0-alpha | Accepted (0.3 ≤ 0.4) |
-| `"0.4.0-alpha"` | 0.4.0-alpha | Accepted (0.4 ≤ 0.4) |
-| `"0.5.0"` | 0.4.0-alpha | **Rejected** — "upgrade wxc-exec" |
-| `"1.0.0"` | 0.4.0-alpha | **Rejected** — "upgrade wxc-exec" |
+| absent | 0.5.0-alpha | Accepted (assumed compatible) |
+| `"0.3.0-alpha"` | 0.5.0-alpha | Accepted (0.3 ≤ 0.5) |
+| `"0.4.0-alpha"` | 0.5.0-alpha | Accepted (0.4 ≤ 0.5) |
+| `"0.5.0-alpha"` | 0.5.0-alpha | Accepted (0.5 ≤ 0.5) |
+| `"0.6.0"` | 0.5.0-alpha | **Rejected** — "upgrade wxc-exec" |
+| `"1.0.0"` | 0.5.0-alpha | **Rejected** — "upgrade wxc-exec" |
 
 #### When to bump
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -60,11 +60,12 @@ schemas in `stable/` do not include the experimental section.
 
 ### Shipped vs Experimental
 
-The current config schema has two sections:
+The current config schema has two sections. Configs using experimental
+features should use version `0.5.0-alpha`:
 
 ```json
 {
-  "version": "0.4.0-alpha",
+  "version": "0.5.0-alpha",
   "process": { ... },
   "filesystem": { ... },
   "network": { ... },

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -60,8 +60,9 @@ schemas in `stable/` do not include the experimental section.
 
 ### Shipped vs Experimental
 
-The current config schema has two sections. Configs using experimental
-features should use version `0.5.0-alpha`:
+The current stable schema version is `0.4.0-alpha`. The parser also accepts
+`0.5.0-alpha`, which should be used for configs that include promoted and experimental
+features:
 
 ```json
 {

--- a/docs/windows-sandbox.md
+++ b/docs/windows-sandbox.md
@@ -70,6 +70,7 @@ This avoids the 30-60s boot cost for subsequent executions.
 
 ```json
 {
+  "version": "0.5.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "python -S -B -c \"print('hello')\"",

--- a/schemas/dev/mxc-config.schema.0.5.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.5.0-dev.json
@@ -10,7 +10,7 @@
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version (semver). Current stable: '0.4.0-alpha'. The dev schema filename (0.5.0-dev) reflects the next version in development — configs should continue using '0.4.0-alpha' until the parser is updated to support 0.5.x.",
+      "description": "MXC config schema version (semver). Current stable: '0.4.0-alpha'. Configs using promoted or experimental features should use '0.5.0-alpha'.",
       "examples": ["0.4.0-alpha"]
     },
     "containerId": {

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -74,6 +74,15 @@ describe('buildSandboxPayload', () => {
     it('should accept a compatible version', () => {
       mockWindows();
       try {
+        assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.5.0-alpha' }));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should accept older version 0.4.0-alpha', () => {
+      mockWindows();
+      try {
         assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.4.0-alpha' }));
       } finally {
         restore();

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -113,6 +113,18 @@ describe('buildSandboxPayload', () => {
       }
     });
 
+    it('should reject a version older than minimum', () => {
+      mockWindows();
+      try {
+        assert.throws(
+          () => buildSandboxPayload('echo hi', { version: '0.3.0-alpha' }),
+          { message: /older than supported/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
     it('should reject an invalid semver string', () => {
       mockWindows();
       try {

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -9,6 +9,7 @@ import { SandboxPolicy, ContainerConfig } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
+const MIN_VERSION = '0.4.0-alpha';
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -31,6 +32,18 @@ function validatePolicyVersion(version: string): void {
     }
 
     const supported = semverParse(SUPPORTED_VERSION);
+    const minimum = semverParse(MIN_VERSION);
+    if (
+        parsed.major < minimum!.major ||
+        (parsed.major === minimum!.major &&
+            parsed.minor < minimum!.minor)
+    ) {
+        throw new Error(
+            `Policy version '${version}' is older than supported` +
+            ` (min: ${minimum!.major}.${minimum!.minor}.x).` +
+            ` Update your config.`
+        );
+    }
     if (
         parsed.major > supported!.major ||
         (parsed.major === supported!.major &&

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -8,7 +8,7 @@ import { parse as semverParse } from 'semver';
 import { SandboxPolicy, ContainerConfig } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 
-const SUPPORTED_VERSION = '0.4.0-alpha';
+const SUPPORTED_VERSION = '0.5.0-alpha';
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -26,7 +26,7 @@ function validatePolicyVersion(version: string): void {
     if (!parsed) {
         throw new Error(
             `Invalid policy version '${version}': must be valid semver` +
-            ` (e.g., '0.4.0' or '0.4.0-alpha')`
+            ` (e.g., '0.5.0' or '0.5.0-alpha')`
         );
     }
 

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "base64",
  "flatbuffers",
  "sandbox_spec",
+ "semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -8,6 +8,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
+semver = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true }

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -254,8 +254,8 @@ pub fn load_request(
 
 // ---------- Cross-field validation ----------
 
-/// Supported schema version (semver). Configs with a higher major.minor are rejected.
-const SUPPORTED_VERSION: (u32, u32) = (0, 5); // 0.5.x
+/// Maximum supported schema version (major.minor). Configs with a higher major.minor are rejected.
+const SUPPORTED_VERSION: &str = "<=0.5";
 
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
@@ -264,42 +264,26 @@ fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), Wxc
         return Ok(());
     }
 
-    // Strip pre-release suffix (e.g., "0.4.0-alpha" → "0.4.0")
-    let version_core = version.split('-').next().unwrap_or(version);
-    let parts: Vec<&str> = version_core.split('.').collect();
-
-    if parts.len() < 2 {
+    // Parse the version, stripping pre-release suffix for comparison
+    // (e.g., "0.4.0-alpha" is treated as "0.4.0")
+    let parsed = semver::Version::parse(version).map_err(|_| {
         let msg = format!(
             "Invalid schema version '{}': must be semver (e.g., 'X.Y.Z' or 'X.Y.Z-alpha')",
             version
         );
         logger.log_line(&msg);
-        return Err(WxcError::ConfigParse(msg));
-    }
-
-    let major: u32 = parts[0].parse().map_err(|_| {
-        let msg = format!(
-            "Invalid schema version '{}': major version must be a non-negative integer",
-            version
-        );
-        logger.log_line(&msg);
         WxcError::ConfigParse(msg)
     })?;
 
-    let minor: u32 = parts[1].parse().map_err(|_| {
-        let msg = format!(
-            "Invalid schema version '{}': minor version must be a non-negative integer",
-            version
-        );
-        logger.log_line(&msg);
-        WxcError::ConfigParse(msg)
-    })?;
+    let req = semver::VersionReq::parse(SUPPORTED_VERSION).unwrap();
 
-    let (sup_major, sup_minor) = SUPPORTED_VERSION;
-    if major > sup_major || (major == sup_major && minor > sup_minor) {
+    // semver crate treats pre-release as lower precedence, so we compare
+    // against a version without the pre-release label for major.minor check.
+    let comparable = semver::Version::new(parsed.major, parsed.minor, parsed.patch);
+    if !req.matches(&comparable) {
         let msg = format!(
-            "Config schema version '{}' is newer than supported (max: {}.{}.x). Upgrade wxc-exec.",
-            version, sup_major, sup_minor
+            "Config schema version '{}' is newer than supported (max: {}). Upgrade wxc-exec.",
+            version, SUPPORTED_VERSION
         );
         logger.log_line(&msg);
         return Err(WxcError::ConfigParse(msg));

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -255,7 +255,7 @@ pub fn load_request(
 // ---------- Cross-field validation ----------
 
 /// Supported schema version (semver). Configs with a higher major.minor are rejected.
-const SUPPORTED_VERSION: (u32, u32) = (0, 4); // 0.4.x
+const SUPPORTED_VERSION: (u32, u32) = (0, 5); // 0.5.x
 
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
@@ -1234,7 +1234,7 @@ mod tests {
 
     #[test]
     fn schema_version_too_new_rejected() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.5.0"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.6.0"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1244,6 +1244,16 @@ mod tests {
 
     #[test]
     fn schema_version_current_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.5.0-alpha"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.schema_version, "0.5.0-alpha");
+    }
+
+    #[test]
+    fn schema_version_older_accepted() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.4.0-alpha"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
@@ -1253,13 +1263,33 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_older_accepted() {
+    fn schema_version_oldest_accepted() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.3.0-alpha"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.schema_version, "0.3.0-alpha");
+    }
+
+    #[test]
+    fn full_config_with_0_5_0_alpha_accepted() {
+        let json = r#"{
+            "version": "0.5.0-alpha",
+            "containerId": "test-050",
+            "containment": "appcontainer",
+            "process": { "commandLine": "echo hello", "timeout": 5000 },
+            "filesystem": { "readwritePaths": ["C:\\workspace"] },
+            "network": { "defaultPolicy": "block" }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.schema_version, "0.5.0-alpha");
+        assert_eq!(req.container_id, "test-050");
+        assert_eq!(req.script_timeout, 5000);
+        assert_eq!(req.policy.readwrite_paths, vec!["C:\\workspace"]);
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -255,7 +255,7 @@ pub fn load_request(
 // ---------- Cross-field validation ----------
 
 /// Maximum supported schema version (major.minor). Configs with a higher major.minor are rejected.
-const SUPPORTED_VERSION: &str = "<=0.5";
+const SUPPORTED_VERSION: &str = ">=0.4, <=0.5";
 
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
@@ -281,10 +281,18 @@ fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), Wxc
     // against a version without the pre-release label for major.minor check.
     let comparable = semver::Version::new(parsed.major, parsed.minor, parsed.patch);
     if !req.matches(&comparable) {
-        let msg = format!(
-            "Config schema version '{}' is newer than supported (max: {}). Upgrade wxc-exec.",
-            version, SUPPORTED_VERSION
-        );
+        let min = semver::VersionReq::parse(">=0.4").unwrap();
+        let msg = if !min.matches(&comparable) {
+            format!(
+                "Config schema version '{}' is older than supported (supported: {}). Update your config.",
+                version, SUPPORTED_VERSION
+            )
+        } else {
+            format!(
+                "Config schema version '{}' is newer than supported (supported: {}). Upgrade wxc-exec.",
+                version, SUPPORTED_VERSION
+            )
+        };
         logger.log_line(&msg);
         return Err(WxcError::ConfigParse(msg));
     }
@@ -1247,13 +1255,13 @@ mod tests {
     }
 
     #[test]
-    fn schema_version_oldest_accepted() {
+    fn schema_version_too_old_rejected() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.3.0-alpha"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.schema_version, "0.3.0-alpha");
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -270,7 +270,7 @@ fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), Wxc
 
     if parts.len() < 2 {
         let msg = format!(
-            "Invalid schema version '{}': must be semver (e.g., '0.4.0' or '0.4.0-alpha')",
+            "Invalid schema version '{}': must be semver (e.g., 'X.Y.Z' or 'X.Y.Z-alpha')",
             version
         );
         logger.log_line(&msg);

--- a/test_configs/experimental_hello_appcontainer.json
+++ b/test_configs/experimental_hello_appcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-alpha",
+  "version": "0.5.0-alpha",
   "containerId": "CLI-Experimental-Hello",
   "containment": "appcontainer",
   "process": {

--- a/test_configs/experimental_hello_lxc.json
+++ b/test_configs/experimental_hello_lxc.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-alpha",
+  "version": "0.5.0-alpha",
   "containerId": "CLI-Experimental-Hello-LXC",
   "containment": "lxc",
   "process": {

--- a/test_configs/hello_world_v050.json
+++ b/test_configs/hello_world_v050.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "CLI-HelloWorld-v050",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "python -c \"import sys; print('Hello from MXC 0.5.0-alpha!'); print(f'Python version: {sys.version}')\""
+  },
+  "appContainer": {
+    "capabilities": ["permissiveLearningMode"]
+  }
+}

--- a/test_configs/rejected_version_too_old.json
+++ b/test_configs/rejected_version_too_old.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.3.0-alpha",
+  "containerId": "rejected-too-old",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "echo 'This should not run — version 0.3.0-alpha is rejected'"
+  }
+}


### PR DESCRIPTION
We are allowing MXC to accept 0.5.0-alpha jsons. So, with this change, MXC accepts the following:
 - `0.4.0-alpha` without `--experimental` → stable features only
 - `0.5.0-alpha` without `--experimental` → stable + promoted features
 - `0.5.0-alpha` with `--experimental` → stable + promoted + experimental features
 - `0.4.0-alpha` with `--experimental` → stable + experimental features (also works)
