### PR TITLE
Enable BaseContainerRunner to light up in 0.5.0-alpha

### DIFF
--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use windows::Win32::Security::Isolation::DeleteAppContainerProfile;
 use wxc_common::appcontainer_runner::AppContainerScriptRunner;
 use wxc_common::base_container_runner::BaseContainerRunner;
-use wxc_common::config_parser::load_request;
+use wxc_common::config_parser::{is_base_container_version, load_request};
 use wxc_common::filesystem_bfs::FileSystemBfsManager;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
@@ -148,11 +148,43 @@ fn main() {
     log_request(&request, &mut logger);
 
     // Run script in selected containment backend.
-    // Sandbox, BaseContainer and MicroVM require --experimental flag.
+    // BaseContainer is used when --experimental is passed or schema version >= 0.5.
+    // Sandbox and MicroVM require --experimental flag.
     let mut runner: Box<dyn ScriptRunner> = match request.containment {
         ContainmentBackend::AppContainer => {
-            if request.experimental_enabled {
-                let _ = writeln!(logger, "Using BaseContainer runner (--experimental)");
+            let version_implies_base_container = is_base_container_version(&request.schema_version);
+            let use_base_container = request.experimental_enabled || version_implies_base_container;
+
+            if use_base_container {
+                if let Err(e) = BaseContainerRunner::is_base_container_api_present() {
+                    if version_implies_base_container {
+                        eprintln!(
+                            "Error: Config schema version '{}' requires the BaseContainer \
+                             backend, but this OS build does not support it: {}",
+                            request.schema_version, e
+                        );
+                        eprintln!(
+                            "Hint: Use schema version '0.4.0-alpha' to fall back to AppContainer."
+                        );
+                    } else {
+                        eprintln!(
+                            "Error: --experimental requested BaseContainer, but this OS build \
+                             does not support it: {}",
+                            e
+                        );
+                        eprintln!(
+                            "Hint: Remove --experimental to use the AppContainer backend, \
+                             or use an OS build with BaseContainer support."
+                        );
+                    }
+                    process::exit(1);
+                }
+                let reason = if version_implies_base_container {
+                    format!("schema version {}", request.schema_version)
+                } else {
+                    "--experimental".to_string()
+                };
+                let _ = writeln!(logger, "Using BaseContainer runner ({reason})");
                 Box::new(BaseContainerRunner::new())
             } else {
                 Box::new(AppContainerScriptRunner::new())

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -57,7 +57,7 @@ type PfnCreateProcessInSandbox = unsafe extern "system" fn(
 pub struct BaseContainerRunner;
 
 /// Windows error code for a function that exists but is not implemented
-/// (e.g., disabled via velocity keys).
+/// (e.g., disabled via feature-enablement mechanisms).
 const ERROR_CALL_NOT_IMPLEMENTED: u32 = 120;
 
 impl BaseContainerRunner {
@@ -73,7 +73,7 @@ impl BaseContainerRunner {
     ///
     /// Note: a successful probe only means the symbol exists. The OS may
     /// still reject calls at runtime with `ERROR_CALL_NOT_IMPLEMENTED` if
-    /// the feature is disabled (e.g., via internal velocity keys).
+    /// the feature is disabled (e.g., via internal feature-enablement mechanisms).
     pub fn is_base_container_api_present() -> Result<(), String> {
         Self::load_api().map(|_| ())
     }
@@ -429,7 +429,7 @@ impl ScriptRunner for BaseContainerRunner {
                 return ScriptResponse::error(
                     "Experimental_CreateProcessInSandbox returned ERROR_CALL_NOT_IMPLEMENTED. \
                      The BaseContainer feature may be disabled on this OS build \
-                     (e.g., via velocity keys). \
+                     (e.g., via feature-enablement mechanisms). \
                      Use schema version '0.4.0-alpha' to fall back to the AppContainer backend.",
                 );
             }

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -56,9 +56,26 @@ type PfnCreateProcessInSandbox = unsafe extern "system" fn(
 #[derive(Default)]
 pub struct BaseContainerRunner;
 
+/// Windows error code for a function that exists but is not implemented
+/// (e.g., disabled via velocity keys).
+const ERROR_CALL_NOT_IMPLEMENTED: u32 = 120;
+
 impl BaseContainerRunner {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Pre-flight probe: check whether the current OS build exports the
+    /// `Experimental_CreateProcessInSandbox` symbol from `processmodel.dll`.
+    ///
+    /// Returns `Ok(())` if the export is resolvable, or `Err` with a
+    /// human-readable description when the DLL or export is missing.
+    ///
+    /// Note: a successful probe only means the symbol exists. The OS may
+    /// still reject calls at runtime with `ERROR_CALL_NOT_IMPLEMENTED` if
+    /// the feature is disabled (e.g., via internal velocity keys).
+    pub fn is_base_container_api_present() -> Result<(), String> {
+        Self::load_api().map(|_| ())
     }
 
     /// JOB_OBJECT_UILIMIT_* flag constants (from UIPolicy_Schema.md).
@@ -408,6 +425,14 @@ impl ScriptRunner for BaseContainerRunner {
 
         if success == 0 {
             let err = unsafe { GetLastError() };
+            if err.0 == ERROR_CALL_NOT_IMPLEMENTED {
+                return ScriptResponse::error(
+                    "Experimental_CreateProcessInSandbox returned ERROR_CALL_NOT_IMPLEMENTED. \
+                     The BaseContainer feature may be disabled on this OS build \
+                     (e.g., via velocity keys). \
+                     Use schema version '0.4.0-alpha' to fall back to the AppContainer backend.",
+                );
+            }
             return ScriptResponse::error(&format!(
                 "Experimental_CreateProcessInSandbox failed: {err:?}"
             ));

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -304,6 +304,27 @@ pub fn load_request(
 /// Maximum supported schema version (major.minor). Configs with a higher major.minor are rejected.
 const SUPPORTED_VERSION: &str = ">=0.4, <=0.5";
 
+/// The minimum schema version that implies BaseContainer backend usage.
+const BASE_CONTAINER_MIN_VERSION: &str = "0.5.0";
+
+/// Returns `true` if `version` is a BaseContainer-era schema version (>= 0.5.0).
+///
+/// Pre-release labels are stripped before comparison, so `"0.5.0-alpha"` is
+/// treated identically to `"0.5.0"`.  Returns `false` for empty or
+/// unparseable version strings.
+pub fn is_base_container_version(version: &str) -> bool {
+    if version.is_empty() {
+        return false;
+    }
+    let parsed = match semver::Version::parse(version) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let comparable = semver::Version::new(parsed.major, parsed.minor, parsed.patch);
+    let threshold = semver::Version::parse(BASE_CONTAINER_MIN_VERSION).unwrap();
+    comparable >= threshold
+}
+
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
 fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), WxcError> {
@@ -1636,5 +1657,23 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.policy.ui.clipboard, ClipboardPolicy::All);
+    }
+
+    #[test]
+    fn is_base_container_version_recognizes_050() {
+        assert!(is_base_container_version("0.5.0-alpha"));
+        assert!(is_base_container_version("0.5.0"));
+        assert!(is_base_container_version("0.5.1"));
+        assert!(is_base_container_version("0.6.0"));
+        assert!(is_base_container_version("1.0.0"));
+    }
+
+    #[test]
+    fn is_base_container_version_rejects_040() {
+        assert!(!is_base_container_version("0.4.0-alpha"));
+        assert!(!is_base_container_version("0.4.0"));
+        assert!(!is_base_container_version("0.4.9"));
+        assert!(!is_base_container_version(""));
+        assert!(!is_base_container_version("not-a-version"));
     }
 }


### PR DESCRIPTION
Turn on BaseContainer is policy version 0.5.0 is passed, or if --experimental is passed.

Error out with appropriate message if the OS doesn't support BaseContainer or if the feature is disabled (via internal velocity mechanism).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/168)