### PR TITLE
Add container policy design proposal (draft)

### DIFF
--- a/docs/proposals/container-policy/ContainerPolicyDesign.md
+++ b/docs/proposals/container-policy/ContainerPolicyDesign.md
@@ -1,0 +1,3090 @@
+# Container Policy Design: Intent, Composition, and Binding
+
+This document defines the policy architecture for sandboxed code execution
+across platforms. It introduces **intent policy** — a single declarative
+language used by four different policy authors — and describes how their
+independent policy statements compose into a concrete, enforceable runtime
+configuration.
+
+A companion document, *Container Sandboxing Mechanisms: A Cross-Platform
+Survey*, covers the underlying isolation mechanisms (namespaces, AppContainer,
+Seatbelt, etc.) that enforce the policies described here.
+
+---
+
+## Table of Contents
+
+- [1. Introduction](#1-introduction)
+  - [1.1 The Problem](#11-the-problem)
+  - [1.2 One Language, Four Authors](#12-one-language-four-authors)
+  - [1.3 Document Road Map](#13-document-road-map)
+- [2. Intent Policy: The Universal Format](#2-intent-policy-the-universal-format)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 The Four Sections](#22-the-four-sections)
+  - [2.3 Storage Classes](#23-storage-classes)
+  - [2.4 Network Service References](#24-network-service-references)
+  - [2.5 Process, IPC, and Device Declarations](#25-process-ipc-and-device-declarations)
+  - [2.6 Constraints](#26-constraints)
+  - [2.7 Claims](#27-claims)
+- [3. The Code Author](#3-the-code-author)
+  - [3.1 What the Code Author Declares](#31-what-the-code-author-declares)
+  - [3.2 Worked Examples](#32-worked-examples)
+  - [3.3 Agentic Authoring](#33-agentic-authoring)
+- [4. The User](#4-the-user)
+  - [4.1 What the User Expresses](#41-what-the-user-expresses)
+  - [4.2 Consent Models](#42-consent-models)
+  - [4.3 Granularity and Revocability](#43-granularity-and-revocability)
+  - [4.4 The user_selected Storage Class](#44-the-user_selected-storage-class)
+  - [4.5 Agentic Delegation](#45-agentic-delegation)
+- [5. The IT Administrator](#5-the-it-administrator)
+  - [5.1 What the Administrator Expresses](#51-what-the-administrator-expresses)
+  - [5.2 Deny-Overlays and Allow-Ceilings](#52-deny-overlays-and-allow-ceilings)
+  - [5.3 Service Catalogs](#53-service-catalogs)
+  - [5.4 Distribution and Management](#54-distribution-and-management)
+  - [5.5 Worked Example](#55-worked-example)
+- [6. The System](#6-the-system)
+  - [6.1 What the Operating System Expresses](#61-what-the-operating-system-expresses)
+  - [6.2 Platform Invariants as Intent](#62-platform-invariants-as-intent)
+  - [6.3 Compile-Time and Runtime Enforcement](#63-compile-time-and-runtime-enforcement)
+  - [6.4 Worked Examples](#64-worked-examples)
+- [7. Composition: How Four Policies Become One](#7-composition-how-four-policies-become-one)
+  - [7.1 The Intersection Rule](#71-the-intersection-rule)
+  - [7.2 Formal Semantics](#72-formal-semantics)
+  - [7.3 Conflict and Failure](#73-conflict-and-failure)
+  - [7.4 Audit Trail](#74-audit-trail)
+  - [7.5 Worked Example: End-to-End Composition](#75-worked-example-end-to-end-composition)
+- [8. Binding: From Intent to Execution](#8-binding-from-intent-to-execution)
+  - [8.1 What the Binder Does](#81-what-the-binder-does)
+  - [8.2 Resolution Steps](#82-resolution-steps)
+  - [8.3 Backend Feasibility Validation](#83-backend-feasibility-validation)
+  - [8.4 Worked Example: Intent to Bound Policy](#84-worked-example-intent-to-bound-policy)
+- [9. Bound Policy Format](#9-bound-policy-format)
+  - [9.1 Structure Overview](#91-structure-overview)
+  - [9.2 Filesystem Rules](#92-filesystem-rules)
+  - [9.3 Network Rules](#93-network-rules)
+  - [9.4 Resources, Environment, and Platform](#94-resources-environment-and-platform)
+- [10. Versioning](#10-versioning)
+  - [10.1 Version Axes](#101-version-axes)
+  - [10.2 The Binder as Version Bridge](#102-the-binder-as-version-bridge)
+  - [10.3 Intent Policy Versioning](#103-intent-policy-versioning)
+  - [10.4 Per-Layer Version Checks](#104-per-layer-version-checks)
+  - [10.5 Capability Profile Versioning](#105-capability-profile-versioning)
+  - [10.6 Bound Policy and Runtime Versioning](#106-bound-policy-and-runtime-versioning)
+  - [10.7 Caller Migration Scenarios](#107-caller-migration-scenarios)
+  - [10.8 Relationship to Existing MXC Versioning](#108-relationship-to-existing-mxc-versioning)
+- [Appendix A: Intent Policy Schema Reference](#appendix-a-intent-policy-schema-reference)
+- [Appendix B: Bound Policy Schema Reference](#appendix-b-bound-policy-schema-reference)
+- [Appendix C: Worked Examples — Intent to Bound Transformations](#appendix-c-worked-examples--intent-to-bound-transformations)
+- [Appendix D: Open Questions and Abstraction Gaps](#appendix-d-open-questions-and-abstraction-gaps)
+  - [D.1 Constraints Blur the Line Between Intent and Configuration](#d1-constraints-blur-the-line-between-intent-and-configuration)
+  - [D.2 Network Operations Are Advisory-Only](#d2-network-operations-are-advisory-only)
+  - [D.3 Claims Lack a Verification Story](#d3-claims-lack-a-verification-story)
+  - [D.4 Service Catalog Resolution Is Underspecified](#d4-service-catalog-resolution-is-underspecified)
+  - [D.5 Network Scope Narrowing Semantics Are Underspecified](#d5-network-scope-narrowing-semantics-are-underspecified)
+  - [D.6 Wall-Time Enforcement Is Universally User-Space](#d6-wall-time-enforcement-is-universally-user-space)
+  - [D.7 IPC and Device Models Are Underdeveloped](#d7-ipc-and-device-models-are-underdeveloped)
+  - [D.8 Exec Whitelisting for Interpreted Languages](#d8-exec-whitelisting-for-interpreted-languages)
+  - [D.9 Multi-Sandbox Orchestration](#d9-multi-sandbox-orchestration)
+
+---
+
+## 1. Introduction
+
+### 1.1 The Problem
+
+Modern software increasingly runs code whose provenance, behavior, and
+trustworthiness are uncertain. AI agents generate code on the fly. CLI tools
+download and execute plugins. Language model "claws" (CLI + LLM agent
+workflows) chain tool invocations that no human has reviewed. Even traditional
+applications run third-party dependencies that receive far less scrutiny than
+the application code itself.
+
+Containing this code — running it in a sandbox that limits what it can access
+and what damage it can do — requires *policy*. But policy authored by whom?
+
+Consider a scenario: an AI coding agent generates a Python script to analyze
+a CSV file. The script needs to read the input file, write an output report,
+and use pandas. It does not need network access, it does not need to read
+`~/.ssh`, and it certainly does not need to modify operating system binaries.
+
+At least four parties have something to say about what this script should be
+allowed to do:
+
+1. **The code author** (or the agent that generated the code) knows what
+   resources the code needs to function.
+2. **The user** who initiated the task knows which specific files to analyze
+   and what level of access they are comfortable granting.
+3. **The IT administrator** may have organizational rules — no sandbox gets
+   network access to external hosts, all executions are memory-capped at 2 GB,
+   only signed runtimes are permitted.
+4. **The operating system** enforces invariants that no other party can
+   override — system binaries are read-only, kernel memory is inaccessible,
+   code signing requirements apply.
+
+Today, these four perspectives are typically expressed in completely different
+formats, at different times, through different mechanisms, if they are
+expressed at all. The result is that sandboxing is either too permissive
+(broad defaults that don't reflect actual needs) or too brittle (hand-crafted
+configurations that break when anything changes).
+
+### 1.2 One Language, Four Authors
+
+This document proposes a different approach: **a single declarative policy
+language — intent policy — that all four parties use.** The same schema, the
+same vocabulary of storage classes, network service references, constraints,
+and capability declarations. The four policy statements are then
+*composed* — intersected so that each can only further restrict, never
+broaden — into a single effective policy. That effective policy is then
+*bound* to the target platform, resolving abstract declarations into concrete
+paths, hostnames, and mechanism configurations.
+
+```
+Code Author Intent ──┐
+                      │
+User Intent ──────────┤
+                      ├──→ Compose (intersect) ──→ Effective Intent ──→ Bind ──→ Bound Policy
+IT Admin Intent ──────┤
+                      │
+System Intent ────────┘
+```
+
+This design has several properties:
+
+- **Composable by construction.** Because all four policies use the same
+  language, intersection is a well-defined operation on matching fields.
+  There is no impedance mismatch between "what the admin says" and "what the
+  developer says."
+
+- **Auditable.** Every restriction in the final bound policy is traceable to
+  a specific policy author. When a sandbox denies an operation, the system can
+  report *which* policy layer caused the denial.
+
+- **Portable.** Intent policies contain no platform-specific paths, hostnames,
+  or mechanism details. The same intent policy works on Linux, macOS, and
+  Windows. Platform specifics enter only at the binding step.
+
+- **Agentic-friendly.** AI agents can generate intent policies using abstract
+  vocabulary ("I need read access to `input_data` and write access to
+  `output_data`") without knowing whether they are running on Ubuntu or
+  Windows 11. The binding step handles platform resolution.
+
+### 1.3 Document Road Map
+
+- **Section 2** defines the intent policy format — the universal schema that
+  all four authors use.
+- **Sections 3–6** describe each policy author: what they express, why, and
+  with what trust model.
+- **Section 7** defines composition — how the four policies are intersected
+  into a single effective policy.
+- **Section 8** describes binding — how abstract intent is resolved to a
+  concrete, platform-specific runtime configuration.
+- **Section 9** defines the bound policy format — the JSON schema that the
+  binder produces and the sandbox runtime consumes.
+- **Appendices** provide schema references and worked examples.
+
+The companion survey document covers the platform-specific isolation
+mechanisms (AppContainer, namespaces, Seatbelt, BFS, etc.) that enforce
+bound policies at runtime. This document is concerned with *what gets
+expressed and how it composes*, not with the enforcement machinery.
+
+A future companion document will cover backend capability profiles — formal
+descriptions of what each platform's sandboxing primitives can enforce — and
+"blessed" policy compositions that guarantee specific security properties.
+See §8.3 for the profile model and `examples/capability_profiles/` for
+concrete primitive and composition profiles.
+
+---
+
+## 2. Intent Policy: The Universal Format
+
+Intent policy is a declarative, platform-agnostic JSON format for expressing
+what a sandboxed workload needs, what constraints apply, and what behavioral
+properties the author asserts. It is the common language shared by all four
+policy sources.
+
+### 2.1 Design Principles
+
+1. **No platform-specific paths, ports, or mechanism details.** An intent
+   policy never names `/usr/bin/python3` or `C:\Python310\python.exe`. It
+   says `"language": "python"`. The binder resolves the rest.
+
+2. **Logical data domains, not OS layout.** Storage is described by semantic
+   class — `workspace`, `input_data`, `temp` — not by filesystem path. This
+   makes intent portable across platforms and across different deployment
+   environments on the same platform.
+
+3. **Named service references, not hostnames.** Network access is expressed
+   as `"service": "weather-api"`, not `"host": "api.weatherapi.com"`. The
+   mapping from logical service name to concrete endpoint is maintained in a
+   service catalog owned by the IT administrator or operating system.
+
+4. **Machine-resolvable.** Every field in an intent policy can be mechanically
+   resolved by the binder without human judgment. If a field requires
+   human interpretation, the schema is wrong.
+
+5. **Composable via intersection.** The schema is designed so that combining
+   two intent policies always produces a valid, more-restrictive intent
+   policy. There are no fields where composition is ambiguous.
+
+### 2.2 The Four Sections
+
+An intent policy document has four top-level sections:
+
+| Section | Purpose | Trust Model |
+|---|---|---|
+| `requires` | What the workload needs to function | Validated by the binder — unresolvable requirements fail the bind |
+| `constraints` | Hard runtime limits the author commits to | Enforced by the sandbox — violation terminates the workload |
+| `claims` | Behavioral properties the author asserts | Informational — future work (see §2.7) |
+| `metadata` | Identity, versioning, description | Informational |
+
+```jsonc
+{
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "example-workload",
+    "version": "1.0.0",
+    "description": "A short description of what this workload does"
+  },
+
+  "requires": {
+    "runtime":     { /* language, version, packages */ },
+    "storage":     [ /* storage class declarations */ ],
+    "network":     [ /* service references and capabilities */ ],
+    "process":     { /* spawn, exec, signals */ },
+    "tools":       [ /* named tool references */ ],
+    "credentials": [ /* named credential references */ ],
+    "ipc":         "none",
+    "devices":     "none"
+  },
+
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 120,
+    /* ... */
+  },
+
+  "claims": {
+    "deterministic": true,
+    /* ... */
+  }
+}
+```
+
+When used by different policy authors, not all sections are equally relevant.
+A code author's intent policy will have rich `requires` declarations. A system
+policy will primarily express constraints and restricted-capability
+declarations. But the schema is the same — and that uniformity is what makes
+composition work.
+
+### 2.3 Storage Classes
+
+Storage classes are the heart of filesystem policy. Rather than naming
+platform-specific paths, intent policies declare *logical data domains* with
+access modes:
+
+| Class | Typical Access | Semantics |
+|---|---|---|
+| `workspace` | read-write | Working directory for the workload |
+| `input_data` | read | Caller-supplied input files |
+| `output_data` | write | Where the workload writes its results |
+| `temp` | read-write | Scratch space, discarded after execution |
+| `cache` | read-write | Persists across invocations, evictable |
+| `config` | read | Application configuration, read-only |
+| `secrets` | read | Credentials and keys, injected at runtime, never on disk |
+| `app_code` | read | The workload's own code bundle |
+| `user_selected` | varies | Files/folders chosen by the user at runtime (see §4.4) |
+
+**What is NOT in this list:** `system_libraries`, `runtime_libraries`, or
+platform-specific directories. The binder derives those from the `runtime`
+declaration — if the workload needs Python 3.10, the binder knows where
+Python's standard library lives on the target platform and grants read access
+to it automatically.
+
+A storage declaration in intent policy:
+
+```jsonc
+"storage": [
+  { "class": "input_data", "access": "read",
+    "description": "CSV files to analyze" },
+  { "class": "output_data", "access": "write",
+    "description": "Analysis report (JSON)" },
+  { "class": "workspace", "access": "read-write",
+    "description": "Working directory for intermediate results" },
+  { "class": "temp", "access": "read-write",
+    "persistence": "ephemeral" }
+]
+```
+
+The `persistence` field indicates whether the storage survives across
+invocations:
+
+| Value | Meaning |
+|---|---|
+| `ephemeral` | Discarded after each execution |
+| `discardable` | May survive across invocations but can be evicted |
+| (omitted) | Persistence determined by the storage class default |
+
+### 2.4 Network Service References
+
+Network access is expressed as named service references, not as hostnames and
+ports:
+
+```jsonc
+"network": [
+  {
+    "service": "weather-api",
+    "protocol": "https",
+    "operations": ["query"],
+    "auth": "injected-token",
+    "description": "Weather data provider"
+  },
+  { "capability": "dns" }
+]
+```
+
+Each service reference names a logical service. The service catalog (§5.3)
+maps logical names to concrete endpoints. The `operations` field is advisory —
+it documents what the code does with the service (query, download, upload) but
+does not currently affect enforcement. The `auth` field describes how
+credentials are delivered:
+
+| Value | Meaning |
+|---|---|
+| `injected-token` | A credential is injected into the sandbox at a well-known path (see `credentials`) |
+| `none` | No authentication required |
+| (omitted) | No authentication or auth is handled within the app |
+
+Generic network capabilities (`dns`, `ntp`, `localhost`) are declared
+separately from named services because they don't map to a specific host:
+
+```jsonc
+{ "capability": "dns" }       // DNS resolution needed
+{ "capability": "localhost" }  // Localhost communication needed
+```
+
+An empty `network` array means no network access at all — the strongest
+network isolation possible.
+
+### 2.5 Process, IPC, and Device Declarations
+
+**Process:**
+
+```jsonc
+"process": {
+  "spawn": true,         // Can the workload create child processes?
+  "max_children": 16,    // Upper bound on child process count
+  "exec": ["cargo", "rustc", "cc", "ld"],  // Named executables (resolved by binder)
+  "signals": "self"      // Signal scope: "self" (own process tree only)
+}
+```
+
+**Tools** are a separate declaration for named executables the workload needs:
+
+```jsonc
+"tools": [
+  { "name": "curl", "access": "execute" },
+  { "name": "jq", "access": "execute" }
+]
+```
+
+The binder resolves tool names to platform-specific executable paths.
+
+**IPC and Devices** use simple capability declarations:
+
+```jsonc
+"ipc": "none",      // No inter-process communication needed
+"devices": "none"   // No device access needed
+```
+
+More granular IPC and device declarations are possible (e.g., specific named
+pipes, specific device capabilities) but the common case for contained code
+is `"none"`.
+
+### 2.6 Constraints
+
+Constraints are hard, enforceable limits that the sandbox runtime must
+respect. Unlike requirements (which declare what the workload *needs*),
+constraints declare ceilings (what the workload *must not exceed*):
+
+```jsonc
+"constraints": {
+  "max_memory_mb": 1024,
+  "max_cpu_cores": 2,
+  "max_wall_time_seconds": 120,
+  "max_processes": 1,
+  "max_open_files": 256,
+  "max_output_bytes": 10485760,
+  "persistent_storage": "forbidden",
+  "privilege_escalation": "forbidden",
+  "inbound_network": "forbidden"
+}
+```
+
+| Field | Type | Meaning |
+|---|---|---|
+| `max_memory_mb` | integer | Memory ceiling in megabytes |
+| `max_cpu_cores` | integer | CPU core count limit |
+| `max_wall_time_seconds` | integer | Wall-clock execution time limit |
+| `max_processes` | integer | Maximum concurrent processes |
+| `max_open_files` | integer | Maximum open file descriptors |
+| `max_output_bytes` | integer | Maximum bytes written to output |
+| `persistent_storage` | `"forbidden"` | Workload may not write to persistent storage |
+| `privilege_escalation` | `"forbidden"` | Workload may not escalate privileges |
+| `inbound_network` | `"forbidden"` | Workload may not accept inbound connections |
+
+Constraints compose naturally via intersection: when two policies both
+declare `max_memory_mb`, the effective constraint is `min(a, b)`. When one
+policy declares `privilege_escalation: "forbidden"` and another is silent, the
+forbidden constraint wins — silence is not permission.
+
+### 2.7 Claims
+
+Claims are self-asserted behavioral properties:
+
+```jsonc
+"claims": {
+  "deterministic": true,
+  "idempotent": true,
+  "no_side_effects_beyond_output": true,
+  "no_credential_exfiltration": true
+}
+```
+
+Claims are **not enforced** by the sandbox runtime. A claim of
+`"deterministic": true` does not cause the sandbox to verify determinism.
+Claims exist to inform trust decisions, audit posture, and future tooling
+that may validate them.
+
+The role of claims in the broader policy architecture is future work. They
+are included in the schema for forward compatibility but are not developed
+further in this document.
+
+---
+
+## 3. The Code Author
+
+The code author — a human developer, an AI agent, or a code generation
+pipeline — is the first policy voice. Their intent policy declares what
+resources the code needs to function correctly.
+
+### 3.1 What the Code Author Declares
+
+The code author's primary contribution is the `requires` section: a
+least-privilege declaration of capabilities. The principle is simple:
+**declare exactly what you need, nothing more.**
+
+The code author also sets initial `constraints` — self-imposed limits that
+reflect the expected resource envelope of the workload. These are not
+aspirational; they are hard limits that the sandbox will enforce. A code
+author who sets `max_memory_mb: 512` is asserting that the code should be
+terminated if it exceeds 512 MB, because that would indicate a bug or
+unexpected behavior.
+
+The code author's intent policy is a **complete, self-contained document.**
+It should be possible to read a code author's intent policy and understand:
+
+- What language and runtime the code needs
+- What data it reads and writes (by storage class)
+- What external services it communicates with (by name)
+- What system tools it invokes
+- What credentials it requires
+- What resource limits apply
+- What behavioral properties the author asserts
+
+### 3.2 Worked Examples
+
+**Example: Offline computation (no network, no credentials)**
+
+A Python data analysis script that reads CSV files, processes them with
+pandas, and writes a JSON report:
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": {
+    "name": "csv-data-analyzer",
+    "version": "1.0.0",
+    "description": "Reads CSV input, performs statistical analysis with pandas,
+                    writes summary report"
+  },
+  "requires": {
+    "runtime": {
+      "language": "python",
+      "min_version": "3.10",
+      "packages": ["pandas", "numpy"]
+    },
+    "storage": [
+      { "class": "input_data", "access": "read",
+        "description": "CSV files to analyze" },
+      { "class": "output_data", "access": "write",
+        "description": "Analysis report (JSON)" },
+      { "class": "workspace", "access": "read-write",
+        "description": "Working directory for intermediate results" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+    "network": [],
+    "process": { "spawn": false },
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 120,
+    "max_processes": 1,
+    "max_output_bytes": 10485760,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+  "claims": {
+    "deterministic": true,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true
+  }
+}
+```
+
+Key observations:
+
+- `"network": []` — the strongest possible network declaration. The code
+  needs no network access at all.
+- `"process": { "spawn": false }` — no child processes. The sandbox can
+  block `fork()` entirely.
+- `"credentials": []` — no secrets needed. The sandbox need not inject any
+  credential material.
+- The constraints reinforce the intent: `max_processes: 1` is consistent
+  with `spawn: false`, and `inbound_network: "forbidden"` is consistent with
+  an empty network array.
+
+**Example: Network services with credentials**
+
+A Node.js API aggregator that queries two external services:
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": {
+    "name": "multi-api-aggregator",
+    "version": "2.1.0",
+    "description": "Queries weather and geocoding APIs, aggregates results"
+  },
+  "requires": {
+    "runtime": {
+      "language": "node",
+      "min_version": "20.0",
+      "packages": ["axios", "zod"]
+    },
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "config", "access": "read",
+        "description": "Query parameters and API config" }
+    ],
+    "network": [
+      { "service": "weather-api", "protocol": "https",
+        "operations": ["query"], "auth": "injected-token" },
+      { "service": "geocoding-api", "protocol": "https",
+        "operations": ["query"], "auth": "injected-token" },
+      { "capability": "dns" }
+    ],
+    "process": { "spawn": false },
+    "ipc": "none",
+    "devices": "none",
+    "credentials": [
+      { "name": "WEATHER_API_KEY", "type": "api-key" },
+      { "name": "GEOCODING_API_KEY", "type": "api-key" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 60,
+    "max_processes": 1,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}
+```
+
+Key observations:
+
+- Network access is declared by *service name*, not by hostname. The code
+  author does not know (or need to know) that `weather-api` resolves to
+  `api.weatherapi.com`.
+- Credentials are declared by name and type. The code author knows the
+  credential exists but does not embed its value. The credential is injected
+  into the sandbox at a well-known path determined by the binder.
+- `auth: "injected-token"` connects the network service to the credential:
+  the sandbox must make `WEATHER_API_KEY` available for the code to use when
+  calling the weather service.
+
+**Example: Tool execution with process spawning**
+
+An infrastructure health check that invokes system tools:
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": {
+    "name": "infra-health-check",
+    "version": "2.0.0",
+    "description": "Shell-based health checker: HTTP endpoints, TLS certs, DB"
+  },
+  "requires": {
+    "runtime": { "language": "bash", "min_version": "5.0" },
+    "tools": [
+      { "name": "curl", "access": "execute" },
+      { "name": "openssl", "access": "execute" },
+      { "name": "psql", "access": "execute" },
+      { "name": "jq", "access": "execute" }
+    ],
+    "storage": [
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "config", "access": "read" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+    "network": [
+      { "service": "internal-api-gateway", "protocol": "https",
+        "operations": ["health-check"] },
+      { "service": "internal-auth-service", "protocol": "https",
+        "operations": ["health-check"] },
+      { "service": "primary-database", "protocol": "tcp",
+        "operations": ["query"], "auth": "injected-token" },
+      { "capability": "dns" }
+    ],
+    "process": {
+      "spawn": true,
+      "max_children": 8,
+      "exec": ["curl", "openssl", "psql", "jq", "bash"],
+      "signals": "self"
+    },
+    "ipc": "none",
+    "devices": "none",
+    "credentials": [
+      { "name": "DB_CONNECTION_STRING", "type": "connection-string" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 120,
+    "max_processes": 16,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}
+```
+
+This example shows richer process control: `spawn: true` with a named
+`exec` list. The sandbox allows child processes but only for the listed
+executables — an arbitrary binary cannot be spawned. The binder resolves
+tool names like `"curl"` to platform-specific paths (`/usr/bin/curl` on
+Linux, `C:\Windows\System32\curl.exe` on Windows).
+
+### 3.3 Agentic Authoring
+
+In agentic workflows — where an AI agent generates both code and the intent
+policy that accompanies it — the abstract nature of intent policy is
+especially important.
+
+**Why agents cannot write platform-specific policy:**
+
+An AI agent generating a Python script does not know:
+- Whether the target machine runs Linux, macOS, or Windows
+- Where Python is installed (`/usr/bin/python3.10`?
+  `/opt/homebrew/bin/python3`? `C:\Python312\python.exe`?)
+- What the filesystem layout looks like
+- What network endpoints correspond to logical services
+- What isolation mechanisms are available
+
+Asking agents to produce platform-specific bound policies would require them
+to have system administration knowledge that is both error-prone and
+unnecessary. Intent policy solves this by letting agents express requirements
+in portable, abstract terms:
+
+```jsonc
+// Agent says: "I need Python with pandas, some files to read, a place to
+// write output, and no network access."
+{
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.10",
+                 "packages": ["pandas"] },
+    "storage": [
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" }
+    ],
+    "network": []
+  }
+}
+```
+
+The binder handles everything else.
+
+**Agent-generated policy is not automatically trusted.** An agent's intent
+policy is treated the same as any other code author's intent — it passes
+through user consent (§4), admin policy (§5), and system constraints (§6)
+before anything executes. An agent that requests `"service": "public-web"`
+with wildcard access will have that request narrowed or denied by admin
+policy if the organization restricts external network access.
+
+**Auditability is critical for agentic scenarios.** When an agent generates
+an intent policy, the policy document itself serves as an audit record of what
+the agent requested. Because the language is abstract and human-readable
+("the agent requested read access to `input_data` and write access to
+`output_data`"), audit review is feasible even when the agent generates
+thousands of workloads. This is dramatically harder if the audit trail
+consists of platform-specific bound policies with concrete paths and IP
+addresses.
+
+---
+
+## 4. The User
+
+The user — the human who initiates or approves the execution of sandboxed
+code — is the second policy voice. Their intent policy narrows the code
+author's requirements to reflect what the user actually consents to for this
+specific invocation.
+
+### 4.1 What the User Expresses
+
+The user's policy answers the question: **"Of the things this code says it
+needs, which am I willing to grant right now?"**
+
+Consider an AI agent that declares it needs `"service": "public-web"` for
+research. The user might:
+
+- **Grant fully:** "Yes, access the web."
+- **Grant partially:** "Yes, but only `*.wikipedia.org`."
+- **Deny:** "No, run this offline."
+
+The user's policy is expressed in the same intent format:
+
+```jsonc
+// User's intent: "I consent to network access, but only to Wikipedia"
+{
+  "requires": {
+    "network": [
+      { "service": "public-web", "protocol": "https",
+        "scope": "*.wikipedia.org" }
+    ]
+  }
+}
+```
+
+When composed with the code author's broader request for `"public-web"`, the
+intersection narrows to Wikipedia only.
+
+### 4.2 Consent Models
+
+User consent can be obtained through several models, depending on the
+deployment context:
+
+**Pre-approved (policy file):** The user provides an intent policy file
+before execution. This is suitable for automation pipelines where a human
+reviews and approves the policy once, and subsequent invocations reuse it.
+
+```jsonc
+// user-policy.jsonc — reviewed and saved by the user
+{
+  "requires": {
+    "storage": [
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" }
+    ],
+    "network": []
+  },
+  "constraints": {
+    "max_memory_mb": 512,
+    "max_wall_time_seconds": 60
+  }
+}
+```
+
+**Interactive (runtime prompts):** The sandbox runtime presents the code
+author's requirements to the user and asks for approval. This is the model
+used by macOS TCC (Transparency, Consent, and Control) dialogs, Android
+runtime permissions, and Windows BFS consent prompting. The user sees
+something like:
+
+```
+"csv-data-analyzer" requests:
+  ✓ Read access to input files
+  ✓ Write access to output directory
+  ✗ No network access requested
+  ✗ No credential access requested
+
+  Memory limit: 1024 MB
+  Time limit: 120 seconds
+
+  [Allow] [Allow Once] [Deny]
+```
+
+The user's response is captured as an intent policy and composed with the
+code author's intent.
+
+**Delegated (trust the code author):** In some contexts, the user trusts the
+code author entirely and does not want to be prompted. The user's policy is
+effectively "allow whatever the code author requests":
+
+```jsonc
+// User delegates fully — no narrowing
+{
+  "requires": {},
+  "constraints": {}
+}
+```
+
+An empty intent policy imposes no additional restrictions. The effective
+policy is determined by the code author, IT admin, and system layers.
+
+### 4.3 Granularity and Revocability
+
+User consent operates at several granularity levels:
+
+| Granularity | Example | Persistence |
+|---|---|---|
+| **Per-invocation** | "Allow this one execution" | Not stored |
+| **Per-session** | "Allow for the duration of this agent session" | Session-scoped |
+| **Per-workload** | "Always allow csv-data-analyzer with these settings" | Stored in user preferences |
+| **Per-author** | "Trust all workloads from this code author" | Stored in user preferences |
+
+Crucially, user consent is **revocable**. Unlike sandbox restrictions (which
+are applied once at container creation and cannot be lifted), user consent
+can be withdrawn at any time:
+
+- A per-session consent expires when the session ends
+- A per-workload consent can be revoked in user preferences
+- A per-author trust delegation can be rescinded
+
+Revocation does not affect currently-running workloads (the sandbox is
+already configured), but it prevents future invocations from inheriting the
+previously granted consent.
+
+### 4.4 The user_selected Storage Class
+
+The `user_selected` storage class represents files or directories chosen by
+the user at runtime — the "Open File" or "Save As" dialog pattern:
+
+```jsonc
+// Code author's intent: "I may need access to a user-chosen file"
+"storage": [
+  { "class": "user_selected", "access": "read",
+    "description": "File chosen by the user to analyze" }
+]
+```
+
+This class is unique because its binding depends entirely on user action:
+
+1. The code author declares that user-selected files may be needed
+2. At runtime, the sandbox presents a file picker (or folder picker)
+3. The user selects specific files or directories
+4. The binder creates filesystem rules for exactly those paths
+5. Only the user-selected paths are accessible — nothing else
+
+This pattern is already well-established:
+- **macOS:** Powerbox file dialogs grant per-file access to sandboxed apps
+- **Windows:** BFS consent prompting brokers access to specific files
+- **Linux:** XDG Desktop Portals provide file chooser dialogs that return
+  file descriptors to sandboxed apps
+
+The `user_selected` class bridges the gap between the code author's abstract
+need ("I will process a file the user chooses") and the user's concrete
+consent ("I choose this specific file").
+
+### 4.5 Agentic Delegation
+
+When an AI agent invokes sandboxed code, the question of "who is the user?"
+becomes nuanced:
+
+**Direct invocation:** A human runs an agent that generates and executes
+code. The human is the user. Consent may be interactive ("the agent wants to
+analyze your spreadsheet — allow?") or pre-approved ("I trust this agent
+to access my Documents folder").
+
+**Chained invocation:** An agent invokes another agent, which generates code.
+The original human may be several levels removed. In this case, the consent
+model must support delegation:
+
+```
+Human ──trusts──→ Agent A ──invokes──→ Agent B ──generates──→ Code
+         ↑                                                        ↓
+         └──────── consent applies to entire chain ──────────────┘
+```
+
+The key principle is that **the human's consent is the ceiling.** Agent A
+cannot grant Agent B more access than the human granted Agent A. Each
+delegation step can only narrow, never broaden — the same intersection
+semantics that govern the four policy layers.
+
+Detailed delegation chain semantics (maximum delegation depth, consent
+inheritance across agent boundaries, revocation propagation) are an active
+area of design and are not fully specified in this document.
+
+---
+
+## 5. The IT Administrator
+
+The IT administrator — or more broadly, the organizational policy authority —
+is the third policy voice. Their intent policy expresses what the
+organization permits, regardless of what individual code authors or users
+request.
+
+### 5.1 What the Administrator Expresses
+
+The administrator's policy answers the question: **"What are our
+organization's rules for sandboxed code execution?"**
+
+Administrator policy typically expresses restrictions:
+- Network boundaries ("no external network access outside `*.corp.example.com`")
+- Resource ceilings ("no sandbox gets more than 2 GB memory")
+- Execution constraints ("only signed runtimes are permitted")
+- Data handling rules ("no persistent storage for agent-generated code")
+
+### 5.2 Deny-Overlays and Allow-Ceilings
+
+Administrator intent policy uses the same format as code author intent, but
+serves a different purpose. Where a code author's `requires` section says
+"I need these capabilities," an administrator's `requires` section says
+"these are the capabilities our organization permits." Where a code author's
+`constraints` section says "I should not exceed these limits," an
+administrator's `constraints` section says "nobody may exceed these limits."
+
+**Example: Organization restricts network and memory**
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": {
+    "name": "corp-sandbox-policy",
+    "version": "1.0.0",
+    "description": "Corporate policy for all sandboxed workloads"
+  },
+  "requires": {
+    "network": [
+      { "service": "*", "protocol": "https",
+        "scope": "*.corp.example.com",
+        "description": "Only internal corporate endpoints allowed" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 2048,
+    "max_wall_time_seconds": 600,
+    "max_processes": 32,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}
+```
+
+When this admin policy is composed with a code author's intent that requests
+`"service": "public-web"` (arbitrary internet access), the intersection
+denies it — the admin policy allows only `*.corp.example.com`, and
+`public-web` falls outside that scope. The bind step fails with an auditable
+explanation: "code author requires `public-web`, denied by admin policy
+`corp-sandbox-policy` which restricts network to `*.corp.example.com`."
+
+### 5.3 Service Catalogs
+
+The IT administrator (or the operating system, for system-level services)
+maintains the **service catalog** — the mapping from logical service names
+to concrete network endpoints:
+
+```jsonc
+{
+  "catalog_version": "1.0",
+  "services": {
+    "weather-api": {
+      "hosts": ["api.weatherapi.com"],
+      "port": 443,
+      "protocol": "https",
+      "auth_method": "bearer-token",
+      "credential_ref": "WEATHER_API_KEY"
+    },
+    "geocoding-api": {
+      "hosts": ["api.opencagedata.com"],
+      "port": 443,
+      "protocol": "https",
+      "auth_method": "bearer-token",
+      "credential_ref": "GEOCODING_API_KEY"
+    },
+    "internal-api-gateway": {
+      "hosts": ["gateway.corp.example.com"],
+      "port": 443,
+      "protocol": "https"
+    },
+    "primary-database": {
+      "hosts": ["db-primary.corp.example.com"],
+      "port": 5432,
+      "protocol": "tcp",
+      "auth_method": "connection-string",
+      "credential_ref": "DB_CONNECTION_STRING"
+    },
+    "llm-api": {
+      "hosts": ["api.anthropic.com"],
+      "port": 443,
+      "protocol": "https",
+      "auth_method": "bearer-token",
+      "credential_ref": "LLM_API_KEY"
+    }
+  }
+}
+```
+
+The service catalog is the single point of truth for "what does service name X
+mean in our environment?" This separation provides several benefits:
+
+- **Code authors don't embed infrastructure knowledge.** The intent policy
+  says `"service": "llm-api"`, and the catalog resolves it. If the
+  organization switches LLM providers, only the catalog changes — not every
+  intent policy that references the service.
+
+- **Administrators control what services exist.** If a service name is not in
+  the catalog, it cannot be resolved, and the bind step fails. This gives
+  administrators an implicit allowlist over available services.
+
+- **Credential binding is centralized.** The catalog's `credential_ref`
+  field connects service names to credential names, which the binder uses to
+  inject the right secrets into the sandbox.
+
+### 5.4 Distribution and Management
+
+Administrator intent policies and service catalogs are distributed through
+standard enterprise management channels:
+
+| Platform | Distribution Mechanism |
+|---|---|
+| Windows | Group Policy Objects (GPO), Microsoft Intune (MDM) |
+| macOS | MDM profiles (Jamf, Workspace ONE) |
+| Linux | Configuration management (Ansible, Puppet, Chef), package managers |
+| Cross-platform | Environment variables, well-known config paths, API endpoints |
+
+The specific distribution mechanism is outside the scope of this document,
+but the format is not — administrator policy is expressed in the same intent
+policy JSON format, distributed to endpoints, and consumed by the binder at
+bind time.
+
+### 5.5 Worked Example
+
+**Scenario:** An organization allows internal services but blocks external
+internet access. An AI agent generates code that requests `llm-api` access.
+
+**Admin policy:**
+```jsonc
+{
+  "requires": {
+    "network": [
+      { "service": "*", "scope": "*.corp.example.com" }
+    ]
+  }
+}
+```
+
+**Code author intent (agent-generated):**
+```jsonc
+{
+  "requires": {
+    "network": [
+      { "service": "llm-api", "protocol": "https",
+        "auth": "injected-token" }
+    ]
+  }
+}
+```
+
+**Service catalog entry:**
+```jsonc
+"llm-api": {
+  "hosts": ["api.anthropic.com"],
+  "port": 443
+}
+```
+
+**Composition result:** The admin policy restricts network to
+`*.corp.example.com`. The `llm-api` service resolves to
+`api.anthropic.com`, which is outside the allowed scope.
+
+**Outcome:** Bind fails. The error message is: *"Network service 'llm-api'
+resolves to 'api.anthropic.com', which is not permitted by admin policy
+'corp-sandbox-policy' (network scope: '*.corp.example.com')."*
+
+If the organization later deploys an internal LLM gateway at
+`llm.corp.example.com`, only the catalog changes:
+
+```jsonc
+"llm-api": {
+  "hosts": ["llm.corp.example.com"],
+  "port": 443
+}
+```
+
+Now the bind succeeds. No intent policies change — neither the agent's nor
+the admin's.
+
+---
+
+## 6. The System
+
+The operating system — the platform itself — is the fourth and final policy
+voice. System intent policy expresses invariants that hold regardless of what
+any code author, user, or administrator requests. It is the security floor
+that cannot be lowered.
+
+### 6.1 What the Operating System Expresses
+
+The system's policy answers the question: **"What does this platform
+guarantee, unconditionally?"**
+
+Every operating system enforces certain security properties that are not
+negotiable:
+
+- Operating system code cannot be modified by applications
+- Kernel memory is not accessible to user-mode processes
+- Code pages cannot be simultaneously writable and executable (W^X)
+- Certain system services and daemons are protected from termination
+- Code signing requirements apply to specific contexts
+
+These are not "policies" in the sense that someone chose them for a
+particular deployment. They are structural properties of the platform —
+invariants that the OS kernel enforces regardless of any policy layer above.
+
+### 6.2 Platform Invariants as Intent
+
+The key insight is that system invariants can be expressed in the same intent
+policy format:
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": {
+    "name": "windows-system-policy",
+    "version": "10.0",
+    "description": "Windows platform security invariants"
+  },
+  "requires": {
+    "storage": [
+      { "class": "system_binaries", "access": "read",
+        "description": "OS binaries are read-only; modification is forbidden" },
+      { "class": "system_config", "access": "read",
+        "description": "System configuration (registry hives, etc.) is read-only" }
+    ]
+  },
+  "constraints": {
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "disable_aslr": "forbidden",
+    "writable_executable_pages": "forbidden"
+  }
+}
+```
+
+By expressing these invariants in intent policy format:
+
+- **Composition works mechanically.** The system policy intersects with
+  the other three layers using the same rules. A code author who requests
+  write access to a storage class that the system has declared read-only
+  will have that request denied at composition time.
+
+- **Failure messages are clear.** "Write access to `system_binaries` denied
+  by system policy `windows-system-policy`" is an actionable error message.
+
+- **The binder knows what to enforce.** When system policy declares
+  `system_binaries` as read-only, the binder maps this to platform-specific
+  paths (`C:\Windows\System32` on Windows, `/usr/lib` on Linux, `/usr/bin`
+  on macOS) and generates the appropriate filesystem rules in the bound
+  policy.
+
+### 6.3 Compile-Time and Runtime Enforcement
+
+System policy operates at two enforcement points:
+
+**Compile-time (static validation):** When the binder produces a bound
+policy, it checks the result against system policy. Any bound policy that
+would grant access forbidden by system policy is rejected before any code
+runs. This catches misconfigurations early.
+
+**Runtime (dynamic enforcement):** Even if a bound policy somehow permits
+something that system policy forbids (e.g., due to a binder bug), the
+operating system's own enforcement mechanisms provide a backstop:
+
+| Platform | Runtime Enforcement |
+|---|---|
+| **Windows** | Integrity levels prevent write-up; PPL protects system processes; KMCS enforces kernel code signing; AppContainer SIDs exclude system paths |
+| **macOS** | SIP (System Integrity Protection) protects system volumes; code signing requirements enforced by the kernel; TCC controls access to protected resources |
+| **Linux** | SELinux/AppArmor mandatory access control; mount namespaces hide system paths; seccomp-BPF filters dangerous syscalls; kernel `STRICT_DEVMEM` protects `/dev/mem` |
+
+System policy in intent format is a *declaration* of these existing
+enforcement mechanisms. It does not create new enforcement — it makes
+existing platform guarantees visible and composable with the other policy
+layers.
+
+### 6.4 Worked Examples
+
+**"Operating system code cannot be modified"**
+
+Intent (system policy):
+```jsonc
+{
+  "requires": {
+    "storage": [
+      { "class": "system_binaries", "access": "read" }
+    ]
+  },
+  "constraints": {
+    "modify_system_binaries": "forbidden"
+  }
+}
+```
+
+Bound on Windows:
+```jsonc
+"filesystem": {
+  "rules": [
+    { "path": "C:\\Windows\\System32", "scope": "subtree",
+      "allow": ["read", "execute"] },
+    { "path": "C:\\Windows\\SysWOW64", "scope": "subtree",
+      "allow": ["read", "execute"] },
+    { "path": "C:\\Program Files\\WindowsApps", "scope": "subtree",
+      "allow": ["read"] }
+  ]
+}
+```
+
+Bound on Linux:
+```jsonc
+"filesystem": {
+  "rules": [
+    { "path": "/usr/bin", "scope": "subtree",
+      "allow": ["read", "execute"] },
+    { "path": "/usr/lib", "scope": "subtree",
+      "allow": ["read", "execute"] },
+    { "path": "/usr/sbin", "scope": "subtree",
+      "allow": ["read", "execute"] }
+  ]
+}
+```
+
+The intent is the same — "system binaries are read-only" — but the bound
+paths are platform-specific.
+
+**"No access to user credentials"**
+
+Intent (system policy):
+```jsonc
+{
+  "requires": {
+    "storage": []  // no storage classes that include credential stores
+  },
+  "constraints": {
+    "access_credential_stores": "forbidden"
+  }
+}
+```
+
+Bound on Windows:
+```jsonc
+"filesystem": {
+  "mask": [
+    "%USERPROFILE%\\.ssh",
+    "%USERPROFILE%\\.aws",
+    "%USERPROFILE%\\.azure",
+    "%APPDATA%\\Microsoft\\Credentials"
+  ]
+}
+```
+
+Bound on Linux:
+```jsonc
+"filesystem": {
+  "mask": [
+    "/home/*/.ssh",
+    "/home/*/.aws",
+    "/home/*/.gnupg",
+    "/home/*/.config/gcloud"
+  ]
+}
+```
+
+---
+
+## 7. Composition: How Four Policies Become One
+
+The four intent policies — code author, user, IT admin, system — are
+composed into a single **effective intent policy** before binding. Composition
+is the central operation of the policy architecture.
+
+### 7.1 The Intersection Rule
+
+The fundamental composition rule is: **each policy layer can only further
+restrict, never broaden.** The effective policy is the intersection of all
+four input policies.
+
+This means:
+- If the code author requests network access and the admin forbids it, the
+  effective policy has no network access.
+- If the code author requests 4 GB memory and the admin caps at 2 GB, the
+  effective limit is 2 GB.
+- If the user denies access to a storage class the code author requested,
+  that storage class is removed from the effective policy.
+- If the system declares certain paths read-only, no other layer can grant
+  write access to those paths.
+
+The beauty of intersection is that it is **unambiguous**. There is no
+priority ordering to debate, no conflict resolution heuristic. The most
+restrictive statement always wins because every layer can only remove
+capabilities, not add them.
+
+### 7.2 Formal Semantics
+
+For each field type in the intent policy schema, composition follows specific
+rules:
+
+**Capability sets (storage, network, tools, credentials):** Intersection.
+A capability must be present in *all* policies that mention it, or it is
+excluded from the effective policy. A policy that is silent on a capability
+set (e.g., admin policy does not mention `storage`) imposes no restriction on
+that set — silence is not denial.
+
+```
+effective.storage = author.storage ∩ user.storage ∩ admin.storage ∩ system.storage
+```
+
+Where `∩` means: retain only storage classes that appear in all policies
+that declare a `storage` section.
+
+**Numeric constraints:** Minimum. The effective value is `min(a, b, c, d)`
+across all policies that declare the constraint.
+
+```
+effective.max_memory_mb = min(
+  author.max_memory_mb,
+  user.max_memory_mb,     // if declared
+  admin.max_memory_mb,    // if declared
+  system.max_memory_mb    // if declared
+)
+```
+
+**Forbidden constraints:** Union. If *any* policy declares something
+forbidden, it is forbidden in the effective policy.
+
+```
+effective.privilege_escalation = "forbidden"
+  if any(author, user, admin, system).privilege_escalation == "forbidden"
+```
+
+**Access modes:** Intersection. If the code author requests `read-write` for
+a storage class and the system declares `read` only, the effective access is
+`read`.
+
+```
+effective.access = author.access ∩ system.access
+// "read-write" ∩ "read" = "read"
+```
+
+**Network service scopes:** Intersection. If the code author requests
+`"public-web"` (any host) and the admin restricts to `"*.corp.example.com"`,
+the effective scope is `"*.corp.example.com"` (or empty, if `public-web`
+hosts fall outside that scope).
+
+### 7.3 Conflict and Failure
+
+When composition produces an effective policy that cannot satisfy the code
+author's requirements, the bind step **fails explicitly** rather than
+silently degrading. This is a critical design choice.
+
+**Why fail-closed?**
+
+A code author who declares `"network": [{ "service": "llm-api" }]` is
+saying: "my code needs LLM API access to function." If admin policy denies
+network access to the LLM endpoint, there is no useful degraded behavior —
+the code will fail at runtime anyway, but in a confusing way (timeout,
+connection refused, cryptic error). Failing at bind time with a clear message
+is better:
+
+```
+Bind failed: code author requires network service 'llm-api',
+  but admin policy 'corp-sandbox-policy' restricts network scope
+  to '*.corp.example.com' and 'llm-api' resolves to
+  'api.anthropic.com' (outside permitted scope).
+```
+
+**Distinguishing required from optional capabilities** is a potential future
+extension. A code author might mark some requirements as "preferred but not
+essential" — the bind could then succeed with a warning when an optional
+capability is denied. This is not currently part of the schema.
+
+### 7.4 Audit Trail
+
+Because all four policies use the same format, and composition is a
+deterministic operation, every restriction in the effective policy is
+**attributable to a specific policy layer:**
+
+| Restriction | Source |
+|---|---|
+| Read-only access to system binaries | System policy |
+| No external network | Admin policy |
+| Memory capped at 512 MB | Code author (self-imposed) |
+| No access to Documents folder | User (denied consent) |
+| Credential injection path | Service catalog (admin) |
+
+The binder can produce an **attribution report** alongside the bound policy,
+documenting the provenance of every rule. This is essential for:
+
+- **Debugging:** "Why can't the workload access the network?" →
+  "Admin policy restricts network to `*.corp.example.com`."
+- **Compliance:** "Who authorized this workload's access to the database?" →
+  "Code author requested `primary-database`; admin catalog resolved it to
+  `db-primary.corp.example.com:5432`; user consented at 2024-01-15T10:30Z."
+- **Agentic audit:** "What did the agent request, and what was it actually
+  granted?" → The intent policy (request) and effective policy (grant) are
+  both human-readable JSON documents.
+
+### 7.5 Worked Example: End-to-End Composition
+
+**Scenario:** An AI agent generates a research tool that needs LLM access
+and web browsing. The user approves with restrictions. The organization has
+a network policy. The OS enforces its invariants.
+
+**Code author intent (agent-generated):**
+```jsonc
+{
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.11",
+                 "packages": ["httpx", "beautifulsoup4"] },
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "cache", "access": "read-write",
+        "persistence": "discardable" }
+    ],
+    "network": [
+      { "service": "llm-api", "protocol": "https",
+        "auth": "injected-token" },
+      { "service": "public-web", "protocol": "https" },
+      { "capability": "dns" }
+    ],
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_wall_time_seconds": 600,
+    "privilege_escalation": "forbidden"
+  }
+}
+```
+
+**User intent (interactive consent):**
+```jsonc
+{
+  "requires": {
+    "network": [
+      { "service": "llm-api" },
+      { "service": "public-web", "scope": "*.wikipedia.org" },
+      { "capability": "dns" }
+    ]
+  },
+  "constraints": {
+    "max_wall_time_seconds": 300
+  }
+}
+```
+
+The user approves LLM access but restricts web browsing to Wikipedia, and
+lowers the time limit.
+
+**Admin intent (organizational policy):**
+```jsonc
+{
+  "requires": {
+    "network": [
+      { "service": "*", "scope": "*.corp.example.com" },
+      { "service": "llm-api" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 2048,
+    "persistent_storage": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}
+```
+
+The admin allows internal endpoints and the LLM API (explicitly
+whitelisted), but blocks other external access.
+
+**System intent (OS invariants):**
+```jsonc
+{
+  "constraints": {
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden"
+  }
+}
+```
+
+**Composition:**
+
+| Capability | Author | User | Admin | System | Effective |
+|---|---|---|---|---|---|
+| `llm-api` | ✓ | ✓ | ✓ (whitelisted) | — | ✓ |
+| `public-web` | ✓ (any) | ✓ (`*.wikipedia.org`) | ✗ (not in scope) | — | **✗ denied** |
+| `dns` | ✓ | ✓ | — | — | ✓ |
+| `max_memory_mb` | 1024 | — | 2048 | — | **1024** (min) |
+| `max_wall_time_seconds` | 600 | 300 | — | — | **300** (min) |
+| `persistent_storage` | — | — | forbidden | — | **forbidden** |
+| `privilege_escalation` | forbidden | — | — | forbidden | **forbidden** |
+
+**Effective intent policy after composition:**
+```jsonc
+{
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.11",
+                 "packages": ["httpx", "beautifulsoup4"] },
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "cache", "access": "read-write",
+        "persistence": "discardable" }
+    ],
+    "network": [
+      { "service": "llm-api", "protocol": "https",
+        "auth": "injected-token" },
+      { "capability": "dns" }
+    ],
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_wall_time_seconds": 300,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}
+```
+
+Note: `public-web` was removed entirely — the admin policy did not permit
+it, even though the user narrowed it to Wikipedia. The intersection of
+"only Wikipedia" and "only *.corp.example.com" is empty.
+
+This effective intent is then passed to the binder for resolution to a
+platform-specific bound policy.
+
+---
+
+## 8. Binding: From Intent to Execution
+
+Binding is the step that transforms an effective intent policy (abstract,
+portable) into a bound policy (concrete, platform-specific). The binder is
+the single component that has platform knowledge — where Python is installed,
+what filesystem paths correspond to storage classes, what hostnames
+correspond to service names.
+
+### 8.1 What the Binder Does
+
+The binder takes three inputs:
+
+1. **Effective intent policy** — the composed result from §7
+2. **Service catalog** — the IT admin / OS mapping of service names to
+   endpoints (§5.3)
+3. **Platform context** — OS type, architecture, installed runtimes, available
+   isolation mechanisms
+
+And produces one output:
+
+- **Bound policy** — a concrete JSON document with platform-specific paths,
+  hostnames, ports, and mechanism configurations
+
+```
+Effective Intent + Service Catalog + Platform Context ──→ Binder ──→ Bound Policy
+```
+
+The bound policy is the document that the sandbox runtime consumes. It
+contains no abstract references — every path is a real filesystem path, every
+host is a resolvable DNS name, every mechanism is a concrete platform
+feature.
+
+### 8.2 Resolution Steps
+
+The binder performs the following resolutions in order:
+
+**1. Runtime resolution.** The intent's `runtime` declaration is resolved to
+concrete executable and library paths:
+
+```
+Intent: { "language": "python", "min_version": "3.10", "packages": ["pandas"] }
+
+Linux: /usr/bin/python3.10, /usr/lib/python3.10/**, /usr/local/lib/python3.10/dist-packages/**
+Windows: C:\Python310\python.exe, C:\Python310\Lib\**, C:\Python310\Lib\site-packages\**
+```
+
+**2. Storage class resolution.** Each storage class maps to a
+platform-specific directory:
+
+| Class | Linux Path | Windows Path |
+|---|---|---|
+| `workspace` | `/workspace` | `C:\Sandbox\Workspace` |
+| `input_data` | `/input` | `C:\Sandbox\Input` |
+| `output_data` | `/output` | `C:\Sandbox\Output` |
+| `temp` | `/tmp` | `C:\Sandbox\Temp` |
+| `cache` | `/cache` | `C:\Sandbox\Cache` |
+| `config` | `/config` | `C:\Sandbox\Config` |
+| `secrets` | `/run/secrets` | `C:\Sandbox\Secrets` |
+| `app_code` | `/app` | `C:\Sandbox\App` |
+
+**3. Service name resolution.** Each network service reference is resolved
+via the service catalog:
+
+```
+Intent: { "service": "weather-api", "protocol": "https" }
+Catalog: { "hosts": ["api.weatherapi.com"], "port": 443 }
+Bound: { "host": "api.weatherapi.com", "port": 443, "protocol": "tcp", "direction": "outbound" }
+```
+
+**4. Tool resolution.** Named tools are resolved to platform-specific
+executable paths:
+
+```
+Intent: { "name": "curl", "access": "execute" }
+Linux: /usr/bin/curl
+Windows: C:\Windows\System32\curl.exe
+```
+
+**5. Credential resolution.** Named credentials are mapped to injection
+paths and environment variables:
+
+```
+Intent: { "name": "WEATHER_API_KEY", "type": "api-key" }
+Linux: /run/secrets/WEATHER_API_KEY (file), WEATHER_API_KEY_FILE env var
+Windows: C:\Sandbox\Secrets\WEATHER_API_KEY (file), WEATHER_API_KEY_FILE env var
+```
+
+**6. Platform mechanism selection.** Based on the OS and available isolation
+primitives, the binder populates the `platform` section of the bound policy:
+
+- **Linux:** Namespace configuration, seccomp-BPF rules, Landlock rules
+- **Windows:** AppContainer capabilities, BFS configuration, Job Object limits
+- **macOS:** Seatbelt profile generation
+
+### 8.3 Backend Feasibility Validation
+
+Before producing the bound policy, the binder validates that the target
+platform can actually enforce the effective intent policy. Each platform's
+sandboxing primitives have specific capabilities and limitations — for
+example, a platform without Landlock support cannot enforce per-directory
+filesystem rules at the kernel level, and macOS lacks cgroups so process
+count limits cannot be expressed as a cap (only as all-or-nothing fork
+denial).
+
+The binder checks policy requirements against a three-layer capability
+model:
+
+#### 8.3.1 Primitive Profiles
+
+Each isolation mechanism has its own **primitive profile** — a formal
+description of what it can enforce, at what granularity, and at what
+enforcement level. Capabilities are organized by policy dimension
+(filesystem, network, process, resources, IPC, credentials, privilege).
+
+For each capability the profile declares:
+
+- **supported** — whether the primitive can enforce this at all
+- **granularity** — the finest unit of control (`per-file`, `per-host-port`,
+  `all-or-nothing`, etc.)
+- **enforcement** — the enforcement level (`kernel`, `user-space`,
+  `advisory`)
+- **mechanism** — how enforcement works (e.g., "LSM hooks on path-based
+  operations" or "Job object memory limits")
+- **limitations** — caveats that affect real-world enforcement
+
+Separate profiles exist for each distinct primitive and version. For
+example, `landlock_v4` is a separate profile from a hypothetical
+`landlock_v2` because v4 adds network filtering that v2 lacks.
+
+See `examples/capability_profiles/primitives/` for concrete profiles
+covering AppContainer, BFS, WFP, Landlock v4, seccomp-bpf, cgroups v2,
+Linux namespaces, and macOS Seatbelt.
+
+#### 8.3.2 Blessed Compositions
+
+Real sandbox environments combine multiple primitives into a **stack**.
+A blessed composition is a named, validated combination of primitives
+whose combined capabilities and **security guarantees** have been
+verified. Each composition declares:
+
+- **primitives** — the set of primitives in the stack, each with its role
+- **effective_capabilities** — the union of individual primitive
+  capabilities, resolved for overlaps (noting which primitive provides
+  each capability via `"via"` attribution)
+- **guarantees** — security properties the composition provides when
+  correctly configured (e.g., `no-filesystem-escape`,
+  `no-network-escape`, `no-privilege-escalation`), each with enforcement
+  level and caveats
+- **known_gaps** — capabilities the composition *cannot* enforce, with
+  workarounds where available
+
+The binder can match intent policy claims against composition guarantees.
+For example, if the effective intent includes
+`"no_credential_exfiltration": true`, the binder verifies the target
+composition has a `no-credential-access` guarantee.
+
+See `examples/capability_profiles/compositions/` for the three platform
+stacks:
+
+| Composition | Primitives | Guarantees |
+|---|---|---|
+| `windows_appcontainer_stack` | AppContainer + BFS + WFP | 5 (filesystem, network, privilege, credentials, process containment) |
+| `linux_namespace_stack` | Namespaces + Landlock v4 + seccomp + cgroups v2 | 7 (adds resource-bounded, exec-restricted) |
+| `macos_seatbelt_stack` | Seatbelt + POSIX rlimits + host timer | 6 (adds exec-restricted, IPC-isolated; weaker resource story) |
+
+#### 8.3.3 Validation and Enforcement Reporting
+
+The binder walks each requirement in the effective intent policy and
+checks it against the target composition's effective capabilities:
+
+1. **Requirement satisfied at kernel level** — the bound policy rule is
+   emitted and tagged with its enforcement level.
+2. **Requirement satisfied at user-space level** — the bound policy rule
+   is emitted with an `"enforcement": "user-space"` annotation.
+3. **Requirement cannot be satisfied** — a gap is identified.
+
+For gaps, the **caller decides** the disposition — not the binder. The
+binder reports gaps with full attribution (which requirement, which
+primitive was checked, what the gap is). The caller or system-level
+policy then determines whether the gap is:
+
+- **Fatal** — bind fails with an error (e.g., "network host filtering
+  required but target platform only supports all-or-nothing")
+- **Warning** — bind succeeds but the bound policy includes an advisory
+  annotation (e.g., "wall_time enforcement is user-space only")
+- **Acceptable** — the gap is known and accepted by policy (e.g., an
+  admin intent might declare `"accept_user_space_wall_time": true`)
+
+This separation ensures the binder is a pure function (intent +
+composition → bound policy + gap report) while enforcement policy
+decisions remain with the appropriate authority.
+
+### 8.4 Worked Example: Intent to Bound Policy
+
+Starting from the effective intent produced in §7.5, here is the bound
+policy the binder produces for Linux:
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "research-agent-tool",
+
+  "filesystem": {
+    "rules": [
+      // Runtime (resolved from "language": "python")
+      { "path": "/usr/bin/python3.11",       "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "/usr/lib/python3.11",       "scope": "subtree",
+        "allow": ["read"] },
+      { "path": "/usr/local/lib/python3.11/dist-packages",
+        "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/x86_64-linux-gnu", "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",            "scope": "subtree",
+        "allow": ["read"] },
+
+      // Storage classes (resolved from abstract classes)
+      { "path": "/workspace",  "scope": "subtree",
+        "allow": ["read", "write", "create"], "ephemeral": true },
+      { "path": "/output",     "scope": "subtree",
+        "allow": ["write", "create"], "ephemeral": true },
+      { "path": "/tmp",        "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"],
+        "ephemeral": true },
+      { "path": "/cache",      "scope": "subtree",
+        "allow": ["read", "write", "create"] },
+
+      // Credentials (resolved from named credentials)
+      { "path": "/run/secrets/LLM_API_KEY", "scope": "exact",
+        "allow": ["read"], "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      // Service resolution (llm-api from catalog)
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_wall_time_seconds": 300,
+    "max_processes": 8,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "LLM_API_KEY_FILE": "/run/secrets/LLM_API_KEY"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}
+```
+
+Every abstract reference has been resolved: `"language": "python"` became
+specific paths to the Python interpreter and libraries;
+`"service": "llm-api"` became `api.anthropic.com:443`;
+`"class": "workspace"` became `/workspace`; `"name": "LLM_API_KEY"` became
+`/run/secrets/LLM_API_KEY`. Note that `public-web` is absent — it was
+removed during composition (§7.5).
+
+---
+
+## 9. Bound Policy Format
+
+The bound policy is the concrete, platform-specific JSON document that the
+sandbox runtime consumes. It is produced by the binder (§8) and is never
+hand-authored. This section documents its structure.
+
+### 9.1 Structure Overview
+
+```jsonc
+{
+  "version": "1.0",         // Schema version
+  "name": "workload-name",  // From intent metadata
+  "description": "...",     // Traceability to intent
+
+  "filesystem": { /* §9.2 */ },
+  "network":    { /* §9.3 */ },
+  "resources":  { /* §9.4 */ },
+  "environment": { /* §9.4 */ },
+  "platform":   { /* §9.4 */ }
+}
+```
+
+### 9.2 Filesystem Rules
+
+The filesystem section is typically the largest part of the bound policy. It
+contains three subsections:
+
+**Rules** — explicit allow-list entries:
+
+```jsonc
+"filesystem": {
+  "rules": [
+    {
+      "path": "/usr/bin/python3.11",
+      "scope": "exact",        // exact | subtree
+      "allow": ["read", "execute"],
+      "ephemeral": false       // true if content is discarded after execution
+    },
+    {
+      "path": "/workspace",
+      "scope": "subtree",
+      "allow": ["read", "write", "create"],
+      "ephemeral": true
+    }
+  ]
+}
+```
+
+| Field | Values | Meaning |
+|---|---|---|
+| `scope` | `exact` | Rule applies to this path only |
+| | `subtree` | Rule applies to this path and all descendants |
+| `allow` | `read`, `write`, `create`, `delete`, `execute` | Permitted operations |
+| `ephemeral` | `true` / `false` | Whether content is discarded after execution |
+
+**Masks** — explicit deny-list paths (deny trumps allow):
+
+```jsonc
+"mask": [
+  "%USERPROFILE%\\.ssh",
+  "%USERPROFILE%\\.aws"
+]
+```
+
+Masked paths are inaccessible even if a broader `subtree` rule would
+otherwise grant access.
+
+**Synthetic mounts** (Linux-specific) — special filesystem entries:
+
+```jsonc
+"synthetic": {
+  "/dev": "minimal",     // Only /dev/null, /dev/zero, /dev/urandom
+  "/proc": "sandboxed",  // Filtered /proc with limited process visibility
+  "/tmp": "ephemeral"    // tmpfs, discarded after execution
+}
+```
+
+### 9.3 Network Rules
+
+```jsonc
+"network": {
+  "mode": "none",         // none | rules | full
+  "rules": [              // Only when mode is "rules"
+    {
+      "direction": "outbound",
+      "action": "connect",
+      "protocol": "tcp",
+      "host": "api.weatherapi.com",
+      "port": 443
+    }
+  ],
+  "allow_dns": true,      // Whether DNS resolution is permitted
+  "allow_localhost": false // Whether localhost communication is permitted
+}
+```
+
+| Mode | Meaning |
+|---|---|
+| `none` | No network access at all — strongest isolation |
+| `rules` | Only connections matching explicit rules are permitted |
+| `full` | Unrestricted network access (rare; typically restricted by admin policy) |
+
+### 9.4 Resources, Environment, and Platform
+
+**Resources** — hard enforcement limits (mapped directly from constraints):
+
+```jsonc
+"resources": {
+  "max_memory_mb": 1024,
+  "max_cpu_percent": 200,     // 200 = 2 cores
+  "max_processes": 8,
+  "max_wall_time_seconds": 300,
+  "max_open_files": 256
+}
+```
+
+**Environment** — environment variables for the sandboxed process:
+
+```jsonc
+"environment": {
+  "mode": "clean",    // clean: no inherited env vars; inherit: pass through parent
+  "set": {
+    "PATH": "/usr/bin:/usr/local/bin",
+    "HOME": "/workspace",
+    "LLM_API_KEY_FILE": "/run/secrets/LLM_API_KEY"
+  }
+}
+```
+
+**Platform** — mechanism-specific configuration:
+
+Linux:
+```jsonc
+"platform": {
+  "linux": {
+    "namespaces": {
+      "user": true, "mount": true, "pid": true,
+      "net": true, "ipc": true, "uts": true, "cgroup": true
+    }
+  }
+}
+```
+
+Windows:
+```jsonc
+"platform": {
+  "windows": {
+    "appcontainer": {
+      "capabilities": ["internetClient"]
+    },
+    "bfs": {
+      "enabled": true,
+      "policy_broker": true
+    }
+  }
+}
+```
+
+The platform section is the only part of the bound policy that is
+platform-specific by design. It bridges the gap between the
+platform-agnostic policy dimensions (filesystem, network, resources) and the
+platform-specific enforcement mechanisms described in the companion survey
+document.
+
+---
+
+## 10. Versioning
+
+The intent policy architecture introduces multiple versioned artifacts that
+evolve independently. This section defines the versioning strategy, how
+versions interact across layers, and how the binder bridges between them.
+
+### 10.1 Version Axes
+
+Five artifacts carry independent version numbers:
+
+| Artifact | Version Field | Changes When | Owner |
+|---|---|---|---|
+| Intent policy schema | `manifest_version` | New intent concepts added (storage classes, constraint types, service reference formats) | Policy design team |
+| Capability profiles | `profile_version` | OS adds capabilities, new backends, new primitives | Platform team |
+| Bound policy / config | `version` | Runtime gains new enforcement features | Runtime team |
+| SDK API | npm semver | `SandboxPolicy` / `IntentPolicy` types change | SDK team |
+| Runtime binary | `SUPPORTED_VERSION` | Binary gains new config handling | Runtime team |
+
+These version axes are **independent**: a new intent concept does not
+necessarily require a new runtime, and a new runtime feature does not
+necessarily require a new intent schema. The binder bridges between them.
+
+### 10.2 The Binder as Version Bridge
+
+The binder (currently in the SDK layer, potentially a standalone
+component in future) sits between intent policy and bound policy. It must
+understand versions in both directions:
+
+- **Input side:** "I can read `manifest_version` 1.0 through 1.3"
+- **Output side:** "I can produce `config version` 0.4 through 0.6"
+- **Cross-version mapping:** "Intent 1.2 feature `requires.gpu` maps to
+  a device section that only exists in config 0.6. If the runtime
+  supports 0.5, this is a gap."
+
+The binder carries an internal **compatibility matrix** that maps intent
+features to the minimum config version required to express them:
+
+```
+intent 1.0                          → config 0.4+
+intent 1.1 (adds storage "secrets") → config 0.4+ (maps to filesystem rules)
+intent 1.2 (adds requires.gpu)      → config 0.6+ (needs device section)
+```
+
+When a new intent feature maps entirely to existing bound policy
+constructs (e.g., a new storage class is just new filesystem rules), the
+config version does not change. When a new intent feature needs runtime
+support that does not exist yet, the binder reports a gap — using the
+same mechanism as capability profile gaps in §8.3.3.
+
+The binder targets the **highest config version the runtime supports**
+that can express the effective intent. This ensures callers get the best
+available enforcement without pinning to a specific config version.
+
+### 10.3 Intent Policy Versioning
+
+Intent policies use semantic versioning (`MAJOR.MINOR.PATCH`) in the
+`manifest_version` field. The rules are:
+
+**Major version (breaking changes):**
+- Restructuring of existing fields (e.g., `requires.network` changes
+  shape)
+- Removal of previously defined fields
+- Semantic changes that alter the meaning of existing fields
+
+**Minor version (additive changes):**
+- New fields in `requires`, `constraints`, or `claims`
+- New storage classes, new network service reference types
+- New constraint types or forbidden flags
+
+**Patch version:**
+- Clarifications, documentation corrections, schema metadata updates
+- No behavioral change
+
+**Version compatibility rules:**
+
+| Binder knows | Policy declares | Result |
+|---|---|---|
+| 1.x | 1.0 | ✓ Accept — backward compatible |
+| 1.1 | 1.1 | ✓ Accept — exact match |
+| 1.1 | 1.3 | ⚠ Accept with gaps — unrecognized 1.3 fields reported as unenforced |
+| 1.x | 2.0 | ✗ Reject — "upgrade MXC to support manifest_version 2.x" |
+
+The critical rule: **if the major version is greater than the binder
+knows about, the binder must fail.** A v2.0 intent policy may have
+restructured security-critical fields. A v1.x binder that ignores those
+fields could silently drop security constraints.
+
+For minor version gaps, the binder **must report** unrecognized fields as
+unenforced gaps. The caller decides whether those gaps are acceptable,
+using the same disposition mechanism as §8.3.3. This is strictly better
+than silent ignoring — the caller always knows what the binder could not
+process.
+
+### 10.4 Per-Layer Version Checks
+
+The four policy layers (code author, user, IT admin, system) are
+deployed independently and may be at different `manifest_version` levels:
+
+| Layer | Deployed By | Version Risk |
+|---|---|---|
+| Code author intent | Shipped with the application/agent | Low — typically aligned with the SDK |
+| User intent | Generated by the SDK's consent UI | Low — aligned with the SDK |
+| Admin intent | Deployed via MDM / group policy | **Medium** — may be authored with a newer policy schema |
+| System intent | Deployed via OS update | **Medium** — may use features from a newer policy schema |
+
+The binder must check `manifest_version` **on each policy layer
+independently** during the composition step:
+
+1. Read developer intent → check `manifest_version` against binder's
+   supported range
+2. Read user intent → same check
+3. Read admin intent → same check (**may be newer**)
+4. Read system intent → same check (**may be newer**)
+
+If any layer has a major version ahead of the binder, composition fails
+with a clear error attributing the failure to the specific layer: "Admin
+policy `corp-sandbox-policy` uses `manifest_version: 2.0`, but this
+binder only supports 1.x. Upgrade MXC."
+
+If a layer has a minor version ahead, the binder proceeds but reports
+which fields from that layer it could not process. This report is
+included in the composition audit trail (§7.4) so that administrators
+can see when their policies are not being fully enforced on specific
+machines.
+
+**Practical implication for IT administrators:** When deploying an admin
+intent policy that uses `manifest_version` 1.3 features, the
+administrator should know that machines running a binder that only
+understands 1.1 will report gaps for the 1.3-specific fields. MDM
+deployments are typically version-targeted, so this can be managed by
+deploying the MXC update before or alongside the policy update.
+
+### 10.5 Capability Profile Versioning
+
+Capability profiles use `profile_version` in their top-level metadata.
+Profiles are typically deployed alongside the MXC installation but may
+also be updated by OS updates (e.g., a Windows update ships a new
+`appcontainer` profile reflecting new OS capabilities).
+
+The binder must handle profile version mismatches:
+
+| Binder knows | Profile declares | Result |
+|---|---|---|
+| 1.x | 1.0 | ✓ Accept — backward compatible |
+| 1.0 | 1.2 | ⚠ Accept — unknown capabilities ignored (conservative: binder assumes it cannot enforce what it doesn't recognize) |
+| 1.x | 2.0 | ✗ Reject — "upgrade MXC to support profile_version 2.x" |
+
+The key difference from intent versioning: for profiles, ignoring
+unknown capabilities is **safe** because it is conservative. The binder
+simply doesn't know the platform can enforce something, which means it
+may report a false gap — but it will never claim enforcement it cannot
+verify. For intents, ignoring unknown fields is **unsafe** because the
+field may express a security constraint the binder is silently dropping.
+
+### 10.6 Bound Policy and Runtime Versioning
+
+Bound policies carry the existing `version` field (currently
+`0.4.0-alpha`). This version represents the configuration schema that
+the runtime binary (wxc-exec, lxc-exec) consumes. The versioning rules
+follow the existing MXC convention documented in `docs/versioning.md`:
+
+- Runtime checks `version` major.minor against its `SUPPORTED_VERSION`
+- Reject if config major.minor > binary major.minor
+- Accept if equal or older (backward compatible)
+- Patch and prerelease labels are ignored for comparison
+
+The binder produces bound policies at the highest config version the
+target runtime supports. Since bound policies are never hand-authored
+(§8), the version is always set by the binder based on what it knows
+about the target runtime.
+
+The bound policy version determines what enforcement features are
+available. The binder's compatibility matrix (§10.2) maps intent features
+to minimum config versions. If the intent requires features beyond what
+the runtime's config version can express, the binder reports a gap.
+
+### 10.7 Caller Migration Scenarios
+
+This section illustrates how version changes propagate through the
+system.
+
+#### Scenario 1: New Intent Field, No Runtime Change
+
+A new storage class `"model_weights"` is added in `manifest_version`
+1.1. The binder maps it to a filesystem path — no new config feature
+needed. The config version stays at 0.4.
+
+- **Developer:** Updates intent to use `"class": "model_weights"`
+- **Binder:** Recognizes 1.1, resolves `model_weights` to a platform
+  path, produces config 0.4
+- **Runtime:** Unchanged — sees the same filesystem rules it always has
+- **Machines with old binder (1.0):** Report unrecognized field
+  `model_weights` as a gap. Bind may fail if the developer's `requires`
+  section cannot be satisfied without it.
+
+#### Scenario 2: New Runtime Capability, No Intent Change
+
+The runtime adds a new seccomp notification mode (config 0.5). The binder
+can now produce better enforcement for existing intent policies.
+
+- **Developer:** No change — same `manifest_version` 1.0 intent
+- **Binder:** Updated to produce config 0.5 when targeting the new
+  runtime. Existing intents automatically get improved enforcement.
+- **Runtime:** Accepts config 0.5, applies new enforcement mode
+- **Machines with old runtime (0.4):** Binder detects runtime supports
+  0.4, produces config 0.4 instead — graceful fallback
+
+#### Scenario 3: New Intent Feature Requires New Runtime
+
+Intent 1.2 adds `requires.gpu`. The binder maps this to a device section
+that only exists in config 0.6.
+
+- **Developer:** Updates intent to `manifest_version` 1.2 with
+  `requires.gpu`
+- **Binder:** Knows `requires.gpu` needs config 0.6
+- **Runtime at 0.6:** Binder produces config 0.6 with device section ✓
+- **Runtime at 0.5:** Binder reports gap: "requires.gpu needs config
+  0.6, but runtime supports 0.5. Upgrade the runtime."
+
+#### Scenario 4: Admin Policy Uses Newer Schema
+
+An IT administrator deploys an admin intent at `manifest_version` 1.3 to
+machines running a binder that understands 1.1.
+
+- **Composition:** Binder reads admin intent, notes `manifest_version`
+  1.3 > 1.1, identifies fields it doesn't recognize
+- **Gap report:** "Admin policy `corp-2025-q2` declares
+  `constraints.max_gpu_memory_mb: 4096` (manifest_version 1.3 field).
+  This binder (1.1) cannot enforce this constraint."
+- **Caller decides:** If the unrecognized constraint is defense-in-depth
+  (the runtime doesn't even expose GPU), the caller may accept the gap.
+  If the constraint is security-critical, the caller rejects and
+  requires an MXC upgrade.
+
+#### Scenario 5: Breaking Schema Change
+
+Intent schema v2.0 restructures `requires.network` (breaking change).
+The binder is updated to support both v1.x and v2.x on the input side.
+
+- **Old intents (1.x):** Continue to work — binder routes to v1 parser
+- **New intents (2.x):** Use the new structure — binder routes to v2
+  parser
+- **Old binder (1.x only):** Rejects v2.0 intents with "upgrade MXC"
+- **Migration window:** Both formats coexist until v1.x is deprecated.
+  The binder logs a deprecation warning when processing v1.x intents.
+
+### 10.8 Relationship to Existing MXC Versioning
+
+The existing MXC versioning system (documented in `docs/versioning.md`)
+covers the config schema version (`0.4.0-alpha`), the experimental
+feature lifecycle, and the SDK's `SandboxPolicy.version` field. The
+intent policy architecture extends this system rather than replacing it:
+
+| Existing Concept | Intent Policy Equivalent |
+|---|---|
+| `SandboxPolicy.version` | Will carry `manifest_version` as intent becomes the SDK input format |
+| `ContainerConfig.version` | Bound policy `version` — unchanged |
+| `SUPPORTED_VERSION` (Rust) | Unchanged — validates bound policy version |
+| `SUPPORTED_VERSION` (SDK) | Extends to also validate `manifest_version` |
+| Experimental feature gate (`--experimental`) | Could gate experimental intent features (e.g., new `requires` types) |
+| Dev schema (`schemas/dev/`) | May gain an intent schema variant with experimental intent fields |
+
+The `SandboxPolicy` type is the natural evolution point. Today it
+accepts concrete paths and boolean flags. As it evolves toward the intent
+format, it gains `requires`, `constraints`, and `claims` sections. The
+`version` field transitions from config schema version to
+`manifest_version`. During the transition period, the SDK can accept
+both formats: a legacy `SandboxPolicy` (routed through the existing
+`buildSandboxPayload()` path) and a new `IntentPolicy` (routed through
+the compose → bind pipeline).
+
+The experimental feature lifecycle applies at the intent layer as well.
+New intent features (e.g., `requires.gpu`) can be introduced under an
+`experimental` section of the intent schema, gated behind
+`--experimental`, and promoted to the stable schema when mature —
+following the same pattern described in `docs/versioning.md` for config
+features.
+
+---
+
+## Appendix A: Intent Policy Schema Reference
+
+This appendix provides the complete field reference for intent policy
+documents. All four policy authors (code author, user, IT admin, system) use
+this schema.
+
+### Top-Level Structure
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `manifest_version` | string | Yes | Schema version (currently `"1.0"`) |
+| `metadata` | object | Yes | Identity and description |
+| `requires` | object | Yes | Capability declarations |
+| `constraints` | object | No | Hard enforceable limits |
+| `claims` | object | No | Self-asserted behavioral properties |
+
+### metadata
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Workload or policy name |
+| `version` | string | Yes | Semantic version |
+| `description` | string | No | Human-readable description |
+| `author` | string | No | Author identity (email, agent ID) |
+
+### requires.runtime
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `language` | string | Yes | Runtime language (`python`, `node`, `rust`, `dotnet`, `bash`, etc.) |
+| `min_version` | string | No | Minimum version required |
+| `packages` | string[] | No | Required packages/libraries |
+
+### requires.storage[]
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `class` | string | Yes | Storage class name (see §2.3) |
+| `access` | string | Yes | `read`, `write`, `read-write` |
+| `description` | string | No | Human-readable purpose |
+| `persistence` | string | No | `ephemeral`, `discardable` |
+
+### requires.network[]
+
+Service reference form:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `service` | string | Yes | Logical service name |
+| `protocol` | string | No | `https`, `tcp`, etc. |
+| `operations` | string[] | No | Advisory: `query`, `download`, `upload` |
+| `auth` | string | No | `injected-token`, `none` |
+| `scope` | string | No | Host pattern restriction (e.g., `*.example.com`) |
+| `description` | string | No | Human-readable purpose |
+
+Capability form:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `capability` | string | Yes | `dns`, `localhost`, `ntp` |
+
+### requires.tools[]
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Tool name (resolved by binder) |
+| `access` | string | Yes | `execute` |
+
+### requires.credentials[]
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | Yes | Credential name (used as env var prefix) |
+| `type` | string | Yes | `api-key`, `connection-string`, `bearer-token`, etc. |
+| `description` | string | No | Human-readable purpose |
+
+### requires.process
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `spawn` | boolean | Yes | Whether child processes are allowed |
+| `max_children` | integer | No | Maximum child process count |
+| `exec` | string[] | No | Allowed executable names (resolved by binder) |
+| `signals` | string | No | `self` (own process tree only) |
+
+### requires.ipc / requires.devices
+
+String values: `"none"` (most common), or an object with granular
+declarations (future extension).
+
+### constraints
+
+| Field | Type | Description |
+|---|---|---|
+| `max_memory_mb` | integer | Memory ceiling |
+| `max_cpu_cores` | integer | CPU core limit |
+| `max_wall_time_seconds` | integer | Execution time limit |
+| `max_processes` | integer | Concurrent process limit |
+| `max_open_files` | integer | Open file descriptor limit |
+| `max_output_bytes` | integer | Output size limit |
+| `persistent_storage` | `"forbidden"` | No persistent writes |
+| `privilege_escalation` | `"forbidden"` | No privilege elevation |
+| `inbound_network` | `"forbidden"` | No inbound connections |
+
+### claims
+
+| Field | Type | Description |
+|---|---|---|
+| `deterministic` | boolean | Same input always produces same output |
+| `idempotent` | boolean | Repeated execution is safe |
+| `no_side_effects_beyond_output` | boolean | Only `output_data` is modified |
+| `no_credential_exfiltration` | boolean | Credentials are not leaked |
+
+---
+
+## Appendix B: Bound Policy Schema Reference
+
+This appendix provides the complete field reference for bound policy
+documents produced by the binder.
+
+### Top-Level Structure
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `version` | string | Yes | Schema version |
+| `name` | string | Yes | From intent metadata |
+| `description` | string | No | Traceability to intent |
+| `filesystem` | object | Yes | Filesystem access rules |
+| `network` | object | Yes | Network access rules |
+| `resources` | object | Yes | Resource limits |
+| `environment` | object | Yes | Environment variable configuration |
+| `platform` | object | Yes | Platform-specific mechanism config |
+
+### filesystem
+
+| Field | Type | Description |
+|---|---|---|
+| `rules[]` | array | Explicit allow-list rules |
+| `rules[].path` | string | Concrete filesystem path |
+| `rules[].scope` | string | `exact` or `subtree` |
+| `rules[].allow` | string[] | `read`, `write`, `create`, `delete`, `execute` |
+| `rules[].ephemeral` | boolean | Content discarded after execution |
+| `mask[]` | string[] | Paths that are always denied |
+| `synthetic` | object | Special filesystem entries (Linux: `/dev`, `/proc`, `/tmp`) |
+
+### network
+
+| Field | Type | Description |
+|---|---|---|
+| `mode` | string | `none`, `rules`, or `full` |
+| `rules[]` | array | Per-connection rules (when mode is `rules`) |
+| `rules[].direction` | string | `outbound` (inbound is typically forbidden) |
+| `rules[].action` | string | `connect` |
+| `rules[].protocol` | string | `tcp`, `udp` |
+| `rules[].host` | string | Concrete hostname or IP |
+| `rules[].port` | integer | Port number |
+| `allow_dns` | boolean | DNS resolution permitted |
+| `allow_localhost` | boolean | Localhost communication permitted |
+
+### resources
+
+| Field | Type | Description |
+|---|---|---|
+| `max_memory_mb` | integer | Memory ceiling |
+| `max_cpu_percent` | integer | CPU limit (100 = 1 core) |
+| `max_processes` | integer | Process count limit |
+| `max_wall_time_seconds` | integer | Execution time limit |
+| `max_open_files` | integer | File descriptor limit |
+
+### environment
+
+| Field | Type | Description |
+|---|---|---|
+| `mode` | string | `clean` (no inheritance) or `inherit` |
+| `set` | object | Key-value pairs of environment variables |
+
+### platform.linux
+
+| Field | Type | Description |
+|---|---|---|
+| `namespaces.user` | boolean | User namespace isolation |
+| `namespaces.mount` | boolean | Mount namespace isolation |
+| `namespaces.pid` | boolean | PID namespace isolation |
+| `namespaces.net` | boolean | Network namespace isolation |
+| `namespaces.ipc` | boolean | IPC namespace isolation |
+| `namespaces.uts` | boolean | UTS namespace isolation |
+| `namespaces.cgroup` | boolean | Cgroup namespace isolation |
+
+### platform.windows
+
+| Field | Type | Description |
+|---|---|---|
+| `appcontainer.capabilities` | string[] | AppContainer capability names |
+| `bfs.enabled` | boolean | BFS filesystem brokering |
+| `bfs.policy_broker` | boolean | Policy-based access brokering |
+
+---
+
+## Appendix C: Worked Examples — Intent to Bound Transformations
+
+This appendix shows complete intent-to-bound transformations for
+representative workload patterns. Each example shows the code author's
+intent manifest and the resulting bound policies for Linux and Windows.
+
+The full set of examples is available in the repository:
+
+- Intent manifests: `examples/intent_manifests/`
+- Bound policies (Linux): `examples/bound_policies/linux/`
+- Bound policies (Windows): `examples/bound_policies/windows/`
+
+### C.1 Offline Computation: Python Data Analysis
+
+**Pattern:** No network, no credentials, no process spawning. Maximum
+isolation.
+
+**Intent:** `examples/intent_manifests/01_python_data_analysis.jsonc`
+
+Key characteristics:
+- `"network": []` — no network access
+- `"credentials": []` — no secrets
+- `"process": { "spawn": false }` — single process
+- Claims: deterministic, idempotent, no side effects
+
+**Binding transformations:**
+
+| Intent | Linux Bound | Windows Bound |
+|---|---|---|
+| `runtime: python 3.10` | `/usr/bin/python3.10`, `/usr/lib/python3.10/**` | `C:\Python310\python.exe`, `C:\Python310\Lib\**` |
+| `storage: input_data` | `/input` (read, subtree) | `C:\Sandbox\Input` (read, subtree) |
+| `storage: output_data` | `/output` (write+create, subtree, ephemeral) | `C:\Sandbox\Output` (write+create, subtree, ephemeral) |
+| `storage: workspace` | `/workspace` (read-write, subtree, ephemeral) | `C:\Sandbox\Workspace` (read-write, subtree, ephemeral) |
+| `storage: temp` | `/tmp` (full access, ephemeral) | `C:\Sandbox\Temp` (full access, ephemeral) |
+| `network: []` | `"mode": "none"` | `"mode": "none"` |
+| platform config | All namespaces enabled | AppContainer (no capabilities), BFS enabled |
+
+### C.2 Network Services: Node.js API Aggregator
+
+**Pattern:** Named service references with injected credentials. Moderate
+network access.
+
+**Intent:** `examples/intent_manifests/02_node_api_aggregator.jsonc`
+
+Key characteristics:
+- Two named services (`weather-api`, `geocoding-api`) with injected tokens
+- DNS capability required
+- Two API key credentials
+- Claims: not deterministic (network calls), idempotent, no credential
+  exfiltration
+
+**Binding transformations:**
+
+| Intent | Linux Bound | Windows Bound |
+|---|---|---|
+| `service: weather-api` | `api.weatherapi.com:443` (outbound TCP) | `api.weatherapi.com:443` (outbound TCP) |
+| `service: geocoding-api` | `api.opencagedata.com:443` (outbound TCP) | `api.opencagedata.com:443` (outbound TCP) |
+| `capability: dns` | `allow_dns: true` | `allow_dns: true` |
+| `credential: WEATHER_API_KEY` | `/run/secrets/WEATHER_API_KEY` + env var | `C:\Sandbox\Secrets\WEATHER_API_KEY` + env var |
+| `credential: GEOCODING_API_KEY` | `/run/secrets/GEOCODING_API_KEY` + env var | `C:\Sandbox\Secrets\GEOCODING_API_KEY` + env var |
+| platform config | All namespaces | AppContainer (`internetClient`), BFS |
+
+Note how the service catalog resolves abstract names to concrete endpoints,
+and credential injection follows a consistent pattern: file at a well-known
+path, environment variable `{NAME}_FILE` pointing to that path.
+
+### C.3 Tool Execution: Rust Snippet Runner
+
+**Pattern:** Process spawning with a named exec-list, network access for
+dependency downloads, persistent cache.
+
+**Intent:** `examples/intent_manifests/03_rust_snippet_runner.jsonc`
+
+Key characteristics:
+- `spawn: true` with `max_children: 16` and named executables
+  (`cargo`, `rustc`, `cc`, `ld`)
+- Network services for crate downloads
+- `cache` storage class with `persistence: "discardable"` — survives across
+  invocations
+- High resource limits (4 GB memory, 4 cores, 32 processes) for compilation
+
+### C.4 Agentic Workload: LLM Research Tool
+
+**Pattern:** AI agent tool with LLM access, web browsing, and credential
+injection. Represents the agentic use case that motivates much of this
+design.
+
+**Intent:** `examples/intent_manifests/04_llm_research_tool.jsonc`
+
+Key characteristics:
+- `service: "llm-api"` with injected token — the LLM provider
+- `service: "public-web"` — arbitrary HTTPS access for research
+- `service: "public-web"` is the capability most likely to be narrowed or
+  denied by user consent (§4) or admin policy (§5)
+- Claim: `no_credential_exfiltration` — the agent asserts it won't leak the
+  LLM API key through the web browsing channel
+
+### C.5 Offline Processing: .NET Image Processor
+
+**Pattern:** Similar to C.1 but with process spawning for parallel
+processing and a separate `app_code` storage class.
+
+**Intent:** `examples/intent_manifests/05_dotnet_image_processor.jsonc`
+
+### C.6 Infrastructure: Bash Health Check
+
+**Pattern:** System administration tool using standard Unix utilities.
+Multiple internal services with one database credential.
+
+**Intent:** `examples/intent_manifests/06_bash_infra_health_check.jsonc`
+
+Key characteristics:
+- Named tools (`curl`, `openssl`, `psql`, `jq`) resolved to platform paths
+- Internal service names (`internal-api-gateway`, `internal-auth-service`,
+  `primary-database`) — these are resolved via the organization's service
+  catalog, not public DNS
+- Database credential with `type: "connection-string"` — more complex than
+  a simple API key
+- This workload is most likely to appear in an IT admin context where the
+  service catalog is well-populated and the admin policy is permissive for
+  internal services
+
+---
+
+## Appendix D: Open Questions and Abstraction Gaps
+
+This appendix catalogs areas where the current design is incomplete,
+where abstractions are weaker than they might appear, or where future
+work is needed. These are recorded here to guide ongoing design rather
+than to invalidate the current model — every policy system has
+boundaries, and it is better to name them explicitly.
+
+### D.1 Constraints Blur the Line Between Intent and Configuration
+
+The `constraints` section (§2.6) contains concrete numeric values
+(`max_memory_mb: 1024`, `max_wall_time_seconds: 120`) that pass through
+composition and binding essentially unchanged. Unlike `requires` — where
+the binder resolves abstract storage classes to concrete paths, or
+logical service names to concrete endpoints — constraints undergo no
+transformation. `max_memory_mb: 1024` in the intent becomes
+`max_memory_mb: 1024` in the bound policy verbatim.
+
+This raises the question: are constraints truly *intent*, or are they
+already *configuration*?
+
+A more intent-flavored approach might use abstract resource tiers:
+
+```jsonc
+"resources": "lightweight"    // resolved to concrete limits per-platform
+"resources": "compute-heavy"  // binder picks appropriate limits
+```
+
+Or relative expressions:
+
+```jsonc
+"max_memory": "2x runtime baseline"
+```
+
+The current concrete-number approach has the advantage of being
+unambiguous, composable (via `min()`), and auditable. But it requires
+every policy author to reason in megabytes and seconds, which is a
+configuration-level concern rather than an intent-level one.
+
+**Open question:** Should the intent layer support abstract resource
+tiers that the binder resolves to concrete limits? If so, how do tiers
+compose across policy layers? `min(lightweight, compute-heavy)` is not
+well-defined without a total ordering on tiers.
+
+### D.2 Network Operations Are Advisory-Only
+
+The `operations` field in network service references (§2.4) documents
+what the code does with a service — `["query"]`, `["download"]`,
+`["completions"]` — but does not affect enforcement. The sandbox cannot
+verify that a process connecting to `weather-api` on port 443 is
+performing a query rather than an upload.
+
+This creates an honesty gap: the field *looks* like a policy constraint
+but is currently a documentation annotation. An administrator reading
+`"operations": ["query"]` might reasonably believe uploads are blocked,
+when in fact only the network connection itself is controlled.
+
+**Options:**
+1. Remove `operations` from the schema to avoid false confidence
+2. Keep as documentation but clearly label as `"advisory_operations"`
+3. Define a future enforcement path (e.g., HTTP-aware proxy that
+   inspects methods, or protocol-specific middleware)
+
+### D.3 Claims Lack a Verification Story
+
+Claims (§2.7) are self-asserted behavioral properties:
+`deterministic: true`, `no_credential_exfiltration: true`,
+`no_side_effects_beyond_output: true`. The document explicitly notes
+that claims are not enforced by the sandbox runtime.
+
+This is appropriate for a v1 design, but the gap between assertion and
+verification is significant. A code author claiming
+`no_credential_exfiltration` provides no more assurance than a pinky
+promise unless some verification mechanism exists.
+
+**Possible verification approaches:**
+- **Static analysis** — inspect code for patterns that violate claims
+  (e.g., code that reads credential files and writes to network)
+- **Runtime monitoring** — observe sandbox behavior and flag violations
+  post-hoc (e.g., data flow tracking between credential reads and
+  network writes)
+- **Formal attestation** — third-party auditor signs a claim after
+  review, and the signature is included in the policy
+- **Sandbox-enforced proxies** — for specific claims like
+  `no_credential_exfiltration`, route all network traffic through an
+  egress proxy that blocks content matching credential patterns
+
+Each approach has different cost, coverage, and false-positive
+characteristics. The right answer likely varies by claim type and
+deployment context.
+
+### D.4 Service Catalog Resolution Is Underspecified
+
+The service catalog (§5.3) maps logical service names to concrete
+endpoints, but several aspects of the resolution process are not yet
+defined:
+
+- **Catalog versioning:** When the catalog changes (a service moves to a
+  new host), do existing bound policies become stale? Is re-binding
+  required?
+- **Conflict resolution:** What happens when an admin-defined catalog and
+  a system-defined catalog both define the same service name with
+  different endpoints?
+- **Resolution timing:** Is the catalog consulted at compose time, bind
+  time, or runtime? Each has different freshness vs. reproducibility
+  tradeoffs.
+- **Catalog discovery:** How does the binder locate the relevant catalog?
+  Is it embedded in the admin intent, referenced by URL, or discovered
+  via a well-known path?
+- **Catalog scope:** Can a code author reference a service name that
+  doesn't exist in any catalog? Should the binder fail, warn, or assume
+  the admin will define it later?
+
+### D.5 Network Scope Narrowing Semantics Are Underspecified
+
+The user consent model (§4) allows narrowing a network service's scope.
+For example, a code author requests `"service": "public-web"` and a user
+restricts it to `"scope": "*.wikipedia.org,*.arxiv.org"`. The
+composition rule intersects these.
+
+But the semantics of scope intersection are not rigorously defined:
+
+- **Pattern language:** Is `*.example.com` a glob? A regex? A DNS suffix
+  match? Does it match `sub.sub.example.com`?
+- **Intersection rules:** What does intersecting `*.example.com` with
+  `api.example.com` produce? Is it `api.example.com` (the more specific
+  pattern)? What about `*.example.com` ∩ `*.api.example.com`?
+- **Disjunction:** Scopes use comma-separated lists
+  (`*.wikipedia.org,*.arxiv.org`). Intersection of two comma-separated
+  lists requires pairwise pattern comparison.
+- **Negation:** Can a scope express "everything except"? If so, how does
+  negation interact with intersection?
+
+A formal scope algebra — probably based on DNS suffix matching with
+explicit rules for wildcard depth — is needed before this feature can be
+implemented reliably.
+
+### D.6 Wall-Time Enforcement Is Universally User-Space
+
+All three blessed compositions (Windows, Linux, macOS) report wall-time
+enforcement as `"user-space"` — a host-side timer that sends
+SIGKILL/TerminateProcess when the deadline expires. No current operating
+system provides a kernel-enforced wall-time deadline for a process group.
+
+This is a systemic gap rather than a per-platform one. For most
+workloads it is acceptable — the host timer is reliable and the latency
+between deadline and termination is small. But it means:
+
+- A compromised host process could fail to enforce the deadline
+- The guarantee is only as strong as the host-side monitor
+- There is a small window between deadline expiry and process termination
+
+**Open question:** Should the document explicitly classify wall-time as
+a "best-effort" resource constraint rather than a hard guarantee? Should
+compositions that list wall_time enforcement as user-space not include it
+in their security guarantees?
+
+### D.7 IPC and Device Models Are Underdeveloped
+
+The current model defaults to `"ipc": "none"` and `"devices": "none"`
+(§2.5), with a brief mention that "more granular" declarations are
+possible. This is adequate for the common case of isolated code
+execution, but several real-world scenarios need more:
+
+- **Mach IPC on macOS** — many system services are accessed via Mach
+  ports. The Seatbelt profile can filter `mach-lookup` by service name,
+  but the intent policy has no way to express "I need access to Mach
+  service `com.apple.securityd`."
+- **D-Bus on Linux** — desktop Linux applications use D-Bus for
+  inter-process communication. Sandboxed processes that need to interact
+  with system services (e.g., NetworkManager) would need D-Bus policy.
+- **Named pipes on Windows** — BFS can redirect named pipe access, but
+  the intent policy has no way to declare named pipe requirements.
+- **GPU/accelerator access** — ML workloads may need access to
+  `/dev/nvidia*` or Metal devices. `"devices": "none"` is too coarse;
+  `"devices": "gpu"` is too vague for security policy.
+
+A future revision should define an IPC declaration model that names
+specific IPC channels or device classes, similar to how network services
+are named today.
+
+### D.8 Exec Whitelisting for Interpreted Languages
+
+The Linux blessed composition includes an `exec-restricted` guarantee:
+"Only explicitly whitelisted executables can be exec'd." But this
+guarantee operates at the binary level — Landlock's
+`LANDLOCK_ACCESS_FS_EXECUTE` controls which files can be passed to
+`execve()`.
+
+For interpreted languages, this means:
+
+- Whitelisting `/usr/bin/python3` allows execution of **any** Python
+  code, including code that the workload downloads at runtime
+- The exec whitelist prevents launching unexpected *binaries* but says
+  nothing about what *scripts* those binaries execute
+- A Rust snippet runner has a meaningful exec whitelist (only `cargo`,
+  `rustc`, `cc`, `ld`), but a Python workload's whitelist is
+  effectively just "Python is allowed"
+
+This is not a bug — it is an inherent limitation of binary-level exec
+control. But it means the `exec-restricted` guarantee is weaker for
+interpreted workloads than the name suggests.
+
+**Possible mitigations:**
+- Filesystem rules that restrict what the interpreter can *read*
+  (preventing it from loading unexpected scripts)
+- `--isolated` or equivalent interpreter flags that disable import hooks
+  and restrict module search paths
+- Content-hash verification of script files before execution
+
+### D.9 Multi-Sandbox Orchestration
+
+This document covers policy for a single sandbox instance. But agentic
+systems frequently involve multiple sandboxes that collaborate:
+
+- A coordinator agent that dispatches work to specialized tool sandboxes
+- A pipeline of sandboxes where one sandbox's output feeds the next
+- A supervisor sandbox that monitors and restarts worker sandboxes
+
+These patterns raise policy questions not addressed in the current model:
+
+- **Inter-sandbox communication:** If sandbox A needs to send data to
+  sandbox B, what policy governs the channel? Is it expressed in A's
+  intent, B's intent, or a separate orchestration policy?
+- **Transitive trust:** If a user trusts coordinator sandbox A, and A
+  spawns worker sandbox B, does the user's trust extend to B? Under what
+  conditions?
+- **Aggregate resource limits:** Six worker sandboxes each with
+  `max_memory_mb: 1024` consume 6 GB total. Should there be an
+  aggregate ceiling for the orchestration as a whole?
+- **Data provenance:** When sandbox B processes data that originated in
+  sandbox A, do A's data handling constraints (e.g.,
+  `persistent_storage: "forbidden"`) propagate?
+- **Shared credentials:** If the coordinator has an API key, can it
+  delegate access to workers? The current model injects credentials per-
+  sandbox with no delegation mechanism.
+
+A future orchestration layer would need to define policy composition
+across sandbox boundaries, not just within a single sandbox.
+
+## Appendix E: Rubric-Based Self-Evaluation
+
+This appendix applies the sandbox evaluation rubric (see
+[SandboxEvaluationRubric.md](SandboxEvaluationRubric.md)) to the intent
+policy system described in this document. The rubric defines six axes for
+evaluating sandboxing and container technologies; here we evaluate the
+*policy framework itself* rather than any single platform primitive it
+targets.
+
+**Technology kind.** The intent policy system does not fit neatly into the
+rubric's existing categories (Primitive, Composition, Broker, Trust Anchor,
+Language Sandbox). It is a **Policy Framework** — an orchestration layer that
+sits above all of those and governs how compositions are selected,
+configured, and validated. This category is worth adding to the rubric.
+
+### E.1 Axis 1 — Isolation Architecture: B+
+
+The system itself does not enforce isolation directly — it produces
+configuration for enforcement mechanisms. The *architectural properties* of
+the design are strong:
+
+| Criterion | Assessment |
+|-----------|-----------|
+| Isolation model | Delegates to platform: Different Universe (namespaces, VMs), Guarded Doors (Seatbelt, Landlock, BFS), Reduced Credentials (AppContainer). The design is model-agnostic, which is correct. |
+| Deny-by-default | **Yes, by construction.** Empty `requires` means no access. Silence is never permission. Deeply embedded in the design. |
+| Monotonic restriction | **Yes, by construction.** The intersection rule (§7.1) means each layer can only further restrict. The single most important architectural property. |
+| Inherited by children | Delegates to platform. The design does not explicitly address whether bound policy applies to child processes. |
+| Enforcement point | Kernel (via delegation). Bound policy targets kernel-enforced mechanisms. But binder and composition steps are user-space — a compromised binder could produce a permissive policy. |
+| Fail-closed on unenforceable policy | **Yes, explicitly.** §7.3 and §8.3.3 define fail-closed behavior with attribution. Gaps are reported; caller decides disposition. |
+| Gap attribution | **Excellent.** The binder reports exactly which requirement failed, which primitive was checked, and why. The audit trail (§7.4) attributes every restriction to a specific policy author. |
+
+**What prevents an A:** The design delegates enforcement entirely. It has no
+mechanism to verify that the underlying platform *actually enforced* what the
+bound policy specified. A correct bound policy plus a buggy runtime equals a
+false sense of security. There is no runtime attestation or enforcement
+verification loop.
+
+### E.2 Axis 2 — Policy Dimension Coverage: A−
+
+The intent schema covers more dimensions, at finer granularity, than any
+single mechanism the survey documents:
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Filesystem | ✓ Full | Storage classes with per-operation granularity (read/write/execute/create/delete), subtree/exact scope, ephemeral/persistent semantics, masks, synthetic mounts. |
+| Network | ✓ Full | Named service references, per-host/port/protocol/direction rules, DNS control, localhost control. Advisory `operations` field (D.2 acknowledges the gap). |
+| Process control | ✓ Good | `spawn`, `max_children`, `exec` allowlist, `signals` scope. |
+| IPC / messaging | ○ Partial | Defaults to `"none"`. §2.5 and D.7 acknowledge granular IPC (Mach ports, D-Bus, named pipes) is underdeveloped. |
+| Device access | ○ Partial | Defaults to `"none"`. D.7 notes GPU/accelerator access is too coarse. No device taxonomy. |
+| Privilege escalation | ✓ Full | `privilege_escalation: "forbidden"` maps to `NO_NEW_PRIVS`, integrity levels, etc. |
+| Syscall filtering | ✗ Indirect | Not in the intent schema. Delegated to platform section of bound policy. No way to express "I only use these syscalls" at the intent level. |
+| Resource limits | ✓ Full | `max_memory_mb`, `max_cpu_cores`, `max_wall_time_seconds`, `max_processes`, `max_open_files`, `max_output_bytes`. |
+| Brokered access | ✓ Good | `user_selected` storage class (§4.4), user consent model (§4.2–4.3), admin service catalogs (§5.3). |
+| Identity / code integrity | ○ Weak | Claims exist (`no_credential_exfiltration`) but are unverified (D.3). No code signing, no exec-hash verification. |
+
+**What prevents an A:** IPC and devices are acknowledged stubs. Syscall
+filtering has no intent-level expression. Claims are unverified promises.
+These are flagged as open questions in Appendix D, which is honest but still
+represents a gap.
+
+### E.3 Axis 3 — Policy Language & Authoring: A
+
+This is where the design excels. It is the core contribution of the
+document.
+
+| Criterion | Assessment |
+|-----------|-----------|
+| Declarative language | Yes. JSON-based, with JSONC (comments) for authoring. |
+| Human-readable | Yes. Storage classes like `workspace`, `input_data` are self-documenting. |
+| Machine-parseable | Yes. Standard JSON with a defined schema. |
+| Schema / formal grammar | Yes. Appendix A defines the intent schema; Appendix B defines the bound policy schema. Schema versions are tracked. |
+| Abstraction level | Excellent. Platform-agnostic: storage classes, named service references, named tools. No platform paths in intent. |
+| Multi-author composition | Yes — four authors: code author, user, IT admin, system. The central innovation. |
+| Composition algebra | Formally defined. §7.2: intersection for capability sets, `min()` for numerics, union for forbidden constraints, intersection for access modes. Deterministic and unambiguous. |
+| AI/tooling authorable | Explicitly designed for this (§3.3 Agentic Authoring). Abstract vocabulary means agents need no platform knowledge. |
+| Validation / dry-run | Yes. The binder validates feasibility before producing bound policy (§8.3). |
+| Static conflict detection | Yes. Composition detects unsatisfiable requirements (§7.3). Fails with attribution. |
+| Denial-to-rule traceability | Excellent. §7.4 defines full attribution — every restriction traceable to a specific policy author and layer. |
+| Learning / discovery mode | Not in the design. The alignment doc notes MXC has ETW-based learning, but the policy design does not incorporate it. |
+| Versioning | Comprehensive. §10 defines 5 independent version axes, semantic versioning, major-version-hard-fail, minor-version-with-gaps. |
+| Machine-readable guarantees | Yes. Blessed compositions (§8.3.2) declare formal guarantees (`no-filesystem-escape`, `exec-restricted`). |
+| Brokered / user-selected resources | Yes. §4.4 `user_selected` storage class for runtime file picking. §4.2–4.3 consent models. |
+
+**What prevents a higher grade:** No formal grammar or BNF — the schema is
+described by example and prose with JSON Schema referenced but not included
+inline. Network scope algebra is explicitly underspecified (D.5). Learning /
+discovery mode is absent.
+
+### E.4 Axis 4 — Composability & Integration: B
+
+| Criterion | Assessment |
+|-----------|-----------|
+| Composable with existing mechanisms | Yes, by design. Bound policy targets existing platform primitives. Capability profiles (§8.3.1) formally describe what each primitive can do. |
+| Stacking is additive | Yes. The intersection rule guarantees this at the policy level. |
+| Interaction semantics documented | Yes for the policy layer. Blessed compositions (§8.3.2) document primitive interactions. |
+| Setup cost | Unknown. The design does not address performance. Composition + binding + validation is potentially expensive for latency-sensitive workloads. |
+| Per-workload cost | Unknown. |
+| Warm reuse | Not addressed. MXC's Windows Sandbox daemon has warm reuse, but the policy design does not model reuse semantics. |
+| State reset | Not addressed. D.9 hints at this but defers it. |
+| Teardown | Not addressed. The design concerns policy, not lifecycle. |
+
+**Rationale:** Strong on policy composability, silent on lifecycle and
+performance. As a policy framework the lifecycle concerns are somewhat out
+of scope, but the rubric asks about them and the design is silent.
+
+### E.5 Axis 5 — Operational Characteristics: B−
+
+| Criterion | Assessment |
+|-----------|-----------|
+| Formal analysis / audit | No. The composition algebra is precise enough to formalize, but no formal proof or analysis has been done. |
+| Known escape vectors | Not analyzed. No threat model or adversarial analysis. What happens if an attacker controls a policy layer? If the binder is compromised? |
+| Defense-in-depth | Strong structurally. Blessed compositions layer multiple primitives. The intersection rule means a compromised layer can only fail to restrict, never broaden. |
+| Overhead | Unknown. No performance analysis. |
+| Debuggability | Strong. Attribution model (§7.4) makes policy denials traceable. The binder gap report is designed for debugging. |
+| Audit trail | Excellent. Every restriction attributed. Effective intent, bound policy, and gap report form a complete audit record. |
+
+**Rationale:** Excellent audit trail and debuggability. No threat model, no
+formal analysis, no performance characterization. For a security-critical
+system, the absence of adversarial analysis is notable.
+
+### E.6 Axis 6 — Cross-Platform Policy Alignment: A
+
+This axis is nearly tautological — the design *is* the cross-platform policy
+alignment system. Evaluating honestly:
+
+| Criterion | Assessment |
+|-----------|-----------|
+| Maps to `requires.storage` | Excellent. Storage classes are the core abstraction; binder resolves to platform paths. |
+| Maps to `requires.network` | Good. Named services + service catalog; binder resolves to host:port. |
+| Maps to `constraints` | Good. Numeric constraints pass through. Capability profiles validate enforceability. |
+| Binder can generate config | Yes, by definition. Bound policy is the output format. |
+| Config format stable / documented | Yes. §9 defines the bound policy schema; §10 defines versioning. |
+| Capability profile writable | Yes. §8.3.1 defines the profile format with examples for all three platforms. |
+| Composition role | Orchestrator. This system decides which composition to use and how to configure it. |
+
+**What prevents a higher grade:** The design does not specify how bound
+policy JSON is translated to the actual configuration format of each
+mechanism (AppContainer API calls, Seatbelt S-expression profiles, LXC
+container config files). The alignment doc (§5) shows MXC's current config
+format diverges from the bound policy format described here.
+
+### E.7 Summary
+
+| Axis | Grade | Key factor |
+|------|-------|------------|
+| 1. Isolation Architecture | B+ | Excellent architectural properties; no enforcement verification loop |
+| 2. Policy Dimension Coverage | A− | 8/10 dimensions strong; IPC, devices, syscalls are stubs |
+| 3. Policy Language & Authoring | A | Standout strength: formal composition algebra, 4-author model, full attribution, comprehensive versioning |
+| 4. Composability & Integration | B | Strong policy composability; silent on lifecycle and performance |
+| 5. Operational Characteristics | B− | Excellent auditability; no threat model or formal analysis |
+| 6. Cross-Platform Alignment | A | The raison d'être; well-designed abstraction with last-mile translation unspecified |
+
+**Overall (Agentic workload weighting):** Isolation 25% × 3.3 + Dimensions
+30% × 3.7 + Language 20% × 4.0 + Composability 10% × 3.0 + Operational 5%
+× 2.7 + Cross-Platform 10% × 4.0 = **3.46 → B** (just below the 3.5
+threshold for A)
+
+### E.8 Key Observations
+
+**Greatest strengths:**
+
+1. **The intersection composition rule** is the single best design decision.
+   It eliminates priority conflicts, makes composition deterministic, and
+   guarantees monotonic restriction.
+2. **The four-author model** maps directly to real-world trust
+   relationships. Code author, user, admin, and system are genuinely
+   distinct trust domains with distinct concerns.
+3. **The abstraction level** is right — storage classes and service names,
+   not paths and ports. This makes the policy genuinely portable and
+   agent-authorable.
+
+**Greatest risks:**
+
+1. **No enforcement verification.** The system trusts that the bound policy
+   is faithfully enforced. A gap between what the binder specifies and what
+   the runtime enforces is invisible. The alignment doc already shows this:
+   MXC's AppContainer backend silently cannot enforce per-port network
+   rules, but the design has no mechanism to detect this at runtime.
+2. **Complexity budget.** The full system (4 authors × intent schema ×
+   composition algebra × binder × capability profiles × blessed
+   compositions × bound policy × versioning) is substantial.
+   PossibleSimplifications.md is evidence the design team sees this risk.
+   The question is whether v1 can ship something useful that is simpler
+   than the full design.
+3. **The IPC/device stub.** `"ipc": "none"` and `"devices": "none"` work
+   for today's agentic workloads. But GPU access for ML workloads and
+   D-Bus/Mach IPC for desktop-adjacent workloads are coming. The stub will
+   need to become a real taxonomy.
+4. **Unverified claims.** The `claims` section is conceptually appealing but
+   currently dead weight. D.3 acknowledges this. Shipping it risks users
+   treating unverified claims as security assurances. The suggestion in
+   PossibleSimplifications.md to drop claims from v1 (S.3) is wise.

--- a/docs/proposals/container-policy/ContainerPolicyThoughts.md
+++ b/docs/proposals/container-policy/ContainerPolicyThoughts.md
@@ -1,0 +1,4286 @@
+# Container Policy Thoughts
+
+This document captures research and design thinking around cross-platform sandbox
+policy — comparing Linux BubbleWrap, macOS Seatbelt, Linux Landlock, seccomp-BPF,
+and Windows AppContainer/Restricted Tokens — and proposes a unified JSON-based policy
+language compiled to FlatBuffers for efficient runtime consumption.
+
+---
+
+## Table of Contents
+
+- [1. Linux BubbleWrap vs macOS Seatbelt](#1-linux-bubblewrap-vs-macos-seatbelt)
+- [2. Seccomp-BPF Filters](#2-seccomp-bpf-filters)
+- [3. Linux Landlock](#3-linux-landlock)
+- [4. SELinux](#4-selinux)
+- [5. Windows Equivalents](#5-windows-equivalents)
+- [6. Common Policy Dimensions](#6-common-policy-dimensions)
+- [7. macOS Seatbelt Profile Language](#7-macos-seatbelt-profile-language)
+- [8. Proposed Cross-Platform JSON Policy Language](#8-proposed-cross-platform-json-policy-language)
+- [9. FlatBuffer Compiled Format](#9-flatbuffer-compiled-format)
+- [10. Policy Layers](#10-policy-layers)
+- [11. Backend Capability Profiles](#11-backend-capability-profiles)
+- [12. Container Lifecycle and Workload Cycling](#12-container-lifecycle-and-workload-cycling)
+- [13. Intent Manifest](#13-intent-manifest)
+
+---
+
+## 1. Linux BubbleWrap vs macOS Seatbelt
+
+### Linux BubbleWrap (`bwrap`)
+
+BubbleWrap is a lightweight, unprivileged sandboxing tool. It is a *building block*,
+not a turnkey sandbox — the caller defines the exact policy.
+
+It leverages Linux kernel namespaces (mount, user, PID, network, IPC, UTS, cgroup)
+to give each sandboxed process an isolated view of the system.
+
+| Mechanism | Purpose |
+|---|---|
+| **User namespaces** | Allows unprivileged users to create sandboxes without root |
+| **Mount namespaces + bind mounts** | Constructs a custom filesystem view (read-only or read-write) |
+| **Seccomp filters** | Restricts which system calls the process can make |
+| **Capability dropping** | Removes Linux capabilities to prevent privilege escalation |
+| **`PR_SET_NO_NEW_PRIVS`** | Blocks setuid escalation from within the sandbox |
+
+**Policy model:** *Explicit allowlist* — nothing is visible unless you bind-mount it
+in. There is no profile language; the policy is expressed entirely through CLI flags.
+
+**Used by:** Flatpak (as its core isolation engine), developer sandboxes, build environments.
+
+### macOS Seatbelt (`sandbox-exec`)
+
+Seatbelt is a kernel-enforced mandatory access control framework. Processes are
+restricted by a *profile* written in an S-expression policy language.
+
+The kernel intercepts system calls and checks them against the loaded profile.
+
+| Mechanism | Purpose |
+|---|---|
+| **Kernel-level MAC enforcement** | All syscalls filtered at the kernel before execution |
+| **S-expression profile language** | Declarative rules for file, network, Mach port, IPC, device access |
+| **Deny-by-default model** | Everything is forbidden unless the profile explicitly `(allow ...)`s it |
+| **Violation logging** | Blocked operations are logged to the system log for debugging |
+| **App Sandbox entitlements** | App Store apps are forced into sandboxing via `com.apple.security.app-sandbox` |
+
+**Policy model:** *Deny-by-default with declarative profiles*.
+
+**Used by:** All Mac App Store apps (mandatory), Chromium renderer processes,
+developer tooling.
+
+### Head-to-Head Comparison
+
+| Dimension | BubbleWrap (Linux) | Seatbelt (macOS) |
+|---|---|---|
+| **Isolation approach** | Namespace-based (process sees an entirely different world) | MAC/filter-based (process sees the real world but is blocked from actions) |
+| **Policy language** | CLI flags — no declarative language | S-expression profiles — declarative, reusable |
+| **Default posture** | Nothing visible unless explicitly mounted | Everything denied unless explicitly allowed |
+| **Filesystem isolation** | Full: custom rootfs via bind mounts, tmpfs, overlays | Partial: rules filter access to the real filesystem |
+| **Network isolation** | Yes — via network namespace (full or none) | Yes — granular per-profile rules |
+| **Privilege model** | Works as unprivileged user (via user namespaces) | Requires profile to be loaded at process start; no special privilege needed |
+| **Scope** | Low-level building block — you compose a sandbox from primitives | Higher-level framework — you write a profile, kernel enforces it |
+| **Syscall filtering** | Via seccomp (separate mechanism, composable) | Built into the framework (profile controls which operations allowed) |
+| **OS integration** | Generic Linux kernel features | Deep macOS integration (Mach ports, IOKit, XPC, TCC) |
+| **Maintenance** | Stable kernel ABI; profiles rarely break | Apple changes internals across OS versions; profiles can break on upgrade |
+| **Status** | Actively maintained, widely used | `sandbox-exec` CLI is deprecated; App Sandbox entitlement system is the supported path |
+
+**Key philosophical difference:** BubbleWrap gives the sandboxed process a
+*different universe* (new PID space, new mount tree, new network stack). Seatbelt
+keeps the process in the *same universe* but puts guards on every door.
+
+---
+
+## 2. Seccomp-BPF Filters
+
+### What Problem Does It Solve?
+
+The Linux kernel exposes ~400+ system calls. Most applications only use a small
+fraction. Every unused syscall is a potential attack vector — if an attacker gets
+code execution inside your process, they can call `mount()`, `ptrace()`, `reboot()`,
+etc. Seccomp lets you say: *"this process may only use these specific syscalls."*
+
+### The Two Modes
+
+**Strict Mode (original, rarely used):**
+Process can only call `read()`, `write()`, `exit()`, and `sigreturn()`. Anything
+else results in instant `SIGKILL`.
+
+**Filter Mode (seccomp-BPF, the one everyone uses):**
+You attach a BPF program that inspects every syscall and decides what to do.
+
+### How It Works Architecturally
+
+```
+  User process calls write(fd, buf, len)
+          │
+          ▼
+  ┌──────────────────────┐
+  │   Kernel syscall      │
+  │   entry point         │
+  │                       │
+  │  ┌─────────────────┐  │
+  │  │ seccomp BPF VM  │  │  ◄── tiny in-kernel virtual machine
+  │  │                 │  │      executes your filter program
+  │  │ Input:          │  │
+  │  │  .nr   = 1      │  │  (syscall number for write)
+  │  │  .arch = x86_64  │  │
+  │  │  .args[0] = fd   │  │
+  │  │  .args[1] = buf  │  │  (raw value, NOT dereferenced)
+  │  │  .args[2] = len  │  │
+  │  │                 │  │
+  │  │ Output: ACTION   │  │
+  │  └─────────────────┘  │
+  │          │             │
+  │          ▼             │
+  │   ALLOW? → execute     │
+  │   KILL?  → SIGKILL     │
+  │   ERRNO? → return err  │
+  │   TRAP?  → SIGSYS      │
+  │   TRACE? → notify ptrace│
+  └──────────────────────┘
+```
+
+The BPF program operates on a `struct seccomp_data`:
+
+```c
+struct seccomp_data {
+    int   nr;                  // syscall number
+    __u32 arch;                // AUDIT_ARCH_* value
+    __u64 instruction_pointer; // where the syscall was made
+    __u64 args[6];             // raw syscall arguments (not dereferenced!)
+};
+```
+
+### Return Actions
+
+| Action | Effect |
+|---|---|
+| `SECCOMP_RET_ALLOW` | Syscall proceeds normally |
+| `SECCOMP_RET_KILL_PROCESS` | Entire process killed with `SIGSYS` |
+| `SECCOMP_RET_KILL_THREAD` | Calling thread killed |
+| `SECCOMP_RET_ERRNO(val)` | Syscall blocked, returns `-val` to caller (e.g., `EPERM`) |
+| `SECCOMP_RET_TRAP` | Sends `SIGSYS` to process (can be caught by a handler) |
+| `SECCOMP_RET_TRACE` | Notifies a `ptrace`-attached tracer to decide |
+| `SECCOMP_RET_LOG` | Allow, but log the syscall |
+| `SECCOMP_RET_USER_NOTIF` | Delegate decision to a userspace supervisor (newer kernels) |
+
+### Code Example (C, using libseccomp)
+
+```c
+#include <seccomp.h>
+#include <unistd.h>
+
+int main() {
+    // Create filter: default action = kill process
+    scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_KILL);
+
+    // Allowlist only what we need
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit_group), 0);
+
+    // Can also filter by argument value:
+    // Only allow write() to stdout (fd == 1)
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 1,
+                     SCMP_A0(SCMP_CMP_EQ, STDOUT_FILENO));
+
+    // Load and enforce the filter
+    seccomp_load(ctx);
+
+    write(1, "allowed\n", 8);   // works
+    open("/etc/passwd", 0);      // KILLED — open() not in allowlist
+
+    seccomp_release(ctx);
+    return 0;
+}
+```
+
+Without libseccomp, you write raw BPF instructions:
+
+```c
+struct sock_filter filter[] = {
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL),
+};
+struct sock_fprog prog = { .len = 4, .filter = filter };
+prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+```
+
+### Key Security Properties
+
+1. **Immutable once loaded** — a process cannot weaken its own filter after installation
+2. **Inherited by children** — `fork()` and `execve()` carry the filter forward
+3. **Stackable** — multiple filters can be layered; *all* must agree to allow a syscall
+4. **No pointer dereferencing** — the BPF program sees raw argument *values*, not the
+   memory they point to; this prevents TOCTOU races where userspace changes memory
+   between the check and the actual syscall
+5. **Requires `PR_SET_NO_NEW_PRIVS`** — the process must first commit to never gaining
+   new privileges
+
+### Who Uses It?
+
+| User | How |
+|---|---|
+| **Docker/containers** | Default seccomp profile blocks ~44 dangerous syscalls |
+| **Chromium** | Renderer processes can only use ~20 syscalls |
+| **systemd** | `SystemCallFilter=` directive in unit files |
+| **Android** | Zygote process applies seccomp before spawning apps |
+| **Flatpak/BubbleWrap** | Passed via `--seccomp` flag |
+| **OpenSSH** | Privilege-separated child uses seccomp |
+
+### Limitations
+
+- **Cannot inspect pointed-to memory** — only raw argument values (by design, to
+  avoid TOCTOU)
+- **Not a full sandbox alone** — only restricts syscalls, not file paths, network
+  destinations, etc.
+- **Architecture-dependent** — syscall numbers differ across architectures; always
+  check `arch` first
+- **Classic BPF only** — uses the older cBPF instruction set, not eBPF
+
+---
+
+## 3. Linux Landlock
+
+### What It Is
+
+Landlock is a Linux Security Module (merged in kernel 5.13) that lets a process
+*restrict itself* — no root, no admin policy, no container runtime needed. A process
+creates a ruleset describing what it is allowed to access, then permanently locks
+itself into that ruleset.
+
+Think of it as: *"I'm about to run untrusted code, so let me voluntarily give up my
+own rights first."*
+
+### Where It Fits in the Linux Security Stack
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │                  Access Request                    │
+  │         (e.g., open("/etc/shadow", O_RDONLY))      │
+  └──────────────┬───────────────────────────────────┘
+                 │
+                 ▼
+  ┌──────────────────────┐
+  │  DAC (Unix perms)    │  ← owner/group/other, rwx bits
+  │  Must pass           │
+  └──────────┬───────────┘
+             ▼
+  ┌──────────────────────┐
+  │  LSM: SELinux /      │  ← admin-defined, system-wide, label-based
+  │       AppArmor       │     policy (if enabled)
+  │  Must pass           │
+  └──────────┬───────────┘
+             ▼
+  ┌──────────────────────┐
+  │  LSM: Landlock       │  ← process-defined, per-process, runtime
+  │  Must pass           │     (stacks with everything above)
+  └──────────┬───────────┘
+             ▼
+        Access granted
+```
+
+Landlock **only restricts further** — it can never grant access that DAC or other
+LSMs would deny.
+
+### The Three Syscalls
+
+| Syscall | Purpose |
+|---|---|
+| `landlock_create_ruleset()` | Create a new ruleset; declare which access types you want to govern |
+| `landlock_add_rule()` | Add rules to the ruleset (e.g., "allow read on this directory") |
+| `landlock_restrict_self()` | Apply the ruleset to the calling process — **permanent and irreversible** |
+
+### How It Works (Step by Step)
+
+```
+1. Create ruleset       "I want to control filesystem reads, writes, and execution"
+       │
+2. Add rules            "Allow read+execute under /usr"
+       │                "Allow read+write under /tmp/myapp"
+       │                "Allow read under /etc/resolv.conf"
+       │
+3. prctl(NO_NEW_PRIVS)  Commit to never gaining new privileges
+       │
+4. Restrict self         Lock it in — from here on, ONLY those paths are accessible
+       │
+5. exec(untrusted_app)   The app (and all its children) are confined
+```
+
+Everything NOT mentioned in the rules is **denied by default**.
+
+### Code Example (C)
+
+```c
+#include <linux/landlock.h>
+#include <sys/syscall.h>
+#include <sys/prctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+    // 1. Check ABI version
+    int abi = syscall(SYS_landlock_create_ruleset, NULL, 0,
+                      LANDLOCK_CREATE_RULESET_VERSION);
+    if (abi < 1) return 1;  // Landlock not available
+
+    // 2. Create ruleset: govern filesystem read/write/execute
+    struct landlock_ruleset_attr ruleset_attr = {
+        .handled_access_fs =
+            LANDLOCK_ACCESS_FS_READ_FILE |
+            LANDLOCK_ACCESS_FS_READ_DIR  |
+            LANDLOCK_ACCESS_FS_WRITE_FILE |
+            LANDLOCK_ACCESS_FS_EXECUTE
+    };
+    int ruleset_fd = syscall(SYS_landlock_create_ruleset,
+                             &ruleset_attr, sizeof(ruleset_attr), 0);
+
+    // 3. Allow read-only access to /usr
+    int usr_fd = open("/usr", O_PATH | O_CLOEXEC);
+    struct landlock_path_beneath_attr rule1 = {
+        .parent_fd = usr_fd,
+        .allowed_access = LANDLOCK_ACCESS_FS_READ_FILE |
+                          LANDLOCK_ACCESS_FS_READ_DIR  |
+                          LANDLOCK_ACCESS_FS_EXECUTE
+    };
+    syscall(SYS_landlock_add_rule, ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH, &rule1, 0);
+    close(usr_fd);
+
+    // 4. Allow read+write to /tmp/myapp
+    int tmp_fd = open("/tmp/myapp", O_PATH | O_CLOEXEC);
+    struct landlock_path_beneath_attr rule2 = {
+        .parent_fd = tmp_fd,
+        .allowed_access = LANDLOCK_ACCESS_FS_READ_FILE |
+                          LANDLOCK_ACCESS_FS_READ_DIR  |
+                          LANDLOCK_ACCESS_FS_WRITE_FILE
+    };
+    syscall(SYS_landlock_add_rule, ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH, &rule2, 0);
+    close(tmp_fd);
+
+    // 5. Lock it in
+    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    syscall(SYS_landlock_restrict_self, ruleset_fd, 0);
+    close(ruleset_fd);
+
+    // From here: can read /usr, read+write /tmp/myapp, nothing else.
+    // open("/etc/passwd", O_RDONLY) → EACCES
+    // open("/home/user/.ssh/id_rsa", O_RDONLY) → EACCES
+}
+```
+
+### ABI Versions
+
+| ABI Version | Kernel | New Capabilities |
+|---|---|---|
+| **v1** | 5.13 | Filesystem: read, write, execute, create, remove, make dirs/chars/blocks/fifos/sockets/symlinks/links |
+| **v2** | 5.19 | `LANDLOCK_ACCESS_FS_REFER` — control cross-directory renames and links |
+| **v3** | 6.2 | `LANDLOCK_ACCESS_FS_TRUNCATE` — control file truncation |
+| **v4** | 6.7 | **Network**: `LANDLOCK_ACCESS_NET_BIND_TCP`, `LANDLOCK_ACCESS_NET_CONNECT_TCP` |
+| **v5** | 6.10 | `LANDLOCK_ACCESS_FS_IOCTL_DEV` — control `ioctl()` on device files |
+| **v6** | 6.12 | **Unix sockets**: `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET`, **signals**: `LANDLOCK_SCOPE_SIGNAL` |
+
+### Landlock vs Other Linux Sandboxing
+
+| Dimension | Landlock | Seccomp-BPF | BubbleWrap (namespaces) | SELinux / AppArmor |
+|---|---|---|---|---|
+| **Who defines policy** | The process itself | The process itself | The caller/wrapper | System administrator |
+| **What it controls** | Files, dirs, network (TCP), devices, signals | Which syscalls are allowed | Entire filesystem/PID/network view | Files, network, capabilities, IPC, etc. |
+| **Granularity** | Path-hierarchy rules | Syscall number + args | Mount-level (whole dirs) | Label/path-based rules |
+| **Needs root** | No | No | No (user namespaces) | Yes (to write policy) |
+| **Irreversible** | Yes | Yes | N/A (separate process) | N/A (admin policy) |
+| **Stacks with others** | Yes | Yes | Orthogonal | Yes |
+| **Best for** | "I only need these files/ports" | "I only need these syscalls" | "Give me a different filesystem" | "Enterprise-wide mandatory policy" |
+
+### Key Design Principles
+
+1. **Self-restriction only** — a process can only restrict itself, never other processes
+2. **Additive restrictions** — you can add more rulesets (tighten), never remove them (loosen)
+3. **Inherited by children** — `fork()` and `execve()` carry all restrictions forward
+4. **Composable** — Landlock + seccomp + namespaces + SELinux all stack cleanly
+5. **No kernel policy language** — rules are defined via syscall structs, not config files
+
+The mental model: Landlock is to **files and network ports** what seccomp is to
+**syscalls** — a way for a process to voluntarily shed its own power before doing
+something risky.
+
+---
+
+## 4. SELinux
+
+### What It Is
+
+Security-Enhanced Linux (SELinux) is a **mandatory access control (MAC) framework**
+built into the Linux kernel as a Linux Security Module (LSM). Originally developed
+by the NSA and released as open source in 2000, it is the most mature and
+comprehensive MAC system on Linux.
+
+Unlike Landlock (self-restriction) or seccomp (syscall filtering), SELinux enforces
+**system-wide policy defined by an administrator**. Every process, file, port, and
+IPC object is assigned a *security label* (called a *security context*), and a
+central policy defines which label-to-label interactions are allowed.
+
+### Where It Fits
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │                  Access Request                    │
+  │         (e.g., open("/etc/shadow", O_RDONLY))      │
+  └──────────────┬───────────────────────────────────┘
+                 │
+                 ▼
+  ┌──────────────────────┐
+  │  DAC (Unix perms)    │  ← owner/group/other, rwx bits
+  │  Must pass           │
+  └──────────┬───────────┘
+             ▼
+  ┌──────────────────────┐
+  │  LSM: SELinux        │  ← admin-defined, system-wide, label-based
+  │  Must pass           │     policy (checks EVERY access)
+  └──────────┬───────────┘
+             ▼
+  ┌──────────────────────┐
+  │  LSM: Landlock       │  ← process-defined, per-process, runtime
+  │  Must pass           │
+  └──────────┬───────────┘
+             ▼
+        Access granted
+```
+
+SELinux checks happen **after** DAC (traditional Unix permissions) and **before**
+Landlock. All must pass.
+
+### Core Concepts
+
+| Concept | Meaning |
+|---|---|
+| **Security context (label)** | A string of the form `user:role:type:level` attached to every object and subject |
+| **Type** | The most important part of the label — most policy rules are written in terms of types |
+| **Type Enforcement (TE)** | The core policy mechanism: rules that say "type A may do operation X on type B" |
+| **Domain** | A type assigned to a *process* (e.g., `httpd_t` for Apache) |
+| **File type** | A type assigned to a *file* (e.g., `httpd_sys_content_t` for web content) |
+| **Role-Based Access Control (RBAC)** | Controls which domains a user/role is allowed to transition into |
+| **Multi-Level Security (MLS)** | Optional sensitivity/category labels for classified environments |
+| **Policy module** | A self-contained unit of policy that can be loaded/unloaded independently |
+
+### The Label System
+
+Everything in SELinux has a security context:
+
+```
+  Process:   system_u:system_r:httpd_t:s0
+  File:      system_u:object_r:httpd_sys_content_t:s0
+  Port:      system_u:object_r:http_port_t:s0
+  Socket:    system_u:object_r:httpd_tmp_t:s0
+                │        │        │         │
+                user     role     type      level (MLS)
+```
+
+Labels are stored as extended attributes (`security.selinux`) on files, and in
+kernel data structures for processes, sockets, and IPC objects.
+
+### Type Enforcement Rules
+
+The policy is expressed as rules allowing specific operations between types:
+
+```
+# Allow Apache to read its content files
+allow httpd_t httpd_sys_content_t:file { read open getattr };
+
+# Allow Apache to listen on HTTP ports
+allow httpd_t http_port_t:tcp_socket { name_bind };
+
+# Allow Apache to connect to database ports
+allow httpd_t postgresql_port_t:tcp_socket { name_connect };
+
+# Allow Apache to execute CGI scripts
+allow httpd_t httpd_sys_script_exec_t:file { execute execute_no_trans };
+
+# Allow Apache to write to its log directory
+allow httpd_t httpd_log_t:file { write create append };
+allow httpd_t httpd_log_t:dir  { search add_name };
+```
+
+Everything not explicitly allowed is **denied by default**.
+
+### Domain Transitions
+
+When a process executes a new binary, SELinux can force a *domain transition* — the
+new process runs in a different (usually more restricted) domain:
+
+```
+# When init_t executes /usr/sbin/httpd (labeled httpd_exec_t),
+# the new process transitions to httpd_t
+type_transition init_t httpd_exec_t:process httpd_t;
+
+# Required supporting rules:
+allow init_t httpd_exec_t:file { execute };       # init can execute the binary
+allow init_t httpd_t:process { transition };       # init can transition to httpd_t
+allow httpd_t httpd_exec_t:file { entrypoint };    # httpd_exec_t is a valid
+                                                    # entrypoint for httpd_t
+```
+
+This is critical for sandboxing: even if an attacker compromises Apache, they are
+confined to `httpd_t`'s permissions — they cannot access files typed for `sshd_t`,
+`mysqld_t`, or `user_home_t`.
+
+### Operating Modes
+
+| Mode | Behavior |
+|---|---|
+| **Enforcing** | Policy is enforced; denied operations are blocked and logged |
+| **Permissive** | Policy is not enforced; violations are logged but allowed (for development/debugging) |
+| **Disabled** | SELinux is completely off |
+
+The mode can be checked and (temporarily) toggled:
+
+```sh
+getenforce            # → Enforcing, Permissive, or Disabled
+setenforce 0          # → switch to Permissive (until reboot)
+setenforce 1          # → switch to Enforcing
+```
+
+### Policy Types
+
+| Policy Type | Use Case |
+|---|---|
+| **Targeted** (default on RHEL/Fedora) | Only specific high-risk daemons are confined; everything else runs as `unconfined_t` |
+| **Strict** | Every process is confined — no unconfined domain |
+| **MLS** | Multi-Level Security for classified environments (government, defense) |
+
+### Practical Workflow
+
+```sh
+# Check a file's security context
+ls -Z /var/www/html/index.html
+# → system_u:object_r:httpd_sys_content_t:s0
+
+# Check a process's security context
+ps -eZ | grep httpd
+# → system_u:system_r:httpd_t:s0   1234  httpd
+
+# Relabel a file to the correct type
+chcon -t httpd_sys_content_t /var/www/html/newfile.html
+
+# Restore default labels from policy
+restorecon -Rv /var/www/html/
+
+# Search for denied operations in the audit log
+ausearch -m avc -ts recent
+
+# Generate a policy module from denials
+audit2allow -a -M mypolicy
+semodule -i mypolicy.pp
+```
+
+### SELinux vs Other Linux Security Mechanisms
+
+| Dimension | SELinux | AppArmor | Landlock | Seccomp-BPF |
+|---|---|---|---|---|
+| **Policy model** | Label-based (types on everything) | Path-based (profiles name files by path) | Path-based (fd-based rules) | Syscall-number-based |
+| **Who defines policy** | System administrator | System administrator | The process itself | The process itself |
+| **Scope** | System-wide, all processes | Per-profile, named processes | Per-process, self-applied | Per-process, self-applied |
+| **What it controls** | Files, network, IPC, processes, devices, capabilities, and more | Files, network, capabilities, some IPC | Files, network (TCP), devices, signals | Which syscalls are allowed |
+| **Granularity** | Fine — per-type, per-operation, per-object-class | Medium — per-path, per-capability | Medium — per-directory-hierarchy | Fine — per-syscall + arg values |
+| **Needs root to configure** | Yes | Yes | No | No |
+| **Stacks with others** | Yes | Mutually exclusive with SELinux on same kernel | Yes | Yes |
+| **Survives exec** | Yes (domain transitions) | Yes (profile follows binary) | Yes (inherited) | Yes (inherited) |
+| **Indirection** | Labels survive rename/move | Path-based — rename can bypass rules | fd-based — survives rename | N/A |
+| **Best for** | System-wide mandatory confinement | Simpler admin-defined confinement | App self-sandboxing (files/net) | App self-sandboxing (syscalls) |
+
+The key architectural difference: SELinux labels are **attached to objects** (via
+xattrs and kernel structures), so policy follows the data even when files are moved
+or renamed. AppArmor matches on **path names**, which is simpler but means a renamed
+file may escape its policy. Landlock and seccomp are **self-restriction** mechanisms
+where the process voluntarily sheds its own power.
+
+### Key Design Principles
+
+1. **Mandatory** — policy is enforced by the kernel, not optional per-process
+2. **Deny-by-default** — everything not explicitly allowed is denied
+3. **Label-based** — policy is decoupled from file paths; labels travel with objects
+4. **Complete mediation** — every kernel access check consults SELinux, not just
+   file opens
+5. **Least privilege** — each domain gets only the permissions it needs
+6. **Composable** — stacks cleanly with DAC, Landlock, seccomp, and other LSMs
+   (since kernel 5.1+ with LSM stacking support)
+
+### Limitations
+
+- **Complexity** — the reference policy has tens of thousands of rules; writing
+  custom policy is notoriously difficult
+- **Admin-only** — unlike Landlock/seccomp, unprivileged processes cannot define
+  their own SELinux policy
+- **Distribution-dependent** — RHEL/Fedora ship with mature policies; Debian/Ubuntu
+  default to AppArmor instead
+- **Labeling overhead** — every file must be correctly labeled; mislabeled files are
+  a common source of access denials
+- **Not self-restriction** — a process cannot voluntarily confine itself further via
+  SELinux (that's what Landlock is for)
+
+---
+
+## 5. Windows Equivalents
+
+Windows does not have a single direct equivalent to BubbleWrap or Seatbelt. Instead,
+it has several complementary mechanisms:
+
+### AppContainer (closest equivalent)
+
+The most analogous to BubbleWrap/Seatbelt for application sandboxing. Introduced in
+Windows 8.
+
+- Process runs with a **restricted token** under a unique per-app SID
+- **Deny-by-default** for file, registry, network, and process access
+- Capabilities must be explicitly granted in the app manifest
+- Each container gets its own writable area
+- Network access is granular (can block localhost, internet, etc.)
+- Used by: UWP/Store apps, Edge renderer processes, and increasingly Win32 apps via
+  **Win32 App Isolation** (preview)
+
+### Restricted Tokens + Job Objects (low-level building blocks)
+
+These are the Windows analog to BubbleWrap's composable primitives:
+
+| Windows Mechanism | Linux Equivalent | Purpose |
+|---|---|---|
+| **Restricted Tokens** | Linux capabilities + seccomp | Strip privileges/SIDs from a process token |
+| **Job Objects** | cgroups + PID namespace | Group processes, limit CPU/memory/process count, control termination |
+| **Integrity Levels** (Low/Untrusted) | No direct equivalent (closest: user namespaces) | Prevent writes to higher-integrity objects |
+| **Desktop isolation** | X11/Wayland separation | Separate window station prevents message-based attacks |
+
+Chromium on Windows uses all four together to sandbox renderer processes.
+
+### Windows Sandbox (VM-based, highest isolation)
+
+A disposable Hyper-V-based lightweight VM. Closest analog is running a throwaway
+QEMU/KVM VM on Linux. Provides complete OS-level isolation but with higher overhead.
+Destroyed on close — no persistence.
+
+### Win32 App Isolation (newer, in preview)
+
+Microsoft's latest effort to bring AppContainer-style isolation to traditional Win32
+desktop apps. Aims to close the gap with Linux/macOS app sandboxing for non-Store apps.
+
+### Cross-Platform Summary
+
+| Capability | Linux (BubbleWrap + kernel) | macOS (Seatbelt/App Sandbox) | Windows (AppContainer + primitives) |
+|---|---|---|---|
+| **Filesystem isolation** | Mount namespaces + bind mounts | Profile rules on real FS | AppContainer SID + virtualized paths |
+| **Network isolation** | Network namespace | Profile rules | AppContainer capabilities |
+| **Syscall filtering** | Seccomp-BPF | Built into Seatbelt profiles | Not directly (rely on token/capability restrictions) |
+| **Resource limits** | cgroups | Not built-in (launchd can limit) | Job Objects |
+| **Process isolation** | PID namespace | Not built-in | Job Objects + desktop isolation |
+| **Privilege reduction** | Capability dropping + `NO_NEW_PRIVS` | Deny-by-default profiles | Restricted tokens + integrity levels |
+| **Unprivileged use** | Yes (user namespaces) | Yes (profiles loaded at exec) | Partially (AppContainer needs token creation) |
+| **Composability** | High (mix and match primitives) | Medium (profile language is flexible) | Medium (combine tokens + jobs + integrity) |
+| **App Store enforcement** | N/A (Flatpak uses bwrap) | Mandatory for Mac App Store | Mandatory for Microsoft Store (UWP) |
+
+---
+
+## 6. Common Policy Dimensions
+
+When you look across all these systems, common policy dimensions emerge. They don't
+all cover every dimension, but they draw from the same well.
+
+### Universal Policy Dimensions
+
+| Policy Dimension | BubbleWrap | Seatbelt | Landlock | Seccomp | AppContainer | Restricted Tokens |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Filesystem access** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Network access** | ✓ | ✓ | ✓ | ○ | ✓ | ○ |
+| **Process visibility/control** | ✓ | ✓ | ○ | ○ | ✓ | ○ |
+| **IPC / messaging** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Device access** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Privilege escalation prevention** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Syscall filtering** | ○ | ✓ | — | ✓ | — | — |
+| **Resource limits (CPU/mem)** | — | — | — | — | ○ | — |
+
+✓ = native to the system, ○ = achievable by composition, — = not addressed
+
+### Filesystem Access — Three Fundamental Strategies
+
+**Strategy A: "Different Universe" (Namespace/Mount-based)**
+Used by BubbleWrap, AppContainer. The process literally cannot *see* files that
+aren't explicitly mounted/mapped in.
+
+**Strategy B: "Same Universe, Guarded Doors" (MAC/Filter-based)**
+Used by Seatbelt, Landlock. The process can *see* the full path namespace but is
+blocked at access time.
+
+**Strategy C: "Reduced Credentials" (Token/ACL-based)**
+Used by Restricted Tokens, AppContainer. The process's identity token is stripped
+down so that existing OS ACLs deny it access.
+
+### What They All Share on Filesystem Policy
+
+Despite the different mechanisms, every system expresses filesystem policy along the
+same axes:
+
+| Axis | How It Appears |
+|---|---|
+| **Which paths** | Specific file, directory subtree, prefix, or regex |
+| **Read vs Write vs Execute** | Always distinguished; read-only is the most common restriction |
+| **Direction of default** | Deny-by-default (allow specific paths) vs allow-by-default (block specific paths) |
+| **Hierarchy inheritance** | "Allow read on `/usr`" implies all children |
+| **Mutability vs creation** | Separate controls for writing existing files vs creating new files |
+
+### Network Access Granularity
+
+| Granularity | BubbleWrap | Seatbelt | Landlock | AppContainer |
+|---|---|---|---|---|
+| **All-or-nothing** | ✓ | — | — | — |
+| **Inbound vs outbound** | — | ✓ | ✓ | ✓ |
+| **By port** | — | ✓ | ✓ | ✓ |
+| **By destination host/IP** | — | ✓ | — | — |
+| **By protocol (TCP/UDP)** | — | ✓ | TCP only (so far) | ✓ |
+| **Localhost specifically** | — | ✓ | ✓ | ✓ |
+
+### IPC — OS-Specific but Same Intent
+
+| System | IPC Mechanism Controlled | Policy Expression |
+|---|---|---|
+| BubbleWrap | Unix sockets, shared memory | `--unshare-ipc` (all-or-nothing) |
+| Seatbelt | Mach ports, XPC, Unix sockets | `(allow mach-lookup (global-name "..."))` |
+| Landlock | Abstract Unix sockets, signals | `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET` |
+| AppContainer | COM, RPC, named pipes, ALPC | Capability-based in manifest |
+
+### Privilege Escalation Prevention — Universal
+
+| Mechanism | How It Prevents Escalation |
+|---|---|
+| BubbleWrap | `PR_SET_NO_NEW_PRIVS` — setuid binaries won't elevate |
+| Seatbelt | Deny-by-default + kernel enforcement — no way to load a weaker profile |
+| Landlock | `PR_SET_NO_NEW_PRIVS` + restrictions are additive-only |
+| Seccomp | `PR_SET_NO_NEW_PRIVS` + filters are immutable once loaded and stack |
+| AppContainer | Low integrity level + unique SID |
+| Restricted Tokens | Stripped privileges + deny-only SIDs |
+
+**Universal principle:** the sandbox boundary is monotonically shrinking — once
+restricted, you cannot regain what you lost.
+
+### The Meta-Pattern
+
+Every sandboxing policy answers the same five questions:
+
+```
+1. WHAT RESOURCES?     Files, network, IPC, devices, processes, syscalls
+2. WHICH ONES?         By path, by port, by service name, by syscall number
+3. WHAT OPERATIONS?    Read vs write vs execute vs create vs delete
+4. DEFAULT POSTURE?    Deny-by-default (allowlist) vs allow-by-default (denylist)
+5. CAN IT BE UNDONE?   No. (Always no.)
+```
+
+These five questions describe the *shape* of a single policy. But real-world
+sandboxing involves multiple stakeholders, each contributing constraints at
+different layers. See [§10 Policy Layers](#10-policy-layers) for that orthogonal
+axis.
+
+---
+
+## 7. macOS Seatbelt Profile Language
+
+Profiles are written in an S-expression (Lisp-like) syntax and stored as `.sb` text
+files. Apple ships built-in ones at `/usr/share/sandbox/` (e.g., `sshd.sb`, `mds.sb`,
+`ntpd.sb`). The language itself is undocumented by Apple but well reverse-engineered.
+
+### Basic Structure
+
+```scheme
+(version 1)          ; required — always 1
+(deny default)       ; deny everything not explicitly allowed
+(import "system.sb") ; import Apple's base rules for basic OS functionality
+
+;; then: a series of (allow ...) and (deny ...) rules
+```
+
+### The Rule Grammar
+
+```
+(allow|deny  <operation>  [<filter> ...])
+```
+
+### Operations Reference
+
+| Category | Operations | What It Controls |
+|---|---|---|
+| **Files** | `file-read*`, `file-read-data`, `file-read-metadata` | Reading files |
+| | `file-write*`, `file-write-data`, `file-write-create`, `file-write-unlink` | Writing/creating/deleting files |
+| | `file-ioctl` | ioctl calls on files |
+| **Network** | `network-outbound`, `network-inbound`, `network-bind` | TCP/UDP connections, listening |
+| **Mach IPC** | `mach-lookup`, `mach-register` | XPC/Mach service access |
+| **Process** | `process-fork`, `process-exec`, `process-exec-interpreter` | Spawning processes |
+| **Signals** | `signal` | Sending signals to other processes |
+| **Sysctl** | `sysctl-read`, `sysctl-write` | Reading/writing kernel parameters |
+| **IOKit** | `iokit-open` | Accessing hardware device interfaces |
+| **Preferences** | `user-preference-read`, `user-preference-write` | NSUserDefaults / plist access |
+| **Info** | `process-info-pidinfo`, `process-info-codesignature` | Inspecting other processes |
+| **Generic** | `default` | Catch-all (used with `deny default`) |
+
+### Filter Types
+
+```scheme
+;; Path filters
+(literal "/etc/resolv.conf")              ; exact path
+(subpath "/Users/alice/project")          ; path and everything under it
+(prefix "/usr/lib/")                      ; paths starting with this string
+(regex #"/tmp/myapp-[0-9]+\.log")         ; regex match on path
+
+;; Path construction
+(string-append (param "HOME") "/Documents")  ; runtime parameter expansion
+
+;; Network filters
+(remote ip "*:443")                       ; outbound to any host, port 443
+(local ip "localhost:8080")               ; bind to localhost:8080
+
+;; Mach service filters
+(global-name "com.apple.FontServer")      ; specific Mach service by name
+(global-name-prefix "com.apple.")         ; any Apple service
+
+;; Boolean combinators
+(require-all <filter1> <filter2>)         ; AND
+(require-any <filter1> <filter2>)         ; OR
+(require-not <filter>)                    ; NOT
+```
+
+### Real-World Examples
+
+#### Minimal: Read-Only Access to One Directory
+
+```scheme
+(version 1)
+(deny default)
+(allow file-read* (subpath "/Users/alice/project"))
+```
+
+#### Web-Facing Tool: Network + Limited Files
+
+```scheme
+(version 1)
+(deny default)
+(import "system.sb")
+
+(allow file-read*
+    (subpath "/usr/lib")
+    (subpath "/System/Library/Frameworks"))
+
+(allow file-read*  (subpath "/Users/alice/project"))
+(allow file-write* (subpath "/Users/alice/project/output"))
+
+(allow network-outbound (remote tcp "*:443"))
+(allow network-outbound (literal "/private/var/run/mDNSResponder"))
+
+(allow user-preference-read (preference-domain "com.example.mytool"))
+```
+
+#### Locked-Down Daemon
+
+```scheme
+(version 1)
+(deny default)
+(import "system.sb")
+
+(allow file-read*
+    (literal "/etc/sshd_config")
+    (subpath "/usr/libexec")
+    (literal "/dev/null")
+    (literal "/dev/random")
+    (literal "/dev/urandom"))
+
+(allow network-inbound  (local tcp "*:22"))
+(allow network-outbound (remote tcp))
+
+(allow process-fork)
+(allow process-exec (literal "/usr/libexec/sshd-session"))
+
+(allow mach-lookup
+    (global-name "com.apple.system.logger")
+    (global-name "com.apple.system.notification_center"))
+
+(allow signal (target self))
+```
+
+#### Using `define` for Reusable Macros
+
+```scheme
+(version 1)
+(deny default)
+
+(define (home-subpath path)
+    (subpath (string-append (param "HOME") path)))
+
+(allow file-read*  (home-subpath "/Documents"))
+(allow file-write* (home-subpath "/Downloads"))
+```
+
+### Running a Profile
+
+```sh
+# Run a command under a sandbox profile
+sandbox-exec -f myprofile.sb /usr/bin/my-command --args
+
+# Or inline
+sandbox-exec -p '(version 1)(deny default)(allow file-read* (subpath "/tmp"))' /bin/ls /tmp
+```
+
+### Caveats
+
+- `sandbox-exec` is **deprecated** by Apple (no replacement CLI; App Sandbox
+  entitlements are the supported path)
+- The profile language is **undocumented** — reverse-engineered from shipped `.sb`
+  files and security research
+- Profiles can **break across macOS upgrades** as Apple renames/moves system services
+- No **memory or thread isolation** — Seatbelt controls access to resources, not
+  computation
+
+---
+
+## 8. Proposed Cross-Platform JSON Policy Language
+
+### Design Principles
+
+1. **Deny-by-default always** — no `"default": "allow"` option; you only express what
+   is permitted
+2. **Declarative, not mechanistic** — say *what* access, not *how* to implement it
+3. **Platform-specific escape hatches** — because real-world policies will need them
+4. **Graduated granularity** — simple things should be simple; complex things should
+   be possible
+
+> **Note on policy layers:** This JSON schema represents a *bound deployment
+> policy* — concrete paths, ports, and hosts are already resolved. In the
+> layered model described in [§10](#10-policy-layers), this corresponds to
+> **Layer 2 (Instance Binding)**. The platform overrides section touches on
+> **Layer 7 (Container Enforcement Capabilities)** and should eventually migrate
+> to the backend capability profiles (§11). For the upstream *intent manifest*
+> that code authors write (Layer 1), see
+> [§13 Intent Manifest](#13-intent-manifest). The pipeline is:
+>
+> ```
+> §13 Intent Manifest → bind → §8 Bound Policy → compile → §9 FlatBuffer
+> (Layer 1, portable)          (Layer 2, concrete)         (.sbxp, runtime)
+> ```
+
+### Example Policy
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "my-web-scraper-sandbox",
+  "description": "Sandbox for an untrusted Python web scraper",
+
+  // ─── Filesystem ───────────────────────────────────────────────
+  "filesystem": {
+    // Each rule: a path scope + a set of allowed operations
+    "rules": [
+      {
+        "path": "/usr/lib",
+        "scope": "subtree",          // "exact", "subtree", "prefix", "pattern"
+        "allow": ["read", "execute"]
+      },
+      {
+        "path": "/usr/bin/python3",
+        "scope": "exact",
+        "allow": ["read", "execute"]
+      },
+      {
+        "path": "${WORK_DIR}",
+        "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"]
+      },
+      {
+        "path": "${WORK_DIR}/output",
+        "scope": "subtree",
+        "allow": ["read", "write", "create"]
+      },
+      {
+        "path": "${HOME}/.config/scraper.conf",
+        "scope": "exact",
+        "allow": ["read"]
+      },
+      {
+        "path": "/tmp",
+        "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"],
+        "ephemeral": true
+      }
+    ],
+
+    // Paths to mask (replace with empty/null)
+    "mask": [
+      "${HOME}/.env",
+      "${HOME}/.aws/credentials"
+    ],
+
+    // Synthetic mounts (not backed by host filesystem)
+    "synthetic": {
+      "/dev":  "minimal",
+      "/proc": "sandboxed",
+      "/tmp":  "ephemeral"
+    }
+  },
+
+  // ─── Network ──────────────────────────────────────────────────
+  "network": {
+    // "none" | "full" | "rules"
+    "mode": "rules",
+
+    "rules": [
+      {
+        "direction": "outbound",
+        "action": "connect",
+        "protocol": "tcp",
+        "host": "*",
+        "port": 443
+      },
+      {
+        "direction": "outbound",
+        "action": "connect",
+        "protocol": "tcp",
+        "host": "*",
+        "port": 80
+      },
+      {
+        "direction": "outbound",
+        "action": "connect",
+        "protocol": "udp",
+        "host": "*",
+        "port": 53,
+        "comment": "Allow DNS resolution"
+      }
+    ],
+
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  // ─── Processes ────────────────────────────────────────────────
+  "process": {
+    "allow_fork": true,
+    "allow_exec": [
+      "/usr/bin/python3",
+      "/usr/bin/curl"
+    ],
+    "visibility": "self",
+    "signals": "self",
+    "hostname": "sandbox",
+    "die_with_parent": true
+  },
+
+  // ─── IPC / Services ──────────────────────────────────────────
+  "ipc": {
+    "isolation": "full",
+
+    "services": [
+      {
+        "name": "com.apple.system.logger",
+        "allow": ["lookup"]
+      },
+      {
+        "name": "org.freedesktop.resolve1",
+        "allow": ["call"]
+      }
+    ]
+  },
+
+  // ─── Devices ──────────────────────────────────────────────────
+  "devices": {
+    "allow": []
+  },
+
+  // ─── Resource Limits ──────────────────────────────────────────
+  "resources": {
+    "max_memory_mb": 512,
+    "max_cpu_percent": 50,
+    "max_processes": 10,
+    "max_open_files": 256,
+    "max_wall_time_seconds": 300
+  },
+
+  // ─── Environment ──────────────────────────────────────────────
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "HOME": "/home/sandbox",
+      "LANG": "en_US.UTF-8",
+      "PATH": "/usr/bin:/usr/local/bin"
+    },
+    "pass_through": [
+      "HTTPS_PROXY",
+      "NO_PROXY"
+    ]
+  },
+
+  // ─── Variables ────────────────────────────────────────────────
+  "variables": {
+    "WORK_DIR": "/home/alice/scraper-project",
+    "HOME": "/home/alice"
+  },
+
+  // ─── Platform Overrides ───────────────────────────────────────
+  "platform": {
+    "linux": {
+      "seccomp": {
+        "mode": "allowlist",
+        "syscalls": ["read", "write", "open", "close", "stat", "fstat",
+                     "mmap", "mprotect", "munmap", "brk", "ioctl",
+                     "socket", "connect", "sendto", "recvfrom",
+                     "clone", "execve", "exit_group", "futex",
+                     "getpid", "getuid", "arch_prctl"]
+      },
+      "landlock_abi": 4,
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    },
+    "macos": {
+      "seatbelt_import": ["system.sb"],
+      "extra_rules": [
+        "(allow mach-lookup (global-name-prefix \"com.apple.cfprefsd\"))"
+      ]
+    },
+    "windows": {
+      "integrity_level": "low",
+      "appcontainer": {
+        "capabilities": ["internetClient"],
+        "deny_capabilities": ["privateNetworkClientServer"]
+      }
+    }
+  }
+}
+```
+
+### How Each Section Maps to Backends
+
+#### Filesystem Rules
+
+| Policy JSON | BubbleWrap | Seatbelt | Landlock | AppContainer |
+|---|---|---|---|---|
+| `"allow": ["read"]` | `--ro-bind path path` | `(allow file-read* (subpath path))` | `READ_FILE \| READ_DIR` | Read ACE on container SID |
+| `"allow": ["read","write","create"]` | `--bind path path` | `(allow file-read* file-write* ...)` | `READ_FILE \| WRITE_FILE \| MAKE_REG` | Read+Write ACE |
+| `"scope": "exact"` | `--ro-bind file file` | `(literal path)` | Rule with `O_PATH` on file | ACE on specific file |
+| `"scope": "subtree"` | `--ro-bind dir dir` | `(subpath path)` | `LANDLOCK_RULE_PATH_BENEATH` | ACE with inheritance |
+| `"ephemeral": true` | `--tmpfs path` | N/A (external setup) | N/A (external setup) | Virtualized path |
+| `"mask": [path]` | `--bind /dev/null path` | `(deny file-read* (literal path))` | No rule for path (denied) | Deny ACE |
+
+#### Network Rules
+
+| Policy JSON | BubbleWrap | Seatbelt | Landlock | AppContainer |
+|---|---|---|---|---|
+| `"mode": "none"` | `--unshare-net` | `(deny network*)` | No `NET_*` rules | Remove `internetClient` cap |
+| `"mode": "full"` | `--share-net` | `(allow network*)` | Allow all `NET_*` | Grant all network caps |
+| `outbound/connect/tcp/443` | `--share-net` (all-or-nothing) | `(allow network-outbound (remote tcp "*:443"))` | `NET_CONNECT_TCP` + port=443 | `internetClient` cap |
+
+---
+
+## 9. FlatBuffer Compiled Format
+
+### Why FlatBuffers
+
+The policy is write-once at build/deploy time, read-many at every sandbox launch,
+often on a hot startup path where you don't want JSON parsing overhead, allocations,
+or dependencies. Zero-copy mmap access means the sandbox runtime can validate and
+apply policy without deserializing anything.
+
+| Format | Parse Cost | Random Access | Zero-Copy | Schema Evolution |
+|---|---|---|---|---|
+| **JSON** | High (full parse) | No | No | N/A |
+| **Protobuf** | Medium (decode) | No (sequential) | No | Yes |
+| **Cap'n Proto** | Zero | Yes | Yes | Yes |
+| **FlatBuffers** | Zero | Yes | Yes | Yes |
+
+### The Pipeline
+
+```
+                    Author time                          Deploy/Runtime
+              ┌──────────────────────┐           ┌─────────────────────────┐
+              │                      │           │                         │
+  policy.jsonc│  Human-readable      │  compile  │  policy.sbxp            │
+  (or .yaml)  │  authoring format    ├──────────►│  FlatBuffer binary      │
+              │  with comments,      │           │  - zero-copy mmap       │
+              │  variables, extends  │           │  - validated at compile │
+              │                      │           │  - optionally signed    │
+              └──────────────────────┘           └────────┬────────────────┘
+                                                          │
+                                                     ┌────┴────┐
+                                                     │ Runtime │
+                                                     │ mmap()  │
+                                                     │ verify  │
+                                                     │ apply   │
+                                                     └─────────┘
+```
+
+### FlatBuffer Schema (`sandbox_policy.fbs`)
+
+```flatbuffers
+namespace Sandbox;
+
+// ═══════════════════════════════════════════════════════════════
+// Enums
+// ═══════════════════════════════════════════════════════════════
+
+enum PathScope : byte {
+    Exact = 0,
+    Subtree,
+    Prefix,
+    Pattern
+}
+
+enum FileOps : uint16 (bit_flags) {
+    Read = 0,       // 0x01
+    Write,          // 0x02
+    Execute,        // 0x04
+    Create,         // 0x08
+    Delete,         // 0x10
+    Metadata,       // 0x20
+    Truncate,       // 0x40
+    Ioctl           // 0x80
+}
+
+enum NetDirection : byte {
+    Outbound = 0,
+    Inbound
+}
+
+enum NetAction : byte {
+    Connect = 0,
+    Bind,
+    Any
+}
+
+enum NetProtocol : byte {
+    TCP = 0,
+    UDP,
+    Any
+}
+
+enum NetworkMode : byte {
+    None = 0,
+    Full,
+    Rules
+}
+
+enum ProcessVisibility : byte {
+    Self = 0,
+    Host
+}
+
+enum SignalScope : byte {
+    None = 0,
+    Self,
+    Any
+}
+
+enum IpcIsolation : byte {
+    Full = 0,
+    Shared
+}
+
+enum EnvironmentMode : byte {
+    Clean = 0,
+    Inherit
+}
+
+enum IntegrityLevel : byte {
+    Untrusted = 0,
+    Low,
+    Medium,
+    High
+}
+
+enum SyntheticType : byte {
+    Minimal = 0,
+    Sandboxed,
+    Ephemeral
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Tables
+// ═══════════════════════════════════════════════════════════════
+
+// ─── Filesystem ────────────────────────────────────────────────
+
+table FsRule {
+    path:         string (required);
+    scope:        PathScope = Exact;
+    allowed_ops:  FileOps;
+    ephemeral:    bool = false;
+}
+
+table FsMask {
+    path: string (required);
+}
+
+table SyntheticMount {
+    path: string (required);
+    type: SyntheticType;
+}
+
+table Filesystem {
+    rules:      [FsRule];
+    masks:      [FsMask];
+    synthetics: [SyntheticMount];
+}
+
+// ─── Network ───────────────────────────────────────────────────
+
+table NetRule {
+    direction: NetDirection;
+    action:    NetAction;
+    protocol:  NetProtocol;
+    host:      string;
+    port_min:  uint16 = 0;
+    port_max:  uint16 = 0;
+}
+
+table Network {
+    mode:            NetworkMode = None;
+    rules:           [NetRule];
+    allow_dns:       bool = false;
+    allow_localhost:  bool = false;
+}
+
+// ─── Process ───────────────────────────────────────────────────
+
+table Process {
+    allow_fork:      bool = true;
+    allowed_exec:    [string];
+    visibility:      ProcessVisibility = Self;
+    signals:         SignalScope = Self;
+    hostname:        string;
+    die_with_parent: bool = true;
+}
+
+// ─── IPC ───────────────────────────────────────────────────────
+
+table ServiceRule {
+    name:   string (required);
+    allow:  [string];
+}
+
+table Ipc {
+    isolation: IpcIsolation = Full;
+    services:  [ServiceRule];
+}
+
+// ─── Devices ───────────────────────────────────────────────────
+
+table DeviceRule {
+    path:       string (required);
+    allowed_ops: FileOps;
+}
+
+table Devices {
+    rules: [DeviceRule];
+}
+
+// ─── Resources ─────────────────────────────────────────────────
+
+table Resources {
+    max_memory_mb:         uint32 = 0;
+    max_cpu_percent:       uint16 = 0;
+    max_processes:         uint16 = 0;
+    max_open_files:        uint16 = 0;
+    max_wall_time_seconds: uint32 = 0;
+}
+
+// ─── Environment ───────────────────────────────────────────────
+
+table EnvVar {
+    key:   string (required);
+    value: string (required);
+}
+
+table Environment {
+    mode:         EnvironmentMode = Clean;
+    vars:         [EnvVar];
+    pass_through: [string];
+}
+
+// ─── Platform-Specific ─────────────────────────────────────────
+
+table SeccompConfig {
+    allowlist: bool = true;
+    syscalls:  [string];
+}
+
+table LinuxNamespaces {
+    user:   bool = true;
+    mount:  bool = true;
+    pid:    bool = true;
+    net:    bool = true;
+    ipc:    bool = true;
+    uts:    bool = true;
+    cgroup: bool = true;
+}
+
+table LinuxPlatform {
+    seccomp:           SeccompConfig;
+    landlock_min_abi:  uint8 = 1;
+    namespaces:        LinuxNamespaces;
+}
+
+table MacOSPlatform {
+    seatbelt_imports: [string];
+    extra_rules:      [string];
+}
+
+table WindowsPlatform {
+    integrity_level:    IntegrityLevel = Low;
+    capabilities:       [string];
+    deny_capabilities:  [string];
+}
+
+table Platform {
+    linux:   LinuxPlatform;
+    macos:   MacOSPlatform;
+    windows: WindowsPlatform;
+}
+
+// ─── Signature / Integrity ─────────────────────────────────────
+
+table Signature {
+    algorithm:  string;
+    key_id:     string;
+    value:      [ubyte];
+}
+
+// ─── Root ──────────────────────────────────────────────────────
+
+table Policy {
+    name:           string;
+    description:    string;
+    schema_version: uint16 = 1;
+
+    filesystem:  Filesystem;
+    network:     Network;
+    process:     Process;
+    ipc:         Ipc;
+    devices:     Devices;
+    resources:   Resources;
+    environment: Environment;
+    platform:    Platform;
+
+    signature:   Signature;
+}
+
+root_type Policy;
+
+file_identifier "SBXP";
+file_extension "sbxp";
+```
+
+### Runtime Access Pattern (C++)
+
+```cpp
+// mmap the file — no parsing, no allocation
+auto buf = mmap(fd, PROT_READ, MAP_PRIVATE);
+
+// Verify magic + schema
+auto policy = Sandbox::GetPolicy(buf);
+assert(Sandbox::PolicyBufferHasIdentifier(buf));
+
+// Direct field access — pointer arithmetic, no deserialization
+auto net = policy->network();
+if (net->mode() == Sandbox::NetworkMode_None) {
+    unshare(CLONE_NEWNET);
+} else {
+    for (auto rule : *net->rules()) {
+        // rule->direction(), rule->port_min(), etc.
+    }
+}
+
+// Check signature before trusting
+auto sig = policy->signature();
+verify_ed25519(sig->key_id(), sig->value(), buf, buf_len);
+```
+
+### Size Estimates
+
+| Component | Small Policy | Large Policy (50 FS rules, 20 net rules) |
+|---|---|---|
+| JSON (authoring) | ~3.5 KB | ~15 KB |
+| FlatBuffer (compiled) | ~800 bytes | ~3-4 KB |
+| With Ed25519 signature | ~870 bytes | ~4 KB |
+
+Small enough to embed in an executable, pass over a pipe, or store in an xattr.
+
+### Signature / Trust Model
+
+Since the policy controls what an untrusted process can do, the policy itself must
+be trusted:
+
+```
+  Author → policy.jsonc → compiler → policy.sbxp → sign(key) → policy.sbxp (signed)
+                                                                      │
+  Runtime: mmap → verify(pubkey) → apply                              │
+           │                                                          │
+           └── if verification fails → refuse to launch sandbox ──────┘
+```
+
+### Compile-Time vs Runtime Responsibilities
+
+| Concern | Compiler (JSON → .sbxp) | Runtime (.sbxp → enforcement) |
+|---|---|---|
+| Variable resolution | `${HOME}` → `/home/alice` | Sees only resolved paths |
+| `extends` / inheritance | Flattened into single policy | Sees only final merged result |
+| Schema validation | Full validation + warnings | Quick `Verify()` + magic check |
+| Platform rule checking | "Warning: regex scope not supported on Landlock" | Skips rules marked unsupported |
+| Signature generation | Signs the buffer | Verifies before applying |
+| Path canonicalization | Resolves symlinks, normalizes paths | Trusts paths are canonical |
+
+---
+
+## 10. Policy Layers
+
+The preceding sections describe the *shape* of a sandbox policy — what dimensions
+it covers (§6), what the authoring format looks like (§8), and how it compiles to an
+efficient binary (§9). But they treat policy as a monolithic artifact. In practice,
+**multiple stakeholders at different layers** contribute to the final effective
+policy. This section introduces that orthogonal axis.
+
+### The Seven Layers
+
+```
+                         POLICY INPUTS                    REALIZATION
+                   (what is wanted/allowed)            (what can be delivered)
+              ┌───────────────────────────────┐   ┌──────────────────────────┐
+              │                               │   │                          │
+  Layer 1     │  Code Requirements            │   │                          │
+              │  (resource types)             │   │                          │
+              │         │                     │   │                          │
+  Layer 2     │  Instance Binding             │   │                          │
+              │  (concrete resources)         │   │                          │
+              │         │                     │   │                          │
+  Layer 3     │  User Consent                 │   │                          │
+              │  (what the user allows)       │   │                          │
+              │         │                     │   │                          │
+  Layer 4     │  IT Admin Policy              │   │                          │
+              │  (organizational constraints) │   │                          │
+              │         │                     │   │                          │
+  Layer 5     │  System Policy                │   │                          │
+              │  (OS-level constraints)       │   │                          │
+              │         │                     │   │                          │
+              └─────────┼─────────────────────┘   │                          │
+                        │                         │                          │
+                        ▼                         │                          │
+               Declared/Authorized Policy ───────►│                          │
+                                                  │                          │
+  Layer 6     │                                   │  System Security Promises│
+              │                                   │  (what guarantees hold)  │
+              │                                   │                          │
+  Layer 7     │                                   │  Container Enforcement   │
+              │                                   │  Capabilities            │
+              │                                   │  (what can be enforced)  │
+              │                                   │                          │
+              │                                   └──────────┬───────────────┘
+              │                                              │
+              │                                              ▼
+              │                                    Realized Policy
+              │                                    + Assurance Level
+              └──────────────────────────────────────────────┘
+```
+
+There is a fundamental split between **Layers 1–5** and **Layers 6–7**:
+
+- **Layers 1–5 are normative** — they express what is wanted, consented to, or
+  forbidden. The effective declared policy is the intersection: each layer can only
+  further restrict, never broaden.
+
+- **Layers 6–7 are descriptive** — they express what the system can actually deliver.
+  They do not add permissions or restrictions; they determine whether the declared
+  policy can be faithfully enforced, and with what level of assurance.
+
+### Layer 1: Code Requirements (Resource Types)
+
+What *types* of resources does the code need? This is the most abstract layer — a
+declaration of capabilities the code expects, without specifying concrete instances.
+
+| Example Requirement | What It Means |
+|---|---|
+| "needs filesystem" | The code reads or writes files |
+| "needs network" | The code makes or accepts connections |
+| "needs GPU" | The code uses hardware-accelerated compute |
+| "needs IPC" | The code communicates with other processes |
+| "needs camera" | The code captures video input |
+
+This layer is analogous to Android's `<uses-permission>` declarations, macOS
+entitlements (`com.apple.security.network.client`), or UWP capability declarations
+in `Package.appxmanifest`.
+
+The key property: **Layer 1 does not name specific files, hosts, or devices.** It
+describes the *kinds* of access, not the *instances*.
+
+### Layer 2: Instance Binding (Concrete Resources)
+
+Where abstract requirements meet concrete resources. This is where "needs
+filesystem" becomes "needs read access to `/data/input.csv`" and "needs network"
+becomes "needs to connect to `api.example.com:443`."
+
+| Abstract (Layer 1) | Bound (Layer 2) |
+|---|---|
+| Filesystem access | `/usr/lib` (read), `${WORK_DIR}` (read/write) |
+| Network access | Outbound TCP to `*:443`, DNS on UDP `*:53` |
+| IPC access | Mach lookup `com.apple.system.logger` |
+| Device access | `/dev/dri/renderD128` (GPU) |
+
+Binding can happen in several ways:
+
+- **Statically** — the developer specifies exact paths/hosts in a policy file (this
+  is what the JSON schema in §8 primarily expresses)
+- **Via brokered selection** — the user picks a file or folder through a system
+  dialog, and that choice becomes the binding (e.g., macOS Powerbox, Android
+  `ACTION_OPEN_DOCUMENT`)
+- **Via convention** — the runtime maps abstract requirements to well-known paths
+  (e.g., XDG directories, `%APPDATA%`)
+
+> **Note:** Binding and user consent (Layer 3) are often interleaved in practice.
+> When a user picks a file via a system open-dialog, they are simultaneously
+> binding a concrete resource *and* consenting to its use. The layered model is
+> conceptual, not a strict temporal sequence.
+
+### Layer 3: User Consent (What the User Allows)
+
+The human running the code decides what access they are comfortable granting. This
+layer is the user's opportunity to narrow the policy beyond what the code requests.
+
+| Platform | Consent Mechanism |
+|---|---|
+| **macOS** | TCC dialogs ("App X wants to access your Documents"), Powerbox file picker |
+| **Android** | Runtime permission prompts (camera, location, contacts) |
+| **iOS** | Runtime permission prompts + App Tracking Transparency |
+| **Windows** | UAC prompts, broker-mediated file pickers, privacy settings |
+| **Linux** | XDG portals (file chooser, screen capture), Flatpak permission prompts |
+| **Web** | `navigator.permissions`, `<input type="file">`, getUserMedia prompts |
+
+Key properties:
+
+- The user can **deny** a Layer 1 requirement — the code says "I need camera" but
+  the user says no. The sandbox must handle this gracefully (deny access, not crash).
+- Consent may be **revocable** — the user can change their mind later (unlike sandbox
+  restrictions, which are monotonically shrinking within a session).
+- Consent may be **granular** — "yes to this specific folder, no to the rest of
+  filesystem."
+
+### Layer 4: IT Admin Policy (Organizational Constraints)
+
+Enterprise and organizational policy that constrains what is allowed regardless of
+what the code requests or the user consents to. Defined by **organizational
+authority** — the IT administrator, fleet operator, or MDM profile.
+
+| Platform | Admin Policy Mechanism |
+|---|---|
+| **Windows** | Group Policy (GPO), Intune/MDM, WDAC, AppLocker |
+| **macOS** | MDM profiles (e.g., Jamf), managed TCC overrides, managed App restrictions |
+| **Linux** | Centralized SELinux/AppArmor policy distribution, fleet management tools |
+| **ChromeOS** | Google Admin Console policies |
+
+Examples:
+
+- "No application may access external network endpoints outside `*.corp.example.com`"
+- "Code execution from USB drives is forbidden"
+- "Only signed executables may run"
+
+> **Relationship to Layer 5:** IT admin policy is distinguished from system policy
+> by **who sets it**, not by the enforcement mechanism. An admin may express a
+> constraint through GPO, which is then enforced by WDAC (a system-level mechanism).
+> Layer 4 is the *authority*; Layer 5 is often the *enforcement substrate*.
+
+### Layer 5: System Policy (OS-Level Constraints)
+
+Constraints enforced by the operating system or platform itself, independent of any
+specific application, user, or administrator. These are the platform's own security
+invariants.
+
+| Platform | System Policy Examples |
+|---|---|
+| **macOS** | System Integrity Protection (SIP), Gatekeeper, hardened runtime requirements |
+| **Windows** | Protected Process Light (PPL), kernel-mode code signing (KMCS), Secure Boot |
+| **Linux** | SELinux/AppArmor in enforcing mode (base policy), Secure Boot + IMA, kernel lockdown |
+| **All** | Address space layout randomization (ASLR), W^X enforcement, stack protections |
+
+Key properties:
+
+- System policy applies **universally** — even a root/admin user cannot bypass SIP on
+  macOS without rebooting into recovery mode.
+- It represents the platform's **own security invariants**, not delegated authority.
+- It is the **floor** — nothing below this layer (including admin policy) can
+  weaken it.
+
+#### System Policy Operates on the Bound Policy
+
+System policy is evaluated against the **bound policy (§8)**, not the intent
+manifest (§13). The intent manifest names abstract resources (`"runtime": "python"`,
+`"storage": [{ "class": "workspace" }]`) — there is nothing platform-specific to
+check against. Only after binding resolves these to concrete paths (`/usr/bin/python3`,
+`C:\Sandbox\Workspace`) can the system policy verify that no invariants are
+violated.
+
+```
+Intent → bind → Bound Policy → SYSTEM POLICY CHECK → compile → .sbxp
+                                      ↑
+                              Checks concrete paths,
+                              ports, registry keys,
+                              Mach services
+```
+
+#### System Policy Schema
+
+System policy is a **deny-overlay** — it does not describe a complete sandbox.
+It describes things that are *never allowed regardless of what other layers say*.
+It is inherently platform-specific: the paths, mechanisms (Windows registry,
+macOS Mach services), and dangerous capabilities differ across platforms.
+
+System policy is authored by the **platform team**, not by code authors or
+deployers. It ships with the platform and is updated alongside OS releases.
+
+```jsonc
+// Example: system-policy-windows.jsonc
+{
+  "system_policy_version": "1.0",
+  "platform": "windows",
+  "description": "System-wide invariants for sandboxed workloads on Windows",
+
+  "deny": {
+    "filesystem": [
+      {
+        "path": "C:\\Windows\\System32",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "OS binaries and system DLLs"
+      },
+      {
+        "path": "C:\\Windows\\SysWOW64",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "32-bit system binaries on 64-bit Windows"
+      },
+      {
+        "path": "C:\\Windows\\Boot",
+        "scope": "subtree",
+        "deny_operations": ["read", "write", "create", "delete", "execute"],
+        "reason": "Boot manager — no sandbox access whatsoever"
+      },
+      {
+        "path": "C:\\ProgramData\\Microsoft\\Crypto",
+        "scope": "subtree",
+        "deny_operations": ["read", "write"],
+        "reason": "Machine certificate private keys"
+      }
+    ],
+
+    "registry": [
+      {
+        "key": "HKLM\\SYSTEM",
+        "scope": "subtree",
+        "deny_operations": ["write"],
+        "reason": "System hive — service configuration, driver loading"
+      },
+      {
+        "key": "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",
+        "scope": "subtree",
+        "deny_operations": ["write"],
+        "reason": "Auto-start programs — persistence mechanism"
+      }
+    ],
+
+    "process": {
+      "deny_capabilities": [
+        "SE_DEBUG_PRIVILEGE",
+        "SE_TAKE_OWNERSHIP_PRIVILEGE",
+        "SE_LOAD_DRIVER_PRIVILEGE",
+        "SE_TCB_PRIVILEGE"
+      ],
+      "reason": "Dangerous privileges that could escape the sandbox"
+    }
+  }
+}
+```
+
+```jsonc
+// Example: system-policy-linux.jsonc
+{
+  "system_policy_version": "1.0",
+  "platform": "linux",
+  "description": "System-wide invariants for sandboxed workloads on Linux",
+
+  "deny": {
+    "filesystem": [
+      {
+        "path": "/usr/bin",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "OS binaries"
+      },
+      {
+        "path": "/usr/sbin",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "System administration binaries"
+      },
+      {
+        "path": "/usr/lib",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "Shared libraries"
+      },
+      {
+        "path": "/boot",
+        "scope": "subtree",
+        "deny_operations": ["read", "write", "create", "delete", "execute"],
+        "reason": "Kernel and bootloader"
+      },
+      {
+        "path": "/etc/shadow",
+        "scope": "exact",
+        "deny_operations": ["read", "write"],
+        "reason": "Password hashes"
+      },
+      {
+        "path": "/proc/sysrq-trigger",
+        "scope": "exact",
+        "deny_operations": ["write"],
+        "reason": "Kernel debug interface"
+      }
+    ],
+
+    "network": [
+      {
+        "direction": "inbound",
+        "port_range": [1, 1023],
+        "reason": "Privileged ports — sandboxed workloads may not bind"
+      }
+    ],
+
+    "process": {
+      "deny_capabilities": [
+        "CAP_SYS_ADMIN",
+        "CAP_NET_ADMIN",
+        "CAP_SYS_PTRACE",
+        "CAP_DAC_OVERRIDE",
+        "CAP_SYS_RAWIO"
+      ],
+      "reason": "Dangerous capabilities that could escape the sandbox"
+    }
+  }
+}
+```
+
+```jsonc
+// Example: system-policy-macos.jsonc
+{
+  "system_policy_version": "1.0",
+  "platform": "macos",
+  "description": "System-wide invariants for sandboxed workloads on macOS",
+
+  "deny": {
+    "filesystem": [
+      {
+        "path": "/System",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "System volume — SIP-protected"
+      },
+      {
+        "path": "/usr/bin",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "OS binaries — SIP-protected"
+      },
+      {
+        "path": "/usr/lib",
+        "scope": "subtree",
+        "deny_operations": ["write", "create", "delete"],
+        "reason": "System frameworks and dylibs — SIP-protected"
+      },
+      {
+        "path": "/Library/Keychains",
+        "scope": "subtree",
+        "deny_operations": ["read", "write"],
+        "reason": "System keychain — stored credentials"
+      }
+    ],
+
+    "mach_services": [
+      {
+        "name": "com.apple.security.authtrampoline",
+        "deny_operations": ["lookup"],
+        "reason": "Authorization trampoline — privilege escalation vector"
+      }
+    ]
+  }
+}
+```
+
+#### System Policy Dimensions Are a Superset of Bound Policy Dimensions
+
+The system policy schema must be able to deny things in **dimensions the bound
+policy doesn't express**. The bound policy (§8) has sections for filesystem,
+network, process, IPC, devices, resources, and environment. System policy needs
+these plus platform-specific dimensions:
+
+| Dimension | In Bound Policy (§8)? | In System Policy? | Platform |
+|---|---|---|---|
+| Filesystem paths | ✓ | ✓ | All |
+| Network rules | ✓ | ✓ | All |
+| Process capabilities | ✓ | ✓ | All |
+| IPC / services | ✓ | ✓ | All |
+| Devices | ✓ | ✓ | All |
+| **Registry keys** | ✗ | ✓ | Windows |
+| **Mach services** | ✗ | ✓ | macOS |
+| **Kernel parameters (sysctl)** | ✗ | ✓ | Linux |
+
+This is by design. The bound policy only expresses what is *allowed* — it uses
+deny-by-default. The system policy expresses what is *never allowed* — an
+additional deny-overlay on top of deny-by-default. The system policy can cover
+dimensions that the bound policy doesn't even have a section for, as an extra
+layer of defense.
+
+#### Evaluation: Compile-Time vs Runtime
+
+System policy checks happen at **two points**:
+
+**Compile-time (static check):** When the bound policy is compiled to a
+FlatBuffer, every explicit rule is checked against the system deny list:
+
+```
+for each bound_rule in bound_policy.filesystem.rules:
+  for each deny_rule in system_policy.deny.filesystem:
+    if paths_overlap(bound_rule.path, deny_rule.path):
+      if bound_rule.operations ∩ deny_rule.deny_operations ≠ ∅:
+        REJECT with diagnostic:
+          "Rule grants {operations} on {path}, which system policy
+           forbids: {reason}"
+```
+
+This catches explicit grants — if the bound policy says "write to
+`C:\Windows\System32`," the compiler rejects it immediately.
+
+**Runtime (dynamic check):** Some enforcement mechanisms grant implicit access
+that doesn't appear as explicit rules in the bound policy. For example, an
+AppContainer capability like `registryRead` may grant broad registry read access
+without enumerating specific keys. The bound policy has no registry section — the
+access comes from the AppContainer mechanism, not from an explicit policy rule.
+
+If the system policy says "deny read on `HKLM\SAM`," the compile-time check
+finds nothing to reject (there's no registry rule in the bound policy). The
+runtime must enforce this denial dynamically — the sandbox runtime checks each
+registry access against the system deny list at access time.
+
+```
+Compile-time check:                 Runtime check:
+  ✓ Catches explicit grants           ✓ Catches implicit grants from
+    in the bound policy                  enforcement mechanisms
+  ✗ Cannot see implicit grants        ✗ Per-access overhead
+    from AppContainer capabilities,
+    broad namespace access, etc.
+```
+
+Both checks are necessary. The compile-time check provides fast feedback and
+clear diagnostics. The runtime check provides defense-in-depth against grants
+that are invisible at the policy level.
+
+#### Redundancy with OS Enforcement
+
+Some system policy deny rules are redundant with existing OS enforcement:
+- macOS SIP already prevents writing to `/System` and `/usr/bin`
+- Windows integrity levels already prevent low-integrity processes from writing
+  to `System32`
+- Linux DAC permissions already prevent non-root writes to `/usr/bin`
+
+The system policy makes these protections **explicit in our framework** so that:
+1. The compiler catches violations early with clear diagnostics, rather than
+   letting them fail at runtime with cryptic OS errors
+2. The invariants are documented and auditable in one place
+3. The protection holds even if the underlying OS mechanism is misconfigured
+   (defense-in-depth)
+
+### Layer 6: System Security Promises (What Guarantees Hold)
+
+This layer shifts from *intent* to *capability*. What security guarantees can the
+system actually deliver given its current configuration and kernel version?
+
+| Question | Example |
+|---|---|
+| Is kernel Landlock available? | If no: cannot enforce per-file access rules via Landlock; must fall back to mount-based isolation or fail |
+| What Landlock ABI version? | ABI < 4: no network port rules; ABI < 6: no Unix socket or signal scoping |
+| Does the kernel support user namespaces? | If no: BubbleWrap cannot run unprivileged |
+| Is Secure Boot enabled? | If no: kernel integrity chain is unverified |
+| Is the hypervisor present? | If no: VM-based isolation (Windows Sandbox, Hyper-V containers) is unavailable |
+| Is TCC database intact? | If compromised: user consent records may be untrustworthy |
+
+This layer determines the **assurance level** of the realized policy. A policy may
+be *declared* but only *partially enforceable* on a given system. The sandbox
+runtime must decide how to handle the gap (see [Failure Modes](#failure-modes)
+below).
+
+### Layer 7: Container Enforcement Capabilities (What Can Be Enforced)
+
+Given a specific container technology, what subset of the declared policy can it
+actually implement?
+
+| Declared Policy | BubbleWrap | Seatbelt | Landlock + seccomp | AppContainer |
+|---|---|---|---|---|
+| File read/write rules | ✓ (bind mounts) | ✓ (profile rules) | ✓ (path rules) | ✓ (ACLs on SID) |
+| Per-port network rules | ✗ (all-or-nothing) | ✓ | ✓ (ABI ≥ 4) | ✓ (capabilities) |
+| Syscall filtering | ✗ (needs seccomp) | ✓ (built-in) | ✗ (needs seccomp) | ✗ |
+| Resource limits (CPU/mem) | ✗ (needs cgroups) | ✗ | ✗ (needs cgroups) | ✓ (Job Objects) |
+| Process visibility | ✓ (PID namespace) | ✗ | ✗ | Partial (Job Objects) |
+| IPC isolation | ✓ (IPC namespace) | ✓ (Mach port rules) | Partial (ABI ≥ 6) | ✓ (capability-based) |
+| Device access control | ✓ (bind mounts) | ✓ (IOKit rules) | ✓ (ABI ≥ 5) | ✓ (capabilities) |
+
+No single container technology covers every policy dimension. In practice, backends
+are composed: BubbleWrap + seccomp + cgroups on Linux, AppContainer + Job Objects +
+Restricted Tokens on Windows. Layer 7 determines which composition is needed and
+whether any policy rules cannot be realized at all. See
+[§11 Backend Capability Profiles](#11-backend-capability-profiles) for the formal
+syntax for describing and composing backend capabilities.
+
+### The Evaluation Pipeline
+
+The effective realized policy is computed as follows:
+
+```
+  Layer 1  ─── Code Requirements ──────────────────────┐
+                                                        │
+  Layer 2  ─── Instance Binding ───────────────────┐    │  Normalize each
+                                                   │    │  layer to a common
+  Layer 3  ─── User Consent ──────────────────┐    │    │  policy model
+                                              │    │    │
+  Layer 4  ─── IT Admin Policy ──────────┐    │    │    │
+                                         │    │    │    │
+  Layer 5  ─── System Policy ───────┐    │    │    │    │
+                                    ▼    ▼    ▼    ▼    ▼
+                              ┌─────────────────────────────┐
+                              │  Intersection (greatest      │
+                              │  lower bound of all          │
+                              │  normative inputs)           │
+                              └──────────┬──────────────────┘
+                                         │
+                                   Declared Policy
+                                         │
+                              ┌──────────▼──────────────────┐
+  Layer 6  ─── Security ─────►│  Can the system deliver     │
+               Promises       │  these guarantees?          │
+                              └──────────┬──────────────────┘
+                                         │
+                              ┌──────────▼──────────────────┐
+  Layer 7  ─── Container ────►│  Can the chosen backend     │
+               Capabilities   │  enforce these rules?       │
+                              └──────────┬──────────────────┘
+                                         │
+                                         ▼
+                              ┌─────────────────────────────┐
+                              │  Realized Policy             │
+                              │  + Assurance Level           │
+                              │  + Unenforceable Rule Set    │
+                              └─────────────────────────────┘
+```
+
+The intersection of Layers 1–5 requires **normalization to a common semantic
+model**. These layers do not all speak the same language — Layer 1 deals in resource
+classes, Layer 2 in concrete instances, Layer 3 in consented grants, Layer 5 in
+OS-native controls. If a layer's constraints cannot be translated into the common
+model, evaluation must **fail closed** — deny rather than ignore.
+
+### Failure Modes
+
+When layers disagree or enforcement gaps exist, the system must choose a response.
+The guiding principle is **fail closed** — when in doubt, deny.
+
+| Situation | Response |
+|---|---|
+| **Empty intersection** — no access satisfies all layers | Launch denied. The code's requirements cannot be met within the constraints. |
+| **Backend cannot enforce a rule** — e.g., BubbleWrap cannot do per-port network filtering | Either reject the launch, compose an additional backend that can (BubbleWrap + iptables), or degrade with an explicit reduction in assurance level. Never silently skip the rule. |
+| **System cannot provide promised isolation** — e.g., Landlock unavailable on kernel < 5.13 | Fail closed (refuse to launch) or fall back to a weaker mechanism with a clear assurance downgrade. |
+| **User/admin revokes access after compile time** — e.g., user revokes camera permission mid-session | Re-evaluate at access time. The compiled `.sbxp` policy represents a point-in-time snapshot; dynamic consent must be checked at runtime against the live authority. |
+| **Layer contradiction** — code requires network but admin policy forbids all network | Launch denied. The code cannot function within the constraints. Surface a clear diagnostic to the user explaining which layers conflict. |
+
+### How This Relates to the JSON Schema (§8) and Compiled Format (§9)
+
+The JSON policy schema in §8 is a **bound deployment policy** — it lives primarily
+at Layer 2, with concrete paths, ports, and hosts already specified. The platform
+overrides section touches Layer 7 by acknowledging backend-specific knobs.
+
+In a fully layered system, additional artifacts would exist upstream:
+
+| Layer | Artifact |
+|---|---|
+| Layer 1 | **Requirements manifest** — abstract capability declarations (analogous to Android permissions or UWP capabilities) |
+| Layer 2 | **Bound policy** — the current JSON schema (§8), with variables resolved to concrete values |
+| Layer 3 | **Consent records** — runtime state tracking user decisions (analogous to macOS TCC database or Android permission grants) |
+| Layer 4 | **Admin policy profiles** — organizational constraints distributed via MDM/GPO (consumed as input to the compiler or enforced at launch) |
+| Layer 5 | **System security baseline** — queried at runtime, not expressed as an artifact |
+| Layer 6 | **Capability probe results** — what the system reports it can do (kernel version, LSM availability, hypervisor presence) |
+| Layer 7 | **Backend rule-support matrix** — what the chosen container technology can enforce (drives backend selection and composition) |
+
+The compiled FlatBuffer (`.sbxp`) represents the **realized policy** — the output
+of evaluating all layers. It is what the sandbox runtime consumes: a fully resolved,
+concrete, enforceable rule set with no remaining variables, authorities, or
+capability questions.
+
+---
+
+## 11. Backend Capability Profiles
+
+Section 10 introduced Layer 7 (Container Enforcement Capabilities) as one of the
+layers in the policy evaluation pipeline. This section defines the formal syntax for
+describing what sandboxing mechanisms can enforce, how they compose, and how the
+compiler evaluates a declared policy against them.
+
+### Design Principles
+
+1. **Primitives are the fundamental unit** — every sandboxing mechanism (mount
+   namespaces, seccomp, AppContainer, Job Objects, etc.) is described by its own
+   primitive profile. The policy system reasons exclusively at this level.
+
+2. **Shorthands are sugar, not abstraction** — named backends like "docker" or
+   "appcontainer+job" expand to a list of primitives early in the compiler pipeline.
+   Nothing downstream sees shorthands; there is no special-casing for named backends.
+
+3. **Profiles are structurally parallel to the policy schema** — for every field in
+   a policy rule, there is a corresponding field in the backend profile that says
+   whether (and which values of) that field are supported. This makes evaluation a
+   mechanical structural walk.
+
+4. **Machine-evaluable** — the compiler can determine whether a backend can enforce
+   a given policy without human judgment. No free-text fields participate in
+   evaluation; they exist only for documentation.
+
+### Isolation Models
+
+Every enforcement capability has an associated *isolation model* that describes the
+strength of the enforcement. Three models emerge from the cross-platform analysis in
+§§1–5:
+
+| Model | Meaning | Examples |
+|---|---|---|
+| `different-universe` | The resource is *invisible* — the process literally cannot see it | Mount namespaces, PID namespaces, network namespaces |
+| `guarded-doors` | The resource is *visible* but access is intercepted and checked | SELinux type enforcement, Seatbelt profiles, Landlock rules |
+| `reduced-credentials` | The process's *identity* is weakened so existing ACLs deny access | AppContainer SIDs, restricted tokens, integrity levels |
+
+These models are ordered by strength:
+
+```
+different-universe > guarded-doors > reduced-credentials
+```
+
+The model does not affect enforceability (all three enforce the rule), but it affects
+the **assurance level** — what security properties hold if the mechanism is correctly
+configured.
+
+Additionally, syscall-level filtering uses a fourth model:
+
+| Model | Meaning | Examples |
+|---|---|---|
+| `kernel-filter` | An in-kernel program inspects each syscall and decides allow/deny | Seccomp-BPF |
+
+### Primitive Profile Schema
+
+A primitive profile describes what a single sandboxing mechanism can enforce. Its
+structure mirrors the policy schema from §8 field-by-field.
+
+```jsonc
+{
+  // ─── Identity ────────────────────────────────────────────────
+  "primitive": "appcontainer",
+  "description": "Windows AppContainer — deny-by-default process isolation via unique SID",
+  "platform": "windows",           // "linux" | "macos" | "windows"
+
+  // ─── Prerequisites ──────────────────────────────────────────
+  // What the host system must provide for this primitive to function.
+  "prerequisites": {
+    "min_os": "10.0.17763",         // Windows-style version
+    "min_kernel": null,             // Linux kernel version (null = N/A)
+    "kernel_config": [],            // Required CONFIG_* options
+    "runtime": null                 // Required userspace runtime
+  },
+
+  // ─── Mutual Exclusions ──────────────────────────────────────
+  // Primitives that cannot be composed with this one.
+  "exclusive_with": [],
+
+  // ─── Enforcement Capabilities ───────────────────────────────
+  // Each key mirrors a section of the policy schema (§8).
+  // Only dimensions this primitive can enforce are listed.
+  // Absent dimensions are implicitly unsupported.
+  "enforcement": {
+
+    "filesystem": {
+      "supported": true,
+      "model": "reduced-credentials",
+
+      // Mirrors PathScope enum in the policy schema
+      "supported_scopes": ["exact", "subtree"],
+
+      // Mirrors FileOps bit-flags in the policy schema
+      "supported_operations": ["read", "write", "execute", "create", "delete"],
+
+      // Mirrors optional fields on FsRule
+      "supports_ephemeral": false,
+      "supports_mask": true,
+      "supported_synthetic_types": []
+    },
+
+    "network": {
+      "supported": true,
+      "model": "reduced-credentials",
+
+      // Mirrors NetworkMode enum
+      "supported_modes": ["none", "full"],
+      // ↑ "rules" NOT listed — cannot do per-rule network filtering
+
+      // Only meaningful when "rules" is in supported_modes.
+      // Mirrors fields on NetRule.
+      "rule_capabilities": {
+        "direction":         true,
+        "per_port":          false,
+        "port_ranges":       false,
+        "per_host":          false,
+        "per_protocol":      [],
+        "localhost_control": true
+      },
+
+      "supports_allow_dns": false
+    },
+
+    // syscalls: not listed → AppContainer cannot filter syscalls
+
+    "process": {
+      "supported": true,
+      "model": "reduced-credentials",
+      // Each field mirrors a field in the Process table
+      "fork_control":          false,
+      "exec_allowlist":        false,
+      "visibility_isolation":  false,
+      "signal_control":        false,
+      "hostname_control":      false,
+      "die_with_parent":       false
+    },
+
+    "ipc": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "full_isolation": true,
+      "service_rules":  true
+    },
+
+    "devices": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "per_device":           false,  // capability-level, not per-device-path
+      "supported_operations": ["read", "write"]
+    },
+
+    // resources: not listed → AppContainer has no resource limiting
+
+    "environment": {
+      "supported": true,
+      "clean_mode":   true,
+      "inherit_mode": true,
+      "set_vars":     true,
+      "pass_through": true
+    }
+  }
+}
+```
+
+### Example Primitive Profiles
+
+#### Linux: Mount Namespace
+
+```jsonc
+{
+  "primitive": "linux-mount-namespace",
+  "description": "Filesystem isolation via mount namespace — process sees a custom filesystem tree",
+  "platform": "linux",
+  "prerequisites": {
+    "min_kernel": "3.8",
+    "kernel_config": ["CONFIG_NAMESPACES", "CONFIG_USER_NS"]
+  },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "filesystem": {
+      "supported": true,
+      "model": "different-universe",
+      "supported_scopes": ["exact", "subtree"],
+      "supported_operations": ["read", "write", "execute", "create", "delete"],
+      "supports_ephemeral": true,
+      "supports_mask": true,
+      "supported_synthetic_types": ["minimal", "sandboxed", "ephemeral"]
+    }
+  }
+}
+```
+
+#### Linux: Seccomp-BPF
+
+```jsonc
+{
+  "primitive": "seccomp-bpf",
+  "description": "Syscall filtering via in-kernel BPF program",
+  "platform": "linux",
+  "prerequisites": {
+    "min_kernel": "3.17",
+    "kernel_config": ["CONFIG_SECCOMP", "CONFIG_SECCOMP_FILTER"]
+  },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "syscalls": {
+      "supported": true,
+      "model": "kernel-filter",
+      "supported_modes": ["allowlist", "denylist"],
+      "per_argument_filtering": true
+    }
+  }
+}
+```
+
+#### Linux: Network Namespace
+
+```jsonc
+{
+  "primitive": "linux-net-namespace",
+  "description": "Network isolation via network namespace — process gets a separate network stack",
+  "platform": "linux",
+  "prerequisites": {
+    "min_kernel": "2.6.29",
+    "kernel_config": ["CONFIG_NET_NS"]
+  },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "network": {
+      "supported": true,
+      "model": "different-universe",
+      "supported_modes": ["none", "full"],
+      // All-or-nothing: full isolation or shared host network.
+      // Per-port/host rules require composition with iptables.
+      "rule_capabilities": {
+        "direction": false,  "per_port": false,
+        "port_ranges": false, "per_host": false,
+        "per_protocol": [],  "localhost_control": true
+      },
+      "supports_allow_dns": false
+    }
+  }
+}
+```
+
+#### Linux: iptables (composes with net namespace for per-rule filtering)
+
+```jsonc
+{
+  "primitive": "iptables",
+  "description": "Packet filtering via iptables/nftables — per-port/host/protocol network rules",
+  "platform": "linux",
+  "prerequisites": {
+    "runtime": "iptables >= 1.8 or nftables >= 0.9"
+  },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "network": {
+      "supported": true,
+      "model": "guarded-doors",
+      "supported_modes": ["rules"],
+      "rule_capabilities": {
+        "direction":         true,
+        "per_port":          true,
+        "port_ranges":       true,
+        "per_host":          true,
+        "per_protocol":      ["tcp", "udp"],
+        "localhost_control": true
+      },
+      "supports_allow_dns": true,
+
+      // This primitive's enforcement is stronger when composed
+      // with a network namespace (rules apply to an isolated stack
+      // rather than the host stack).
+      "enhanced_by": ["linux-net-namespace"]
+    }
+  }
+}
+```
+
+#### Linux: Landlock
+
+```jsonc
+{
+  "primitive": "landlock",
+  "description": "Process self-restriction for filesystem and network access via Landlock LSM",
+  "platform": "linux",
+  "prerequisites": {
+    "min_kernel": "5.13",
+    "kernel_config": ["CONFIG_SECURITY_LANDLOCK"]
+  },
+  "exclusive_with": [],
+
+  // Landlock capabilities depend on ABI version.
+  // This profile represents ABI v4 (kernel 6.7+).
+  "abi_version": 4,
+
+  "enforcement": {
+    "filesystem": {
+      "supported": true,
+      "model": "guarded-doors",
+      "supported_scopes": ["exact", "subtree"],
+      "supported_operations": ["read", "write", "execute", "create", "delete",
+                                "truncate"],
+      "supports_ephemeral": false,
+      "supports_mask": false,
+      "supported_synthetic_types": []
+    },
+    "network": {
+      "supported": true,
+      "model": "guarded-doors",
+      "supported_modes": ["rules"],
+      "rule_capabilities": {
+        "direction":         true,
+        "per_port":          true,
+        "port_ranges":       false,
+        "per_host":          false,
+        "per_protocol":      ["tcp"],
+        "localhost_control": true
+      },
+      "supports_allow_dns": false
+    }
+  }
+}
+```
+
+#### Linux: SELinux (Targeted Policy)
+
+```jsonc
+{
+  "primitive": "selinux-targeted",
+  "description": "Mandatory access control via SELinux targeted policy — label-based type enforcement",
+  "platform": "linux",
+  "prerequisites": {
+    "min_kernel": "2.6.0",
+    "kernel_config": ["CONFIG_SECURITY_SELINUX"],
+    "runtime": "SELinux in enforcing mode with targeted policy loaded"
+  },
+  "exclusive_with": ["apparmor"],
+
+  "enforcement": {
+    "filesystem": {
+      "supported": true,
+      "model": "guarded-doors",
+      "supported_scopes": ["subtree"],
+      // SELinux operates on types, not paths — "subtree" is the closest
+      // analog since all files with a given type share access rules.
+      "supported_operations": ["read", "write", "execute", "create", "delete",
+                                "metadata", "ioctl"],
+      "supports_ephemeral": false,
+      "supports_mask": false,
+      "supported_synthetic_types": []
+    },
+    "network": {
+      "supported": true,
+      "model": "guarded-doors",
+      "supported_modes": ["rules"],
+      "rule_capabilities": {
+        "direction":         true,
+        "per_port":          true,   // via port type labels
+        "port_ranges":       false,
+        "per_host":          false,  // no host-level granularity
+        "per_protocol":      ["tcp", "udp"],
+        "localhost_control": false
+      },
+      "supports_allow_dns": false
+    },
+    "process": {
+      "supported": true,
+      "model": "guarded-doors",
+      "fork_control":          true,  // domain transitions control exec
+      "exec_allowlist":        true,  // entrypoint rules
+      "visibility_isolation":  false, // no PID namespace
+      "signal_control":        true,  // inter-domain signal rules
+      "hostname_control":      false,
+      "die_with_parent":       false
+    },
+    "ipc": {
+      "supported": true,
+      "model": "guarded-doors",
+      "full_isolation": false,
+      "service_rules":  true   // type enforcement on IPC objects
+    },
+    "devices": {
+      "supported": true,
+      "model": "guarded-doors",
+      "per_device":           true,
+      "supported_operations": ["read", "write", "ioctl"]
+    }
+  }
+}
+```
+
+#### Windows: Job Object
+
+```jsonc
+{
+  "primitive": "job-object",
+  "description": "Windows Job Object — resource limits, process grouping, and termination control",
+  "platform": "windows",
+  "prerequisites": { "min_os": "6.1" },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "process": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "fork_control":          false,
+      "exec_allowlist":        false,
+      "visibility_isolation":  true,
+      "signal_control":        false,
+      "hostname_control":      false,
+      "die_with_parent":       true
+    },
+    "resources": {
+      "supported": true,
+      "memory_limit":        true,
+      "cpu_limit":           true,
+      "process_count_limit": true,
+      "open_files_limit":    false,
+      "wall_time_limit":     true
+    }
+  }
+}
+```
+
+#### Windows: Restricted Token
+
+```jsonc
+{
+  "primitive": "restricted-token",
+  "description": "Windows restricted token — strip SIDs and privileges from process token",
+  "platform": "windows",
+  "prerequisites": { "min_os": "5.1" },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "filesystem": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "supported_scopes": ["exact", "subtree"],
+      "supported_operations": ["read", "write", "execute"],
+      "supports_ephemeral": false,
+      "supports_mask": false,
+      "supported_synthetic_types": []
+    },
+    "ipc": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "full_isolation": false,
+      "service_rules":  false
+    }
+  }
+}
+```
+
+#### Windows: Integrity Level
+
+```jsonc
+{
+  "primitive": "integrity-level",
+  "description": "Windows integrity levels — prevent writes to higher-integrity objects",
+  "platform": "windows",
+  "prerequisites": { "min_os": "6.0" },
+  "exclusive_with": [],
+
+  "enforcement": {
+    "filesystem": {
+      "supported": true,
+      "model": "reduced-credentials",
+      "supported_scopes": ["subtree"],
+      // Only controls write access — low-integrity processes can read
+      // anything DAC allows, but cannot write to medium/high objects.
+      "supported_operations": ["write"],
+      "supports_ephemeral": false,
+      "supports_mask": false,
+      "supported_synthetic_types": []
+    }
+  }
+}
+```
+
+### Composition
+
+No single primitive covers every policy dimension. Real sandboxes are compositions
+of multiple primitives. The policy system composes primitive profiles using
+well-defined merge semantics.
+
+#### Composition Rules
+
+```
+compose(primitives[]) → ComposedProfile:
+
+  1. CONFLICTS    Check exclusive_with — error if any two primitives conflict
+  2. PREREQS      Union of all prerequisites
+  3. PER-DIM      For each policy dimension:
+     a. supported          = OR   across all primitives
+     b. model              = MAX  across supporting primitives
+     c. supported_scopes   = UNION
+     d. supported_ops      = UNION
+     e. boolean fields     = OR   (if any primitive supports it, composition does)
+     f. per_protocol       = UNION
+     g. supported_modes    = UNION
+  4. RESULT       Return composed profile + prerequisite list
+```
+
+The model ordering for the MAX operation:
+
+```
+different-universe > guarded-doors > reduced-credentials
+```
+
+When multiple primitives contribute to the same dimension, the composed model
+reflects the strongest contributor. For example, composing mount namespaces
+(`different-universe`) with Landlock (`guarded-doors`) for filesystem produces a
+composed model of `different-universe` — the namespace isolation is the dominant
+property.
+
+#### Example: Docker Default Composition
+
+```jsonc
+{
+  "backend": "docker-default",
+  "compose": [
+    "linux-mount-namespace",
+    "linux-pid-namespace",
+    "linux-net-namespace",
+    "linux-ipc-namespace",
+    "linux-uts-namespace",
+    "seccomp-bpf",
+    "iptables",
+    "cgroups-v2"
+  ],
+  "description": "Standard Docker container isolation"
+}
+```
+
+The compiler expands this shorthand, loads each primitive profile, checks for
+conflicts, and computes the composed capability profile:
+
+| Dimension | Contributing Primitives | Composed Model | Key Capabilities |
+|---|---|---|---|
+| Filesystem | mount-namespace | different-universe | exact, subtree; read/write/execute/create/delete; ephemeral; mask; synthetics |
+| Network | net-namespace + iptables | different-universe | none/full/rules; per-port; per-host; per-protocol |
+| Syscalls | seccomp-bpf | kernel-filter | allowlist/denylist; per-argument filtering |
+| Process | pid-namespace | different-universe | visibility isolation, die-with-parent |
+| IPC | ipc-namespace | different-universe | full isolation |
+| Resources | cgroups-v2 | — | memory, cpu, process count, open files |
+| Environment | uts-namespace | different-universe | hostname control |
+
+#### Example: Windows AppContainer Composition
+
+```jsonc
+{
+  "backend": "appcontainer-sandbox",
+  "compose": [
+    "appcontainer",
+    "job-object",
+    "integrity-level"
+  ],
+  "description": "AppContainer with Job Object resource limits and low integrity level"
+}
+```
+
+| Dimension | Contributing Primitives | Composed Model | Key Capabilities |
+|---|---|---|---|
+| Filesystem | appcontainer + integrity-level | reduced-credentials | exact, subtree; read/write/execute/create/delete |
+| Network | appcontainer | reduced-credentials | none/full; localhost control |
+| Process | job-object | reduced-credentials | visibility isolation, die-with-parent |
+| IPC | appcontainer | reduced-credentials | full isolation, service rules |
+| Devices | appcontainer | reduced-credentials | read, write |
+| Resources | job-object | — | memory, cpu, process count, wall time |
+
+#### Example: Chromium Renderer on Windows
+
+```jsonc
+{
+  "backend": "chromium-renderer-win",
+  "compose": [
+    "restricted-token",
+    "integrity-level",
+    "job-object",
+    "desktop-isolation"
+  ],
+  "description": "Chromium-style renderer sandbox on Windows"
+}
+```
+
+### The Compiler Pipeline
+
+Shorthands are expanded at the start of the pipeline. Everything downstream sees
+only primitives.
+
+```
+  policy.jsonc + backend ref ("docker-default")
+         │
+         ▼
+  ┌───────────────┐
+  │ Expand         │  "docker-default"
+  │ shorthand      │    → [mount-ns, pid-ns, net-ns, ipc-ns,
+  │                │       uts-ns, seccomp, iptables, cgroups-v2]
+  └───────┬───────┘
+          ▼
+  ┌───────────────┐
+  │ Load           │  Read each primitive profile from the profile library
+  │ primitives     │  Check exclusive_with constraints
+  │                │  Collect union of prerequisites
+  └───────┬───────┘
+          ▼
+  ┌───────────────┐
+  │ Compose        │  Union scopes/ops/modes, MAX model, OR booleans
+  │                │  Produce composed capability profile
+  └───────┬───────┘
+          ▼
+  ┌───────────────┐
+  │ Evaluate       │  Walk policy rules against composed capabilities
+  │ policy         │  For each rule, check every field against the profile
+  └───────┬───────┘
+          ▼
+  ┌───────────────┐
+  │ Result         │  Enforceable / not-enforceable
+  │                │  Per-rule diagnostics
+  │                │  Assurance level per dimension
+  └───────────────┘
+```
+
+### Policy Evaluation Algorithm
+
+The compiler evaluates a declared policy against a composed (or single-primitive)
+backend profile by walking each policy section and checking that every rule field is
+supported.
+
+```
+evaluate(policy, composed_profile) → EvaluationResult:
+
+  failures = []
+
+  // ─── Filesystem ─────────────────────────────────────────────
+  if policy.filesystem has rules:
+    if not composed.enforcement.filesystem.supported:
+      FAIL "Backend does not support filesystem enforcement"
+    for each rule in policy.filesystem.rules:
+      if rule.scope NOT IN composed...supported_scopes:
+        FAIL "Scope '{rule.scope}' not supported"
+      if rule.allowed_ops ⊄ composed...supported_operations:
+        FAIL "Operations {difference} not supported"
+      if rule.ephemeral AND NOT composed...supports_ephemeral:
+        FAIL "Ephemeral mounts not supported"
+
+  if policy.filesystem has masks:
+    if NOT composed...supports_mask:
+      FAIL "Path masking not supported"
+
+  // ─── Network ────────────────────────────────────────────────
+  if policy.network.mode NOT IN composed...supported_modes:
+    FAIL "Network mode '{policy.network.mode}' not supported"
+  if policy.network.mode == "rules":
+    for each rule in policy.network.rules:
+      if rule.port specified AND NOT composed...per_port:
+        FAIL "Per-port network rules not supported"
+      if rule.host != "*" AND NOT composed...per_host:
+        FAIL "Per-host network rules not supported"
+      if rule.protocol NOT IN composed...per_protocol:
+        FAIL "Protocol '{rule.protocol}' filtering not supported"
+
+  // ─── Syscalls ───────────────────────────────────────────────
+  if policy has syscall rules:
+    if not composed.enforcement.syscalls.supported:
+      FAIL "Syscall filtering not supported"
+
+  // ─── Process ────────────────────────────────────────────────
+  if policy.process.visibility == "self"
+     AND NOT composed...visibility_isolation:
+    FAIL "Process visibility isolation not supported"
+  if policy.process.allowed_exec is non-empty
+     AND NOT composed...exec_allowlist:
+    FAIL "Exec allowlisting not supported"
+  // ... same pattern for fork_control, signal_control, etc.
+
+  // ─── IPC ────────────────────────────────────────────────────
+  if policy.ipc.services is non-empty
+     AND NOT composed...service_rules:
+    FAIL "Per-service IPC rules not supported"
+
+  // ─── Resources ──────────────────────────────────────────────
+  if policy.resources.max_wall_time_seconds > 0
+     AND NOT composed...wall_time_limit:
+    FAIL "Wall-time limits not supported"
+  // ... same pattern for each resource field
+
+  return EvaluationResult {
+    enforceable: failures is empty,
+    failures: failures,
+    assurance: { per-dimension model from composed profile }
+  }
+```
+
+### Evaluation Result Format
+
+The compiler produces a structured result:
+
+```jsonc
+{
+  // Overall verdict
+  "enforceable": false,
+
+  // Per-rule failures with actionable diagnostics
+  "failures": [
+    {
+      "dimension": "network",
+      "field": "rule_capabilities.per_host",
+      "rule_index": 2,
+      "reason": "Backend does not support per-host filtering",
+      "policy_value": "api.example.com",
+      "suggestion": "Use host '*' or choose a backend that supports per-host rules"
+    },
+    {
+      "dimension": "resources",
+      "field": "wall_time_limit",
+      "reason": "Backend does not support wall-time limits",
+      "policy_value": 300
+    }
+  ],
+
+  // Assurance level per dimension (for enforceable rules)
+  "assurance": {
+    "filesystem": "different-universe",
+    "network":    "different-universe",
+    "process":    "different-universe",
+    "syscalls":   "kernel-filter",
+    "ipc":        "different-universe",
+    "resources":  null
+  },
+
+  // Prerequisites the host must satisfy
+  "prerequisites": {
+    "min_kernel": "5.13",
+    "kernel_config": ["CONFIG_NAMESPACES", "CONFIG_SECCOMP", "CONFIG_CGROUPS"],
+    "runtime": "containerd >= 1.6"
+  }
+}
+```
+
+### Assurance Requirements
+
+A policy author may optionally require a minimum assurance level per dimension. This
+goes beyond enforceability ("can the rule be applied?") to assurance ("how strongly
+is it enforced?"):
+
+```jsonc
+// In the policy (new optional top-level field)
+"assurance_requirements": {
+  "filesystem": "different-universe",
+  "network":    "different-universe"
+}
+```
+
+The compiler checks: does the composed profile's model for each dimension meet or
+exceed the required level? Using the ordering:
+
+```
+different-universe > guarded-doors > reduced-credentials
+```
+
+For example, a policy requiring `"filesystem": "different-universe"` would pass
+against a Docker backend (mount namespace) but fail against an AppContainer backend
+(reduced-credentials), even though both can enforce filesystem rules.
+
+### Backend Auto-Selection
+
+Given a policy and a library of available primitives, the compiler can search for
+the minimum composition that enforces all rules:
+
+```
+auto_select(policy, available_primitives[]) → Composition:
+
+  Find smallest subset S ⊆ available_primitives such that:
+    1. compose(S) can enforce all rules in policy
+    2. No exclusive_with violations exist within S
+    3. All prerequisites in compose(S) are satisfiable on the target system
+    4. Assurance requirements (if any) are met
+
+  If multiple minimal sets exist, prefer:
+    a. Fewer primitives (simpler composition)
+    b. Stronger assurance models
+    c. Fewer prerequisites
+```
+
+This is a set-cover problem — NP-hard in the general case but tractable in practice
+because the number of available primitives per platform is small (typically 10–15).
+
+---
+
+## 12. Container Lifecycle and Workload Cycling
+
+### The Problem: Setup Cost
+
+The standard container lifecycle assumes containers are cheap to create and
+destroy. For a Linux process in a pre-built namespace, this is roughly true —
+setup is milliseconds. But when the "container" is a Hyper-V micro-VM, a Windows
+Session with desktop initialization, or any environment requiring OS boot and
+runtime library loading, setup can be seconds to tens of seconds.
+
+| Container Type | Approximate Setup Cost | Teardown Cost |
+|---|---|---|
+| Linux process + namespaces | ~10–50 ms | ~1 ms |
+| Linux process + seccomp + Landlock | ~5–20 ms | ~1 ms |
+| Docker container (cached image) | ~200–500 ms | ~100 ms |
+| gVisor / Firecracker micro-VM | ~125–500 ms | ~50 ms |
+| Windows AppContainer process | ~50–200 ms | ~10 ms |
+| Windows Session (new logon session) | ~1–5 s | ~500 ms |
+| Hyper-V micro-VM (Windows) | ~2–10 s | ~1 s |
+| Full VM (boot + OS init) | ~10–60 s | ~5 s |
+
+If an agent invokes a Python sandbox 50 times in a session, paying 5 seconds of
+VM boot per invocation is prohibitive. The solution is to separate the
+**container lifecycle** from the **workload lifecycle**.
+
+### Two Lifecycles
+
+```
+CONTAINER LIFECYCLE (expensive, done once):
+
+  Creating ──► Initializing ──► Ready ─────────────────────► Draining ──► Stopped
+                                  │         ▲                    ▲
+                                  │         │                    │
+                                  ▼         │                    │
+                             ┌────────────────────┐              │
+                             │  WORKLOAD CYCLE    │              │
+                             │  (cheap, repeated) │              │
+                             │                    │              │
+                             │  Bind policy       │              │
+                             │  Mount workspace   │              │
+                             │  Execute           │              │
+                             │  Collect result    │              │
+                             │  Reset state ──────┘              │
+                             │                                   │
+                             │  (no more workloads) ─────────────┘
+                             └────────────────────┘
+```
+
+The container reaches **Ready** once — VM booted, OS initialized, runtime
+libraries loaded, sandbox primitives configured. It then serves multiple
+workloads, each with its own policy binding, workspace, and execution. Between
+workloads, state is reset but the expensive infrastructure stays warm.
+
+### What Happens at Each Phase
+
+#### Container Setup (once, expensive)
+
+| Phase | What Happens | Examples |
+|---|---|---|
+| **Creating** | Allocate resources, pull/verify image, create security boundary | Boot VM, create AppContainer SID, create namespaces |
+| **Initializing** | Load runtime, install immutable security filters, configure invariant policy | Load Python interpreter, install seccomp filter, set up mount tree, apply base Landlock ruleset |
+| **Ready** | Container is warm and waiting for workloads | VM idle, process waiting on IPC channel |
+
+#### Per-Workload Cycle (many times, cheap)
+
+| Phase | What Happens | Examples |
+|---|---|---|
+| **Bind policy** | Apply workload-specific policy that further restricts within the base | Mount workload workspace, set environment variables, add Landlock rules for specific paths |
+| **Mount workspace** | Make workload-specific files available to the container | Bind-mount input directory, overlay FS for writable workspace |
+| **Execute** | Run the workload (script, tool invocation, code execution) | `python3 /workspace/script.py` |
+| **Collect result** | Retrieve output, capture exit code, apply flow labels | Read stdout/files from workspace, label output with integrity tags |
+| **Reset state** | Clean up workload side effects without tearing down the container | Discard overlay upper layer, unmount workspace, terminate workload process, clear environment |
+
+### Base Policy vs Workload Policy
+
+This lifecycle split implies a **two-tier policy model**. The container carries
+a *base policy* that is fixed at creation time (establishing the security
+boundary). Each workload carries a *workload policy* that further restricts
+within that base.
+
+The monotonic invariant holds: the workload policy can only restrict, never
+expand the base policy.
+
+```
+  Base Policy (fixed at container creation)
+  ┌──────────────────────────────────────────────────────┐
+  │                                                      │
+  │  • Syscall filter (immutable once loaded)            │
+  │  • Trust tier ceiling                                │
+  │  • Maximum resource limits                           │
+  │  • Network posture (none / full / rules ceiling)     │
+  │  • Invariant filesystem mounts (read-only system     │
+  │    paths, runtime libraries)                         │
+  │  • Namespace configuration                           │
+  │  • Integrity level / AppContainer SID                │
+  │                                                      │
+  │   ┌────────────────────────────────────────────────┐ │
+  │   │  Workload Policy A  (further restricts base)   │ │
+  │   │                                                │ │
+  │   │  • Specific workspace paths (r/w)              │ │
+  │   │  • Specific network endpoints (if base allows) │ │
+  │   │  • Environment variables                       │ │
+  │   │  • Wall-time limit for this execution          │ │
+  │   │  • Per-workload resource budget                │ │
+  │   └────────────────────────────────────────────────┘ │
+  │                                                      │
+  │   ┌────────────────────────────────────────────────┐ │
+  │   │  Workload Policy B  (different restrictions)   │ │
+  │   │                                                │ │
+  │   │  • Different workspace                         │ │
+  │   │  • Different network endpoints                 │ │
+  │   │  • Different wall-time limit                   │ │
+  │   └────────────────────────────────────────────────┘ │
+  │                                                      │
+  └──────────────────────────────────────────────────────┘
+```
+
+#### Example: Base Policy (JSON)
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "python-sandbox-base",
+  "description": "Base policy for a warm Python execution sandbox",
+
+  "filesystem": {
+    "rules": [
+      // Immutable system paths — available to all workloads
+      { "path": "/usr/lib",        "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/bin/python3","scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/python3","scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",           "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                       "ephemeral": true }
+    ],
+    "synthetic": { "/dev": "minimal", "/proc": "sandboxed" }
+  },
+
+  "network": { "mode": "none" },
+
+  "process": {
+    "allow_fork": true,
+    "allow_exec": ["/usr/bin/python3"],
+    "visibility": "self",
+    "die_with_parent": true
+  },
+
+  "resources": {
+    "max_memory_mb": 512,
+    "max_cpu_percent": 50,
+    "max_processes": 10,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "HOME": "/home/sandbox",
+      "LANG": "en_US.UTF-8",
+      "PATH": "/usr/bin:/usr/local/bin"
+    }
+  }
+}
+```
+
+#### Example: Workload Policy (JSON)
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "data-analysis-workload",
+  "description": "Run a specific data analysis script",
+
+  // Only fields that add restrictions or bind concrete resources.
+  // Cannot grant anything the base policy doesn't allow.
+
+  "filesystem": {
+    "rules": [
+      // Workload-specific workspace — mounted fresh, discarded after
+      { "path": "/workspace",     "scope": "subtree",
+        "allow": ["read", "write", "create"] }
+    ]
+  },
+
+  "environment": {
+    "set": {
+      "SCRIPT_INPUT":  "/workspace/input.json",
+      "SCRIPT_OUTPUT": "/workspace/output.json"
+    }
+  },
+
+  "resources": {
+    // Tighter than base — this workload gets 30s, not unlimited
+    "max_wall_time_seconds": 30,
+    // Memory budget for this workload (must be ≤ base)
+    "max_memory_mb": 256
+  }
+}
+```
+
+### State Reset Between Workloads
+
+If a container runs workload A and then workload B, workload A's side effects
+must not leak to workload B. This is both a correctness requirement (workload B
+should see a clean environment) and a security requirement (workload A's data
+must not be accessible to workload B).
+
+| Concern | What Can Leak | Reset Mechanism |
+|---|---|---|
+| **Filesystem** | Written files, modified files | Discard overlay upper layer; or unmount/remount tmpfs |
+| **Environment** | Environment variables set by the workload | Process termination (env dies with process) |
+| **Memory** | Heap data, stack data, mmap'd regions | Process termination (kernel reclaims all) |
+| **Network** | Open TCP connections, DNS cache, socket state | Process termination (kernel closes fds); namespace stays |
+| **IPC** | Shared memory segments, semaphores, message queues | IPC namespace cleanup or explicit `ipcrm` |
+| **Temp files** | `/tmp` contents | Unmount/remount tmpfs; or overlay discard |
+| **Flow labels** | Taint from workload A's data | Reset process secrecy/integrity labels to container baseline |
+| **Kernel state** | Cached file metadata, dentry cache | Generally acceptable (metadata, not content) |
+
+The cleanest model: the container provides the *execution environment* (the VM,
+the namespace set, the security boundary), but each workload runs as a **new
+process** within that environment. Process death gives natural cleanup for
+memory, file descriptors, connections, and environment. Filesystem cleanup via
+overlay discard handles persistent state.
+
+```
+Container (warm, long-lived)
+┌──────────────────────────────────────────────┐
+│  VM / namespace set / security boundary       │
+│  Python runtime loaded, libraries cached      │
+│                                               │
+│  Workload A:                                  │
+│  ┌─────────────────────────────────────────┐  │
+│  │ PID 42: python3 /workspace/script_a.py  │  │
+│  │ overlay: /workspace (upper_a)           │  │
+│  │ env: SCRIPT_INPUT=/workspace/input.json │  │
+│  └──────────────────┬──────────────────────┘  │
+│                     │ exit(0)                  │
+│                     ▼                         │
+│  Reset: discard upper_a, unmount workspace    │
+│                                               │
+│  Workload B:                                  │
+│  ┌─────────────────────────────────────────┐  │
+│  │ PID 43: python3 /workspace/script_b.py  │  │
+│  │ overlay: /workspace (upper_b)           │  │
+│  │ env: SCRIPT_INPUT=/workspace/data.csv   │  │
+│  └─────────────────────────────────────────┘  │
+│                                               │
+└──────────────────────────────────────────────┘
+```
+
+### Implications for Backend Capability Profiles (§11)
+
+The container vs workload lifecycle distinction affects what primitives can do.
+Some primitives are "setup once" (immutable after creation), some can be adjusted
+per-workload:
+
+| Primitive | Setup (once) | Per-Workload Adjustment | Supports Warm Reuse |
+|---|---|---|---|
+| **seccomp-bpf** | Install filter | None (filters are immutable) | ✓ (filter persists) |
+| **linux-mount-namespace** | Create namespace | Add/remove bind mounts, discard overlay | ✓ |
+| **linux-pid-namespace** | Create namespace | New process inherits namespace | ✓ |
+| **linux-net-namespace** | Create namespace | Connections die with process | ✓ |
+| **landlock** | Create base ruleset, restrict_self | Add tighter ruleset per workload (stackable) | ✓ |
+| **cgroups-v2** | Create cgroup, set base limits | Adjust limits per workload (within base) | ✓ |
+| **appcontainer** | Create SID, set capabilities | N/A (SID is per-process) | Partial (new process in same SID) |
+| **job-object** | Create job, set base limits | Adjust limits per workload | ✓ |
+| **integrity-level** | Set on container token | Inherited by child processes | ✓ |
+| **hyper-v-vm** | Boot VM | New process inside VM | ✓ |
+
+This suggests extending primitive profiles with lifecycle metadata:
+
+```jsonc
+{
+  "primitive": "linux-mount-namespace",
+  // ... existing enforcement fields ...
+
+  "lifecycle": {
+    "setup_cost": "medium",
+    "per_workload_cost": "low",
+    "supports_warm_reuse": true,
+    "per_workload_operations": [
+      "add_bind_mount",
+      "remove_bind_mount",
+      "discard_overlay_upper"
+    ],
+    "reset_mechanism": "overlay-discard",
+    "state_isolation_between_workloads": "full"
+  }
+}
+```
+
+```jsonc
+{
+  "primitive": "seccomp-bpf",
+  // ... existing enforcement fields ...
+
+  "lifecycle": {
+    "setup_cost": "low",
+    "per_workload_cost": "none",
+    "supports_warm_reuse": true,
+    "per_workload_operations": [],
+    // Filter is immutable — same filter applies to all workloads.
+    // This is a feature: the security boundary cannot be weakened
+    // between workloads.
+    "reset_mechanism": null,
+    "state_isolation_between_workloads": "inherent"
+  }
+}
+```
+
+```jsonc
+{
+  "primitive": "hyper-v-vm",
+  // ... existing enforcement fields ...
+
+  "lifecycle": {
+    "setup_cost": "high",
+    "per_workload_cost": "low",
+    "supports_warm_reuse": true,
+    "per_workload_operations": [
+      "mount_workspace",
+      "unmount_workspace",
+      "spawn_process",
+      "adjust_resource_limits"
+    ],
+    "reset_mechanism": "process-termination + filesystem-scrub",
+    "state_isolation_between_workloads": "full"
+  }
+}
+```
+
+### Warm Pools
+
+For latency-sensitive workloads (interactive agent tool invocations), even a
+single warm container may not be enough — the agent might want to invoke multiple
+tools concurrently, or the reset cycle between workloads may be too slow.
+
+A **warm pool** maintains multiple pre-initialized containers ready to accept
+workloads immediately:
+
+```
+  Warm Pool: "python-sandbox" (size: 3, max: 5)
+  ┌─────────────────────────────────────────────┐
+  │                                             │
+  │  Container A:  Ready (idle)                 │
+  │  Container B:  Running workload             │
+  │  Container C:  Resetting (overlay discard)  │
+  │                                             │
+  │  Pool policy:                               │
+  │    min_warm: 2     (always keep 2 ready)    │
+  │    max_total: 5    (never exceed 5)         │
+  │    idle_timeout: 300s  (reclaim after 5min) │
+  │    base_policy: "python-sandbox-base"       │
+  │    backend: "docker-default"                │
+  │                                             │
+  └─────────────────────────────────────────────┘
+```
+
+When a workload arrives:
+
+1. Pick an idle container from the pool
+2. Bind the workload policy (mount workspace, set env)
+3. Execute
+4. Collect result
+5. Reset state
+6. Return container to pool
+
+If no idle containers are available and pool size < max, create a new one (paying
+the setup cost). If pool is at max, queue the workload.
+
+### Relationship to Policy Evaluation
+
+The two-tier policy model (base + workload) affects the compiler pipeline from
+§11. Policy evaluation happens at two points:
+
+```
+  Container creation:
+    evaluate(base_policy, composed_backend) → must be fully enforceable
+
+  Workload binding:
+    evaluate(workload_policy, base_policy)  → workload ⊆ base
+    bind(workload_policy, container)        → mount workspace, set env, etc.
+```
+
+The first evaluation uses the full backend capability profile machinery. The
+second evaluation is simpler — it only checks that the workload policy is a
+subset of the base policy. No new primitives are needed; the base already
+established the security boundary.
+
+### Container Lifetime States
+
+Combining the two lifecycles into a complete state machine:
+
+```
+  ┌───────────┐
+  │  Creating  │ ── image pull, resource allocation, security boundary creation
+  └─────┬─────┘
+        ▼
+  ┌──────────────┐
+  │ Initializing │ ── runtime load, immutable filter install, base policy apply
+  └──────┬───────┘
+         ▼
+  ┌──────────────┐    ┌────────────────────────────────────┐
+  │    Ready     │◄───┤  Resetting (between workloads)     │
+  │  (idle,      │    │  overlay discard, env clear,       │
+  │   waiting)   │    │  process termination               │
+  └──────┬───────┘    └────────────────────────────────────┘
+         │                         ▲
+         │ workload arrives        │ workload completes
+         ▼                         │
+  ┌──────────────┐    ┌────────────┴───────────────────────┐
+  │   Binding    │───►│  Executing                         │
+  │  workload    │    │  (process running, workload active) │
+  │  policy      │    └────────────────────────────────────┘
+  └──────────────┘
+         │
+         │ (idle timeout or explicit teardown)
+         ▼
+  ┌──────────────┐
+  │   Draining   │ ── complete in-flight workload, flush results
+  └──────┬───────┘
+         ▼
+  ┌──────────────┐
+  │   Stopped    │ ── destroy security boundary, release resources
+  └──────────────┘
+```
+
+---
+
+## 13. Intent Manifest
+
+### The Problem: Intent vs Configuration
+
+The JSON policy language in §8 names **concrete, platform-specific resources** —
+paths like `/usr/lib`, ports like `443`, hosts like `api.example.com`. This makes
+it a *bound deployment policy* (Layer 2 in the §10 model): precise, unambiguous,
+and directly compilable to a FlatBuffer. But it is not what code authors should
+write.
+
+A code author writing a Python web scraper should not need to know that Python
+lives at `/usr/bin/python3` on Linux, `/opt/homebrew/bin/python3` on macOS, and
+`C:\Python312\python.exe` on Windows. They should not need to decide between
+`scope: "subtree"` and `scope: "exact"`. They should express *what they need*,
+not *how to enforce it*.
+
+The intent manifest (Layer 1) is the format code authors write. It expresses
+abstract requirements and behavioral commitments. A **binding step** resolves it
+to a concrete Layer 2 policy on a specific platform.
+
+```
+  §13 Intent Manifest              §8 Bound Policy              §9 FlatBuffer
+  (Layer 1, portable)              (Layer 2, concrete)           (compiled, runtime)
+
+  "I need python,            bind()  "/usr/bin/python3 execute,  compile()  .sbxp
+   workspace rw,            ────────► /home/alice/work rw,      ────────►  (binary,
+   outbound HTTPS"                    TCP *:443 outbound"                  signed)
+
+  Written by:                       Produced by:                 Consumed by:
+  code author                       binder/orchestrator          sandbox runtime
+```
+
+### Design Principles
+
+1. **No platform-specific paths, ports, or mechanism details** — the manifest is
+   portable across Linux, macOS, and Windows
+2. **Logical data domains, not OS layout** — the manifest names `workspace` and
+   `config`, not `/usr/lib` and `/etc`
+3. **Named service references, not hostnames** — the manifest names `llm-api`,
+   not `api.anthropic.com`
+4. **Enforceable constraints separated from self-asserted claims** — what the
+   runtime must enforce vs what the author promises
+5. **Machine-resolvable** — a binder can map every field to a concrete Layer 2
+   value without human judgment
+
+### Schema Overview
+
+The intent manifest has four top-level sections:
+
+| Section | Purpose | Trust Model |
+|---|---|---|
+| `requires` | What the code needs to function | Validated by the binder — unresolvable requirements fail the bind |
+| `constraints` | Hard limits the runtime must enforce | Enforced by the sandbox — violation terminates the workload |
+| `claims` | Behavioral properties the author asserts | Informational — cannot be blindly trusted; may influence policy selection but not enforcement |
+| `metadata` | Identity, versioning, description | Informational |
+
+### Full Schema
+
+```jsonc
+{
+  "manifest_version": "1.0",
+
+  // ─── Metadata ─────────────────────────────────────────────
+  "metadata": {
+    "name": "web-scraper",
+    "version": "1.2.0",
+    "description": "Python web scraper that fetches and parses HTML pages",
+    "author": "alice@example.com"
+  },
+
+  // ─── Requirements ─────────────────────────────────────────
+  // What the code needs to function. The binder resolves each
+  // requirement to concrete resources on the target platform.
+  "requires": {
+
+    // Runtime: what language/interpreter the code needs.
+    // The binder locates the runtime on the target platform
+    // and implicitly grants read+execute access to it and
+    // its standard library.
+    "runtime": {
+      "language": "python",
+      "min_version": "3.10"
+    },
+
+    // Storage: logical data domains the code needs access to.
+    // Each domain maps to a platform-specific path at bind time.
+    "storage": [
+      {
+        "class": "workspace",
+        "access": "read-write",
+        "description": "Working directory for script execution"
+      },
+      {
+        "class": "input_data",
+        "access": "read",
+        "description": "Input files provided by the caller"
+      },
+      {
+        "class": "output_data",
+        "access": "write",
+        "description": "Results produced by the script"
+      },
+      {
+        "class": "temp",
+        "access": "read-write",
+        "persistence": "ephemeral",
+        "description": "Scratch space, discarded after execution"
+      },
+      {
+        "class": "cache",
+        "access": "read-write",
+        "persistence": "discardable",
+        "description": "Reusable across invocations but may be evicted"
+      }
+    ],
+
+    // Network: what services or network capabilities the code needs.
+    // Two modes: named service references (resolved by the binder
+    // through a service catalog) and generic capability classes.
+    "network": [
+      {
+        // Named service: resolved to concrete hosts/ports/auth
+        // by the binder's service catalog.
+        "service": "public-web",
+        "protocol": "https",
+        "description": "Fetch arbitrary web pages over HTTPS"
+      },
+      {
+        // Named service: a specific API the code calls.
+        "service": "search-api",
+        "operations": ["query"],
+        "auth": "injected-token",
+        "description": "Search provider API for web queries"
+      },
+      {
+        // Generic capability: DNS resolution.
+        "capability": "dns"
+      }
+    ],
+
+    // Process: what process-level capabilities the code needs.
+    "process": {
+      "spawn": true,
+      "max_children": 4,
+      "exec": ["python3"],
+      "signals": "self"
+    },
+
+    // IPC: inter-process communication requirements.
+    "ipc": "none",
+
+    // Devices: hardware access requirements.
+    "devices": "none",
+
+    // Identity / auth: what credentials the code needs injected.
+    "credentials": [
+      {
+        "name": "SEARCH_API_KEY",
+        "type": "api-key",
+        "description": "API key for search provider"
+      }
+    ]
+  },
+
+  // ─── Constraints ──────────────────────────────────────────
+  // Hard limits the runtime MUST enforce. These are not requests —
+  // they are ceilings. If the code exceeds them, the workload is
+  // terminated.
+  "constraints": {
+    "max_memory_mb": 512,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 300,
+    "max_processes": 10,
+    "max_open_files": 256,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  // ─── Claims ───────────────────────────────────────────────
+  // Author-asserted behavioral properties. These are NOT enforced
+  // by the runtime — they are metadata that MAY influence policy
+  // selection, audit posture, or trust tier assignment. They MUST
+  // NOT be trusted without independent verification.
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true,
+    "no_credential_exfiltration": true
+  }
+}
+```
+
+### Storage Classes
+
+The `storage` section uses **logical data domains** rather than OS filesystem
+paths. The binder maps each class to a concrete path on the target platform.
+
+| Storage Class | Description | Typical Binding |
+|---|---|---|
+| `workspace` | Working directory for the code | Orchestrator-assigned directory; overlay FS for isolation |
+| `input_data` | Files provided as input | Caller-supplied directory, mounted read-only |
+| `output_data` | Files produced as output | Orchestrator-assigned output directory |
+| `temp` | Ephemeral scratch space | `tmpfs` (Linux), ephemeral overlay (Windows); discarded after execution |
+| `cache` | Persistent but evictable storage | Warm container's cache directory; survives workloads, may be evicted |
+| `config` | Application configuration | App-specific config files, mounted read-only |
+| `secrets` | Credentials and keys | `tmpfs`-backed mount (never on disk); injected by orchestrator |
+| `app_code` | The application's own code | Read-only mount of the code bundle/image |
+| `user_selected` | Files chosen by the user at runtime | Brokered via file picker; binding and consent happen together |
+
+**What is NOT in the manifest:** `system_libraries`, `runtime_libraries`, or
+any platform-specific path. The binder derives system library access from the
+`runtime` declaration — if the code needs Python 3.10, the binder grants read
+access to wherever Python and its stdlib live on this platform.
+
+### Network Service References
+
+Network requirements use **named service references** that are resolved through
+a service catalog at bind time.
+
+```jsonc
+// In the intent manifest (Layer 1):
+{ "service": "search-api", "operations": ["query"], "auth": "injected-token" }
+
+// Resolved by the binder to (Layer 2):
+{
+  "direction": "outbound",
+  "action": "connect",
+  "protocol": "tcp",
+  "host": "api.search-provider.com",
+  "port": 443
+}
+```
+
+The service catalog is environment-specific:
+
+```jsonc
+{
+  "services": {
+    "search-api": {
+      "hosts": ["api.search-provider.com"],
+      "port": 443,
+      "protocol": "https",
+      "auth_method": "bearer-token",
+      "credential_ref": "SEARCH_API_KEY"
+    },
+    "public-web": {
+      "hosts": ["*"],
+      "port": 443,
+      "protocol": "https"
+    }
+  }
+}
+```
+
+This separation means:
+- The **manifest** says "I need a search API" (portable, audit-friendly)
+- The **service catalog** says "the search API is at `api.search-provider.com`"
+  (environment-specific, operator-managed)
+- The **bound policy** says "`api.search-provider.com:443` outbound TCP"
+  (concrete, compilable)
+
+### Generic Network Capabilities
+
+For common network needs that don't map to named services, the manifest uses
+capability references:
+
+| Capability | Description | Bound To |
+|---|---|---|
+| `dns` | DNS resolution | UDP port 53 outbound (or system resolver) |
+| `ntp` | Time synchronization | NTP port 123 outbound |
+| `localhost` | Loopback access | `127.0.0.1` / `::1` |
+
+### Constraints vs Claims
+
+The distinction between `constraints` and `claims` is critical:
+
+**Constraints** are enforced by the sandbox runtime. If the code exceeds them,
+the workload is terminated. The runtime is responsible for enforcement.
+
+```jsonc
+"constraints": {
+  "max_memory_mb": 512,             // Enforced via cgroups, Job Objects
+  "max_wall_time_seconds": 300,     // Enforced via timeout
+  "persistent_storage": "forbidden" // Enforced via ephemeral workspace
+}
+```
+
+**Claims** are self-asserted by the code author. They cannot be blindly trusted.
+They may influence:
+- **Trust tier assignment** — a claim of `no_side_effects_beyond_output` might
+  qualify the code for a higher trust tier
+- **Audit posture** — claims are recorded and can be verified post-hoc
+- **Policy selection** — an orchestrator might relax monitoring for code that
+  claims idempotency
+
+```jsonc
+"claims": {
+  "deterministic": false,
+  "idempotent": true,                     // May re-run safely
+  "no_credential_exfiltration": true      // Author says credentials won't leak
+}
+```
+
+A claim of `"no_credential_exfiltration": true` does **not** mean the runtime
+skips credential protection. The runtime always protects credentials regardless
+of claims. Claims are metadata, not policy.
+
+### Layer 2 Is Never Hand-Authored
+
+A key design decision: **the bound policy (§8) is always produced by the binder,
+never written directly by humans or agents.** It is an intermediate artifact —
+the output of the binding step, the input to compilation. No one authors it.
+
+This means there is exactly one way to express policy requirements: the intent
+manifest. There are no shortcuts, no "advanced mode" where you write Layer 2
+directly, no intent annotations mixed into Layer 2. The system has one policy
+authoring format, and it is intent.
+
+This decision has several consequences:
+
+1. **All authority checks (Layers 3–5) operate on intent.** Admin policy says
+   "no external network access," and that matches against `"service": "public-web"`,
+   not against `"host": "104.18.32.7"`. The authority doesn't need to understand
+   platform-specific details.
+
+2. **Audit trails are readable.** "The agent requested LLM API access and
+   read-write workspace" is more useful than "the agent requested TCP connect to
+   104.18.32.7:443 and subtree read-write on /workspace."
+
+3. **The binder is the single point of platform knowledge.** All platform-specific
+   decisions (where Python lives, what ports services use, what filesystem layout
+   to use) are made in one place, not scattered across policy files.
+
+4. **Agents don't need platform knowledge.** An agent loop generating a Python
+   script emits `"runtime": { "language": "python" }` regardless of whether the
+   workload will execute on Linux, Windows, or in a VM. The binder handles
+   resolution.
+
+### Agents as Policy Authors
+
+In agentic systems, the "code author" is often an LLM-based agent loop that
+generates both the code and the policy for that code. This raises the question:
+if the agent wrote the code and knows exactly what it does, why make it go
+through an abstract intent manifest instead of emitting concrete config directly?
+
+**The agent should still emit intent, for three reasons:**
+
+1. **The agent doesn't have full platform knowledge.** It knows it generated
+   `import json` in Python, but it may not know that this requires read access to
+   `/usr/lib/python3.11/json/__init__.py`, `decoder.py`, `encoder.py`,
+   `scanner.py`, and a C extension at
+   `/usr/lib/python3.11/lib-dynload/_json.cpython-311-x86_64-linux-gnu.so`.
+   The intent manifest says `"runtime": "python"` and the binder handles the
+   rest via a base policy (see below).
+
+2. **The agent shouldn't hardcode infrastructure decisions.** If the agent emits
+   `"host": "api.anthropic.com"`, it has baked in a deployment choice that
+   belongs to the orchestrator. The orchestrator might route to a different LLM
+   provider, or admin policy might block one provider but allow another. Intent
+   says `"service": "llm-api"`; the service catalog resolves it.
+
+3. **Multi-platform dispatch.** An agent loop running on one machine may dispatch
+   workloads to different platforms (Linux workers, Windows workers, cloud VMs).
+   It doesn't know the target platform at code-generation time. Intent is
+   platform-independent; config is not.
+
+The overhead of intent → bind → config is minimal (the binder is fast) and the
+correctness and portability benefits are significant.
+
+### Base Policies (Runtime Profiles)
+
+When the manifest says `"runtime": { "language": "python", "min_version": "3.11" }`,
+the binder needs to know everything Python requires at the filesystem level —
+interpreter binary, standard library, compiled extensions, certificate bundles,
+dynamic linker paths, etc. This is a large, platform-specific set of rules that
+no policy author (human or agent) should enumerate.
+
+**Base policies** (also called runtime profiles) are curated, system-provided
+policy fragments that capture this knowledge. They are analogous to OCI base
+images — you select `python:3.11-slim` and trust that it contains the right
+dependencies.
+
+#### Schema
+
+```jsonc
+{
+  "base_policy_version": "1.0",
+  "name": "python3.11-linux-x64",
+  "description": "CPython 3.11 on Linux x86_64 — interpreter, stdlib, and common extensions",
+  "platform": "linux",
+  "architecture": "x86_64",
+
+  "matches": {
+    // Which intent manifest runtime declarations this profile satisfies
+    "language": "python",
+    "version_range": ">=3.11.0, <3.12.0"
+  },
+
+  // Filesystem rules this profile contributes to the bound policy
+  "filesystem_rules": [
+    { "path": "/usr/bin/python3.11",       "scope": "exact",   "allow": ["read", "execute"] },
+    { "path": "/usr/bin/python3",          "scope": "exact",   "allow": ["read", "execute"] },
+    { "path": "/usr/lib/python3.11",       "scope": "subtree", "allow": ["read"] },
+    { "path": "/usr/lib/python3/dist-packages", "scope": "subtree", "allow": ["read"] },
+    { "path": "/usr/lib/x86_64-linux-gnu", "scope": "subtree", "allow": ["read", "execute"] },
+    { "path": "/etc/ssl/certs",            "scope": "subtree", "allow": ["read"] },
+    { "path": "/etc/resolv.conf",          "scope": "exact",   "allow": ["read"] },
+    { "path": "/lib/x86_64-linux-gnu",     "scope": "subtree", "allow": ["read", "execute"] },
+    { "path": "/usr/local/lib/python3.11/dist-packages", "scope": "subtree",
+      "allow": ["read"] }
+  ],
+
+  // Environment variables this profile sets
+  "environment": {
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUNBUFFERED": "1"
+  }
+}
+```
+
+A corresponding Windows profile:
+
+```jsonc
+{
+  "base_policy_version": "1.0",
+  "name": "python3.11-windows-x64",
+  "description": "CPython 3.11 on Windows x64",
+  "platform": "windows",
+  "architecture": "x86_64",
+
+  "matches": {
+    "language": "python",
+    "version_range": ">=3.11.0, <3.12.0"
+  },
+
+  "filesystem_rules": [
+    { "path": "C:\\Python311\\python.exe",    "scope": "exact",   "allow": ["read", "execute"] },
+    { "path": "C:\\Python311\\python311.dll",  "scope": "exact",   "allow": ["read", "execute"] },
+    { "path": "C:\\Python311\\Lib",            "scope": "subtree", "allow": ["read"] },
+    { "path": "C:\\Python311\\DLLs",           "scope": "subtree", "allow": ["read", "execute"] },
+    { "path": "C:\\Windows\\System32\\vcruntime140.dll", "scope": "exact",
+      "allow": ["read", "execute"] },
+    { "path": "C:\\Windows\\System32\\ucrtbase.dll", "scope": "exact",
+      "allow": ["read", "execute"] }
+  ],
+
+  "environment": {
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONUNBUFFERED": "1"
+  }
+}
+```
+
+#### Composition
+
+A workload that needs Python plus additional tools references multiple profiles.
+The binder merges their filesystem rules:
+
+```jsonc
+// Intent manifest:
+{
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.11" },
+    "tools": [
+      { "name": "ffmpeg", "access": "execute" },
+      { "name": "curl", "access": "execute" }
+    ]
+  }
+}
+```
+
+The binder finds `python3.11-linux-x64`, `ffmpeg-linux-x64`, and
+`curl-linux-x64` profiles and merges their filesystem rules into the bound
+policy. The merge is a simple union — all paths from all matching profiles are
+included.
+
+#### Connection to §12 (Lifecycle)
+
+Base policies also drive **warm container initialization**. When a warm pool
+(§12) is configured for Python workloads, the base policy determines what gets
+installed and configured at container creation time:
+
+```
+  Base policy "python3.11-linux-x64"
+       │
+       ├── Container creation: install Python, grant filesystem access
+       │   (expensive, done once)
+       │
+       └── Workload arrival: binder only resolves workspace, network,
+           credentials (cheap, per-workload)
+```
+
+The base policy's filesystem rules become part of the container's **base
+policy** (§12), and each workload's resolved requirements become the **workload
+policy** that further restricts within it.
+
+### Policy Discovery (Learning Mode)
+
+When a developer has existing code but no intent manifest, a **learning mode**
+can help bootstrap one. The idea — used by SELinux's `audit2allow`, AppArmor's
+`aa-logprof`, and MXC's existing `permissiveLearningMode` — is to run the
+workload in a permissive sandbox that logs every access without blocking, then
+generate policy from the log.
+
+#### What Learning Mode Captures
+
+Learning mode observes **concrete access events** at the mechanism level:
+
+```
+Process 1234 opened /usr/lib/python3.11/json/__init__.py  READ
+Process 1234 opened /home/alice/project/input.csv         READ
+Process 1234 opened /tmp/tmpxyz123                        WRITE CREATE
+Process 1234 connected TCP 10.0.0.1 → 104.18.32.7:443
+Process 1234 connected TCP 10.0.0.1 → 8.8.8.8:53
+Process 1234 called clone()
+```
+
+This is Layer 2 data — concrete paths, concrete IPs, concrete syscalls.
+Generating a bound config (§8) from this is mechanical: group paths by prefix,
+determine read vs write, list hosts/ports. SELinux's `audit2allow` does exactly
+this.
+
+#### The Uplift Problem: Layer 2 → Layer 1
+
+Generating an *intent manifest* (Layer 1) from observation is harder because
+**intent is about purpose, and purpose is not observable from system calls.**
+Learning mode tells you *what the code did*; intent tells you *what the code is
+trying to accomplish.*
+
+| Category | Automation Quality | Why |
+|---|---|---|
+| **Runtime detection** | ✓ High | Strong patterns — Python loading `/usr/lib/python3.11/**` is unmistakable |
+| **Temp/scratch** | ✓ High | Path conventions — `/tmp/tmp*`, `%TEMP%` |
+| **DNS/NTP** | ✓ High | Port patterns — UDP port 53 is unambiguous |
+| **Process spawning** | ✓ High | Syscall trace — `clone()`, `fork()` |
+| **Workspace/input/output** | ⚠ Medium | Heuristics — read-only vs read-write observed, but one run may not show all code paths |
+| **Network services** | ⚠ Medium | Requires a service catalog to map `104.18.32.7` → `"service": "llm-api"` |
+| **Credentials** | ⚠ Medium | Pattern matching on paths (`/run/secrets/*`) and env vars (`*_API_KEY`) |
+| **Resource constraints** | ⚠ Medium | Single-run observation is a lower bound; needs safety margin |
+| **Claims** | ✗ Cannot automate | Semantic properties like `idempotent` require author knowledge |
+| **Persistence intent** | ✗ Cannot automate | *Why* a file was written is not observable |
+
+#### The Two-Pass Workflow
+
+Learning mode produces a draft intent manifest through a two-pass process:
+
+**Pass 1: Generate Layer 2 config** — mechanical, high accuracy. Group file
+accesses, identify read/write/execute, list network destinations.
+
+**Pass 2: Uplift to Layer 1** — apply heuristics to classify Layer 2 data into
+intent categories:
+
+1. **Strip runtime accesses.** Match observed paths against a known-runtimes
+   database. Everything that matches gets collapsed into
+   `"runtime": { "language": "python" }` and removed from the storage rules.
+
+2. **Classify storage.** Apply heuristics:
+   - Read-only files → `input_data`
+   - Created and written files that didn't exist before → `output_data`
+   - Read-and-write files → `workspace`
+   - `/tmp` and temp-patterned paths → `temp`
+
+3. **Resolve network.** Match observed hosts against a service catalog. Matches
+   become named service references; unmatched hosts get flagged for review.
+
+4. **Set constraints conservatively.** Observed maximums × a safety margin
+   (e.g., observed 200MB memory → suggest `max_memory_mb: 512`).
+
+5. **Leave claims empty.** Cannot be inferred.
+
+#### Draft Output With Annotations
+
+The learning tool produces a **draft manifest with confidence annotations** that
+indicate what was inferred confidently vs what needs review:
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": { "name": "unknown-workload" },
+
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.11" },
+    // ✓ CONFIDENT: Process executed /usr/bin/python3.11, loaded stdlib
+
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      // ⚠ REVIEW: /home/alice/project/** — read+write observed; could
+      //   be split into input_data (r) + output_data (w) if author knows
+
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+      // ✓ CONFIDENT: /tmp/tmp* — classic temp pattern
+    ],
+
+    "network": [
+      { "service": "llm-api", "protocol": "https" },
+      // ✓ MATCHED: api.anthropic.com:443 found in service catalog
+
+      { "capability": "dns" }
+      // ✓ CONFIDENT: UDP 8.8.8.8:53 observed
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 512,
+    // ⚠ ESTIMATED: peak 203MB observed — padded 2.5×
+
+    "max_wall_time_seconds": 120
+    // ⚠ ESTIMATED: completed in 47s — padded 2.5×
+  },
+
+  "claims": {
+    // ✗ EMPTY: Cannot be inferred. Author must fill in.
+  }
+}
+```
+
+The annotations (✓ CONFIDENT, ⚠ REVIEW, ⚠ ESTIMATED, ✗ EMPTY) are not part of
+the schema — they are comments in the draft output that the author (human or
+agent) reviews before finalizing.
+
+#### Practical Assessment
+
+Learning mode can automate approximately **60–70%** of an intent manifest. The
+remaining 30–40% requires author knowledge — primarily storage classification
+refinement, claims, and persistence intent. For agent-authored code, the agent
+already has this knowledge (it wrote the code), so the agent can fill in the
+gaps. For legacy code without an available author, the draft with review
+annotations is the best achievable outcome.
+
+### The Binding Step
+
+Binding resolves an intent manifest to a bound policy (§8) on a specific
+platform. It consumes:
+
+1. **Intent manifest** (Layer 1) — what the code needs
+2. **Base policies** — runtime profiles for the declared runtime and tools
+3. **Platform inventory** — what the target system has (runtime locations, kernel
+   version, available backends)
+4. **Service catalog** — named service → concrete host/port mapping
+5. **User consent** (Layer 3) — what the user approves
+6. **Admin policy** (Layer 4) — what organizational constraints apply
+
+And produces:
+
+6. **Bound policy** (Layer 2, §8) — concrete paths, ports, hosts
+7. **Bind report** — what was resolved, what was denied, what requires consent
+
+```
+resolve(manifest, base_policies, platform, services, consent, admin_policy)
+    → BoundPolicy:
+
+  // Base policy resolution
+  base = find_base_policy(manifest.requires.runtime, platform)
+  merge base.filesystem_rules into bound policy
+  merge base.environment into bound policy
+  for each tool in manifest.requires.tools:
+    tool_base = find_base_policy(tool, platform)
+    merge tool_base.filesystem_rules into bound policy
+
+  // Storage binding
+  for each storage requirement:
+    path = allocate_path(storage.class, platform)
+    add filesystem rule: { path, scope: subtree, allow: storage.access }
+
+  // Network binding
+  for each network requirement:
+    if requirement.service:
+      hosts, port, protocol = services.resolve(requirement.service)
+      for host in hosts:
+        add network rule: { direction: outbound, host, port, protocol }
+    if requirement.capability == "dns":
+      set allow_dns = true
+
+  // Credential injection
+  for each credential:
+    source = secrets.resolve(credential.name)
+    mount as tmpfs-backed read-only at secrets path
+
+  // Constraint mapping
+  map constraints to resource limits in the bound policy
+
+  // Authority checks
+  for each bound resource:
+    check user consent (Layer 3)
+    check admin policy (Layer 4)
+    check system policy (Layer 5)
+    if denied: add to bind_report.denied
+
+  return BoundPolicy + BindReport
+```
+
+### Bind Failures
+
+When the binder cannot resolve a requirement:
+
+| Situation | Response |
+|---|---|
+| Runtime not found on platform | Bind fails: "Python 3.10+ not found on this system" |
+| Named service not in catalog | Bind fails: "Service 'search-api' not defined in service catalog" |
+| Admin policy forbids a requirement | Bind fails: "Outbound HTTPS denied by admin policy" |
+| User declines consent for a resource | Bind succeeds with resource excluded; code must handle graceful degradation |
+| Constraint exceeds system capacity | Bind fails: "Requested 512MB memory exceeds system limit of 256MB for sandboxed containers" |
+
+### Relationship to Other Sections
+
+| Section | Relationship |
+|---|---|
+| **§8 (Bound Policy)** | The binder's output — §13 is input, §8 is output |
+| **§9 (FlatBuffer)** | The compiler's input is the §8 bound policy, not the §13 manifest |
+| **§10 (Policy Layers)** | §13 is Layer 1 (Code Requirements) and partially Layer 2 (Instance Binding for abstract resources). §8 is Layer 2 (fully bound). Layers 3–5 are consumed during the binding step. |
+| **§11 (Backend Profiles)** | The binder uses backend profiles to validate that the resolved policy can be enforced. If not, the binder can select a different backend or fail. |
+| **§12 (Lifecycle)** | The manifest's `constraints` (wall time, persistence) and `storage.persistence` fields inform the lifecycle model — ephemeral vs warm-cacheable vs persistent. |
+
+### Example: Full Pipeline
+
+**Layer 1 — Author writes intent manifest:**
+
+```jsonc
+{
+  "manifest_version": "1.0",
+  "metadata": { "name": "summarizer", "version": "1.0.0" },
+  "requires": {
+    "runtime": { "language": "python", "min_version": "3.11" },
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "input_data", "access": "read" }
+    ],
+    "network": [
+      { "service": "llm-api", "operations": ["completions"], "auth": "injected-token" }
+    ],
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key" }
+    ]
+  },
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_wall_time_seconds": 60,
+    "persistent_storage": "forbidden"
+  }
+}
+```
+
+**Binder resolves on Linux:**
+
+```jsonc
+// Service catalog entry:
+{ "llm-api": { "hosts": ["api.anthropic.com"], "port": 443, "protocol": "https" } }
+
+// Platform inventory:
+{ "python3": "/usr/bin/python3", "python3_stdlib": "/usr/lib/python3.11" }
+```
+
+**Layer 2 — Bound policy (§8 format):**
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "summarizer",
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/python3",    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/python3.11", "scope": "subtree", "allow": ["read"] },
+      { "path": "/workspace",          "scope": "subtree", "allow": ["read", "write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/input",              "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",                "scope": "subtree", "allow": ["read", "write", "create",
+                                                                      "delete"],
+                                                            "ephemeral": true },
+      // Credential mount — tmpfs-backed, never written to disk, read-only to the process.
+      // The orchestrator injects the secret value at bind time.
+      { "path": "/run/secrets/LLM_API_KEY", "scope": "exact", "allow": ["read"],
+                                                               "ephemeral": true }
+    ],
+    // No persistent writable storage exists — /workspace and /tmp are both
+    // ephemeral (overlay upper layer or tmpfs). This is how the intent
+    // constraint "persistent_storage": "forbidden" manifests in the bound
+    // policy: every writable path is ephemeral, and there are no writable
+    // paths without the ephemeral flag.
+    "synthetic": {
+      "/tmp": "ephemeral"
+    }
+  },
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 }
+    ],
+    "allow_dns": true
+  },
+  "resources": {
+    "max_memory_mb": 256,
+    "max_wall_time_seconds": 60
+  },
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin",
+      "HOME": "/workspace",
+      "LLM_API_KEY_FILE": "/run/secrets/LLM_API_KEY"
+    }
+  }
+}
+```
+
+**How intent constraints map to the bound policy:**
+
+| Intent Constraint | Bound Policy Expression |
+|---|---|
+| `"persistent_storage": "forbidden"` | All writable paths (`/workspace`, `/tmp`) are marked `"ephemeral": true` — backed by overlay or tmpfs, discarded after execution. No writable path without `ephemeral` exists. |
+| `"max_memory_mb": 256` | `resources.max_memory_mb: 256` — direct passthrough |
+| `"max_wall_time_seconds": 60` | `resources.max_wall_time_seconds: 60` — direct passthrough |
+| `credentials[].name: "LLM_API_KEY"` | Filesystem rule for `/run/secrets/LLM_API_KEY` (read-only, ephemeral tmpfs mount) + environment variable `LLM_API_KEY_FILE` pointing to the mount path |
+
+**Binder resolves the same manifest on Windows:**
+
+```jsonc
+// Platform inventory:
+{ "python3": "C:\\Python311\\python.exe", "python3_stdlib": "C:\\Python311\\Lib" }
+```
+
+**Layer 2 — Bound policy (§8 format, Windows):**
+
+```jsonc
+{
+  "version": "1.0",
+  "name": "summarizer",
+  "filesystem": {
+    // On Windows, the Brokered File System (BFS) maps host paths into the
+    // container's view. The container sees these paths; BFS enforces the
+    // access mode. Paths not listed are invisible to the container.
+    "rules": [
+      // Runtime — BFS maps the host Python installation read-only
+      { "path": "C:\\Python311\\python.exe", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Python311\\Lib",        "scope": "subtree",
+        "allow": ["read"] },
+      { "path": "C:\\Python311\\DLLs",       "scope": "subtree",
+        "allow": ["read", "execute"] },
+
+      // Workspace — BFS maps a host directory as an ephemeral overlay.
+      // Writes go to a scratch layer that is discarded after execution.
+      { "path": "C:\\Sandbox\\Workspace",    "scope": "subtree",
+        "allow": ["read", "write", "create"],
+        "ephemeral": true },
+
+      // Input data — BFS maps the caller-supplied directory read-only
+      { "path": "C:\\Sandbox\\Input",        "scope": "subtree",
+        "allow": ["read"] },
+
+      // Temp — ephemeral scratch space, discarded after execution
+      { "path": "C:\\Sandbox\\Temp",         "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"],
+        "ephemeral": true },
+
+      // Credential — ephemeral file, never written to host disk.
+      // The orchestrator writes the secret value into this path
+      // inside the container at bind time.
+      { "path": "C:\\Sandbox\\Secrets\\LLM_API_KEY",  "scope": "exact",
+        "allow": ["read"],
+        "ephemeral": true }
+    ],
+
+    // Paths to mask — these exist on the host but must be invisible
+    // inside the container, even if BFS would otherwise inherit them.
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 }
+    ],
+    "allow_dns": true
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_wall_time_seconds": 60
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Python311;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "LLM_API_KEY_FILE": "C:\\Sandbox\\Secrets\\LLM_API_KEY"
+    }
+  },
+
+  // Windows-specific backend configuration.
+  // On Windows the binder selects the enforcement primitives and
+  // populates platform overrides. This section will eventually
+  // migrate to backend profiles (§11).
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": ["internetClient"]
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}
+```
+
+Note how the **same intent manifest** produces different bound policies on Linux
+and Windows:
+
+| Intent | Linux Binding | Windows Binding |
+|---|---|---|
+| `runtime: python 3.11` | `/usr/bin/python3`, `/usr/lib/python3.11` | `C:\Python311\python.exe`, `C:\Python311\Lib`, `C:\Python311\DLLs` |
+| `storage: workspace (rw)` | `/workspace` (overlay) | `C:\Sandbox\Workspace` (BFS ephemeral overlay) |
+| `storage: input_data (r)` | `/input` | `C:\Sandbox\Input` (BFS read-only) |
+| `storage: temp` | `/tmp` (tmpfs) | `C:\Sandbox\Temp` (BFS ephemeral) |
+| `credentials: LLM_API_KEY` | `/run/secrets/LLM_API_KEY` (tmpfs) | `C:\Sandbox\Secrets\LLM_API_KEY` (ephemeral) |
+| `network: llm-api` | `api.anthropic.com:443` TCP | `api.anthropic.com:443` TCP + `internetClient` capability |
+| `persistent_storage: forbidden` | All writable paths ephemeral | All writable paths BFS-ephemeral; host paths masked |
+
+**Layer 2 → FlatBuffer (§9):**
+
+Compiled to `.sbxp` binary for zero-copy runtime consumption.

--- a/docs/proposals/container-policy/PossibleSimplifications.md
+++ b/docs/proposals/container-policy/PossibleSimplifications.md
@@ -1,0 +1,244 @@
+# Possible Simplifications
+
+This document captures potential simplifications to the Container Policy
+Design (`ContainerPolicyDesign.md`) that could reduce complexity
+without losing the core architectural properties. These are recorded for
+future consideration, not immediate action.
+
+---
+
+## Core Properties to Preserve
+
+Any simplification must preserve these properties:
+
+1. **Intent as universal format** — one schema for all policy authors
+2. **Composition via intersection** — each layer restricts, never broadens
+3. **Fail-closed on conflict** — if composed policy can't satisfy
+   requirements, fail with attribution
+4. **Binder produces bound policy** — bound policy is never hand-authored
+5. **Abstract → concrete resolution** — storage classes, service names,
+   tool names resolved by the binder
+6. **Major version = hard fail** — the one versioning rule that really
+   matters
+
+---
+
+## S.1 Merge System Intents into Binder / Capability Profiles
+
+**Current design:** System intents are separate JSON files
+(`examples/system_intents/*.jsonc`) expressing OS-level invariants like
+"system binaries are read-only" and "no kernel memory access." These
+participate in four-layer composition alongside developer, user, and
+admin intents.
+
+**Observation:** System intents describe properties of the platform, not
+policies someone authors. The binder already consults capability profiles
+to know what the platform enforces. System invariants (read-only system
+paths, no privilege escalation) are intrinsic to the platform — they
+don't change per-workload.
+
+**Simplification:** Fold system invariants into the binder's platform
+knowledge or into capability profiles. The binder always applies them
+when producing a bound policy. No separate "system intent file" needed.
+
+**Trade-off:** Loses the ability to express system policy in the same
+format as other layers (less uniform). Makes it harder for an OS vendor
+to ship updated system constraints independently of an MXC update.
+
+**Risk:** Low. System invariants change rarely and are tightly coupled
+to the platform the binder already understands.
+
+---
+
+## S.2 Simplify User Consent to Approval Annotations
+
+**Current design:** User intents are full intent policy documents
+(`examples/user_intents/*.jsonc`) with their own `manifest_version`,
+`metadata`, `requires`, and `constraints` sections. They participate in
+composition as a co-equal fourth layer.
+
+**Observation:** In practice, user consent is narrowing — the user can
+only restrict, never broaden. In most agentic scenarios the user either
+approves or rejects what the developer requested. That's a boolean
+per-resource, not a full intent policy document.
+
+**Simplification:** User consent becomes a UI interaction that produces
+approval annotations on the developer intent. For example:
+
+```jsonc
+{
+  "consent": {
+    "manifest_ref": "csv-data-analyzer/1.0.0",
+    "approved": {
+      "storage": ["input_data", "output_data", "workspace", "temp"],
+      "network": [],
+      "credentials": []
+    },
+    "overrides": {
+      "max_wall_time_seconds": 90
+    }
+  }
+}
+```
+
+This is simpler than a full intent document and directly expresses the
+user's actual interaction: "I approve these capabilities and want to
+lower this limit."
+
+**Trade-off:** Loses the uniformity of "all four layers use the same
+format." The consent annotation format is a different schema from intent
+policy. However, it more accurately models what users actually do.
+
+**Risk:** Medium. The full intent format for users enables power-user
+scenarios (e.g., a security-conscious user writing detailed network
+scope restrictions). The annotation model may not be expressive enough
+for those cases.
+
+---
+
+## S.3 Drop Claims from v1
+
+**Current design:** The `claims` section holds self-asserted behavioral
+properties (`deterministic`, `idempotent`, `no_credential_exfiltration`,
+etc.). They are explicitly not enforced and not verified. §2.7 and
+Appendix D.3 both acknowledge there is no verification story.
+
+**Observation:** Claims add schema surface area for no current benefit.
+No consumer reads them. No enforcement mechanism exists. The document
+defers their treatment to future work.
+
+**Simplification:** Remove `claims` from the v1 intent schema entirely.
+Add them back in a future version when there is a verification or
+attestation mechanism.
+
+**Trade-off:** Loses forward compatibility — policies written today
+won't carry claims, so when verification arrives, all policies need
+updating. However, this is a minor cost vs. carrying dead weight in
+every policy document.
+
+**Risk:** Low. Claims can be added as a minor version bump when needed.
+
+---
+
+## S.4 Inline Service Catalog into Admin Intent
+
+**Current design:** §5.3 defines a service catalog — a separate
+abstraction that maps logical service names to concrete endpoints. The
+catalog has its own versioning, discovery, and conflict resolution
+concerns (all flagged as underspecified in Appendix D.4).
+
+**Observation:** The admin intent examples already contain endpoint
+information directly. The catalog abstraction adds significant
+complexity (versioning, discovery, conflict resolution) for a problem
+that can be solved by the admin declaring allowed endpoints in their
+intent policy.
+
+**Simplification:** Admin intents declare allowed services with their
+endpoints directly:
+
+```jsonc
+"requires": {
+  "network": [
+    { "service": "weather-api", "protocol": "https",
+      "endpoints": ["api.weatherapi.com:443"] },
+    { "service": "internal-api", "protocol": "https",
+      "endpoints": ["gateway.corp.example.com:443"] }
+  ]
+}
+```
+
+The binder resolves developer-declared service names against the admin's
+endpoint declarations. No separate catalog infrastructure needed for v1.
+
+**Trade-off:** Loses the separation between "which services are
+permitted" and "where services live." In large organizations, the
+network team and the security team may be different groups. A catalog
+lets the network team manage endpoints while the security team manages
+permissions.
+
+**Risk:** Medium. This simplification works well for small/medium
+deployments but may not scale to enterprises with thousands of services
+and separate operational concerns.
+
+---
+
+## S.5 Drop Blessed Compositions, Keep Primitive Profiles
+
+**Current design:** Capability profiles have two layers — primitive
+profiles (per-mechanism) and blessed compositions (validated stacks with
+formal security guarantees). The binder matches intent claims against
+composition guarantees.
+
+**Observation:** Primitive profiles are clearly needed — the binder must
+know what each mechanism can enforce. But blessed compositions with
+formal guarantees add a layer of abstraction over the primitives. For
+v1, the binder could simply check each intent requirement against the
+set of primitives available on the platform.
+
+**Simplification:** The binder consults primitive profiles directly. It
+knows "on this Linux machine, I have Landlock v4 + seccomp + cgroups v2
++ namespaces" and checks each requirement against each primitive. No
+blessed composition files needed.
+
+**Trade-off:** Loses the pre-validated guarantee story. Without blessed
+compositions, the binder can report "each individual requirement is
+enforceable" but cannot assert composite properties like
+"no-filesystem-escape" that depend on multiple primitives working
+together correctly. The guarantee model is valuable for audit and
+compliance.
+
+**Risk:** Medium. Primitive-level checking is sufficient for
+functionality. Composition-level guarantees are important for security
+assurance, which matters most in enterprise/compliance contexts.
+
+---
+
+## S.6 Simplify Versioning: Defer Compatibility Matrix
+
+**Current design:** §10.2 describes a binder compatibility matrix
+mapping intent features to minimum config versions. §10.7 has five
+detailed migration scenarios.
+
+**Observation:** With one intent version and one config version today,
+the compatibility matrix is speculative architecture. The five migration
+scenarios illustrate situations that don't yet exist.
+
+**Simplification:** Reduce versioning to three rules:
+
+1. Major version ahead on any input → hard fail
+2. Minor version ahead on any input → accept with reported gaps
+3. Binder produces bound policy at the config version the runtime
+   supports
+
+Defer the compatibility matrix and detailed migration scenarios until
+there are actually multiple versions in the wild.
+
+**Trade-off:** Loses the forward-looking design guidance. When version 2
+arrives, the compatibility model will need to be designed then. However,
+designing it now without real usage patterns may produce the wrong
+abstraction.
+
+**Risk:** Low. The three rules are sufficient. The matrix can be
+designed when there is empirical data on how versions actually diverge.
+
+---
+
+## Summary: What Would a Simplified v1 Look Like?
+
+If all simplifications were adopted:
+
+| Current Design | Simplified v1 |
+|---|---|
+| 4 policy layers (developer, user, admin, system) | 2 layers + annotations (developer intent, admin overlay, user approval annotations) |
+| Full intent schema for all 4 authors | Full intent for developer + admin; approval annotations for user; platform knowledge in binder |
+| `claims` section | Removed — added later with verification |
+| Service catalog abstraction | Endpoints declared directly in admin intent |
+| Primitive profiles + blessed compositions | Primitive profiles only |
+| Compatibility matrix + 5 migration scenarios | 3 versioning rules |
+
+**Composition becomes:** developer intent ∩ admin overlay ∩ user
+approvals, with platform constraints applied by the binder.
+
+**Core properties preserved:** Intent format, intersection composition,
+fail-closed, binder-produced bound policy, abstract→concrete resolution,
+major version fail.

--- a/docs/proposals/container-policy/README.md
+++ b/docs/proposals/container-policy/README.md
@@ -1,0 +1,79 @@
+# Container Policy — Design Proposal
+
+> **Status: Draft / Exploratory.**
+> This work is **not authoritative** and is subject to substantial change.
+> Nothing here describes shipped MXC behavior. For the current shipped
+> sandbox policy, see [`docs/sandbox-policy/v1/policy.md`](../../sandbox-policy/v1/policy.md).
+
+This folder collects research, design, and evaluation work on a
+cross-platform **intent policy** model for sandboxed code execution. It
+introduces a single declarative language used by four policy authors —
+code author, user, IT administrator, and system — and describes how their
+independent statements compose into an enforceable runtime configuration.
+
+The work is recorded here so it can be reviewed, critiqued, and iterated
+on without being mistaken for an approved design.
+
+---
+
+## Reading Order
+
+The documents build on each other. New readers should follow this order:
+
+1. **[`SandboxSurvey.md`](SandboxSurvey.md)** — Cross-platform survey of
+   sandboxing mechanisms (Linux namespaces, Landlock, seccomp; macOS
+   Seatbelt; Windows AppContainer, BFS, WFP). Establishes vocabulary.
+2. **[`ContainerPolicyThoughts.md`](ContainerPolicyThoughts.md)** —
+   Original research and design thinking. Compares mechanisms, proposes a
+   unified JSON policy language, FlatBuffer compiled format, policy
+   layers, capability profiles, lifecycle, and intent manifests. The raw
+   material that fed the formal design.
+3. **[`ContainerPolicyDesign.md`](ContainerPolicyDesign.md)** — The formal
+   design proposal. Defines intent policy, the four-author composition
+   model, the binder, and the bound-policy format. Contains a rubric-based
+   self-evaluation in Appendix E.
+4. **[`SandboxEvaluationRubric.md`](SandboxEvaluationRubric.md)** —
+   Six-axis evaluation framework for sandboxing technologies and policy
+   languages. Designed to be applied to any technology, not just the
+   proposal here.
+5. **[`PossibleSimplifications.md`](PossibleSimplifications.md)** —
+   Internal critique of the design. Identifies six areas where complexity
+   could be reduced for a v1 without losing core architectural properties.
+6. **[`mxc_container_policy_alignment.md`](mxc_container_policy_alignment.md)**
+   — Maps the design against the current MXC codebase. Identifies what
+   MXC already implements, where gaps exist, and where MXC has
+   capabilities the design doesn't yet cover.
+
+---
+
+## Examples
+
+The [`examples/`](examples/) tree mirrors the layering described in
+`ContainerPolicyDesign.md`. Reading top-to-bottom shows policy composing
+from author intent into a runnable bound form:
+
+| Folder | Layer |
+|---|---|
+| `examples/admin_intents/` | IT administrator policy |
+| `examples/system_intents/` | OS / platform invariants |
+| `examples/user_intents/` | User consent declarations |
+| `examples/intent_manifests/` | Code-author intent (earlier format) |
+| `examples/composed_policies/` | Code-author intent + composition |
+| `examples/capability_profiles/` | Backend primitive + composition profiles |
+| `examples/bound_policies/` | Resolved per-platform runtime configuration |
+
+All examples are illustrative. They are not consumed by any tool in the
+repository today.
+
+---
+
+## Status of Open Questions
+
+`ContainerPolicyDesign.md` Appendix D enumerates known abstraction gaps
+(constraints vs. configuration, network operation enforcement, claim
+verification, service catalog resolution, IPC and device taxonomy, exec
+whitelisting, multi-sandbox orchestration). Appendix E grades the design
+against the rubric and calls out the most material risks: no enforcement
+verification loop, complexity budget, IPC/device stubs, and unverified
+claims. These should be resolved or explicitly deferred before any part
+of this proposal is treated as authoritative.

--- a/docs/proposals/container-policy/SandboxEvaluationRubric.md
+++ b/docs/proposals/container-policy/SandboxEvaluationRubric.md
@@ -1,0 +1,742 @@
+# Sandbox & Container Technology Evaluation Rubric
+
+This rubric provides a systematic framework for evaluating sandboxing and
+container isolation technologies — and the policy languages that govern
+them — for use in cross-platform workload containment. It is derived from
+the conceptual frameworks established in *Container Sandboxing Mechanisms:
+A Cross-Platform Survey* (`SandboxSurvey.md`) and *Container Policy
+Design: Intent, Composition, and Binding* (`ContainerPolicyDesign.md`).
+
+The rubric is designed to be applied to any sandboxing technology,
+including those not yet surveyed in this repository. Section 9 catalogs
+known technologies that are **not currently covered** by the branch's
+survey work.
+
+---
+
+## Table of Contents
+
+- [1. How to Use This Rubric](#1-how-to-use-this-rubric)
+- [2. Technology Classification](#2-technology-classification)
+- [3. Axis 1 — Isolation Architecture](#3-axis-1--isolation-architecture)
+- [4. Axis 2 — Policy Dimension Coverage](#4-axis-2--policy-dimension-coverage)
+- [5. Axis 3 — Policy Language & Authoring](#5-axis-3--policy-language--authoring)
+- [6. Axis 4 — Composability & Integration](#6-axis-4--composability--integration)
+- [7. Axis 5 — Operational Characteristics](#7-axis-5--operational-characteristics)
+- [8. Axis 6 — Cross-Platform Policy Alignment](#8-axis-6--cross-platform-policy-alignment)
+- [9. Technologies Not Currently Covered](#9-technologies-not-currently-covered)
+- [10. Applying the Rubric — Worked Example](#10-applying-the-rubric--worked-example)
+- [Appendix: Blank Evaluation Scorecard](#appendix-blank-evaluation-scorecard)
+
+---
+
+## 1. How to Use This Rubric
+
+For each technology (or composition of technologies), evaluate it along
+six axes. Each axis contains specific criteria scored on a three-level
+scale:
+
+| Score | Meaning |
+|-------|---------|
+| **Full (✓)** | The technology natively supports this criterion |
+| **Partial (○)** | Achievable through composition, workarounds, or with caveats |
+| **None (✗)** | Not addressed; would require a separate mechanism |
+
+Some criteria are qualitative rather than scored — these ask for a
+classification (e.g., which isolation model) rather than a coverage
+rating.
+
+### Per-Axis Grading (A–F)
+
+After completing the criteria for each axis, assign an overall letter
+grade. The grade reflects how well the technology performs across that
+axis's criteria **relative to its technology kind** (§2.1) — a Primitive
+is not penalized for lacking lifecycle management, and a Broker is not
+penalized for lacking syscall filtering.
+
+| Grade | Meaning | Guideline |
+|-------|---------|-----------|
+| **A** | Excellent | Meets or exceeds all applicable criteria. Best-in-class for its kind. Few or no gaps. |
+| **B** | Good | Meets most applicable criteria with minor gaps. Gaps are well-understood and can be mitigated by composition. |
+| **C** | Adequate | Meets core criteria but has meaningful gaps in granularity, coverage, or maturity. Usable but requires significant complementary mechanisms. |
+| **D** | Weak | Meets some criteria but has substantial gaps that limit usefulness. May require workarounds that undermine the security model. |
+| **F** | Inadequate | Fails to meet the axis's core requirements, or the technology is fundamentally unsuited to this axis. |
+| **N/A** | Not Applicable | The axis does not apply to this technology kind (e.g., resource limits for a Broker). |
+
+### Overall Grade
+
+After grading all six axes, compute an overall grade using this
+procedure:
+
+1. **Exclude N/A axes** — only grade axes that apply to the technology's
+   kind.
+2. **Weight by deployment context.** The rubric does not prescribe fixed
+   weights because different deployment contexts value different axes.
+   Three reference weighting profiles are provided below.
+3. **Compute a weighted letter grade** using the mapping A=4, B=3, C=2,
+   D=1, F=0, then convert back.
+
+| Weight Profile | Use When | Axis Weights |
+|----------------|----------|--------------|
+| **Agentic workloads** | AI agent tool execution, code generation sandboxing | Isolation 25%, Dimensions 30%, Policy Language 20%, Composability 10%, Operational 5%, Cross-Platform 10% |
+| **Enterprise / compliance** | Regulated environments, audit requirements | Isolation 20%, Dimensions 20%, Policy Language 15%, Composability 10%, Operational 10%, Cross-Platform 25% |
+| **CI / build isolation** | Build systems, test runners, ephemeral containers | Isolation 15%, Dimensions 20%, Policy Language 10%, Composability 25%, Operational 25%, Cross-Platform 5% |
+
+**Grade boundaries (weighted GPA):**
+
+| GPA Range | Overall Grade |
+|-----------|---------------|
+| 3.5 – 4.0 | A |
+| 2.5 – 3.4 | B |
+| 1.5 – 2.4 | C |
+| 0.5 – 1.4 | D |
+| 0.0 – 0.4 | F |
+
+> **Important:** The overall grade is a summary heuristic, not a
+> verdict. A technology with an overall B may still be the right choice
+> if its A-grade axis aligns with your highest-priority concern. Always
+> read the per-axis grades and notes.
+
+---
+
+## 2. Technology Classification
+
+Before evaluating, classify the technology. Different kinds of
+technologies serve different roles in a sandboxing stack, and comparing
+a primitive to a full composition on the same scorecard produces
+misleading results.
+
+### 2.1 Technology Kind
+
+| Kind | Description | Examples |
+|------|-------------|----------|
+| **Primitive** | A single kernel or OS mechanism that enforces one or a few policy dimensions | Seccomp-BPF, Landlock, Linux namespaces, AppContainer, Integrity Levels, Job Objects |
+| **Composition / Runtime** | A system that combines multiple primitives into a complete sandbox | Docker, Flatpak, Chromium sandbox, Win32 App Isolation, BubbleWrap |
+| **Broker / Consent Layer** | A mechanism that mediates access to resources outside the sandbox boundary, optionally with user consent | BFS, macOS TCC, Flatpak/XDG portals, macOS Powerbox / security-scoped bookmarks |
+| **Trust Anchor / Hardening** | A mechanism that establishes a trust foundation or hardens the platform, but does not sandbox per-workload | VBS/HVCI, Hardened Runtime, WDAC, Process Mitigation Policies |
+| **Language / Runtime Sandbox** | Isolation provided by a language runtime or bytecode VM rather than the OS kernel | WebAssembly, Deno permissions, Java SecurityManager (deprecated) |
+
+Mark the technology's kind first. Then:
+
+- **Primitives** will have **N/A** on many composition-level criteria
+  (lifecycle, warm reuse, multi-dimension coverage). That's expected.
+- **Compositions** should be evaluated as a whole *and* by listing which
+  primitives they compose.
+- **Brokers** should be evaluated primarily on Axis 3 (policy language)
+  and Axis 6 (cross-platform alignment), plus the brokered-access
+  criteria in Axis 2.
+- **Trust Anchors** are evaluated primarily on Axis 1 (enforcement
+  point) and Axis 5 (security properties). Many Axis 2 dimensions will
+  be N/A.
+- **Language sandboxes** should be evaluated on their capability model
+  and how it maps to the intent policy, understanding that OS-level
+  enforcement may be absent.
+
+### 2.2 Platform Scope
+
+| Scope | Platforms |
+|-------|-----------|
+| Linux-only | |
+| macOS-only | |
+| Windows-only | |
+| Multi-platform | List which platforms |
+| Platform-agnostic | Runs anywhere (e.g., Wasm) |
+
+---
+
+## 3. Axis 1 — Isolation Architecture
+
+This axis classifies the fundamental isolation strategy. Every mechanism
+falls into one (or more) of the models identified in the survey (§7.1).
+
+### 3.1 Isolation Model
+
+Classify the technology:
+
+| Model | Description | Information Leakage |
+|-------|-------------|---------------------|
+| **Different Universe** | The sandboxed process sees a constructed view of the system — unauthorized resources are invisible | Lowest — cannot even enumerate what it cannot access |
+| **Guarded Doors** | The process sees the real system but access is intercepted and checked by the kernel | Medium — can discover resource existence via error codes |
+| **Reduced Credentials** | The process's identity token is weakened so existing access controls deny it | Higher — interacts with real ACL system; error patterns reveal topology |
+| **Kernel Filter** | An in-kernel program inspects each syscall and decides allow/deny | Varies — depends on what the filter covers |
+| **Hypervisor Boundary** | The process runs in a separate VM with its own kernel | Lowest — hardware-enforced isolation |
+
+A technology may combine models (e.g., AppContainer is Reduced
+Credentials for filesystem, but Guarded Doors when combined with BFS).
+
+### 3.2 Default Posture
+
+| Criterion | Answer |
+|-----------|--------|
+| **Deny-by-default?** | Does the technology deny all access unless explicitly permitted? |
+| **Monotonic restriction?** | Once privileges are dropped, can they be regained? (Answer must be "no" for serious sandboxing) |
+| **Inherited by children?** | Do `fork()`/`exec()`/`CreateProcess()` carry restrictions forward? |
+
+### 3.3 Enforcement Point
+
+| Criterion | Answer |
+|-----------|--------|
+| **Where is policy enforced?** | Kernel, hypervisor, user-space runtime, or some combination? |
+| **Is enforcement mandatory?** | Can the sandboxed process opt out or modify its own policy? |
+| **Is enforcement complete?** | Does the mechanism cover all paths to the protected resource, or can the resource be accessed through an unchecked path? |
+| **Fail-closed on unenforceable policy?** | If a policy rule cannot be enforced by this mechanism, does it fail (reject the config), warn, or silently degrade? |
+| **Gap attribution?** | If enforcement is incomplete, can the system report *which* specific rules cannot be enforced and *why*? |
+
+> **Axis 1 Grade: ___** (A–F or N/A)
+
+---
+
+## 4. Axis 2 — Policy Dimension Coverage
+
+This axis evaluates which resource types the technology can govern. These
+dimensions are drawn from the survey's cross-platform analysis (§3) and
+the alignment document's gap analysis (§4).
+
+For each dimension, score coverage (✓/○/✗) and note the granularity.
+
+### 4.1 Filesystem
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Can restrict filesystem access at all** | | |
+| **Per-path granularity** (file, directory, subtree, prefix, pattern) | | |
+| **Per-operation granularity** (read / write / execute / create / delete / metadata / truncate) | | |
+| **Hierarchy inheritance** (rules on parent apply to children) | | |
+| **Deny-by-default posture** | | |
+| **Supports both allowlist and denylist** | | |
+
+### 4.2 Network
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Can restrict network access at all** | | |
+| **All-or-nothing isolation** (network on/off) | | |
+| **Inbound vs outbound distinction** | | |
+| **Per-port filtering** | | |
+| **Per-host/IP filtering** | | |
+| **Per-protocol filtering** (TCP, UDP, ICMP) | | |
+| **Localhost/loopback control** | | |
+| **DNS control** | | |
+
+### 4.3 Process Control
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Fork/spawn control** (can the process create children?) | | |
+| **Exec control** (which executables can be launched?) | | |
+| **Visibility isolation** (can the process see other processes?) | | |
+| **Signal control** (can the process signal others?) | | |
+| **Termination coupling** (children die with parent?) | | |
+
+### 4.4 IPC / Messaging
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **IPC isolation** (shared memory, semaphores, message queues) | | |
+| **Named pipe / Unix socket control** | | |
+| **Platform IPC control** (Mach ports, D-Bus, COM/RPC, ALPC) | | |
+
+### 4.5 Device Access
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Device visibility control** | | |
+| **Per-device granularity** | | |
+| **GPU/accelerator access control** | | |
+
+### 4.6 Privilege Escalation Prevention
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Prevents setuid/setgid escalation** (e.g., `NO_NEW_PRIVS`) | | |
+| **Prevents capability acquisition** | | |
+| **Prevents token elevation** | | |
+
+### 4.7 Syscall Filtering
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Can filter syscalls** | | |
+| **Per-syscall granularity** | | |
+| **Per-argument filtering** | | |
+| **Architecture-aware** (handles syscall number differences) | | |
+
+### 4.8 Resource Limits
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Memory limits** | | |
+| **CPU limits** (rate, cores, time) | | |
+| **Process count limits** | | |
+| **Open file descriptor limits** | | |
+| **Wall-time limits** | | |
+| **Disk I/O limits** | | |
+
+### 4.9 Brokered / Consent-Mediated Access
+
+This sub-axis evaluates whether the technology supports mediated access
+to resources outside the sandbox boundary — a key concept in the policy
+design document (BFS on Windows, TCC on macOS, Flatpak portals on
+Linux).
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Supports brokered access to host resources** | | Can the sandbox request access to specific files/services outside its boundary? |
+| **Per-invocation grants** | | Can access be granted for a single operation, not persisted? |
+| **Per-session grants** | | Can access be granted for the lifetime of one sandbox session? |
+| **Persistent grants** | | Can grants be remembered across sessions? |
+| **Revocability** | | Can previously granted access be revoked for future runs? |
+| **User consent UX** | | Is there a user-facing dialog or approval mechanism? |
+| **Programmatic grant API** | | Can grants be made programmatically (e.g., by an admin policy)? |
+
+### 4.10 Identity / Code Integrity
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Code signing verification** | | Can the sandbox verify that executables/scripts are signed? |
+| **Exec whitelisting** | | Can the sandbox restrict which binaries/scripts are allowed to execute? |
+| **Runtime identity** | | Does the sandbox have a verifiable identity (e.g., AppContainer SID, SELinux label)? |
+| **Provenance tracking** | | Can the origin of code running in the sandbox be traced? |
+
+> **Axis 2 Grade: ___** (A–F or N/A)
+
+---
+
+## 5. Axis 3 — Policy Language & Authoring
+
+This axis evaluates how policy is expressed, which directly affects
+whether the technology can participate in the intent→compose→bind
+pipeline described in the policy design document.
+
+### 5.1 Policy Expression
+
+| Criterion | Answer |
+|-----------|--------|
+| **Is there a declarative policy language?** | Yes (profile files, JSON schemas, etc.) / No (imperative CLI flags, API calls only) |
+| **What is the policy format?** | S-expressions, JSON, YAML, XML, binary, CLI flags, kernel structs, etc. |
+| **Is the policy human-readable?** | Can a security reviewer read and audit the policy? |
+| **Is the policy machine-parseable?** | Can tooling programmatically generate and validate policy? |
+| **Is there a schema or formal grammar?** | Is the policy language formally specified? |
+
+### 5.2 Abstraction Level
+
+| Criterion | Answer |
+|-----------|--------|
+| **Platform-specific or abstract?** | Does the policy reference platform-specific paths/ports/syscall numbers, or abstract concepts? |
+| **Can express intent without mechanism details?** | Can you say "read access to input files" without naming `/home/user/data`? |
+| **Supports logical names / service references?** | Can you reference `weather-api` instead of `api.weatherapi.com:443`? |
+| **Supports storage classes / data domains?** | Can you reference `workspace` instead of `/tmp/sandbox-work`? |
+
+### 5.3 Authoring Model
+
+| Criterion | Answer |
+|-----------|--------|
+| **Who authors the policy?** | Developer, user, admin, OS vendor, or some combination? |
+| **Is multi-author composition supported?** | Can multiple parties contribute to the final policy? |
+| **Is there a composition algebra?** | How are conflicting or overlapping policies resolved? (Intersection, union, priority, undefined?) |
+| **Is composition deterministic?** | Given the same inputs, does composition always produce the same output? |
+| **Can policy be generated by tooling / AI agents?** | Is the format amenable to programmatic authoring? |
+
+### 5.4 Validation & Debugging
+
+| Criterion | Answer |
+|-----------|--------|
+| **Can policy be validated before enforcement?** | Is there a dry-run, lint, or compile-check mode? |
+| **Static conflict detection?** | Can tooling detect conflicting rules or empty intersections before runtime? |
+| **Redundancy detection?** | Can tooling identify rules that are subsumed by other rules? |
+| **Are violations logged with attribution?** | When access is denied, does the log say *which rule* caused the denial? |
+| **Denial-to-rule traceability?** | Can a runtime denial be traced back to a specific policy author/layer? |
+| **Is there a learning/discovery mode?** | Can the system observe a workload and suggest a policy? |
+
+### 5.5 Versioning & Compatibility
+
+| Criterion | Answer |
+|-----------|--------|
+| **Is the policy format versioned?** | Schema version, ABI version, or similar? |
+| **Forward compatibility behavior?** | What happens when a newer policy is loaded by an older runtime? (Fail, warn, ignore unknown fields?) |
+| **Backward compatibility behavior?** | What happens when an older policy is loaded by a newer runtime? |
+| **Is there a compatibility matrix?** | Documented mapping between policy features and minimum runtime versions? |
+
+### 5.6 Guarantees & Claims
+
+| Criterion | Answer |
+|-----------|--------|
+| **Can the technology express security guarantees?** | e.g., "no-filesystem-escape", "exec-restricted" |
+| **Are guarantees machine-readable?** | Can tooling verify that a composition provides claimed guarantees? |
+| **Can claims be validated against guarantees?** | If a policy claims `deterministic: true`, can the sandbox verify or refute it? |
+| **Support for brokered/user-selected resources in policy?** | Can the policy language express "access to files the user chooses at runtime"? |
+
+> **Axis 3 Grade: ___** (A–F or N/A)
+
+---
+
+## 6. Axis 4 — Composability & Integration
+
+This axis evaluates whether the technology can be combined with others
+and integrated into the MXC policy pipeline.
+
+### 6.1 Composability with Other Mechanisms
+
+| Criterion | Score | Notes |
+|-----------|-------|-------|
+| **Can be layered with other sandboxing mechanisms** | | e.g., seccomp + namespaces + Landlock |
+| **Stacking is additive (more restrictive)** | | Each added layer can only further restrict |
+| **No conflicts with other mechanisms** | | Adding this mechanism doesn't break another |
+| **Well-defined interaction semantics** | | Is it documented how this mechanism interacts with others on the same system? |
+
+### 6.2 Lifecycle Integration
+
+| Criterion | Answer |
+|-----------|--------|
+| **Setup cost** | How expensive is initial sandbox creation? (ms, seconds, minutes) |
+| **Per-workload cost** | How expensive is running a workload in an existing sandbox? |
+| **Warm reuse** | Can the sandbox be reused across workloads without teardown/rebuild? |
+| **State reset** | Can workload side effects be rolled back between executions? |
+| **Teardown** | Is cleanup automatic? Are there resource leaks on abnormal termination? |
+
+### 6.3 Platform Requirements
+
+| Criterion | Answer |
+|-----------|--------|
+| **Required OS / kernel version** | Minimum version needed |
+| **Requires root / admin / special privileges?** | Can unprivileged users create sandboxes? |
+| **Requires kernel modules or drivers?** | e.g., BFS mini-filter, SELinux LSM |
+| **Available on which platforms?** | Linux, macOS, Windows, or cross-platform |
+| **Maturity / support status** | Production-stable, preview, deprecated, unsupported? |
+
+> **Axis 4 Grade: ___** (A–F or N/A)
+
+---
+
+## 7. Axis 5 — Operational Characteristics
+
+### 7.1 Security Properties
+
+| Criterion | Answer |
+|-----------|--------|
+| **Has been formally analyzed or audited?** | Published CVEs, penetration test results, or formal verification? |
+| **Known escape vectors?** | Are there documented ways to bypass the sandbox? |
+| **Defense in depth contribution** | Does it add a unique layer, or does it overlap with existing mechanisms? |
+
+### 7.2 Performance Impact
+
+| Criterion | Answer |
+|-----------|--------|
+| **Syscall overhead** | Per-syscall latency added by the mechanism |
+| **Startup overhead** | Time to establish the sandbox |
+| **Memory overhead** | Additional memory consumed by the mechanism |
+| **I/O overhead** | Impact on filesystem and network throughput |
+
+### 7.3 Debuggability & Observability
+
+| Criterion | Answer |
+|-----------|--------|
+| **Can observe what the sandboxed process is doing?** | Tracing, logging, profiling |
+| **Can diagnose policy denials?** | Clear error messages when access is blocked |
+| **Audit trail** | Is there a record of all policy decisions for post-hoc review? |
+
+> **Axis 5 Grade: ___** (A–F or N/A)
+
+---
+
+## 8. Axis 6 — Cross-Platform Policy Alignment
+
+This axis evaluates how well the technology fits into the
+intent→compose→bind policy pipeline from the ContainerPolicyDesign
+document. This is the most MXC-specific axis.
+
+### 8.1 Intent Mapping
+
+| Criterion | Answer |
+|-----------|--------|
+| **Can the technology enforce intent policy `requires.storage` declarations?** | Which storage classes map to which mechanism features? |
+| **Can it enforce `requires.network` declarations?** | Service references, DNS, localhost control? |
+| **Can it enforce `constraints`?** | Memory, CPU, wall-time, process count? |
+| **Which dimensions require a *different* mechanism?** | What gaps must be filled by composition? |
+
+### 8.2 Binder Integration
+
+| Criterion | Answer |
+|-----------|--------|
+| **Can a binder produce configuration for this technology from bound policy?** | Is the technology's configuration format suitable for generation from abstract policy? |
+| **Is the configuration format documented and stable?** | Can tooling reliably generate configurations across versions? |
+| **Is there a capability profile (or could one be written)?** | Can the technology's capabilities be formally described for the binder to reason about? |
+
+### 8.3 Composition Role
+
+| Criterion | Answer |
+|-----------|--------|
+| **What role does this technology play in a full composition?** | Primary boundary? Defense-in-depth layer? Resource governor? |
+| **Which other technologies does it typically compose with?** | e.g., AppContainer + BFS + Job Objects + Integrity Levels |
+| **Does it duplicate another mechanism's coverage?** | Overlap is acceptable for defense-in-depth, but important to note |
+
+> **Axis 6 Grade: ___** (A–F or N/A)
+>
+> **Overall Grade: ___** (weighted per §1 weight profile: _______________)
+
+---
+
+## 9. Technologies Not Currently Covered
+
+The survey and design documents cover: Linux Namespaces/BubbleWrap,
+Seccomp-BPF, Landlock, SELinux, macOS Seatbelt/App Sandbox, Windows
+AppContainer, Restricted Tokens, Job Objects, Integrity Levels, Windows
+Sandbox (Hyper-V), Win32 App Isolation, and BFS.
+
+The following technologies are **not yet surveyed** but are relevant to
+cross-platform workload sandboxing. They are grouped by technology kind
+(§2.1) and then by platform.
+
+### 9.1 Primitives — Not Covered
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **AppArmor** | Linux | The default MAC on Debian/Ubuntu (where SELinux is not). Path-based (vs SELinux's label-based). Used by Docker, LXD, Snap. Policy is more approachable than SELinux. |
+| **cgroups v2** | Linux | The primary Linux mechanism for memory, CPU, I/O, and PID limits. The Linux equivalent of Windows Job Objects. Mentioned in passing in the survey but not surveyed as a mechanism. |
+| **Landlock** (already surveyed but) **ABI v5–v6** | Linux | ABI v5 adds device ioctl; v6 adds Unix socket and signal scoping. The survey covers v4. |
+| **eBPF / LSM-BPF** | Linux | eBPF programs attached to LSM hooks. More flexible than seccomp-BPF. Can implement custom MAC policies without kernel modules. Emerging alternative to SELinux/AppArmor for dynamic policy. |
+| **io_uring restrictions** | Linux | `io_uring` bypasses traditional syscall paths, requiring separate restriction (kernel 5.17+). A gap in seccomp-only sandboxes. |
+| **iptables / nftables** | Linux | The standard Linux firewall. Already used by MXC's LXC backend but not surveyed as a sandbox primitive. Important for the network policy dimension. |
+| **POSIX rlimits** | Linux/macOS | `setrlimit()` for per-process resource limits (memory, file descriptors, CPU time). Simple, portable, complementary to cgroups. |
+| **launchd resource controls** | macOS | macOS service manager can impose resource limits. The macOS-native path for constraining daemon resources. |
+| **Windows Filtering Platform (WFP)** | Windows | The kernel-mode network filtering framework. Already used by MXC's firewall implementation but not surveyed as a primitive. Provides per-port, per-protocol, per-application network policy. |
+| **Process Mitigation Policies** | Windows | Per-process flags: CFG, CIG (Code Integrity Guard), ACG (Arbitrary Code Guard), DEP. Not a sandbox per se, but directly relevant to privilege escalation prevention and code integrity. |
+
+### 9.2 Compositions / Runtimes — Not Covered
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **Docker / OCI containers** | Linux (primarily) | Docker composes namespaces + seccomp + cgroups + AppArmor/SELinux. The most widely understood container composition. Worth surveying as a blessed composition reference. |
+| **Podman** | Linux | Rootless containers by design. Demonstrates unprivileged sandboxing at the container level. |
+| **Flatpak** | Linux | Full desktop sandboxing using BubbleWrap + seccomp + portals. Has its own permission model and portal-brokered access. |
+| **Snap confinement** | Linux | Canonical's sandboxing for Snap packages. Uses AppArmor + seccomp + mount namespaces. Has its own interface/plug/slot permission model. |
+| **systemd-nspawn** | Linux | systemd's built-in container tool. Uses namespaces + seccomp. Has a configuration format. |
+| **Firejail** | Linux | User-friendly sandbox for desktop Linux apps. Uses namespaces + seccomp + Landlock. Has its own profile format. |
+| **nsjail** | Linux | Google's sandboxing tool (used for CTF, build isolation). Config-file-driven namespace sandbox. |
+| **Minijail** | Linux/ChromeOS | Chrome OS's sandboxing tool (also Android). Minimal, composable, production-hardened. |
+| **Chromium sandbox** | Cross-platform | Multi-layer, broker-heavy, mature reference design. Uses seccomp+namespaces (Linux), Seatbelt (macOS), Restricted Tokens+Job Objects+Integrity Levels (Windows). Highly relevant as a cross-platform composition example. |
+| **gVisor (runsc)** | Linux | Google's user-space kernel that intercepts syscalls. "Different Universe" without a full VM. Used by GKE Sandbox. Strong isolation model worth comparing to Hyper-V. |
+| **Kata Containers** | Linux | Each container runs in its own VM (QEMU/Cloud Hypervisor/Firecracker). Similar to Windows Sandbox's Hyper-V approach for OCI containers. |
+| **Firecracker** | Linux | AWS's minimal VMM. Sub-second boot. Powers Lambda and Fargate. Comparable to NanVix MicroVM. |
+| **FreeBSD jails** | FreeBSD | OS-level virtualization. Relevant as a conceptual reference and because some BSD-derived ideas influence other systems. |
+
+### 9.3 Brokers / Consent Layers — Not Covered
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **TCC (Transparency, Consent, and Control)** | macOS | The system behind "App X wants to access your Photos" dialogs. Governs camera, microphone, location, contacts, calendars. The macOS analog of Android runtime permissions. Directly relevant to user consent modeling (§4 of the policy design). |
+| **Flatpak / XDG Desktop Portals** | Linux | D-Bus-based brokered access to host resources (files, printing, screenshots, camera). The Linux analog of BFS's brokered access. |
+| **macOS Powerbox / security-scoped bookmarks** | macOS | File access brokering for sandboxed macOS apps. User picks files via system dialog; app receives scoped access tokens. Directly comparable to BFS and the `user_selected` storage class. |
+| **XPC Services** | macOS | macOS IPC mechanism for decomposing apps into least-privilege components. Relevant to the IPC policy dimension and privilege separation. |
+
+### 9.4 Trust Anchors / Hardening — Not Covered
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **WDAC (Windows Defender Application Control)** | Windows | Kernel-enforced controls over which executables/scripts/DLLs can run. The Windows analog of exec whitelisting. Directly relevant to the exec-control gap (Appendix D.8 of the policy design). |
+| **AppLocker** | Windows | Predecessor to WDAC. Simpler but less capable. Still widely deployed in enterprises. |
+| **VBS (Virtualization-Based Security)** | Windows | Uses the hypervisor to create isolated memory regions. Powers Credential Guard, HVCI. Relevant as a hardware-enforced trust anchor. |
+| **HVCI (Hypervisor-enforced Code Integrity)** | Windows | Verifies code integrity using the hypervisor. Prevents unsigned kernel-mode code. Relevant to the "system intent" layer. |
+| **WDAG (Windows Defender Application Guard)** | Windows | Hyper-V-based browser isolation. Similar to Windows Sandbox but purpose-built for browsing. |
+| **Hardened Runtime** | macOS | Required for notarization. Prevents code injection, DYLD hijacking, unsigned code execution. Kernel-enforced, not a profile. |
+| **macOS Endpoint Security framework** | macOS | Apple's supported API for monitoring process execution, file access, network activity. Potential enforcement/observability point. |
+| **macOS System Extensions** | macOS | User-space replacements for kernel extensions (kexts) for network and endpoint security. Relevant for enforcement-point architecture. |
+
+### 9.5 Language / Runtime Sandboxes — Not Covered
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **WebAssembly (Wasm)** | Cross-platform | Memory-safe, capability-based sandbox by default. No filesystem, no network, no syscalls unless explicitly provided via WASI. The purest "deny-by-default" model. |
+| **WASI (WebAssembly System Interface)** | Cross-platform | The capability-based system interface for Wasm. Maps closely to the intent policy's storage class and network service model. |
+| **Deno permissions model** | Cross-platform | Requires explicit `--allow-read`, `--allow-net`, etc. A runtime-level deny-by-default with per-dimension granularity. Interesting policy language comparison. |
+| **Wasmtime / Wasmer / WasmEdge** | Cross-platform | Production Wasm runtimes with different capability-injection models worth comparing. |
+
+### 9.6 Conceptual References (Other OS)
+
+| Technology | Platform | Why It Matters |
+|------------|----------|----------------|
+| **Capsicum** | FreeBSD | Capability-based sandbox mode. Influenced academic work on capability systems. Chromium uses it on FreeBSD. Theoretically clean model. |
+| **pledge / unveil (OpenBSD)** | OpenBSD | Process self-restriction. `pledge()` restricts syscalls by category; `unveil()` restricts filesystem paths. Influenced Landlock's design. Elegant minimal API. |
+
+---
+
+## 10. Applying the Rubric — Worked Example
+
+### Example: Evaluating Landlock v4 (Linux)
+
+**Classification**
+- Technology Kind: **Primitive**
+- Platform: **Linux-only**
+
+**Axis 1 — Isolation Architecture**
+- Model: **Guarded Doors** (kernel intercepts access, checks against ruleset)
+- Deny-by-default: **Yes** — everything not mentioned in rules is denied
+- Monotonic restriction: **Yes** — rulesets are permanent once applied
+- Inherited by children: **Yes** — `fork()` and `execve()` carry restrictions
+- Enforcement point: **Kernel** (LSM hook)
+- Mandatory: **No** — self-restriction only (process must opt in)
+- Fail-closed: **Yes** — unrecognized access types are denied by default
+- Gap attribution: **No** — denials produce generic `EACCES`
+
+> **Axis 1 Grade: A** — Strong: kernel-enforced, deny-by-default, monotonic, inherited. Loses only on the opt-in (not mandatory) and poor gap attribution.
+
+**Axis 2 — Policy Dimension Coverage**
+- Filesystem: **✓ Full** — per-path, per-operation (read/write/execute/create/delete/truncate)
+- Network: **○ Partial** — TCP bind/connect only (ABI v4+); no host filtering, no UDP
+- Process: **✗** — no fork/exec/visibility control
+- IPC: **○ Partial** — abstract Unix socket scoping (ABI v6+)
+- Devices: **○ Partial** — ioctl control (ABI v5+)
+- Privilege escalation: **✓** — requires `NO_NEW_PRIVS`, irreversible
+- Syscalls: **✗** — not a syscall filter (use seccomp)
+- Resources: **✗** — no CPU/memory/process limits
+- Brokered access: **✗** — no consent/brokering model
+- Identity: **✗** — no code signing or identity model
+
+> **Axis 2 Grade: C** — Strong filesystem, decent privilege escalation prevention, but 4 of 10 dimensions are ✗ and 3 are only partial. Requires composition for a complete sandbox.
+
+**Axis 3 — Policy Language & Authoring**
+- Declarative language: **No** — policy is expressed via C syscalls (`landlock_create_ruleset()`, `landlock_add_rule()`, `landlock_restrict_self()`)
+- Machine-parseable: **Not applicable** — there is no file format; policy is programmatic
+- Abstraction level: **Platform-specific** — references file descriptors and syscall constants
+- Multi-author composition: **No** — single process restricts itself
+- Composition algebra: **Additive only** — can stack rulesets (tighter), but no intersection/union semantics
+- Versioning: **Yes** — ABI version negotiation via `landlock_create_ruleset()`
+- Learning mode: **No**
+- Guarantees: **No** — no machine-readable guarantee model
+
+> **Axis 3 Grade: D** — No declarative language, no file format, no multi-author support. The ABI versioning is well-designed, but from a policy-language perspective this is a bare programmatic API.
+
+**Axis 4 — Composability & Integration**
+- Composable: **✓** — stacks cleanly with seccomp, namespaces, SELinux, AppArmor
+- Stacking is additive: **✓** — additional rulesets only tighten
+- Setup cost: **Negligible** — three syscalls
+- Warm reuse: **N/A** — applied per-process, not per-container
+- Requires root: **No** — unprivileged; requires only `NO_NEW_PRIVS`
+
+> **Axis 4 Grade: A** — Exemplary composability. Layers cleanly with every other Linux mechanism. Zero setup cost. Unprivileged.
+
+**Axis 5 — Operational Characteristics**
+- Kernel version: **5.13+** (filesystem); **6.7+** (network)
+- Overhead: **Very low** — LSM hook on each access check
+- Known escapes: None published (as of this writing)
+- Debuggability: **Poor** — denials produce `EACCES` with no detail
+
+> **Axis 5 Grade: B** — Excellent performance and security posture, but poor debuggability drags it down. No audit trail for policy decisions.
+
+**Axis 6 — Cross-Platform Policy Alignment**
+- Intent mapping: Can enforce `requires.storage` (filesystem) well; `requires.network` partially (TCP only)
+- Binder integration: Would need the binder to emit C code or use a helper library; no config file format to generate
+- Composition role: **Defense-in-depth layer** — complements namespaces (which provide the primary "Different Universe" boundary)
+
+> **Axis 6 Grade: C** — Good filesystem-to-intent mapping, but the lack of a config file format makes binder integration harder than mechanisms with declarative profiles. Linux-only, so no cross-platform story.
+>
+> **Overall Grade: B** (Agentic workloads weighting: 4+2+1+4+3+2 = weighted 2.6 → B)
+> Landlock is an excellent defense-in-depth primitive with best-in-class composability, but it cannot stand alone as a sandbox and has no policy language for the binder to target.
+
+---
+
+## Appendix: Blank Evaluation Scorecard
+
+Copy this template for each technology evaluation.
+
+```
+# Technology: _______________
+# Platform: _______________
+# Version Evaluated: _______________
+# Technology Kind: Primitive | Composition | Broker | Trust Anchor | Language Sandbox
+
+## Axis 1 — Isolation Architecture
+- Isolation model:
+- Deny-by-default:
+- Monotonic restriction:
+- Inherited by children:
+- Enforcement point:
+- Mandatory or opt-in:
+- Enforcement completeness:
+- Fail-closed on unenforceable policy:
+- Gap attribution:
+> **Axis 1 Grade: ___**
+
+## Axis 2 — Policy Dimension Coverage
+| Dimension             | Score | Granularity Notes |
+|-----------------------|-------|-------------------|
+| Filesystem            |       |                   |
+| Network               |       |                   |
+| Process control       |       |                   |
+| IPC / messaging       |       |                   |
+| Device access         |       |                   |
+| Privilege escalation  |       |                   |
+| Syscall filtering     |       |                   |
+| Resource limits       |       |                   |
+| Brokered access       |       |                   |
+| Identity / code integrity |   |                   |
+> **Axis 2 Grade: ___**
+
+## Axis 3 — Policy Language & Authoring
+- Declarative language:
+- Policy format:
+- Human-readable:
+- Machine-parseable:
+- Schema/formal grammar:
+- Abstraction level:
+- Multi-author composition:
+- Composition algebra:
+- Composition deterministic:
+- Tooling/AI authorable:
+- Validation/dry-run:
+- Static conflict detection:
+- Redundancy detection:
+- Violation logging w/ attribution:
+- Denial-to-rule traceability:
+- Learning/discovery mode:
+- Policy format versioned:
+- Forward compatibility behavior:
+- Backward compatibility behavior:
+- Machine-readable guarantees:
+- Claims validatable against guarantees:
+- Supports brokered/user-selected resources:
+> **Axis 3 Grade: ___**
+
+## Axis 4 — Composability & Integration
+- Composable with other mechanisms:
+- Stacking is additive:
+- Interaction semantics documented:
+- Setup cost:
+- Per-workload cost:
+- Warm reuse:
+- State reset:
+- Teardown:
+> **Axis 4 Grade: ___**
+
+## Axis 5 — Operational Characteristics
+- Platform requirements:
+- Requires root/admin:
+- Requires kernel modules/drivers:
+- Maturity/support status:
+- Formal analysis/audit:
+- Known escape vectors:
+- Defense-in-depth contribution:
+- Syscall overhead:
+- Startup overhead:
+- Memory overhead:
+- Debuggability:
+- Audit trail:
+> **Axis 5 Grade: ___**
+
+## Axis 6 — Cross-Platform Policy Alignment
+- Maps to intent `requires.storage`:
+- Maps to intent `requires.network`:
+- Maps to intent `constraints`:
+- Gaps requiring other mechanisms:
+- Binder can generate config:
+- Config format stable/documented:
+- Capability profile writable:
+- Composition role:
+- Typical composition partners:
+- Duplicates another mechanism's coverage:
+> **Axis 6 Grade: ___**
+
+## Summary
+> **Overall Grade: ___** (Weight profile: _______________)
+> Brief justification:
+```

--- a/docs/proposals/container-policy/SandboxSurvey.md
+++ b/docs/proposals/container-policy/SandboxSurvey.md
@@ -1,0 +1,1585 @@
+# Container Sandboxing Mechanisms: A Cross-Platform Survey
+
+This document surveys the sandboxing and container isolation mechanisms available
+on Linux, macOS, and Windows. It establishes a common conceptual framework for
+evaluating these mechanisms and compares them across platforms.
+
+A companion document, *Container Policy Design*, covers the policy language,
+intent manifests, binding, compilation, and runtime enforcement pipeline built on
+top of these mechanisms.
+
+---
+
+## Table of Contents
+
+- [1. Introduction](#1-introduction)
+- [2. The Five Questions Every Sandbox Answers](#2-the-five-questions-every-sandbox-answers)
+- [3. Common Policy Dimensions](#3-common-policy-dimensions)
+  - [3.1 Filesystem Access](#31-filesystem-access)
+  - [3.2 Network Access](#32-network-access)
+  - [3.3 Process Control](#33-process-control)
+  - [3.4 Inter-Process Communication (IPC)](#34-inter-process-communication-ipc)
+  - [3.5 Device Access](#35-device-access)
+  - [3.6 Privilege Escalation Prevention](#36-privilege-escalation-prevention)
+  - [3.7 Resource Limits](#37-resource-limits)
+  - [3.8 Syscall Filtering](#38-syscall-filtering)
+- [4. Linux Mechanisms](#4-linux-mechanisms)
+  - [4.1 Namespaces and BubbleWrap](#41-namespaces-and-bubblewrap)
+  - [4.2 Seccomp-BPF](#42-seccomp-bpf)
+  - [4.3 Landlock](#43-landlock)
+  - [4.4 SELinux](#44-selinux)
+- [5. macOS Mechanisms](#5-macos-mechanisms)
+  - [5.1 Seatbelt and App Sandbox](#51-seatbelt-and-app-sandbox)
+- [6. Windows Mechanisms](#6-windows-mechanisms)
+  - [6.1 AppContainer](#61-appcontainer)
+  - [6.2 Restricted Tokens](#62-restricted-tokens)
+  - [6.3 Job Objects](#63-job-objects)
+  - [6.4 Integrity Levels](#64-integrity-levels)
+  - [6.5 Windows Sandbox](#65-windows-sandbox)
+  - [6.6 Win32 App Isolation](#66-win32-app-isolation)
+  - [6.7 Brokered File System (BFS)](#67-brokered-file-system-bfs)
+- [7. Cross-Platform Comparison](#7-cross-platform-comparison)
+  - [7.1 Isolation Models](#71-isolation-models)
+  - [7.2 Dimension Coverage Matrix](#72-dimension-coverage-matrix)
+  - [7.3 Capability Mapping Across Platforms](#73-capability-mapping-across-platforms)
+  - [7.4 Composability](#74-composability)
+- [Appendix A: macOS Seatbelt Profile Language](#appendix-a-macos-seatbelt-profile-language)
+- [Appendix B: Seccomp-BPF Programming Details](#appendix-b-seccomp-bpf-programming-details)
+- [Appendix C: Landlock Programming Details](#appendix-c-landlock-programming-details)
+- [Appendix D: SELinux Policy Language](#appendix-d-selinux-policy-language)
+- [Appendix E: BFS Architecture and Programming Details](#appendix-e-bfs-architecture-and-programming-details)
+
+---
+
+## 1. Introduction
+
+Running untrusted or semi-trusted code is a fundamental requirement of modern
+systems — from browser tabs to CI pipelines to AI agent tool invocations. The
+operating system provides the execution environment, but that environment is far
+too permissive by default. A process can read arbitrary files, open network
+connections, spawn children, send signals, and access devices. Sandboxing
+restricts these capabilities to only what the code actually needs.
+
+Every major operating system has evolved sandboxing mechanisms, but they differ
+significantly in architecture, policy model, and granularity. Linux offers a
+composable toolkit of kernel primitives (namespaces, seccomp, Landlock, SELinux).
+macOS provides a kernel-enforced mandatory access control framework (Seatbelt/App
+Sandbox). Windows uses a combination of restricted tokens, AppContainer SIDs,
+Job Objects, and integrity levels.
+
+Understanding these mechanisms — their capabilities, limitations, and how they
+compose — is a prerequisite for designing a cross-platform sandbox policy system.
+This document provides that understanding.
+
+### What This Document Covers
+
+- The **conceptual framework** for reasoning about sandbox policy (§2–3)
+- A **survey of mechanisms** on Linux (§4), macOS (§5), and Windows (§6)
+- A **cross-platform comparison** that maps mechanisms to common dimensions (§7)
+- **Programming deep-dives** in appendices for implementers who need specifics
+
+### What This Document Does Not Cover
+
+- The design of a cross-platform policy language (see companion document)
+- Intent manifests, policy binding, or policy compilation
+- Container lifecycle management, warm pools, or workload cycling
+- Backend capability profiles or policy evaluation algorithms
+
+---
+
+## 2. The Five Questions Every Sandbox Answers
+
+Despite the diversity of mechanisms across platforms, every sandboxing system
+answers the same five fundamental questions:
+
+```
+1. WHAT RESOURCES?     Files, network, IPC, devices, processes, syscalls
+2. WHICH ONES?         By path, by port, by service name, by syscall number
+3. WHAT OPERATIONS?    Read vs write vs execute vs create vs delete
+4. DEFAULT POSTURE?    Deny-by-default (allowlist) vs allow-by-default (denylist)
+5. CAN IT BE UNDONE?   No. (Always no.)
+```
+
+These five questions are the *shape* of a policy. They apply regardless of
+whether the mechanism is Linux namespaces, macOS Seatbelt profiles, or Windows
+AppContainer capabilities.
+
+**Question 1: What resources?** Every mechanism governs access to some subset of
+system resources. No single mechanism covers all resources — this is why
+sandboxes are typically composed from multiple primitives.
+
+**Question 2: Which ones?** Resources are identified differently across systems —
+by filesystem path, by network port, by IPC service name, by syscall number, by
+device node, by security label. The identification scheme determines the
+granularity of policy.
+
+**Question 3: What operations?** Read, write, and execute are the universal
+triple, but systems distinguish further: create vs modify, truncate vs append,
+metadata access vs data access, connect vs bind vs listen.
+
+**Question 4: Default posture?** The most consequential architectural choice.
+Deny-by-default (allowlist) means nothing works unless explicitly permitted —
+secure by default, but requires complete enumeration of needs. Allow-by-default
+(denylist) means everything works unless explicitly forbidden — easier to adopt,
+but one missed entry is a vulnerability. Modern sandboxing systems universally
+prefer deny-by-default.
+
+**Question 5: Can it be undone?** The answer is always no. This is not a
+limitation — it is a security invariant. Every serious sandboxing mechanism
+enforces **monotonic restriction**: once a privilege is dropped, it cannot be
+regained. Seccomp filters are immutable once loaded. Landlock rulesets are
+permanent once applied. AppContainer tokens cannot be upgraded. Seatbelt profiles
+cannot be weakened. This prevents a compromised process from escaping its sandbox
+by modifying its own policy.
+
+---
+
+## 3. Common Policy Dimensions
+
+The five questions describe the *shape* of a single policy decision. But
+policies are not single decisions — they are collections of rules across
+multiple **dimensions**. This section identifies the dimensions that recur
+across all sandboxing systems and establishes the vocabulary used throughout
+the rest of this document.
+
+### Dimension Coverage Overview
+
+| Policy Dimension | BubbleWrap | Seatbelt | Landlock | Seccomp | AppContainer | Restricted Tokens |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Filesystem access** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Network access** | ✓ | ✓ | ✓ | ○ | ✓ | ○ |
+| **Process visibility/control** | ✓ | ✓ | ○ | ○ | ✓ | ○ |
+| **IPC / messaging** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Device access** | ✓ | ✓ | ✓ | ○ | ✓ | ✓ |
+| **Privilege escalation prevention** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Syscall filtering** | ○ | ✓ | — | ✓ | — | — |
+| **Resource limits (CPU/mem)** | — | — | — | — | ○ | — |
+
+✓ = native to the system | ○ = achievable by composition | — = not addressed
+
+### 3.1 Filesystem Access
+
+Filesystem isolation is the most common policy dimension. Every mechanism
+addresses it, but through fundamentally different strategies.
+
+#### Three Isolation Strategies
+
+**Strategy A: "Different Universe" (Namespace/Mount-based)**
+
+The process literally cannot *see* files that aren't explicitly mounted or
+mapped into its view. The filesystem it observes is a custom-constructed tree —
+a different universe from the host.
+
+Used by: BubbleWrap (mount namespaces + bind mounts), Linux containers (overlay
+filesystems).
+
+**Strategy B: "Guarded Doors" (MAC/Filter-based)**
+
+The process can *see* the full path namespace but is blocked at access time. The
+kernel intercepts each access request and checks it against a policy. The
+process knows the files exist but cannot touch them.
+
+Used by: macOS Seatbelt profiles, Linux Landlock, SELinux type enforcement.
+
+**Strategy C: "Reduced Credentials" (Token/ACL-based)**
+
+The process's identity token is stripped down so that existing OS access control
+lists (ACLs) deny it access. The process is who it claims to be — but it claims
+to be less powerful than it was.
+
+Used by: Windows AppContainer (unique SID), Windows Restricted Tokens (stripped
+privileges), Windows Integrity Levels.
+
+#### Common Filesystem Policy Axes
+
+Despite the different strategies, every system expresses filesystem policy along
+the same axes:
+
+| Axis | How It Appears |
+|---|---|
+| **Which paths** | Specific file, directory subtree, prefix, or regex |
+| **Read vs Write vs Execute** | Always distinguished; read-only is the most common restriction |
+| **Direction of default** | Deny-by-default (allow specific paths) vs allow-by-default (block specific paths) |
+| **Hierarchy inheritance** | "Allow read on `/usr`" implies all children |
+| **Mutability vs creation** | Separate controls for writing existing files vs creating new files |
+
+### 3.2 Network Access
+
+Network policy varies the most in granularity across mechanisms:
+
+| Granularity | BubbleWrap | Seatbelt | Landlock | AppContainer |
+|---|---|---|---|---|
+| **All-or-nothing** | ✓ | — | — | — |
+| **Inbound vs outbound** | — | ✓ | ✓ | ✓ |
+| **By port** | — | ✓ | ✓ | ✓ |
+| **By destination host/IP** | — | ✓ | — | — |
+| **By protocol (TCP/UDP)** | — | ✓ | TCP only (so far) | ✓ |
+| **Localhost specifically** | — | ✓ | ✓ | ✓ |
+
+BubbleWrap provides all-or-nothing network isolation via network namespaces —
+the process either shares the host network stack or gets an empty one. Achieving
+per-port or per-host filtering requires composition with iptables/nftables.
+
+Seatbelt offers the finest granularity: per-host, per-port, per-protocol rules
+expressed declaratively in the profile language.
+
+Landlock added network support in ABI v4 (kernel 6.7) but is limited to TCP
+bind/connect control — no host filtering, no UDP.
+
+AppContainer uses capability-based network access: `internetClient` for outbound,
+`internetClientServer` for inbound, with localhost control as a separate knob.
+
+### 3.3 Process Control
+
+Process-related policy governs spawning, visibility, and signaling:
+
+| Capability | How It Appears |
+|---|---|
+| **Fork/spawn control** | Whether the process can create children at all |
+| **Exec control** | Which executables the process can launch |
+| **Visibility isolation** | Whether the process can see other processes on the system |
+| **Signal control** | Whether the process can send signals to other processes |
+| **Termination coupling** | Whether children die when the parent dies |
+
+Linux PID namespaces provide full visibility isolation — the sandboxed process
+only sees itself and its children. macOS Seatbelt can restrict `process-fork` and
+`process-exec` operations. Windows Job Objects provide process grouping and
+can enforce termination when the job handle closes.
+
+### 3.4 Inter-Process Communication (IPC)
+
+IPC mechanisms are highly OS-specific, but the *intent* of IPC policy is the
+same everywhere: control which services or communication channels the sandboxed
+process can access.
+
+| System | IPC Mechanism Controlled | Policy Expression |
+|---|---|---|
+| BubbleWrap | Unix sockets, shared memory | `--unshare-ipc` (all-or-nothing) |
+| Seatbelt | Mach ports, XPC, Unix sockets | `(allow mach-lookup (global-name "..."))` |
+| Landlock | Abstract Unix sockets, signals | `LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET` (ABI v6) |
+| AppContainer | COM, RPC, named pipes, ALPC | Capability-based in manifest |
+
+### 3.5 Device Access
+
+Device access control prevents sandboxed code from interacting with hardware —
+cameras, GPUs, USB devices, serial ports. Mechanisms range from not mounting
+device nodes at all (BubbleWrap) to capability-based grants (AppContainer) to
+kernel-level mediation (Seatbelt IOKit rules, Landlock `IOCTL_DEV`).
+
+### 3.6 Privilege Escalation Prevention
+
+Every sandbox must prevent the sandboxed process from regaining dropped
+privileges. This is the monotonic restriction invariant from Question 5.
+
+| Mechanism | How It Prevents Escalation |
+|---|---|
+| BubbleWrap | `PR_SET_NO_NEW_PRIVS` — setuid binaries won't elevate |
+| Seatbelt | Deny-by-default + kernel enforcement — no way to load a weaker profile |
+| Landlock | `PR_SET_NO_NEW_PRIVS` + restrictions are additive-only |
+| Seccomp | `PR_SET_NO_NEW_PRIVS` + filters are immutable once loaded and stack |
+| AppContainer | Low integrity level + unique SID — cannot access higher-integrity objects |
+| Restricted Tokens | Stripped privileges + deny-only SIDs — cannot re-add removed SIDs |
+
+The universal principle: the sandbox boundary is monotonically shrinking. Once
+restricted, you cannot regain what you lost.
+
+### 3.7 Resource Limits
+
+Resource limits (CPU, memory, process count, open files, wall-clock time)
+prevent denial-of-service attacks from within the sandbox. They are orthogonal
+to access control — a process might be allowed to write to a file but not
+allowed to consume unbounded memory doing so.
+
+Most sandboxing mechanisms do not address resource limits directly:
+
+- **Linux:** cgroups (v1 or v2) provide memory, CPU, and process count limits.
+  These are a separate mechanism composed alongside namespace-based sandboxes.
+- **macOS:** No built-in resource limit framework for sandboxed processes.
+  `launchd` can impose some limits.
+- **Windows:** Job Objects provide memory limits, CPU rate control, process
+  count limits, and can enforce wall-clock timeouts.
+
+### 3.8 Syscall Filtering
+
+Syscall filtering restricts *which kernel operations* a process can invoke,
+regardless of what resources those operations target. It is the most
+fine-grained form of sandboxing — and the most mechanism-specific.
+
+- **Linux:** seccomp-BPF runs an in-kernel BPF program on every syscall, with
+  per-argument filtering capability. See §4.2 and Appendix B.
+- **macOS:** Seatbelt profiles implicitly filter operations at the kernel level.
+  There is no separate syscall filtering mechanism.
+- **Windows:** No direct equivalent. Sandboxing relies on token-based access
+  control rather than syscall interception.
+
+---
+
+## 4. Linux Mechanisms
+
+Linux offers the richest set of composable sandboxing primitives. No single
+mechanism provides complete isolation — they are designed to be layered.
+
+### 4.1 Namespaces and BubbleWrap
+
+#### Namespaces
+
+Linux namespaces give a process an isolated view of a specific system resource.
+Each namespace type isolates one dimension:
+
+| Namespace | Isolates | Effect |
+|---|---|---|
+| **Mount** | Filesystem mount table | Process sees a custom filesystem tree |
+| **PID** | Process ID space | Process only sees itself and its children |
+| **Network** | Network stack | Process gets a separate set of interfaces, routes, iptables rules |
+| **IPC** | System V IPC, POSIX message queues | Process cannot see other processes' shared memory or semaphores |
+| **UTS** | Hostname and domain name | Process can have its own hostname |
+| **User** | UID/GID mappings | Process can map its UID to root inside the namespace without being root outside |
+| **Cgroup** | Cgroup root directory | Process sees its own cgroup as the root |
+
+User namespaces are the key enabler for unprivileged sandboxing: they allow a
+non-root process to create all other namespace types by mapping its real UID to
+UID 0 inside the namespace.
+
+#### BubbleWrap (`bwrap`)
+
+BubbleWrap is a lightweight sandboxing tool that composes these namespaces into
+a complete sandbox via command-line flags. It is a *building block*, not a
+turnkey sandbox — the caller defines the exact policy.
+
+**Policy model:** Explicit allowlist — nothing is visible unless you bind-mount
+it in. There is no declarative profile language; the policy is expressed
+entirely through CLI flags.
+
+| Feature | Mechanism |
+|---|---|
+| Custom filesystem view | Mount namespace + bind mounts, tmpfs overlays |
+| Syscall filtering | Via `--seccomp` flag (separate mechanism, composable) |
+| Capability dropping | Removes Linux capabilities to prevent privilege escalation |
+| `PR_SET_NO_NEW_PRIVS` | Blocks setuid escalation from within the sandbox |
+
+**Key philosophical property:** BubbleWrap gives the sandboxed process a
+*different universe* — new PID space, new mount tree, new network stack. The
+process cannot see what it hasn't been explicitly shown.
+
+**Used by:** Flatpak (as its core isolation engine), developer sandboxes, build
+environments.
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ Full | "Different universe" — custom mount tree via bind mounts |
+| Network | ✓ All-or-nothing | Network namespace: full isolation or shared host stack |
+| Process | ✓ PID isolation | PID namespace: only sees own children |
+| IPC | ✓ Full isolation | IPC namespace: `--unshare-ipc` |
+| Devices | ✓ Via mount control | Only devices explicitly mounted are visible |
+| Syscalls | ○ Via composition | Passes seccomp filter via `--seccomp` flag |
+| Resources | ✗ Not addressed | Requires separate cgroup setup |
+
+**Limitations:**
+- Network is all-or-nothing — per-port/host filtering requires iptables composition
+- No declarative policy language — policy is imperative CLI flags
+- Resource limits require separate cgroup configuration
+
+### 4.2 Seccomp-BPF
+
+Seccomp (Secure Computing) lets a process restrict which system calls it can
+make. The Linux kernel exposes ~400+ syscalls; most applications use a small
+fraction. Every unused syscall is a potential attack vector.
+
+**How it works:** A BPF (Berkeley Packet Filter) program is attached to the
+process. The in-kernel BPF virtual machine inspects every syscall — its number,
+architecture, and raw argument values — and returns a verdict: allow, kill,
+return an error, trap, or notify a supervisor.
+
+```
+  User process calls write(fd, buf, len)
+          │
+          ▼
+  ┌──────────────────────┐
+  │   Kernel syscall      │
+  │   entry point         │
+  │                       │
+  │  ┌─────────────────┐  │
+  │  │ seccomp BPF VM  │  │  ← in-kernel virtual machine
+  │  │                 │  │    executes filter program
+  │  │ Input:          │  │
+  │  │  .nr   = 1      │  │  (syscall number for write)
+  │  │  .arch = x86_64  │  │
+  │  │  .args[0..5]    │  │  (raw values, NOT dereferenced)
+  │  │                 │  │
+  │  │ Output: ACTION   │  │
+  │  └─────────────────┘  │
+  │          │             │
+  │   ALLOW? → execute     │
+  │   KILL?  → SIGKILL     │
+  │   ERRNO? → return err  │
+  │   TRAP?  → SIGSYS      │
+  └──────────────────────┘
+```
+
+**Key security properties:**
+1. **Immutable once loaded** — a process cannot weaken its own filter
+2. **Inherited by children** — `fork()` and `execve()` carry the filter forward
+3. **Stackable** — multiple filters can be layered; *all* must agree to allow
+4. **No pointer dereferencing** — the BPF program sees raw argument *values*,
+   not the memory they point to, preventing TOCTOU races
+5. **Requires `PR_SET_NO_NEW_PRIVS`** — the process must first commit to never
+   gaining new privileges
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Syscalls | ✓ Full | Per-syscall, per-argument filtering |
+| Filesystem | ○ Indirect | Can block `open()`, `openat()`, etc., but cannot distinguish paths |
+| Network | ○ Indirect | Can block `socket()`, `connect()`, etc. |
+| All others | ✗ | Syscall-level only — no path or resource awareness |
+
+**Used by:** Docker (default profile blocks ~44 dangerous syscalls), Chromium
+(renderers limited to ~20 syscalls), systemd (`SystemCallFilter=`), Android,
+Flatpak/BubbleWrap, OpenSSH.
+
+**Limitations:**
+- Cannot inspect pointed-to memory — only raw argument values (by design)
+- Not a full sandbox alone — only restricts syscalls, not file paths or network
+  destinations
+- Architecture-dependent — syscall numbers differ across architectures
+- Uses classic BPF (cBPF), not the newer eBPF
+
+See [Appendix B](#appendix-b-seccomp-bpf-programming-details) for programming
+details and code examples.
+
+### 4.3 Landlock
+
+Landlock is a Linux Security Module (merged in kernel 5.13) that lets a process
+*restrict itself* — no root, no admin policy, no container runtime needed. A
+process creates a ruleset describing what it is allowed to access, then
+permanently locks itself into that ruleset.
+
+**Where it fits in the Linux security stack:**
+
+```
+  Access Request
+        │
+        ▼
+  DAC (Unix perms)      ← owner/group/other, rwx bits
+        │ Must pass
+        ▼
+  LSM: SELinux/AppArmor ← admin-defined, system-wide
+        │ Must pass
+        ▼
+  LSM: Landlock          ← process-defined, per-process, runtime
+        │ Must pass
+        ▼
+  Access granted
+```
+
+Landlock **only restricts further** — it can never grant access that DAC or
+other LSMs would deny.
+
+**How it works (three syscalls):**
+
+| Syscall | Purpose |
+|---|---|
+| `landlock_create_ruleset()` | Create a new ruleset; declare which access types to govern |
+| `landlock_add_rule()` | Add rules (e.g., "allow read on this directory") |
+| `landlock_restrict_self()` | Apply the ruleset — **permanent and irreversible** |
+
+Everything NOT mentioned in the rules is **denied by default**.
+
+**ABI evolution:**
+
+| ABI | Kernel | Added Capabilities |
+|---|---|---|
+| v1 | 5.13 | Filesystem: read, write, execute, create, remove, make dirs/chars/blocks/fifos/sockets/symlinks/links |
+| v2 | 5.19 | Cross-directory renames and links (`REFER`) |
+| v3 | 6.2 | File truncation |
+| v4 | 6.7 | **Network**: TCP bind and connect control |
+| v5 | 6.10 | Device `ioctl()` control |
+| v6 | 6.12 | **Unix sockets** and **signals** scoping |
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ Full | Path-hierarchy rules, per-operation control |
+| Network | ✓ Partial (ABI ≥ 4) | TCP bind/connect; no host filtering, no UDP |
+| IPC | ✓ Partial (ABI ≥ 6) | Abstract Unix socket scoping, signal scoping |
+| Devices | ✓ Partial (ABI ≥ 5) | `ioctl()` control on device files |
+| Process | ✗ | No fork/exec/visibility control |
+| Resources | ✗ | No resource limits |
+
+**Key design principles:**
+1. **Self-restriction only** — can only restrict itself, never other processes
+2. **Additive restrictions** — can add more rulesets (tighten), never remove
+3. **Inherited by children** — `fork()` and `execve()` carry restrictions forward
+4. **Composable** — stacks cleanly with seccomp, namespaces, and SELinux
+
+The mental model: Landlock is to **files and network ports** what seccomp is to
+**syscalls** — a way for a process to voluntarily shed its own power.
+
+See [Appendix C](#appendix-c-landlock-programming-details) for programming
+details, code examples, and ABI version handling.
+
+### 4.4 SELinux
+
+Security-Enhanced Linux (SELinux) is a **mandatory access control (MAC)
+framework** built into the Linux kernel as a Linux Security Module. Originally
+developed by the NSA, it is the most mature and comprehensive MAC system on
+Linux.
+
+Unlike Landlock (self-restriction) or seccomp (syscall filtering), SELinux
+enforces **system-wide policy defined by an administrator**. Every process,
+file, port, and IPC object is assigned a *security label* (called a *security
+context*), and a central policy defines which label-to-label interactions are
+allowed.
+
+**The label system:** Everything has a security context of the form
+`user:role:type:level`. The **type** is the most important part — most policy
+rules are written in terms of types.
+
+```
+  Process:   system_u:system_r:httpd_t:s0
+  File:      system_u:object_r:httpd_sys_content_t:s0
+  Port:      system_u:object_r:http_port_t:s0
+```
+
+Labels are stored as extended attributes (`security.selinux`) on files, and in
+kernel data structures for processes, sockets, and IPC objects.
+
+**Type Enforcement:** The policy engine. Rules define what operations type A may
+perform on type B:
+
+```
+allow httpd_t httpd_sys_content_t:file { read open getattr };
+allow httpd_t http_port_t:tcp_socket { name_bind };
+```
+
+Everything not explicitly allowed is **denied by default**.
+
+**Domain transitions:** When a process executes a new binary, SELinux can force
+a transition to a different (usually more restricted) domain. Even if an attacker
+compromises Apache (`httpd_t`), they are confined to that domain's permissions —
+they cannot access files typed for `sshd_t`, `mysqld_t`, or `user_home_t`.
+
+**Operating modes:** Enforcing (policy enforced, violations blocked and logged),
+Permissive (violations logged but allowed), Disabled.
+
+**Policy types:** Targeted (default on RHEL/Fedora — only high-risk daemons
+confined), Strict (every process confined), MLS (Multi-Level Security for
+classified environments).
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ Full | Label-based type enforcement on files, directories |
+| Network | ✓ Per-port | Port type labels; no per-host granularity |
+| Process | ✓ Domain transitions | Exec control via entrypoint rules, signal control |
+| IPC | ✓ Type enforcement | Rules on IPC objects |
+| Devices | ✓ Per-device | Device node type labels |
+| Syscalls | ✗ | Not a syscall filter (use seccomp for that) |
+| Resources | ✗ | No resource limits |
+
+**Key design principles:**
+1. **Mandatory** — enforced by the kernel, not optional per-process
+2. **Deny-by-default** — everything not explicitly allowed is denied
+3. **Label-based** — policy is decoupled from file paths; labels travel with
+   objects (survives rename/move)
+4. **Complete mediation** — every kernel access check consults SELinux
+5. **Composable** — stacks with DAC, Landlock, seccomp
+
+**Key architectural difference from path-based systems:** SELinux labels are
+*attached to objects* via xattrs, so policy follows the data even when files are
+moved or renamed. AppArmor (an alternative Linux MAC) matches on *path names* —
+simpler, but a renamed file may escape its policy.
+
+**Limitations:**
+- Complexity — the reference policy has tens of thousands of rules
+- Admin-only — unprivileged processes cannot define their own SELinux policy
+- Distribution-dependent — RHEL/Fedora ship mature policies; Debian/Ubuntu
+  default to AppArmor instead
+- Labeling overhead — every file must be correctly labeled
+
+See [Appendix D](#appendix-d-selinux-policy-language) for policy language
+details, domain transition examples, and practical workflow.
+
+---
+
+## 5. macOS Mechanisms
+
+### 5.1 Seatbelt and App Sandbox
+
+Seatbelt is a kernel-enforced mandatory access control framework on macOS.
+Processes are restricted by a *profile* — the kernel intercepts system calls and
+checks them against the loaded profile.
+
+There are two faces of the same underlying mechanism:
+
+- **`sandbox-exec`** — a CLI tool (now deprecated by Apple) that loads an
+  S-expression profile and runs a command under it. Used for custom sandboxing.
+- **App Sandbox** — the supported path for Mac App Store apps, using entitlements
+  (`com.apple.security.app-sandbox`) rather than hand-written profiles.
+
+**Policy model:** Deny-by-default with declarative profiles. The kernel checks
+every operation against the profile before execution.
+
+| Feature | Mechanism |
+|---|---|
+| Kernel-level MAC enforcement | All syscalls filtered at kernel before execution |
+| S-expression profile language | Declarative rules for file, network, Mach port, IPC, device access |
+| Deny-by-default model | Everything forbidden unless the profile explicitly allows it |
+| Violation logging | Blocked operations logged to system log |
+| App Sandbox entitlements | App Store apps forced into sandboxing |
+
+**Key philosophical property:** Seatbelt keeps the process in the *same
+universe* but puts guards on every door. The process can *see* the filesystem
+but is blocked from accessing unauthorized paths. This contrasts with
+BubbleWrap's "different universe" approach where unauthorized paths are
+invisible.
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ Full | Per-path rules: literal, subpath, prefix, regex |
+| Network | ✓ Full | Per-host, per-port, per-protocol, inbound/outbound |
+| Process | ✓ Fork/exec control | `process-fork`, `process-exec` operations |
+| IPC | ✓ Mach port rules | `mach-lookup` with service name filters |
+| Devices | ✓ IOKit rules | `iokit-open` for hardware device access |
+| Syscalls | ✓ Built-in | Operations are implicitly syscall-level |
+| Resources | ✗ | No memory/CPU limits (not built-in) |
+
+**Caveats:**
+- `sandbox-exec` is deprecated by Apple — no replacement CLI
+- The profile language is undocumented — reverse-engineered from shipped `.sb`
+  files
+- Profiles can break across macOS upgrades as Apple renames/moves system services
+- No memory or thread isolation — controls access to resources, not computation
+
+See [Appendix A](#appendix-a-macos-seatbelt-profile-language) for the profile
+language syntax, filter types, and example profiles.
+
+---
+
+## 6. Windows Mechanisms
+
+Windows does not have a single equivalent to BubbleWrap or Seatbelt. Instead,
+it has several complementary mechanisms that are typically composed together.
+
+### 6.1 AppContainer
+
+The most comprehensive Windows sandboxing mechanism. Introduced in Windows 8,
+AppContainer is closest in spirit to BubbleWrap/Seatbelt for application
+sandboxing.
+
+- Process runs with a **restricted token** under a unique per-app SID
+  (Security Identifier)
+- **Deny-by-default** for file, registry, network, and process access
+- Capabilities must be explicitly granted (e.g., `internetClient`,
+  `privateNetworkClientServer`)
+- Each container gets its own writable area
+- Network access is granular — can separately control internet, private network,
+  and localhost
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ ACL-based | Unique SID + ACLs; subtree via inheritance |
+| Network | ✓ Capability-based | `internetClient`, `privateNetworkClientServer`, localhost |
+| IPC | ✓ Capability-based | COM, RPC, named pipes, ALPC — controlled via capabilities |
+| Devices | ✓ Capability-based | `microphone`, `webcam`, etc. |
+| Process | ○ Partial | Process runs at low integrity; limited visibility |
+| Resources | ✗ | No resource limits (use Job Objects) |
+| Syscalls | ✗ | No syscall filtering |
+
+**Used by:** UWP/Store apps (mandatory), Edge renderer processes, and
+increasingly Win32 apps via Win32 App Isolation.
+
+### 6.2 Restricted Tokens
+
+A lower-level building block. A restricted token is a copy of a process token
+with certain SIDs and privileges removed or converted to deny-only.
+
+- SIDs can be converted to **deny-only** — they only match deny ACEs, not allow
+  ACEs
+- Privileges (like `SeDebugPrivilege`) can be stripped entirely
+- The resulting token cannot be upgraded back to the original
+
+**Dimensions covered:** Filesystem (reduced-credentials model), IPC (via token
+identity). The most composable Windows primitive — used as a building block
+rather than a standalone sandbox.
+
+**Used by:** Chromium renderer processes (in combination with Job Objects,
+integrity levels, and desktop isolation).
+
+### 6.3 Job Objects
+
+Windows Job Objects group processes and enforce resource limits. They are the
+Windows analog to Linux cgroups + PID namespace.
+
+| Capability | Notes |
+|---|---|
+| **Memory limits** | Per-job commit limit |
+| **CPU rate control** | CPU rate limiting and hard caps |
+| **Process count limits** | Maximum active processes in the job |
+| **Termination control** | All processes in the job die when the job handle closes |
+| **Process visibility** | Processes within a job can be enumerated together |
+| **Wall-time limits** | Per-job and per-process time limits |
+
+Job Objects do not control filesystem or network access — they are purely about
+resource limits and process grouping.
+
+### 6.4 Integrity Levels
+
+Windows Mandatory Integrity Control assigns an integrity level to every process
+and object: Untrusted, Low, Medium, High, System.
+
+The key rule: **a process cannot write to objects at a higher integrity level.**
+A Low-integrity process can read Medium-integrity files (if DAC allows) but
+cannot write to them.
+
+This is a coarse-grained mechanism — it distinguishes only four levels — but
+it provides a strong baseline: sandboxed processes run at Low or Untrusted
+integrity and are structurally prevented from modifying most system and user
+objects.
+
+### 6.5 Windows Sandbox
+
+A disposable Hyper-V-based lightweight VM. Provides complete OS-level isolation
+with higher overhead than process-based mechanisms. The sandbox is destroyed on
+close — no persistence.
+
+Closest analog: running a throwaway QEMU/KVM VM on Linux.
+
+Use case: running completely untrusted code where the overhead of VM boot
+(seconds) is acceptable.
+
+### 6.6 Win32 App Isolation
+
+Microsoft's latest effort to bring AppContainer-style isolation to traditional
+Win32 desktop apps. Aims to close the gap with Linux/macOS app sandboxing for
+non-Store applications. Currently in preview.
+
+### 6.7 Brokered File System (BFS)
+
+BFS is a kernel-mode mini-filter driver that brokers file system access for
+sandboxed applications. Where AppContainer makes the sandboxed process
+*invisible* to most filesystem resources by removing it from ACLs, BFS provides
+the complementary mechanism: controlled, policy-governed access to specific
+files and directories *outside* the sandbox boundary.
+
+**The problem BFS solves:** AppContainer and App Silo processes are
+deny-by-default — they cannot access files they do not own or that lack
+explicit ACL grants. But real applications need to open user documents, read
+shared configuration, and communicate over named pipes. BFS intercepts file
+operations at the kernel level and makes access decisions based on per-app
+policy, optionally prompting the user for consent.
+
+**Core concepts:**
+
+- **Mini-filter driver** registered at altitude 150,000 (FSFilter
+  Virtualization group). Intercepts `IRP_MJ_CREATE` (open/create),
+  `IRP_MJ_SET_INFORMATION` (rename/delete), `IRP_MJ_CLEANUP`, and
+  `IRP_MJ_CREATE_NAMED_PIPE`.
+- **Per-app policy** keyed by `{UserSID, PackageSID}`. Each isolated
+  application has its own policy tree stored in a custom block-based filesystem
+  under `%SystemRoot%\System32\config\BFS\`.
+- **Four policy levels** governing how brokered access executes:
+  - **AsSelf** — operation runs with the sandboxed app's own token (no
+    elevation)
+  - **AsUser** — operation runs with the *user's* token, granting broader
+    access
+  - **AsUserQueryOnly** — like AsUser but limited to read-only access
+  - **AsSelfNoPrompt** — AsSelf with user prompting suppressed (used after a
+    user denies consent)
+- **Inheritance model** — directory policies can propagate to child entries
+  via `ContainerInherit` flags, with `Protected` entries that cannot be
+  overridden by parent policy.
+- **Named pipe redirection** — transparent rewriting of named pipe paths so
+  isolated processes can communicate with host-side services through
+  per-app-mapped pipe names.
+- **User consent prompting** — when an app first requests access to an
+  un-policied file, BFS can RPC to a user-mode service to present a consent
+  dialog. The user's decision is cached in the policy for future operations.
+
+**Request flow (simplified):**
+
+```
+App opens file → mini-filter intercepts IRP_MJ_CREATE
+  → Extract token, check if caller is AppContainer/App Silo
+  → Look up {UserSID, PackageSID} in policy hash table
+  → Walk policy tree for target path
+  → If policy found:
+      - AsSelf: allow with app's own token
+      - AsUser: impersonate user's token, strip WRITE_OWNER/WRITE_DAC
+  → If no policy and prompting enabled:
+      - RPC to user-mode consent service
+      - Cache user's decision as new policy entry
+  → Post-operation: restore original security context
+```
+
+**Dimensions covered:**
+
+| Dimension | Coverage | Notes |
+|---|---|---|
+| Filesystem | ✓ Policy-brokered | Per-file/directory granular policies with inheritance |
+| IPC | ✓ Pipe redirection | Named pipe transparent remapping per app |
+| Network | ✗ | Not in scope (handled by AppContainer capabilities) |
+| Devices | ✗ | Not in scope |
+| Process | ✗ | Not in scope |
+| Resources | ✗ | Not in scope (use Job Objects) |
+| Syscalls | ✗ | Not in scope |
+
+**Isolation model:** BFS is a **Guarded Doors** mechanism — the file system
+is not hidden (the process can see paths exist), but access is intercepted and
+brokered at the kernel level. This contrasts with mount namespaces on Linux
+(Different Universe) where unauthorized paths are literally invisible.
+
+**Relationship to other Windows mechanisms:** BFS does not replace AppContainer
+or integrity levels — it *complements* them. A typical Win32 App Isolation
+composition is:
+
+- AppContainer provides the deny-by-default security boundary
+- BFS punches controlled holes in that boundary for specific files/directories
+- Job Objects enforce resource limits
+- Integrity levels prevent write-up
+
+This is analogous to how Linux sandboxes use mount namespaces for the default
+boundary and then bind-mount specific host paths into the namespace for
+controlled access — except BFS does it at the access-check layer rather than
+the namespace layer.
+
+**Used by:** Win32 App Isolation (App Silo), browser isolation containers
+(Edge/Chromium renderer, WebView2, JIT, Flash, DevTools), and agentic
+application scenarios.
+
+See [Appendix E](#appendix-e-bfs-architecture-and-programming-details) for
+mini-filter architecture, policy storage format, IOCTL interface, and security
+token handling details.
+
+---
+
+## 7. Cross-Platform Comparison
+
+### 7.1 Isolation Models
+
+Three isolation models emerge from the cross-platform analysis. Every mechanism
+falls into one of these categories:
+
+| Model | Meaning | Examples |
+|---|---|---|
+| **Different Universe** | The resource is *invisible* — the process literally cannot see it | Mount namespaces, PID namespaces, network namespaces |
+| **Guarded Doors** | The resource is *visible* but access is intercepted and checked | SELinux, Seatbelt profiles, Landlock rules |
+| **Reduced Credentials** | The process's *identity* is weakened so existing ACLs deny access | AppContainer SIDs, restricted tokens, integrity levels |
+
+These models are ordered by isolation strength:
+
+```
+Different Universe > Guarded Doors > Reduced Credentials
+```
+
+The ordering reflects information leakage:
+- **Different Universe:** the process cannot even *enumerate* what it cannot
+  access. It has no knowledge of unauthorized resources.
+- **Guarded Doors:** the process can *discover* that a resource exists (e.g.,
+  by listing a directory) but cannot access it. The denial reveals information.
+- **Reduced Credentials:** the process interacts with the real OS identity
+  system. Access patterns and error messages can reveal system topology.
+
+Additionally, syscall-level filtering uses a fourth model:
+
+| Model | Meaning | Examples |
+|---|---|---|
+| **Kernel Filter** | An in-kernel program inspects each syscall and decides allow/deny | Seccomp-BPF |
+
+### 7.2 Dimension Coverage Matrix
+
+| Capability | Linux (BubbleWrap + kernel) | macOS (Seatbelt/App Sandbox) | Windows (AppContainer + primitives) |
+|---|---|---|---|
+| **Filesystem isolation** | Mount namespaces + bind mounts | Profile rules on real FS | AppContainer SID + BFS brokered access |
+| **Network isolation** | Network namespace | Profile rules | AppContainer capabilities |
+| **Syscall filtering** | Seccomp-BPF | Built into Seatbelt profiles | Not directly (rely on token/capability restrictions) |
+| **Resource limits** | cgroups | Not built-in (launchd can limit) | Job Objects |
+| **Process isolation** | PID namespace | Not built-in | Job Objects + desktop isolation |
+| **Privilege reduction** | Capability dropping + `NO_NEW_PRIVS` | Deny-by-default profiles | Restricted tokens + integrity levels |
+| **Unprivileged use** | Yes (user namespaces) | Yes (profiles loaded at exec) | Partially (AppContainer needs token creation) |
+| **Composability** | High (mix and match primitives) | Medium (profile language is flexible) | Medium (combine tokens + jobs + integrity) |
+| **App Store enforcement** | N/A (Flatpak uses bwrap) | Mandatory for Mac App Store | Mandatory for Microsoft Store (UWP) |
+
+### 7.3 Capability Mapping Across Platforms
+
+| Linux Mechanism | Windows Equivalent | Purpose |
+|---|---|---|
+| Restricted Tokens (capabilities + seccomp) | Restricted Tokens | Strip privileges/SIDs from a process token |
+| cgroups + PID namespace | Job Objects | Group processes, limit CPU/memory/process count, control termination |
+| User namespaces | No direct equivalent (closest: integrity levels) | Prevent writes to higher-integrity objects |
+| X11/Wayland separation | Desktop isolation | Separate window station prevents message-based attacks |
+| Mount namespaces | BFS (Brokered File System) | Construct a custom filesystem view |
+| Network namespaces | AppContainer network capabilities | Isolate or restrict network access |
+| Seccomp-BPF | No equivalent | Syscall-level filtering |
+
+### 7.4 Composability
+
+No single mechanism on any platform provides complete isolation. Real sandboxes
+are compositions:
+
+**Linux (typical composition):**
+- Mount namespace (filesystem isolation) +
+- PID namespace (process visibility) +
+- Network namespace (network isolation) +
+- IPC namespace (IPC isolation) +
+- UTS namespace (hostname) +
+- seccomp-BPF (syscall filtering) +
+- cgroups v2 (resource limits) +
+- Landlock (additional filesystem/network rules, self-applied)
+
+This is the composition Docker uses by default.
+
+**Windows (typical composition):**
+- AppContainer (deny-by-default filesystem, network, IPC via SID) +
+- BFS (controlled file/directory access through the AppContainer boundary) +
+- Job Object (resource limits, process grouping) +
+- Integrity Level (write prevention to higher-integrity objects) +
+- Optionally: Restricted Token (stripped SIDs/privileges) +
+- Optionally: Desktop isolation (window station separation)
+
+This is the composition Win32 App Isolation uses. Chromium uses a similar
+composition (without BFS) for renderer processes.
+
+**macOS:**
+- Seatbelt profile (filesystem, network, IPC, devices — all in one) +
+- Optional: XPC service boundaries (privilege separation)
+
+macOS is the least compositional — Seatbelt is a comprehensive single mechanism
+rather than a set of orthogonal primitives.
+
+**Composability implications for cross-platform policy:**
+
+A policy system that targets all three platforms must handle this asymmetry:
+- On Linux, each policy dimension maps to a separate mechanism. Policy rules
+  are distributed across multiple enforcement primitives.
+- On macOS, most dimensions are enforced by a single mechanism (Seatbelt).
+  The policy compiles to one profile.
+- On Windows, enforcement falls between these extremes. AppContainer handles
+  several dimensions but needs Job Objects for resource limits and integrity
+  levels for write prevention.
+
+The cross-platform policy language must be mechanism-agnostic — it expresses
+*what* should be enforced, not *how*. The platform-specific binding and
+compilation steps translate policy dimensions into the appropriate mechanism
+composition for each platform. This is addressed in the companion document.
+
+---
+
+## Appendix A: macOS Seatbelt Profile Language
+
+Seatbelt profiles are written in an S-expression (Lisp-like) syntax and stored
+as `.sb` text files. Apple ships built-in profiles at `/usr/share/sandbox/`
+(e.g., `sshd.sb`, `mds.sb`, `ntpd.sb`). The language itself is undocumented by
+Apple but well reverse-engineered.
+
+### Basic Structure
+
+```scheme
+(version 1)          ; required — always 1
+(deny default)       ; deny everything not explicitly allowed
+(import "system.sb") ; import Apple's base rules for basic OS functionality
+
+;; then: a series of (allow ...) and (deny ...) rules
+```
+
+### Rule Grammar
+
+```
+(allow|deny  <operation>  [<filter> ...])
+```
+
+### Operations Reference
+
+| Category | Operations | What It Controls |
+|---|---|---|
+| **Files** | `file-read*`, `file-read-data`, `file-read-metadata` | Reading files |
+| | `file-write*`, `file-write-data`, `file-write-create`, `file-write-unlink` | Writing/creating/deleting files |
+| | `file-ioctl` | ioctl calls on files |
+| **Network** | `network-outbound`, `network-inbound`, `network-bind` | TCP/UDP connections, listening |
+| **Mach IPC** | `mach-lookup`, `mach-register` | XPC/Mach service access |
+| **Process** | `process-fork`, `process-exec`, `process-exec-interpreter` | Spawning processes |
+| **Signals** | `signal` | Sending signals to other processes |
+| **Sysctl** | `sysctl-read`, `sysctl-write` | Reading/writing kernel parameters |
+| **IOKit** | `iokit-open` | Accessing hardware device interfaces |
+| **Preferences** | `user-preference-read`, `user-preference-write` | NSUserDefaults / plist access |
+| **Info** | `process-info-pidinfo`, `process-info-codesignature` | Inspecting other processes |
+| **Generic** | `default` | Catch-all (used with `deny default`) |
+
+### Filter Types
+
+```scheme
+;; Path filters
+(literal "/etc/resolv.conf")              ; exact path
+(subpath "/Users/alice/project")          ; path and everything under it
+(prefix "/usr/lib/")                      ; paths starting with this string
+(regex #"/tmp/myapp-[0-9]+\.log")         ; regex match on path
+
+;; Path construction
+(string-append (param "HOME") "/Documents")  ; runtime parameter expansion
+
+;; Network filters
+(remote ip "*:443")                       ; outbound to any host, port 443
+(local ip "localhost:8080")               ; bind to localhost:8080
+
+;; Mach service filters
+(global-name "com.apple.FontServer")      ; specific Mach service by name
+(global-name-prefix "com.apple.")         ; any Apple service
+
+;; Boolean combinators
+(require-all <filter1> <filter2>)         ; AND
+(require-any <filter1> <filter2>)         ; OR
+(require-not <filter>)                    ; NOT
+```
+
+### Example Profiles
+
+#### Minimal: Read-Only Access to One Directory
+
+```scheme
+(version 1)
+(deny default)
+(allow file-read* (subpath "/Users/alice/project"))
+```
+
+#### Web-Facing Tool: Network + Limited Files
+
+```scheme
+(version 1)
+(deny default)
+(import "system.sb")
+
+(allow file-read*
+    (subpath "/usr/lib")
+    (subpath "/System/Library/Frameworks"))
+
+(allow file-read*  (subpath "/Users/alice/project"))
+(allow file-write* (subpath "/Users/alice/project/output"))
+
+(allow network-outbound (remote tcp "*:443"))
+(allow network-outbound (literal "/private/var/run/mDNSResponder"))
+
+(allow user-preference-read (preference-domain "com.example.mytool"))
+```
+
+#### Locked-Down Daemon
+
+```scheme
+(version 1)
+(deny default)
+(import "system.sb")
+
+(allow file-read*
+    (literal "/etc/sshd_config")
+    (subpath "/usr/libexec")
+    (literal "/dev/null")
+    (literal "/dev/random")
+    (literal "/dev/urandom"))
+
+(allow network-inbound  (local tcp "*:22"))
+(allow network-outbound (remote tcp))
+
+(allow process-fork)
+(allow process-exec (literal "/usr/libexec/sshd-session"))
+
+(allow mach-lookup
+    (global-name "com.apple.system.logger")
+    (global-name "com.apple.system.notification_center"))
+
+(allow signal (target self))
+```
+
+#### Reusable Macros with `define`
+
+```scheme
+(version 1)
+(deny default)
+
+(define (home-subpath path)
+    (subpath (string-append (param "HOME") path)))
+
+(allow file-read*  (home-subpath "/Documents"))
+(allow file-write* (home-subpath "/Downloads"))
+```
+
+### Running a Profile
+
+```sh
+# Run a command under a sandbox profile
+sandbox-exec -f myprofile.sb /usr/bin/my-command --args
+
+# Or inline
+sandbox-exec -p '(version 1)(deny default)(allow file-read* (subpath "/tmp"))' /bin/ls /tmp
+```
+
+---
+
+## Appendix B: Seccomp-BPF Programming Details
+
+### The BPF Virtual Machine
+
+The seccomp filter operates on a `struct seccomp_data`:
+
+```c
+struct seccomp_data {
+    int   nr;                  // syscall number
+    __u32 arch;                // AUDIT_ARCH_* value
+    __u64 instruction_pointer; // where the syscall was made
+    __u64 args[6];             // raw syscall arguments (not dereferenced!)
+};
+```
+
+### Return Actions
+
+| Action | Effect |
+|---|---|
+| `SECCOMP_RET_ALLOW` | Syscall proceeds normally |
+| `SECCOMP_RET_KILL_PROCESS` | Entire process killed with `SIGSYS` |
+| `SECCOMP_RET_KILL_THREAD` | Calling thread killed |
+| `SECCOMP_RET_ERRNO(val)` | Syscall blocked, returns `-val` to caller |
+| `SECCOMP_RET_TRAP` | Sends `SIGSYS` to process (can be caught) |
+| `SECCOMP_RET_TRACE` | Notifies a `ptrace`-attached tracer |
+| `SECCOMP_RET_LOG` | Allow, but log the syscall |
+| `SECCOMP_RET_USER_NOTIF` | Delegate decision to userspace supervisor (newer kernels) |
+
+### Code Example (C, using libseccomp)
+
+```c
+#include <seccomp.h>
+#include <unistd.h>
+
+int main() {
+    // Create filter: default action = kill process
+    scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_KILL);
+
+    // Allowlist only what we need
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(read), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(exit_group), 0);
+
+    // Can also filter by argument value:
+    // Only allow write() to stdout (fd == 1)
+    seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(write), 1,
+                     SCMP_A0(SCMP_CMP_EQ, STDOUT_FILENO));
+
+    // Load and enforce the filter
+    seccomp_load(ctx);
+
+    write(1, "allowed\n", 8);   // works
+    open("/etc/passwd", 0);      // KILLED — open() not in allowlist
+
+    seccomp_release(ctx);
+    return 0;
+}
+```
+
+### Raw BPF Instructions (without libseccomp)
+
+```c
+struct sock_filter filter[] = {
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL),
+};
+struct sock_fprog prog = { .len = 4, .filter = filter };
+prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+```
+
+---
+
+## Appendix C: Landlock Programming Details
+
+### Code Example (C)
+
+```c
+#include <linux/landlock.h>
+#include <sys/syscall.h>
+#include <sys/prctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+int main(void) {
+    // 1. Check ABI version
+    int abi = syscall(SYS_landlock_create_ruleset, NULL, 0,
+                      LANDLOCK_CREATE_RULESET_VERSION);
+    if (abi < 1) return 1;  // Landlock not available
+
+    // 2. Create ruleset: govern filesystem read/write/execute
+    struct landlock_ruleset_attr ruleset_attr = {
+        .handled_access_fs =
+            LANDLOCK_ACCESS_FS_READ_FILE |
+            LANDLOCK_ACCESS_FS_READ_DIR  |
+            LANDLOCK_ACCESS_FS_WRITE_FILE |
+            LANDLOCK_ACCESS_FS_EXECUTE
+    };
+    int ruleset_fd = syscall(SYS_landlock_create_ruleset,
+                             &ruleset_attr, sizeof(ruleset_attr), 0);
+
+    // 3. Allow read-only access to /usr
+    int usr_fd = open("/usr", O_PATH | O_CLOEXEC);
+    struct landlock_path_beneath_attr rule1 = {
+        .parent_fd = usr_fd,
+        .allowed_access = LANDLOCK_ACCESS_FS_READ_FILE |
+                          LANDLOCK_ACCESS_FS_READ_DIR  |
+                          LANDLOCK_ACCESS_FS_EXECUTE
+    };
+    syscall(SYS_landlock_add_rule, ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH, &rule1, 0);
+    close(usr_fd);
+
+    // 4. Allow read+write to /tmp/myapp
+    int tmp_fd = open("/tmp/myapp", O_PATH | O_CLOEXEC);
+    struct landlock_path_beneath_attr rule2 = {
+        .parent_fd = tmp_fd,
+        .allowed_access = LANDLOCK_ACCESS_FS_READ_FILE |
+                          LANDLOCK_ACCESS_FS_READ_DIR  |
+                          LANDLOCK_ACCESS_FS_WRITE_FILE
+    };
+    syscall(SYS_landlock_add_rule, ruleset_fd,
+            LANDLOCK_RULE_PATH_BENEATH, &rule2, 0);
+    close(tmp_fd);
+
+    // 5. Lock it in
+    prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    syscall(SYS_landlock_restrict_self, ruleset_fd, 0);
+    close(ruleset_fd);
+
+    // From here: can read /usr, read+write /tmp/myapp, nothing else.
+    // open("/etc/passwd", O_RDONLY) → EACCES
+    // open("/home/user/.ssh/id_rsa", O_RDONLY) → EACCES
+}
+```
+
+### ABI Version Handling
+
+Programs should check the ABI version at runtime and adapt their ruleset
+accordingly. Newer ABI versions add capabilities that older kernels don't
+support:
+
+```
+ABI ≥ 1: Filesystem rules (read, write, execute, create, remove, etc.)
+ABI ≥ 2: Cross-directory rename/link control (REFER)
+ABI ≥ 3: File truncation control
+ABI ≥ 4: Network TCP bind/connect control
+ABI ≥ 5: Device ioctl control
+ABI ≥ 6: Abstract Unix socket and signal scoping
+```
+
+When running on an older kernel, graceful degradation means: apply all rules
+the kernel supports, log warnings for unsupported rules, and optionally fail
+if a critical rule cannot be enforced.
+
+### Landlock vs Other Linux Sandboxing
+
+| Dimension | Landlock | Seccomp-BPF | BubbleWrap (namespaces) | SELinux / AppArmor |
+|---|---|---|---|---|
+| **Who defines policy** | The process itself | The process itself | The caller/wrapper | System administrator |
+| **What it controls** | Files, dirs, network (TCP), devices, signals | Which syscalls are allowed | Entire filesystem/PID/network view | Files, network, capabilities, IPC, etc. |
+| **Granularity** | Path-hierarchy rules | Syscall number + args | Mount-level (whole dirs) | Label/path-based rules |
+| **Needs root** | No | No | No (user namespaces) | Yes (to write policy) |
+| **Irreversible** | Yes | Yes | N/A (separate process) | N/A (admin policy) |
+| **Stacks with others** | Yes | Yes | Orthogonal | Yes |
+| **Best for** | "I only need these files/ports" | "I only need these syscalls" | "Give me a different filesystem" | "Enterprise-wide mandatory policy" |
+
+---
+
+## Appendix D: SELinux Policy Language
+
+### Type Enforcement Rules
+
+The policy is expressed as rules allowing specific operations between types:
+
+```
+# Allow Apache to read its content files
+allow httpd_t httpd_sys_content_t:file { read open getattr };
+
+# Allow Apache to listen on HTTP ports
+allow httpd_t http_port_t:tcp_socket { name_bind };
+
+# Allow Apache to connect to database ports
+allow httpd_t postgresql_port_t:tcp_socket { name_connect };
+
+# Allow Apache to execute CGI scripts
+allow httpd_t httpd_sys_script_exec_t:file { execute execute_no_trans };
+
+# Allow Apache to write to its log directory
+allow httpd_t httpd_log_t:file { write create append };
+allow httpd_t httpd_log_t:dir  { search add_name };
+```
+
+### Domain Transitions
+
+When a process executes a new binary, SELinux can force a *domain transition*:
+
+```
+# When init_t executes /usr/sbin/httpd (labeled httpd_exec_t),
+# the new process transitions to httpd_t
+type_transition init_t httpd_exec_t:process httpd_t;
+
+# Required supporting rules:
+allow init_t httpd_exec_t:file { execute };       # init can execute the binary
+allow init_t httpd_t:process { transition };       # init can transition to httpd_t
+allow httpd_t httpd_exec_t:file { entrypoint };    # httpd_exec_t is a valid
+                                                    # entrypoint for httpd_t
+```
+
+### Practical Workflow
+
+```sh
+# Check a file's security context
+ls -Z /var/www/html/index.html
+# → system_u:object_r:httpd_sys_content_t:s0
+
+# Check a process's security context
+ps -eZ | grep httpd
+# → system_u:system_r:httpd_t:s0   1234  httpd
+
+# Relabel a file to the correct type
+chcon -t httpd_sys_content_t /var/www/html/newfile.html
+
+# Restore default labels from policy
+restorecon -Rv /var/www/html/
+
+# Search for denied operations in the audit log
+ausearch -m avc -ts recent
+
+# Generate a policy module from denials
+audit2allow -a -M mypolicy
+semodule -i mypolicy.pp
+```
+
+### SELinux vs Other Linux Security Mechanisms
+
+| Dimension | SELinux | AppArmor | Landlock | Seccomp-BPF |
+|---|---|---|---|---|
+| **Policy model** | Label-based (types on everything) | Path-based (profiles name files by path) | Path-based (fd-based rules) | Syscall-number-based |
+| **Who defines policy** | System administrator | System administrator | The process itself | The process itself |
+| **Scope** | System-wide, all processes | Per-profile, named processes | Per-process, self-applied | Per-process, self-applied |
+| **What it controls** | Files, network, IPC, processes, devices, capabilities | Files, network, capabilities, some IPC | Files, network (TCP), devices, signals | Which syscalls are allowed |
+| **Granularity** | Fine — per-type, per-operation, per-object-class | Medium — per-path, per-capability | Medium — per-directory-hierarchy | Fine — per-syscall + arg values |
+| **Needs root to configure** | Yes | Yes | No | No |
+| **Stacks with others** | Yes | Mutually exclusive with SELinux | Yes | Yes |
+| **Survives exec** | Yes (domain transitions) | Yes (profile follows binary) | Yes (inherited) | Yes (inherited) |
+| **Indirection** | Labels survive rename/move | Path-based — rename can bypass | fd-based — survives rename | N/A |
+| **Best for** | System-wide mandatory confinement | Simpler admin-defined confinement | App self-sandboxing (files/net) | App self-sandboxing (syscalls) |
+
+---
+
+## Appendix E: BFS Architecture and Programming Details
+
+BFS (Brokered File System) is implemented as a Windows kernel-mode mini-filter
+driver. This appendix covers the internal architecture, policy storage format,
+driver interfaces, and security token handling for those who need to understand
+or extend the mechanism.
+
+### Mini-Filter Registration
+
+BFS registers with the Windows Filter Manager (FltMgr) framework:
+
+| Property | Value |
+|---|---|
+| **Altitude** | 150,000 |
+| **Group** | FSFilter Virtualization |
+| **Device name** | `\Device\Bfs` |
+| **Start type** | Automatic (boot) |
+| **Dependencies** | FltMgr, CNG (cryptography) |
+
+The altitude places BFS in the virtualization filter group, meaning it
+processes I/O *after* base filesystem drivers but *before* higher-level filters
+like antivirus. This is important because BFS needs to see the real filesystem
+paths before any other virtualization layer rewrites them.
+
+**Intercepted operations:**
+
+| IRP | Purpose |
+|---|---|
+| `IRP_MJ_CREATE` | File open/create — the primary enforcement point |
+| `IRP_MJ_SET_INFORMATION` | Rename/delete tracking — invalidates cached policies |
+| `IRP_MJ_CLEANUP` | Handle close — cleanup file tracking state |
+| `IRP_MJ_CREATE_NAMED_PIPE` | Named pipe creation — apply pipe redirection |
+
+### Policy Storage Format
+
+BFS uses a custom block-based filesystem for policy storage rather than
+relying on NTFS directories or the registry. This design choice provides:
+
+- Compact representation (16 KB blocks, ~106 directory entries per block)
+- Atomic updates via block-level operations
+- Independence from NTFS ACL complexity
+- Efficient hierarchical path lookups via AVL trees
+
+**Storage location:** `%SystemRoot%\System32\config\BFS\`
+
+**On-disk layout:**
+
+```
+Block 0: Core Block (magic: 'CsfB', version 1.0)
+  ├── BlockSize: 16384 bytes
+  ├── RootBlock → root directory block
+  ├── IndexBlock → file ID index
+  └── BlockBitmap[] → allocation tracking
+
+Directory Blocks (magic: 'DsfB'):
+  ├── NextBlock → linked list for overflow
+  └── Entries[~106]:
+        ├── EntryType: File | Directory
+        ├── Policy: AsSelf | AsUser | AsUserQueryOnly | AsSelfNoPrompt
+        ├── InheritFlags: None | ContainerInherit | Protected
+        ├── DirectoryBlock → child directory (if type is Directory)
+        └── Name[256] → UTF-16 path component
+
+Index Blocks (magic: 'IsfB'):
+  └── Entries[] → FILE_ID_128 mappings for rename/delete tracking
+```
+
+**Policy tree structure:** Policies form a hierarchical tree that mirrors the
+filesystem path structure. Looking up a policy for
+`C:\Users\Alice\Documents\report.docx` walks:
+
+```
+Root → Users → Alice → Documents → report.docx
+```
+
+At each level, the entry carries a `BFS_POLICY` value and inheritance flags.
+If `report.docx` has no explicit entry but `Documents` has
+`ContainerInherit`, the directory's policy applies.
+
+### Policy Table and Caching
+
+The in-memory policy table is a hash table keyed by `{UserSID, PackageSID}`:
+
+```
+BFS_POLICY_TABLE
+  ├── HashTable: RTL_DYNAMIC_HASH_TABLE
+  │     Key: Hash(UserSID + PackageSID)
+  │     Value: BFS_POLICY_ENTRY
+  ├── LastVisitListHead → LRU tracking for idle eviction
+  └── IdleCheckTimer → fires every 30 seconds
+
+BFS_POLICY_ENTRY
+  ├── UserSid, PackageSid → identity pair
+  ├── Storage → handle to on-disk policy file
+  ├── State: Uninitialized | Active | PendingCreation | NotPresent | Failed
+  ├── PromptState → whether user prompting is enabled
+  ├── ReferenceCount → thread-safe ref counting
+  └── RegistryPrefix1, RegistryPrefix2 → registry virtualization paths
+```
+
+**Idle eviction:** Policies not accessed for 5 minutes are unloaded from
+memory. The background timer checks every 30 seconds and releases entries
+whose last-visit timestamp exceeds the idle threshold. This bounds kernel
+memory usage when many isolated apps are installed but few are running.
+
+### IOCTL Interface
+
+User-mode tools (primarily `bfscfg.exe`) manage policies through the
+`\Device\Bfs` control device:
+
+| IOCTL | Purpose |
+|---|---|
+| `SET_POLICY` | Add or modify a policy entry for a file/directory |
+| `QUERY_POLICY` | Retrieve all policies for an app (by token) |
+| `QUERY_POLICY_SIZE` | Get required buffer size before querying |
+| `DELETE_POLICY` | Remove a single policy entry |
+| `CLEAR_POLICY` | Remove all policies for an app |
+
+**Example: adding a policy via `bfscfg`:**
+
+```
+bfscfg --addpolicy --appid <PackageFamilyName> \
+       --filename "C:\Users\Alice\Documents" \
+       --entrytype directory \
+       --policybrokerreadonly \
+       --containerinherit
+```
+
+This grants the isolated app read-only brokered access to the Documents
+directory and all its children.
+
+### Named Pipe Redirection
+
+Isolated apps cannot directly open named pipes created by host-side services
+because the pipe's ACL does not include the app's AppContainer SID. BFS
+solves this by transparently rewriting pipe names:
+
+```
+App opens \\.\pipe\MyService
+  → BFS looks up mapping for {UserSID, PackageSID, "MyService"}
+  → Rewrites to \\.\pipe\{PackageSID}\MyService
+  → Host-side service listens on the redirected name
+  → Both ends communicate transparently
+```
+
+Pipe mappings are stored in a separate hash table
+(`BFS_PIPE_MAPPING_TABLE`) and keyed by `{UserSID, PackageSID, PipeName}`.
+The rewrite happens during `IRP_MJ_CREATE_NAMED_PIPE` processing via a
+reparse operation — the filter completes the original IRP with
+`STATUS_REPARSE` and the I/O manager reissues the request with the rewritten
+path.
+
+### Security Token Handling
+
+The token handling flow during a brokered file operation:
+
+1. **Extract token** — get the caller's impersonation or primary token
+2. **Validate applicability** — confirm the token belongs to an AppContainer,
+   App Silo, or agentic app context
+3. **Check impersonation level** — must be at least `SecurityImpersonation`
+4. **Apply policy:**
+   - *AsSelf:* operation proceeds with the app's own token
+   - *AsUser:* BFS impersonates the user's token for the duration of the
+     operation, but strips `WRITE_OWNER` and `WRITE_DAC` to prevent the
+     sandboxed app from modifying ACLs or taking ownership
+5. **Post-operation cleanup** — restore the original security context
+
+**Consent prompting flow** (when no policy exists and prompting is enabled):
+
+1. Pre-create callback defers the operation to a worker thread
+2. Worker calls `BfsPromptForConsent()` via RPC to a user-mode service
+3. The user-mode service presents a consent dialog (requires
+   `appSiloFileSystem` capability)
+4. User's decision is cached as a new policy entry
+5. On approval, the file operation is retried with the new policy; on denial,
+   `AsSelfNoPrompt` is stored to suppress future prompts for that path
+
+### Browser Isolation Containers
+
+BFS is used extensively by browser isolation, where different process types
+run in different container configurations:
+
+| Container | Code | Purpose |
+|---|---|---|
+| MRAC | `mrac` | Multi-process rendering agent |
+| LRAC | `lrac` | Low-integrity rendering agent |
+| WebView | `webvw` | WebView2 hosting |
+| Flash | `flash` | Adobe Flash plugin (legacy) |
+| JIT | `jit` | JavaScript JIT compilation |
+| Dev | `dev` | Developer/content hosting |
+| EDP | `edp` | Enterprise Data Protection |
+
+Each container type has its own set of mandatory and optional mitigations
+(DEP, ASLR, CFG, ACG, Win32k filtering) in addition to BFS file system
+policies. The Win32k filter in particular provides a limited form of syscall
+filtering — it restricts which Win32k (GUI subsystem) system calls the
+container process can make, with per-container-type allow lists for
+operations like IME input, PDF rendering, and Flash content.
+
+### ETW Logging
+
+BFS provides operational telemetry through ETW:
+
+- **Provider:** `Microsoft-Windows-Security-Isolation-BrokeringFileSystem`
+- **Channel:** Operational
+- **Events:** File access decisions, policy loads/unloads, prompt outcomes,
+  errors

--- a/docs/proposals/container-policy/examples/admin_intents/01_corporate_standard.jsonc
+++ b/docs/proposals/container-policy/examples/admin_intents/01_corporate_standard.jsonc
@@ -1,0 +1,43 @@
+{
+  // Corporate standard policy for sandboxed workloads.
+  // Applies to general-purpose business workloads (scenarios 01, 02, 05).
+  //
+  // Key restrictions:
+  // - No external internet except explicitly whitelisted services
+  // - Memory capped at 2 GB
+  // - No persistent storage
+  // - All sandbox executions are time-limited
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "corp-standard-sandbox-policy",
+    "version": "2.0.0",
+    "description": "Corporate standard: whitelisted services only, 2 GB memory ceiling, no persistence"
+  },
+
+  "requires": {
+    "network": [
+      {
+        "service": "weather-api",
+        "description": "Approved external data provider"
+      },
+      {
+        "service": "geocoding-api",
+        "description": "Approved external data provider"
+      },
+      { "capability": "dns" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 2048,
+    "max_cpu_cores": 4,
+    "max_wall_time_seconds": 300,
+    "max_processes": 32,
+    "max_open_files": 2048,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/admin_intents/02_research_lab.jsonc
+++ b/docs/proposals/container-policy/examples/admin_intents/02_research_lab.jsonc
@@ -1,0 +1,53 @@
+{
+  // Research lab policy for sandboxed workloads.
+  // Applies to research and development workloads (scenarios 03, 04).
+  //
+  // More permissive than corporate standard:
+  // - Allows LLM API access
+  // - Allows public-web access (researchers need to browse)
+  // - Allows crate/package registry access for compilation
+  // - Higher memory ceiling (4 GB) for compilation and LLM response handling
+  // - Longer wall time for complex builds and research tasks
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "research-lab-sandbox-policy",
+    "version": "1.0.0",
+    "description": "Research lab: allows LLM, web, package registries; 4 GB memory; longer time limits"
+  },
+
+  "requires": {
+    "network": [
+      {
+        "service": "llm-api",
+        "description": "LLM provider approved for research use"
+      },
+      {
+        "service": "public-web",
+        "protocol": "https",
+        "description": "Web access for research — may be narrowed by user consent"
+      },
+      {
+        "service": "crates-io",
+        "description": "Rust crate registry"
+      },
+      {
+        "service": "github-crate-sources",
+        "description": "GitHub-hosted crate source archives"
+      },
+      { "capability": "dns" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 4096,
+    "max_cpu_cores": 8,
+    "max_wall_time_seconds": 600,
+    "max_processes": 64,
+    "max_open_files": 8192,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/admin_intents/03_production_ops.jsonc
+++ b/docs/proposals/container-policy/examples/admin_intents/03_production_ops.jsonc
@@ -1,0 +1,48 @@
+{
+  // Production operations policy for sandboxed workloads.
+  // Applies to infrastructure management workloads (scenario 06).
+  //
+  // Strict but allows internal services:
+  // - Only internal corporate endpoints permitted
+  // - Database access approved for monitoring
+  // - Tight resource limits (these are health checks, not heavy compute)
+  // - Short wall time — health checks should be fast
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "production-ops-sandbox-policy",
+    "version": "1.0.0",
+    "description": "Production ops: internal services only, database access, tight resource limits"
+  },
+
+  "requires": {
+    "network": [
+      {
+        "service": "internal-api-gateway",
+        "description": "Internal API gateway — health monitoring approved"
+      },
+      {
+        "service": "internal-auth-service",
+        "description": "Internal auth service — health monitoring approved"
+      },
+      {
+        "service": "primary-database",
+        "protocol": "tcp",
+        "description": "PostgreSQL primary — read-only monitoring queries approved"
+      },
+      { "capability": "dns" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 512,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 180,
+    "max_processes": 16,
+    "max_open_files": 512,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/01_python_data_analysis.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/01_python_data_analysis.jsonc
@@ -1,0 +1,62 @@
+{
+  "version": "1.0",
+  "name": "csv-data-analyzer",
+  "description": "Bound policy for csv-data-analyzer on Linux x86_64 (from composed policy 01)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/python3.10",                "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/python3",                   "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/python3.10",                "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/python3/dist-packages",     "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/local/lib/python3.10/dist-packages", "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/workspace",        "scope": "subtree", "allow": ["read", "write", "create"],
+                                                          "ephemeral": true },
+      { "path": "/input",            "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",           "scope": "subtree", "allow": ["write", "create"],
+                                                          "ephemeral": true },
+      { "path": "/tmp",              "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                          "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 1,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "PYTHONUNBUFFERED": "1"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/02_node_api_aggregator.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/02_node_api_aggregator.jsonc
@@ -1,0 +1,74 @@
+{
+  "version": "1.0",
+  "name": "multi-api-aggregator",
+  "description": "Bound policy for multi-api-aggregator on Linux x86_64 (from composed policy 02)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/node",                      "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/nodejs",                    "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/share/nodejs",                  "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/resolv.conf",                   "scope": "exact",   "allow": ["read"] },
+
+      { "path": "/workspace",           "scope": "subtree", "allow": ["read", "write", "create"],
+                                                             "ephemeral": true },
+      { "path": "/workspace/node_modules", "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",              "scope": "subtree", "allow": ["write", "create"],
+                                                             "ephemeral": true },
+      { "path": "/config",              "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",                 "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                             "ephemeral": true },
+      { "path": "/run/secrets/WEATHER_API_KEY",   "scope": "exact", "allow": ["read"],
+                                                                     "ephemeral": true },
+      { "path": "/run/secrets/GEOCODING_API_KEY", "scope": "exact", "allow": ["read"],
+                                                                     "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.weatherapi.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.opencagedata.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 1,
+    "max_wall_time_seconds": 45,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "NODE_ENV": "production",
+      "WEATHER_API_KEY_FILE": "/run/secrets/WEATHER_API_KEY",
+      "GEOCODING_API_KEY_FILE": "/run/secrets/GEOCODING_API_KEY"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/03_rust_snippet_runner.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/03_rust_snippet_runner.jsonc
@@ -1,0 +1,81 @@
+{
+  "version": "1.0",
+  "name": "rust-snippet-runner",
+  "description": "Bound policy for rust-snippet-runner on Linux x86_64 (from composed policy 03)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/cargo",                     "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/rustc",                     "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/cc",                        "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/ld",                        "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/rustlib",                   "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/include",                       "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/resolv.conf",                   "scope": "exact",   "allow": ["read"] },
+
+      { "path": "/input",              "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",             "scope": "subtree", "allow": ["write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/workspace",          "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true },
+      { "path": "/cache/cargo-registry","scope": "subtree", "allow": ["read", "write", "create", "delete"] },
+      { "path": "/cache/cargo-target",  "scope": "subtree", "allow": ["read", "write", "create", "delete"] },
+      { "path": "/tmp",                "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "static.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "index.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "github.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "objects.githubusercontent.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 4096,
+    "max_cpu_percent": 400,
+    "max_processes": 32,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 4096
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "CARGO_HOME": "/cache/cargo-registry",
+      "CARGO_TARGET_DIR": "/cache/cargo-target",
+      "RUSTUP_HOME": "/usr/lib/rustlib"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/04_llm_research_tool.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/04_llm_research_tool.jsonc
@@ -1,0 +1,76 @@
+{
+  "version": "1.0",
+  "name": "research-agent-tool",
+  "description": "Bound policy for research-agent-tool on Linux x86_64 (from composed policy 04)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/python3.11",                "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/python3",                   "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/python3.11",                "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/python3/dist-packages",     "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/local/lib/python3.11/dist-packages", "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/resolv.conf",                   "scope": "exact",   "allow": ["read"] },
+
+      { "path": "/workspace",          "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true },
+      { "path": "/output",             "scope": "subtree", "allow": ["write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/cache/http",         "scope": "subtree", "allow": ["read", "write", "create", "delete"] },
+      { "path": "/tmp",                "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true },
+      { "path": "/run/secrets/LLM_API_KEY", "scope": "exact", "allow": ["read"],
+                                                               "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.wikipedia.org", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.arxiv.org", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 8,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "PYTHONUNBUFFERED": "1",
+      "LLM_API_KEY_FILE": "/run/secrets/LLM_API_KEY"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/05_dotnet_image_processor.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/05_dotnet_image_processor.jsonc
@@ -1,0 +1,62 @@
+{
+  "version": "1.0",
+  "name": "image-processor",
+  "description": "Bound policy for image-processor on Linux x86_64 (from composed policy 05)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/dotnet",                    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/share/dotnet",                  "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/app",                "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/input",              "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",             "scope": "subtree", "allow": ["write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/workspace",          "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true },
+      { "path": "/config",             "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",                "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 2048,
+    "max_cpu_percent": 400,
+    "max_processes": 12,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 1024
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/share/dotnet",
+      "HOME": "/workspace",
+      "DOTNET_ROOT": "/usr/share/dotnet",
+      "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+      "DOTNET_NOLOGO": "1"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/linux/06_bash_infra_health_check.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/linux/06_bash_infra_health_check.jsonc
@@ -1,0 +1,75 @@
+{
+  "version": "1.0",
+  "name": "infra-health-check",
+  "description": "Bound policy for infra-health-check on Linux x86_64 (from composed policy 06)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/bin/bash",                      "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/curl",                      "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/openssl",                   "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/psql",                      "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/jq",                        "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib/x86_64-linux-gnu",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/lib/x86_64-linux-gnu",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/lib/postgresql",                "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                     "scope": "subtree", "allow": ["read"] },
+      { "path": "/etc/resolv.conf",                   "scope": "exact",   "allow": ["read"] },
+      { "path": "/usr/share/ca-certificates",         "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/output",             "scope": "subtree", "allow": ["write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/workspace",          "scope": "subtree", "allow": ["read", "write", "create"],
+                                                            "ephemeral": true },
+      { "path": "/config",             "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",                "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                            "ephemeral": true },
+      { "path": "/run/secrets/DB_CONNECTION_STRING", "scope": "exact", "allow": ["read"],
+                                                                        "ephemeral": true }
+    ],
+    "synthetic": {
+      "/dev": "minimal",
+      "/proc": "sandboxed",
+      "/tmp": "ephemeral"
+    }
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api-gateway.internal.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "auth.internal.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "db-primary.internal.example.com", "port": 5432 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 16,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "DB_CONNECTION_STRING_FILE": "/run/secrets/DB_CONNECTION_STRING"
+    }
+  },
+
+  "platform": {
+    "linux": {
+      "namespaces": {
+        "user": true, "mount": true, "pid": true,
+        "net": true, "ipc": true, "uts": true, "cgroup": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/01_python_data_analysis.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/01_python_data_analysis.jsonc
@@ -1,0 +1,66 @@
+{
+  // Bound policy for csv-data-analyzer on macOS arm64
+  // Derived from: composed_policies/01_python_data_analysis.jsonc
+
+  "version": "1.0",
+  "name": "csv-data-analyzer",
+  "description": "Bound policy for csv-data-analyzer on macOS arm64 (from composed policy 01)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/opt/homebrew/bin/python3.10",                   "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/bin/python3",                      "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/Cellar/python@3.10",               "scope": "subtree", "allow": ["read"] },
+      { "path": "/opt/homebrew/Frameworks/Python.framework",      "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/lib/python3.10/site-packages",     "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib",                                       "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                                 "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/ssl",                               "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/workspace",   "scope": "subtree", "allow": ["read", "write", "create"],
+                                                     "ephemeral": true },
+      { "path": "/input",       "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",      "scope": "subtree", "allow": ["write", "create"],
+                                                     "ephemeral": true },
+      { "path": "/tmp",         "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                     "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/.gnupg",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 1,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/opt/homebrew/bin:/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "PYTHONUNBUFFERED": "1"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/02_node_api_aggregator.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/02_node_api_aggregator.jsonc
@@ -1,0 +1,78 @@
+{
+  // Bound policy for multi-api-aggregator on macOS arm64
+  // Derived from: composed_policies/02_node_api_aggregator.jsonc
+
+  "version": "1.0",
+  "name": "multi-api-aggregator",
+  "description": "Bound policy for multi-api-aggregator on macOS arm64 (from composed policy 02)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/opt/homebrew/bin/node",                    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/Cellar/node@20",              "scope": "subtree", "allow": ["read"] },
+      { "path": "/opt/homebrew/lib/node_modules",            "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib",                                  "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                            "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/ssl",                          "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/resolv.conf",                  "scope": "exact",   "allow": ["read"] },
+
+      { "path": "/workspace",              "scope": "subtree", "allow": ["read", "write", "create"],
+                                                                "ephemeral": true },
+      { "path": "/workspace/node_modules", "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",                 "scope": "subtree", "allow": ["write", "create"],
+                                                                "ephemeral": true },
+      { "path": "/config",                 "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",                    "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                "ephemeral": true },
+      { "path": "/run/secrets/WEATHER_API_KEY",   "scope": "exact", "allow": ["read"],
+                                                                     "ephemeral": true },
+      { "path": "/run/secrets/GEOCODING_API_KEY", "scope": "exact", "allow": ["read"],
+                                                                     "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.weatherapi.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.opencagedata.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 1,
+    "max_wall_time_seconds": 45,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/opt/homebrew/bin:/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "NODE_ENV": "production",
+      "WEATHER_API_KEY_FILE": "/run/secrets/WEATHER_API_KEY",
+      "GEOCODING_API_KEY_FILE": "/run/secrets/GEOCODING_API_KEY"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true,
+        "allow_network_outbound": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/03_rust_snippet_runner.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/03_rust_snippet_runner.jsonc
@@ -1,0 +1,83 @@
+{
+  // Bound policy for rust-snippet-runner on macOS arm64
+  // Derived from: composed_policies/03_rust_snippet_runner.jsonc
+
+  "version": "1.0",
+  "name": "rust-snippet-runner",
+  "description": "Bound policy for rust-snippet-runner on macOS arm64 (from composed policy 03)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/opt/homebrew/bin/cargo",                "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/bin/rustc",                "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/cc",                            "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/ld",                            "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/Cellar/rust",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/lib",                               "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/Library/Developer/CommandLineTools",    "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                         "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/ssl",                       "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/input",             "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",            "scope": "subtree", "allow": ["write", "create"],
+                                                           "ephemeral": true },
+      { "path": "/workspace",         "scope": "subtree", "allow": ["read", "write", "create"],
+                                                           "ephemeral": true },
+      { "path": "/cache/cargo-registry", "scope": "subtree", "allow": ["read", "write", "create"] },
+      { "path": "/cache/cargo-target",   "scope": "subtree", "allow": ["read", "write", "create"] },
+      { "path": "/tmp",               "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                           "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "static.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "index.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "github.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 4096,
+    "max_cpu_percent": 400,
+    "max_processes": 32,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 4096
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/opt/homebrew/bin:/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "CARGO_HOME": "/cache/cargo-registry",
+      "CARGO_TARGET_DIR": "/cache/cargo-target",
+      "RUSTUP_HOME": "/opt/homebrew/Cellar/rust"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true,
+        "allow_network_outbound": true,
+        "allow_process_exec": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/04_llm_research_tool.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/04_llm_research_tool.jsonc
@@ -1,0 +1,80 @@
+{
+  // Bound policy for research-agent-tool on macOS arm64
+  // Derived from: composed_policies/04_llm_research_tool.jsonc
+  //
+  // NOTE: public-web scope restricted to *.wikipedia.org and *.arxiv.org
+  //       by user consent (composed through intersection)
+
+  "version": "1.0",
+  "name": "research-agent-tool",
+  "description": "Bound policy for research-agent-tool on macOS arm64 (from composed policy 04)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/opt/homebrew/bin/python3.11",                    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/Cellar/python@3.11",                "scope": "subtree", "allow": ["read"] },
+      { "path": "/opt/homebrew/Frameworks/Python.framework",       "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/lib/python3.11/site-packages",      "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib",                                        "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",                                  "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/ssl",                                "scope": "subtree", "allow": ["read"] },
+
+      { "path": "/workspace",  "scope": "subtree", "allow": ["read", "write", "create"],
+                                                    "ephemeral": true },
+      { "path": "/output",     "scope": "subtree", "allow": ["write", "create"],
+                                                    "ephemeral": true },
+      { "path": "/cache",      "scope": "subtree", "allow": ["read", "write", "create"] },
+      { "path": "/tmp",        "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                    "ephemeral": true },
+      { "path": "/run/secrets/LLM_API_KEY", "scope": "exact", "allow": ["read"],
+                                                               "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.wikipedia.org", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.arxiv.org", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 8,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/opt/homebrew/bin:/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "LLM_API_KEY_FILE": "/run/secrets/LLM_API_KEY"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true,
+        "allow_network_outbound": true,
+        "allow_process_exec": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/05_dotnet_image_processor.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/05_dotnet_image_processor.jsonc
@@ -1,0 +1,64 @@
+{
+  // Bound policy for image-processor on macOS arm64
+  // Derived from: composed_policies/05_dotnet_image_processor.jsonc
+
+  "version": "1.0",
+  "name": "image-processor",
+  "description": "Bound policy for image-processor on macOS arm64 (from composed policy 05)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/usr/local/share/dotnet/dotnet",          "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/local/share/dotnet/shared",          "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/usr/local/share/dotnet/packs",           "scope": "subtree", "allow": ["read"] },
+      { "path": "/usr/lib",                                "scope": "subtree", "allow": ["read", "execute"] },
+
+      { "path": "/app",         "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/input",       "scope": "subtree", "allow": ["read"] },
+      { "path": "/output",      "scope": "subtree", "allow": ["write", "create"],
+                                                     "ephemeral": true },
+      { "path": "/workspace",   "scope": "subtree", "allow": ["read", "write", "create"],
+                                                     "ephemeral": true },
+      { "path": "/config",      "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",         "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                     "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 2048,
+    "max_cpu_percent": 400,
+    "max_processes": 12,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 1024
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/usr/local/share/dotnet:/usr/bin:/usr/local/bin",
+      "HOME": "/workspace",
+      "DOTNET_CLI_HOME": "/workspace/.dotnet",
+      "DOTNET_NOLOGO": "1"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true,
+        "allow_process_exec": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/macos/06_bash_infra_health_check.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/macos/06_bash_infra_health_check.jsonc
@@ -1,0 +1,79 @@
+{
+  // Bound policy for infra-health-check on macOS arm64
+  // Derived from: composed_policies/06_bash_infra_health_check.jsonc
+
+  "version": "1.0",
+  "name": "infra-health-check",
+  "description": "Bound policy for infra-health-check on macOS arm64 (from composed policy 06)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "/bin/bash",                    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/bin/curl",                "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/bin/openssl",    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/bin/psql",       "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/bin/jq",         "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "/usr/lib",                     "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/opt/homebrew/lib",            "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "/etc/ssl/certs",               "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/ssl",             "scope": "subtree", "allow": ["read"] },
+      { "path": "/private/etc/resolv.conf",     "scope": "exact",   "allow": ["read"] },
+
+      { "path": "/output",     "scope": "subtree", "allow": ["write", "create"],
+                                                    "ephemeral": true },
+      { "path": "/workspace",  "scope": "subtree", "allow": ["read", "write", "create"],
+                                                    "ephemeral": true },
+      { "path": "/config",     "scope": "subtree", "allow": ["read"] },
+      { "path": "/tmp",        "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                    "ephemeral": true },
+      { "path": "/run/secrets/DB_CONNECTION_STRING", "scope": "exact", "allow": ["read"],
+                                                                       "ephemeral": true }
+    ],
+    "mask": [
+      "/Users/*/.ssh",
+      "/Users/*/.aws",
+      "/Users/*/Library/Keychains"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "gateway.corp.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "auth.corp.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "db-primary.corp.example.com", "port": 5432 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 16,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 512
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "/opt/homebrew/bin:/usr/bin:/bin",
+      "HOME": "/workspace",
+      "DB_CONNECTION_STRING_FILE": "/run/secrets/DB_CONNECTION_STRING"
+    }
+  },
+
+  "platform": {
+    "macos": {
+      "seatbelt": {
+        "profile": "deny-default",
+        "allow_dyld_cache": true,
+        "allow_network_outbound": true,
+        "allow_process_exec": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/01_python_data_analysis.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/01_python_data_analysis.jsonc
@@ -1,0 +1,68 @@
+{
+  "version": "1.0",
+  "name": "csv-data-analyzer",
+  "description": "Bound policy for csv-data-analyzer on Windows x64 (from composed policy 01)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Python310\\python.exe",        "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Python310\\python310.dll",     "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Python310\\Lib",               "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Python310\\DLLs",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "C:\\Python310\\Lib\\site-packages","scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll",  "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",      "scope": "exact",
+        "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\Workspace",   "scope": "subtree", "allow": ["read", "write", "create"],
+                                                                 "ephemeral": true },
+      { "path": "C:\\Sandbox\\Input",       "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Output",      "scope": "subtree", "allow": ["write", "create"],
+                                                                 "ephemeral": true },
+      { "path": "C:\\Sandbox\\Temp",        "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                 "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 1,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Python310;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "PYTHONUNBUFFERED": "1"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": []
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/02_node_api_aggregator.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/02_node_api_aggregator.jsonc
@@ -1,0 +1,76 @@
+{
+  "version": "1.0",
+  "name": "multi-api-aggregator",
+  "description": "Bound policy for multi-api-aggregator on Windows x64 (from composed policy 02)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Program Files\\nodejs\\node.exe",   "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\nodejs",             "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll","scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",   "scope": "exact",   "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\Workspace",       "scope": "subtree", "allow": ["read", "write", "create"],
+                                                                     "ephemeral": true },
+      { "path": "C:\\Sandbox\\Workspace\\node_modules", "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Output",          "scope": "subtree", "allow": ["write", "create"],
+                                                                     "ephemeral": true },
+      { "path": "C:\\Sandbox\\Config",          "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Temp",            "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                     "ephemeral": true },
+      { "path": "C:\\Sandbox\\Secrets\\WEATHER_API_KEY",   "scope": "exact", "allow": ["read"],
+                                                                              "ephemeral": true },
+      { "path": "C:\\Sandbox\\Secrets\\GEOCODING_API_KEY", "scope": "exact", "allow": ["read"],
+                                                                              "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.weatherapi.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.opencagedata.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 1,
+    "max_wall_time_seconds": 45,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Program Files\\nodejs;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "NODE_ENV": "production",
+      "WEATHER_API_KEY_FILE": "C:\\Sandbox\\Secrets\\WEATHER_API_KEY",
+      "GEOCODING_API_KEY_FILE": "C:\\Sandbox\\Secrets\\GEOCODING_API_KEY"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": ["internetClient"]
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/03_rust_snippet_runner.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/03_rust_snippet_runner.jsonc
@@ -1,0 +1,95 @@
+{
+  "version": "1.0",
+  "name": "rust-snippet-runner",
+  "description": "Bound policy for rust-snippet-runner on Windows x64 (from composed policy 03)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Rust\\.cargo\\bin\\cargo.exe",    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Rust\\.cargo\\bin\\rustc.exe",    "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Rust\\toolchains\\stable-x86_64-pc-windows-msvc", "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC",
+        "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files (x86)\\Windows Kits\\10\\Include",
+        "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Program Files (x86)\\Windows Kits\\10\\Lib",
+        "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",     "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\kernel32.dll",     "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ntdll.dll",        "scope": "exact",
+        "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\Input",        "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Output",       "scope": "subtree", "allow": ["write", "create"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Workspace",    "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Cache\\cargo-registry", "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"] },
+      { "path": "C:\\Sandbox\\Cache\\cargo-target",   "scope": "subtree",
+        "allow": ["read", "write", "create", "delete"] },
+      { "path": "C:\\Sandbox\\Temp",         "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                  "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "static.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "index.crates.io", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "github.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "objects.githubusercontent.com", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 4096,
+    "max_cpu_percent": 400,
+    "max_processes": 32,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 4096
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Rust\\.cargo\\bin;C:\\Program Files\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.39.33519\\bin\\Hostx64\\x64;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "CARGO_HOME": "C:\\Sandbox\\Cache\\cargo-registry",
+      "CARGO_TARGET_DIR": "C:\\Sandbox\\Cache\\cargo-target"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": ["internetClient"]
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/04_llm_research_tool.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/04_llm_research_tool.jsonc
@@ -1,0 +1,81 @@
+{
+  "version": "1.0",
+  "name": "research-agent-tool",
+  "description": "Bound policy for research-agent-tool on Windows x64 (from composed policy 04)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Python311\\python.exe",        "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Python311\\python311.dll",     "scope": "exact",   "allow": ["read", "execute"] },
+      { "path": "C:\\Python311\\Lib",               "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Python311\\DLLs",              "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "C:\\Python311\\Lib\\site-packages","scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll",  "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",      "scope": "exact",
+        "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\Workspace",    "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Output",       "scope": "subtree", "allow": ["write", "create"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Cache\\http",  "scope": "subtree", "allow": ["read", "write", "create", "delete"] },
+      { "path": "C:\\Sandbox\\Temp",         "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Secrets\\LLM_API_KEY", "scope": "exact", "allow": ["read"],
+                                                                        "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api.anthropic.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.wikipedia.org", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "*.arxiv.org", "port": 443 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 1024,
+    "max_cpu_percent": 200,
+    "max_processes": 8,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Python311;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "PYTHONDONTWRITEBYTECODE": "1",
+      "PYTHONUNBUFFERED": "1",
+      "LLM_API_KEY_FILE": "C:\\Sandbox\\Secrets\\LLM_API_KEY"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": ["internetClient"]
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/05_dotnet_image_processor.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/05_dotnet_image_processor.jsonc
@@ -1,0 +1,74 @@
+{
+  "version": "1.0",
+  "name": "image-processor",
+  "description": "Bound policy for image-processor on Windows x64 (from composed policy 05)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Program Files\\dotnet\\dotnet.exe", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\dotnet\\shared",     "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\dotnet\\host",       "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",     "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\kernel32.dll",     "scope": "exact",
+        "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\App",           "scope": "subtree", "allow": ["read", "execute"] },
+      { "path": "C:\\Sandbox\\Input",         "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Output",        "scope": "subtree", "allow": ["write", "create"],
+                                                                   "ephemeral": true },
+      { "path": "C:\\Sandbox\\Workspace",     "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                   "ephemeral": true },
+      { "path": "C:\\Sandbox\\Config",        "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Temp",          "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                   "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "none"
+  },
+
+  "resources": {
+    "max_memory_mb": 2048,
+    "max_cpu_percent": 400,
+    "max_processes": 12,
+    "max_wall_time_seconds": 300,
+    "max_open_files": 1024
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Program Files\\dotnet;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "DOTNET_ROOT": "C:\\Program Files\\dotnet",
+      "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+      "DOTNET_NOLOGO": "1"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": []
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/bound_policies/windows/06_bash_infra_health_check.jsonc
+++ b/docs/proposals/container-policy/examples/bound_policies/windows/06_bash_infra_health_check.jsonc
@@ -1,0 +1,91 @@
+{
+  "version": "1.0",
+  "name": "infra-health-check",
+  "description": "Bound policy for infra-health-check on Windows x64 (from composed policy 06)",
+
+  "filesystem": {
+    "rules": [
+      { "path": "C:\\Program Files\\Git\\usr\\bin\\bash.exe",    "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\bin\\curl.exe",    "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\bin\\openssl.exe", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\bin\\jq.exe",      "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\bin",              "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\lib",              "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\Git\\usr\\ssl",              "scope": "subtree",
+        "allow": ["read"] },
+      { "path": "C:\\Program Files\\PostgreSQL\\16\\bin\\psql.exe", "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Program Files\\PostgreSQL\\16\\lib",           "scope": "subtree",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\vcruntime140.dll",  "scope": "exact",
+        "allow": ["read", "execute"] },
+      { "path": "C:\\Windows\\System32\\ucrtbase.dll",      "scope": "exact",
+        "allow": ["read", "execute"] },
+
+      { "path": "C:\\Sandbox\\Output",       "scope": "subtree", "allow": ["write", "create"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Workspace",    "scope": "subtree", "allow": ["read", "write", "create"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Config",       "scope": "subtree", "allow": ["read"] },
+      { "path": "C:\\Sandbox\\Temp",         "scope": "subtree", "allow": ["read", "write", "create", "delete"],
+                                                                  "ephemeral": true },
+      { "path": "C:\\Sandbox\\Secrets\\DB_CONNECTION_STRING", "scope": "exact",
+        "allow": ["read"], "ephemeral": true }
+    ],
+    "mask": [
+      "C:\\Users",
+      "%USERPROFILE%\\.ssh",
+      "%USERPROFILE%\\.aws"
+    ]
+  },
+
+  "network": {
+    "mode": "rules",
+    "rules": [
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "api-gateway.internal.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "auth.internal.example.com", "port": 443 },
+      { "direction": "outbound", "action": "connect", "protocol": "tcp",
+        "host": "db-primary.internal.example.com", "port": 5432 }
+    ],
+    "allow_dns": true,
+    "allow_localhost": false
+  },
+
+  "resources": {
+    "max_memory_mb": 256,
+    "max_processes": 16,
+    "max_wall_time_seconds": 90,
+    "max_open_files": 256
+  },
+
+  "environment": {
+    "mode": "clean",
+    "set": {
+      "PATH": "C:\\Program Files\\Git\\usr\\bin;C:\\Program Files\\PostgreSQL\\16\\bin;C:\\Windows\\System32",
+      "TEMP": "C:\\Sandbox\\Temp",
+      "TMP": "C:\\Sandbox\\Temp",
+      "USERPROFILE": "C:\\Sandbox\\Workspace",
+      "DB_CONNECTION_STRING_FILE": "C:\\Sandbox\\Secrets\\DB_CONNECTION_STRING"
+    }
+  },
+
+  "platform": {
+    "windows": {
+      "appcontainer": {
+        "capabilities": ["internetClient"]
+      },
+      "bfs": {
+        "enabled": true,
+        "policy_broker": true
+      }
+    }
+  }
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/compositions/linux_namespace_stack.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/compositions/linux_namespace_stack.jsonc
@@ -1,0 +1,179 @@
+{
+  // Blessed Composition: Linux LXC/Namespace Stack
+  //
+  // The standard Linux sandbox stack for MXC. Combines Linux namespaces
+  // (mount, net, pid, user, ipc, uts) with Landlock v4 for filesystem
+  // and network access control, seccomp-bpf for syscall filtering, and
+  // cgroups v2 for resource limits. This composition has been validated
+  // to provide specific security guarantees when all four primitives
+  // are active.
+  //
+  // Platform: Linux kernel 6.7+
+
+  "profile_version": "1.0",
+  "composition_id": "linux_namespace_stack",
+  "display_name": "Linux Namespaces + Landlock v4 + seccomp-bpf + cgroups v2",
+  "platform": "linux",
+  "min_kernel_version": "6.7",
+
+  "primitives": [
+    {
+      "primitive_id": "linux_namespaces",
+      "role": "Provides isolated views of filesystem (mount ns), network (net ns), process tree (pid ns), user/group IDs (user ns), IPC (ipc ns), and hostname (uts ns). Foundation layer that reshapes what the sandboxed process can see.",
+      "required": true
+    },
+    {
+      "primitive_id": "landlock_v4",
+      "role": "Fine-grained path-based filesystem access control and per-port network filtering. Provides the access-control layer on top of namespace visibility isolation.",
+      "required": true
+    },
+    {
+      "primitive_id": "seccomp_bpf",
+      "role": "Syscall filtering. Blocks dangerous syscalls (ptrace, mount, reboot, kexec_load, etc.) and provides all-or-nothing IPC and spawn control where Landlock cannot.",
+      "required": true
+    },
+    {
+      "primitive_id": "cgroups_v2",
+      "role": "Resource limits — memory, CPU, PID count, and I/O bandwidth. Provides the resource dimension that other primitives lack.",
+      "required": true
+    }
+  ],
+
+  "effective_capabilities": {
+
+    "filesystem": {
+      "path_rules":       { "supported": true,  "granularity": "per-file",   "enforcement": "kernel", "via": ["landlock_v4"] },
+      "subtree_rules":    { "supported": true,                                "enforcement": "kernel", "via": ["landlock_v4"] },
+      "masking":          { "supported": true,                                "enforcement": "kernel", "via": ["linux_namespaces"],
+                            "notes": "Mount namespace provides true path hiding via bind mounts and tmpfs overlays." },
+      "exec_whitelist":   { "supported": true,                                "enforcement": "kernel", "via": ["landlock_v4"],
+                            "notes": "LANDLOCK_ACCESS_FS_EXECUTE granted only on whitelisted paths." },
+      "synthetic_mounts": { "supported": true,                                "enforcement": "kernel", "via": ["linux_namespaces"],
+                            "notes": "Mount namespace allows tmpfs, procfs, devpts with custom options." }
+    },
+
+    "network": {
+      "outbound_filter": { "supported": true, "granularity": "per-host-port", "enforcement": "kernel",
+                           "via": ["linux_namespaces", "landlock_v4"],
+                           "notes": "Network namespace provides host-level filtering (via nftables on veth bridge). Landlock v4 provides per-port filtering. Combined: per-host-port." },
+      "inbound_block":   { "supported": true,                                  "enforcement": "kernel",
+                           "via": ["linux_namespaces", "landlock_v4"],
+                           "notes": "Network namespace blocks all inbound by default. Landlock v4 BIND_TCP restricts bind ports." },
+      "dns_filter":      { "supported": true, "granularity": "per-domain",     "enforcement": "user-space",
+                           "via": ["linux_namespaces"],
+                           "notes": "Custom /etc/resolv.conf in mount namespace points to a filtering DNS proxy." },
+      "localhost":       { "supported": true,                                  "enforcement": "kernel",
+                           "via": ["linux_namespaces"],
+                           "notes": "Network namespace has separate loopback; host loopback not accessible." }
+    },
+
+    "process": {
+      "spawn_control":    { "supported": true, "enforcement": "kernel", "via": ["seccomp_bpf", "cgroups_v2"],
+                            "notes": "seccomp can block fork/clone entirely. cgroups pids.max provides a limit. Choose based on intent." },
+      "exec_whitelist":   { "supported": true, "enforcement": "kernel", "via": ["landlock_v4"] },
+      "signal_isolation": { "supported": true, "enforcement": "kernel", "via": ["linux_namespaces"],
+                            "notes": "PID namespace limits signal delivery to processes visible in the namespace." }
+    },
+
+    "resources": {
+      "memory_limit":        { "supported": true,  "enforcement": "kernel", "via": ["cgroups_v2"],  "mechanism": "memory.max" },
+      "cpu_limit":           { "supported": true,  "enforcement": "kernel", "via": ["cgroups_v2"],  "mechanism": "cpu.max (bandwidth) + cpuset (pinning)" },
+      "wall_time":           { "supported": true,  "enforcement": "user-space", "via": ["host-timer"], "mechanism": "Host-side timer + SIGKILL" },
+      "process_count_limit": { "supported": true,  "enforcement": "kernel", "via": ["cgroups_v2"],  "mechanism": "pids.max" },
+      "open_file_limit":     { "supported": true,  "enforcement": "kernel", "via": ["setrlimit"],   "mechanism": "RLIMIT_NOFILE (not cgroups — set before exec)" },
+      "io_limit":            { "supported": true,  "enforcement": "kernel", "via": ["cgroups_v2"],  "mechanism": "io.max (BPS/IOPS per device)" }
+    },
+
+    "ipc": {
+      "isolation":   { "supported": true, "enforcement": "kernel", "via": ["linux_namespaces", "seccomp_bpf"],
+                       "notes": "IPC namespace isolates SysV IPC. seccomp blocks IPC syscalls as needed. Mount namespace isolates POSIX shm." }
+    },
+
+    "credentials": {
+      "injection":       { "supported": true, "enforcement": "user-space", "via": ["host-setup"],
+                           "notes": "File-based injection into mount namespace (e.g., /run/secrets/) or environment variables." },
+      "store_isolation": { "supported": true, "enforcement": "kernel",     "via": ["linux_namespaces", "landlock_v4"],
+                           "notes": "Mount namespace hides credential paths. Landlock denies read to any that remain visible." }
+    },
+
+    "privilege": {
+      "escalation_prevention": { "supported": true, "enforcement": "kernel", "via": ["linux_namespaces", "seccomp_bpf", "landlock_v4"],
+                                  "notes": "User namespace maps root to unprivileged UID. no_new_privs bit set. seccomp blocks privilege syscalls." },
+      "capability_dropping":   { "supported": true, "enforcement": "kernel", "via": ["linux_namespaces"],
+                                  "notes": "User namespace capabilities don't map to host capabilities." }
+    }
+  },
+
+  "guarantees": [
+    {
+      "id": "no-filesystem-escape",
+      "description": "Sandboxed process cannot read or write files outside the explicitly granted set. Landlock enforces per-path access rules at the LSM layer; mount namespace controls filesystem topology; seccomp blocks mount/pivot_root/chroot to prevent namespace manipulation.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Already-opened file descriptors inherited from the host bypass Landlock rules",
+        "Landlock rules cannot be relaxed once applied (security feature, not a bug)"
+      ]
+    },
+    {
+      "id": "no-network-escape",
+      "description": "Sandboxed process cannot make network connections outside the explicitly allowed set. Network namespace provides full stack isolation; host-side nftables rules control forwarding; Landlock v4 restricts TCP port binding and connection.",
+      "enforcement": "kernel",
+      "caveats": [
+        "DNS filtering is user-space enforced (resolver-based) — a process that hardcodes DNS server IPs could bypass",
+        "Host-side nftables rules must be correctly configured for the network namespace"
+      ]
+    },
+    {
+      "id": "no-privilege-escalation",
+      "description": "Sandboxed process cannot gain host-level privileges. User namespace maps container UIDs to unprivileged host UIDs. no_new_privs prevents setuid escalation. seccomp blocks privilege-related syscalls.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Kernel vulnerabilities could bypass namespace/seccomp boundaries"
+      ]
+    },
+    {
+      "id": "no-credential-access",
+      "description": "Sandboxed process cannot access the host's credential stores. Mount namespace hides credential directories (overlay with empty tmpfs). Landlock denies read access as a second layer.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Credentials explicitly injected via /run/secrets/ or environment are accessible by design"
+      ]
+    },
+    {
+      "id": "process-containment",
+      "description": "All child processes are fully contained. PID namespace limits visibility. cgroups pids.max limits total process count. seccomp filters are inherited and irremovable. Landlock rulesets are inherited.",
+      "enforcement": "kernel",
+      "caveats": []
+    },
+    {
+      "id": "resource-bounded",
+      "description": "Resource consumption is bounded by cgroups limits. Memory, CPU, PID count, and I/O are all kernel-enforced. OOM kills contained to the cgroup.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Wall time is user-space enforced (host timer + SIGKILL)",
+        "Buffered I/O may temporarily exceed io.max due to page cache writeback"
+      ]
+    },
+    {
+      "id": "exec-restricted",
+      "description": "Only explicitly whitelisted executables can be exec'd. Landlock EXECUTE permission is granted only on specific paths.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Interpreted code (e.g., Python scripts) only needs execute on the interpreter binary, not the script file"
+      ]
+    }
+  ],
+
+  "known_gaps": [
+    {
+      "capability": "network.dns_filter",
+      "description": "DNS filtering is user-space only (custom resolv.conf + proxy). A process that bypasses the resolver can query arbitrary DNS servers if UDP/53 outbound is permitted.",
+      "workaround": "Block UDP/53 and TCP/53 outbound via nftables except to the designated DNS proxy"
+    },
+    {
+      "capability": "resources.wall_time",
+      "enforcement_note": "user-space only — host-side timer + SIGKILL",
+      "workaround": "Acceptable for most workloads; combine with cgroups memory limits to prevent resource exhaustion before timeout"
+    }
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/compositions/macos_seatbelt_stack.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/compositions/macos_seatbelt_stack.jsonc
@@ -1,0 +1,202 @@
+{
+  // Blessed Composition: macOS Seatbelt Stack
+  //
+  // The standard macOS sandbox stack for MXC. Combines Seatbelt (App
+  // Sandbox / sandbox-exec) for mandatory access control with POSIX
+  // resource limits (setrlimit) and host-side process management for
+  // resource bounding. Seatbelt is unusually comprehensive for a single
+  // primitive — covering filesystem, network, process, IPC, and
+  // credentials — so the composition is simpler than Windows or Linux.
+  //
+  // Platform: macOS 10.15+ (Catalina)
+
+  "profile_version": "1.0",
+  "composition_id": "macos_seatbelt_stack",
+  "display_name": "macOS Seatbelt + POSIX Resource Limits",
+  "platform": "macos",
+  "min_os_version": "10.15",
+
+  "primitives": [
+    {
+      "primitive_id": "seatbelt",
+      "role": "Primary isolation layer. Provides MAC-enforced filesystem rules (per-path, per-operation), network filtering (per-host-port), process control (fork/exec whitelist, signal isolation), IPC filtering (POSIX, SysV, Mach), and credential store isolation. Default-deny model via SBPL profiles.",
+      "required": true
+    },
+    {
+      "primitive_id": "posix_rlimits",
+      "role": "Resource bounding via setrlimit(). Provides per-process memory (RLIMIT_AS/RLIMIT_DATA), CPU time (RLIMIT_CPU), open file (RLIMIT_NOFILE), file size (RLIMIT_FSIZE), and core dump (RLIMIT_CORE) limits. Set before exec, inherited by children.",
+      "required": true,
+      "notes": "Not a separate profile file — POSIX rlimits are a standard OS facility, not a standalone isolation primitive. Included here because macOS lacks cgroups."
+    },
+    {
+      "primitive_id": "host_timer",
+      "role": "Wall-time enforcement. Host-side timer sends SIGKILL to the sandbox process group when the deadline expires.",
+      "required": true,
+      "notes": "Standard user-space enforcement pattern shared with Windows and Linux stacks."
+    }
+  ],
+
+  "effective_capabilities": {
+
+    "filesystem": {
+      "path_rules":       { "supported": true,  "granularity": "per-file",   "enforcement": "kernel", "via": ["seatbelt"],
+                            "notes": "SBPL distinguishes read-data, read-metadata, write-data, write-create, write-unlink, execute, ioctl — finer-grained than other platforms." },
+      "subtree_rules":    { "supported": true,                                "enforcement": "kernel", "via": ["seatbelt"],
+                            "mechanism": "(allow file-read* (subpath \"/path\"))" },
+      "masking":          { "supported": true,                                "enforcement": "kernel", "via": ["seatbelt"],
+                            "notes": "Default-deny means unmentioned paths are inaccessible. Names may still appear in readdir but open fails with EPERM." },
+      "exec_whitelist":   { "supported": true,                                "enforcement": "kernel", "via": ["seatbelt"],
+                            "mechanism": "(allow process-exec (path \"/usr/bin/python3\"))" },
+      "synthetic_mounts": { "supported": false,
+                            "notes": "Seatbelt filters operations on existing topology; it cannot reshape mount points." }
+    },
+
+    "network": {
+      "outbound_filter": { "supported": true, "granularity": "per-host-port", "enforcement": "kernel", "via": ["seatbelt"],
+                           "mechanism": "(allow network-outbound (remote tcp \"api.example.com:443\"))" },
+      "inbound_block":   { "supported": true,                                  "enforcement": "kernel", "via": ["seatbelt"] },
+      "dns_filter":      { "supported": false,
+                           "notes": "No per-domain DNS filtering. DNS is just network-outbound to port 53." },
+      "localhost":       { "supported": true,                                  "enforcement": "kernel", "via": ["seatbelt"] }
+    },
+
+    "process": {
+      "spawn_control":    { "supported": true, "enforcement": "kernel", "via": ["seatbelt"],
+                            "mechanism": "(deny process-fork) or pids limit is not available — fork can be blocked entirely but not capped." },
+      "exec_whitelist":   { "supported": true, "enforcement": "kernel", "via": ["seatbelt"] },
+      "signal_isolation": { "supported": true, "enforcement": "kernel", "via": ["seatbelt"],
+                            "mechanism": "(deny signal (target others))" }
+    },
+
+    "resources": {
+      "memory_limit":        { "supported": true,  "enforcement": "kernel",     "via": ["posix_rlimits"],
+                               "mechanism": "RLIMIT_AS (virtual address space) and RLIMIT_DATA (heap)",
+                               "notes": "Less precise than cgroups — RLIMIT_AS includes all mappings (shared libs, mmap). May need generous headroom." },
+      "cpu_limit":           { "supported": true,  "enforcement": "kernel",     "via": ["posix_rlimits"],
+                               "mechanism": "RLIMIT_CPU (cumulative CPU seconds). Sends SIGXCPU then SIGKILL.",
+                               "notes": "CPU time limit, not CPU rate/bandwidth. Cannot express '1 core equivalent' like cgroups cpu.max." },
+      "wall_time":           { "supported": true,  "enforcement": "user-space", "via": ["host_timer"] },
+      "process_count_limit": { "supported": false,
+                               "notes": "macOS has no per-sandbox PID limit. Seatbelt can deny process-fork entirely (all-or-nothing) but cannot cap at N children." },
+      "open_file_limit":     { "supported": true,  "enforcement": "kernel",     "via": ["posix_rlimits"],
+                               "mechanism": "RLIMIT_NOFILE" },
+      "io_limit":            { "supported": false,
+                               "notes": "No I/O bandwidth limiting on macOS. No cgroups equivalent." }
+    },
+
+    "ipc": {
+      "isolation": { "supported": true, "enforcement": "kernel", "via": ["seatbelt"],
+                     "notes": "Seatbelt can deny ipc-posix*, ipc-sysv*, and mach-lookup (Mach IPC). Mach port filtering is critical on macOS." }
+    },
+
+    "credentials": {
+      "injection":       { "supported": true,  "enforcement": "user-space", "via": ["host-setup"],
+                           "notes": "File-based injection or environment variables set before exec." },
+      "store_isolation": { "supported": true,  "enforcement": "kernel",     "via": ["seatbelt"],
+                           "notes": "Deny file-read* to ~/Library/Keychains + deny mach-lookup to Security framework services. Two-layer protection." }
+    },
+
+    "privilege": {
+      "escalation_prevention": { "supported": true, "enforcement": "kernel", "via": ["seatbelt"],
+                                  "notes": "Sandbox profile is irrevocable. (deny process-exec (with setuid)) blocks setuid. SIP provides additional system-level protection." },
+      "capability_dropping":   { "supported": false,
+                                  "notes": "macOS uses entitlements (per-binary, compile-time) not runtime capabilities. Cannot drop entitlements at sandbox creation." }
+    }
+  },
+
+  "guarantees": [
+    {
+      "id": "no-filesystem-escape",
+      "description": "Sandboxed process cannot access files outside the SBPL-allowed set. Default-deny profile ensures all access is explicitly granted. Kernel-enforced via TrustedBSD MAC hooks.",
+      "enforcement": "kernel",
+      "caveats": [
+        "File names may appear in readdir even when access is denied (partial masking)",
+        "Already-opened file descriptors inherited from the host bypass Seatbelt rules"
+      ]
+    },
+    {
+      "id": "no-network-escape",
+      "description": "Sandboxed process cannot make network connections outside the SBPL-allowed set. Outbound filtering is per-host-port, kernel-enforced.",
+      "enforcement": "kernel",
+      "caveats": [
+        "DNS resolution may leak queried domain names (no per-domain DNS filtering)",
+        "If network-outbound to port 53 is allowed, process can query arbitrary DNS servers"
+      ]
+    },
+    {
+      "id": "no-privilege-escalation",
+      "description": "Sandboxed process cannot elevate privileges. Sandbox profile is irrevocable. Setuid execution blocked. SIP protects system files independently.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Kernel vulnerabilities could bypass TrustedBSD MAC framework"
+      ]
+    },
+    {
+      "id": "no-credential-access",
+      "description": "Sandboxed process cannot access Keychain or Security framework credentials. Dual protection: filesystem access denied to Keychain paths + Mach IPC denied to Security services.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Credentials explicitly injected via environment or file are accessible by design"
+      ]
+    },
+    {
+      "id": "exec-restricted",
+      "description": "Only explicitly whitelisted executables can be exec'd via SBPL process-exec rules.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Interpreted code only needs execute on the interpreter binary"
+      ]
+    },
+    {
+      "id": "ipc-isolated",
+      "description": "POSIX IPC, SysV IPC, and Mach IPC are all filtered by Seatbelt. Mach port lookups restricted to explicitly allowed services.",
+      "enforcement": "kernel",
+      "caveats": [
+        "New system services with unknown Mach port names may bypass filters if not denied by wildcard rules"
+      ]
+    }
+  ],
+
+  "known_gaps": [
+    {
+      "capability": "resources.process_count_limit",
+      "description": "Cannot cap child process count at N. Seatbelt can only deny fork entirely (all-or-nothing).",
+      "workaround": "Allow fork and rely on memory/CPU limits to bound total resource consumption indirectly"
+    },
+    {
+      "capability": "resources.io_limit",
+      "description": "No I/O bandwidth limiting on macOS",
+      "workaround": "None available at the kernel level"
+    },
+    {
+      "capability": "resources.memory_limit",
+      "enforcement_note": "RLIMIT_AS is coarser than cgroups memory.max — includes all virtual mappings, not just resident memory",
+      "workaround": "Set generous headroom (e.g., 2x intended limit) to account for shared library mappings"
+    },
+    {
+      "capability": "resources.cpu_limit",
+      "enforcement_note": "RLIMIT_CPU measures cumulative CPU seconds, not bandwidth. Cannot express '2 cores max' or rate limiting.",
+      "workaround": "Combine RLIMIT_CPU with wall-time limit. For rate limiting, use macOS QoS classes (advisory only)."
+    },
+    {
+      "capability": "resources.wall_time",
+      "enforcement_note": "user-space only — host-side timer + SIGKILL",
+      "workaround": "Standard pattern across all platforms"
+    },
+    {
+      "capability": "filesystem.synthetic_mounts",
+      "description": "Cannot reshape filesystem topology — Seatbelt filters but does not virtualize",
+      "workaround": "Use SBPL deny rules to hide paths; accept that file names may leak in directory listings"
+    },
+    {
+      "capability": "privilege.capability_dropping",
+      "description": "macOS entitlements are per-binary at compile time, not runtime-adjustable",
+      "workaround": "Ensure sandbox helper binary has minimal entitlements"
+    },
+    {
+      "capability": "network.dns_filter",
+      "description": "No per-domain DNS filtering at the Seatbelt level",
+      "workaround": "Block network-outbound to port 53 except to a designated filtering DNS proxy (requires known proxy IP)"
+    }
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/compositions/windows_appcontainer_stack.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/compositions/windows_appcontainer_stack.jsonc
@@ -1,0 +1,154 @@
+{
+  // Blessed Composition: Windows AppContainer Stack
+  //
+  // The standard Windows sandbox stack for MXC. Combines AppContainer
+  // token-based isolation with BFS for filesystem brokering and WFP
+  // for network filtering. This composition has been validated to
+  // provide specific security guarantees when all three primitives
+  // are active.
+  //
+  // Platform: Windows 10 22H2+ (10.0.22621+)
+
+  "profile_version": "1.0",
+  "composition_id": "windows_appcontainer_stack",
+  "display_name": "Windows AppContainer + BFS + WFP",
+  "platform": "windows",
+  "min_os_version": "10.0.22621",
+
+  "primitives": [
+    {
+      "primitive_id": "appcontainer",
+      "role": "Primary isolation container. Provides token-based access control, job object resource limits, IPC namespace isolation, and privilege escalation prevention.",
+      "required": true
+    },
+    {
+      "primitive_id": "bfs",
+      "role": "Filesystem brokering layer. Adds fine-grained per-path rules, path masking, and optional consent prompting on top of AppContainer's coarse DACL model.",
+      "required": true
+    },
+    {
+      "primitive_id": "wfp",
+      "role": "Network filtering layer. Adds per-host-port outbound rules scoped to the AppContainer SID, beyond AppContainer's coarse internet/private capability model.",
+      "required": true
+    }
+  ],
+
+  // Combined capabilities — what the stack can enforce when all
+  // primitives are active. This is the union of individual capabilities,
+  // resolved for overlaps.
+  "effective_capabilities": {
+
+    "filesystem": {
+      "path_rules":       { "supported": true, "granularity": "per-file",    "enforcement": "kernel", "via": ["appcontainer", "bfs"] },
+      "subtree_rules":    { "supported": true,                                "enforcement": "kernel", "via": ["appcontainer", "bfs"] },
+      "masking":          { "supported": true,                                "enforcement": "kernel", "via": ["bfs"] },
+      "exec_whitelist":   { "supported": false, "notes": "Neither AppContainer nor BFS can restrict which executables are launched. Planned for future Win32 App Isolation integration." },
+      "synthetic_mounts": { "supported": false }
+    },
+
+    "network": {
+      "outbound_filter": { "supported": true, "granularity": "per-host-port", "enforcement": "kernel", "via": ["wfp"] },
+      "inbound_block":   { "supported": true,                                  "enforcement": "kernel", "via": ["appcontainer", "wfp"] },
+      "dns_filter":      { "supported": true, "granularity": "per-domain",     "enforcement": "kernel", "via": ["wfp"],
+                           "notes": "Requires NRPT configuration; not available out of the box." },
+      "localhost":       { "supported": true,                                  "via": ["appcontainer", "wfp"] }
+    },
+
+    "process": {
+      "spawn_control":   { "supported": true,  "enforcement": "kernel",   "via": ["appcontainer"],
+                           "notes": "Children inherit container token — equally constrained, not prevented." },
+      "exec_whitelist":  { "supported": false },
+      "signal_isolation": { "supported": true,  "enforcement": "kernel",   "via": ["appcontainer"] }
+    },
+
+    "resources": {
+      "memory_limit":        { "supported": true,  "enforcement": "kernel",     "via": ["appcontainer"], "mechanism": "Job object" },
+      "cpu_limit":           { "supported": true,  "enforcement": "kernel",     "via": ["appcontainer"], "mechanism": "Job object CPU rate" },
+      "wall_time":           { "supported": true,  "enforcement": "user-space", "via": ["host-timer"],   "mechanism": "Host-side timer + TerminateProcess" },
+      "process_count_limit": { "supported": true,  "enforcement": "kernel",     "via": ["appcontainer"], "mechanism": "Job object" },
+      "open_file_limit":     { "supported": false }
+    },
+
+    "ipc": {
+      "isolation":    { "supported": true, "enforcement": "kernel", "via": ["appcontainer"] },
+      "named_pipes":  { "supported": true, "enforcement": "kernel", "via": ["appcontainer", "bfs"] }
+    },
+
+    "credentials": {
+      "injection":       { "supported": true,  "enforcement": "user-space", "via": ["host-setup"] },
+      "store_isolation": { "supported": true,  "enforcement": "kernel",     "via": ["appcontainer", "bfs"] }
+    },
+
+    "privilege": {
+      "escalation_prevention": { "supported": true, "enforcement": "kernel", "via": ["appcontainer"] },
+      "capability_dropping":   { "supported": true, "enforcement": "kernel", "via": ["appcontainer"] }
+    }
+  },
+
+  // Security guarantees this composition provides when correctly configured.
+  // The binder can match intent policy claims against these guarantees.
+  "guarantees": [
+    {
+      "id": "no-filesystem-escape",
+      "description": "Sandboxed process cannot read or write files outside the explicitly granted set. BFS enforces per-path rules at the kernel mini-filter level; AppContainer token ensures default-deny.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Already-opened file descriptors inherited from the host bypass BFS rules",
+        "DACLs on target files must not grant the package SID broader access than intended"
+      ]
+    },
+    {
+      "id": "no-network-escape",
+      "description": "Sandboxed process cannot make network connections outside the explicitly allowed host:port set. WFP enforces per-connection rules scoped to the AppContainer SID.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Requires BFE (Base Filtering Engine) service to be running",
+        "DNS resolution may leak queried domain names even if the connection is blocked"
+      ]
+    },
+    {
+      "id": "no-privilege-escalation",
+      "description": "Sandboxed process cannot elevate privileges. AppContainer token runs at low integrity level with UAC prompts suppressed.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Kernel vulnerabilities could bypass token-based isolation"
+      ]
+    },
+    {
+      "id": "no-credential-access",
+      "description": "Sandboxed process cannot access the user's credential stores (Windows Credential Manager, DPAPI, SSH keys). BFS masks credential paths; AppContainer token lacks credential store capabilities.",
+      "enforcement": "kernel",
+      "caveats": [
+        "Credentials explicitly injected via environment or file are accessible by design"
+      ]
+    },
+    {
+      "id": "process-containment",
+      "description": "All child processes inherit the same AppContainer token and are equally constrained. No child can escape the sandbox.",
+      "enforcement": "kernel",
+      "caveats": [
+        "No exec whitelist — any accessible executable can be launched within the sandbox"
+      ]
+    }
+  ],
+
+  // Gaps — things this composition CANNOT enforce. The binder must
+  // check intent requirements against these and fail/warn accordingly.
+  "known_gaps": [
+    {
+      "capability": "filesystem.exec_whitelist",
+      "description": "Cannot restrict which executables are launched within the sandbox",
+      "workaround": "Use Win32 App Isolation (future integration) for exec whitelisting"
+    },
+    {
+      "capability": "resources.open_file_limit",
+      "description": "No per-process handle limit beyond system-wide defaults",
+      "workaround": "None available at the kernel level on Windows"
+    },
+    {
+      "capability": "resources.wall_time",
+      "enforcement_note": "user-space only — host-side timer, not kernel-enforced deadline",
+      "workaround": "Acceptable for most workloads; not suitable if kernel-level enforcement is required"
+    }
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/appcontainer.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/appcontainer.jsonc
@@ -1,0 +1,163 @@
+{
+  // Capability Profile: Windows AppContainer
+  //
+  // Token-based isolation primitive. Processes run under a low-integrity
+  // AppContainer token with a unique package SID. Access to resources is
+  // denied by default unless the resource's DACL explicitly grants the
+  // package SID (or a named capability SID).
+  //
+  // Platform: Windows 10+ (10.0.17763+)
+  // Enforcement: Kernel (NT object manager, token checks)
+
+  "profile_version": "1.0",
+  "primitive_id": "appcontainer",
+  "display_name": "Windows AppContainer",
+  "platform": "windows",
+  "min_os_version": "10.0.17763",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "path_rules": {
+        "supported": true,
+        "granularity": "per-file",
+        "enforcement": "kernel",
+        "mechanism": "DACL on NTFS objects; package SID must be in ACE",
+        "operations_distinguishable": ["read", "write", "execute", "delete"],
+        "notes": "Rules are expressed as ACEs on the target object, not as a policy file. Requires pre-configuring DACLs on paths the sandbox should access."
+      },
+      "subtree_rules": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Inheritable ACEs on directory objects",
+        "notes": "Inheritance propagates to new children but existing files may need explicit ACE addition."
+      },
+      "masking": {
+        "supported": false,
+        "notes": "AppContainer alone cannot hide paths — the object is visible but access is denied. See BFS primitive for true path masking."
+      },
+      "synthetic_mounts": {
+        "supported": false
+      }
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "per-capability",
+        "enforcement": "kernel",
+        "mechanism": "Network capability SIDs (internetClient, internetClientServer, privateNetworkClientServer) checked by WinSock and kernel",
+        "notes": "AppContainer alone provides coarse-grained network control (internet yes/no, private network yes/no). Per-host filtering requires WFP rules."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Denied unless internetClientServer capability is granted"
+      },
+      "dns_filter": {
+        "supported": false,
+        "notes": "DNS resolution follows network capability; no per-domain filtering at this layer."
+      },
+      "localhost": {
+        "supported": true,
+        "mechanism": "Loopback allowed only with explicit loopback exemption via CheckNetIsolation"
+      }
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Child processes inherit the AppContainer token",
+        "notes": "Cannot prevent spawning entirely at this layer, but children are equally constrained."
+      },
+      "exec_whitelist": {
+        "supported": false,
+        "notes": "Any executable accessible to the package SID can be launched. Use Win32 App Isolation or BFS for exec restrictions."
+      },
+      "signal_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Process in AppContainer cannot open handles to processes outside the container"
+      }
+    },
+
+    "resources": {
+      "memory_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Job object memory limits applied to the container's job",
+        "notes": "Requires wrapping the process in a Win32 Job Object."
+      },
+      "cpu_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Job object CPU rate control"
+      },
+      "wall_time": {
+        "supported": true,
+        "enforcement": "user-space",
+        "mechanism": "Host-side timer terminates process; not kernel-enforced inside the container",
+        "notes": "Process itself is unaware of the time limit."
+      },
+      "open_file_limit": {
+        "supported": false,
+        "notes": "No per-process handle limit beyond system-wide defaults."
+      },
+      "process_count_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Job object active process limit"
+      }
+    },
+
+    "ipc": {
+      "isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Named objects (mutexes, events, sections) are created in a per-package object namespace. Cross-container access denied by default."
+      },
+      "named_pipes": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Pipe DACLs; AppContainer can only connect to pipes whose DACL includes the package SID"
+      }
+    },
+
+    "credentials": {
+      "injection": {
+        "supported": true,
+        "enforcement": "user-space",
+        "mechanism": "Environment variables or file-based secret injection by the host before process start"
+      },
+      "store_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Windows Credential Manager / DPAPI scoped to user SID; AppContainer token cannot access user's credential stores without explicit capability"
+      }
+    },
+
+    "privilege": {
+      "escalation_prevention": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Low integrity level + AppContainer token. UAC prompts suppressed; no elevation possible."
+      },
+      "capability_dropping": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Only capabilities (SIDs) explicitly granted at container creation are available"
+      }
+    }
+  },
+
+  "limitations": [
+    "Filesystem rules require per-object DACL configuration; no centralized policy file",
+    "No exec whitelist — any accessible executable can be launched",
+    "No path masking — denied paths are visible (access denied, not hidden)",
+    "Network filtering is coarse (internet/private/none) without WFP",
+    "No open file handle limit",
+    "Wall time enforcement is user-space only"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/bfs.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/bfs.jsonc
@@ -1,0 +1,97 @@
+{
+  // Capability Profile: Brokered File System (BFS)
+  //
+  // Kernel mini-filter driver (altitude 150,000) that intercepts filesystem
+  // operations for AppContainer / App Silo processes. Provides fine-grained
+  // per-path brokering with consent prompting, path masking, and named pipe
+  // redirection. Policies keyed by {UserSID, PackageSID}.
+  //
+  // Platform: Windows 10 22H2+ (10.0.22621+)
+  // Enforcement: Kernel (mini-filter in IO manager stack)
+  //
+  // NOTE: BFS is a filesystem-only primitive. It augments AppContainer's
+  // filesystem capabilities but does not cover network, process, or resources.
+
+  "profile_version": "1.0",
+  "primitive_id": "bfs",
+  "display_name": "Brokered File System (BFS)",
+  "platform": "windows",
+  "min_os_version": "10.0.22621",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "path_rules": {
+        "supported": true,
+        "granularity": "per-file",
+        "enforcement": "kernel",
+        "mechanism": "Mini-filter pre-operation callbacks intercept IRP_MJ_CREATE and subsequent operations. Policy evaluated per-path against {UserSID, PackageSID} rule table.",
+        "operations_distinguishable": ["read", "write", "execute", "create", "delete"],
+        "notes": "Four policy levels: AsSelf (full access as calling user), AsUser (user-level access), AsUserQueryOnly (read-only), AsSelfNoPrompt (silent full access)."
+      },
+      "subtree_rules": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Wildcard path matching in policy rules with subtree semantics"
+      },
+      "masking": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Pre-operation callback returns STATUS_ACCESS_DENIED before the underlying filesystem sees the request. Directory enumeration filtering hides masked entries.",
+        "notes": "Unlike bare AppContainer (where denied paths are visible), BFS can make paths invisible to the sandboxed process."
+      },
+      "consent_prompting": {
+        "supported": true,
+        "enforcement": "user-space",
+        "mechanism": "RPC call to user-mode BFS broker service which presents a consent dialog. Grants are cached in the policy table with configurable TTL.",
+        "notes": "Requires an interactive session. Non-interactive scenarios use AsSelfNoPrompt or pre-configured grants."
+      },
+      "named_pipe_redirection": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "STATUS_REPARSE returned for pipe opens, redirecting to broker-controlled pipe endpoints"
+      },
+      "synthetic_mounts": {
+        "supported": false
+      }
+    },
+
+    "network": {
+      "_note": "BFS is filesystem-only. Network capabilities require a separate primitive (e.g., WFP, AppContainer network capabilities)."
+    },
+
+    "process": {
+      "_note": "BFS is filesystem-only. Process control requires a separate primitive."
+    },
+
+    "resources": {
+      "_note": "BFS is filesystem-only. Resource limits require a separate primitive (e.g., Job Objects)."
+    },
+
+    "ipc": {
+      "named_pipes": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "BFS intercepts named pipe opens and can redirect via STATUS_REPARSE to broker-controlled endpoints",
+        "notes": "This is filesystem-layer IPC control specifically for named pipes."
+      }
+    },
+
+    "credentials": {
+      "_note": "BFS does not manage credentials directly. It can mask paths to credential stores (e.g., hide .ssh directories)."
+    },
+
+    "privilege": {
+      "_note": "BFS does not manage privilege. It operates within the existing token's integrity level."
+    }
+  },
+
+  "limitations": [
+    "Filesystem-only primitive — must be combined with other primitives for full isolation",
+    "Policy storage uses custom block-based filesystem (16KB blocks) under %SystemRoot%\\System32\\config\\BFS\\",
+    "Consent prompting requires interactive session — headless scenarios need pre-configured policy",
+    "Policy lookup uses LRU cache with 5-minute idle eviction — cold starts may have latency",
+    "Only applies to AppContainer / App Silo processes (not arbitrary processes)"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/cgroups_v2.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/cgroups_v2.jsonc
@@ -1,0 +1,100 @@
+{
+  // Capability Profile: Linux cgroups v2
+  //
+  // Resource accounting and limiting via the unified cgroup hierarchy.
+  // Provides hard limits on memory, CPU, PIDs, and I/O for a group
+  // of processes. Used alongside namespaces and seccomp/Landlock for
+  // resource dimension of sandboxing.
+  //
+  // Platform: Linux kernel 5.2+ (unified hierarchy with all controllers)
+  // Enforcement: Kernel (scheduler, memory manager, PID allocator)
+
+  "profile_version": "1.0",
+  "primitive_id": "cgroups_v2",
+  "display_name": "cgroups v2 (unified hierarchy)",
+  "platform": "linux",
+  "min_kernel_version": "5.2",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "_note": "cgroups v2 does not provide filesystem isolation. Use Landlock or mount namespaces."
+    },
+
+    "network": {
+      "_note": "cgroups v2 does not provide network filtering. Use Landlock v4, netfilter, or network namespaces."
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "pids.max controller limits total number of processes in the cgroup",
+        "notes": "Does not prevent fork() — instead, fork() fails with EAGAIN when the limit is reached."
+      },
+      "exec_whitelist": {
+        "supported": false
+      },
+      "signal_isolation": {
+        "supported": false,
+        "notes": "cgroups does not filter signals. Use PID namespaces."
+      }
+    },
+
+    "resources": {
+      "memory_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "memory.max sets hard limit. OOM killer invoked when exceeded. memory.high sets soft limit (throttling).",
+        "notes": "memory.swap.max controls swap independently. memory.oom.group can trigger group-wide OOM kill."
+      },
+      "cpu_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "cpu.max sets bandwidth limit (quota/period). cpu.weight sets relative share.",
+        "notes": "cpu.max 100000 100000 = 1 CPU core equivalent. Can also set cpuset for core pinning."
+      },
+      "wall_time": {
+        "supported": false,
+        "notes": "cgroups does not have a wall-time limit. Must be implemented by the host (e.g., timer + SIGKILL)."
+      },
+      "open_file_limit": {
+        "supported": false,
+        "notes": "Per-process file descriptor limits are managed by setrlimit(RLIMIT_NOFILE), not cgroups."
+      },
+      "process_count_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "pids.max in the pids controller"
+      },
+      "io_limit": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "io.max sets per-device BPS/IOPS limits. io.weight sets relative I/O share.",
+        "notes": "Only applies to direct I/O on block devices. Buffered writes go through page cache and may not be throttled immediately."
+      }
+    },
+
+    "ipc": {
+      "_note": "cgroups does not manage IPC. Use IPC namespaces."
+    },
+
+    "credentials": {
+      "_note": "cgroups does not manage credentials."
+    },
+
+    "privilege": {
+      "_note": "cgroups does not manage privilege. Processes in a cgroup run with their existing credentials."
+    }
+  },
+
+  "limitations": [
+    "Resource-only primitive — must be combined with Landlock/seccomp/namespaces for access control",
+    "No wall-time limit — host must implement externally",
+    "No file descriptor limits — use setrlimit(RLIMIT_NOFILE) separately",
+    "Memory OOM kills the process rather than gracefully denying allocation",
+    "I/O throttling for buffered I/O is deferred (writeback may bypass limits temporarily)",
+    "Requires root or delegated cgroup subtree to create new cgroups"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/landlock_v4.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/landlock_v4.jsonc
@@ -1,0 +1,131 @@
+{
+  // Capability Profile: Linux Landlock v4
+  //
+  // Unprivileged security sandboxing mechanism. Processes create a ruleset
+  // defining permitted filesystem and network operations, then enforce it
+  // via prctl(). Rules are stackable — nested sandboxes only restrict further.
+  //
+  // Platform: Linux kernel 6.7+
+  // Enforcement: Kernel (LSM hooks)
+  //
+  // Version history:
+  //   v1 (5.13): Filesystem read/write/execute/make-dir/etc.
+  //   v2 (5.19): LANDLOCK_ACCESS_FS_REFER (cross-directory rename/link)
+  //   v3 (6.2):  LANDLOCK_ACCESS_FS_TRUNCATE
+  //   v4 (6.7):  Network TCP bind/connect filtering
+
+  "profile_version": "1.0",
+  "primitive_id": "landlock_v4",
+  "display_name": "Landlock v4",
+  "platform": "linux",
+  "min_kernel_version": "6.7",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "path_rules": {
+        "supported": true,
+        "granularity": "per-file",
+        "enforcement": "kernel",
+        "mechanism": "LSM hooks on path-based operations. Rules specify (path, access_rights) pairs where access_rights are bitmask of LANDLOCK_ACCESS_FS_* flags.",
+        "operations_distinguishable": [
+          "read_file", "read_dir", "write_file", "truncate",
+          "execute", "make_char", "make_dir", "make_reg",
+          "make_sock", "make_fifo", "make_block", "make_sym",
+          "remove_dir", "remove_file", "refer"
+        ]
+      },
+      "subtree_rules": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Rules on a directory fd apply to the entire subtree. Access rights propagate to all descendants.",
+        "notes": "Cannot grant more access to a child than its parent allows."
+      },
+      "masking": {
+        "supported": false,
+        "notes": "Landlock denies access but does not hide paths. Directory listings still show denied entries (opendir succeeds, access to contents fails). Use mount namespace for true hiding."
+      },
+      "synthetic_mounts": {
+        "supported": false,
+        "notes": "Landlock operates on the existing filesystem topology. Mount manipulation requires mount namespaces."
+      }
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "per-port",
+        "enforcement": "kernel",
+        "mechanism": "LANDLOCK_ACCESS_NET_CONNECT_TCP rules on port numbers",
+        "notes": "Filters by TCP port only — no host/IP filtering at this layer. Host-level filtering requires network namespaces + iptables/nftables."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "LANDLOCK_ACCESS_NET_BIND_TCP controls which ports the process can bind"
+      },
+      "dns_filter": {
+        "supported": false,
+        "notes": "No DNS-level filtering. DNS is just TCP/UDP to port 53."
+      },
+      "localhost": {
+        "supported": false,
+        "notes": "Cannot distinguish localhost from remote at this layer."
+      }
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": false,
+        "notes": "Landlock does not restrict fork/clone. Use seccomp for spawn prevention."
+      },
+      "exec_whitelist": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "LANDLOCK_ACCESS_FS_EXECUTE on specific paths restricts which files can be exec'd",
+        "notes": "Indirect: achieved by granting execute only on whitelisted paths."
+      },
+      "signal_isolation": {
+        "supported": false,
+        "notes": "Landlock does not filter signals. Use PID namespaces or seccomp."
+      }
+    },
+
+    "resources": {
+      "_note": "Landlock does not manage resource limits. Use cgroups v2 for memory, CPU, process count, etc."
+    },
+
+    "ipc": {
+      "_note": "Landlock does not filter IPC. Use IPC namespaces or seccomp for IPC isolation."
+    },
+
+    "credentials": {
+      "store_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Deny read access to credential file paths (e.g., ~/.ssh, ~/.aws)",
+        "notes": "Indirect: achieved by not granting filesystem read access to credential directories."
+      }
+    },
+
+    "privilege": {
+      "escalation_prevention": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Landlock rulesets are inherited across exec and cannot be removed. no_new_privs is required before enforcing.",
+        "notes": "The no_new_privs bit prevents setuid escalation."
+      }
+    }
+  },
+
+  "limitations": [
+    "Network filtering is port-only — no IP/host filtering (need netfilter for that)",
+    "No path masking — denied paths are still visible in directory listings",
+    "No resource limits — requires cgroups v2",
+    "No process spawn prevention — requires seccomp",
+    "No signal or IPC filtering — requires namespaces or seccomp",
+    "Rules cannot be relaxed once applied; only further restricted",
+    "Already-opened file descriptors are not affected by new rules"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/linux_namespaces.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/linux_namespaces.jsonc
@@ -1,0 +1,131 @@
+{
+  // Capability Profile: Linux Namespaces
+  //
+  // Kernel-level virtualization of global system resources. Each namespace
+  // type provides an isolated view of a specific resource class. Namespaces
+  // are stackable and composable.
+  //
+  // Platform: Linux kernel 5.6+ (all namespace types including time)
+  // Enforcement: Kernel (per-namespace resource tables)
+
+  "profile_version": "1.0",
+  "primitive_id": "linux_namespaces",
+  "display_name": "Linux Namespaces (mount, net, pid, user, ipc, uts, time)",
+  "platform": "linux",
+  "min_kernel_version": "5.6",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "path_rules": {
+        "supported": false,
+        "notes": "Mount namespaces provide filesystem topology isolation (what's visible) but not per-path access control. Use Landlock for fine-grained path rules."
+      },
+      "subtree_rules": {
+        "supported": false,
+        "notes": "Same as path_rules — mount ns controls visibility, not access rights."
+      },
+      "masking": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Mount namespace with bind mounts, tmpfs overlays, or inaccessible mounts (mount --make-private, mount -t tmpfs over sensitive paths)",
+        "notes": "True path masking — the path literally does not exist in the namespace."
+      },
+      "synthetic_mounts": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Mount namespace allows mounting tmpfs, procfs, sysfs, devpts with custom options",
+        "notes": "Can create a minimal /dev, restricted /proc, etc."
+      }
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "per-host-port",
+        "enforcement": "kernel",
+        "mechanism": "Network namespace with veth pair + nftables/iptables rules on the host side",
+        "notes": "Process gets its own network stack. Host-side firewall rules control what traffic is forwarded."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Network namespace — no ports are reachable unless explicitly forwarded from host"
+      },
+      "dns_filter": {
+        "supported": true,
+        "granularity": "per-domain",
+        "enforcement": "user-space",
+        "mechanism": "Custom /etc/resolv.conf in mount namespace pointing to a filtering DNS proxy",
+        "notes": "DNS filtering is user-space enforced at the resolver level."
+      },
+      "localhost": {
+        "supported": true,
+        "mechanism": "Separate loopback in network namespace; host loopback not accessible"
+      }
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": false,
+        "notes": "Namespaces do not limit process creation. Use cgroups pids controller."
+      },
+      "exec_whitelist": {
+        "supported": false,
+        "notes": "Use Landlock EXECUTE permission for exec whitelisting."
+      },
+      "signal_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "PID namespace — process can only signal PIDs visible in its namespace"
+      }
+    },
+
+    "resources": {
+      "_note": "Namespaces do not impose resource limits. Use cgroups v2."
+    },
+
+    "ipc": {
+      "isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "IPC namespace provides isolated System V IPC (shared memory, semaphores, message queues)",
+        "notes": "POSIX shared memory (shm_open) is on a per-mount tmpfs; isolated if /dev/shm is a per-namespace mount."
+      }
+    },
+
+    "credentials": {
+      "store_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Mount namespace hides host credential files (bind-mount /dev/null or tmpfs over ~/.ssh, etc.)",
+        "notes": "True hiding — paths do not exist or are replaced with empty mounts."
+      }
+    },
+
+    "privilege": {
+      "escalation_prevention": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "User namespace maps container root to unprivileged host UID. Capabilities apply only within the namespace.",
+        "notes": "Even 'root' inside a user namespace has no host privileges."
+      },
+      "capability_dropping": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "User namespace starts with full capability set mapped to unprivileged host user. Capabilities can be further dropped inside the namespace."
+      }
+    }
+  },
+
+  "limitations": [
+    "Namespaces provide isolation (separate views) not access control (per-path rules)",
+    "Filesystem masking requires mount namespace setup (bind mounts, overlayfs)",
+    "Network filtering via netns requires host-side firewall rule management",
+    "DNS filtering is user-space (resolver-based), not kernel-enforced",
+    "No resource limits — requires cgroups v2",
+    "Creating user namespaces may be restricted by sysctl (unprivileged_userns_clone)",
+    "Time namespace (clock offsets) available only on kernel 5.6+"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/seatbelt.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/seatbelt.jsonc
@@ -1,0 +1,158 @@
+{
+  // Capability Profile: macOS Seatbelt (sandbox_init / sandbox-exec)
+  //
+  // Mandatory access control framework using Scheme-based profile
+  // language (SBPL). Profiles declare permitted operations; everything
+  // else is denied. Enforced by the TrustedBSD MAC framework in the
+  // kernel.
+  //
+  // Platform: macOS 10.15+ (Catalina)
+  // Enforcement: Kernel (TrustedBSD MAC hooks)
+  //
+  // NOTE: Apple considers the SBPL language a private API. The profile
+  // format is not guaranteed stable across OS versions.
+
+  "profile_version": "1.0",
+  "primitive_id": "seatbelt",
+  "display_name": "macOS Seatbelt (App Sandbox / sandbox-exec)",
+  "platform": "macos",
+  "min_os_version": "10.15",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "path_rules": {
+        "supported": true,
+        "granularity": "per-file",
+        "enforcement": "kernel",
+        "mechanism": "SBPL rules: (allow file-read* (path \"/path/to/file\")), (allow file-write* (subpath \"/path/to/dir\")). Operations: file-read-data, file-read-metadata, file-write-data, file-write-create, file-write-unlink.",
+        "operations_distinguishable": [
+          "read-data", "read-metadata", "write-data", "write-create",
+          "write-unlink", "write-flags", "execute", "ioctl"
+        ],
+        "notes": "Rich operation taxonomy — finer-grained than most other sandbox systems."
+      },
+      "subtree_rules": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(allow file-read* (subpath \"/path/to/dir\")) applies to entire subtree"
+      },
+      "masking": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Default-deny profile. Unmentioned paths return EPERM. Directory listing of denied paths may still show names but open fails.",
+        "notes": "Not true invisibility (names may appear in readdir), but access is kernel-denied."
+      },
+      "synthetic_mounts": {
+        "supported": false,
+        "notes": "Seatbelt does not manipulate mount topology. It filters operations on the existing filesystem."
+      }
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "per-host-port",
+        "enforcement": "kernel",
+        "mechanism": "(allow network-outbound (remote tcp \"*:443\")) or (allow network-outbound (remote ip \"93.184.216.34:*\"))",
+        "notes": "Can filter by protocol, host, port, and whether connection is to local or remote."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(deny network-inbound) blocks bind/listen/accept"
+      },
+      "dns_filter": {
+        "supported": false,
+        "notes": "No per-domain DNS filtering. DNS is network-outbound to port 53."
+      },
+      "localhost": {
+        "supported": true,
+        "mechanism": "(allow network-outbound (local ip)) specifically for localhost connections"
+      }
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(deny process-fork) or (deny process-exec*) in SBPL profile"
+      },
+      "exec_whitelist": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(allow process-exec (path \"/usr/bin/python3\")) — whitelist specific executables"
+      },
+      "signal_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(deny signal (target others)) — restrict signal delivery"
+      }
+    },
+
+    "resources": {
+      "memory_limit": {
+        "supported": false,
+        "notes": "Seatbelt does not provide resource limits. macOS has no direct cgroup equivalent. Use launchd resource limits or RLIMIT_AS."
+      },
+      "cpu_limit": {
+        "supported": false,
+        "notes": "No CPU limiting in Seatbelt. Use RLIMIT_CPU or QoS classes."
+      },
+      "wall_time": {
+        "supported": false,
+        "notes": "Must be implemented by host-side timer + SIGKILL."
+      },
+      "open_file_limit": {
+        "supported": false,
+        "notes": "Use setrlimit(RLIMIT_NOFILE)."
+      },
+      "process_count_limit": {
+        "supported": false,
+        "notes": "No per-sandbox PID limit. Can deny process-fork to prevent all spawning."
+      }
+    },
+
+    "ipc": {
+      "isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "(deny ipc-posix*) and (deny ipc-sysv*) in SBPL profile. Can also restrict Mach IPC: (deny mach-lookup (global-name \"com.apple.service\")).",
+        "notes": "Mach IPC filtering is particularly important on macOS as many system services use Mach ports."
+      }
+    },
+
+    "credentials": {
+      "store_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Deny file-read* to keychain paths (/Users/*/Library/Keychains). Can also deny mach-lookup to Security framework services.",
+        "notes": "Two-layer protection: filesystem access denial + Mach service access denial."
+      }
+    },
+
+    "privilege": {
+      "escalation_prevention": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Sandbox profile is irrevocable once applied. (deny process-exec (with setuid)) blocks setuid execution.",
+        "notes": "Combined with macOS SIP (System Integrity Protection) for system-level protection."
+      },
+      "capability_dropping": {
+        "supported": false,
+        "notes": "macOS does not have a Linux-style capability system. Entitlements are per-binary, not runtime-adjustable."
+      }
+    }
+  },
+
+  "limitations": [
+    "SBPL profile language is Apple-private and not guaranteed stable across OS versions",
+    "No resource limits (memory, CPU, PID count) — requires external mechanisms (RLIMIT, launchd)",
+    "No synthetic mount support — cannot reshape filesystem topology",
+    "Path masking is partial: file names may appear in readdir even when access is denied",
+    "Mach IPC filtering requires knowing service names — new services may bypass filters",
+    "No DNS-level filtering",
+    "Cannot restrict already-opened file descriptors passed from parent"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/seccomp_bpf.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/seccomp_bpf.jsonc
@@ -1,0 +1,105 @@
+{
+  // Capability Profile: Linux seccomp-bpf
+  //
+  // System call filtering via BPF programs attached to a process.
+  // Filters are inherited by children and cannot be removed.
+  // Operates at the syscall boundary — can allow, deny, trap, or log
+  // individual system calls based on syscall number and arguments.
+  //
+  // Platform: Linux kernel 3.17+ (seccomp-bpf with TSYNC)
+  // Enforcement: Kernel (syscall entry point)
+
+  "profile_version": "1.0",
+  "primitive_id": "seccomp_bpf",
+  "display_name": "seccomp-bpf",
+  "platform": "linux",
+  "min_kernel_version": "3.17",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "_note": "seccomp can block filesystem-related syscalls (open, openat, mkdir, etc.) but cannot make path-based decisions. Use Landlock for path-level filesystem rules."
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "all-or-nothing",
+        "enforcement": "kernel",
+        "mechanism": "Block connect() / sendto() / sendmsg() syscalls entirely",
+        "notes": "Cannot distinguish destination host/port at the seccomp layer. For per-host filtering, use network namespaces + nftables."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block bind() / listen() / accept() syscalls"
+      },
+      "dns_filter": {
+        "supported": false
+      },
+      "localhost": {
+        "supported": false,
+        "notes": "Cannot distinguish localhost from remote at syscall level."
+      }
+    },
+
+    "process": {
+      "spawn_control": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block fork() / clone() / clone3() syscalls",
+        "notes": "Can also use SECCOMP_RET_ERRNO to return EPERM on spawn attempts."
+      },
+      "exec_whitelist": {
+        "supported": false,
+        "notes": "seccomp can block execve()/execveat() entirely but cannot filter by path argument (pointer arguments are not dereferenceable in BPF). Use Landlock for exec whitelisting."
+      },
+      "signal_isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block kill() / tkill() / tgkill() or filter by signal number argument"
+      }
+    },
+
+    "resources": {
+      "_note": "seccomp does not manage resource limits. Use cgroups v2."
+    },
+
+    "ipc": {
+      "isolation": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block shmget() / shmat() / msgget() / msgsnd() / semget() etc.",
+        "notes": "All-or-nothing IPC blocking at the syscall level."
+      }
+    },
+
+    "credentials": {
+      "_note": "seccomp cannot manage credentials but can block credential-related syscalls (keyctl, etc.)."
+    },
+
+    "privilege": {
+      "escalation_prevention": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block setuid() / setgid() / setresuid() / setresgid() / prctl(PR_SET_NO_NEW_PRIVS). Combined with no_new_privs bit.",
+        "notes": "Filters are irremovable once installed; children inherit the filter."
+      },
+      "capability_dropping": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "Block capset() or prctl(PR_CAP_AMBIENT) to prevent capability manipulation"
+      }
+    }
+  },
+
+  "limitations": [
+    "Cannot make path-based decisions — syscall arguments that are pointers cannot be dereferenced in BPF",
+    "Network filtering is all-or-nothing at the syscall level (block connect or not)",
+    "No resource limits — requires cgroups v2",
+    "Filter programs have complexity limits (BPF instruction count)",
+    "Argument inspection limited to register values (integers, not strings/paths)",
+    "SECCOMP_RET_USER_NOTIF allows user-space policy decisions but adds latency"
+  ]
+}

--- a/docs/proposals/container-policy/examples/capability_profiles/primitives/wfp.jsonc
+++ b/docs/proposals/container-policy/examples/capability_profiles/primitives/wfp.jsonc
@@ -1,0 +1,84 @@
+{
+  // Capability Profile: Windows Filtering Platform (WFP)
+  //
+  // Kernel-mode network filtering framework. Provides per-host, per-port,
+  // per-protocol network rules. Used alongside AppContainer to add
+  // fine-grained network control beyond the coarse capability-SID model.
+  //
+  // Platform: Windows 10+ (10.0.17763+)
+  // Enforcement: Kernel (tcpip.sys / netio.sys filter engine)
+
+  "profile_version": "1.0",
+  "primitive_id": "wfp",
+  "display_name": "Windows Filtering Platform (WFP)",
+  "platform": "windows",
+  "min_os_version": "10.0.17763",
+  "enforcement_level": "kernel",
+
+  "capabilities": {
+
+    "filesystem": {
+      "_note": "WFP is network-only. Filesystem capabilities require a separate primitive."
+    },
+
+    "network": {
+      "outbound_filter": {
+        "supported": true,
+        "granularity": "per-host-port",
+        "enforcement": "kernel",
+        "mechanism": "Callout filters at ALE (Application Layer Enforcement) connect layers. Rules can match on remote IP, port, protocol, and AppContainer SID.",
+        "notes": "Can scope rules to a specific AppContainer by filtering on the token's package SID. Supports both allow-list and block-list models."
+      },
+      "inbound_block": {
+        "supported": true,
+        "enforcement": "kernel",
+        "mechanism": "ALE receive/accept layers block unsolicited inbound connections"
+      },
+      "dns_filter": {
+        "supported": true,
+        "granularity": "per-domain",
+        "enforcement": "kernel",
+        "mechanism": "DNS proxy / name resolution policy table (NRPT) integration",
+        "notes": "Requires NRPT configuration or custom callout driver for full per-domain DNS filtering."
+      },
+      "localhost": {
+        "supported": true,
+        "mechanism": "Loopback traffic can be explicitly allowed or denied via ALE filters"
+      },
+      "protocol_filter": {
+        "supported": true,
+        "granularity": "per-protocol",
+        "enforcement": "kernel",
+        "mechanism": "Transport layer filters can distinguish TCP, UDP, ICMP, etc."
+      }
+    },
+
+    "process": {
+      "_note": "WFP is network-only. Process control requires a separate primitive."
+    },
+
+    "resources": {
+      "_note": "WFP is network-only. Resource limits require a separate primitive."
+    },
+
+    "ipc": {
+      "_note": "WFP is network-only."
+    },
+
+    "credentials": {
+      "_note": "WFP is network-only."
+    },
+
+    "privilege": {
+      "_note": "WFP is network-only."
+    }
+  },
+
+  "limitations": [
+    "Network-only primitive — must be combined with other primitives for full isolation",
+    "Requires BFE (Base Filtering Engine) service to be running",
+    "Per-domain DNS filtering requires NRPT or custom callout — not available out of the box",
+    "Filter rules are system-wide objects; proper scoping to a specific container requires AppContainer SID matching",
+    "Complex rule sets may impact network performance"
+  ]
+}

--- a/docs/proposals/container-policy/examples/composed_policies/01_python_data_analysis.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/01_python_data_analysis.jsonc
@@ -1,0 +1,67 @@
+{
+  // COMPOSED POLICY: csv-data-analyzer
+  //
+  // Composition of:
+  //   Developer: intent_manifests/01_python_data_analysis.jsonc
+  //   User:      user_intents/01_data_analysis_consent.jsonc
+  //   Admin:     admin_intents/01_corporate_standard.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - max_wall_time_seconds: min(120, 90, 300) = 90 (user tightened)
+  //   - max_memory_mb: min(1024, 2048) = 1024 (author's self-imposed limit wins)
+  //   - network: [] ∩ [] ∩ [whitelisted] = [] (no network — all agree)
+  //   - No conflicts — this is a clean offline workload
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "csv-data-analyzer",
+    "version": "1.0.0",
+    "description": "Effective policy: offline CSV analysis (composed from 4 layers)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "python",
+      "min_version": "3.10",
+      "packages": ["pandas", "numpy"]
+    },
+
+    "storage": [
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [],
+
+    "process": { "spawn": false },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 90,
+    "max_processes": 1,
+    "max_output_bytes": 10485760,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": true,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/composed_policies/02_node_api_aggregator.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/02_node_api_aggregator.jsonc
@@ -1,0 +1,79 @@
+{
+  // COMPOSED POLICY: multi-api-aggregator
+  //
+  // Composition of:
+  //   Developer: intent_manifests/02_node_api_aggregator.jsonc
+  //   User:      user_intents/02_api_access_consent.jsonc
+  //   Admin:     admin_intents/01_corporate_standard.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - max_wall_time_seconds: min(60, 45, 300) = 45 (user tightened)
+  //   - network: [weather-api, geocoding-api, dns] ∩ [same] ∩ [same + whitelisted] = [weather-api, geocoding-api, dns]
+  //     (all three layers approve these services)
+  //   - credentials: [WEATHER_API_KEY, GEOCODING_API_KEY] approved by user and admin
+  //   - max_memory_mb: min(256, 2048) = 256 (author's limit wins)
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "multi-api-aggregator",
+    "version": "2.1.0",
+    "description": "Effective policy: API aggregation with two services (composed from 4 layers)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "node",
+      "min_version": "20.0",
+      "packages": ["axios", "zod"]
+    },
+
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "config", "access": "read" }
+    ],
+
+    "network": [
+      { "service": "weather-api", "protocol": "https",
+        "operations": ["query"], "auth": "injected-token" },
+      { "service": "geocoding-api", "protocol": "https",
+        "operations": ["query"], "auth": "injected-token" },
+      { "capability": "dns" }
+    ],
+
+    "process": { "spawn": false },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "WEATHER_API_KEY", "type": "api-key" },
+      { "name": "GEOCODING_API_KEY", "type": "api-key" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 45,
+    "max_processes": 1,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/composed_policies/03_rust_snippet_runner.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/03_rust_snippet_runner.jsonc
@@ -1,0 +1,83 @@
+{
+  // COMPOSED POLICY: rust-snippet-runner
+  //
+  // Composition of:
+  //   Developer: intent_manifests/03_rust_snippet_runner.jsonc
+  //   User:      (delegated — no user intent file)
+  //   Admin:     admin_intents/02_research_lab.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - No user narrowing — fully delegated
+  //   - network: [crates-io, github-crate-sources, dns] ∩ [same in admin] = approved
+  //   - max_memory_mb: min(4096, 4096) = 4096 (author and admin agree)
+  //   - max_wall_time_seconds: min(300, 600) = 300 (author's limit wins)
+  //   - max_processes: min(32, 64) = 32 (author's limit wins)
+  //   - System constraints added: no writable+executable pages, no privilege escalation, etc.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "rust-snippet-runner",
+    "version": "1.0.0",
+    "description": "Effective policy: Rust compilation and execution (composed from 3 layers, user delegated)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "rust",
+      "min_version": "1.75"
+    },
+
+    "tools": [
+      { "name": "cargo", "access": "execute" },
+      { "name": "rustc", "access": "execute" }
+    ],
+
+    "storage": [
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "cache", "access": "read-write", "persistence": "discardable" }
+    ],
+
+    "network": [
+      { "service": "crates-io", "protocol": "https", "operations": ["download"] },
+      { "service": "github-crate-sources", "protocol": "https", "operations": ["download"] },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 16,
+      "exec": ["cargo", "rustc", "cc", "ld"],
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 4096,
+    "max_cpu_cores": 4,
+    "max_wall_time_seconds": 300,
+    "max_processes": 32,
+    "max_open_files": 4096,
+    "max_output_bytes": 52428800,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": false
+  }
+}

--- a/docs/proposals/container-policy/examples/composed_policies/04_llm_research_tool.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/04_llm_research_tool.jsonc
@@ -1,0 +1,84 @@
+{
+  // COMPOSED POLICY: research-agent-tool (LLM research)
+  //
+  // Composition of:
+  //   Developer: intent_manifests/04_llm_research_tool.jsonc
+  //   User:      user_intents/03_web_research_consent.jsonc
+  //   Admin:     admin_intents/02_research_lab.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - network: Developer requests [llm-api, public-web, dns]
+  //     User restricts public-web to *.wikipedia.org,*.arxiv.org
+  //     Admin allows [llm-api, public-web, dns]
+  //     Effective: [llm-api, public-web (*.wikipedia.org,*.arxiv.org only), dns]
+  //   - max_wall_time_seconds: min(600, 300, 600) = 300 (user tightened)
+  //   - max_memory_mb: min(1024, 4096) = 1024 (author's limit wins)
+  //   - NOTE: public-web is narrowed by user, not removed. Admin permits it for research.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "research-agent-tool",
+    "version": "3.0.0",
+    "description": "Effective policy: LLM research with restricted web (composed from 4 layers)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "python",
+      "min_version": "3.11",
+      "packages": ["httpx", "beautifulsoup4", "tiktoken"]
+    },
+
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "cache", "access": "read-write", "persistence": "discardable" }
+    ],
+
+    "network": [
+      { "service": "llm-api", "protocol": "https",
+        "operations": ["completions"], "auth": "injected-token" },
+      { "service": "public-web", "protocol": "https",
+        "scope": "*.wikipedia.org,*.arxiv.org" },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 4,
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 300,
+    "max_processes": 8,
+    "max_output_bytes": 5242880,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": false,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/composed_policies/05_dotnet_image_processor.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/05_dotnet_image_processor.jsonc
@@ -1,0 +1,76 @@
+{
+  // COMPOSED POLICY: image-processor
+  //
+  // Composition of:
+  //   Developer: intent_manifests/05_dotnet_image_processor.jsonc
+  //   User:      (delegated — no user intent file)
+  //   Admin:     admin_intents/01_corporate_standard.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - No user narrowing — fully delegated
+  //   - network: [] (author requests none, all layers agree)
+  //   - max_memory_mb: min(2048, 2048) = 2048 (author and admin equal)
+  //   - max_wall_time_seconds: min(600, 300) = 300 (admin tightened)
+  //   - max_processes: min(12, 32) = 12 (author's limit wins)
+  //   - System constraints added
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "image-processor",
+    "version": "1.4.0",
+    "description": "Effective policy: offline image processing (composed from 3 layers, user delegated)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "dotnet",
+      "min_version": "8.0",
+      "packages": ["SixLabors.ImageSharp"]
+    },
+
+    "storage": [
+      { "class": "app_code", "access": "read" },
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "config", "access": "read" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [],
+
+    "process": {
+      "spawn": true,
+      "max_children": 8,
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 2048,
+    "max_cpu_cores": 4,
+    "max_wall_time_seconds": 300,
+    "max_processes": 12,
+    "max_open_files": 1024,
+    "max_output_bytes": 524288000,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": true,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/composed_policies/06_bash_infra_health_check.jsonc
+++ b/docs/proposals/container-policy/examples/composed_policies/06_bash_infra_health_check.jsonc
@@ -1,0 +1,92 @@
+{
+  // COMPOSED POLICY: infra-health-check
+  //
+  // Composition of:
+  //   Developer: intent_manifests/06_bash_infra_health_check.jsonc
+  //   User:      user_intents/04_internal_services_consent.jsonc
+  //   Admin:     admin_intents/03_production_ops.jsonc
+  //   System:    system_intents/* (common constraints)
+  //
+  // Key composition effects:
+  //   - network: All three internal services approved by all layers
+  //   - max_wall_time_seconds: min(120, 90, 180) = 90 (user tightened)
+  //   - max_memory_mb: min(256, 512) = 256 (author's limit wins)
+  //   - max_processes: min(16, 16) = 16 (author and admin agree)
+  //   - credentials: DB_CONNECTION_STRING approved by user and admin
+  //   - System constraints added
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "infra-health-check",
+    "version": "2.0.0",
+    "description": "Effective policy: infra health checks with internal services (composed from 4 layers)"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "bash",
+      "min_version": "5.0"
+    },
+
+    "tools": [
+      { "name": "curl", "access": "execute" },
+      { "name": "openssl", "access": "execute" },
+      { "name": "psql", "access": "execute" },
+      { "name": "jq", "access": "execute" }
+    ],
+
+    "storage": [
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "config", "access": "read" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [
+      { "service": "internal-api-gateway", "protocol": "https",
+        "operations": ["health-check"] },
+      { "service": "internal-auth-service", "protocol": "https",
+        "operations": ["health-check"] },
+      { "service": "primary-database", "protocol": "tcp",
+        "operations": ["query"], "auth": "injected-token" },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 8,
+      "exec": ["curl", "openssl", "psql", "jq", "bash"],
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "DB_CONNECTION_STRING", "type": "connection-string" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 90,
+    "max_processes": 16,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "access_credential_stores": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/01_python_data_analysis.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/01_python_data_analysis.jsonc
@@ -1,0 +1,51 @@
+{
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "csv-data-analyzer",
+    "version": "1.0.0",
+    "description": "Reads CSV input, performs statistical analysis with pandas, writes summary report"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "python",
+      "min_version": "3.10",
+      "packages": ["pandas", "numpy"]
+    },
+
+    "storage": [
+      { "class": "input_data", "access": "read", "description": "CSV files to analyze" },
+      { "class": "output_data", "access": "write", "description": "Analysis report (JSON)" },
+      { "class": "workspace", "access": "read-write", "description": "Working directory for intermediate results" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [],
+
+    "process": {
+      "spawn": false
+    },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 120,
+    "max_processes": 1,
+    "max_output_bytes": 10485760,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": true,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/02_node_api_aggregator.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/02_node_api_aggregator.jsonc
@@ -1,0 +1,76 @@
+{
+  // Node.js API client that queries multiple external services, aggregates
+  // results, and writes a consolidated JSON report. Needs network access
+  // to two named services and DNS.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "multi-api-aggregator",
+    "version": "2.1.0",
+    "description": "Queries weather and geocoding APIs, aggregates results into a report"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "node",
+      "min_version": "20.0",
+      "packages": ["axios", "zod"]
+    },
+
+    "storage": [
+      { "class": "workspace", "access": "read-write", "description": "Working directory" },
+      { "class": "output_data", "access": "write", "description": "Aggregated report (JSON)" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      { "class": "config", "access": "read", "description": "Query parameters and API config" }
+    ],
+
+    "network": [
+      {
+        "service": "weather-api",
+        "protocol": "https",
+        "operations": ["query"],
+        "auth": "injected-token",
+        "description": "Weather data provider"
+      },
+      {
+        "service": "geocoding-api",
+        "protocol": "https",
+        "operations": ["query"],
+        "auth": "injected-token",
+        "description": "Geocoding service for lat/lng lookup"
+      },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": false
+    },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "WEATHER_API_KEY", "type": "api-key", "description": "Weather service API key" },
+      { "name": "GEOCODING_API_KEY", "type": "api-key", "description": "Geocoding service API key" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 60,
+    "max_processes": 1,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/03_rust_snippet_runner.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/03_rust_snippet_runner.jsonc
@@ -1,0 +1,83 @@
+{
+  // Rust CLI tool that compiles and runs a user-supplied Rust snippet.
+  // Needs the Rust toolchain, cargo, and network access to download
+  // crate dependencies from crates.io. Spawns child processes (cargo,
+  // rustc). Cache is used for the cargo registry and build artifacts.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "rust-snippet-runner",
+    "version": "1.0.0",
+    "description": "Compiles and executes a user-supplied Rust code snippet with cargo"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "rust",
+      "min_version": "1.75"
+    },
+
+    "tools": [
+      { "name": "cargo", "access": "execute" },
+      { "name": "rustc", "access": "execute" }
+    ],
+
+    "storage": [
+      { "class": "input_data", "access": "read", "description": "Rust source file to compile" },
+      { "class": "output_data", "access": "write", "description": "Compiled binary output and stdout" },
+      { "class": "workspace", "access": "read-write", "description": "Cargo project directory" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      {
+        "class": "cache",
+        "access": "read-write",
+        "persistence": "discardable",
+        "description": "Cargo registry cache and build artifacts — survives across invocations"
+      }
+    ],
+
+    "network": [
+      {
+        "service": "crates-io",
+        "protocol": "https",
+        "operations": ["download"],
+        "description": "Rust crate registry for dependency resolution"
+      },
+      {
+        "service": "github-crate-sources",
+        "protocol": "https",
+        "operations": ["download"],
+        "description": "GitHub-hosted crate source archives"
+      },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 16,
+      "exec": ["cargo", "rustc", "cc", "ld"],
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 4096,
+    "max_cpu_cores": 4,
+    "max_wall_time_seconds": 300,
+    "max_processes": 32,
+    "max_open_files": 4096,
+    "max_output_bytes": 52428800,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": false
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/04_llm_research_tool.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/04_llm_research_tool.jsonc
@@ -1,0 +1,82 @@
+{
+  // LLM-powered research agent tool. Receives a query, calls an LLM
+  // for reasoning, searches the web for supporting evidence, and
+  // produces a structured research report. Needs two external services,
+  // credentials for both, and moderate resources for LLM response
+  // handling.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "research-agent-tool",
+    "version": "3.0.0",
+    "description": "Agent tool: searches the web and synthesizes findings via LLM"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "python",
+      "min_version": "3.11",
+      "packages": ["httpx", "beautifulsoup4", "tiktoken"]
+    },
+
+    "storage": [
+      { "class": "workspace", "access": "read-write", "description": "Scratch space for downloaded pages and intermediate analysis" },
+      { "class": "output_data", "access": "write", "description": "Structured research report (JSON)" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" },
+      {
+        "class": "cache",
+        "access": "read-write",
+        "persistence": "discardable",
+        "description": "HTTP response cache — avoids re-fetching pages across invocations"
+      }
+    ],
+
+    "network": [
+      {
+        "service": "llm-api",
+        "protocol": "https",
+        "operations": ["completions"],
+        "auth": "injected-token",
+        "description": "LLM provider for reasoning and synthesis"
+      },
+      {
+        "service": "public-web",
+        "protocol": "https",
+        "description": "Fetch arbitrary web pages for research"
+      },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 4,
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key", "description": "LLM provider API key" }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 1024,
+    "max_cpu_cores": 2,
+    "max_wall_time_seconds": 600,
+    "max_processes": 8,
+    "max_output_bytes": 5242880,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": false,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/05_dotnet_image_processor.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/05_dotnet_image_processor.jsonc
@@ -1,0 +1,69 @@
+{
+  // Image processing pipeline using .NET and ImageSharp. Reads images
+  // from input, applies transformations (resize, watermark, format
+  // conversion), writes processed images to output. No network access,
+  // no credentials — purely offline computation.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "image-processor",
+    "version": "1.4.0",
+    "description": "Batch image processing: resize, watermark, and format conversion"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "dotnet",
+      "min_version": "8.0",
+      "packages": ["SixLabors.ImageSharp"]
+    },
+
+    "storage": [
+      { "class": "app_code", "access": "read", "description": "Published .NET application" },
+      {
+        "class": "input_data",
+        "access": "read",
+        "description": "Source images (JPEG, PNG, WebP)"
+      },
+      {
+        "class": "output_data",
+        "access": "write",
+        "description": "Processed images"
+      },
+      { "class": "workspace", "access": "read-write", "description": "Intermediate processing directory" },
+      { "class": "config", "access": "read", "description": "Processing pipeline configuration (JSON)" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [],
+
+    "process": {
+      "spawn": true,
+      "max_children": 8,
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_memory_mb": 2048,
+    "max_cpu_cores": 4,
+    "max_wall_time_seconds": 600,
+    "max_processes": 12,
+    "max_open_files": 1024,
+    "max_output_bytes": 524288000,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": true,
+    "idempotent": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/intent_manifests/06_bash_infra_health_check.jsonc
+++ b/docs/proposals/container-policy/examples/intent_manifests/06_bash_infra_health_check.jsonc
@@ -1,0 +1,94 @@
+{
+  // Bash/shell script that runs infrastructure health checks — pinging
+  // internal services, checking certificate expiry, querying a database
+  // for replication lag. Uses standard Unix tools (curl, openssl, psql).
+  // Needs access to multiple internal services and a database credential.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "infra-health-check",
+    "version": "2.0.0",
+    "description": "Shell-based infrastructure health checker: HTTP endpoints, TLS certs, DB replication"
+  },
+
+  "requires": {
+    "runtime": {
+      "language": "bash",
+      "min_version": "5.0"
+    },
+
+    "tools": [
+      { "name": "curl", "access": "execute" },
+      { "name": "openssl", "access": "execute" },
+      { "name": "psql", "access": "execute" },
+      { "name": "jq", "access": "execute" }
+    ],
+
+    "storage": [
+      { "class": "output_data", "access": "write", "description": "Health check report (JSON)" },
+      { "class": "workspace", "access": "read-write", "description": "Scratch space for intermediate results" },
+      { "class": "config", "access": "read", "description": "List of endpoints and thresholds" },
+      { "class": "temp", "access": "read-write", "persistence": "ephemeral" }
+    ],
+
+    "network": [
+      {
+        "service": "internal-api-gateway",
+        "protocol": "https",
+        "operations": ["health-check"],
+        "description": "Internal API gateway health endpoint"
+      },
+      {
+        "service": "internal-auth-service",
+        "protocol": "https",
+        "operations": ["health-check"],
+        "description": "Authentication service health endpoint"
+      },
+      {
+        "service": "primary-database",
+        "protocol": "tcp",
+        "operations": ["query"],
+        "auth": "injected-token",
+        "description": "PostgreSQL primary for replication lag check"
+      },
+      { "capability": "dns" }
+    ],
+
+    "process": {
+      "spawn": true,
+      "max_children": 8,
+      "exec": ["curl", "openssl", "psql", "jq", "bash"],
+      "signals": "self"
+    },
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      {
+        "name": "DB_CONNECTION_STRING",
+        "type": "connection-string",
+        "description": "PostgreSQL connection string with read-only credentials"
+      }
+    ]
+  },
+
+  "constraints": {
+    "max_memory_mb": 256,
+    "max_cpu_cores": 1,
+    "max_wall_time_seconds": 120,
+    "max_processes": 16,
+    "max_output_bytes": 1048576,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  },
+
+  "claims": {
+    "deterministic": false,
+    "idempotent": true,
+    "no_credential_exfiltration": true,
+    "no_side_effects_beyond_output": true
+  }
+}

--- a/docs/proposals/container-policy/examples/system_intents/01_windows.jsonc
+++ b/docs/proposals/container-policy/examples/system_intents/01_windows.jsonc
@@ -1,0 +1,39 @@
+{
+  // Windows system intent policy.
+  // Expresses platform invariants that Windows enforces unconditionally.
+  // These constraints cannot be weakened by any other policy layer.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "windows-system-policy",
+    "version": "10.0.0",
+    "description": "Windows platform security invariants — enforced by OS regardless of other policy"
+  },
+
+  "requires": {
+    "storage": [
+      {
+        "class": "system_binaries",
+        "access": "read",
+        "description": "Windows system binaries (System32, SysWOW64) are read-only"
+      },
+      {
+        "class": "system_config",
+        "access": "read",
+        "description": "System registry hives and configuration are read-only"
+      }
+    ]
+  },
+
+  "constraints": {
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "disable_aslr": "forbidden",
+    "access_credential_stores": "forbidden",
+    "load_unsigned_kernel_code": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/system_intents/02_linux.jsonc
+++ b/docs/proposals/container-policy/examples/system_intents/02_linux.jsonc
@@ -1,0 +1,40 @@
+{
+  // Linux system intent policy.
+  // Expresses platform invariants that Linux enforces unconditionally
+  // via kernel protections, seccomp defaults, and MAC policies.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "linux-system-policy",
+    "version": "6.1.0",
+    "description": "Linux platform security invariants — enforced by kernel regardless of other policy"
+  },
+
+  "requires": {
+    "storage": [
+      {
+        "class": "system_binaries",
+        "access": "read",
+        "description": "System binaries (/usr/bin, /usr/lib, /usr/sbin) are read-only"
+      },
+      {
+        "class": "system_config",
+        "access": "read",
+        "description": "System configuration (/etc) is read-only"
+      }
+    ]
+  },
+
+  "constraints": {
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "disable_aslr": "forbidden",
+    "access_credential_stores": "forbidden",
+    "raw_device_access": "forbidden",
+    "ptrace_other_processes": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/system_intents/03_macos.jsonc
+++ b/docs/proposals/container-policy/examples/system_intents/03_macos.jsonc
@@ -1,0 +1,40 @@
+{
+  // macOS system intent policy.
+  // Expresses platform invariants that macOS enforces unconditionally
+  // via SIP, code signing, and kernel protections.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "macos-system-policy",
+    "version": "14.0.0",
+    "description": "macOS platform security invariants — enforced by SIP and kernel regardless of other policy"
+  },
+
+  "requires": {
+    "storage": [
+      {
+        "class": "system_binaries",
+        "access": "read",
+        "description": "SIP-protected system volume is read-only"
+      },
+      {
+        "class": "system_config",
+        "access": "read",
+        "description": "Protected system configuration is read-only"
+      }
+    ]
+  },
+
+  "constraints": {
+    "privilege_escalation": "forbidden",
+    "modify_system_binaries": "forbidden",
+    "kernel_memory_access": "forbidden",
+    "writable_executable_pages": "forbidden",
+    "disable_aslr": "forbidden",
+    "access_credential_stores": "forbidden",
+    "modify_sip_protected_paths": "forbidden",
+    "load_unsigned_code": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/user_intents/01_data_analysis_consent.jsonc
+++ b/docs/proposals/container-policy/examples/user_intents/01_data_analysis_consent.jsonc
@@ -1,0 +1,33 @@
+{
+  // User consent for offline data analysis workloads (scenarios 01, 05).
+  // The user approves file access and tightens the time limit but otherwise
+  // delegates to the code author's declared requirements.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "offline-analysis-consent",
+    "version": "1.0.0",
+    "description": "User consent for offline computation — approves file access, tightens time limit"
+  },
+
+  "requires": {
+    "storage": [
+      { "class": "input_data", "access": "read" },
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "temp", "access": "read-write" }
+    ],
+
+    "network": [],
+    "ipc": "none",
+    "devices": "none",
+    "credentials": []
+  },
+
+  "constraints": {
+    "max_wall_time_seconds": 90,
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/user_intents/02_api_access_consent.jsonc
+++ b/docs/proposals/container-policy/examples/user_intents/02_api_access_consent.jsonc
@@ -1,0 +1,44 @@
+{
+  // User consent for the API aggregator (scenario 02).
+  // The user approves both named services and DNS, but lowers the
+  // wall-time limit and denies any storage classes beyond what the
+  // code author declared.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "api-access-consent",
+    "version": "1.0.0",
+    "description": "User consent for API aggregation — approves named services, tightens time"
+  },
+
+  "requires": {
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write" },
+      { "class": "config", "access": "read" }
+    ],
+
+    "network": [
+      { "service": "weather-api", "protocol": "https" },
+      { "service": "geocoding-api", "protocol": "https" },
+      { "capability": "dns" }
+    ],
+
+    "ipc": "none",
+    "devices": "none",
+
+    "credentials": [
+      { "name": "WEATHER_API_KEY", "type": "api-key" },
+      { "name": "GEOCODING_API_KEY", "type": "api-key" }
+    ]
+  },
+
+  "constraints": {
+    "max_wall_time_seconds": 45,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/user_intents/03_web_research_consent.jsonc
+++ b/docs/proposals/container-policy/examples/user_intents/03_web_research_consent.jsonc
@@ -1,0 +1,43 @@
+{
+  // User consent for the LLM research tool (scenario 04).
+  // The user approves LLM API access but restricts public-web browsing
+  // to Wikipedia and arXiv only. Wall time is halved.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "web-research-consent",
+    "version": "1.0.0",
+    "description": "User consent for LLM research — approves LLM, restricts web to Wikipedia and arXiv"
+  },
+
+  "requires": {
+    "storage": [
+      { "class": "workspace", "access": "read-write" },
+      { "class": "output_data", "access": "write" },
+      { "class": "temp", "access": "read-write" },
+      { "class": "cache", "access": "read-write" }
+    ],
+
+    "network": [
+      { "service": "llm-api", "protocol": "https" },
+      {
+        "service": "public-web",
+        "protocol": "https",
+        "scope": "*.wikipedia.org,*.arxiv.org"
+      },
+      { "capability": "dns" }
+    ],
+
+    "credentials": [
+      { "name": "LLM_API_KEY", "type": "api-key" }
+    ]
+  },
+
+  "constraints": {
+    "max_wall_time_seconds": 300,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/examples/user_intents/04_internal_services_consent.jsonc
+++ b/docs/proposals/container-policy/examples/user_intents/04_internal_services_consent.jsonc
@@ -1,0 +1,40 @@
+{
+  // User consent for infrastructure health checks (scenario 06).
+  // The user approves all three internal services and the database
+  // credential. Network is restricted to the declared services only.
+
+  "manifest_version": "1.0",
+
+  "metadata": {
+    "name": "internal-services-consent",
+    "version": "1.0.0",
+    "description": "User consent for infra health check — approves internal services and DB access"
+  },
+
+  "requires": {
+    "storage": [
+      { "class": "output_data", "access": "write" },
+      { "class": "workspace", "access": "read-write" },
+      { "class": "config", "access": "read" },
+      { "class": "temp", "access": "read-write" }
+    ],
+
+    "network": [
+      { "service": "internal-api-gateway", "protocol": "https" },
+      { "service": "internal-auth-service", "protocol": "https" },
+      { "service": "primary-database", "protocol": "tcp" },
+      { "capability": "dns" }
+    ],
+
+    "credentials": [
+      { "name": "DB_CONNECTION_STRING", "type": "connection-string" }
+    ]
+  },
+
+  "constraints": {
+    "max_wall_time_seconds": 90,
+    "persistent_storage": "forbidden",
+    "privilege_escalation": "forbidden",
+    "inbound_network": "forbidden"
+  }
+}

--- a/docs/proposals/container-policy/mxc_container_policy_alignment.md
+++ b/docs/proposals/container-policy/mxc_container_policy_alignment.md
@@ -1,0 +1,428 @@
+# MXC ↔ ContainerPolicyThoughts Alignment
+
+This document maps the MXC codebase (Rust source + TypeScript SDK) against the
+design concepts in `ContainerPolicyThoughts.md`, identifying where the
+implementation aligns, where gaps exist, and where the codebase has capabilities
+the design document doesn't yet cover.
+
+---
+
+## Table of Contents
+
+- [1. MXC Architecture Summary](#1-mxc-architecture-summary)
+- [2. Containment Backends](#2-containment-backends)
+- [3. Mapping to Sandboxing Mechanisms (§§1–5)](#3-mapping-to-sandboxing-mechanisms-15)
+- [4. Mapping to Common Policy Dimensions (§6)](#4-mapping-to-common-policy-dimensions-6)
+- [5. Mapping to JSON Policy Language (§8)](#5-mapping-to-json-policy-language-8)
+- [6. Mapping to FlatBuffer Compiled Format (§9)](#6-mapping-to-flatbuffer-compiled-format-9)
+- [7. Mapping to Policy Layers (§10)](#7-mapping-to-policy-layers-10)
+- [8. Mapping to Backend Capability Profiles (§11)](#8-mapping-to-backend-capability-profiles-11)
+- [9. Mapping to Container Lifecycle and Workload Cycling (§12)](#9-mapping-to-container-lifecycle-and-workload-cycling-12)
+- [10. Where MXC Goes Beyond the Design Document](#10-where-mxc-goes-beyond-the-design-document)
+- [11. Gap Summary](#11-gap-summary)
+
+---
+
+## 1. MXC Architecture Summary
+
+MXC (Microsoft eXecution Containers) is a **Rust-based multi-backend sandboxing
+framework** with a TypeScript SDK. It spawns untrusted scripts inside isolated
+environments and captures their output.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  TypeScript SDK (sdk/)                                   │
+│  spawnSandbox() → locates wxc-exec, builds JSON config   │
+└───────────────────┬──────────────────────────────────────┘
+                    │ JSON config (file or base64)
+┌───────────────────▼──────────────────────────────────────┐
+│  wxc-exec / lxc-exec  (Rust, src/wxc/ and src/lxc/)     │
+│  Parse JSON → validate → route to containment backend    │
+└───────────────────┬──────────────────────────────────────┘
+                    │
+        ┌───────────┼───────────┬──────────────┐
+        ▼           ▼           ▼              ▼
+  ┌──────────┐ ┌─────────┐ ┌────────┐  ┌────────────┐
+  │AppContain│ │ Windows  │ │  LXC   │  │  NanVix    │
+  │er Runner │ │ Sandbox  │ │ Runner │  │  MicroVM   │
+  │          │ │ Daemon + │ │        │  │            │
+  │ BFS +    │ │ Guest    │ │ mounts │  │            │
+  │ Firewall │ │ Agent    │ │ +      │  │            │
+  │          │ │          │ │iptables│  │            │
+  └──────────┘ └─────────┘ └────────┘  └────────────┘
+       │            │           │            │
+       ▼            ▼           ▼            ▼
+   Windows OS   Hyper-V VM   Linux kernel  Lightweight VM
+   APIs         (sandbox)    namespaces    (NanVix)
+```
+
+**13 Rust crates** in the workspace, **4 TypeScript packages** (SDK, CLI), and
+**6 containment backends**.
+
+### Key Source Files
+
+| File | Purpose |
+|---|---|
+| `src/wxc_common/src/models.rs` | Core data types: `CodexRequest`, `ContainerPolicy`, `ContainmentBackend` |
+| `src/wxc_common/src/config_parser.rs` | JSON config parsing (~1100 lines) |
+| `src/wxc_common/src/script_runner.rs` | `ScriptRunner` trait — backend abstraction |
+| `src/wxc_common/src/appcontainer_runner.rs` | AppContainer implementation (~570 lines) |
+| `src/wxc_common/src/base_container_runner.rs` | BaseContainer / `CreateProcessInSandbox` (~360 lines) |
+| `src/wxc_common/src/windows_sandbox_runner.rs` | Windows Sandbox client |
+| `src/wxc_common/src/filesystem_bfs.rs` | BFS filesystem policy via `bfscfg.exe` |
+| `src/wxc_common/src/network_manager.rs` | Windows Firewall + proxy management |
+| `src/wxc_common/src/proxy_coordinator.rs` | Proxy lifecycle (elevated shim, loopback exemption) |
+| `src/wxc_common/src/sandbox_protocol.rs` | Windows Sandbox control protocol (length-prefixed JSON) |
+| `src/wxc_windows_sandbox_daemon/` | Host-side Windows Sandbox VM manager |
+| `src/wxc_windows_sandbox_guest/` | Guest agent inside Windows Sandbox |
+| `src/lxc_common/src/lxc_runner.rs` | LXC container execution |
+| `src/lxc_common/src/filesystem_mounts.rs` | Linux mount-based filesystem policy |
+| `src/lxc_common/src/network_iptables.rs` | Linux iptables network policy |
+| `src/lxc_common/src/lxc_bindings.rs` | FFI bindings to `liblxc` C API |
+| `src/generated/base_container_specification/` | FlatBuffer-generated `SandboxSpec` types |
+| `sdk/src/sandbox.ts` | TypeScript SDK: `spawnSandbox()`, config building |
+| `sdk/src/types.ts` | TypeScript policy types: `SandboxPolicy`, `ContainerConfig` |
+| `sdk/src/platform.ts` | Platform detection (Windows build version, LXC availability) |
+
+---
+
+## 2. Containment Backends
+
+MXC supports six containment backends, each using a different isolation strategy:
+
+| Backend | Platform | §11 Isolation Model | Crate | Status |
+|---|---|---|---|---|
+| **AppContainer** | Windows | reduced-credentials | `wxc_common` (appcontainer_runner) | Production |
+| **Windows Sandbox** | Windows | different-universe (Hyper-V VM) | `wxc_windows_sandbox_daemon` + `wxc_windows_sandbox_guest` | Experimental |
+| **BaseContainer** | Windows | reduced-credentials (new OS API) | `wxc_common` (base_container_runner) | Experimental |
+| **LXC** | Linux | different-universe (namespaces) | `lxc_common` | Production |
+| **NanVix MicroVM** | Windows | different-universe (lightweight VM) | `nanvix_common` + `nanvix_binaries` | Experimental |
+| **WSL Container SDK** | Windows→Linux | different-universe | `wslc_common` | Phase 3 (stub) |
+
+All backends implement the `ScriptRunner` trait:
+
+```rust
+pub trait ScriptRunner {
+    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse;
+}
+```
+
+The `containment` field in the JSON config selects the backend:
+
+```json
+{ "containment": "appcontainer" | "windows_sandbox" | "lxc" | "microvm" | "wslc" | "vm" }
+```
+
+---
+
+## 3. Mapping to Sandboxing Mechanisms (§§1–5)
+
+### §1 Linux BubbleWrap
+
+MXC's LXC backend (`lxc_common/`) uses the same kernel namespace primitives that
+BubbleWrap uses — mount namespaces, PID namespaces, network namespaces. LXC
+provides a higher-level abstraction over these primitives (full container
+lifecycle management, distribution support) whereas BubbleWrap is a lower-level
+building block.
+
+| BubbleWrap Mechanism | MXC LXC Equivalent |
+|---|---|
+| Mount namespaces + bind mounts | `lxc_runner.rs` — LXC manages the mount tree |
+| Network namespaces | LXC creates network namespace per container |
+| `--seccomp` flag | Not used — LXC default seccomp profile (if any) |
+| PID namespace | LXC creates PID namespace per container |
+
+### §2 Seccomp-BPF
+
+**Not directly used.** Neither the Windows nor Linux paths explicitly configure
+seccomp filters. On Windows, AppContainer's capability model serves a roughly
+analogous role (restricting what APIs the process can call). On Linux, LXC may
+apply a default seccomp profile, but MXC does not configure or customize it.
+
+### §3 Linux Landlock
+
+**Not used.** The LXC path uses mount-based filesystem isolation rather than
+Landlock self-restriction. Landlock could be added as a defense-in-depth layer
+within the LXC container.
+
+### §4 SELinux
+
+**Not used.** The LXC path does not configure SELinux type enforcement. On
+Fedora/RHEL systems where SELinux is enforcing, LXC containers would be subject
+to whatever system SELinux policy applies, but MXC does not manage or customize
+that policy.
+
+### §5 Windows Equivalents
+
+This is where MXC has the deepest implementation:
+
+| §5 Mechanism | MXC Implementation | File |
+|---|---|---|
+| **AppContainer** | Full implementation: `CreateAppContainerProfile`, capability SIDs, LPAC mode (`PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT`), console inheritance, auto-injected capabilities (`AgenticAppContainer`, conditional `internetClient`) | `appcontainer_runner.rs` |
+| **Restricted Tokens** | Not directly used — relies on AppContainer SID instead | — |
+| **Job Objects** | Not used — no CPU/memory/process-count limits | — |
+| **Integrity Levels** | Present in the BaseContainer FlatBuffer spec (`integrity_level` field) but not in AppContainer path | `base_container_specification_generated.rs` |
+| **Windows Sandbox (VM)** | Full implementation: daemon/guest architecture, Hyper-V VM lifecycle, TCP bridge, firewall lockdown, rendezvous discovery, idle timeout | `wxc_windows_sandbox_daemon/`, `wxc_windows_sandbox_guest/` |
+| **Win32 App Isolation** | The BaseContainer path uses `Experimental_CreateProcessInSandbox` — a new Windows API in this space | `base_container_runner.rs` |
+
+---
+
+## 4. Mapping to Common Policy Dimensions (§6)
+
+| §6 Policy Dimension | MXC Support | Implementation | Gap |
+|---|---|---|---|
+| **Filesystem access** | ✓ | BFS (`bfscfg.exe`) on Windows; mounts on Linux. Three path lists: readwrite, readonly, denied. | No per-operation granularity (read vs write vs execute vs create vs delete). No scope types (subtree vs exact vs pattern). No ephemeral, mask, or synthetic mounts in policy. |
+| **Network access** | ✓ | Windows Firewall + AppContainer capabilities; iptables on Linux. Per-host allow/block with default policy. | No per-port or per-protocol filtering. No per-direction control in the config schema. |
+| **Process visibility** | Partial | AppContainer SID boundaries (Windows); PID namespace (Linux) | Not configurable — implicit in the backend choice. No `allow_exec` allowlist, no signal control. |
+| **IPC / messaging** | Implicit | AppContainer SID prevents cross-container IPC (Windows); IPC namespace (Linux) | Not configurable in policy. No service-level IPC rules. |
+| **Syscall filtering** | ✗ | Not implemented on either platform | — |
+| **Resource limits** | Timeout only | `script_timeout` in milliseconds, enforced via `WaitForSingleObject` (Windows) or process timeout (Linux) | No CPU, memory, process-count, or open-files limits. No Job Object integration. |
+| **Device access** | ✗ | Not addressed | — |
+
+---
+
+## 5. Mapping to JSON Policy Language (§8)
+
+MXC's JSON config schema (v0.4.0-alpha) covers similar ground to §8's proposed
+language but at a coarser granularity.
+
+### Filesystem
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `rules[]` with `path`, `scope` (exact/subtree/prefix/pattern), `allow` (read/write/execute/create/delete), `ephemeral` | Three flat arrays: `readwritePaths[]`, `readonlyPaths[]`, `deniedPaths[]` |
+| `mask[]` — paths to replace with empty/null | Not supported |
+| `synthetic` — `/dev`, `/proc`, `/tmp` mount types | Not supported in policy (LXC handles internally) |
+
+### Network
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `mode` (none/full/rules), `rules[]` with direction/action/protocol/host/port | `defaultPolicy` (allow/block), `enforcementMode` (capabilities/firewall/both), `allowedHosts[]`, `blockedHosts[]` |
+| `allow_dns`, `allow_localhost` | Not explicit (loopback exemption managed separately for proxy) |
+| Per-port, per-protocol, per-direction rules | Not supported — per-host only |
+
+### Process
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `allow_fork`, `allow_exec[]`, `visibility`, `signals`, `hostname`, `die_with_parent` | `process.commandLine`, `process.cwd`, `process.env[]`, `process.timeout` — runtime config rather than security policy |
+
+### Resources
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `max_memory_mb`, `max_cpu_percent`, `max_processes`, `max_open_files`, `max_wall_time_seconds` | Only `timeout` (milliseconds) |
+
+### Environment
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `mode` (clean/inherit), `set` (key-value), `pass_through[]` | `process.env[]` as `KEY=VALUE` strings — simple passthrough, no clean/inherit mode |
+
+### Platform Overrides
+
+| §8 Proposed | MXC Actual |
+|---|---|
+| `platform.linux.seccomp`, `platform.macos.seatbelt_import`, `platform.windows.appcontainer` | Backend-specific config sections: `appContainer {}`, `lxc {}`, `wslc {}` — similar intent, different structure |
+
+### MXC Additions Not in §8
+
+MXC's config has features that §8's proposed schema does not cover:
+
+| MXC Feature | Description |
+|---|---|
+| `containment` backend selector | Explicit backend choice (appcontainer, windows_sandbox, lxc, etc.) |
+| `network.proxy` config | Per-AppContainer proxy policy (built-in test server or localhost proxy) |
+| `network.enforcementMode` | Choose enforcement mechanism: capabilities only, firewall only, or both |
+| `lifecycle.destroyOnExit` | Whether to tear down the container after execution |
+| `lifecycle.preservePolicy` | Whether to keep BFS/firewall policy after exit |
+| `appContainer.learningMode` | ETW tracing for policy discovery (debug builds only) |
+| `lxc.distribution` / `lxc.release` | Linux distribution selection for LXC containers |
+| `wslc.cpuCount`, `wslc.memoryMb`, `wslc.gpu` | VM resource allocation for WSL containers |
+
+---
+
+## 6. Mapping to FlatBuffer Compiled Format (§9)
+
+**MXC already uses FlatBuffers.** The `generated/base_container_specification`
+crate contains FlatBuffer-generated types for `SandboxSpec`:
+
+```rust
+pub struct SandboxSpec {
+    version: String,
+    app_container: bool,
+    integrity_level: i32,
+    ui_restrictions: i32,
+    least_privilege: bool,
+    capabilities: Option<String>,   // comma-joined
+    fs_read_write: Option<Vec<String>>,
+    fs_read_only: Option<Vec<String>>
+}
+```
+
+This is used by `base_container_runner.rs` to serialize sandbox intent for
+`Experimental_CreateProcessInSandbox`. It validates §9's architectural decision
+(JSON for authoring, FlatBuffer for runtime consumption) but is much simpler
+than §9's full schema:
+
+| §9 FlatBuffer Schema | MXC FlatBuffer |
+|---|---|
+| 15+ tables covering filesystem, network, process, IPC, devices, resources, environment, platform, signature | 1 table: `SandboxSpec` with ~8 fields |
+| `FileOps` bit-flags (read/write/execute/create/delete/metadata/truncate/ioctl) | Two path lists (read-write, read-only) |
+| `NetRule` with direction/action/protocol/host/port | Not in FlatBuffer (network policy is applied externally) |
+| Signature/integrity block | Not present |
+
+---
+
+## 7. Mapping to Policy Layers (§10)
+
+| §10 Layer | MXC Coverage | Details |
+|---|---|---|
+| **L1: Code Requirements** | Minimal | `appContainer.capabilities[]` is a crude requirements manifest ("I need `internetClient`"). No abstract resource-type declarations. |
+| **L2: Instance Binding** | Primary focus | `filesystem.readwritePaths`, `network.allowedHosts` bind concrete resources. The JSON config lives almost entirely at this layer. |
+| **L3: User Consent** | Not modeled | Whoever writes the JSON config implicitly consents. No runtime permission prompts. |
+| **L4: IT Admin Policy** | Not modeled | No GPO, MDM, or Intune integration. No mechanism for organizational constraints. |
+| **L5: System Policy** | Minimal | `platform.ts` checks Windows build version (≥26100) and LXC availability. No awareness of WDAC, AppLocker, or other system security policies. |
+| **L6: System Security Promises** | Minimal | Platform detection in `platform.ts` is a rudimentary form: "is this Windows build new enough?" and "is LXC installed?" No kernel capability probing. |
+| **L7: Container Enforcement** | Implicit | The `containment` enum selects a backend, but there is no formal capability profile. Each `ScriptRunner` implementation hardcodes what it can enforce. |
+
+---
+
+## 8. Mapping to Backend Capability Profiles (§11)
+
+### What Exists
+
+MXC has the **architectural seams** that §11 describes but not the **formal
+profile system**:
+
+- The `ScriptRunner` trait is the backend abstraction point
+- The `ContainmentBackend` enum names the backends
+- Each runner implementation (`AppContainerScriptRunner`, `LxcScriptRunner`,
+  etc.) knows what it can enforce — but this knowledge is embedded in Rust code,
+  not expressed as a machine-evaluable profile
+
+### What's Missing
+
+| §11 Concept | MXC Status |
+|---|---|
+| **Primitive profiles** | ✗ Not formalized. Each runner is a monolithic composition (AppContainer + BFS + Firewall are wired together in `appcontainer_runner.rs`, not composed from independent primitives). |
+| **Composition system** | ✗ Primitives (AppContainer, BFS, Firewall) are hardcoded together in each runner. Adding a new primitive (e.g., Job Objects) requires modifying Rust source. |
+| **Named shorthands** | The `containment` enum serves this role — `"appcontainer"` selects a fixed composition. But it maps to hardcoded implementations, not to a list of primitives. |
+| **Compiler evaluation** | ✗ No policy-vs-backend validation. If a policy requests per-port network rules, the AppContainer backend silently cannot enforce them. No warnings, no errors. |
+| **Isolation model / assurance levels** | ✗ No distinction between `different-universe` (Windows Sandbox VM) and `reduced-credentials` (AppContainer). The user must know which backend provides what assurance. |
+| **Auto-selection** | ✗ The user must choose the backend manually via the `containment` field. |
+| **Lifecycle metadata** | ✗ No setup cost, per-workload cost, or warm-reuse metadata on backends. |
+
+### What Each Backend Can Actually Enforce
+
+If MXC were to formalize backend profiles, they would look like:
+
+| Dimension | AppContainer | Windows Sandbox | LXC | BaseContainer |
+|---|---|---|---|---|
+| **Filesystem** | ✓ BFS (reduced-credentials) | ✓ VM boundary (different-universe) | ✓ mounts (different-universe) | ✓ via FlatBuffer spec |
+| **Network** | ✓ Firewall + caps (guarded-doors + reduced-credentials) | ✓ Guest firewall lockdown (different-universe) | ✓ iptables (guarded-doors) | ✗ |
+| **Process isolation** | Partial (SID boundaries) | ✓ Full (separate OS) | ✓ Full (PID namespace) | Partial (SID) |
+| **Syscall filtering** | ✗ | N/A (separate kernel) | ✗ (possible via LXC) | ✗ |
+| **Resource limits** | Timeout only | VM resource limits | Timeout only | Timeout only |
+| **IPC isolation** | Partial (SID) | ✓ Full (separate OS) | ✓ Full (IPC namespace) | Partial (SID) |
+| **Warm reuse** | Partial (`destroyOnExit: false`) | ✓ (daemon keeps VM warm) | ✗ (new container per run) | ✗ |
+
+---
+
+## 9. Mapping to Container Lifecycle and Workload Cycling (§12)
+
+### Windows Sandbox: Warm Container Model
+
+The Windows Sandbox daemon/guest architecture already implements §12's
+two-lifecycle model:
+
+**Container lifecycle** (expensive, once):
+- `sandbox_vm.rs`: Generate `.wsb` config, launch `WindowsSandbox.exe`
+- Guest boots, runs `wxc-windows-sandbox-guest.exe` as LogonCommand
+- Guest writes rendezvous file with `ip:port`
+- Host connects 4 TCP streams (control, stdin, stdout, stderr)
+- Guest locks down firewall to host-only (`firewall.rs`)
+
+**Workload lifecycle** (cheap, repeated):
+- Host sends `Exec { script_code, working_directory, timeout_ms }` on control channel
+- Guest spawns process, bridges stdio
+- Guest sends `Exit { exit_code }` when done
+- Guest re-accepts data connections for next workload
+
+**Idle timeout**: Daemon tears down VM after configurable idle period (default
+300 seconds). This maps directly to §12's warm pool `idle_timeout` concept.
+
+### Gap: State Reset
+
+The guest `executor.rs` contains a TODO noting that **state reset between
+workloads is not implemented** — previous scripts' filesystem side effects
+persist in the VM. This is exactly the gap §12's "State Reset Between Workloads"
+subsection addresses. The VM would need overlay-discard or filesystem scrub
+between executions.
+
+### AppContainer: Simple Lifecycle
+
+AppContainer uses the simple create→execute→cleanup model:
+
+```
+Create profile → Apply BFS → Apply Firewall → Run script → Cleanup → Delete
+```
+
+The `lifecycle.destroyOnExit: false` option keeps the AppContainer profile for
+reuse, but BFS and firewall rules are typically removed. There is no
+base-policy-vs-workload-policy split.
+
+### LXC: Simple Lifecycle
+
+LXC also uses create→execute→cleanup per invocation. The `destroy_on_exit` flag
+controls whether the container is torn down, but there is no workload cycling.
+
+---
+
+## 10. Where MXC Goes Beyond the Design Document
+
+Several MXC capabilities are not yet reflected in ContainerPolicyThoughts.md:
+
+| MXC Capability | Description | Document Gap |
+|---|---|---|
+| **Network proxy integration** | Per-AppContainer WinHTTP proxy policy via elevated shim (`wxc_winhttp_proxy_shim`), loopback exemption via `CheckNetIsolation.exe`, built-in test proxy server | §8's network section has no proxy concept |
+| **Enforcement mode selection** | `capabilities` / `firewall` / `both` — choose which Windows mechanisms to use for network policy | §11's backend profiles don't model multiple enforcement modes within a single primitive |
+| **Learning mode** | ETW tracing to discover what policy a script needs (debug builds only, stripped in release) | The document doesn't discuss policy discovery/learning |
+| **Guest agent architecture** | Windows Sandbox uses a host daemon + guest agent pattern with TCP bridge and rendezvous discovery | §12 discusses warm containers abstractly but doesn't detail the host/guest communication pattern |
+| **Console inheritance** | AppContainer child shares parent's ConPTY — no explicit pipe relay | Not discussed in the document |
+| **WSL Container SDK** | Future backend using WSL Container SDK C API for Linux containers from Windows | Not mentioned in the document |
+| **NanVix MicroVM** | Lightweight VM backend with downloaded kernel/runtime binaries | Not mentioned in the document |
+| **BaseContainer / `CreateProcessInSandbox`** | New Windows API with FlatBuffer spec for declarative sandbox creation | The document discusses FlatBuffers (§9) but doesn't mention this specific API |
+
+---
+
+## 11. Gap Summary
+
+### Gaps in MXC Relative to the Design Document
+
+| Priority | Gap | §§ Reference | Impact |
+|---|---|---|---|
+| **High** | No resource limits beyond timeout (no Job Objects, no cgroups) | §6, §8, §12 | Cannot enforce CPU/memory/process-count budgets |
+| **High** | No policy-vs-backend validation | §11 | Silent enforcement failures when policy exceeds backend capabilities |
+| **High** | No state reset between workloads in Windows Sandbox | §12 | Prior workload side effects leak to subsequent workloads |
+| **Medium** | No per-operation filesystem granularity | §6, §8 | Cannot distinguish read vs write vs execute vs create vs delete |
+| **Medium** | No per-port/per-protocol network rules | §6, §8 | Can only filter by host, not by port or protocol |
+| **Medium** | No seccomp/Landlock integration on Linux | §§2–3 | Missing defense-in-depth layers in LXC path |
+| **Medium** | No formal backend capability profiles | §11 | Backend capabilities are hardcoded, not machine-evaluable |
+| **Medium** | No composition system for primitives | §11 | Adding a new primitive (e.g., Job Objects) requires modifying Rust code |
+| **Low** | No macOS support | §§1, 7 | Seatbelt integration not started |
+| **Low** | No SELinux integration | §4 | Missing on Fedora/RHEL LXC deployments |
+| **Low** | No environment variable policy | §8 | env vars are passthrough, not policy-controlled |
+| **Low** | No IPC service rules | §6, §8 | IPC isolation is implicit in backend choice |
+
+### Gaps in the Design Document Relative to MXC
+
+| Gap | MXC Feature | Suggested Addition |
+|---|---|---|
+| No proxy concept | Network proxy integration with elevated shim and loopback exemption | Add proxy configuration to §8 network section |
+| No policy discovery | Learning mode with ETW tracing | Add policy discovery/learning section |
+| No enforcement mode selection | Choose capabilities vs firewall vs both for network policy | Model enforcement mode in §11 primitive profiles |
+| No host/guest communication pattern | Windows Sandbox daemon/guest with TCP bridge and rendezvous | Detail the host/guest architecture in §12 |
+| No mention of `CreateProcessInSandbox` | BaseContainer backend with FlatBuffer-based declarative sandbox | Reference this API in §5 and §9 |
+| No mention of WSL Container SDK or NanVix | Future/experimental backends | Add to §5 or a new cross-platform backend inventory section |


### PR DESCRIPTION
Records exploratory work on a cross-platform intent policy model for
sandboxed code execution under docs/proposals/container-policy/. The
proposal introduces a single declarative language used by four policy
authors — code author, user, IT administrator, system — whose
independent statements compose into an enforceable runtime configuration
via an intersection rule.

Documents:
- SandboxSurvey.md: cross-platform survey of isolation mechanisms
  (Linux namespaces / Landlock / seccomp, macOS Seatbelt, Windows
  AppContainer / BFS / WFP).
- ContainerPolicyThoughts.md: original research that fed the design;
  proposes a unified JSON policy language, FlatBuffer compiled format,
  policy layers, capability profiles, lifecycle, intent manifests.
- ContainerPolicyDesign.md: formal design — intent schema, four-author
  composition algebra, binder, bound policy format, versioning, plus a
  rubric-based self-evaluation in Appendix E.
- SandboxEvaluationRubric.md: six-axis framework (isolation
  architecture, dimension coverage, language and authoring,
  composability, operational characteristics, cross-platform alignment)
  applicable to any sandboxing technology.
- PossibleSimplifications.md: internal critique identifying six v1
  complexity reductions.
- mxc_container_policy_alignment.md: gap analysis mapping the design
  against the current MXC codebase.
- README.md: status banner, reading order, layer-to-folder map.

Examples: 51 .jsonc files across seven layer folders (admin_intents,
system_intents, user_intents, intent_manifests, composed_policies,
capability_profiles, bound_policies for linux/macos/windows) illustrate
each layer of the model.

Status: draft / exploratory / not authoritative. Not consumed by any
tool today. See docs/sandbox-policy/v1/policy.md for shipped behavior.