### PR TITLE
fix(sdk): look for executables under bin/<rustTriple> in addition to bin/<sdkArch>

### DIFF
--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -177,6 +177,8 @@ export function findWxcExecutable(): string | null {
   const possiblePaths = [
     // Bundled in the SDK package (e.g. when installed via npm)
     path.join(__dirname, '..', 'bin', getSdkArch(), 'wxc-exec.exe'),
+    // Bundled under Rust target triple (npm pack may use this layout)
+    path.join(__dirname, '..', 'bin', targetTriple, 'wxc-exec.exe'),
     // Architecture-specific release build output (monorepo dev)
     path.join(targetDir, targetTriple, 'release', 'wxc-exec.exe'),
     // Architecture-specific debug build output (monorepo dev)
@@ -230,6 +232,8 @@ export function findLxcExecutable(): string | null {
   const possiblePaths = [
     // Bundled in the SDK package
     path.join(__dirname, '..', 'bin', getSdkArch(), 'lxc-exec'),
+    // Bundled under Rust target triple (npm pack may use this layout)
+    path.join(__dirname, '..', 'bin', targetTriple, 'lxc-exec'),
     // Architecture-specific release build
     path.join(targetDir, targetTriple, 'release', 'lxc-exec'),
     // Architecture-specific debug build


### PR DESCRIPTION
npm pack ships binaries under `bin/x86_64-pc-windows-msvc/` but `findWxcExecutable`/`findLxcExecutable` only checked `bin/x64/` (via `getSdkArch`). Add the Rust target triple as a fallback candidate for the bundled npm package layout.

Fixes #173
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/174)