### PR TITLE
SDK: update network enforcement and allow binary path to be passed in as parameter

### DIFF
--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -3,6 +3,7 @@
 
 import * as pty from 'node-pty';
 import * as os from 'os';
+import * as fs from 'fs';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
 import { SandboxPolicy, ContainerConfig, ContainmentType } from './types';
@@ -104,9 +105,13 @@ function buildProcessBaseContainerConfig(
         },
     };
 
-    // Windows uses both capabilities and firewall for network enforcement
+    // Network enforcement: use firewall only when host filtering is needed (requires admin)
     if (config.network) {
-        config.network.enforcementMode = 'both';
+        if (config.network.allowedHosts?.length || config.network.blockedHosts?.length) {
+            config.network.enforcementMode = 'both';
+        } else {
+            config.network.enforcementMode = 'capabilities';
+        }
     }
 
     return config;
@@ -176,7 +181,7 @@ export function createConfigFromPolicy(
         injection: policy.ui?.allowInputInjection ?? false,
     };
 
-    // Network mapping (cross-platform)
+    // Network mapping (cross-platform) — default-deny: block if not explicitly allowed
     if (policy.network) {
         if (policy.network.proxy && platform === 'linux') {
             throw new Error('Proxy configuration is not supported on Linux');
@@ -191,6 +196,10 @@ export function createConfigFromPolicy(
             allowedHosts: policy.network.allowedHosts,
             blockedHosts: policy.network.blockedHosts,
             proxy: policy.network.proxy,
+        };
+    } else {
+        config.network = {
+            defaultPolicy: 'block',
         };
     }
 
@@ -242,6 +251,14 @@ export interface SandboxSpawnOptions {
   experimental?: boolean;
 
   /**
+   * Explicit path to the wxc-exec (or lxc-exec) binary.
+   * When set, the SDK uses this path directly instead of searching.
+   * Useful for packaged apps (e.g., Electron) where the binary
+   * is bundled in a known location.
+   */
+  executablePath?: string;
+
+  /**
    * PTY options to pass to node-pty
    */
   ptyOptions?: pty.IPtyForkOptions;
@@ -268,7 +285,14 @@ function spawnWithConfig(
   const platform = os.platform();
   let executablePath: string | null;
 
-  if (platform === 'linux') {
+  if (options.executablePath) {
+    if (!fs.existsSync(options.executablePath)) {
+      throw new Error(
+        `File not found: ${options.executablePath}`
+      );
+    }
+    executablePath = options.executablePath;
+  } else if (platform === 'linux') {
     executablePath = findLxcExecutable();
     if (!executablePath) {
       throw new Error(
@@ -279,7 +303,7 @@ function spawnWithConfig(
     executablePath = findWxcExecutable();
     if (!executablePath) {
       throw new Error(
-        'wxc-exec.exe not found. Please specify the path or ensure it exists in a standard location.'
+        'wxc-exec.exe not found. Set options.executablePath or ensure it exists in a standard location.'
       );
     }
   }


### PR DESCRIPTION
### Why is this change being made?

- Sandboxes were unintentionally network-open when no `network` section was provided.
- Network enforcement also always used `'both'` mode (capabilities + firewall) for the windows process base container even though firewall rules aren't working yet.
- Electron apps for example that consumed the SDK as a dependency have no clean way to specify the wxc-exec binary location should they be packaged in a different location.

### What changed?

- **Default-deny network**: `createConfigFromPolicy` now sets `defaultPolicy: 'block'` when no network section is provided.
- **enforcementMode**: Defaults to `'capabilities'` Only uses `'both'` when `allowedHosts`/`blockedHosts` are specified.
- **`executablePath` option**: New `SandboxSpawnOptions.executablePath` lets consumers pass the binary path directly.

## How was the change tested?

- Tested via VM using an electron app that consumes the sdk where I ran through a scenario where a configs script attempts to go out to the web and there is no networking section to the config. Before this change it would go out to the web. After this change it would it should be blocked

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/180)