### PR TITLE
Update pipeline to copy binaries to bin/<arch>/ for SDK compatibility

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -84,12 +84,12 @@ extends:
         parameters:
           targets:
             - artifact: wxc-binaries-x86_64-pc-windows-msvc
-              path: x86_64-pc-windows-msvc
+              sdkArch: x64
             - artifact: wxc-binaries-aarch64-pc-windows-msvc
-              path: aarch64-pc-windows-msvc
+              sdkArch: arm64
             - artifact: lxc-binaries-x86_64-unknown-linux-gnu
-              path: x86_64-unknown-linux-gnu
+              sdkArch: x64
             - artifact: lxc-binaries-aarch64-unknown-linux-gnu
-              path: aarch64-unknown-linux-gnu
+              sdkArch: arm64
 
           ESRPInfo: ${{ parameters.ESRPInfo }}

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -4,7 +4,7 @@
 parameters:
 - name: Targets
   type: object
-  default: []   # list of { artifact, path }
+  default: []   # list of { artifact, path, sdkArch }
 - name: ESRPInfo
   type: object
   default: {}
@@ -30,7 +30,7 @@ jobs:
         displayName: Download ${{ target.artifact }}
         inputs:
           artifact: ${{ target.artifact }}
-          path: $(sdkDirectory)/bin/${{ target.path }}
+          path: $(sdkDirectory)/bin/${{ target.sdkArch }}
 
     # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
     - task: CopyFiles@2


### PR DESCRIPTION
Fix how the azure pipeline packages the wxc binaries in the sdk to align with #149 

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/182)