### PR TITLE
[WSLC] Gate WSLC SDK linking

### DIFF
--- a/src/wslc_common/Cargo.toml
+++ b/src/wslc_common/Cargo.toml
@@ -3,6 +3,10 @@ name = "wslc_common"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+link-wslcsdk = []
+
 [dependencies]
 wxc_common = { workspace = true }
 windows = { workspace = true }

--- a/src/wslc_common/build.rs
+++ b/src/wslc_common/build.rs
@@ -13,6 +13,13 @@
 use std::path::PathBuf;
 
 fn main() {
+    // Skip nupkg extraction and linking unless the `link-sdk` feature is
+    // enabled. Without this gate, workspace builds would extract the nupkg
+    // and emit linker directives even when no binary depends on wslc_common.
+    if std::env::var("CARGO_FEATURE_LINK_WSLCSDK").is_err() {
+        return;
+    }
+
     // WSLC SDK is Windows-only — skip linking entirely on other platforms.
     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
         return;

--- a/src/wxc/Cargo.toml
+++ b/src/wxc/Cargo.toml
@@ -23,4 +23,4 @@ nanvix_common = { path = "../nanvix_common" }
 [features]
 default = []
 microvm = ["nanvix_binaries"]
-wslc = ["dep:wslc_common"]
+wslc = ["dep:wslc_common", "wslc_common/link-wslcsdk"]


### PR DESCRIPTION
The WSLC SDK nupkg is checked into external/wslc-sdk/, causing wslc_common/build.rs to extract it and emit linker directives on every build, even when no binary uses the WSLC backend. This change gates the entire nupkg extraction and linking logic behind a new link-wslcsdk feature flag on wslc_common. The wxc crate's existing wslc feature flag now activates link-wslcsdk automatically.
 
 - cargo build -> wslc_common compiles but build.rs is a no-op
 - cargo build --features wslc -> nupkg extracted, wslcsdk.lib linked, DLL copied

No behavior changes for WSLC developers. Default builds no longer touch the WSLC SDK.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/187)