### PR TITLE
Use static CRT for Windows binaries to remove vcruntime dependency

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -90,12 +90,10 @@ jobs:
         displayName: Install ARM64 toolchain
         condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
 
-      - task: CopyFiles@2
+      # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
+      - powershell: |
+          Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
         displayName: Setup Cargo Config
-        inputs:
-          SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.cargo'
-          Contents: 'config.toml'
-          TargetFolder: '$(Build.SourcesDirectory)/.cargo'
 
       - task: 1ES.Build.Rust.Setup@1
       - task: 1ES.Build.Rust.Restore@1

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+
+# Use static CRT for Windows targets so vcruntime DLLs don't need to be
+# pre-installed on the machine.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
- Add src/.cargo/config.toml with +crt-static rustflag for x86_64 and aarch64 Windows MSVC targets.
- Update pipeline to append its cargo config into the workspace config instead of copying to repo root

Fixes #181 

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/194)