### PR TITLE
Add policy to remove Needs-Triage label on issue assignment

### DIFF
--- a/.github/policies/labelManagement.issueAssigned.yml
+++ b/.github/policies/labelManagement.issueAssigned.yml
@@ -13,6 +13,8 @@ configuration:
           - payloadType: Issues
           - isAction:
               action: Assigned
+          - hasLabel:
+              label: Needs-Triage
         then:
           - removeLabel:
               label: Needs-Triage

--- a/.github/policies/labelManagement.issueAssigned.yml
+++ b/.github/policies/labelManagement.issueAssigned.yml
@@ -1,0 +1,20 @@
+id: labelManagement.issueAssigned
+name: GitOps.PullRequestIssueManagement
+description: Handlers when an issue is assigned to a user
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove Needs-Triage label when an issue is assigned
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Assigned
+        then:
+          - removeLabel:
+              label: Needs-Triage
+onFailure:
+onSuccess:


### PR DESCRIPTION
When an issue is assigned to a user, the **Needs-Triage** label is automatically removed since assignment implies triage has occurred.

This adds a new \.github/policies/labelManagement.issueAssigned.yml\ policy rule that listens for the \Issues.Assigned\ event and removes the \Needs-Triage\ label.

This follows the same pattern as the existing \labelManagement.issueClosed.yml\ and \labelManagement.issueOpened.yml\ policies.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/197)