### PR TITLE
[WSLC] Add test configs for more custom registry pulls

### DIFF
--- a/test_configs/wslc_custom_registry_ghcr.json
+++ b/test_configs/wslc_custom_registry_ghcr.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-ghcr-registry",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "echo 'Image pulled from GHCR' && cat /etc/alpine-release"
+  },
+  "network": {
+    "defaultPolicy": "allow"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "ghcr.io/linuxserver/baseimage-alpine:3.21"
+    }
+  }
+}

--- a/test_configs/wslc_custom_registry_quay.json
+++ b/test_configs/wslc_custom_registry_quay.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-quay-registry",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "echo 'Image pulled from Quay' && cat /etc/os-release | head -4"
+  },
+  "network": {
+    "defaultPolicy": "allow"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "quay.io/fedora/fedora-minimal:latest"
+    }
+  }
+}

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -145,6 +145,8 @@ Write-Host "`n--- Image Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_python_hello.json" -OutputContains "Hello from Python"))
 $null = $results.Add((Run-WslcTest "wslc_python_stdlib.json"))
 $null = $results.Add((Run-WslcTest "wslc_custom_registry.json" -OutputContains "Image pulled from MCR"))
+$null = $results.Add((Run-WslcTest "wslc_custom_registry_ghcr.json" -OutputContains "Image pulled from GHCR"))
+$null = $results.Add((Run-WslcTest "wslc_custom_registry_quay.json" -OutputContains "Image pulled from Quay"))
 $null = $results.Add((Run-WslcTest "wslc_tar_import_rootfs.json" -OutputContains "Hello from tar-imported image"))
 $null = $results.Add((Run-WslcTest "wslc_tar_import_docker_save.json" -OutputContains "Hello from docker-save image"))
 


### PR DESCRIPTION
Add test configs to validate WSLC container image pulls from GitHub Container Registry and Red Hat Quay, complementing the existing MCR test. Update the E2E test runner to include the new configs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/198)