### PR TITLE
Update sign config type in azure pipeline so binaries are Microsoft signed for external distribution

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -124,6 +124,7 @@ jobs:
           Pattern: |
             $(signPattern)
           UseMinimatch: true
+          signConfigType: 'inlineSignParams'
           inlineOperation: >-
             [
               {


### PR DESCRIPTION
Found out our binaries were only being test signed. This was due to us missing the `signConfigType: 'inlineSignParams'`  line in the `EsrpCodeSigning@5` task in our azure pipeline. This should fix it so now the binaries are Microsoft signed for external distribution.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/200)