### PR TITLE
feat(sdk): AEGIS governance integration — cookie redemption and managed mode enforcement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,7 +98,7 @@ The Rust workspace (`src/`) implements multiple sandboxing backends behind the `
 
 ### TypeScript layers
 
-- **SDK** (`sdk/`, `@microsoft/mxc-sdk`) — the public API. `spawnSandbox()` builds a `ContainerConfig` from a `SandboxPolicy`, serializes to base64, and spawns the correct native binary (`wxc-exec.exe` or `lxc-exec`) via `node-pty`. Platform detection is in `platform.ts`.
+- **SDK** (`sdk/`, `@microsoft/mxc-sdk`) — the public API. `SandboxPolicy` is a union type: `SandboxPolicySpec` (caller-specified constraints) or `SandboxPolicyCookie` (AEGIS governance cookie redeemed with the daemon at spawn time). `spawnSandbox()` accepts a spec and spawns synchronously; `spawnSandboxPty()` accepts either type asynchronously. The SDK builds a `ContainerConfig` from the policy, serializes to base64, and spawns the correct native binary (`wxc-exec.exe` or `lxc-exec`) via `node-pty`. Platform detection is in `platform.ts`.
 - **CLI** (`cli/`, `mxc-cli`) — thin Commander.js wrapper around the SDK. Depends on `@microsoft/mxc-sdk` via `file:../sdk`.
 
 The SDK auto-discovers native binaries by checking `sdk/bin/<target-triple>/` (npm-packaged) and `src/target/<target-triple>/{release,debug}/` (local dev). The `build.bat`/`build.sh` scripts copy binaries into the SDK bin directory.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -7,7 +7,7 @@ import {
   spawnSandbox,
   spawnSandboxWithoutPty,
   getPlatformSupport,
-  SandboxPolicy,
+  SandboxPolicySpec,
   ContainmentType,
   getAvailableToolsPolicy,
 } from '@microsoft/mxc-sdk';
@@ -110,7 +110,7 @@ program
         process.exit(1);
       }
 
-      let policy: SandboxPolicy;
+      let policy: SandboxPolicySpec;
       if (options.policy) {
         policy = JSON.parse(options.policy);
       } else if (options.policyFile) {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -324,6 +324,44 @@ const policy: SandboxPolicy = {
 const ptyProcess = spawnSandbox('python script.py', policy, {}, 'C:\\workspace');
 ```
 
+### AEGIS Governance (Cookie-Based Policy)
+
+`SandboxPolicy` is a union type: `SandboxPolicySpec | SandboxPolicyCookie`.
+
+When an enterprise governance daemon (AEGIS) is active, callers pass a **cookie** instead of a policy spec. The SDK redeems the cookie with the daemon to obtain the execution envelope — the caller never sees it.
+
+```typescript
+// Cookie-based policy — envelope retrieved from AEGIS daemon
+const cookiePolicy: SandboxPolicy = {
+  cookie: 'a3f8b2c1d4e5f6071829304a5b6c7d8e',
+  toolName: 'bash',
+  toolArgsJson: '{"command":"git status"}',  // JSON-serialized tool arguments
+};
+
+// Use the async variant (cookie redemption is async)
+const ptyProcess = await spawnSandboxPty('bash -c "git status"', cookiePolicy, {}, cwd);
+```
+
+#### `SandboxPolicyCookie`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cookie` | `string` | Opaque 32-hex-char token from the AEGIS daemon |
+| `toolName` | `string` | Tool being executed (for context verification on redemption) |
+| `toolArgsJson` | `string` | Tool arguments as a JSON string (exact string match on redemption) |
+
+#### `spawnSandboxPty(script, policy, options?, workingDirectory?, containerName?, env?): Promise<IPty>`
+
+Async spawn that accepts both `SandboxPolicySpec` and `SandboxPolicyCookie`. When a cookie is provided, it is redeemed with the AEGIS daemon on `\\.\pipe\aegis-{username}` before spawning. Returns an `IPty` for interactive terminal I/O.
+
+> **Security note:** The SDK connects to the daemon pipe by well-known name and currently does not verify the server process identity. A Phase 4 hardening step will add server PID verification via `GetNamedPipeServerProcessId`. In practice, the daemon is auto-launched on first use, making pipe-squatting attacks difficult.
+
+> **Security note:** Governance enforcement (managed mode check, cookie redemption) lives in the SDK. If a caller invokes `wxc-exec` directly with a hand-crafted config JSON, it bypasses these checks entirely. Phase 4 will address this at the `wxc-exec` level.
+
+#### `isAegisManagedMode(): boolean`
+
+Returns `true` when `HKLM\Software\Policies\Aegis\ManagedMode` is set to `1`. In managed mode, the sync spawn functions (`spawnSandbox`, `spawnSandboxWithoutPty`, `spawnSandboxFromConfig`) throw, requiring callers to use `spawnSandboxPty` or `spawnSandboxAsync` with a cookie policy. Result is cached for the process lifetime.
+
 ## Examples
 
 ### Minimal — Run a Command

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "clean": "rimraf dist",
-    "test": "node --test dist/sandbox.test.js",
+    "test": "node --test dist/sandbox.test.js dist/cookieRedeemer.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/sdk/src/cookieRedeemer.test.ts
+++ b/sdk/src/cookieRedeemer.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { getPipePath, redeemCookie } from './cookieRedeemer';
+
+describe('getPipePath', () => {
+  it('returns a Windows named pipe path', () => {
+    const pipePath = getPipePath();
+    assert.ok(pipePath.startsWith('\\\\.\\pipe\\aegis-'), `Expected pipe path to start with \\\\.\\pipe\\aegis-, got: ${pipePath}`);
+  });
+
+  it('includes the current username', () => {
+    const pipePath = getPipePath();
+    const username = process.env.USERNAME || process.env.USER || 'unknown';
+    assert.ok(pipePath.endsWith(username), `Expected pipe path to end with ${username}, got: ${pipePath}`);
+  });
+});
+
+describe('redeemCookie', () => {
+  it('returns error when cookie is invalid or daemon is not running', async () => {
+    const argsJson = JSON.stringify({ command: 'echo hello' });
+    const result = await redeemCookie('nonexistent-cookie', 'bash', argsJson, '/workspace');
+    assert.strictEqual(result.valid, false);
+    assert.ok(result.error);
+    // May get connection error (daemon not running) or invalid cookie (daemon running but cookie unknown)
+    assert.ok(
+      result.error!.includes('AEGIS daemon connection failed') || result.error!.includes('Invalid') || result.error!.includes('cookie'),
+      `Unexpected error: ${result.error}`
+    );
+  });
+});

--- a/sdk/src/cookieRedeemer.ts
+++ b/sdk/src/cookieRedeemer.ts
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Redeems execution cookies with the AEGIS daemon over a named pipe.
+ *
+ * Instead of verifying signed tickets locally, the SDK sends the cookie
+ * and tool context to the AEGIS daemon, which validates and returns the
+ * sandbox envelope.
+ */
+
+import * as net from 'net';
+
+const PIPE_NAME = `aegis-${process.env.USERNAME || process.env.USER || 'unknown'}`;
+
+export interface RedeemResult {
+  valid: boolean;
+  decision?: string;
+  reason?: string;
+  envelope?: {
+    mode?: string;
+    sandboxProfile?: string;
+    timeoutSeconds?: number;
+    networkEnabled?: boolean;
+    allowLocalNetwork?: boolean;
+    deniedPaths?: string[];
+    readonlyPaths?: string[];
+    readwritePaths?: string[];
+  };
+  error?: string;
+}
+
+/**
+ * Get the named pipe path for the AEGIS daemon.
+ */
+export function getPipePath(): string {
+  return `\\\\.\\pipe\\${PIPE_NAME}`;
+}
+
+/**
+ * Redeem a cookie with the AEGIS daemon.
+ * Sends the cookie + tool context (including raw args), daemon verifies and returns the envelope.
+ */
+export async function redeemCookie(
+  cookie: string,
+  toolName: string,
+  args: string,
+  cwd?: string,
+): Promise<RedeemResult> {
+  const pipePath = getPipePath();
+  const request = JSON.stringify({
+    redeem: cookie,
+    toolName,
+    args,
+    ...(cwd !== undefined && { cwd }),
+  });
+
+  return new Promise<RedeemResult>((resolve) => {
+    let resolved = false;
+    const done = (result: RedeemResult) => {
+      if (resolved) return;
+      resolved = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    const socket = net.connect(pipePath, () => {
+      socket.write(request + '\n');
+    });
+
+    socket.setTimeout(10_000);
+    socket.on('timeout', () => {
+      done({ valid: false, error: 'AEGIS daemon connection timed out (10s)' });
+    });
+
+    let data = '';
+    socket.on('data', (chunk) => {
+      data += chunk.toString();
+      const newlineIdx = data.indexOf('\n');
+      if (newlineIdx !== -1) {
+        const line = data.slice(0, newlineIdx);
+        try {
+          done(JSON.parse(line) as RedeemResult);
+        } catch {
+          done({ valid: false, error: `Invalid JSON response from daemon: ${line}` });
+        }
+      }
+    });
+
+    socket.on('error', (err) => {
+      done({ valid: false, error: `AEGIS daemon connection failed: ${err.message}` });
+    });
+
+    socket.on('end', () => {
+      if (data.length > 0) {
+        try {
+          done(JSON.parse(data.trim()) as RedeemResult);
+        } catch {
+          done({ valid: false, error: `Invalid JSON response from daemon: ${data}` });
+        }
+      } else {
+        done({ valid: false, error: 'AEGIS daemon closed connection without response' });
+      }
+    });
+  });
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -28,6 +28,8 @@
 // Export types
 export {
   SandboxPolicy,
+  SandboxPolicySpec,
+  SandboxPolicyCookie,
   SandboxingMethod,
   ContainmentType,
   ExperimentalBackends,
@@ -44,10 +46,12 @@ export {
 export {
   createConfigFromPolicy,
   spawnSandbox,
+  spawnSandboxFromConfig,
   spawnSandboxAsync,
   spawnSandboxWithoutPty,
-  spawnSandboxFromConfig,
+  spawnSandboxPty,
   buildSandboxPayload,
+  isAegisManagedMode,
   SandboxSpawnOptions,
 } from './sandbox';
 
@@ -59,3 +63,10 @@ export {
   FilesystemPolicyResult,
   ToolsPolicyOptions,
 } from './policy';
+
+// Export cookie redemption functions
+export {
+  redeemCookie,
+  getPipePath,
+  RedeemResult,
+} from './cookieRedeemer';

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -4,14 +4,98 @@
 import * as pty from 'node-pty';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
+import { execFileSync } from "child_process";
 import * as fs from 'fs';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
+import { SandboxPolicy, SandboxPolicySpec, SandboxPolicyCookie, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
 const MIN_VERSION = '0.4.0-alpha';
+
+const AEGIS_MANAGED_MODE_KEY = "HKLM\\Software\\Policies\\Aegis";
+
+let _managedModeCache: boolean | undefined;
+
+/**
+ * Checks whether AEGIS managed mode is active via the HKLM registry.
+ * When managed mode is on, all sandbox spawns must provide a cookie.
+ * Result is cached for the lifetime of the process (managed mode
+ * doesn't change at runtime).
+ *
+ * Returns false on non-Windows platforms or if the registry key is absent.
+ */
+export function isAegisManagedMode(): boolean {
+  if (_managedModeCache !== undefined) return _managedModeCache;
+  if (os.platform() !== 'win32') { _managedModeCache = false; return false; }
+
+  try {
+    const stdout = execFileSync("reg.exe", [
+      "query", AEGIS_MANAGED_MODE_KEY, "/v", "ManagedMode"
+    ], { encoding: "utf8", windowsHide: true, timeout: 3000 });
+
+    const match = stdout.match(/ManagedMode\s+REG_DWORD\s+0x(\d+)/i);
+    _managedModeCache = match !== null && parseInt(match[1], 16) !== 0;
+  } catch {
+    _managedModeCache = false;
+  }
+  return _managedModeCache;
+}
+
+/** Type guard: is this policy a cookie-based policy? */
+function isCookiePolicy(policy: SandboxPolicy): policy is SandboxPolicyCookie {
+  return 'cookie' in policy;
+}
+
+/**
+ * Resolve a SandboxPolicy to a SandboxPolicySpec. If the policy is a cookie,
+ * redeem it with the AEGIS daemon to obtain the execution envelope.
+ */
+async function resolvePolicy(policy: SandboxPolicy, cwd?: string): Promise<SandboxPolicySpec> {
+  if (!isCookiePolicy(policy)) {
+    if (isAegisManagedMode()) {
+      throw new Error(
+        'AEGIS managed mode is active — sandbox policy must include a governance cookie.'
+      );
+    }
+    return policy;
+  }
+
+  const { redeemCookie } = await import('./cookieRedeemer');
+  const result = await redeemCookie(policy.cookie, policy.toolName, policy.toolArgsJson, cwd);
+
+  if (!result.valid || !result.envelope) {
+    throw new Error(
+      `AEGIS cookie redemption failed: ${result.error || 'no envelope returned'}`
+    );
+  }
+
+  const envelope = result.envelope;
+  const spec: SandboxPolicySpec = {
+    version: SUPPORTED_VERSION,
+    filesystem: {
+      readwritePaths: envelope.readwritePaths,
+      readonlyPaths: envelope.readonlyPaths,
+      deniedPaths: envelope.deniedPaths,
+    },
+    network: envelope.networkEnabled !== undefined ? {
+      allowOutbound: envelope.networkEnabled,
+      allowLocalNetwork: envelope.allowLocalNetwork,
+    } : undefined,
+    timeoutMs: envelope.timeoutSeconds ? envelope.timeoutSeconds * 1000 : undefined,
+  };
+
+  // Validate the resolved policy — a malformed daemon response should not
+  // silently produce an invalid sandbox config.
+  try {
+    validatePolicyVersion(spec.version);
+  } catch (err) {
+    throw new Error(`AEGIS daemon returned an invalid policy: ${(err as Error).message}`);
+  }
+
+  return spec;
+}
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -19,7 +103,6 @@ const MIN_VERSION = '0.4.0-alpha';
 function generateRandomContainerName(): string {
     return randomBytes(4).toString("hex");
 }
-
 function validatePolicyVersion(version: string): void {
     if (!version) {
         throw new Error('Policy version is required');
@@ -108,7 +191,7 @@ function buildLinuxProcessConfig(
  */
 function buildProcessBaseContainerConfig(
     config: ContainerConfig,
-    policy: SandboxPolicy,
+    policy: SandboxPolicySpec,
     containerId: string,
 ): ContainerConfig {
     const capabilities: string[] = [];
@@ -149,7 +232,7 @@ function buildProcessBaseContainerConfig(
  */
 function buildMicroVmConfig(
     config: ContainerConfig,
-    policy: SandboxPolicy,
+    policy: SandboxPolicySpec,
 ): ContainerConfig {
     if (os.platform() !== 'win32') {
         throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
@@ -203,7 +286,7 @@ function buildMicroVmConfig(
  * ```
  */
 export function createConfigFromPolicy(
-    policy: SandboxPolicy,
+    policy: SandboxPolicySpec,
     containment: ContainmentType = "process",
     containerName?: string,
 ): ContainerConfig {
@@ -297,7 +380,7 @@ export function createConfigFromPolicy(
  */
 export function buildSandboxPayload(
     script: string,
-    policy: SandboxPolicy,
+    policy: SandboxPolicySpec,
     workingDirectory?: string,
     containerName?: string,
     containment: ContainmentType = "process",
@@ -471,6 +554,16 @@ export function spawnSandbox(
   env?: { [key: string]: string | undefined },
   containment?: ContainmentType,
 ): pty.IPty {
+  if (isCookiePolicy(policy)) {
+    throw new Error(
+      'Cookie-based policy requires async resolution. Use spawnSandboxAsync() instead.'
+    );
+  }
+  if (isAegisManagedMode()) {
+    throw new Error(
+      'AEGIS managed mode is active — pass a { cookie } policy to spawnSandboxAsync().'
+    );
+  }
   const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
   return spawnWithConfig(config, options, workingDirectory, env);
 }
@@ -512,6 +605,16 @@ export function spawnSandboxWithoutPty(
   env?: { [key: string]: string | undefined },
   containment?: ContainmentType,
 ): ChildProcess {
+  if (isCookiePolicy(policy)) {
+    throw new Error(
+      'Cookie-based policy requires async resolution. Use spawnSandboxAsync() instead.'
+    );
+  }
+  if (isAegisManagedMode()) {
+    throw new Error(
+      'AEGIS managed mode is active — pass a { cookie } policy to spawnSandboxAsync().'
+    );
+  }
   if (options.ptyOptions) {
     console.warn('Warning: ptyOptions are ignored by spawnSandboxWithoutPty (non-PTY). Use spawnSandbox for PTY support.');
   }
@@ -551,6 +654,33 @@ export function spawnSandboxFromConfig(
   workingDirectory?: string,
   env?: { [key: string]: string | undefined }
 ): pty.IPty {
+  if (isAegisManagedMode()) {
+    throw new Error(
+      'AEGIS managed mode is active — pass a { cookie } policy to spawnSandboxAsync().'
+    );
+  }
+  return spawnWithConfig(config, options, workingDirectory, env);
+}
+
+/**
+ * Async spawn that accepts both policy specs and cookie-based policies,
+ * returning an IPty for interactive terminal I/O.
+ *
+ * When a cookie policy is provided, the cookie is redeemed with the AEGIS
+ * daemon to obtain the execution envelope before spawning. The caller
+ * never sees the envelope.
+ */
+export async function spawnSandboxPty(
+  script: string,
+  policy: SandboxPolicy,
+  options: SandboxSpawnOptions = {},
+  workingDirectory?: string,
+  containerName?: string,
+  env?: { [key: string]: string | undefined },
+  containment?: ContainmentType,
+): Promise<pty.IPty> {
+  const spec = await resolvePolicy(policy, workingDirectory);
+  const config = buildSandboxPayload(script, spec, workingDirectory, containerName, containment);
   return spawnWithConfig(config, options, workingDirectory, env);
 }
 
@@ -578,16 +708,18 @@ export function spawnSandboxFromConfig(
  * console.log('Exit code:', result.exitCode);
  * ```
  */
-export function spawnSandboxAsync(
+export async function spawnSandboxAsync(
   script: string,
   policy: SandboxPolicy,
   options: SandboxSpawnOptions = {},
   workingDirectory?: string,
   containerName?: string,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const spec = await resolvePolicy(policy, workingDirectory);
   return new Promise((resolve, reject) => {
     try {
-      const ptyProcess = spawnSandbox(script, policy, options, workingDirectory, containerName);
+      const config = buildSandboxPayload(script, spec, workingDirectory, containerName);
+      const ptyProcess = spawnWithConfig(config, options, workingDirectory);
       let output = '';
 
       ptyProcess.onData((data: string) => {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -196,12 +196,13 @@ export interface ContainerConfig {
 
 /**
  * The main sandbox policy configuration interface for external consumers
- * to define sandboxed execution environments.
+/**
+ * A directly-specified sandbox policy with explicit constraints.
  *
  * Policy describes *what* the caller wants restricted. Cross-platform.
  * No OS-specific content. Omitted fields = most restrictive (default-deny).
  */
-export type SandboxPolicy = {
+export interface SandboxPolicySpec {
   /** Policy version (semver). Must match a supported schema version. */
   version: string;
   /** Filesystem access restrictions */
@@ -243,6 +244,29 @@ export type SandboxPolicy = {
   /** Execution timeout in milliseconds. Omitted = no timeout. */
   timeoutMs?: number;
 }
+
+/**
+ * An AEGIS governance cookie. When provided instead of a policy spec,
+ * the mxc SDK redeems the cookie with the AEGIS daemon to obtain the
+ * execution envelope. The agent runtime never sees the envelope.
+ */
+export interface SandboxPolicyCookie {
+  /** Opaque cookie from the AEGIS daemon (32 hex chars). */
+  cookie: string;
+  /** Tool name for context verification on redemption. */
+  toolName: string;
+  /** Tool arguments as JSON string for context verification. */
+  toolArgsJson: string;
+}
+
+/**
+ * Sandbox policy: either a directly-specified policy or an AEGIS cookie.
+ *
+ * Use a `SandboxPolicySpec` when the caller controls the sandbox constraints.
+ * Use a `SandboxPolicyCookie` when AEGIS governance is active — the daemon
+ * holds the execution envelope and the cookie is redeemed at spawn time.
+ */
+export type SandboxPolicy = SandboxPolicySpec | SandboxPolicyCookie;
 
 /**
  * LXC container configuration for Linux sandbox


### PR DESCRIPTION
## AEGIS governance integration for mxc SDK

Fixes #203

Adds support for the AEGIS cookie-based trust chain, where execution envelopes flow directly from the AEGIS daemon to mxc without passing through the untrusted agent runtime.

### What's included

- **`SandboxPolicy` union type** (`types.ts`) — `SandboxPolicySpec | SandboxPolicyCookie`. Callers pass either explicit constraints or `{cookie, toolName, toolArgsJson}` to delegate policy to the AEGIS daemon.
- **`spawnSandboxPty()`** (`sandbox.ts`) — Async spawn accepting either policy type, returns `IPty`. When a cookie is provided, it's redeemed with the daemon before spawning.
- **`isAegisManagedMode()`** (`sandbox.ts`) — Checks `HKLM\Software\Policies\Aegis\ManagedMode`. When active, sync spawn functions throw, requiring the cookie path. Result cached for process lifetime.
- **Cookie redemption** (`cookieRedeemer.ts`) — Connects to AEGIS daemon on `\\.\pipe\aegis-{username}`, sends `{redeem, cookie, toolName, args, cwd}`, receives execution envelope (one-time use). 10s socket timeout, single-resolve guard, socket cleanup on all paths.
- **Resolved policy validation** — Envelopes from the daemon are validated before use; malformed responses are rejected.
- **README** updated with AEGIS governance section, `SandboxPolicyCookie` API docs, and security notes.
- **`.github/copilot-instructions.md`** updated with `SandboxPolicy` union type and `spawnSandboxPty` API.
- **38 tests passing**, 0 skipped

### How it works

```mermaid
sequenceDiagram
    participant CLI as Agent (CLI)
    participant SDK as mxc SDK
    participant Daemon as AEGIS Daemon
    participant AC as AppContainer

    CLI->>SDK: spawnSandboxPty(script, {cookie, toolName, toolArgsJson})
    SDK->>Daemon: redeem(cookie, toolName, args, cwd)
    Note over Daemon: Verify context match
    Daemon-->>SDK: envelope (one-time use)
    Note over SDK: Validate + build SandboxPolicy from envelope
    Note over SDK: Apply FS ACLs + network rules
    SDK->>AC: Spawn AppContainer
```

### Known limitations

- **Pipe server identity not verified** — mxc connects to the daemon pipe by well-known name and does not verify the server process. A pipe-squatting attacker could return a permissive envelope. Mitigated by daemon auto-launch (hard to race). Phase 4 will add `GetNamedPipeServerProcessId` or Authenticode verification.
- **Direct wxc-exec bypass** — Governance enforcement (managed mode check, cookie redemption) lives in the SDK. If a caller invokes `wxc-exec` directly with a hand-crafted config JSON, it bypasses these checks. Phase 4 will address this at the `wxc-exec` level.
- **Windows-only** — Cookie redemption uses Windows named pipes; no POSIX equivalent for Linux/macOS AEGIS integration yet.

---

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/201)
