### PR TITLE
[CLI/SDK] Add auto file logging for debug mode

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -13,7 +13,6 @@ import {
 } from '@microsoft/mxc-sdk';
 
 import * as fs from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { ContainerConfig } from '@microsoft/mxc-sdk/dist/types';
 
@@ -148,16 +147,9 @@ program
 
       const containment = options.containment as ContainmentType | undefined;
 
-      // When --debug is passed, write diagnostic logs to temp directory
-      let logDir: string | undefined;
-      if (options.debug) {
-        logDir = path.join(os.tmpdir(), 'mxc-logs');
-      }
-
       const spawnOptions = {
         debug: options.debug ?? false,
         experimental: options.experimental ?? false,
-        logDir,
       };
 
       if (options.pty === false) {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -13,6 +13,7 @@ import {
 } from '@microsoft/mxc-sdk';
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { ContainerConfig } from '@microsoft/mxc-sdk/dist/types';
 
@@ -92,7 +93,7 @@ program
   .option('--container-name <name>', 'Name for the sandbox container')
   .option('--containment <backend>', 'Override containment backend')
   .option('--no-pty', 'Use child_process.spawn instead of node-pty (reliable exit codes)')
-  .option('--debug', 'Enable debug output')
+  .option('--debug', 'Enable debug output and diagnostic log file')
   .option('--experimental', 'Enable experimental features')
   .action(async (options: { script?: string; scriptFile?: string; policy?: string; policyFile?: string; cwd?: string; containerName?: string; containment?: string; pty?: boolean; debug?: boolean; experimental?: boolean }) => {
     try {
@@ -147,9 +148,16 @@ program
 
       const containment = options.containment as ContainmentType | undefined;
 
+      // When --debug is passed, write diagnostic logs to temp directory
+      let logDir: string | undefined;
+      if (options.debug) {
+        logDir = path.join(os.tmpdir(), 'mxc-logs');
+      }
+
       const spawnOptions = {
         debug: options.debug ?? false,
         experimental: options.experimental ?? false,
+        logDir,
       };
 
       if (options.pty === false) {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "clean": "rimraf dist",
-    "test": "node --test dist/sandbox.test.js",
+    "test": "node --test dist/sandbox.test.js dist/policy.test.js dist/logger.test.js",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -59,3 +59,8 @@ export {
   FilesystemPolicyResult,
   ToolsPolicyOptions,
 } from './policy';
+
+// Export diagnostic logging
+export {
+  FileLogger,
+} from './logger';

--- a/sdk/src/logger.test.ts
+++ b/sdk/src/logger.test.ts
@@ -1,0 +1,46 @@
+// sdk/src/logger.test.ts
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { FileLogger } from './logger';
+
+describe('FileLogger', () => {
+  let tmpDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mxc-log-test-'));
+    logPath = path.join(tmpDir, 'test.log');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should create log file and write entries with timestamp', () => {
+    const logger = new FileLogger(logPath);
+    logger.log('info', 'test message', { key: 'value' });
+    logger.close();
+    const content = fs.readFileSync(logPath, 'utf-8');
+    assert.ok(content.includes('INFO'));
+    assert.ok(content.includes('test message'));
+    assert.ok(content.includes('"key":"value"'));
+    assert.ok(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(content));
+  });
+
+  it('should emit console.warn on invalid path and degrade to no-op', () => {
+    let warned = false;
+    const origWarn = console.warn;
+    console.warn = () => { warned = true; };
+    try {
+      const logger = new FileLogger(path.join(tmpDir, '\0invalid'));
+      logger.log('info', 'this should not throw');
+      logger.close();
+      assert.ok(warned, 'console.warn should have been called');
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+});

--- a/sdk/src/logger.ts
+++ b/sdk/src/logger.ts
@@ -1,0 +1,42 @@
+// sdk/src/logger.ts
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Appends timestamped log lines to a file.
+ * Emits console.warn if the file cannot be opened, then degrades to no-op.
+ */
+export class FileLogger {
+  private fd: number | null = null;
+
+  constructor(filePath: string) {
+    try {
+      const dir = path.dirname(filePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      this.fd = fs.openSync(filePath, 'a');
+    } catch (err) {
+      console.warn(`[mxc-sdk] Could not open log file '${filePath}': ${err}`);
+      this.fd = null;
+    }
+  }
+
+  log(level: 'info' | 'warn' | 'error', message: string, data?: Record<string, unknown>): void {
+    if (this.fd === null) return;
+    try {
+      const ts = new Date().toISOString();
+      const suffix = data ? ' ' + JSON.stringify(data) : '';
+      const line = `[${ts}] ${level.toUpperCase()} ${message}${suffix}\n`;
+      fs.writeSync(this.fd, line);
+    } catch { /* never throw from logging */ }
+  }
+
+  close(): void {
+    if (this.fd !== null) {
+      try { fs.closeSync(this.fd); } catch { /* ignore */ }
+      this.fd = null;
+    }
+  }
+}

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -446,6 +446,7 @@ function spawnWithConfig(
   if (logDir) {
     logFile = makeLogFilePath(logDir);
     logger = new FileLogger(logFile);
+    logger.log('info', 'mxc.log.created', { logFile });
   }
 
   const startTime = Date.now();

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -349,9 +349,7 @@ export interface SandboxSpawnOptions {
   ptyOptions?: pty.IPtyForkOptions;
 
   /**
-   * Directory for diagnostic log files. Both the SDK and the native
-   * binary (wxc-exec/lxc-exec) append to a timestamped file in this
-   * directory (e.g. mxc-diag-2026-04-23T10-36-55-a1b2c3.log).
+   * Directory for diagnostic log files
    */
   logDir?: string;
 }
@@ -444,8 +442,9 @@ function spawnWithConfig(
 ): pty.IPty {
   let logger: FileLogger | undefined;
   let logFile: string | undefined;
-  if (options.logDir) {
-    logFile = makeLogFilePath(options.logDir);
+  const logDir = options.logDir ?? (options.debug ? path.join(os.tmpdir(), 'mxc-logs') : undefined);
+  if (logDir) {
+    logFile = makeLogFilePath(logDir);
     logger = new FileLogger(logFile);
   }
 

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -5,10 +5,21 @@ import * as pty from 'node-pty';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
 import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
+import { FileLogger } from './logger';
+
+/**
+ * Generate a timestamped log file path in the given directory.
+ */
+function makeLogFilePath(dir: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const suffix = randomBytes(3).toString('hex');
+  return path.join(dir, `mxc-diag-${ts}-${suffix}.log`);
+}
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
 const MIN_VERSION = '0.4.0-alpha';
@@ -336,6 +347,13 @@ export interface SandboxSpawnOptions {
    * PTY options to pass to node-pty (only used by spawnSandbox)
    */
   ptyOptions?: pty.IPtyForkOptions;
+
+  /**
+   * Directory for diagnostic log files. Both the SDK and the native
+   * binary (wxc-exec/lxc-exec) append to a timestamped file in this
+   * directory (e.g. mxc-diag-2026-04-23T10-36-55-a1b2c3.log).
+   */
+  logDir?: string;
 }
 
 /**
@@ -424,7 +442,28 @@ function spawnWithConfig(
   workingDirectory?: string,
   env?: { [key: string]: string | undefined },
 ): pty.IPty {
-  const { executablePath, args } = resolveExecutableAndArgs(config, options);
+  let logger: FileLogger | undefined;
+  let logFile: string | undefined;
+  if (options.logDir) {
+    logFile = makeLogFilePath(options.logDir);
+    logger = new FileLogger(logFile);
+  }
+
+  const startTime = Date.now();
+  logger?.log('info', 'mxc.spawn.start', {
+    platform: os.platform(),
+    arch: os.arch(),
+    containment: config.containment,
+  });
+
+  try {
+    const { executablePath, args } = resolveExecutableAndArgs(config, options);
+
+    if (logFile) {
+      args.push('--log-file', logFile);
+    }
+
+    logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
 
   const ptyOpts: pty.IPtyForkOptions = {
     name: "xterm-color",
@@ -435,7 +474,21 @@ function spawnWithConfig(
     env: env ?? options.ptyOptions?.env,
   };
 
-  return pty.spawn(executablePath, args, ptyOpts);
+  const ptyProcess = pty.spawn(executablePath, args, ptyOpts);
+
+  ptyProcess.onExit((event) => {
+    logger?.log('info', 'mxc.spawn.exit', {
+      exitCode: event.exitCode,
+      durationMs: Date.now() - startTime,
+    });
+    logger?.close();
+  });
+
+  return ptyProcess;
+  } catch (err) {
+    logger?.close();
+    throw err;
+  }
 }
 
 /**

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -42,6 +42,10 @@ struct Cli {
     /// Enable experimental features
     #[arg(long)]
     experimental: bool,
+
+    /// Path to diagnostic log file (appends, creates if missing)
+    #[arg(long = "log-file")]
+    log_file: Option<String>,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -102,6 +106,12 @@ fn main() {
     } else {
         Mode::Buffer
     });
+
+    if let Some(ref log_path) = cli.log_file {
+        if let Err(e) = logger.enable_file_sink(std::path::Path::new(log_path)) {
+            eprintln!("Warning: could not open log file '{}': {}", log_path, e);
+        }
+    }
 
     // Delete mode
     if cli.delete {

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Write;
 use std::process;
+use std::time::Instant;
 
 use clap::Parser;
 use wxc_common::config_parser::load_request;
@@ -152,7 +153,10 @@ fn main() {
         &request.container_id,
         &request.lifecycle,
     );
+    let run_start = Instant::now();
     let response = runner.run(&request, &mut logger);
+    let run_elapsed = run_start.elapsed();
+    let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
     display_script_results(&response, &mut logger);
 
     print!("{}", response.standard_out);

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::Write;
 use std::process;
+use std::time::Instant;
 
 use clap::Parser;
 use windows::Win32::Security::Isolation::DeleteAppContainerProfile;
@@ -255,7 +256,10 @@ fn main() {
             Box::new(WindowsSandboxScriptRunner::new(&sandbox_config))
         }
     };
+    let run_start = Instant::now();
     let response = runner.run(&request, &mut logger);
+    let run_elapsed = run_start.elapsed();
+    let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
     display_script_results(&response, &mut logger);
 
     // Output was already relayed to the console by pipe threads.

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -46,6 +46,10 @@ struct Cli {
     /// Enable experimental features
     #[arg(long)]
     experimental: bool,
+
+    /// Path to diagnostic log file (appends, creates if missing)
+    #[arg(long = "log-file")]
+    log_file: Option<String>,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -119,6 +123,12 @@ fn main() {
     } else {
         Mode::Buffer
     });
+
+    if let Some(ref log_path) = cli.log_file {
+        if let Err(e) = logger.enable_file_sink(std::path::Path::new(log_path)) {
+            eprintln!("Warning: could not open log file '{}': {}", log_path, e);
+        }
+    }
 
     // Delete mode
     if cli.delete {

--- a/src/wxc_common/src/logger.rs
+++ b/src/wxc_common/src/logger.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
+use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
@@ -30,10 +31,7 @@ impl Logger {
 
     /// Enable writing to a log file in addition to console/buffer output.
     pub fn enable_file_sink(&mut self, path: &Path) -> std::io::Result<()> {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)?;
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
         self.file = Some(file);
         Ok(())
     }
@@ -44,7 +42,11 @@ impl Logger {
             Mode::Buffer => self.buffer.push_str(msg),
         }
         if let Some(ref mut f) = self.file {
-            let _ = write!(f, "{}", msg);
+            let secs = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let _ = write!(f, "[{}] {}", secs, msg);
         }
     }
 
@@ -57,7 +59,11 @@ impl Logger {
             }
         }
         if let Some(ref mut f) = self.file {
-            let _ = writeln!(f, "{}", msg);
+            let secs = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let _ = writeln!(f, "[{}] {}", secs, msg);
         }
     }
 

--- a/src/wxc_common/src/logger.rs
+++ b/src/wxc_common/src/logger.rs
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 
 use std::fmt;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Mode {
@@ -13,6 +16,7 @@ pub enum Mode {
 pub struct Logger {
     mode: Mode,
     buffer: String,
+    file: Option<File>,
 }
 
 impl Logger {
@@ -20,13 +24,27 @@ impl Logger {
         Self {
             mode,
             buffer: String::new(),
+            file: None,
         }
+    }
+
+    /// Enable writing to a log file in addition to console/buffer output.
+    pub fn enable_file_sink(&mut self, path: &Path) -> std::io::Result<()> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        self.file = Some(file);
+        Ok(())
     }
 
     pub fn log(&mut self, msg: &str) {
         match self.mode {
             Mode::Console => print!("{}", msg),
             Mode::Buffer => self.buffer.push_str(msg),
+        }
+        if let Some(ref mut f) = self.file {
+            let _ = write!(f, "{}", msg);
         }
     }
 
@@ -37,6 +55,9 @@ impl Logger {
                 self.buffer.push_str(msg);
                 self.buffer.push('\n');
             }
+        }
+        if let Some(ref mut f) = self.file {
+            let _ = writeln!(f, "{}", msg);
         }
     }
 


### PR DESCRIPTION
Adds opt-in diagnostic file logging across the MXC stack
Auto enabled with CLI : --debug.
And SDK : spawnSandbox('echo hi', policy, { debug: true });

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] This pull request is related to an issue.
- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/205)