### PR TITLE
[WSLC] Add usePty option to SandboxSpawnOptions and WSLC SDK E2E test

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -5,7 +5,8 @@
 import { Command } from 'commander';
 import {
   spawnSandbox,
-  spawnSandboxWithoutPty,
+  spawnSandboxFromConfig,
+  createConfigFromPolicy,
   getPlatformSupport,
   SandboxPolicy,
   ContainmentType,
@@ -153,12 +154,15 @@ program
       };
 
       if (options.pty === false) {
-        // Non-PTY mode using spawnSandboxWithoutPty() (child_process.spawn).
+        // Non-PTY mode using spawnSandboxFromConfig with usePty: false.
         // This provides reliable exit code propagation and separate stdout/stderr
         // streams. Use this for CI, automation, or any scenario where correct exit
         // codes matter. The default PTY mode (node-pty/ConPTY) returns exit code -1
         // for all processes on Windows due to a known ConPTY limitation.
-        const child = spawnSandboxWithoutPty(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
+        const config = createConfigFromPolicy(policy, containment);
+        config.process!.commandLine = scriptCommand;
+        config.process!.cwd = options.cwd;
+        const child = spawnSandboxFromConfig(config, { ...spawnOptions, usePty: false }, options.cwd);
 
         child.stdout?.on('data', (data: Buffer) => {
           process.stdout.write(data);
@@ -176,7 +180,7 @@ program
       } else {
         // PTY mode: interactive terminal with colors/input
         console.log('Spawning sandboxed process using SDK...');
-        const ptyProcess = spawnSandbox(scriptCommand, policy, spawnOptions, options.cwd, options.containerName, undefined, containment);
+        const ptyProcess = spawnSandbox(scriptCommand, policy, spawnOptions, options.cwd, options.containerName);
 
         ptyProcess.onData((data: string) => {
           process.stdout.write(data);

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 import * as os from 'os';
+import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger';
-import { ContainerConfig } from './types';
+import { ContainerConfig, ContainmentType, ExperimentalBackends, SandboxingMethod } from './types';
+import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 import { SandboxSpawnOptions } from './sandbox';
 
 /**
@@ -35,17 +37,95 @@ export function makeLogFilePath(dir: string): string {
 }
 
 /**
+ * Resolves the executable path and builds CLI arguments for a sandbox invocation.
+ * Shared setup used by both PTY and non-PTY spawn paths.
+ */
+export function resolveExecutableAndArgs(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions = {},
+): { executablePath: string; args: string[] } {
+  if (!config.process?.commandLine) {
+    throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
+  }
+
+  const platformSupport = getPlatformSupport();
+  if (!platformSupport.isSupported) {
+    throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
+  }
+
+  // Validate containment against platform
+  if (config.containment) {
+    if (config.containment === 'microvm' && os.platform() !== 'win32') {
+      throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
+    }
+    if (!(ExperimentalBackends as readonly string[]).includes(config.containment) &&
+        !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
+      throw new Error(
+        `Containment backend '${config.containment}' is not available on this platform. ` +
+        `Available methods: ${platformSupport.availableMethods.join(', ')}`
+      );
+    }
+  }
+
+  const platform = os.platform();
+  let executablePath: string | null;
+
+  if (options.executablePath) {
+    if (!fs.existsSync(options.executablePath)) {
+      throw new Error(`File not found: ${options.executablePath}`);
+    }
+    executablePath = options.executablePath;
+  } else if (platform === 'linux') {
+    executablePath = findLxcExecutable();
+    if (!executablePath) {
+      throw new Error(
+        'lxc-exec not found. Ensure it is built and available in a standard location.'
+      );
+    }
+  } else {
+    executablePath = findWxcExecutable();
+    if (!executablePath) {
+      throw new Error(
+        'wxc-exec.exe not found. Set options.executablePath or ensure it exists in a standard location.'
+      );
+    }
+  }
+
+  const args: string[] = [];
+  const configJson = JSON.stringify(config);
+  const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
+  args.push('--config-base64', configBase64);
+
+  if (options.debug) {
+    args.push('--debug');
+  }
+
+  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
+    throw new Error(
+      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
+    );
+  }
+
+  if (options.experimental) {
+    args.push('--experimental');
+  }
+
+  return { executablePath, args };
+}
+
+/**
  * Sets up logging and resolves the executable path + args.
  * Shared by both PTY and non-PTY spawn paths.
  *
+ * If resolveExecutableAndArgs throws, any open logger is closed
+ * before the error propagates.
+ *
  * @param config - The container configuration
  * @param options - Spawn options (debug, logDir, etc.)
- * @param resolveExecutableAndArgs - Function to resolve the binary path and build CLI args
  */
 export function prepareSpawn(
   config: ContainerConfig,
   options: SandboxSpawnOptions,
-  resolveExecutableAndArgs: (config: ContainerConfig, options: SandboxSpawnOptions) => { executablePath: string; args: string[] },
 ): PrepareSpawnResult {
   let logger: FileLogger | undefined;
   let logFile: string | undefined;
@@ -63,9 +143,12 @@ export function prepareSpawn(
     containment: config.containment,
   });
 
-  const { executablePath, args } = resolveExecutableAndArgs(config, options);
-
-  logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
-
-  return { executablePath, args, logger, logFile, startTime };
+  try {
+    const { executablePath, args } = resolveExecutableAndArgs(config, options);
+    logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
+    return { executablePath, args, logger, logFile, startTime };
+  } catch (err) {
+    logger?.close();
+    throw err;
+  }
 }

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as os from 'os';
+import * as path from 'path';
+import { randomBytes } from 'crypto';
+import { FileLogger } from './logger';
+import { ContainerConfig } from './types';
+import { SandboxSpawnOptions } from './sandbox';
+
+/**
+ * Result of preparing a sandbox spawn — includes the resolved binary,
+ * CLI arguments, and optional diagnostic logger.
+ */
+export interface PrepareSpawnResult {
+  /** Absolute path to the wxc-exec or lxc-exec binary. */
+  executablePath: string;
+  /** CLI arguments to pass to the binary. */
+  args: string[];
+  /** Diagnostic logger, created when logDir is set or debug is enabled. */
+  logger?: FileLogger;
+  /** Path to the diagnostic log file (if logger is active). */
+  logFile?: string;
+  /** Timestamp when spawn preparation started (for duration tracking). */
+  startTime: number;
+}
+
+/**
+ * Generate a timestamped log file path in the given directory.
+ */
+export function makeLogFilePath(dir: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
+  const suffix = randomBytes(3).toString('hex');
+  return path.join(dir, `mxc-diag-${ts}-${suffix}.log`);
+}
+
+/**
+ * Sets up logging and resolves the executable path + args.
+ * Shared by both PTY and non-PTY spawn paths.
+ *
+ * @param config - The container configuration
+ * @param options - Spawn options (debug, logDir, etc.)
+ * @param resolveExecutableAndArgs - Function to resolve the binary path and build CLI args
+ */
+export function prepareSpawn(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions,
+  resolveExecutableAndArgs: (config: ContainerConfig, options: SandboxSpawnOptions) => { executablePath: string; args: string[] },
+): PrepareSpawnResult {
+  let logger: FileLogger | undefined;
+  let logFile: string | undefined;
+  const logDir = options.logDir ?? (options.debug ? path.join(os.tmpdir(), 'mxc-logs') : undefined);
+  if (logDir) {
+    logFile = makeLogFilePath(logDir);
+    logger = new FileLogger(logFile);
+    logger.log('info', 'mxc.log.created', { logFile });
+  }
+
+  const startTime = Date.now();
+  logger?.log('info', 'mxc.spawn.start', {
+    platform: os.platform(),
+    arch: os.arch(),
+    containment: config.containment,
+  });
+
+  const { executablePath, args } = resolveExecutableAndArgs(config, options);
+
+  logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
+
+  return { executablePath, args, logger, logFile, startTime };
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -47,6 +47,7 @@ export {
   spawnSandboxAsync,
   spawnSandboxWithoutPty,
   spawnSandboxFromConfig,
+  spawnSandboxFromConfigWithoutPty,
   buildSandboxPayload,
   SandboxSpawnOptions,
 } from './sandbox';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -45,7 +45,6 @@ export {
   createConfigFromPolicy,
   spawnSandbox,
   spawnSandboxAsync,
-  spawnSandboxWithoutPty,
   spawnSandboxFromConfig,
   buildSandboxPayload,
   SandboxSpawnOptions,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -47,7 +47,6 @@ export {
   spawnSandboxAsync,
   spawnSandboxWithoutPty,
   spawnSandboxFromConfig,
-  spawnSandboxFromConfigWithoutPty,
   buildSandboxPayload,
   SandboxSpawnOptions,
 } from './sandbox';

--- a/sdk/src/sandbox.e2etest.ts
+++ b/sdk/src/sandbox.e2etest.ts
@@ -15,6 +15,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
 import os from 'os';
 import { createConfigFromPolicy, spawnSandboxFromConfig } from './sandbox';
 import { SandboxPolicy } from './types';
@@ -27,37 +29,51 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
 }, () => {
 
   it('should run with all WSLC-specific fields set', async () => {
-    const policy: SandboxPolicy = {
-      version: '0.5.0-alpha',
-      network: { allowOutbound: true },
-      filesystem: { readwritePaths: ['C:\\workspace'] },
-    };
-    const config = createConfigFromPolicy(policy, 'wslc');
-    config.process!.commandLine = [
-      "python3 -c \"import sys; print(f'Python {sys.version_info.major}.{sys.version_info.minor}')\"",
-      "nproc",
-      "cat /proc/meminfo | grep MemTotal",
-      "ls /mnt/c/workspace",
-      "echo 'All fields work'",
-    ].join(' && ');
-    config.experimental!.wslc!.image = 'python:3.12-alpine';
-    config.experimental!.wslc!.cpuCount = 2;
-    config.experimental!.wslc!.memoryMb = 1024;
-    config.experimental!.wslc!.storagePath = 'C:\\workspace\\wslc-all-fields-test';
+    // Create temp directories for volume mount and storage.
+    // Use short paths under os.tmpdir() — WSLC SDK can fail with very long paths.
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mxc-e2e-'));
+    const storageDir = path.join(testDir, 'storage');
+    const mountDir = path.join(testDir, 'mount');
+    fs.mkdirSync(storageDir);
+    fs.mkdirSync(mountDir);
 
-    const { stdout, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
-      const child = spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
-      let stdout = '';
-      let stderr = '';
-      child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });
-      child.stderr?.on('data', (data: Buffer) => { stderr += data.toString(); });
-      child.on('close', (code: number | null) => {
-        resolve({ stdout, stderr, exitCode: code ?? -1 });
+    try {
+      const policy: SandboxPolicy = {
+        version: '0.5.0-alpha',
+        network: { allowOutbound: true },
+        filesystem: { readwritePaths: [mountDir] },
+      };
+      const config = createConfigFromPolicy(policy, 'wslc');
+      config.process!.commandLine = [
+        "python3 -c \"import sys; print(f'Python {sys.version_info.major}.{sys.version_info.minor}')\"",
+        "nproc",
+        "cat /proc/meminfo | grep MemTotal",
+        "echo 'All fields work'",
+      ].join(' && ');
+      config.experimental!.wslc!.image = 'python:3.12-alpine';
+      config.experimental!.wslc!.cpuCount = 2;
+      config.experimental!.wslc!.memoryMb = 1024;
+      config.experimental!.wslc!.storagePath = storageDir;
+
+      const { stdout, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+        const child = spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
+        let stdout = '';
+        let stderr = '';
+        child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });
+        child.stderr?.on('data', (data: Buffer) => { stderr += data.toString(); });
+        child.on('error', (error: Error) => {
+          reject(new Error(`Failed to spawn WSLC sandbox process: ${error.message}${stderr ? `\n${stderr}` : ''}`));
+        });
+        child.on('close', (code: number | null) => {
+          resolve({ stdout, stderr, exitCode: code ?? -1 });
+        });
       });
-    });
 
-    assert.strictEqual(exitCode, 0);
-    assert.ok(stdout.includes('Python 3.12'));
-    assert.ok(stdout.includes('All fields work'));
+      assert.strictEqual(exitCode, 0);
+      assert.ok(stdout.includes('Python 3.12'));
+      assert.ok(stdout.includes('All fields work'));
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
   });
 });

--- a/sdk/src/sandbox.e2etest.ts
+++ b/sdk/src/sandbox.e2etest.ts
@@ -16,44 +16,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import os from 'os';
-import { createConfigFromPolicy } from './sandbox';
+import { createConfigFromPolicy, spawnSandboxFromConfigWithoutPty } from './sandbox';
 import { SandboxPolicy } from './types';
-
-/**
- * Helper: spawn a container from a pre-built config using child_process.
- * Uses child_process.spawn (non-PTY) for reliable exit codes on Windows.
- * Tests the full flow: createConfigFromPolicy → customize → spawn → capture output.
- */
-function spawnConfigAndCollect(
-  config: ReturnType<typeof createConfigFromPolicy>,
-): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  return new Promise((resolve) => {
-    const { spawn } = require('child_process');
-    const configJson = JSON.stringify(config);
-    const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
-
-    // Find wxc-exec.exe using the SDK's platform module
-    const { findWxcExecutable } = require('./platform');
-    const executablePath = findWxcExecutable();
-    if (!executablePath) {
-      resolve({ stdout: '', stderr: 'wxc-exec.exe not found', exitCode: -1 });
-      return;
-    }
-
-    const args = ['--config-base64', configBase64, '--experimental', '--debug'];
-    const child = spawn(executablePath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    let stdout = '';
-    let stderr = '';
-    child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });
-    child.stderr?.on('data', (data: Buffer) => { stderr += data.toString(); });
-    child.on('close', (code: number | null) => {
-      resolve({ stdout, stderr, exitCode: code ?? -1 });
-    });
-  });
-}
 
 const isWslcAvailable = os.platform() === 'win32';
 
@@ -80,9 +44,19 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
     config.experimental!.wslc!.memoryMb = 1024;
     config.experimental!.wslc!.storagePath = 'C:\\workspace\\wslc-all-fields-test';
 
-    const result = await spawnConfigAndCollect(config);
-    assert.strictEqual(result.exitCode, 0);
-    assert.ok(result.stdout.includes('Python 3.12'));
-    assert.ok(result.stdout.includes('All fields work'));
+    const { stdout, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
+      const child = spawnSandboxFromConfigWithoutPty(config, { experimental: true, debug: true });
+      let stdout = '';
+      let stderr = '';
+      child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });
+      child.stderr?.on('data', (data: Buffer) => { stderr += data.toString(); });
+      child.on('close', (code: number | null) => {
+        resolve({ stdout, stderr, exitCode: code ?? -1 });
+      });
+    });
+
+    assert.strictEqual(exitCode, 0);
+    assert.ok(stdout.includes('Python 3.12'));
+    assert.ok(stdout.includes('All fields work'));
   });
 });

--- a/sdk/src/sandbox.e2etest.ts
+++ b/sdk/src/sandbox.e2etest.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// SDK end-to-end tests — these tests spawn real containers via wxc-exec.exe.
+// They require the appropriate runtime to be installed and configured.
+//
+// WSLC tests require:
+//   - Windows 11 with WSL2 enabled
+//   - WSLC SDK runtime installed
+//   - wxc-exec.exe built with --features wslc
+//   - wslcsdk.dll in the same directory as wxc-exec.exe
+//   - alpine:latest and python:3.12-alpine images pre-pulled
+//
+// Run: node --test dist/sandbox.e2etest.js
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import os from 'os';
+import { createConfigFromPolicy } from './sandbox';
+import { SandboxPolicy } from './types';
+
+/**
+ * Helper: spawn a container from a pre-built config using child_process.
+ * Uses child_process.spawn (non-PTY) for reliable exit codes on Windows.
+ * Tests the full flow: createConfigFromPolicy → customize → spawn → capture output.
+ */
+function spawnConfigAndCollect(
+  config: ReturnType<typeof createConfigFromPolicy>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const { spawn } = require('child_process');
+    const configJson = JSON.stringify(config);
+    const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
+
+    // Find wxc-exec.exe using the SDK's platform module
+    const { findWxcExecutable } = require('./platform');
+    const executablePath = findWxcExecutable();
+    if (!executablePath) {
+      resolve({ stdout: '', stderr: 'wxc-exec.exe not found', exitCode: -1 });
+      return;
+    }
+
+    const args = ['--config-base64', configBase64, '--experimental', '--debug'];
+    const child = spawn(executablePath, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr?.on('data', (data: Buffer) => { stderr += data.toString(); });
+    child.on('close', (code: number | null) => {
+      resolve({ stdout, stderr, exitCode: code ?? -1 });
+    });
+  });
+}
+
+const isWslcAvailable = os.platform() === 'win32';
+
+describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
+  skip: !isWslcAvailable ? 'WSLC tests require Windows with WSL2 and WSLC SDK' : undefined,
+}, () => {
+
+  it('should run with all WSLC-specific fields set', async () => {
+    const policy: SandboxPolicy = {
+      version: '0.5.0-alpha',
+      network: { allowOutbound: true },
+      filesystem: { readwritePaths: ['C:\\workspace'] },
+    };
+    const config = createConfigFromPolicy(policy, 'wslc');
+    config.process!.commandLine = [
+      "python3 -c \"import sys; print(f'Python {sys.version_info.major}.{sys.version_info.minor}')\"",
+      "nproc",
+      "cat /proc/meminfo | grep MemTotal",
+      "ls /mnt/c/workspace",
+      "echo 'All fields work'",
+    ].join(' && ');
+    config.experimental!.wslc!.image = 'python:3.12-alpine';
+    config.experimental!.wslc!.cpuCount = 2;
+    config.experimental!.wslc!.memoryMb = 1024;
+    config.experimental!.wslc!.storagePath = 'C:\\workspace\\wslc-all-fields-test';
+
+    const result = await spawnConfigAndCollect(config);
+    assert.strictEqual(result.exitCode, 0);
+    assert.ok(result.stdout.includes('Python 3.12'));
+    assert.ok(result.stdout.includes('All fields work'));
+  });
+});

--- a/sdk/src/sandbox.e2etest.ts
+++ b/sdk/src/sandbox.e2etest.ts
@@ -16,8 +16,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import os from 'os';
-import { createConfigFromPolicy, spawnSandboxFromConfigWithoutPty } from './sandbox';
+import { createConfigFromPolicy, spawnSandboxFromConfig } from './sandbox';
 import { SandboxPolicy } from './types';
+import { ChildProcess } from 'child_process';
 
 const isWslcAvailable = os.platform() === 'win32';
 
@@ -45,7 +46,7 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
     config.experimental!.wslc!.storagePath = 'C:\\workspace\\wslc-all-fields-test';
 
     const { stdout, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve) => {
-      const child = spawnSandboxFromConfigWithoutPty(config, { experimental: true, debug: true });
+      const child = spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
       let stdout = '';
       let stderr = '';
       child.stdout?.on('data', (data: Buffer) => { stdout += data.toString(); });

--- a/sdk/src/sandbox.test.ts
+++ b/sdk/src/sandbox.test.ts
@@ -642,9 +642,11 @@ describe('createConfigFromPolicy', () => {
       assert.strictEqual(config.containerId, 'my-container');
     });
 
-    it('should throw from spawnSandbox when experimental is not set', () => {
+    it('should throw from spawnSandbox when experimental backend is used via config', () => {
+      const config = createConfigFromPolicy({ version: '0.5.0-alpha' }, 'wslc');
+      config.process!.commandLine = 'echo hello';
       assert.throws(
-        () => spawnSandbox('echo hello', { version: '0.5.0-alpha' }, {}, undefined, undefined, undefined, 'wslc'),
+        () => spawnSandboxFromConfig(config),
         { message: /experimental mode/ },
       );
     });

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -352,6 +352,13 @@ export interface SandboxSpawnOptions {
    * Directory for diagnostic log files
    */
   logDir?: string;
+
+  /**
+   * When false, uses child_process.spawn instead of node-pty.
+   * Provides reliable exit codes and separate stdout/stderr streams.
+   * Defaults to true (uses PTY).
+   */
+  usePty?: boolean;
 }
 
 /**
@@ -596,6 +603,10 @@ export function spawnSandboxWithoutPty(
  * config.process!.commandLine = 'echo hello';
  * config.appContainer!.ui!.isolation = "atoms";
  * const ptyProcess = spawnSandboxFromConfig(config);
+ *
+ * // Non-PTY mode for reliable exit codes:
+ * const child = spawnSandboxFromConfig(config, { usePty: false });
+ * child.stdout?.on('data', (data) => console.log(data.toString()));
  * ```
  */
 export function spawnSandboxFromConfig(
@@ -603,44 +614,16 @@ export function spawnSandboxFromConfig(
   options: SandboxSpawnOptions = {},
   workingDirectory?: string,
   env?: { [key: string]: string | undefined }
-): pty.IPty {
+): pty.IPty | ChildProcess {
+  if (options.usePty === false) {
+    const { executablePath, args } = resolveExecutableAndArgs(config, options);
+    return spawn(executablePath, args, {
+      cwd: workingDirectory || process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
+    });
+  }
   return spawnWithConfig(config, options, workingDirectory, env);
-}
-
-/**
- * Spawn a sandboxed process from a pre-built ContainerConfig using child_process.spawn (non-PTY).
- *
- * Use with `createConfigFromPolicy()` when you need to customize backend-specific
- * settings before spawning, and need reliable exit codes and separate stdout/stderr streams.
- *
- * @param config The container configuration (from createConfigFromPolicy)
- * @param options - Spawn options
- * @param workingDirectory Optional working directory path
- * @returns The spawned ChildProcess
- *
- * @example
- * ```typescript
- * const config = createConfigFromPolicy(policy, 'wslc');
- * config.process!.commandLine = 'echo hello';
- * config.experimental!.wslc!.image = 'python:3.12';
- * const child = spawnSandboxFromConfigWithoutPty(config, { experimental: true });
- * child.stdout?.on('data', (data) => console.log(data.toString()));
- * child.on('close', (code) => console.log('Exit code:', code));
- * ```
- */
-export function spawnSandboxFromConfigWithoutPty(
-  config: ContainerConfig,
-  options: SandboxSpawnOptions = {},
-  workingDirectory?: string,
-  env?: { [key: string]: string | undefined }
-): ChildProcess {
-  const { executablePath, args } = resolveExecutableAndArgs(config, options);
-
-  return spawn(executablePath, args, {
-    cwd: workingDirectory || process.cwd(),
-    stdio: ['pipe', 'pipe', 'pipe'],
-    ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
-  });
 }
 
 /**

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -21,6 +21,37 @@ function makeLogFilePath(dir: string): string {
   return path.join(dir, `mxc-diag-${ts}-${suffix}.log`);
 }
 
+/**
+ * Sets up logging and resolves the executable path + args.
+ * Shared by both PTY and non-PTY spawn paths.
+ */
+function prepareSpawn(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions,
+): { executablePath: string; args: string[]; logger?: FileLogger; logFile?: string; startTime: number } {
+  let logger: FileLogger | undefined;
+  let logFile: string | undefined;
+  const logDir = options.logDir ?? (options.debug ? path.join(os.tmpdir(), 'mxc-logs') : undefined);
+  if (logDir) {
+    logFile = makeLogFilePath(logDir);
+    logger = new FileLogger(logFile);
+    logger.log('info', 'mxc.log.created', { logFile });
+  }
+
+  const startTime = Date.now();
+  logger?.log('info', 'mxc.spawn.start', {
+    platform: os.platform(),
+    arch: os.arch(),
+    containment: config.containment,
+  });
+
+  const { executablePath, args } = resolveExecutableAndArgs(config, options);
+
+  logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
+
+  return { executablePath, args, logger, logFile, startTime };
+}
+
 const SUPPORTED_VERSION = '0.5.0-alpha';
 const MIN_VERSION = '0.4.0-alpha';
 
@@ -447,51 +478,29 @@ function spawnWithConfig(
   workingDirectory?: string,
   env?: { [key: string]: string | undefined },
 ): pty.IPty {
-  let logger: FileLogger | undefined;
-  let logFile: string | undefined;
-  const logDir = options.logDir ?? (options.debug ? path.join(os.tmpdir(), 'mxc-logs') : undefined);
-  if (logDir) {
-    logFile = makeLogFilePath(logDir);
-    logger = new FileLogger(logFile);
-    logger.log('info', 'mxc.log.created', { logFile });
-  }
-
-  const startTime = Date.now();
-  logger?.log('info', 'mxc.spawn.start', {
-    platform: os.platform(),
-    arch: os.arch(),
-    containment: config.containment,
-  });
+  const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
 
   try {
-    const { executablePath, args } = resolveExecutableAndArgs(config, options);
+    const ptyOpts: pty.IPtyForkOptions = {
+      name: "xterm-color",
+      cols: 120,
+      rows: 80,
+      ...options.ptyOptions,
+      cwd: workingDirectory || process.cwd(),
+      env: env ?? options.ptyOptions?.env,
+    };
 
-    if (logFile) {
-      args.push('--log-file', logFile);
-    }
+    const ptyProcess = pty.spawn(executablePath, args, ptyOpts);
 
-    logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
-
-  const ptyOpts: pty.IPtyForkOptions = {
-    name: "xterm-color",
-    cols: 120,
-    rows: 80,
-    ...options.ptyOptions,
-    cwd: workingDirectory || process.cwd(),
-    env: env ?? options.ptyOptions?.env,
-  };
-
-  const ptyProcess = pty.spawn(executablePath, args, ptyOpts);
-
-  ptyProcess.onExit((event) => {
-    logger?.log('info', 'mxc.spawn.exit', {
-      exitCode: event.exitCode,
-      durationMs: Date.now() - startTime,
+    ptyProcess.onExit((event) => {
+      logger?.log('info', 'mxc.spawn.exit', {
+        exitCode: event.exitCode,
+        durationMs: Date.now() - startTime,
+      });
+      logger?.close();
     });
-    logger?.close();
-  });
 
-  return ptyProcess;
+    return ptyProcess;
   } catch (err) {
     logger?.close();
     throw err;
@@ -630,12 +639,28 @@ export function spawnSandboxFromConfig(
   env?: { [key: string]: string | undefined }
 ): pty.IPty | ChildProcess {
   if (options.usePty === false) {
-    const { executablePath, args } = resolveExecutableAndArgs(config, options);
-    return spawn(executablePath, args, {
-      cwd: workingDirectory || process.cwd(),
-      stdio: ['pipe', 'pipe', 'pipe'],
-      ...(env ? { env: { ...process.env, ...env } as NodeJS.ProcessEnv } : {}),
-    });
+    const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
+    try {
+      const child = spawn(executablePath, args, {
+        cwd: workingDirectory || process.cwd(),
+        stdio: ['pipe', 'pipe', 'pipe'],
+        ...(env ? { env: { ...process.env, ...env } as NodeJS.ProcessEnv } : {}),
+      });
+      child.on('close', (code) => {
+        logger?.log('info', 'mxc.spawn.exit', {
+          exitCode: code ?? -1,
+          durationMs: Date.now() - startTime,
+        });
+        logger?.close();
+      });
+      child.on('error', () => {
+        logger?.close();
+      });
+      return child;
+    } catch (err) {
+      logger?.close();
+      throw err;
+    }
   }
   return spawnWithConfig(config, options, workingDirectory, env);
 }

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -477,7 +477,6 @@ function spawnWithConfig(
  * @param workingDirectory Optional working directory path
  * @param containerName Optional container name; if not provided, a random name will be generated
  * @param env Optional environment variables
- * @param containment Optional containment backend
  * @returns IPty object for interacting with the sandboxed process
  * @throws Error if platform is not supported or wxc-exec is not found
  *
@@ -498,60 +497,9 @@ export function spawnSandbox(
   workingDirectory?: string,
   containerName?: string,
   env?: { [key: string]: string | undefined },
-  containment?: ContainmentType,
 ): pty.IPty {
-  const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
+  const config = buildSandboxPayload(script, policy, workingDirectory, containerName);
   return spawnWithConfig(config, options, workingDirectory, env);
-}
-
-/**
- * Spawn a sandboxed process using child_process.spawn (non-PTY).
- *
- * Returns the `ChildProcess` directly so the caller can manage stdout, stderr,
- * and exit events. Use this for CI/automation where reliable exit codes and
- * separate output streams are required.
- *
- * @param script The command line script to execute
- * @param policy The sandbox policy
- * @param options - Spawn options
- * @param workingDirectory Optional working directory path
- * @param containerName Optional container name
- * @param env Optional environment variables
- * @param containment Optional containment backend
- *
- * @returns The spawned ChildProcess
- *
- * @example
- * ```typescript
- * const child = spawnSandboxWithoutPty(
- *   "print('Hello from sandbox!')",
- *   { version: '0.4.0-alpha' },
- *   { experimental: true }
- * );
- * child.stdout?.on('data', (data) => console.log(data.toString()));
- * child.on('close', (code) => console.log('Exit code:', code));
- * ```
- */
-export function spawnSandboxWithoutPty(
-  script: string,
-  policy: SandboxPolicy,
-  options: SandboxSpawnOptions = {},
-  workingDirectory?: string,
-  containerName?: string,
-  env?: { [key: string]: string | undefined },
-  containment?: ContainmentType,
-): ChildProcess {
-  if (options.ptyOptions) {
-    console.warn('Warning: ptyOptions are ignored by spawnSandboxWithoutPty (non-PTY). Use spawnSandbox for PTY support.');
-  }
-  const config = buildSandboxPayload(script, policy, workingDirectory, containerName, containment);
-  const { executablePath, args } = resolveExecutableAndArgs(config, options);
-
-  return spawn(executablePath, args, {
-    cwd: workingDirectory || process.cwd(),
-    stdio: ['pipe', 'pipe', 'pipe'],
-    ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
-  });
 }
 
 /**

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -595,20 +595,34 @@ export function spawnSandboxWithoutPty(
  * @param config The container configuration (from createConfigFromPolicy)
  * @param options - Spawn options
  * @param workingDirectory Optional working directory path
- * @returns IPty object for interacting with the sandboxed process
+ * @returns IPty when usePty is true or unset; ChildProcess when usePty is false
  *
  * @example
  * ```typescript
  * const config = createConfigFromPolicy(policy, "process");
  * config.process!.commandLine = 'echo hello';
  * config.appContainer!.ui!.isolation = "atoms";
+ *
+ * // PTY mode (default) — returns IPty:
  * const ptyProcess = spawnSandboxFromConfig(config);
  *
- * // Non-PTY mode for reliable exit codes:
+ * // Non-PTY mode — returns ChildProcess with reliable exit codes:
  * const child = spawnSandboxFromConfig(config, { usePty: false });
  * child.stdout?.on('data', (data) => console.log(data.toString()));
  * ```
  */
+export function spawnSandboxFromConfig(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions & { usePty: false },
+  workingDirectory?: string,
+  env?: { [key: string]: string | undefined }
+): ChildProcess;
+export function spawnSandboxFromConfig(
+  config: ContainerConfig,
+  options?: SandboxSpawnOptions,
+  workingDirectory?: string,
+  env?: { [key: string]: string | undefined }
+): pty.IPty;
 export function spawnSandboxFromConfig(
   config: ContainerConfig,
   options: SandboxSpawnOptions = {},
@@ -620,7 +634,7 @@ export function spawnSandboxFromConfig(
     return spawn(executablePath, args, {
       cwd: workingDirectory || process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'],
-      ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
+      ...(env ? { env: { ...process.env, ...env } as NodeJS.ProcessEnv } : {}),
     });
   }
   return spawnWithConfig(config, options, workingDirectory, env);

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -5,52 +5,12 @@ import * as pty from 'node-pty';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
-import * as path from 'path';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
 import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 import { FileLogger } from './logger';
-
-/**
- * Generate a timestamped log file path in the given directory.
- */
-function makeLogFilePath(dir: string): string {
-  const ts = new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, '');
-  const suffix = randomBytes(3).toString('hex');
-  return path.join(dir, `mxc-diag-${ts}-${suffix}.log`);
-}
-
-/**
- * Sets up logging and resolves the executable path + args.
- * Shared by both PTY and non-PTY spawn paths.
- */
-function prepareSpawn(
-  config: ContainerConfig,
-  options: SandboxSpawnOptions,
-): { executablePath: string; args: string[]; logger?: FileLogger; logFile?: string; startTime: number } {
-  let logger: FileLogger | undefined;
-  let logFile: string | undefined;
-  const logDir = options.logDir ?? (options.debug ? path.join(os.tmpdir(), 'mxc-logs') : undefined);
-  if (logDir) {
-    logFile = makeLogFilePath(logDir);
-    logger = new FileLogger(logFile);
-    logger.log('info', 'mxc.log.created', { logFile });
-  }
-
-  const startTime = Date.now();
-  logger?.log('info', 'mxc.spawn.start', {
-    platform: os.platform(),
-    arch: os.arch(),
-    containment: config.containment,
-  });
-
-  const { executablePath, args } = resolveExecutableAndArgs(config, options);
-
-  logger?.log('info', 'mxc.binary.resolved', { resolved: !!executablePath });
-
-  return { executablePath, args, logger, logFile, startTime };
-}
+import { prepareSpawn } from './helper';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
 const MIN_VERSION = '0.4.0-alpha';
@@ -478,7 +438,7 @@ function spawnWithConfig(
   workingDirectory?: string,
   env?: { [key: string]: string | undefined },
 ): pty.IPty {
-  const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
+  const { executablePath, args, logger, startTime } = prepareSpawn(config, options, resolveExecutableAndArgs);
 
   try {
     const ptyOpts: pty.IPtyForkOptions = {
@@ -639,7 +599,7 @@ export function spawnSandboxFromConfig(
   env?: { [key: string]: string | undefined }
 ): pty.IPty | ChildProcess {
   if (options.usePty === false) {
-    const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
+    const { executablePath, args, logger, startTime } = prepareSpawn(config, options, resolveExecutableAndArgs);
     try {
       const child = spawn(executablePath, args, {
         cwd: workingDirectory || process.cwd(),

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -4,12 +4,9 @@
 import * as pty from 'node-pty';
 import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
-import * as fs from 'fs';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, SandboxingMethod, ContainerConfig, ContainmentType, ExperimentalBackends } from './types';
-import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
-import { FileLogger } from './logger';
+import { SandboxPolicy, ContainerConfig, ContainmentType } from './types';
 import { prepareSpawn } from './helper';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
@@ -353,83 +350,6 @@ export interface SandboxSpawnOptions {
 }
 
 /**
- * Resolves the executable path and builds CLI arguments for a sandbox invocation.
- * Shared setup used by both PTY and non-PTY spawn paths.
- */
-function resolveExecutableAndArgs(
-  config: ContainerConfig,
-  options: SandboxSpawnOptions = {},
-): { executablePath: string; args: string[] } {
-  if (!config.process?.commandLine) {
-    throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
-  }
-
-  const platformSupport = getPlatformSupport();
-  if (!platformSupport.isSupported) {
-    throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
-  }
-
-  // Validate containment against platform
-  if (config.containment) {
-    if (config.containment === 'microvm' && os.platform() !== 'win32') {
-      throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
-    }
-    if (!(ExperimentalBackends as readonly string[]).includes(config.containment) &&
-        !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
-      throw new Error(
-        `Containment backend '${config.containment}' is not available on this platform. ` +
-        `Available methods: ${platformSupport.availableMethods.join(', ')}`
-      );
-    }
-  }
-
-  const platform = os.platform();
-  let executablePath: string | null;
-
-  if (options.executablePath) {
-    if (!fs.existsSync(options.executablePath)) {
-      throw new Error(`File not found: ${options.executablePath}`);
-    }
-    executablePath = options.executablePath;
-  } else if (platform === 'linux') {
-    executablePath = findLxcExecutable();
-    if (!executablePath) {
-      throw new Error(
-        'lxc-exec not found. Ensure it is built and available in a standard location.'
-      );
-    }
-  } else {
-    executablePath = findWxcExecutable();
-    if (!executablePath) {
-      throw new Error(
-        'wxc-exec.exe not found. Set options.executablePath or ensure it exists in a standard location.'
-      );
-    }
-  }
-
-  const args: string[] = [];
-  const configJson = JSON.stringify(config);
-  const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
-  args.push('--config-base64', configBase64);
-
-  if (options.debug) {
-    args.push('--debug');
-  }
-
-  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
-    throw new Error(
-      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
-    );
-  }
-
-  if (options.experimental) {
-    args.push('--experimental');
-  }
-
-  return { executablePath, args };
-}
-
-/**
  * Internal helper: resolves the executor binary path and spawns a PTY process.
  */
 function spawnWithConfig(
@@ -438,7 +358,7 @@ function spawnWithConfig(
   workingDirectory?: string,
   env?: { [key: string]: string | undefined },
 ): pty.IPty {
-  const { executablePath, args, logger, startTime } = prepareSpawn(config, options, resolveExecutableAndArgs);
+  const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
 
   try {
     const ptyOpts: pty.IPtyForkOptions = {
@@ -547,7 +467,7 @@ export function spawnSandboxFromConfig(
   env?: { [key: string]: string | undefined }
 ): pty.IPty | ChildProcess {
   if (options.usePty === false) {
-    const { executablePath, args, logger, startTime } = prepareSpawn(config, options, resolveExecutableAndArgs);
+    const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
     try {
       const child = spawn(executablePath, args, {
         cwd: workingDirectory || process.cwd(),

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -608,6 +608,42 @@ export function spawnSandboxFromConfig(
 }
 
 /**
+ * Spawn a sandboxed process from a pre-built ContainerConfig using child_process.spawn (non-PTY).
+ *
+ * Use with `createConfigFromPolicy()` when you need to customize backend-specific
+ * settings before spawning, and need reliable exit codes and separate stdout/stderr streams.
+ *
+ * @param config The container configuration (from createConfigFromPolicy)
+ * @param options - Spawn options
+ * @param workingDirectory Optional working directory path
+ * @returns The spawned ChildProcess
+ *
+ * @example
+ * ```typescript
+ * const config = createConfigFromPolicy(policy, 'wslc');
+ * config.process!.commandLine = 'echo hello';
+ * config.experimental!.wslc!.image = 'python:3.12';
+ * const child = spawnSandboxFromConfigWithoutPty(config, { experimental: true });
+ * child.stdout?.on('data', (data) => console.log(data.toString()));
+ * child.on('close', (code) => console.log('Exit code:', code));
+ * ```
+ */
+export function spawnSandboxFromConfigWithoutPty(
+  config: ContainerConfig,
+  options: SandboxSpawnOptions = {},
+  workingDirectory?: string,
+  env?: { [key: string]: string | undefined }
+): ChildProcess {
+  const { executablePath, args } = resolveExecutableAndArgs(config, options);
+
+  return spawn(executablePath, args, {
+    cwd: workingDirectory || process.cwd(),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...(env ? { env: env as NodeJS.ProcessEnv } : {}),
+  });
+}
+
+/**
  * Spawn a sandboxed process and return a promise that resolves with output.
  * Convenience wrapper around spawnSandbox for non-interactive use cases.
  *


### PR DESCRIPTION
Adds a usePty option to SandboxSpawnOptions so spawnSandboxFromConfig can use child_process.spawn (non-PTY) for reliable exit codes and separate stdout/stderr streams. Also adds the first SDK-level E2E test for WSLC, validating that WSLC-specific fields flow through end-to-end.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/209)