### PR TITLE
[WSLC] Add execution timeout enforcement for WSLC containers

### DIFF
--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -814,17 +814,45 @@ impl WSLContainerRunner {
         }
         let process_guard = WslcProcessGuard::from_raw(process, sdk.WslcReleaseProcess);
 
-        // -- Step 12: Wait for exit (callbacks capture I/O during execution) --
+        // -- Step 12: Wait for exit with timeout enforcement --
         let mut exit_event: HANDLE = ptr::null_mut();
         let hr = (sdk.WslcGetProcessExitEvent)(process_guard.as_raw(), &mut exit_event);
         if hr != S_OK {
             return sdk_error("WslcGetProcessExitEvent failed", hr, "");
         }
+
+        // Use configured timeout, or wait indefinitely if not set.
+        let wait_ms = if request.script_timeout > 0 {
+            request.script_timeout
+        } else {
+            u32::MAX
+        };
+
+        let mut timed_out = false;
         if !exit_event.is_null() {
-            windows::Win32::System::Threading::WaitForSingleObject(
+            let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
                 windows::Win32::Foundation::HANDLE(exit_event),
-                u32::MAX,
+                wait_ms,
             );
+            // WAIT_TIMEOUT = 0x00000102 (258)
+            if wait_result.0 == 258 {
+                timed_out = true;
+                let _ = writeln!(
+                    logger,
+                    "[WSLC] Execution timeout ({}ms) reached — stopping container",
+                    wait_ms
+                );
+                // Send SIGTERM with 2-second grace period; the SDK escalates
+                // to SIGKILL automatically if the process doesn't exit.
+                err_msg = CoTaskMemPWSTR::null();
+                let _ = WslcStopContainer(
+                    container_guard.as_raw(),
+                    WslcSignal::SigTerm,
+                    2,
+                    err_msg.as_mut_ptr(),
+                );
+                drop(err_msg);
+            }
         }
 
         // Wait for exit callback to fire — this guarantees all I/O is flushed
@@ -849,10 +877,14 @@ impl WSLContainerRunner {
 
         let mut exit_code: i32 = -1;
         let hr = (sdk.WslcGetProcessExitCode)(process_guard.as_raw(), &mut exit_code);
-        if hr != S_OK {
+        if hr != S_OK && !timed_out {
             return sdk_error("WslcGetProcessExitCode failed", hr, "");
         }
-        let _ = writeln!(logger, "[WSLC] Process exited with code {}", exit_code);
+        if timed_out {
+            let _ = writeln!(logger, "[WSLC] Process killed after timeout");
+        } else {
+            let _ = writeln!(logger, "[WSLC] Process exited with code {}", exit_code);
+        }
 
         // -- Step 13: Collect captured I/O from callbacks (guaranteed flushed) --
         let stdout =
@@ -900,10 +932,14 @@ impl WSLContainerRunner {
         // for the Release calls, and the process exits shortly after.
 
         ScriptResponse {
-            exit_code,
+            exit_code: if timed_out { -1 } else { exit_code },
             standard_out: stdout,
             standard_err: stderr,
-            error_message: String::new(),
+            error_message: if timed_out {
+                format!("Process timed out after {}ms and was terminated", wait_ms)
+            } else {
+                String::new()
+            },
         }
     }
 }

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -845,7 +845,7 @@ impl WSLContainerRunner {
                 // Send SIGTERM with 2-second grace period; the SDK escalates
                 // to SIGKILL automatically if the process doesn't exit.
                 err_msg = CoTaskMemPWSTR::null();
-                let _ = WslcStopContainer(
+                let _ = (sdk.WslcStopContainer)(
                     container_guard.as_raw(),
                     WslcSignal::SigTerm,
                     2,

--- a/test_configs/wslc_timeout.json
+++ b/test_configs/wslc_timeout.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-timeout-test",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "sh -c 'echo Starting long task; sleep 120; echo Should not reach here'",
+    "timeout": 5000
+  },
+  "network": {
+    "defaultPolicy": "block"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "alpine:latest"
+    }
+  }
+}

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -150,6 +150,9 @@ $null = $results.Add((Run-WslcTest "wslc_custom_registry_quay.json" -OutputConta
 $null = $results.Add((Run-WslcTest "wslc_tar_import_rootfs.json" -OutputContains "Hello from tar-imported image"))
 $null = $results.Add((Run-WslcTest "wslc_tar_import_docker_save.json" -OutputContains "Hello from docker-save image"))
 
+Write-Host "`n--- Timeout Tests ---" -ForegroundColor Cyan
+$null = $results.Add((Run-WslcTest "wslc_timeout.json" -ExpectedExit -1 -OutputContains "Starting long task"))
+
 # Summary
 $passed = ($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count
 $failed = ($results | Where-Object { -not $_.Pass -and -not $_.Skipped }).Count


### PR DESCRIPTION
Implements process execution timeout for the WSLC backend. Previously, WaitForSingleObject waited indefinitely (u32::MAX) for the process to exit, meaning a hung or long-running process would block forever. Now the configured script_timeout is enforced- the container is killed after the specified duration.

Fixes #160 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/210)