### PR TITLE
Refactor SDK tests: dry-run support and test restructure

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -110,6 +110,16 @@ extends:
             displayName: Use Node.js 20
             inputs:
               versionSpec: '20.x'
+          - task: CopyFiles@2
+            displayName: Copy .npmrc to SDK
+            inputs:
+              SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
+              Contents: '.npmrc'
+              TargetFolder: '$(Build.SourcesDirectory)/sdk'
+          - task: NpmAuthenticate@0
+            displayName: NPM Authenticate
+            inputs:
+              workingFile: '$(Build.SourcesDirectory)/sdk/.npmrc'
           - script: npm ci
             workingDirectory: $(Build.SourcesDirectory)/sdk
             displayName: npm ci

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -106,6 +106,10 @@ extends:
           os: windows
         steps:
           - checkout: self
+          - task: NodeTool@0
+            displayName: Use Node.js 20
+            inputs:
+              versionSpec: '20.x'
           - script: npm ci
             workingDirectory: $(Build.SourcesDirectory)/sdk
             displayName: npm ci

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -31,6 +31,11 @@ parameters:
       signCertName: ''
       clientId: ''
 
+  - name: debug
+    displayName: Enable debug output for SDK tests
+    type: boolean
+    default: false
+
 variables:
   # Prevents failure when no Rust tests are found; pipeline runs will still fail if present
   # tests do not pass.
@@ -99,9 +104,13 @@ extends:
       dependsOn: []
       jobs:
       - template: .azure-pipelines/templates/SDK.Unit.Test.Job.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}
 
     - stage: SDK_Integration_Tests
       displayName: 'SDK Integration Tests'
       dependsOn: Package_MXC_NPM_SDK
       jobs:
       - template: .azure-pipelines/templates/SDK.Integration.Test.Job.yml@self
+        parameters:
+          debug: ${{ parameters.debug }}

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -96,7 +96,7 @@ extends:
 
     - stage: SDK_Unit_Tests
       displayName: 'SDK Unit Tests'
-      dependsOn: Build_Binaries
+      dependsOn: []
       jobs:
       - job: sdk_unit_tests_windows
         displayName: SDK Unit Tests (Windows)

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -94,6 +94,28 @@ extends:
 
           ESRPInfo: ${{ parameters.ESRPInfo }}
 
+    - stage: SDK_Unit_Tests
+      displayName: 'SDK Unit Tests'
+      dependsOn: Build_Binaries
+      jobs:
+      - job: sdk_unit_tests_windows
+        displayName: SDK Unit Tests (Windows)
+        pool:
+          name: Azure-Pipelines-1ESPT-ExDShared
+          image: windows-2022
+          os: windows
+        steps:
+          - checkout: self
+          - script: npm ci
+            workingDirectory: $(Build.SourcesDirectory)/sdk
+            displayName: npm ci
+          - script: npm run build
+            workingDirectory: $(Build.SourcesDirectory)/sdk
+            displayName: npm run build
+          - script: npm test
+            workingDirectory: $(Build.SourcesDirectory)/sdk
+            displayName: npm test
+
     - stage: SDK_Integration_Tests
       displayName: 'SDK Integration Tests'
       dependsOn: Package_MXC_NPM_SDK

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -93,3 +93,9 @@ extends:
               sdkArch: arm64
 
           ESRPInfo: ${{ parameters.ESRPInfo }}
+
+    - stage: SDK_Integration_Tests
+      displayName: 'SDK Integration Tests'
+      dependsOn: Package_MXC_NPM_SDK
+      jobs:
+      - template: .azure-pipelines/templates/SDK.Integration.Test.Job.yml@self

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -98,37 +98,7 @@ extends:
       displayName: 'SDK Unit Tests'
       dependsOn: []
       jobs:
-      - job: sdk_unit_tests_windows
-        displayName: SDK Unit Tests (Windows)
-        pool:
-          name: Azure-Pipelines-1ESPT-ExDShared
-          image: windows-2022
-          os: windows
-        steps:
-          - checkout: self
-          - task: NodeTool@0
-            displayName: Use Node.js 20
-            inputs:
-              versionSpec: '20.x'
-          - task: CopyFiles@2
-            displayName: Copy .npmrc to SDK
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
-              Contents: '.npmrc'
-              TargetFolder: '$(Build.SourcesDirectory)/sdk'
-          - task: NpmAuthenticate@0
-            displayName: NPM Authenticate
-            inputs:
-              workingFile: '$(Build.SourcesDirectory)/sdk/.npmrc'
-          - script: npm ci
-            workingDirectory: $(Build.SourcesDirectory)/sdk
-            displayName: npm ci
-          - script: npm run build
-            workingDirectory: $(Build.SourcesDirectory)/sdk
-            displayName: npm run build
-          - script: npm test
-            workingDirectory: $(Build.SourcesDirectory)/sdk
-            displayName: npm test
+      - template: .azure-pipelines/templates/SDK.Unit.Test.Job.yml@self
 
     - stage: SDK_Integration_Tests
       displayName: 'SDK Integration Tests'

--- a/.azure-pipelines/1ES.Release.yml
+++ b/.azure-pipelines/1ES.Release.yml
@@ -57,8 +57,6 @@ extends:
             artifactName: mxc-npm-sdk-package
 
         displayName: Publish to NPM
-        pool:
-          type: release
         steps:
         - task: EsrpRelease@10
           displayName: 'Publish to NPM'

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -24,6 +24,11 @@ jobs:
   steps:
     - checkout: self
 
+    - task: NodeTool@0
+      displayName: Use Node.js 20
+      inputs:
+        versionSpec: '20.x'
+
     # Download all artifacts dynamically
     - ${{ each target in parameters.targets }}:
       - task: DownloadPipelineArtifact@2
@@ -31,6 +36,11 @@ jobs:
         inputs:
           artifact: ${{ target.artifact }}
           path: $(sdkDirectory)/bin/${{ target.sdkArch }}
+
+    # Pipeline artifact downloads strip Unix execute permissions.
+    # Restore +x on Linux binaries so the tarball preserves them.
+    - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
+      displayName: Restore execute permission on lxc-exec
 
     # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
     - task: CopyFiles@2

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -63,10 +63,6 @@ jobs:
       workingDirectory: $(sdkDirectory)
       displayName: npm run build
 
-    - script: npm test
-      workingDirectory: $(sdkDirectory)
-      displayName: npm test
-
     - script: npm pack
       workingDirectory: $(sdkDirectory)
       displayName: npm pack

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -14,11 +14,11 @@ jobs:
   displayName: Package Mxc Npm Sdk
   pool:
     name: Azure-Pipelines-1ESPT-ExDShared
-    image: windows-latest
-    os: windows
+    image: ubuntu-latest
+    os: linux
   variables:
-    outputDirectory: $(Build.SourcesDirectory)\out
-    sdkDirectory: $(Build.SourcesDirectory)\sdk
+    outputDirectory: $(Build.SourcesDirectory)/out
+    sdkDirectory: $(Build.SourcesDirectory)/sdk
     artifactBaseName: mxc-npm-sdk-package
 
   steps:
@@ -52,6 +52,10 @@ jobs:
     - script: npm run build
       workingDirectory: $(sdkDirectory)
       displayName: npm run build
+
+    - script: npm test
+      workingDirectory: $(sdkDirectory)
+      displayName: npm test
 
     - script: npm pack
       workingDirectory: $(sdkDirectory)

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -53,10 +53,6 @@ jobs:
       workingDirectory: $(sdkDirectory)
       displayName: npm run build
 
-    - script: npm test
-      workingDirectory: $(sdkDirectory)
-      displayName: npm test
-
     - script: npm pack
       workingDirectory: $(sdkDirectory)
       displayName: npm pack

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -63,6 +63,10 @@ jobs:
       workingDirectory: $(sdkDirectory)
       displayName: npm run build
 
+    - script: npm test
+      workingDirectory: $(sdkDirectory)
+      displayName: npm test
+
     - script: npm pack
       workingDirectory: $(sdkDirectory)
       displayName: npm pack

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -24,10 +24,10 @@ jobs:
   steps:
     - checkout: self
 
-    - task: NodeTool@0
+    - task: UseNode@1
       displayName: Use Node.js 20
       inputs:
-        versionSpec: '20.x'
+        version: '20.x'
 
     # Download all artifacts dynamically
     - ${{ each target in parameters.targets }}:

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -46,8 +46,8 @@ jobs:
         signPattern: |
             wxc-exec.exe
             winhttp-proxy-shim.exe
-            wxc-sandbox-daemon.exe
-            wxc-sandbox-agent.exe
+            wxc-windows-sandbox-daemon.exe
+            wxc-windows-sandbox-guest.exe
             wxc-test-proxy.exe
 
       # Linux specific variables

--- a/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - checkout: self
 
-      - task: NodeTool@0
+      - task: UseNode@1
         displayName: Use Node.js 20
         inputs:
-          versionSpec: '20.x'
+          version: '20.x'
 
       - task: DownloadPipelineArtifact@2
         displayName: Download SDK package

--- a/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
@@ -1,0 +1,90 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: sdkArtifact
+  type: string
+  default: mxc-npm-sdk-package
+- name: debug
+  type: boolean
+  default: false
+- name: targets
+  type: object
+  default:
+    - name: windows
+      os: windows
+    - name: linux
+      os: linux
+
+jobs:
+- ${{ each target in parameters.targets }}:
+  - job: 'test_mxc_sdk_integration_${{ target.name }}'
+    displayName: 'Test MXC SDK Integration (${{ target.name }})'
+
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      ${{ if eq(target.os, 'windows') }}:
+        image: windows-latest
+        os: windows
+      ${{ if eq(target.os, 'linux') }}:
+        image: ubuntu-latest
+        os: linux
+
+    variables:
+      integrationDirectory: $(Build.SourcesDirectory)/sdk/tests/integration
+      sdkPkgDirectory: $(Build.SourcesDirectory)/sdk-pkg
+
+    steps:
+      - checkout: self
+
+      - task: NodeTool@0
+        displayName: Use Node.js 20
+        inputs:
+          versionSpec: '20.x'
+
+      - task: DownloadPipelineArtifact@2
+        displayName: Download SDK package
+        inputs:
+          artifact: ${{ parameters.sdkArtifact }}
+          path: $(sdkPkgDirectory)
+
+      - task: CopyFiles@2
+        displayName: Copy .npmrc to integration tests
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
+          Contents: '.npmrc'
+          TargetFolder: '$(integrationDirectory)'
+
+      - task: NpmAuthenticate@0
+        displayName: NPM Authenticate
+        inputs:
+          workingFile: '$(integrationDirectory)/.npmrc'
+
+      - pwsh: |
+          $sdkTgz = (Get-Item "$(sdkPkgDirectory)/*.tgz").FullName
+          npm ci
+          npm install $sdkTgz
+        workingDirectory: $(integrationDirectory)
+        displayName: Install dependencies and SDK from artifact
+
+      - script: npm run build
+        workingDirectory: $(integrationDirectory)
+        displayName: npm run build
+
+      - ${{ if eq(target.os, 'linux') }}:
+        - script: |
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq lxc lxc-utils dnsmasq-base iptables
+          displayName: Install LXC
+
+        - script: sudo MXC_SKIP_LXC_NETWORK_TESTS=1 MXC_DEBUG=${{ parameters.debug }} npm test
+          workingDirectory: $(integrationDirectory)
+          displayName: npm test (sudo, with LXC)
+
+      - ${{ if eq(target.os, 'windows') }}:
+        - script: npm test
+          workingDirectory: $(integrationDirectory)
+          displayName: npm test
+          env:
+            MXC_DEBUG: ${{ parameters.debug }}
+            MXC_SKIP_OS_BUILD_DEPENDENT_TESTS: '1'

--- a/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+- name: targets
+  type: object
+  default:
+    - name: windows
+      os: windows
+    - name: linux
+      os: linux
+
+jobs:
+- ${{ each target in parameters.targets }}:
+  - job: 'sdk_unit_tests_${{ target.name }}'
+    displayName: 'SDK Unit Tests (${{ target.name }})'
+
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      ${{ if eq(target.os, 'windows') }}:
+        image: windows-2022
+        os: windows
+      ${{ if eq(target.os, 'linux') }}:
+        image: ubuntu-latest
+        os: linux
+
+    variables:
+      sdkDirectory: $(Build.SourcesDirectory)/sdk
+
+    steps:
+      - checkout: self
+
+      - task: NodeTool@0
+        displayName: Use Node.js 20
+        inputs:
+          versionSpec: '20.x'
+
+      - task: CopyFiles@2
+        displayName: Copy .npmrc to SDK
+        inputs:
+          SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
+          Contents: '.npmrc'
+          TargetFolder: '$(sdkDirectory)'
+
+      - task: NpmAuthenticate@0
+        displayName: NPM Authenticate
+        inputs:
+          workingFile: '$(sdkDirectory)/.npmrc'
+
+      - script: npm ci
+        workingDirectory: $(sdkDirectory)
+        displayName: npm ci
+
+      - script: npm run build
+        workingDirectory: $(sdkDirectory)
+        displayName: npm run build
+
+      - script: npm test
+        workingDirectory: $(sdkDirectory)
+        displayName: npm test

--- a/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
@@ -33,10 +33,10 @@ jobs:
     steps:
       - checkout: self
 
-      - task: NodeTool@0
+      - task: UseNode@1
         displayName: Use Node.js 20
         inputs:
-          versionSpec: '20.x'
+          version: '20.x'
 
       - task: CopyFiles@2
         displayName: Copy .npmrc to SDK

--- a/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 parameters:
+- name: debug
+  type: boolean
+  default: false
 - name: targets
   type: object
   default:
@@ -58,3 +61,5 @@ jobs:
       - script: npm test
         workingDirectory: $(sdkDirectory)
         displayName: npm test
+        env:
+          MXC_DEBUG: ${{ parameters.debug }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,8 @@ jobs:
             src/target/${{ matrix.target }}/release/wxc-exec.exe
             src/target/${{ matrix.target }}/release/winhttp-proxy-shim.exe
             src/target/${{ matrix.target }}/release/wxc-test-proxy.exe
+            src/target/${{ matrix.target }}/release/wxc-windows-sandbox-daemon.exe
+            src/target/${{ matrix.target }}/release/wxc-windows-sandbox-guest.exe
 
 
   # Build and package the TypeScript SDK with bundled wxc-exec binaries
@@ -131,15 +133,15 @@ jobs:
           path: sdk/*.tgz
 
 
-  # Build and package the TypeScript Test CLI
-  mxc-typescript-test-cli:
-    name: MXC TypeScript Test CLI
+  # Build and test the SDK integration tests against the packaged SDK
+  mxc-sdk-integration-tests:
+    name: MXC SDK Integration Tests
     needs: mxc-typescript-sdk
     runs-on: windows-latest
 
     defaults:
       run:
-        working-directory: cli
+        working-directory: sdk/tests/integration
 
     steps:
       - uses: actions/checkout@v4
@@ -154,22 +156,15 @@ jobs:
           name: npm-packages
           path: sdk-pkg
 
-      - name: Install CLI dependencies using SDK artifact
+      - name: Install dependencies and SDK from artifact
         run: |
-          $sdkTgz = (Get-Item ..\sdk-pkg\*.tgz).FullName
-          npm ci
+          $sdkTgz = (Get-Item ..\..\..\sdk-pkg\*.tgz).FullName
           npm install $sdkTgz
 
-      - name: Build CLI
+      - name: Build tests
         run: npm run build
 
       - name: Run tests
         run: npm test
-
-      - name: Pack npm package
-        run: npm pack
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cli-npm-package
-          path: cli/*.tgz
+        env:
+          MXC_SKIP_OS_BUILD_DEPENDENT_TESTS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ bld/
 *.etl
 *.log
 
+# npm pack artifacts
+*.tgz
+
 # NuGet
 packages/
 nuget.exe

--- a/build.bat
+++ b/build.bat
@@ -109,6 +109,12 @@ call npm install & call npm run build
 popd
 
 echo.
+echo Building SDK integration tests...
+pushd sdk\tests\integration
+call npm install & call npm run build
+popd
+
+echo.
 echo Build complete.
 exit /b 0
 

--- a/cli/src/test-helpers.ts
+++ b/cli/src/test-helpers.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 
-export function findTestProxyBinary(): string {
+function findTestProxyBinary(): string {
   const triple = os.arch() === 'arm64' ? 'aarch64-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
   const sdkBinPath = path.join(require.resolve('@microsoft/mxc-sdk'), '..', '..', 'bin', triple, 'wxc-test-proxy.exe');
   if (fs.existsSync(sdkBinPath)) {

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-tests/
 bin/**/*.exe
 *.log
 .DS_Store

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -10,9 +10,12 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:test-unit": "cd tests/unit && npx tsc",
     "watch": "tsc --watch",
     "clean": "rimraf dist",
-    "test": "node --test dist/sandbox.test.js dist/policy.test.js dist/logger.test.js",
+    "test": "npm run test:unit",
+    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js",
+    "test:integration": "cd tests/integration && npm install && npm run build && npm test",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -104,6 +104,10 @@ export function resolveExecutableAndArgs(
   const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
   args.push('--config-base64', configBase64);
 
+  if (options.dryRun) {
+    args.push('--dry-run');
+  }
+
   if (options.debug) {
     args.push('--debug');
   }

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -91,9 +91,9 @@ export function getPlatformSupport(): PlatformSupport {
 
   if (platform === 'linux') {
     // LXC is the only containment backend on Linux
-    support.availableMethods = ['lxc'];
     if (isLxcAvailable()) {
       support.isSupported = true;
+      support.availableMethods = ['lxc'];
     } else {
       support.reason = 'LXC is not installed or not available on this system';
     }

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -90,13 +90,13 @@ export function getPlatformSupport(): PlatformSupport {
   }
 
   if (platform === 'linux') {
-    // Check if LXC is available
+    // LXC is the only containment backend on Linux
+    support.availableMethods = ['lxc'];
     if (isLxcAvailable()) {
       support.isSupported = true;
-      support.availableMethods = ['lxc'];
-      return support;
+    } else {
+      support.reason = 'LXC is not installed or not available on this system';
     }
-    support.reason = 'LXC is not installed or not available on this system';
     return support;
   }
 

--- a/sdk/src/policy.ts
+++ b/sdk/src/policy.ts
@@ -7,7 +7,7 @@
  */
 
 import * as fs from 'fs';
-import os from 'os';
+import * as os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { randomBytes } from 'crypto';

--- a/sdk/src/policy.ts
+++ b/sdk/src/policy.ts
@@ -7,7 +7,7 @@
  */
 
 import * as fs from 'fs';
-import * as os from 'os';
+import os from 'os';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import { randomBytes } from 'crypto';

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -349,6 +349,12 @@ export interface SandboxSpawnOptions {
   ptyOptions?: pty.IPtyForkOptions;
 
   /**
+   * Dry run mode: parse and validate config without executing.
+   * The native binary validates the config then exits.
+   */
+  dryRun?: boolean;
+
+  /**
    * Directory for diagnostic log files
    */
   logDir?: string;
@@ -366,9 +372,28 @@ function resolveExecutableAndArgs(
     throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
   }
 
+  // Check experimental mode before resolving binaries
+  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
+    throw new Error(
+      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
+    );
+  }
+
   const platformSupport = getPlatformSupport();
+
   if (!platformSupport.isSupported) {
-    throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
+    if (options.dryRun) {
+      const platformHint = os.platform() === 'win32'
+        ? 'Requires Windows build 26100+ (with UBR 7965+ for builds 26100-26500).'
+        : `Platform issue: ${platformSupport.reason}.`;
+      console.warn(
+        `[mxc] Warning: ${platformSupport.reason}.\n` +
+        `  ${platformHint}\n` +
+        `  Dry-run will attempt config validation but a normal run would fail.`
+      );
+    } else {
+      throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
+    }
   }
 
   // Validate containment against platform
@@ -418,14 +443,12 @@ function resolveExecutableAndArgs(
     args.push('--debug');
   }
 
-  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
-    throw new Error(
-      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
-    );
-  }
-
   if (options.experimental) {
     args.push('--experimental');
+  }
+
+  if (options.dryRun) {
+    args.push('--dry-run');
   }
 
   return { executablePath, args };

--- a/sdk/tests/integration/.gitignore
+++ b/sdk/tests/integration/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.npmrc

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -20,10 +20,14 @@ describe('Platform support', () => {
   });
 });
 
+const skipOsBuildTests = process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
+
 for (const schemaVersion of supportedVersions) {
   const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
 
-  describe(`Dry-run smoke tests (schema ${schemaVersion})`, () => {
+  describe(`Dry-run smoke tests (schema ${schemaVersion})`, {
+    skip: skipOsBuildTests ? 'Skipped in CI (MXC_SKIP_OS_BUILD_DEPENDENT_TESTS)' : undefined,
+  }, () => {
     const policy = {
       version: schemaVersion.raw,
       filesystem: {

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -21,6 +21,8 @@ describe('Platform support', () => {
 });
 
 const skipOsBuildTests = process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
+const isLinux = os.platform() === 'linux';
+const echoCommand = isLinux ? 'echo test' : 'cmd.exe /c echo test';
 
 for (const schemaVersion of supportedVersions) {
   const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
@@ -46,7 +48,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandboxFromConfig with usePty: false', async () => {
       const config = sdk.createConfigFromPolicy(policy);
       config.process = config.process || {};
-      config.process.commandLine = 'cmd.exe /c echo test';
+      config.process.commandLine = echoCommand;
       config.containerName = `dryrun-npty-${schemaVersion}`;
 
       const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
@@ -63,7 +65,7 @@ for (const schemaVersion of supportedVersions) {
 
     it('should dry-run via spawnSandboxAsync', async () => {
       const result = await sdk.spawnSandboxAsync(
-        'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-async-${schemaVersion}`,
+        echoCommand, policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-async-${schemaVersion}`,
       );
       assertDryRunResult(result.stdout, result.exitCode, dryRunExpectation, schemaVersion.raw);
     });
@@ -71,7 +73,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandboxFromConfig', async () => {
       const config = sdk.createConfigFromPolicy(policy);
       config.process = config.process || {};
-      config.process.commandLine = 'cmd.exe /c echo test';
+      config.process.commandLine = echoCommand;
       config.containerName = `dryrun-fromcfg-${schemaVersion}`;
 
       const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
@@ -88,7 +90,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandbox (PTY)', async () => {
       const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
         const ptyProcess = sdk.spawnSandbox(
-          'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-pty-${schemaVersion}`,
+          echoCommand, policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-pty-${schemaVersion}`,
         );
         let stdout = '';
         ptyProcess.onData((data: string) => { stdout += data; });

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -39,11 +39,14 @@ for (const schemaVersion of supportedVersions) {
       timeoutMs: 30000,
     };
 
-    it('should dry-run via spawnSandboxWithoutPty', async () => {
+    it('should dry-run via spawnSandboxFromConfig with usePty: false', async () => {
+      const config = sdk.createConfigFromPolicy(policy);
+      config.process = config.process || {};
+      config.process.commandLine = 'cmd.exe /c echo test';
+      config.containerName = `dryrun-npty-${schemaVersion}`;
+
       const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
-        const child = sdk.spawnSandboxWithoutPty(
-          'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-npty-${schemaVersion}`,
-        );
+        const child = sdk.spawnSandboxFromConfig(config, { dryRun: true, usePty: false, ...debugSpawnOptions });
         let stdout = '';
         let stderr = '';
         child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import os from 'os';
+import {
+  sdk,
+  supportedVersions,
+  expectDryRunValidationPass,
+  assertDryRunResult,
+  debugSpawnOptions,
+} from './test-helpers';
+
+describe('Platform support', () => {
+  it('should report platform support information', () => {
+    const support = sdk.getPlatformSupport();
+    const assert = require('node:assert');
+    assert.ok(typeof support.isSupported === 'boolean', 'isSupported should be a boolean');
+    assert.ok(Array.isArray(support.availableMethods), 'availableMethods should be an array');
+  });
+});
+
+for (const schemaVersion of supportedVersions) {
+  const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
+
+  describe(`Dry-run smoke tests (schema ${schemaVersion})`, () => {
+    const policy = {
+      version: schemaVersion.raw,
+      filesystem: {
+        readwritePaths: [os.tmpdir()],
+        readonlyPaths: [process.cwd()],
+      },
+      network: {
+        allowOutbound: false,
+      },
+      ui: {
+        allowWindows: false,
+      },
+      timeoutMs: 30000,
+    };
+
+    it('should dry-run via spawnSandboxWithoutPty', async () => {
+      const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
+        const child = sdk.spawnSandboxWithoutPty(
+          'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-npty-${schemaVersion}`,
+        );
+        let stdout = '';
+        let stderr = '';
+        child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+        child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+        child.on('close', (code: number) => resolve({ code, stdout, stderr }));
+        child.on('error', reject);
+      });
+      assertDryRunResult(result.stdout, result.code, dryRunExpectation, schemaVersion.raw);
+    });
+
+    it('should dry-run via spawnSandboxAsync', async () => {
+      const result = await sdk.spawnSandboxAsync(
+        'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-async-${schemaVersion}`,
+      );
+      assertDryRunResult(result.stdout, result.exitCode, dryRunExpectation, schemaVersion.raw);
+    });
+
+    it('should dry-run via spawnSandboxFromConfig', async () => {
+      const config = sdk.createConfigFromPolicy(policy);
+      config.process = config.process || {};
+      config.process.commandLine = 'cmd.exe /c echo test';
+      config.containerName = `dryrun-fromcfg-${schemaVersion}`;
+
+      const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
+        const ptyProcess = sdk.spawnSandboxFromConfig(config, { dryRun: true, ...debugSpawnOptions });
+        let stdout = '';
+        ptyProcess.onData((data: string) => { stdout += data; });
+        ptyProcess.onExit((event: { exitCode: number }) => {
+          resolve({ exitCode: event.exitCode, stdout });
+        });
+      });
+      assertDryRunResult(result.stdout, result.exitCode, dryRunExpectation, schemaVersion.raw);
+    });
+
+    it('should dry-run via spawnSandbox (PTY)', async () => {
+      const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
+        const ptyProcess = sdk.spawnSandbox(
+          'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-pty-${schemaVersion}`,
+        );
+        let stdout = '';
+        ptyProcess.onData((data: string) => { stdout += data; });
+        ptyProcess.onExit((event: { exitCode: number }) => {
+          resolve({ exitCode: event.exitCode, stdout });
+        });
+      });
+      assertDryRunResult(result.stdout, result.exitCode, dryRunExpectation, schemaVersion.raw);
+    });
+  });
+}

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -20,10 +20,15 @@ describe('Platform support', () => {
   });
 });
 
+const platformSupport = sdk.getPlatformSupport();
+
 for (const schemaVersion of supportedVersions) {
   const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
+  const skipReason = !platformSupport.isSupported
+    ? `Platform not supported: ${platformSupport.reason}`
+    : undefined;
 
-  describe(`Dry-run smoke tests (schema ${schemaVersion})`, () => {
+  describe(`Dry-run smoke tests (schema ${schemaVersion})`, { skip: skipReason }, () => {
     const policy = {
       version: schemaVersion.raw,
       filesystem: {

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -20,9 +20,6 @@ describe('Platform support', () => {
   });
 });
 
-const isLinux = os.platform() === 'linux';
-const echoCommand = isLinux ? 'echo test' : 'cmd.exe /c echo test';
-
 for (const schemaVersion of supportedVersions) {
   const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
 
@@ -45,7 +42,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandboxFromConfig with usePty: false', async () => {
       const config = sdk.createConfigFromPolicy(policy);
       config.process = config.process || {};
-      config.process.commandLine = echoCommand;
+      config.process.commandLine = 'cmd.exe /c echo test';
       config.containerName = `dryrun-npty-${schemaVersion}`;
 
       const result = await new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
@@ -62,7 +59,7 @@ for (const schemaVersion of supportedVersions) {
 
     it('should dry-run via spawnSandboxAsync', async () => {
       const result = await sdk.spawnSandboxAsync(
-        echoCommand, policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-async-${schemaVersion}`,
+        'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-async-${schemaVersion}`,
       );
       assertDryRunResult(result.stdout, result.exitCode, dryRunExpectation, schemaVersion.raw);
     });
@@ -70,7 +67,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandboxFromConfig', async () => {
       const config = sdk.createConfigFromPolicy(policy);
       config.process = config.process || {};
-      config.process.commandLine = echoCommand;
+      config.process.commandLine = 'cmd.exe /c echo test';
       config.containerName = `dryrun-fromcfg-${schemaVersion}`;
 
       const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
@@ -87,7 +84,7 @@ for (const schemaVersion of supportedVersions) {
     it('should dry-run via spawnSandbox (PTY)', async () => {
       const result = await new Promise<{ exitCode: number; stdout: string }>((resolve) => {
         const ptyProcess = sdk.spawnSandbox(
-          echoCommand, policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-pty-${schemaVersion}`,
+          'cmd.exe /c echo test', policy, { dryRun: true, ...debugSpawnOptions }, undefined, `dryrun-pty-${schemaVersion}`,
         );
         let stdout = '';
         ptyProcess.onData((data: string) => { stdout += data; });

--- a/sdk/tests/integration/common.test.ts
+++ b/sdk/tests/integration/common.test.ts
@@ -20,16 +20,13 @@ describe('Platform support', () => {
   });
 });
 
-const skipOsBuildTests = process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
 const isLinux = os.platform() === 'linux';
 const echoCommand = isLinux ? 'echo test' : 'cmd.exe /c echo test';
 
 for (const schemaVersion of supportedVersions) {
   const dryRunExpectation = expectDryRunValidationPass(schemaVersion);
 
-  describe(`Dry-run smoke tests (schema ${schemaVersion})`, {
-    skip: skipOsBuildTests ? 'Skipped in CI (MXC_SKIP_OS_BUILD_DEPENDENT_TESTS)' : undefined,
-  }, () => {
+  describe(`Dry-run smoke tests (schema ${schemaVersion})`, () => {
     const policy = {
       version: schemaVersion.raw,
       filesystem: {

--- a/sdk/tests/integration/linux-process-container.test.ts
+++ b/sdk/tests/integration/linux-process-container.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  sdk,
+  supportedVersions,
+  isLinuxRoot,
+  createTempDir,
+  NETWORK_TEST_URL,
+  lxcNetworkSkipReason,
+  debugSpawnOptions,
+} from './test-helpers';
+
+for (const schemaVersion of supportedVersions) {
+describe(`Linux Process Container (schema ${schemaVersion})`, {
+  skip: !isLinuxRoot ? 'Linux Process Container tests require Linux with root privileges (sudo npm test)' : undefined,
+}, () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('should execute hello world in LXC container', async () => {
+    const result = await sdk.spawnSandboxAsync(
+      "echo 'Hello from LXC via CLI'",
+      { version: schemaVersion.raw },
+      debugSpawnOptions,
+      undefined,
+      `lxc-hello-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Hello from LXC via CLI'));
+  });
+
+  it('should propagate exit code', async () => {
+    const result = await sdk.spawnSandboxAsync(
+      "echo 'about to exit' && exit 0",
+      { version: schemaVersion.raw },
+      debugSpawnOptions,
+      undefined,
+      `lxc-exit-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('about to exit'));
+  });
+
+  it('should report system info', async () => {
+    const result = await sdk.spawnSandboxAsync(
+      "uname -a && echo 'System info test passed'",
+      { version: schemaVersion.raw },
+      debugSpawnOptions,
+      undefined,
+      `lxc-sysinfo-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('System info test passed'));
+  });
+
+  it('should allow outbound network access', { skip: lxcNetworkSkipReason }, async () => {
+    const policy = { version: schemaVersion.raw, network: { allowOutbound: true } };
+    const result = await sdk.spawnSandboxAsync(
+      `wget -q -T 10 -O /dev/null '${NETWORK_TEST_URL}' && echo 'Network accessible'`,
+      policy,
+      debugSpawnOptions,
+      undefined,
+      `lxc-net-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Network accessible'));
+  });
+
+  it('should mount readwrite filesystem path', async () => {
+    tempDir = createTempDir('mxc-lxc-test');
+    fs.writeFileSync(path.join(tempDir, 'test.txt'), 'original');
+    const policy = { version: schemaVersion.raw, filesystem: { readwritePaths: [tempDir] } };
+    const script = `cat ${tempDir}/test.txt && echo 'overwritten' > ${tempDir}/test.txt && cat ${tempDir}/test.txt`;
+    const result = await sdk.spawnSandboxAsync(
+      script, policy, debugSpawnOptions, undefined, `lxc-rw-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('overwritten'));
+  });
+
+  it('should mount readonly filesystem path', async () => {
+    tempDir = createTempDir('mxc-lxc-test');
+    fs.writeFileSync(path.join(tempDir, 'data.txt'), 'readonly content');
+    const policy = { version: schemaVersion.raw, filesystem: { readonlyPaths: [tempDir] } };
+    const result = await sdk.spawnSandboxAsync(
+      `cat ${tempDir}/data.txt && echo 'Read succeeded'`,
+      policy,
+      debugSpawnOptions,
+      undefined,
+      `lxc-ro-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Read succeeded'));
+  });
+
+  it('should download file to writable mount', { skip: lxcNetworkSkipReason }, async () => {
+    tempDir = createTempDir('mxc-lxc-test');
+    const policy = {
+      version: schemaVersion.raw,
+      filesystem: { readwritePaths: [tempDir] },
+      network: { allowOutbound: true },
+    };
+    const script =
+      `wget -q -T 10 -O ${tempDir}/download.json '${NETWORK_TEST_URL}'` +
+      ` && test -s ${tempDir}/download.json && echo 'Combined test passed'`;
+    const result = await sdk.spawnSandboxAsync(
+      script, policy, debugSpawnOptions, undefined, `lxc-combined-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Combined test passed'));
+  });
+
+  it('should access HTTPS endpoint', { skip: lxcNetworkSkipReason }, async () => {
+    const policy = { version: schemaVersion.raw, network: { allowOutbound: true } };
+    const result = await sdk.spawnSandboxAsync(
+      `wget -q -T 10 -O /dev/null '${NETWORK_TEST_URL}' && echo 'HTTPS endpoint accessible'`,
+      policy,
+      debugSpawnOptions,
+      undefined,
+      `lxc-https-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('HTTPS endpoint accessible'));
+  });
+
+  it('should run multi-command pipeline', async () => {
+    const script = "echo 'step 1' && ls / && echo 'step 2' && whoami && echo 'Multi-command passed'";
+    const result = await sdk.spawnSandboxAsync(
+      script, { version: schemaVersion.raw }, debugSpawnOptions, undefined, `lxc-pipeline-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Multi-command passed'));
+  });
+});
+}

--- a/sdk/tests/integration/package-lock.json
+++ b/sdk/tests/integration/package-lock.json
@@ -1,0 +1,98 @@
+{
+  "name": "mxc-integration-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mxc-integration-tests",
+      "version": "0.0.0",
+      "dependencies": {
+        "@microsoft/mxc-sdk": "file:../../"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@types/semver": "^7.7.1",
+        "semver": "^7.7.4",
+        "typescript": "^5.3.3"
+      }
+    },
+    "../..": {
+      "name": "@microsoft/mxc-sdk",
+      "version": "0.1.5",
+      "license": "MIT",
+      "os": [
+        "win32",
+        "linux"
+      ],
+      "dependencies": {
+        "node-pty": "^1.2.0-beta.12",
+        "semver": "^7.7.4"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@types/semver": "^7.7.1",
+        "rimraf": "^6.1.3",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@microsoft/mxc-sdk": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/sdk/tests/integration/package.json
+++ b/sdk/tests/integration/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mxc-integration-tests",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "prebuild": "node -e \"try{require('fs').rmSync('dist',{recursive:true})}catch{}\"",
+    "build": "tsc -p tsconfig.json --listEmittedFiles",
+    "test": "node run-tests.js"
+  },
+  "dependencies": {
+    "@microsoft/mxc-sdk": "file:../../"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "@types/semver": "^7.7.1",
+    "semver": "^7.7.4",
+    "typescript": "^5.3.3"
+  }
+}

--- a/sdk/tests/integration/package.test.ts
+++ b/sdk/tests/integration/package.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  getSdkBinDir,
+  EXPECTED_WINDOWS_BINARIES,
+  EXPECTED_LINUX_BINARIES,
+  ALL_KNOWN_BINARIES,
+  platformName,
+} from './test-helpers';
+
+const expectedBinaries: Record<string, string[]> = {
+  win32: EXPECTED_WINDOWS_BINARIES,
+  linux: EXPECTED_LINUX_BINARIES,
+};
+
+describe('SDK package binaries', () => {
+  const binDir = getSdkBinDir();
+  const platform = os.platform();
+  const osName = platformName();
+  const expected = expectedBinaries[platform] ?? [];
+
+  it('should have a bin directory for the current architecture', () => {
+    assert.ok(
+      fs.existsSync(binDir),
+      `SDK bin directory not found: ${binDir}`,
+    );
+  });
+
+  for (const binary of expected) {
+    it(`should include ${binary}`, () => {
+      const fullPath = path.join(binDir, binary);
+      assert.ok(
+        fs.existsSync(fullPath),
+        `Expected binary not found: ${fullPath}`,
+      );
+    });
+  }
+
+  it(`should have all ${osName} binaries present`, () => {
+    if (expected.length === 0) {
+      // No binary expectations for this platform — skip
+      return;
+    }
+    const missing = expected.filter(b => !fs.existsSync(path.join(binDir, b)));
+    assert.deepStrictEqual(
+      missing, [],
+      `Missing binaries in ${binDir}: ${missing.join(', ')}`,
+    );
+  });
+
+  it('should not contain unexpected binaries', () => {
+    if (!fs.existsSync(binDir)) {
+      return;
+    }
+    const actual = fs.readdirSync(binDir).filter(f => {
+      const stat = fs.statSync(path.join(binDir, f));
+      return stat.isFile();
+    });
+    // The npm package bundles binaries for all platforms in the same arch
+    // directory, so allow any known binary regardless of current OS.
+    const unexpected = actual.filter(f => !ALL_KNOWN_BINARIES.includes(f));
+    assert.deepStrictEqual(
+      unexpected, [],
+      `Unexpected binaries in ${binDir} — add them to the expected lists in test-helpers.ts: ${unexpected.join(', ')}`,
+    );
+  });
+});

--- a/sdk/tests/integration/run-tests.js
+++ b/sdk/tests/integration/run-tests.js
@@ -1,0 +1,16 @@
+const { readdirSync } = require('fs');
+const { join } = require('path');
+const { execFileSync } = require('child_process');
+
+const files = readdirSync('dist')
+  .filter(f => f.endsWith('.test.js'))
+  .map(f => join('dist', f));
+
+if (!files.length) {
+  console.error('No test files found in dist/');
+  process.exit(1);
+}
+
+execFileSync(process.execPath, [
+  '--test', '--test-reporter', 'spec', '--test-force-exit', ...files
+], { stdio: 'inherit' });

--- a/sdk/tests/integration/test-helpers.ts
+++ b/sdk/tests/integration/test-helpers.ts
@@ -1,0 +1,265 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawn, ChildProcess, execSync } from 'child_process';
+import assert from 'node:assert';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import semver from 'semver';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+export const sdk = require('@microsoft/mxc-sdk');
+
+// Schema versions
+
+export const supportedVersions = [
+  new semver.SemVer('0.4.0-alpha'),
+  new semver.SemVer('0.5.0-dev'),
+];
+
+// SDK package location
+
+/** Resolve the root directoryof the installed @microsoft/mxc-sdk package. */
+function getSdkPackageRoot(): string {
+  const sdkPkg = require.resolve('@microsoft/mxc-sdk/package.json');
+  return path.dirname(sdkPkg);
+}
+
+/** Return the SDK bin directory for the current architecture. */
+export function getSdkBinDir(): string {
+  const arch = os.arch() === 'arm64' ? 'arm64' : 'x64';
+  return path.join(getSdkPackageRoot(), 'bin', arch);
+}
+
+// Expected package binaries
+
+export const EXPECTED_WINDOWS_BINARIES = [
+  'wxc-exec.exe',
+  'winhttp-proxy-shim.exe',
+  'wxc-test-proxy.exe',
+  'wxc-windows-sandbox-daemon.exe',
+  'wxc-windows-sandbox-guest.exe',
+];
+
+export const EXPECTED_LINUX_BINARIES = [
+  'lxc-exec',
+];
+
+// Binaries that are optional (feature-gated or only present in certain builds)
+// but still legitimate if found in the package.
+const OPTIONAL_BINARIES = [
+  'wslcsdk.dll',   // Only built with --with-wslc
+];
+
+// Combined list of all known binaries across platforms. The npm package
+// bundles both Windows and Linux binaries in the same arch directory, so
+// the "no unexpected binaries" check must allow binaries from either OS.
+export const ALL_KNOWN_BINARIES = [
+  ...EXPECTED_WINDOWS_BINARIES,
+  ...EXPECTED_LINUX_BINARIES,
+  ...OPTIONAL_BINARIES,
+];
+
+// Platform / version helpers
+
+/** Return a human-friendly OS name for test descriptions. */
+export function platformName(): string {
+  return os.platform() === 'win32' ? 'Windows' : 'Linux';
+}
+
+/**
+ * Check whether the BaseContainer API(processmodel.dll) is likely available.
+ * Mirrors the Rust-side probe in `BaseContainerRunner::load_api()`.
+ */
+function isBaseContainerApiPresent(): boolean {
+  const dllPath = path.join(
+    process.env.SystemRoot ?? 'C:\\Windows',
+    'System32',
+    'processmodel.dll',
+  );
+  return fs.existsSync(dllPath);
+}
+
+export enum DryRunExpectation {
+  ValidationPass = 'validation_pass',
+  ValidationFail = 'validation_fail',
+}
+
+const BASE_CONTAINER_MIN_VERSION = new semver.SemVer('0.5.0');
+
+/** Returns true if the given schema version selects the BaseContainer backend. */
+function isBaseContainerVersion(schemaVersion: semver.SemVer): boolean {
+  return schemaVersion.major > BASE_CONTAINER_MIN_VERSION.major ||
+    (schemaVersion.major === BASE_CONTAINER_MIN_VERSION.major &&
+     schemaVersion.minor >= BASE_CONTAINER_MIN_VERSION.minor);
+}
+
+/** Returns the expected dry-run outcome for the given schema version on this platform. */
+export function expectDryRunValidationPass(schemaVersion: semver.SemVer): DryRunExpectation {
+  if (os.platform() !== 'win32') {
+    return DryRunExpectation.ValidationPass;
+  }
+  if (isBaseContainerVersion(schemaVersion) && !isBaseContainerApiPresent()) {
+    return DryRunExpectation.ValidationFail;
+  }
+  return DryRunExpectation.ValidationPass;
+}
+
+/** Assert that a dry-run result matches the expected outcome. */
+export function assertDryRunResult(
+  stdout: string,
+  exitCode: number,
+  expectation: DryRunExpectation,
+  version: string,
+): void {
+  if (expectation === DryRunExpectation.ValidationPass) {
+    assert.strictEqual(exitCode, 0, `[${version}] Expected exit 0 but got ${exitCode}`);
+    assert.ok(stdout.includes('Dry run completed. Result: validation passed'), `[${version}] ${stdout}`);
+  } else {
+    assert.notStrictEqual(exitCode, 0, `[${version}] Expected non-zero exit for validation failure`);
+    assert.ok(stdout.includes('Dry run completed. Result: validation failed'), `[${version}] ${stdout}`);
+  }
+}
+
+// Environment / skip helpers
+
+const skipOsDependentTests= process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
+export const sandboxSkipReason = skipOsDependentTests
+  ? 'Skipped in CI (MXC_SKIP_OS_BUILD_DEPENDENT_TESTS)'
+  : undefined;
+
+export const isLinuxRoot = os.platform() === 'linux' && process.getuid?.() === 0;
+
+// When MXC_DEBUG=true, integration tests pass { debug: true } to spawn options
+// so wxc-exec / lxc-exec emit verbose output. Enable via pipeline parameter or locally.
+const debugMode = process.env.MXC_DEBUG === 'true';
+export const debugSpawnOptions = debugMode ? { debug: true } : {};
+
+// Network test endpoint reachable from both CI (Azure DevOps agents block
+// external traffic but allow Azure Artifacts feeds) and local builds.
+export const NETWORK_TEST_URL =
+  'https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/npm/registry/@types/json-schema';
+
+// TODO: Investigate LXC container networking on CI agents. Containers lack
+// network bridge/NAT config on hosted Ubuntu runners, causing outbound
+// requests to fail. Needs lxcbr0 bridge + IP forwarding + DNS setup.
+// Set MXC_SKIP_LXC_NETWORK_TESTS=1 to skip network-dependent LXC tests.
+const skipLxcNetworkTests = process.env.MXC_SKIP_LXC_NETWORK_TESTS === '1';
+export const lxcNetworkSkipReason = skipLxcNetworkTests
+  ? 'Skipped: LXC network not available in this environment (MXC_SKIP_LXC_NETWORK_TESTS)'
+  : undefined;
+
+// Temp directory helpers
+
+export function createTempDir(prefix: string = 'mxc-test'): string {
+  const tmpBase = fs.realpathSync.native(os.tmpdir());
+  const dir = path.join(tmpBase, `${prefix}-${Date.now()}`);
+  fs.mkdirSync(dir);
+  return dir;
+}
+
+// Python helpers
+
+/** Detect a usable Python command. Returns undefined if not installed. */
+function detectPython(): { command: string | undefined; prefix: string | undefined } {
+  const candidates = os.platform() === 'win32' ? ['python', 'python3'] : ['python3', 'python'];
+  for (const cmd of candidates) {
+    try {
+      const prefix = execSync(`${cmd} -c "import sys; print(sys.prefix)"`, {
+        encoding: 'utf-8',
+        timeout: 10000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      if (!prefix || prefix.toLowerCase().includes('was not found')) continue;
+      return { command: cmd, prefix };
+    } catch {
+      continue;
+    }
+  }
+  return { command: undefined, prefix: undefined };
+}
+
+const _python = detectPython();
+
+export const pythonCommand: string | undefined = _python.command;
+export const pythonSkipReason: string | undefined = _python.command ? undefined : 'No Python installation found';
+
+/**
+ * Merge host tool paths into a policy so the container can find installed tools.
+ * Adds the Python prefix as a readwrite path when needed for DLL loading.
+ */
+export function withToolPaths(policy: Record<string, any>): Record<string, any> {
+  const toolsPolicy = sdk.getAvailableToolsPolicy(process.env);
+  const merged = { ...policy, filesystem: { ...policy.filesystem } };
+
+  const extraReadwrite: string[] = [];
+  if (_python.prefix) {
+    extraReadwrite.push(_python.prefix);
+  }
+
+  if (toolsPolicy.readonlyPaths.length > 0) {
+    merged.filesystem.readonlyPaths = [
+      ...(merged.filesystem.readonlyPaths ?? []),
+      ...toolsPolicy.readonlyPaths,
+    ];
+  }
+  if (toolsPolicy.readwritePaths.length > 0 || extraReadwrite.length > 0) {
+    merged.filesystem.readwritePaths = [
+      ...(merged.filesystem.readwritePaths ?? []),
+      ...toolsPolicy.readwritePaths,
+      ...extraReadwrite,
+    ];
+  }
+  return merged;
+}
+
+// Windows-only: proxy helpers
+
+/** Locate wxc-test-proxy.exein the SDK package bin directory (package only, no local fallback). */
+function findTestProxyBinary(): string {
+  const binDir = getSdkBinDir();
+  const proxyPath = path.join(binDir, 'wxc-test-proxy.exe');
+  if (fs.existsSync(proxyPath)) {
+    return proxyPath;
+  }
+  throw new Error(`wxc-test-proxy.exe not found at expected SDK package location: ${proxyPath}`);
+}
+
+/**
+ * Start wxc-test-proxy.exe in a child process.
+ * It binds to an OS-assigned port and writes it to a ready file.
+ * Uses --parent-pid so the proxy exits when tests finish.
+ */
+export function startTestProxy(dir: string): { port: number; proxyProcess: ChildProcess } {
+  const proxyPath = findTestProxyBinary();
+  const readyFile = path.join(dir, 'proxy-ready.txt');
+  const eventName = `Local\\mxc-cli-test-${process.pid}-${Date.now()}`;
+
+  const proxyProcess = spawn(proxyPath, [
+    '--ready-file', readyFile,
+    '--cleanup-event', eventName,
+    '--parent-pid', process.pid.toString(),
+  ], { stdio: 'ignore' });
+
+  // Poll for the ready file (up to 15 seconds)
+  const deadline = Date.now() + 15000;
+  while (!fs.existsSync(readyFile) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+
+  if (!fs.existsSync(readyFile)) {
+    proxyProcess.kill();
+    throw new Error('wxc-test-proxy did not write ready file within 15 seconds');
+  }
+
+  const portStr = fs.readFileSync(readyFile, 'utf-8').trim();
+  const port = parseInt(portStr, 10);
+  if (isNaN(port) || port <= 0) {
+    proxyProcess.kill();
+    throw new Error(`Invalid port in ready file: ${portStr}`);
+  }
+
+  return { port, proxyProcess };
+}
+

--- a/sdk/tests/integration/test_issues.md
+++ b/sdk/tests/integration/test_issues.md
@@ -1,0 +1,13 @@
+# Known Test Issues
+
+## Store Python fails in AppContainer and BaseContainer
+
+**Tests:** `should execute python in process container`, `should allow writing to brokered readwrite path`
+
+Store Python's App Execution Alias reparse points can't be resolved inside sandboxes. Use MSI Python with `ALL APPLICATION PACKAGES:(RX)` ACL instead.
+
+## Proxy tests timeout
+
+**Tests:** `should route traffic through built-in proxy`, `should route traffic through external proxy`
+
+Base process container proxy test stalls mid-round-trip. Tests should use PowerShell and WinHTTP COM instead of curl.

--- a/sdk/tests/integration/test_issues.md
+++ b/sdk/tests/integration/test_issues.md
@@ -2,12 +2,12 @@
 
 ## Store Python fails in AppContainer and BaseContainer
 
-**Tests:** `should execute python in process container`, `should allow writing to brokered readwrite path`
-
-Store Python's App Execution Alias reparse points can't be resolved inside sandboxes. Use MSI Python with `ALL APPLICATION PACKAGES:(RX)` ACL instead.
+Store Python App Execution Alias reparse points can't be resolved inside sandboxes. See #66.
 
 ## Proxy tests timeout
 
-**Tests:** `should route traffic through built-in proxy`, `should route traffic through external proxy`
+Base process container proxy test stalls mid-round-trip when using 0.5.0 schema. Traffic reaches the proxy but times out on external requests.
 
-Base process container proxy test stalls mid-round-trip. Tests should use PowerShell and WinHTTP COM instead of curl.
+## LXC network tests fail in CI
+
+LXC containers lack network bridge/NAT config on hosted Ubuntu runners, causing outbound connectivity failures.

--- a/sdk/tests/integration/tsconfig.json
+++ b/sdk/tests/integration/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/sdk/tests/integration/windows-process-container.test.ts
+++ b/sdk/tests/integration/windows-process-container.test.ts
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, before, after, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  sdk,
+  supportedVersions,
+  sandboxSkipReason,
+  createTempDir,
+  withToolPaths,
+  startTestProxy,
+  debugSpawnOptions,
+  pythonCommand,
+  pythonSkipReason,
+} from './test-helpers';
+
+for (const schemaVersion of supportedVersions) {
+describe(`Windows Process Container (schema ${schemaVersion})`, {
+  skip: os.platform() !== 'win32' ? 'Windows Process Container tests can only be ran on Windows' : undefined,
+}, () => {
+  let tempDir = '';
+
+  afterEach(() => {
+    if (tempDir && fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      tempDir = '';
+    }
+  });
+
+  it('should execute cmd.exe in process container', { skip: sandboxSkipReason }, async () => {
+    const result = await sdk.spawnSandboxAsync(
+      'cmd.exe /c echo Container test successful',
+      { version: schemaVersion.raw },
+      debugSpawnOptions,
+      undefined,
+      `test-1-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Container test successful'));
+  });
+
+  it('should execute powershell 5.1 in process container', { skip: sandboxSkipReason }, async () => {
+    const result = await sdk.spawnSandboxAsync(
+      "powershell.exe -NoProfile -Command Write-Output 'PowerShell test successful'",
+      { version: schemaVersion.raw, ui: { allowWindows: true } },
+      debugSpawnOptions,
+      undefined,
+      `test-2-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('PowerShell test successful'));
+  });
+
+  it('should execute python in process container', { skip: sandboxSkipReason ?? pythonSkipReason }, async () => {
+    const policy = withToolPaths({ version: schemaVersion.raw, ui: { allowWindows: true } });
+    const result = await sdk.spawnSandboxAsync(
+      `${pythonCommand} -c "print('Python test successful')"`,
+      policy,
+      debugSpawnOptions,
+      undefined,
+      `test-3-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Python test successful'));
+  });
+
+  it('should allow writing to brokered readwrite path', { skip: sandboxSkipReason ?? pythonSkipReason }, async () => {
+    tempDir = createTempDir();
+    const testFile = path.join(tempDir, 'output.txt');
+    const scriptFile = path.join(tempDir, 'write_test.py');
+    fs.writeFileSync(scriptFile, `f = open(r'${testFile}', 'w')\nf.write('hello')\nf.close()\nprint('WRITE_OK')\n`);
+    const policy = withToolPaths({
+      version: schemaVersion.raw,
+      ui: { allowWindows: true },
+      filesystem: { readwritePaths: [tempDir] },
+    });
+    const result = await sdk.spawnSandboxAsync(
+      `${pythonCommand} ${scriptFile}`,
+      policy,
+      debugSpawnOptions,
+      tempDir,
+      `test-4-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('WRITE_OK'));
+    assert.ok(fs.existsSync(testFile), 'File should have been written to readwrite path');
+  });
+
+  it('should allow reading from brokered readonly path', { skip: sandboxSkipReason }, async () => {
+    tempDir = createTempDir();
+    fs.writeFileSync(path.join(tempDir, 'input.txt'), 'readonly test data');
+    const inputFile = path.join(tempDir, 'input.txt');
+    const policy = withToolPaths({
+      version: schemaVersion.raw,
+      filesystem: { readonlyPaths: [tempDir] },
+    });
+    const result = await sdk.spawnSandboxAsync(
+      `cmd.exe /c type ${inputFile}`,
+      policy,
+      debugSpawnOptions,
+      tempDir,
+      `test-5-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('readonly test data'));
+  });
+
+  it('should launch basic process container with valid version', { skip: sandboxSkipReason }, async () => {
+    const result = await sdk.spawnSandboxAsync(
+      'cmd.exe /c echo version ok',
+      { version: schemaVersion.raw },
+      debugSpawnOptions,
+      undefined,
+      `test-ver-${schemaVersion}`,
+    );
+    assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+    assert.ok(result.stdout.includes('version ok'));
+  });
+
+  describe('proxy end-to-end', { skip: sandboxSkipReason }, () => {
+    let proxyProcess: ChildProcess | null = null;
+    let originalMaxListeners: number;
+
+    // Proxy tests can accumulate socket listeners when connections hang (e.g. BaseContainer proxy issues).
+    // Raise the cap to avoid spurious MaxListenersExceededWarning noise in test output.
+    before(() => {
+      originalMaxListeners = EventEmitter.defaultMaxListeners;
+      EventEmitter.defaultMaxListeners = 30;
+    });
+    after(() => {
+      EventEmitter.defaultMaxListeners = originalMaxListeners;
+    });
+
+    afterEach(() => {
+      if (proxyProcess) {
+        proxyProcess.kill();
+        proxyProcess = null;
+      }
+    });
+
+    it('should route traffic through built-in proxy', async () => {
+      tempDir = createTempDir('mxc-proxy-test');
+      const policy = withToolPaths({
+        version: schemaVersion.raw,
+        network: { allowOutbound: true, proxy: { builtinTestServer: true } },
+        ui: { allowWindows: true },
+      });
+      const script =
+        `powershell.exe -NoProfile -Command "` +
+        `$h = New-Object -ComObject WinHttp.WinHttpRequest.5.1; ` +
+        `$h.Open('GET','https://api.github.com/zen',$false); ` +
+        `$h.Send(); ` +
+        `Write-Output ('PROXY_RESPONSE: ' + $h.ResponseText)"`;
+      const result = await sdk.spawnSandboxAsync(
+        script, policy, { debug: true }, undefined, `proxy-builtin-${schemaVersion}`,
+      );
+
+      assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+      assert.ok(result.stdout.includes('PROXY_RESPONSE:'));
+      assert.ok(result.stdout.includes('Proxy policy active'));
+    });
+
+    it('should route traffic through external proxy', async () => {
+      tempDir = createTempDir('mxc-proxy-test');
+      const { port, proxyProcess: proc } = startTestProxy(tempDir);
+      proxyProcess = proc;
+
+      const policy = withToolPaths({
+        version: schemaVersion.raw,
+        network: { allowOutbound: true, proxy: { localhost: port } },
+        ui: { allowWindows: true },
+      });
+      const script =
+        `powershell.exe -NoProfile -Command "` +
+        `$h = New-Object -ComObject WinHttp.WinHttpRequest.5.1; ` +
+        `$h.Open('GET','https://api.github.com/zen',$false); ` +
+        `$h.Send(); ` +
+        `Write-Output ('PROXY_RESPONSE: ' + $h.ResponseText)"`;
+      const result = await sdk.spawnSandboxAsync(
+        script, policy, { debug: true }, undefined, `proxy-ext-${schemaVersion}`,
+      );
+
+      assert.strictEqual(result.exitCode, 0, `[${schemaVersion}] Expected exit 0: ${result.stderr}`);
+      assert.ok(result.stdout.includes('PROXY_RESPONSE:'));
+      assert.ok(result.stdout.includes('Proxy policy active'));
+    });
+  });
+});
+}

--- a/sdk/tests/integration/wslc-e2e.test.ts
+++ b/sdk/tests/integration/wslc-e2e.test.ts
@@ -21,8 +21,7 @@ import os from 'os';
 import { ChildProcess } from 'child_process';
 import { sdk } from './test-helpers';
 
-const skipInCi = process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
-const isWslcAvailable = os.platform() === 'win32' && !skipInCi;
+const isWslcAvailable = os.platform() === 'win32';
 
 describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
   skip: !isWslcAvailable ? 'WSLC tests require Windows with WSL2 and WSLC SDK' : undefined,

--- a/sdk/tests/integration/wslc-e2e.test.ts
+++ b/sdk/tests/integration/wslc-e2e.test.ts
@@ -21,7 +21,8 @@ import os from 'os';
 import { ChildProcess } from 'child_process';
 import { sdk } from './test-helpers';
 
-const isWslcAvailable = os.platform() === 'win32';
+const skipInCi = process.env.MXC_SKIP_OS_BUILD_DEPENDENT_TESTS === '1';
+const isWslcAvailable = os.platform() === 'win32' && !skipInCi;
 
 describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
   skip: !isWslcAvailable ? 'WSLC tests require Windows with WSL2 and WSLC SDK' : undefined,

--- a/sdk/tests/integration/wslc-e2e.test.ts
+++ b/sdk/tests/integration/wslc-e2e.test.ts
@@ -21,10 +21,12 @@ import os from 'os';
 import { ChildProcess } from 'child_process';
 import { sdk } from './test-helpers';
 
-const isWslcAvailable = os.platform() === 'win32';
+// WSLC tests require a Windows machine with WSL2 and WSLC SDK installed.
+// Opt-in via MXC_ENABLE_WSLC_TESTS=1 since most CI agents lack the runtime.
+const isWslcAvailable = os.platform() === 'win32' && process.env.MXC_ENABLE_WSLC_TESTS === '1';
 
 describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
-  skip: !isWslcAvailable ? 'WSLC tests require Windows with WSL2 and WSLC SDK' : undefined,
+  skip: !isWslcAvailable ? 'WSLC tests require MXC_ENABLE_WSLC_TESTS=1 on Windows with WSL2 and WSLC SDK' : undefined,
 }, () => {
 
   it('should run with all WSLC-specific fields set', async () => {

--- a/sdk/tests/unit/logger.test.ts
+++ b/sdk/tests/unit/logger.test.ts
@@ -1,10 +1,10 @@
-// sdk/src/logger.test.ts
+// sdk/tests/unit/logger.test.ts
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { FileLogger } from './logger';
+import { FileLogger } from '../../src/logger';
 
 describe('FileLogger', () => {
   let tmpDir: string;

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { getAvailableToolsPolicy } from './policy';
+import { getAvailableToolsPolicy } from '../../src/policy';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -84,7 +84,7 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         );
     });
 
-    it('should return empty policy on non-Windows even when pwsh.exe is on PATH', () => {
+    it('should return empty policy on non-Windows even when pwsh.exe is on PATH', { skip: isLinux }, () => {
         mockLinux();
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -89,8 +89,12 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
         const result = getAvailableToolsPolicy(env);
-        assert.strictEqual(result.readonlyPaths.length, 0,
-            'readonlyPaths should be empty on Linux',
+        // On Linux, the temp dir containing pwsh.exe may appear in readonlyPaths
+        // (it exists on disk), but PowerShell-specific paths like the system root
+        // (C:\) and PSReadLine dir must NOT be added.
+        assert.ok(
+            !result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
+            'System root (e.g. C:\\) should not be in readonlyPaths on Linux',
         );
         assert.strictEqual(result.readwritePaths.length, 0,
             'readwritePaths should be empty on Linux',

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -1,22 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, afterEach, mock } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { getAvailableToolsPolicy } from '../../src/policy';
 import * as fs from 'fs';
-import os from 'os';
+import * as os from 'os';
 import * as path from 'path';
 
+// TODO: Investigate why Object.defineProperty(process, 'platform', ...) does not
+// take effect on Linux ADO pipeline runners (Node.js v20.19.x). These tests mock
+// process.platform to 'win32' and must be skipped on Linux until the root cause
+// is understood.
+const isLinux = process.platform === 'linux';
+
 describe('getAvailableToolsPolicy - PowerShell discovery', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
     let tmpDir: string | undefined;
 
     const mockWindows = () => {
-        mock.method(os, 'platform', () => 'win32');
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'win32' });
     };
 
     const mockLinux = () => {
-        mock.method(os, 'platform', () => 'linux');
+        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+        Object.defineProperty(process, 'platform', { value: 'linux' });
     };
 
     /** Create a temp directory containing a fake pwsh.exe and return its path. */
@@ -27,14 +36,17 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
     };
 
     afterEach(() => {
-        mock.restoreAll();
+        if (originalPlatform) {
+            Object.defineProperty(process, 'platform', originalPlatform);
+            originalPlatform = undefined;
+        }
         if (tmpDir) {
             fs.rmSync(tmpDir, { recursive: true, force: true });
             tmpDir = undefined;
         }
     });
 
-    it('should add system root to readonlyPaths when pwsh.exe is on PATH', () => {
+    it('should add system root to readonlyPaths when pwsh.exe is on PATH', { skip: isLinux }, () => {
         mockWindows();
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
@@ -45,7 +57,7 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         );
     });
 
-    it('should add PSReadLine dir to readwritePaths when pwsh.exe is on PATH', () => {
+    it('should add PSReadLine dir to readwritePaths when pwsh.exe is on PATH', { skip: isLinux }, () => {
         mockWindows();
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
@@ -59,7 +71,7 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         );
     });
 
-    it('should not add PowerShell paths when pwsh.exe is not on PATH', () => {
+    it('should not add PowerShell paths when pwsh.exe is not on PATH', { skip: isLinux }, () => {
         mockWindows();
         const env = { PATH: 'C:\\Windows\\System32', USERPROFILE: 'C:\\Users\\TestUser' };
         const result = getAvailableToolsPolicy(env);
@@ -85,7 +97,7 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         );
     });
 
-    it('should not add PSReadLine path when USERPROFILE is not set', () => {
+    it('should not add PSReadLine path when USERPROFILE is not set', { skip: isLinux }, () => {
         mockWindows();
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir };

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -1,25 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it, afterEach } from 'node:test';
+import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { getAvailableToolsPolicy } from '../../src/policy';
 import * as fs from 'fs';
-import * as os from 'os';
+import os from 'os';
 import * as path from 'path';
 
 describe('getAvailableToolsPolicy - PowerShell discovery', () => {
-    let originalPlatform: PropertyDescriptor | undefined;
     let tmpDir: string | undefined;
 
     const mockWindows = () => {
-        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-        Object.defineProperty(process, 'platform', { value: 'win32' });
+        mock.method(os, 'platform', () => 'win32');
     };
 
     const mockLinux = () => {
-        originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
-        Object.defineProperty(process, 'platform', { value: 'linux' });
+        mock.method(os, 'platform', () => 'linux');
     };
 
     /** Create a temp directory containing a fake pwsh.exe and return its path. */
@@ -30,10 +27,7 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
     };
 
     afterEach(() => {
-        if (originalPlatform) {
-            Object.defineProperty(process, 'platform', originalPlatform);
-            originalPlatform = undefined;
-        }
+        mock.restoreAll();
         if (tmpDir) {
             fs.rmSync(tmpDir, { recursive: true, force: true });
             tmpDir = undefined;
@@ -78,14 +72,13 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         );
     });
 
-    it('should not add PowerShell paths on non-Windows platforms', () => {
+    it('should return empty policy on non-Windows even when pwsh.exe is on PATH', () => {
         mockLinux();
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
         const result = getAvailableToolsPolicy(env);
-        assert.ok(
-            !result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
-            'System root should not be added on Linux',
+        assert.strictEqual(result.readonlyPaths.length, 0,
+            'readonlyPaths should be empty on Linux',
         );
         assert.strictEqual(result.readwritePaths.length, 0,
             'readwritePaths should be empty on Linux',

--- a/sdk/tests/unit/policy.test.ts
+++ b/sdk/tests/unit/policy.test.ts
@@ -89,9 +89,6 @@ describe('getAvailableToolsPolicy - PowerShell discovery', () => {
         const pwshDir = createFakePwshDir();
         const env = { PATH: pwshDir, USERPROFILE: 'C:\\Users\\TestUser' };
         const result = getAvailableToolsPolicy(env);
-        // On Linux, the temp dir containing pwsh.exe may appear in readonlyPaths
-        // (it exists on disk), but PowerShell-specific paths like the system root
-        // (C:\) and PSReadLine dir must NOT be added.
         assert.ok(
             !result.readonlyPaths.some(p => /^[a-z]:\\$/i.test(p)),
             'System root (e.g. C:\\) should not be in readonlyPaths on Linux',

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -3,8 +3,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import { buildSandboxPayload, createConfigFromPolicy, spawnSandbox, spawnSandboxFromConfig } from './sandbox';
-import { SandboxPolicy } from './types';
+import { buildSandboxPayload, createConfigFromPolicy, spawnSandbox, spawnSandboxFromConfig } from '../../src/sandbox';
+import { SandboxPolicy } from '../../src/types';
 
 describe('buildSandboxPayload', () => {
   const defaultPolicy: SandboxPolicy = { version: '0.4.0-alpha' };

--- a/sdk/tests/unit/tsconfig.json
+++ b/sdk/tests/unit/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "../../dist-tests",
+    "rootDir": "../..",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "declaration": false,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts", "../../src/**/*.ts"]
+}

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use wxc_common::config_parser::load_request;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
-use wxc_common::script_runner::ScriptRunner;
+use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
 
 use lxc_common::lxc_runner::LxcScriptRunner;
 
@@ -43,6 +43,10 @@ struct Cli {
     /// Enable experimental features
     #[arg(long)]
     experimental: bool,
+
+    /// Parse and validate config then exit without executing
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 
     /// Path to diagnostic log file (appends, creates if missing)
     #[arg(long = "log-file")]
@@ -138,6 +142,7 @@ fn main() {
     };
 
     request.experimental_enabled = cli.experimental;
+    request.dry_run = cli.dry_run;
 
     log_request(&request, &mut logger);
 
@@ -157,6 +162,11 @@ fn main() {
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
+
+    if cli.dry_run {
+        handle_dry_run_exit(&response, &mut logger);
+    }
+
     display_script_results(&response, &mut logger);
 
     print!("{}", response.standard_out);

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -14,7 +14,6 @@ use wxc_common::models::{
     CodexRequest, LifecycleConfig, LxcConfig, NetworkEnforcementMode, ScriptResponse,
 };
 use wxc_common::script_runner::ScriptRunner;
-use wxc_common::validator::validate_request;
 
 use crate::filesystem_mounts;
 use crate::lxc_bindings::LxcContainer;
@@ -224,12 +223,7 @@ impl LxcScriptRunner {
 }
 
 impl ScriptRunner for LxcScriptRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        // Validate the request first
-        if let Err(e) = validate_request(request) {
-            return ScriptResponse::error(&e.to_string());
-        }
-
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         // Run with panic catching for safety
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             self.run_internal(request, logger)

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -318,7 +318,7 @@ fn sdk_error(context: &str, hr: HRESULT, sdk_msg: &str) -> ScriptResponse {
 }
 
 impl ScriptRunner for WSLContainerRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         unsafe { self.run_internal(request, logger) }
     }
 }

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -14,7 +14,7 @@ use wxc_common::filesystem_bfs::FileSystemBfsManager;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
 use wxc_common::nanvix_runner::NanVixScriptRunner;
-use wxc_common::script_runner::ScriptRunner;
+use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
 use wxc_common::windows_sandbox_runner::WindowsSandboxScriptRunner;
 
 #[derive(Parser)]
@@ -47,6 +47,10 @@ struct Cli {
     /// Enable experimental features
     #[arg(long)]
     experimental: bool,
+
+    /// Parse and validate config then exit without executing
+    #[arg(long = "dry-run")]
+    dry_run: bool,
 
     /// Path to diagnostic log file (appends, creates if missing)
     #[arg(long = "log-file")]
@@ -155,6 +159,7 @@ fn main() {
     };
 
     request.experimental_enabled = cli.experimental;
+    request.dry_run = cli.dry_run;
 
     log_request(&request, &mut logger);
 
@@ -167,29 +172,6 @@ fn main() {
             let use_base_container = request.experimental_enabled || version_implies_base_container;
 
             if use_base_container {
-                if let Err(e) = BaseContainerRunner::is_base_container_api_present() {
-                    if version_implies_base_container {
-                        eprintln!(
-                            "Error: Config schema version '{}' requires the BaseContainer \
-                             backend, but this OS build does not support it: {}",
-                            request.schema_version, e
-                        );
-                        eprintln!(
-                            "Hint: Use schema version '0.4.0-alpha' to fall back to AppContainer."
-                        );
-                    } else {
-                        eprintln!(
-                            "Error: --experimental requested BaseContainer, but this OS build \
-                             does not support it: {}",
-                            e
-                        );
-                        eprintln!(
-                            "Hint: Remove --experimental to use the AppContainer backend, \
-                             or use an OS build with BaseContainer support."
-                        );
-                    }
-                    process::exit(1);
-                }
                 let reason = if version_implies_base_container {
                     format!("schema version {}", request.schema_version)
                 } else {
@@ -260,6 +242,11 @@ fn main() {
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
+
+    if cli.dry_run {
+        handle_dry_run_exit(&response, &mut logger);
+    }
+
     display_script_results(&response, &mut logger);
 
     // Output was already relayed to the console by pipe threads.

--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -494,14 +494,9 @@ impl Default for AppContainerScriptRunner {
 }
 
 impl ScriptRunner for AppContainerScriptRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         use crate::filesystem_bfs::FileSystemBfsManager;
         use crate::network_manager::NetworkManager;
-        use crate::validator::validate_request;
-
-        if let Err(e) = validate_request(request) {
-            return ScriptResponse::error(&e.to_string());
-        }
 
         // Apply experimental features when flag is set
         if request.experimental_enabled {

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -320,7 +320,29 @@ impl BaseContainerRunner {
 }
 
 impl ScriptRunner for BaseContainerRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+    fn validate_runner(&self, request: &CodexRequest) -> Result<(), ScriptResponse> {
+        Self::is_base_container_api_present().map_err(|e| {
+            let hint = if !request.experimental_enabled {
+                format!(
+                    "BaseContainer API unavailable: {e}\n\
+                     Hint: Config schema version '{}' requires the BaseContainer backend, \
+                     but this OS build does not support it. \
+                     Use schema version '0.4.0-alpha' to fall back to AppContainer.",
+                    request.schema_version
+                )
+            } else {
+                format!(
+                    "BaseContainer API unavailable: {e}\n\
+                     Hint: --experimental requested BaseContainer, but this OS build \
+                     does not support it. Remove --experimental to use the AppContainer \
+                     backend, or use an OS build with BaseContainer support."
+                )
+            };
+            ScriptResponse::error(&hint)
+        })
+    }
+
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         let _ = writeln!(logger, "BaseContainer: building sandbox specification...");
 
         // Launch builtin test proxy if requested (before building spec so we have the port).

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -640,6 +640,7 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
         lxc_config,
         experimental_enabled: false,
         experimental,
+        dry_run: false,
     })
 }
 

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -334,6 +334,9 @@ pub struct CodexRequest {
     pub experimental_enabled: bool,
     /// Experimental feature configs (only applied when experimental_enabled is true).
     pub experimental: ExperimentalConfig,
+    /// Dry-run mode: validate config and runner setup then return success
+    /// without executing the sandboxed process.
+    pub dry_run: bool,
 }
 
 impl Default for CodexRequest {
@@ -352,6 +355,7 @@ impl Default for CodexRequest {
             lxc_config: LxcConfig::default(),
             experimental_enabled: false,
             experimental: ExperimentalConfig::default(),
+            dry_run: false,
         }
     }
 }

--- a/src/wxc_common/src/nanvix_runner.rs
+++ b/src/wxc_common/src/nanvix_runner.rs
@@ -477,11 +477,11 @@ impl NanVixScriptRunner {
 }
 
 impl ScriptRunner for NanVixScriptRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        if let Err(e) = Self::validate_policies(request) {
-            return e.to_response();
-        }
+    fn validate_runner(&self, request: &CodexRequest) -> Result<(), ScriptResponse> {
+        Self::validate_policies(request).map_err(|e| e.to_response())
+    }
 
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         let (nanvixd_path, bin_dir, ramfs_path, python_path) = match self.resolve_paths() {
             Ok(paths) => paths,
             Err(e) => return e.to_response(),
@@ -548,6 +548,7 @@ mod tests {
     fn policy_rejects_filesystem_paths() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 readwrite_paths: vec!["/tmp".to_string()],
                 ..Default::default()
@@ -564,6 +565,7 @@ mod tests {
     fn policy_rejects_readonly_paths() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 readonly_paths: vec!["/data".to_string()],
                 ..Default::default()
@@ -580,6 +582,7 @@ mod tests {
     fn policy_rejects_network_hosts() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 allowed_hosts: vec!["example.com".to_string()],
                 ..Default::default()
@@ -596,6 +599,7 @@ mod tests {
     fn policy_rejects_blocked_network_hosts() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 blocked_hosts: vec!["evil.com".to_string()],
                 ..Default::default()
@@ -612,6 +616,7 @@ mod tests {
     fn policy_rejects_network_block_policy() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 default_network_policy: NetworkPolicy::Block,
                 ..Default::default()
@@ -628,6 +633,7 @@ mod tests {
     fn policy_rejects_working_directory() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             working_directory: "/home/user".to_string(),
             ..Default::default()
         };
@@ -642,7 +648,10 @@ mod tests {
         // A request with all-default policies should pass validation and
         // fail later on path resolution (nanvixd not found), NOT on policy.
         let mut runner = NanVixScriptRunner::new();
-        let request = CodexRequest::default();
+        let request = CodexRequest {
+            script_code: "echo test".to_string(),
+            ..Default::default()
+        };
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
@@ -664,6 +673,7 @@ mod tests {
     fn policy_rejects_network_proxy() {
         let mut runner = NanVixScriptRunner::new();
         let request = CodexRequest {
+            script_code: "echo test".to_string(),
             policy: ContainerPolicy {
                 network_proxy: crate::models::ProxyConfig {
                     address: Some(crate::models::ProxyAddress::new(

--- a/src/wxc_common/src/script_runner.rs
+++ b/src/wxc_common/src/script_runner.rs
@@ -3,14 +3,49 @@
 
 use crate::logger::Logger;
 use crate::models::{CodexRequest, ScriptResponse};
+use crate::validator::validate_common;
 
 /// Trait for executing scripts within a containment backend.
 ///
 /// Each backend (AppContainer, Windows Sandbox, etc.) implements this trait
 /// to provide a uniform interface for `wxc-exec`.
+///
+/// Implementors provide [`execute`](ScriptRunner::execute) and optionally
+/// [`validate`](ScriptRunner::validate). The provided
+/// [`run`](ScriptRunner::run) method handles validation, dry-run mode,
+/// and delegates to [`execute`](ScriptRunner::execute).
 pub trait ScriptRunner {
+    /// Validate the request before execution. Override to add
+    /// runner-specific checks. Default accepts all requests.
+    fn validate_runner(&self, _request: &CodexRequest) -> Result<(), ScriptResponse> {
+        Ok(())
+    }
+
     /// Execute the script inside this backend's containment and return the response.
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse;
+    /// Implement this instead of `run` — validation and dry-run are handled by the trait.
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse;
+
+    /// Entry point called by the binary. Runs shared validation, runner-specific
+    /// validation, checks for dry-run mode, then delegates to
+    /// [`execute`](ScriptRunner::execute).
+    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+        if let Err(response) = validate_common(request) {
+            return response;
+        }
+
+        if let Err(response) = self.validate_runner(request) {
+            return response;
+        }
+
+        if request.dry_run {
+            return ScriptResponse {
+                exit_code: 0,
+                ..Default::default()
+            };
+        }
+
+        self.execute(request, logger)
+    }
 }
 
 /// Convert a timeout value to milliseconds, treating 0 as infinite (INFINITE = `u32::MAX`).
@@ -22,14 +57,28 @@ pub fn get_timeout_milliseconds(timeout: u32) -> u32 {
     }
 }
 
+/// Print a dry-run result message to the logger, flush, and exit the process.
+pub fn handle_dry_run_exit(response: &ScriptResponse, logger: &mut Logger) -> ! {
+    use std::fmt::Write;
+    if response.exit_code == 0 {
+        let _ = writeln!(logger, "Dry run completed. Result: validation passed");
+    } else {
+        let _ = writeln!(logger, "Dry run completed. Result: validation failed");
+    }
+    print!("{}", logger.get_buffer());
+    std::process::exit(response.exit_code);
+}
+
 #[cfg(test)]
 mod tests {
     use super::get_timeout_milliseconds;
+
     #[test]
     fn timeout_zero_returns_u32_max() {
         let result = get_timeout_milliseconds(0);
         assert_eq!(result, u32::MAX);
     }
+
     #[test]
     fn timeout_non_zero_returns_same_value() {
         let value = 1500u32;

--- a/src/wxc_common/src/validator.rs
+++ b/src/wxc_common/src/validator.rs
@@ -1,42 +1,41 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::error::WxcError;
-use crate::models::CodexRequest;
+use crate::models::{CodexRequest, ScriptResponse};
 
-pub fn validate_request(request: &CodexRequest) -> Result<(), WxcError> {
+/// Validates non-backend-specific parts of the request (e.g. non-empty script).
+pub fn validate_common(request: &CodexRequest) -> Result<(), ScriptResponse> {
     if request.script_code.is_empty() {
-        return Err(WxcError::Validation(
-            "Script content must not be empty.".into(),
-        ));
+        return Err(ScriptResponse::error("Script content must not be empty."));
     }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::validate_common;
+    use crate::models::CodexRequest;
 
     #[test]
-    fn validate_request_with_valid_script() {
-        let req = CodexRequest {
-            script_code: "echo hello".to_string(),
-            ..Default::default()
-        };
-        assert!(validate_request(&req).is_ok());
-    }
-
-    #[test]
-    fn validate_request_with_empty_script() {
+    fn rejects_empty_script() {
         let req = CodexRequest {
             script_code: String::new(),
             ..Default::default()
         };
-        assert!(validate_request(&req).is_err());
+        assert!(validate_common(&req).is_err());
     }
 
     #[test]
-    fn validate_request_with_full_config() {
+    fn accepts_valid_script() {
+        let req = CodexRequest {
+            script_code: "echo hello".to_string(),
+            ..Default::default()
+        };
+        assert!(validate_common(&req).is_ok());
+    }
+
+    #[test]
+    fn accepts_full_config() {
         let req = CodexRequest {
             script_code: "print('test')".to_string(),
             working_directory: "C:\\temp".to_string(),
@@ -44,14 +43,17 @@ mod tests {
             container_id: "Test".to_string(),
             ..Default::default()
         };
-        assert!(validate_request(&req).is_ok());
+        assert!(validate_common(&req).is_ok());
     }
 
     #[test]
-    fn validate_request_error_contains_message() {
+    fn error_mentions_empty() {
         let req = CodexRequest::default();
-        let err = validate_request(&req).unwrap_err();
-        let msg = format!("{}", err);
-        assert!(msg.contains("empty"), "Error should mention empty: {}", msg);
+        let err = validate_common(&req).unwrap_err();
+        assert!(
+            err.error_message.contains("empty"),
+            "Error should mention empty: {}",
+            err.error_message
+        );
     }
 }

--- a/src/wxc_common/src/windows_sandbox_runner.rs
+++ b/src/wxc_common/src/windows_sandbox_runner.rs
@@ -186,7 +186,7 @@ impl WindowsSandboxScriptRunner {
 }
 
 impl ScriptRunner for WindowsSandboxScriptRunner {
-    fn run(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+    fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         self.execute_via_daemon(request, logger)
     }
 }


### PR DESCRIPTION
### Why is this change needed?

We plan to remove the `CLI/` project via: #212 to make the repository easier to understand/navigate. One step in this direction is to move the integration tests from there directly into the SDK.

That said, some tests can't run in the pipelines because they require OS-level sandbox infrastructure such as BaseContainer API, LXC networking. These aren't all available on standard build runners. So we also need a way to test SDK -> wxc binary interaction without creating any sandboxes. This change helps alleviate this issue by adding "dry-run" tests where data flow goes through sdk -> wxc-exec and returns right before attempting to run the runners.

### What Changed?

- **`--dry-run` flag** added to `wxc-exec` and `lxc-exec` : validates that the executables are invoked.
- **`dryRun` option** added to SDK `SandboxSpawnOptions` : passes `--dry-run` to the native binary
- **`ScriptRunner` trait refactored**: `run()` is now a provided method with a dry-run guard; runners implement `execute()`, structurally enforcing dry-run for any new backend
- **Moved SDK tests** : Moved integration tests to sdk under `integration/` folder and `unit` folder for unit tests. The integration tests consumes the SDK npm package directly.
- **Dry-run smoke tests** added exercising all3 SDK spawn functions (`spawnSandbox`, `spawnSandboxAsync`, `spawnSandboxFromConfig`)
- **Azure Pipeline** : added `SDK_Integration_Tests` and `SDK_Unit_Tests` stages to `1ES.Build.yml`
- **Pipeline Environment variables** : added `MXC_SKIP_OS_BUILD_DEPENDENT_TESTS` and `MXC_SKIP_LXC_NETWORK_TESTS`  for tests the can't run in the pipeline.
- `test issues`: Added sdk/tests/integration/test_issues.md which has a list of current issues.

### How was it tested?

- All integration tests should run locally based on the platform unless `MXC_SKIP_OS_BUILD_DEPENDENT_TESTS` or ``MXC_SKIP_LXC_NETWORK_TESTS`` for lxc is set in the environment variables.
   - Note: We will need to figure out how we can unskip these in the pipeline in the future (different windows internal build pool maybe).
- Dry-run tests pass which should validate SDK <--> exec binary communication
- Confirmed via build in azure pipeline as well: https://microsoft.visualstudio.com/Dart/_build/results?buildId=145686041&view=results

fixes #202
<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/211)