### PR TITLE
Add policy bot rules to auto-label issue types and OS areas

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -23,5 +23,88 @@ configuration:
         then:
           - addLabel:
               label: Needs-Triage
+      ### Issue Type Labels
+      - description: Add Issue-Bug label to bug reports
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: '### Steps to reproduce'
+              isRegex: False
+        then:
+          - addLabel:
+              label: Issue-Bug
+      - description: Add Issue-Feature label to feature requests
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: '### Description of the new feature'
+              isRegex: False
+        then:
+          - addLabel:
+              label: Issue-Feature
+      - description: Add Issue-Task label to tasks
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: '### Description of the task'
+              isRegex: False
+        then:
+          - addLabel:
+              label: Issue-Task
+      - description: Add Issue-Docs label to documentation issues
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: '### Brief description of your issue'
+              isRegex: False
+          - not:
+              bodyContains:
+                pattern: '### Steps to reproduce'
+                isRegex: False
+        then:
+          - addLabel:
+              label: Issue-Docs
+      ### OS Area Labels
+      - description: Add OS-Linux label from bug report area
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: 'Relevant area\(s\)\s*\n.*Linux'
+              isRegex: True
+        then:
+          - addLabel:
+              label: OS-Linux
+      - description: Add OS-MacOS label from bug report area
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: 'Relevant area\(s\)\s*\n.*macOS'
+              isRegex: True
+        then:
+          - addLabel:
+              label: OS-MacOS
+      - description: Add OS-Windows label from bug report area
+        if:
+          - payloadType: Issues
+          - isAction:
+              action: Opened
+          - bodyContains:
+              pattern: 'Relevant area\(s\)\s*\n.*Windows'
+              isRegex: True
+        then:
+          - addLabel:
+              label: OS-Windows
 onFailure:
 onSuccess:

--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -32,6 +32,16 @@ configuration:
           - bodyContains:
               pattern: '### Steps to reproduce'
               isRegex: False
+          - not:
+              or:
+                - hasLabel:
+                    label: Issue-Bug
+                - hasLabel:
+                    label: Issue-Feature
+                - hasLabel:
+                    label: Issue-Task
+                - hasLabel:
+                    label: Issue-Docs
         then:
           - addLabel:
               label: Issue-Bug
@@ -43,6 +53,16 @@ configuration:
           - bodyContains:
               pattern: '### Description of the new feature'
               isRegex: False
+          - not:
+              or:
+                - hasLabel:
+                    label: Issue-Bug
+                - hasLabel:
+                    label: Issue-Feature
+                - hasLabel:
+                    label: Issue-Task
+                - hasLabel:
+                    label: Issue-Docs
         then:
           - addLabel:
               label: Issue-Feature
@@ -54,6 +74,16 @@ configuration:
           - bodyContains:
               pattern: '### Description of the task'
               isRegex: False
+          - not:
+              or:
+                - hasLabel:
+                    label: Issue-Bug
+                - hasLabel:
+                    label: Issue-Feature
+                - hasLabel:
+                    label: Issue-Task
+                - hasLabel:
+                    label: Issue-Docs
         then:
           - addLabel:
               label: Issue-Task
@@ -69,6 +99,16 @@ configuration:
               bodyContains:
                 pattern: '### Steps to reproduce'
                 isRegex: False
+          - not:
+              or:
+                - hasLabel:
+                    label: Issue-Bug
+                - hasLabel:
+                    label: Issue-Feature
+                - hasLabel:
+                    label: Issue-Task
+                - hasLabel:
+                    label: Issue-Docs
         then:
           - addLabel:
               label: Issue-Docs


### PR DESCRIPTION
## Summary

Adds policy bot rules to automatically apply issue type labels and OS area labels when issues are opened. This closes the gap where template-defined labels (e.g. \Issue-Bug\, \Issue-Feature\) were not being applied when issues were created outside the GitHub web UI template chooser (API, CLI, mobile, project board quick-create).

## What changed

Updated \.github/policies/labelManagement.issueOpened.yml\ with new \ventResponderTasks\:

### Issue Type Labels (body content detection)
| Template | Body marker | Label applied |
|----------|------------|---------------|
| Bug Report | \### Steps to reproduce\ | \Issue-Bug\ |
| Feature Request | \### Description of the new feature\ | \Issue-Feature\ |
| Task | \### Description of the task\ | \Issue-Task\ |
| Documentation | \### Brief description of your issue\ (without \### Steps to reproduce\) | \Issue-Docs\ |

### OS Area Labels (regex matching on bug report dropdown)
| Dropdown selection | Label applied |
|-------------------|---------------|
| Linux | \OS-Linux\ |
| macOS | \OS-MacOS\ |
| Windows | \OS-Windows\ |

## Pattern reference

Follows the same \odyContains\ pattern used in [microsoft/winget-cli](https://github.com/microsoft/winget-cli/blob/master/.github/policies/labelManagement.issueOpened.yml) for auto-labeling based on issue template content.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/215)