### PR TITLE
[LXC] Fix container unconditionally destroyed on start() failure

### DIFF
--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -146,7 +146,9 @@ impl LxcScriptRunner {
         if !container.is_running() {
             let _ = writeln!(logger, "Starting LXC container...");
             if let Err(e) = container.start() {
-                let _ = container.destroy();
+                if self.destroy_on_exit || container_created {
+                    let _ = container.destroy();
+                }
                 return ScriptResponse::error(&format!("Failed to start container: {}", e));
             }
             let _ = writeln!(logger, "Container started successfully.");


### PR DESCRIPTION
When container.start() fails in lxc_runner.rs, the error path unconditionally calls container.destroy()- even when the container pre-existed and was not created by the current invocation. This causes data loss for persistent containers configured with destroyOnExit: false.

We add a guard to the start() failure path:
 if self.destroy_on_exit || container_created {
     let _ = container.destroy();
 }

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/220)