### PR TITLE
Prepare SDK v0.1.6 for release

### DIFF
--- a/.azure-pipelines/1ES.Release.yml
+++ b/.azure-pipelines/1ES.Release.yml
@@ -57,8 +57,6 @@ extends:
             artifactName: mxc-npm-sdk-package
 
         displayName: Publish to NPM
-        pool:
-          type: release
         steps:
         - task: EsrpRelease@10
           displayName: 'Publish to NPM'

--- a/sdk/LICENSE.md
+++ b/sdk/LICENSE.md
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,5 +1,7 @@
 # MXC SDK
 
+> **Status: Public Preview** - MXC is experimental and in active development.
+
 ## Overview
 
 The MXC SDK provides a Node.js interface for creating and managing policy-based containers. It exposes APIs for:

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "os": [
         "win32",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "TypeScript SDK for MXC (Microsoft eXecution Containers)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "bin/",
-    "dist/"
+    "dist/",
+    "LICENSE.md"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Update SDK to prepare it for release:

### What changed?
- Bump @microsoft/mxc-sdk version to 0.1.6
- Add LICENSE.md to SDK npm package. (Note copied the same MIT license file that the repo uses to the SDK folder)
- Add Public Preview status banner to SDK README which is similar to what winapp-npm does:  https://github.com/microsoft/winappCli/blob/main/src/winapp-npm/README.md
- Remove `pool: type: release` from 1ES.Release.yml as this was overriding the `Azure-Pipelines-1ESPT-ExDShared` pool that we set up at the top of 1ES.Release.yml. We need the pipeline to actually run in the `Azure-Pipelines-1ESPT-ExDShared`  pool for 1ES release.

Note: I didn't see any guidance on prerelease packages in npm starting with 0.1.0, so I'm just going with the bump of our current 0.1.5 SDK version to 0.1.6.

fixes #222

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/223)