### PR TITLE
Remove release to private npm registry  in SDKs package.json

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -42,8 +42,5 @@
   "os": [
     "win32",
     "linux"
-  ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
-  }
+  ]
 }


### PR DESCRIPTION
### Why is this needed?
Currently the `package.json` file was set up to publish to a private GitHub registry in the hopes that GitHub Copilot Cli would be able to ingest that into their pipeline (See: #32). It turned out that they can only ingest publicly available npm packages from the npm registry. This change removes the private `publishConfig` as we want to release to the public registry. 

See: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#publishconfig

Also see winapp cli's package.json for an example:  https://github.com/microsoft/winappCli/blob/main/src/winapp-npm/package.json

They publish to the npm registry without this config: https://www.npmjs.com/package/@microsoft/winappcli

Without this change, npm publish would target the GitHub Packages registry instead of the public npm registry.
