### PR TITLE
Reference build pipeline in release pipeline so release knows where to grab npm artifact from 

### DIFF
--- a/.azure-pipelines/1ES.Release.yml
+++ b/.azure-pipelines/1ES.Release.yml
@@ -9,6 +9,12 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+  pipelines:
+  # Reference pipeline that created the signed npm artifacts so we can consume them later
+  - pipeline: MXC 
+    source: 'MXC-Official-Build'
+    trigger: none
+
 
 # Parameters for ESRP release info will be passed from the ADO UI.
 parameters:
@@ -53,6 +59,7 @@ extends:
           isProduction: true
           inputs:
           - input: pipelineArtifact
+            pipeline: MXC
             targetPath: '$(Pipeline.Workspace)/packages'
             artifactName: mxc-npm-sdk-package
 


### PR DESCRIPTION
Reference build pipeline in release pipeline so release knows where to grab npm artifact from 

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/229)