### PR TITLE
feat: add TraceLogging ETW telemetry (experimental)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -186,7 +186,12 @@ Error messages are sanitized to strip file paths and usernames before emission.
 
 ### Capturing events
 
-Use standard ETW tools to capture telemetry events:
+Use standard ETW tools to capture telemetry events.
+
+> **Note**: The `Microsoft.MXC` provider GUID is pending provisioning through
+> the Windows Telemetry onboarding process. Once available, it will be
+> documented here. In the meantime, the GUID can be obtained at runtime
+> from `MXC_PROVIDER.id()` in the source code.
 
 ```bash
 tracelog -start MXCTrace -f MXCTrace.etl -guid #<PROVIDER_GUID>

--- a/Readme.md
+++ b/Readme.md
@@ -137,6 +137,69 @@ Execute your script with AppContainer in permissive learning mode:
 }
 ```
 
+## Telemetry
+
+MXC supports optional TraceLogging ETW telemetry for execution observability and
+adoption metrics. Telemetry is an **experimental feature** and requires the
+`--experimental` CLI flag.
+
+### Enabling telemetry
+
+Add `experimental.telemetry.enabled` to your JSON config and pass `--experimental`:
+
+```json
+{
+  "process": { "commandLine": "echo hello" },
+  "experimental": {
+    "telemetry": { "enabled": true }
+  }
+}
+```
+
+```bash
+wxc-exec --experimental config.json
+```
+
+### Default behavior
+
+Telemetry is **off by default**. It requires both `--experimental` and
+`experimental.telemetry.enabled: true` in the JSON config.
+
+Without `--experimental`, telemetry is always off regardless of the config.
+
+### What is collected
+
+Events are emitted to the local ETW subsystem via the `Microsoft.MXC` TraceLogging
+provider. **No PII is collected.** The following fields are recorded:
+
+| Field | Description |
+|-------|-------------|
+| `mxc.backend` | Containment backend (appcontainer, sandbox, lxc, wslc, microvm) |
+| `mxc.outcome` | success or failure |
+| `mxc.exit_code` | Process exit code |
+| `mxc.duration_ms` | Total execution wall-clock time |
+| `mxc.init_duration_ms` | Container initialization time |
+| `mxc.version` | MXC version |
+| `mxc.failure_reason` | Bounded error category (on failure only) |
+
+Error messages are sanitized to strip file paths and usernames before emission.
+
+### Capturing events
+
+Use standard ETW tools to capture telemetry events:
+
+```bash
+tracelog -start MXCTrace -f MXCTrace.etl -guid #<PROVIDER_GUID>
+wxc-exec --experimental config.json
+tracelog -stop MXCTrace
+tracefmt -o MXCTrace.txt MXCTrace.etl
+```
+
+### Consent
+
+MXC does not implement consent prompts or persistent consent storage.
+Consent is the responsibility of the calling agent (SDK consumer).
+
 ### Stop Tracing
 
 When execution completes:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -69,6 +69,9 @@ production configs and the dev schema when working on experimental features:
             "memoryMb": 2048,              // Memory in MB for WSLC session
             "gpu": false,                  // GPU passthrough
             "storagePath": "C:\\wslc-storage"  // Image store path
+        },
+        "telemetry": {                     // Telemetry (experimental)
+            "enabled": true                // Enable TraceLogging ETW event emission
         }
     }
 }

--- a/examples/14_telemetry_enabled.json
+++ b/examples/14_telemetry_enabled.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-alpha",
+  "version": "0.5.0-alpha",
   "containerId": "CLI-TelemetryDemo",
   "containment": "appcontainer",
   "process": {

--- a/examples/14_telemetry_enabled.json
+++ b/examples/14_telemetry_enabled.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-TelemetryDemo",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "cmd /c echo Hello with telemetry enabled"
+  },
+  "appContainer": {
+    "capabilities": ["permissiveLearningMode"]
+  },
+  "experimental": {
+    "telemetry": {
+      "enabled": true
+    }
+  }
+}

--- a/schemas/dev/mxc-config.schema.0.5.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.5.0-dev.json
@@ -308,6 +308,16 @@
               "description": "Storage path for the WSLC session image store. Omit to use a temporary directory."
             }
           }
+        },
+        "telemetry": {
+          "type": "object",
+          "description": "Telemetry configuration (experimental). Emits TraceLogging ETW events for execution observability. Consent is the caller's responsibility.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Explicit telemetry override. When true, telemetry is enabled. When false or omitted, telemetry is disabled. Requires --experimental CLI flag."
+            }
+          }
         }
       }
     }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -164,6 +164,14 @@ export interface PortMapping {
 }
 
 /**
+ * Telemetry configuration. Consent is the caller's responsibility.
+ */
+export interface TelemetryConfig {
+  /** Explicit telemetry override. Omit to use build-type default. */
+  enabled?: boolean;
+}
+
+/**
  * Main WXC configuration
  */
 export interface ContainerConfig {
@@ -189,6 +197,8 @@ export interface ContainerConfig {
   experimental?: {
     /** WSLC SDK configuration for Linux containers from Windows */
     wslc?: WslcConfig;
+    /** Telemetry configuration (experimental). Consent is the caller's responsibility. */
+    telemetry?: TelemetryConfig;
   };
   /** Cross-platform UI configuration */
   ui?: UiConfig;

--- a/specs/001-add-observability/spec.md
+++ b/specs/001-add-observability/spec.md
@@ -1,0 +1,365 @@
+# Feature Specification: Observability — TraceLogging ETW Telemetry & Adoption Metrics
+
+**Feature Branch**: `001-add-observability`  
+**Created**: 2026-03-25  
+**Revised**: 2026-04-28 — replaced 1DS C++ SDK with TraceLogging ETW via `tracelogging` Rust crate  
+**Status**: Draft  
+
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Rust Core Execution Observability (Priority: P1)
+
+An operator or developer runs `wxc-exec` to execute a sandboxed script. They want to
+understand what happened during execution — which container backend was used, how long
+initialization and execution took, and whether any errors or policy violations occurred —
+without having to read raw process output or ETW traces.
+
+After this story is implemented, every Rust execution path emits TraceLogging ETW events
+that can be captured by any ETW controller (e.g., `tracelog`, `logman`, WPR, or a
+custom ETW consumer).
+
+**Why this priority**: This is the foundational observability layer. Without Rust-level ETW
+events, there is nothing to build adoption metrics on top of, and the TypeScript layer has no
+semantic context to propagate. It also makes immediately actionable the requirement to add
+telemetry "where no telemetry is present."
+
+**Independent Test**: Run `wxc-exec` with a valid JSON configuration against any backend
+(AppContainer, Sandbox, or LXC) with telemetry enabled. Verify that an `MXC.Execution`
+ETW event is emitted containing backend type, exit code, and duration — with no PII
+fields present. Events can be captured via `tracelog` or `logman`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid JSON configuration and telemetry enabled,
+   **When** `wxc-exec` runs a script to completion,
+   **Then** an `MXC.Execution` ETW event is emitted containing fields for backend type,
+   exit code, duration, init duration, and version.
+
+2. **Given** `wxc-exec` is configured with the AppContainer backend,
+   **When** execution completes successfully,
+   **Then** the emitted `MXC.Execution` event includes `mxc.backend=appcontainer`,
+   `mxc.exit_code=0`, `mxc.outcome=success`, and `mxc.duration_ms`; and does NOT include
+   script content, file paths, usernames, or machine names.
+
+3. **Given** `wxc-exec` encounters an error (e.g., policy validation failure),
+   **When** the error is raised,
+   **Then** an `MXC.Error` ETW event is emitted with a sanitized error message and a
+   bounded `mxc.error_type` category — without recording the full script content.
+
+4. **Given** telemetry has not been explicitly enabled,
+   **When** `wxc-exec` runs without `--experimental` or without `experimental.telemetry.enabled`,
+   **Then** no ETW events are emitted (the TraceLogging provider is not registered).
+
+---
+
+### User Story 2 — Product Adoption Metrics (Priority: P2)
+
+The MXC product team wants to understand how the tool is being adopted in the wild:
+which execution backends are in use, how often the tool is invoked, and what the overall
+success and failure rate is. This data enables prioritization of backend investment and
+validates distribution and adoption growth.
+
+Adoption metrics are emitted as ETW event fields (backend, outcome, duration) alongside
+the existing execution events, enabling consumer-side aggregation for counters and histograms.
+
+**Why this priority**: Adoption metrics require the foundational ETW infrastructure from US1
+and the opt-out mechanism. They are designed to enable operators and the product
+team to understand adoption patterns.
+
+**Independent Test**: Run `wxc-exec --experimental` multiple times with different backends (AppContainer, LXC)
+and confirm that execution count, backend-type breakdowns, and latency data are available
+as ETW event fields that can be aggregated by any ETW consumer.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ETW trace session is capturing the `Microsoft.MXC` provider,
+   **When** `wxc-exec` completes an execution,
+   **Then** the following metrics are recorded: execution count (by backend),
+   success/failure count (by backend), and execution latency (histogram, by backend).
+
+2. **Given** multiple executions occur across different backends,
+   **When** a team member queries the captured ETW trace,
+   **Then** per-backend breakdowns are available without any PII-bearing dimensions.
+
+3. **Given** the opt-out mechanism is active,
+   **When** `wxc-exec` runs,
+   **Then** no metrics are emitted (consistent with opt-out behavior).
+
+4. **Given** the JSON config includes `"experimental": { "telemetry": { "enabled": true } }`
+   and `--experimental` is passed,
+   **When** `wxc-exec` runs,
+   **Then** events are emitted to the local ETW subsystem where any registered consumer
+   can capture them.
+
+---
+
+### User Story 3 — TypeScript SDK/CLI Telemetry Propagation (Priority: P3)
+
+A developer using the TypeScript SDK (`@microsoft/mxc-sdk`) or the `mxc-cli` to automate
+script execution wants telemetry configuration to be correctly propagated to the Rust binary
+so that ETW events are emitted when telemetry is enabled.
+
+**Why this priority**: The TypeScript layer is the primary integration surface for Node.js and
+Electron callers. Without correct telemetry propagation, the Rust binary cannot honor the
+caller's telemetry preferences (enabled/disabled). This is lower priority than the
+Rust core because the Rust binary always runs regardless of which TS API is used.
+
+**Independent Test**: Write a TypeScript program using the SDK's `run()` method with a
+config object containing `experimental: { telemetry: { enabled: true } }`. Verify that the
+spawned `wxc-exec` JSON config includes the `experimental.telemetry` section. Verify that
+omitting the `telemetry` field results in no telemetry override.
+
+**Acceptance Scenarios**:
+
+1. **Given** the TypeScript SDK is called with `experimental: { telemetry: { enabled: true } }`,
+   **When** `WxcExecutor.run()` is called,
+   **Then** the JSON config passed to `wxc-exec` includes
+   `"experimental": { "telemetry": { "enabled": true } }` and the Rust binary emits ETW events.
+
+2. **Given** only the TypeScript CLI is used (no custom SDK code),
+   **When** `mxc-cli run` is invoked with a config containing
+   `"experimental": { "telemetry": { "enabled": true } }`,
+   **Then** the JSON config includes the telemetry section and the Rust binary
+   emits events to the local ETW subsystem.
+
+3. **Given** the `experimental.telemetry` section is omitted from the config (release build),
+   **When** any TypeScript SDK or CLI method is called,
+   **Then** no telemetry override is injected and the Rust binary defaults to telemetry off.
+
+---
+
+### Edge Cases
+
+- What happens when the `experimental.telemetry` section is present but malformed?
+  Malformed telemetry config MUST be treated as if telemetry is disabled
+  (safe default) and a warning emitted to stderr.
+- Can PII be accidentally emitted through error messages or event properties?
+  All error messages captured in events MUST be sanitized: file paths, script content,
+  and environment variable values MUST NOT appear in event fields.
+- What happens when `--experimental` is not passed but `experimental.telemetry` is in the config?
+  Telemetry MUST NOT be activated. The `--experimental` CLI flag is a required gate.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The Rust execution layer MUST emit a TraceLogging `MXC.Execution` ETW event
+  for every invocation of `wxc-exec`, capturing the full execution lifecycle including
+  container initialization, policy application, script execution, and teardown timing.
+  Linux (`lxc-exec`) telemetry is a P2 requirement (see Linux Support section).
+- **FR-002**: Each emitted ETW event MUST include structured fields: `mxc.backend`
+  (enum: appcontainer, sandbox, lxc, wslc), `mxc.exit_code` (integer), `mxc.duration_ms`
+  (integer), `mxc.init_duration_ms` (integer), and `mxc.version` (string).
+- **FR-003**: Emitted ETW events MUST NOT include: script source code, command-line
+  argument values, file paths, environment variable values, usernames, machine hostnames,
+  or IP addresses.
+- **FR-004**: The Rust execution layer MUST emit ETW telemetry events containing adoption
+  metrics as event fields: execution count (by backend and outcome), failure count
+  (by backend and failure reason category), and execution latency in milliseconds (by
+  backend). Consumer-side aggregation on ETW traces provides counter and histogram
+  equivalents from these event fields.
+- **FR-005**: Setting `"experimental": { "telemetry": { "enabled": true } }` in the JSON
+  configuration with the `--experimental` CLI flag MUST activate TraceLogging ETW event
+  emission for that invocation (explicit opt-in).
+- **FR-006**: Setting `"experimental": { "telemetry": { "enabled": false } }` in the JSON
+  configuration MUST suppress TraceLogging ETW event emission for that invocation
+  (explicit opt-out), overriding the default.
+- **FR-007**: The telemetry resolution logic MUST follow this priority order:
+  1. `--experimental` CLI flag must be present (gate).
+  2. `experimental.telemetry.enabled` in JSON config — explicit override, always wins.
+  3. Default: off (telemetry requires explicit opt-in).
+  Consent is the responsibility of the calling agent (SDK consumer), not MXC.
+- **FR-008**: Telemetry failures (provider registration failure, event write error) MUST NOT
+  propagate as user-visible errors, affect execution output, or alter the exit code of
+  `wxc-exec`.
+- **FR-009**: The TypeScript SDK MUST pass the `experimental.telemetry` section from the
+  caller-provided config object through to the JSON config file used to spawn `wxc-exec`.
+  The SDK MUST NOT read environment variables for telemetry configuration.
+- **FR-010**: The TypeScript CLI MUST pass the `experimental.telemetry` section from the
+  JSON config file through to the executor, ensuring the Rust binary receives the correct
+  telemetry configuration.
+- **FR-011**: The TypeScript layer MUST NOT independently interpret or override the
+  `experimental.telemetry` section; it is a transparent pass-through to the Rust binary.
+- **FR-012**: TraceLogging events are emitted to the local ETW subsystem. No remote
+  endpoints or regional routing is required. ETW consumers (trace controllers, WPR,
+  `logman`, or a 1DS UTC agent if deployed separately) are responsible for collecting
+  and routing events.
+- **FR-013**: Telemetry instrumentation MUST use the `tracelogging` Rust crate (v1.2+)
+  from the [microsoft/tracelogging](https://github.com/microsoft/tracelogging) repository.
+  Events are emitted via TraceLogging ETW using `define_provider!` and `write_event!`
+  macros. No C/C++ FFI, git submodule, or CMake build is required.
+- **FR-014**: Existing `Logger` and ETW instrumentation MUST remain fully functional;
+  TraceLogging telemetry is additive and MUST NOT replace or break existing debug output.
+- **FR-015**: The project README MUST include a dedicated `Telemetry` section that describes:
+  (a) that telemetry is an experimental feature requiring `--experimental`,
+  (b) how to enable it (`experimental.telemetry.enabled: true` in JSON config),
+  (c) how to disable it (`experimental.telemetry.enabled: false`),
+  (d) the exact set of event fields collected,
+  (e) the explicit guarantee that no PII is collected, and
+  (f) how to capture events using ETW tools (`tracelog`, `logman`, WPR).
+- **FR-016**: TraceLogging events are written synchronously to the ETW subsystem via
+  `write_event!`. The total overhead added to `wxc-exec` wall-clock execution time by
+  the telemetry subsystem MUST NOT exceed 5 ms.
+- **FR-017**: The Rust binary MUST call `MY_PROVIDER.unregister()` on the TraceLogging
+  provider before process exit to ensure clean ETW session teardown.
+- **FR-018**: No changes to the GitHub Actions CI pipeline checkout step are required.
+  The `tracelogging` crate is a standard Cargo dependency with no submodule or
+  external toolchain requirements.
+- **FR-019**: No additional CI build agent toolchain requirements are introduced.
+  The `tracelogging` crate compiles with the standard Rust toolchain and links
+  `advapi32.lib` (a Windows system library).
+- **FR-020** *(removed)*: CMake caching is no longer needed; there is no C++ build step.
+- **FR-021**: The `wxc-exec-lint` CI job MUST continue to pass `cargo clippy` and
+  `cargo fmt` checks after the `tracelogging` dependency is added to the workspace.
+- **FR-022** *(removed)*: Submodule guard is no longer needed; the `tracelogging` crate
+  is fetched by Cargo like any other dependency.
+- **FR-023** *(removed)*: Consent prompt eliminated — consent is the SDK consumer's responsibility.\n- **FR-024** *(removed)*: TTY detection eliminated — no interactive prompt.\n- **FR-025** *(removed)*: Consent file eliminated — no persistent consent storage.\n- **FR-026** *(removed)*: Consent resolution chain simplified — see FR-007.\n- **FR-027** *(removed)*: Consent prompt UX eliminated.
+
+### Key Entities
+
+- **Telemetry Configuration**: An optional section under `experimental.telemetry` in the
+  MXC JSON config schema that controls telemetry behavior for an invocation. Key field:
+  `enabled` (boolean). Requires the `--experimental` CLI flag to be active.
+- **Calling Agent**: The process that invokes MXC (e.g., GitHub Copilot, Nanoclaw). The agent
+  is responsible for obtaining user consent and passing it to MXC via the JSON config
+  `experimental.telemetry.enabled` field. Consent management is entirely the agent's
+  responsibility — MXC does not implement consent prompts or persistent consent storage.
+- **Opt-In Signal**: The state derived from (in priority order): (1) `--experimental` CLI
+  flag (gate), (2) `experimental.telemetry.enabled` field (explicit override),
+  (3) default: off (telemetry requires explicit opt-in).
+- **Execution Event**: A TraceLogging `MXC.Execution` ETW event covering the full lifetime
+  of a single `wxc-exec` run, with fields for backend, outcome, exit code, duration, and
+  version.
+- **Error Event**: A TraceLogging `MXC.Error` ETW event emitted on failure, with a bounded
+  error type category and a sanitized error message.
+- **Adoption Metric**: Adoption data is derived from `MXC.Execution` event fields
+  (backend type, outcome, duration) via consumer-side aggregation on ETW traces.
+  Dimensions are limited to: backend type, outcome (success/failure), and failure reason
+  category (no finer granularity).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every successful and failed execution of the Rust binary produces at least one
+  TraceLogging `MXC.Execution` ETW event containing backend type, exit code, and duration —
+  verifiable by capturing events via `tracelog` / `logman` or a programmatic ETW consumer.
+- **SC-002**: With no `experimental.telemetry` section in the JSON config or without the
+  `--experimental` flag (release build), zero ETW events are emitted and the TraceLogging
+  provider is not registered — verifiable with ETW tracing.
+  Adding `--experimental` with `\"experimental\": { \"telemetry\": { \"enabled\": true } }`
+  activates telemetry.
+- **SC-003**: No ETW event field contains any of the following: script source code, file
+  paths, environment variable values, usernames, or machine names — verifiable by static
+  code review and integration test assertions against emitted event fields.
+- **SC-004**: Execution count and latency data are emitted per-backend (as `mxc.backend`
+  field) so the team can distinguish AppContainer, Sandbox, LXC, and WSLC adoption
+  trends independently via consumer-side aggregation.
+- **SC-005**: When an ETW trace session is not active, `wxc-exec` exit code and stdout/stderr
+  output are identical to a run with telemetry disabled — verifiable by comparing outputs.
+- **SC-006**: The TypeScript SDK and CLI correctly pass through the `telemetry` section
+  from the caller-provided config to the Rust binary via the JSON config — verifiable
+  by inspecting the JSON config passed to `wxc-exec`.
+- **SC-007**: When telemetry is enabled, the total added wall-clock overhead to a `wxc-exec`
+  run MUST NOT exceed 5 ms — verifiable by timing 100 identical runs with and without
+  `experimental.telemetry.enabled: true` and comparing p95 latency.
+- **SC-008**: On a run where `wxc-exec` completes in under 500 ms, all emitted ETW events
+  are still written to the ETW buffer — verifiable by confirming events appear in the
+  captured trace for short-lived executions (enabled by `unregister()` before exit).
+- **SC-009**: (Manual) An end-to-end integration test confirms that telemetry events flow
+  from `wxc-exec` through TraceLogging to the ETW subsystem — verifiable by a human tester
+  starting an ETW trace session for the `Microsoft.MXC` provider, running `wxc-exec`, and
+  confirming events appear in the decoded trace output.
+
+## Scope
+
+### In Scope
+
+- TraceLogging ETW events (`MXC.Execution`, `MXC.Error`) for Windows execution backends
+  (AppContainer, Sandbox, WSLC). Linux backends (LXC) are P2 (see Linux Support section).
+- Adoption metrics as ETW event fields (execution count, outcome, latency per backend).
+- Caller-delegated consent: the invoking agent (e.g., GitHub Copilot, Nanoclaw)
+  is responsible for obtaining user consent. MXC does not implement consent
+  prompts or persistent consent storage.
+- Opt-in via `"experimental": { "telemetry": { "enabled": true } }` with `--experimental`.
+- Opt-out via `"experimental": { "telemetry": { "enabled": false } }`.
+- TypeScript SDK and CLI telemetry config propagation to the Rust binary.
+- JSON configuration schema extension for the `experimental.telemetry` section.
+- Privacy audit: static enforcement that no PII fields are captured in any event field.
+
+### Out of Scope
+
+- Replacing or removing existing `Logger` / ETW instrumentation.
+- Building a custom telemetry dashboard or data pipeline.
+- 1DS pipeline integration (TraceLogging emits to local ETW; remote collection is out of scope).
+- Regional endpoint routing or EUDB compliance (these are concerns of any downstream
+  ETW consumer, not of MXC itself).
+- Changing existing exit codes, stdout format, or any user-visible behavior of `wxc-exec`.
+- Telemetry for the build system or CI pipeline.
+- Linux telemetry (P2 — the `tracelogging` crate compiles as no-ops on non-Windows;
+  LTTng support may be added later).
+
+## Assumptions
+
+- MXC is typically invoked by a calling agent (e.g., GitHub Copilot, Nanoclaw)
+  rather than directly by a human user. The calling agent is responsible
+  for obtaining user consent. MXC does not implement consent prompts or
+  persistent consent storage. Consent is entirely the agent's responsibility.
+- Telemetry is an experimental feature gated behind the `--experimental` CLI flag.
+  It is controlled by a two-level resolution: (1) `experimental.telemetry.enabled`
+  in JSON config (explicit override), (2) default: off (telemetry requires
+  explicit opt-in).
+- The `tracelogging` Rust crate (v1.2+, from [microsoft/tracelogging](https://github.com/microsoft/tracelogging))
+  is the telemetry backend. It provides `define_provider!` and `write_event!` macros that
+  emit self-describing ETW events. No C/C++ FFI, git submodule, or CMake build is required.
+  On non-Windows platforms (Linux), the crate compiles as no-ops.
+- The TypeScript SDK and CLI pass the `experimental.telemetry` section from the
+  caller-provided config through to the Rust binary. No TypeScript-side telemetry SDK is used.
+- Linux telemetry is a P2 requirement. The `tracelogging` crate compiles as no-ops on Linux,
+  so the code compiles cleanly but does not emit events. A future iteration may add
+  LTTng tracepoint support using the same `microsoft/tracelogging` repo.
+- No 1DS compatibility is required. Events are emitted to the local ETW subsystem.
+  If a downstream 1DS UTC agent or other ETW consumer is present, it can collect events
+  independently, but MXC does not directly integrate with 1DS endpoints.
+- **Operational prerequisite — Windows Telemetry pipeline onboarding**: The
+  `Microsoft.MXC` TraceLogging provider joins the Microsoft Telemetry provider
+  group via `group_id("4f50731a-89cf-4782-b3e0-dce8c90476ba")` (the Rust equivalent
+  of the C/C++ `TraceLoggingOptionGroup` macro with the well-known Microsoft
+  Telemetry GUID). This tells the Windows **Connected User Experiences and Telemetry**
+  component (CUET, also known as DiagTrack / `diagtrack.dll`) that this provider
+  is a Microsoft first-party telemetry source.
+
+  For events to flow from devices to Microsoft's backend, the following operational
+  steps must be completed (these are not code changes):
+
+  1. **Provider onboarding with the Windows Telemetry team**: Register the
+     `Microsoft.MXC` provider with the Windows Telemetry onboarding process.
+     This authorizes the provider GUID within the CUET pipeline and configures
+     which events are collected. The CUET component uses **OneSettings** (a
+     cloud-based configuration service) to control which providers and event
+     keywords it listens to — a new provider is not collected by default.
+
+  2. **Event schema registration**: Register the `MXC.Execution` and `MXC.Error`
+     event schemas with the telemetry pipeline so events are correctly parsed
+     and stored upon ingestion at `v10.events.data.microsoft.com`.
+
+  3. **Data access and querying**: Set up access to the ingested data in
+     **Kusto** (Azure Data Explorer) or the internal telemetry dashboarding
+     tools to query and visualize the MXC telemetry events.
+
+  Note: This is distinct from "1DS/Aria" — while 1DS and Aria are related
+  Microsoft telemetry systems, the Windows diagnostic data pipeline
+  (CUET/DiagTrack → `v10.events.data.microsoft.com` → Cosmos/Kusto) is the
+  path for TraceLogging providers using the Microsoft Telemetry provider group.
+  These steps are tracked separately from this feature spec and must be completed
+  before telemetry data flows end-to-end in production.
+- The failure reason category dimension on metrics is a bounded enum (e.g., config_error,
+  policy_error, process_error, timeout) — not a free-form string — to prevent accidental PII.
+- Malformed telemetry configuration is treated as `enabled: false` (safe default) rather than failing the run.
+- The existing Cargo workspace structure is extended, not restructured. `wxc_common` gains
+  a `telemetry/` module. No new crate is needed.
+- The GitHub Actions CI pipeline requires no changes for TraceLogging support.
+  The `tracelogging` crate is a standard Cargo dependency.
+
+

--- a/specs/001-add-observability/spec.md
+++ b/specs/001-add-observability/spec.md
@@ -133,7 +133,8 @@ omitting the `telemetry` field results in no telemetry override.
 
 - What happens when the `experimental.telemetry` section is present but malformed?
   Malformed telemetry config MUST be treated as if telemetry is disabled
-  (safe default) and a warning emitted to stderr.
+  (safe default). No warning is emitted to stderr; the malformed value is
+  silently ignored to avoid polluting captured output.
 - Can PII be accidentally emitted through error messages or event properties?
   All error messages captured in events MUST be sanitized: file paths, script content,
   and environment variable values MUST NOT appear in event fields.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1349,6 +1349,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracelogging"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0015caf14cad7613b7bbbb9ee44399ad9a694307be545d8af4e2711178e547e"
+dependencies = [
+ "tracelogging_macros",
+]
+
+[[package]]
+name = "tracelogging_macros"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e2d891464ff33bc1814c4cbbb251bae7800458b1efdb6ac8b7c01ee6382563"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1798,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "tracelogging",
  "url",
  "widestring",
  "windows",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -59,5 +59,6 @@ wslc_common = { path = "wslc_common" }
 isolation_session_bindings = { path = "isolation_session_bindings" }
 flatbuffers = "25"
 sandbox_spec = { path = "generated/base_container_specification" }
+tracelogging = { version = "1.2", features = ["etw"] }
 widestring = "1"
 url = "2"

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -10,6 +10,7 @@ use wxc_common::config_parser::load_request;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
 use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
+use wxc_common::telemetry;
 
 use lxc_common::lxc_runner::LxcScriptRunner;
 
@@ -158,16 +159,68 @@ fn main() {
         &request.container_id,
         &request.lifecycle,
     );
+
+    // Initialize telemetry (TraceLogging ETW — no-op on Linux) after all early-exit validation.
+    let telemetry_active = if request.experimental_enabled {
+        let telemetry_config = request
+            .experimental
+            .telemetry
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        telemetry::init(&telemetry_config)
+    } else {
+        false
+    };
+
     let run_start = Instant::now();
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
 
     if cli.dry_run {
+        if telemetry_active {
+            telemetry::shutdown();
+        }
         handle_dry_run_exit(&response, &mut logger);
     }
 
     display_script_results(&response, &mut logger);
+
+    // Emit telemetry events
+    if telemetry_active {
+        let outcome = if response.exit_code == 0 {
+            "success"
+        } else {
+            "failure"
+        };
+        let failure_reason = if response.exit_code != 0 {
+            Some(telemetry::FailureReason::ProcessError)
+        } else {
+            None
+        };
+
+        telemetry::log_execution(&telemetry::ExecutionEvent {
+            backend: "lxc",
+            exit_code: response.exit_code,
+            outcome,
+            duration_ms: run_elapsed.as_millis() as u64,
+            init_duration_ms: 0,
+            version: telemetry::version(),
+            failure_reason,
+        });
+
+        if response.exit_code != 0 && !response.error_message.is_empty() {
+            telemetry::log_error(
+                "lxc",
+                telemetry::FailureReason::ProcessError,
+                &response.error_message,
+                telemetry::version(),
+            );
+        }
+
+        telemetry::shutdown();
+    }
 
     print!("{}", response.standard_out);
     eprint!("{}", response.standard_err);

--- a/src/lxc/src/main.rs
+++ b/src/lxc/src/main.rs
@@ -194,6 +194,8 @@ fn main() {
         } else {
             "failure"
         };
+        // TODO: Currently all failures are classified as ProcessError. Once ScriptResponse
+        // carries a structured failure category, map to the appropriate FailureReason variant.
         let failure_reason = if response.exit_code != 0 {
             Some(telemetry::FailureReason::ProcessError)
         } else {

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -17,6 +17,7 @@ use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
 use wxc_common::nanvix_runner::NanVixScriptRunner;
 use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
+use wxc_common::telemetry;
 use wxc_common::windows_sandbox_runner::WindowsSandboxScriptRunner;
 
 #[derive(Parser)]
@@ -273,16 +274,79 @@ fn main() {
             }
         }
     };
+
+    // Initialize telemetry (TraceLogging ETW) after all early-exit validation.
+    // SAFETY of provider registration: shutdown() is guaranteed to run because
+    // there are no process::exit() calls between here and the shutdown below.
+    let telemetry_active = if request.experimental_enabled {
+        let telemetry_config = request
+            .experimental
+            .telemetry
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        telemetry::init(&telemetry_config)
+    } else {
+        false
+    };
+
     let run_start = Instant::now();
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
 
     if cli.dry_run {
+        if telemetry_active {
+            telemetry::shutdown();
+        }
         handle_dry_run_exit(&response, &mut logger);
     }
 
     display_script_results(&response, &mut logger);
+
+    // Emit telemetry events
+    if telemetry_active {
+        let backend_str = match request.containment {
+            ContainmentBackend::AppContainer => "appcontainer",
+            ContainmentBackend::WindowsSandbox => "sandbox",
+            ContainmentBackend::Lxc => "lxc",
+            ContainmentBackend::Wslc => "wslc",
+            ContainmentBackend::MicroVm => "microvm",
+            ContainmentBackend::Vm => "vm",
+            ContainmentBackend::IsolationSession => "isolation_session",
+        };
+        let outcome = if response.exit_code == 0 {
+            "success"
+        } else {
+            "failure"
+        };
+        let failure_reason = if response.exit_code != 0 {
+            Some(telemetry::FailureReason::ProcessError)
+        } else {
+            None
+        };
+
+        telemetry::log_execution(&telemetry::ExecutionEvent {
+            backend: backend_str,
+            exit_code: response.exit_code,
+            outcome,
+            duration_ms: run_elapsed.as_millis() as u64,
+            init_duration_ms: 0, // will be instrumented per-backend later
+            version: telemetry::version(),
+            failure_reason,
+        });
+
+        if response.exit_code != 0 && !response.error_message.is_empty() {
+            telemetry::log_error(
+                backend_str,
+                telemetry::FailureReason::ProcessError,
+                &response.error_message,
+                telemetry::version(),
+            );
+        }
+
+        telemetry::shutdown();
+    }
 
     // Output was already relayed to the console by pipe threads.
     // Only print captured output if present (e.g. from error paths).

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -320,6 +320,9 @@ fn main() {
         } else {
             "failure"
         };
+        // TODO: Currently all failures are classified as ProcessError. Once ScriptResponse
+        // carries a structured failure category, map to the appropriate FailureReason variant
+        // (ConfigError, PolicyError, InitError, Timeout, etc.) for more accurate telemetry.
         let failure_reason = if response.exit_code != 0 {
             Some(telemetry::FailureReason::ProcessError)
         } else {

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -10,6 +10,7 @@ isolation_session = ["dep:isolation_session_bindings", "dep:windows-future"]
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracelogging = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
 semver = "1"

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -153,6 +153,14 @@ struct RawExperimental {
     wslc: Option<RawContainerConfig>,
     #[serde(rename = "isolation_session")]
     isolation_session: Option<RawIsolationSession>,
+    telemetry: Option<RawTelemetry>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+struct RawTelemetry {
+    /// Accepts any JSON value for `enabled`; non-bool values are treated as None (disabled).
+    enabled: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize, Default)]
@@ -668,6 +676,9 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
             windows_sandbox,
             wslc,
             isolation_session,
+            telemetry: raw_exp.telemetry.map(|t| crate::models::TelemetryConfig {
+                enabled: t.enabled.and_then(|v| v.as_bool()),
+            }),
         }
     } else {
         ExperimentalConfig::default()
@@ -1889,5 +1900,129 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(req.experimental.isolation_session.is_none());
+    }
+
+    // ---- Telemetry config parsing tests ----
+
+    #[test]
+    fn telemetry_enabled_parsed_from_experimental() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "telemetry": {"enabled": true}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let telemetry = req
+            .experimental
+            .telemetry
+            .expect("telemetry should be Some");
+        assert_eq!(telemetry.enabled, Some(true));
+    }
+
+    #[test]
+    fn telemetry_disabled_parsed_from_experimental() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "telemetry": {"enabled": false}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let telemetry = req
+            .experimental
+            .telemetry
+            .expect("telemetry should be Some");
+        assert_eq!(telemetry.enabled, Some(false));
+    }
+
+    #[test]
+    fn telemetry_absent_defaults_to_none() {
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.experimental.telemetry.is_none());
+    }
+
+    #[test]
+    fn telemetry_empty_object_defaults_enabled_to_none() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "telemetry": {}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let telemetry = req
+            .experimental
+            .telemetry
+            .expect("telemetry should be Some");
+        assert_eq!(telemetry.enabled, None);
+    }
+
+    #[test]
+    fn telemetry_malformed_does_not_break_config() {
+        // telemetry.enabled is a string instead of bool — treated as None (disabled)
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "telemetry": {"enabled": "yes"}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        // Malformed enabled value should be treated as disabled, not error
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let telemetry = req
+            .experimental
+            .telemetry
+            .expect("telemetry should be Some");
+        assert_eq!(telemetry.enabled, None);
+    }
+
+    #[test]
+    fn telemetry_unknown_fields_ignored() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "telemetry": {"enabled": true, "unknown_field": 42}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let telemetry = req
+            .experimental
+            .telemetry
+            .expect("telemetry should be Some");
+        assert_eq!(telemetry.enabled, Some(true));
+    }
+
+    #[test]
+    fn experimental_without_telemetry_has_none() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "experimental": {
+                "windows_sandbox": {}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.experimental.telemetry.is_none());
     }
 }

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod models;
 #[cfg(target_os = "windows")]
 pub mod nanvix_runner;
 pub mod script_runner;
+pub mod telemetry;
 pub mod validator;
 
 // Windows-specific modules

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -339,6 +339,19 @@ pub struct ExperimentalConfig {
     /// Isolation Session backend (experimental).
     #[serde(rename = "isolation_session")]
     pub isolation_session: Option<IsolationSessionConfig>,
+    /// Telemetry configuration (experimental).
+    pub telemetry: Option<TelemetryConfig>,
+}
+
+/// Telemetry configuration parsed from the JSON config `experimental.telemetry` section.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TelemetryConfig {
+    /// Explicit telemetry override.
+    /// `Some(true)` enables telemetry.
+    /// `Some(false)` disables telemetry.
+    /// `None` leaves telemetry disabled (explicit opt-in required).
+    pub enabled: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/wxc_common/src/telemetry/events.rs
+++ b/src/wxc_common/src/telemetry/events.rs
@@ -1,0 +1,207 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TraceLogging ETW event emission for MXC telemetry.
+
+use tracelogging as tlg;
+
+use super::MXC_PROVIDER;
+
+/// Bounded set of failure categories for error classification.
+/// Prevents free-form strings that could contain PII.
+#[derive(Debug, Clone, Copy)]
+pub enum FailureReason {
+    ConfigError,
+    PolicyError,
+    ProcessError,
+    Timeout,
+    InitError,
+    Unknown,
+}
+
+impl FailureReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ConfigError => "config_error",
+            Self::PolicyError => "policy_error",
+            Self::ProcessError => "process_error",
+            Self::Timeout => "timeout",
+            Self::InitError => "init_error",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Sanitize an error message by stripping potential PII (file paths, usernames).
+pub fn sanitize_error_message(msg: &str) -> String {
+    let mut sanitized = String::with_capacity(msg.len());
+    let mut chars = msg.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        // Detect Windows paths: letter followed by :\
+        if c.is_ascii_alphabetic() {
+            if let Some(&next) = chars.peek() {
+                if next == ':' {
+                    // Peek further for backslash
+                    let rest: String = chars.clone().take(2).collect();
+                    if rest.starts_with(":\\") {
+                        sanitized.push_str("<path>");
+                        // Skip until whitespace or quote
+                        for ch in chars.by_ref() {
+                            if ch.is_whitespace() || ch == '\'' || ch == '"' {
+                                sanitized.push(ch);
+                                break;
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+            sanitized.push(c);
+            continue;
+        }
+
+        // Detect Unix paths: /home/, /tmp/, /var/, /usr/, /etc/, /root/, /mnt/, /opt/
+        if c == '/' {
+            let prefixes = [
+                "home/", "tmp/", "var/", "usr/", "etc/", "root/", "mnt/", "opt/",
+            ];
+            let upcoming: String = chars.clone().take(5).collect();
+            if prefixes.iter().any(|p| upcoming.starts_with(p)) {
+                sanitized.push_str("<path>");
+                // Skip until whitespace or quote
+                for ch in chars.by_ref() {
+                    if ch.is_whitespace() || ch == '\'' || ch == '"' {
+                        sanitized.push(ch);
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+
+        sanitized.push(c);
+    }
+
+    // Truncate to a reasonable length (safe for multi-byte UTF-8)
+    if sanitized.len() > 256 {
+        let truncate_at = sanitized
+            .char_indices()
+            .map(|(i, _)| i)
+            .take_while(|&i| i <= 256)
+            .last()
+            .unwrap_or(0);
+        sanitized.truncate(truncate_at);
+        sanitized.push_str("...");
+    }
+
+    sanitized
+}
+
+/// Data for an MXC.Execution ETW event.
+pub struct ExecutionEvent<'a> {
+    pub backend: &'a str,
+    pub exit_code: i32,
+    pub outcome: &'a str,
+    pub duration_ms: u64,
+    pub init_duration_ms: u64,
+    pub version: &'a str,
+    pub failure_reason: Option<FailureReason>,
+}
+
+/// Log an MXC.Execution ETW event.
+pub fn log_execution(event: &ExecutionEvent<'_>) {
+    match event.failure_reason {
+        Some(failure_reason) => {
+            tlg::write_event!(
+                MXC_PROVIDER,
+                "MXC.Execution",
+                level(Informational),
+                keyword(0x1),
+                str8("mxc.backend", event.backend),
+                i32("mxc.exit_code", &event.exit_code),
+                str8("mxc.outcome", event.outcome),
+                u64("mxc.duration_ms", &event.duration_ms),
+                u64("mxc.init_duration_ms", &event.init_duration_ms),
+                str8("mxc.version", event.version),
+                str8("mxc.failure_reason", failure_reason.as_str()),
+            );
+        }
+        None => {
+            tlg::write_event!(
+                MXC_PROVIDER,
+                "MXC.Execution",
+                level(Informational),
+                keyword(0x1),
+                str8("mxc.backend", event.backend),
+                i32("mxc.exit_code", &event.exit_code),
+                str8("mxc.outcome", event.outcome),
+                u64("mxc.duration_ms", &event.duration_ms),
+                u64("mxc.init_duration_ms", &event.init_duration_ms),
+                str8("mxc.version", event.version),
+            );
+        }
+    }
+}
+
+/// Log an MXC.Error ETW event.
+pub fn log_error(backend: &str, error_type: FailureReason, error_message: &str, version: &str) {
+    let sanitized = sanitize_error_message(error_message);
+
+    tlg::write_event!(
+        MXC_PROVIDER,
+        "MXC.Error",
+        level(Warning),
+        keyword(0x2),
+        str8("mxc.backend", backend),
+        str8("mxc.error_type", error_type.as_str()),
+        str8("mxc.error_message", &sanitized),
+        str8("mxc.version", version),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_reason_as_str() {
+        assert_eq!(FailureReason::ConfigError.as_str(), "config_error");
+        assert_eq!(FailureReason::PolicyError.as_str(), "policy_error");
+        assert_eq!(FailureReason::ProcessError.as_str(), "process_error");
+        assert_eq!(FailureReason::Timeout.as_str(), "timeout");
+        assert_eq!(FailureReason::InitError.as_str(), "init_error");
+        assert_eq!(FailureReason::Unknown.as_str(), "unknown");
+    }
+
+    #[test]
+    fn sanitize_strips_windows_paths() {
+        let msg = "Failed to read C:\\Users\\alice\\secret\\config.json";
+        let result = sanitize_error_message(msg);
+        assert!(!result.contains("alice"));
+        assert!(!result.contains("secret"));
+        assert!(result.contains("<path>"));
+    }
+
+    #[test]
+    fn sanitize_strips_unix_paths() {
+        let msg = "Cannot open /home/bob/project/data.txt";
+        let result = sanitize_error_message(msg);
+        assert!(!result.contains("bob"));
+        assert!(result.contains("<path>"));
+    }
+
+    #[test]
+    fn sanitize_truncates_long_messages() {
+        let long_msg = "x".repeat(500);
+        let result = sanitize_error_message(&long_msg);
+        assert!(result.len() < 300);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn sanitize_preserves_safe_messages() {
+        let msg = "Firewall rule creation failed";
+        assert_eq!(sanitize_error_message(msg), msg);
+    }
+}

--- a/src/wxc_common/src/telemetry/mod.rs
+++ b/src/wxc_common/src/telemetry/mod.rs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! TraceLogging ETW telemetry for MXC.
+//!
+//! Provides structured event emission for execution observability
+//! and adoption metrics. Events are emitted to the local ETW subsystem
+//! via the `tracelogging` crate and can be captured by any ETW consumer
+//! (tracelog, logman, WPR, or an external agent).
+
+pub mod events;
+
+use tracelogging as tlg;
+
+use crate::models::TelemetryConfig;
+
+pub use events::{log_error, log_execution, ExecutionEvent, FailureReason};
+
+// Define the TraceLogging ETW provider at the module level so it is
+// accessible to both this module and the events submodule.
+//
+// The group_id is the well-known Microsoft Telemetry provider group GUID.
+// This is the Rust equivalent of C/C++ TraceLoggingOptionGroup(...) with this
+// GUID (sometimes wrapped as TraceLoggingOptionMicrosoftTelemetry()).
+// Joining this group tells the Windows Connected User Experiences and Telemetry
+// component (CUET / DiagTrack) that this is a Microsoft first-party telemetry
+// provider. The CUET component must also be configured via OneSettings to
+// collect from this specific provider before events flow to the backend.
+tlg::define_provider!(
+    MXC_PROVIDER,
+    "Microsoft.MXC",
+    group_id("4f50731a-89cf-4782-b3e0-dce8c90476ba")
+);
+
+/// MXC version string, set at compile time.
+const MXC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Returns the MXC version string.
+pub fn version() -> &'static str {
+    MXC_VERSION
+}
+
+/// Resolve whether telemetry is enabled for this invocation.
+///
+/// Resolution:
+/// - `experimental.telemetry.enabled` in JSON config — explicit override.
+/// - Default: off (telemetry requires explicit opt-in).
+///
+/// Note: Consent is the SDK consumer's responsibility. MXC does not implement
+/// consent prompts or persistent consent storage.
+pub fn is_enabled(config: &TelemetryConfig) -> bool {
+    config.enabled.unwrap_or(false)
+}
+
+/// Initialize the TraceLogging ETW provider.
+///
+/// If telemetry is enabled, registers the `Microsoft.MXC` provider with ETW.
+/// Returns `true` if telemetry was activated, `false` if disabled.
+/// Errors during registration are silently swallowed (telemetry must not
+/// affect execution).
+pub fn init(config: &TelemetryConfig) -> bool {
+    if !is_enabled(config) {
+        return false;
+    }
+
+    // SAFETY: We guarantee that `shutdown()` is called before the process exits,
+    // which calls `MXC_PROVIDER.unregister()`.
+    unsafe {
+        MXC_PROVIDER.register();
+    }
+
+    true
+}
+
+/// Unregister the TraceLogging ETW provider.
+///
+/// Must be called before process exit if `init()` returned `true`.
+pub fn shutdown() {
+    MXC_PROVIDER.unregister();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_enabled_explicit_true() {
+        let config = TelemetryConfig {
+            enabled: Some(true),
+        };
+        assert!(is_enabled(&config));
+    }
+
+    #[test]
+    fn is_enabled_explicit_false() {
+        let config = TelemetryConfig {
+            enabled: Some(false),
+        };
+        assert!(!is_enabled(&config));
+    }
+
+    #[test]
+    fn is_enabled_default_off() {
+        let config = TelemetryConfig::default();
+        assert!(!is_enabled(&config));
+    }
+
+    #[test]
+    fn version_is_not_empty() {
+        assert!(!version().is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Add structured TraceLogging ETW telemetry to MXC for execution observability and adoption metrics. Telemetry is gated behind the \--experimental\ CLI flag and requires explicit opt-in via the JSON config.

## Changes

**Provider**: \Microsoft.MXC\ (joins the Microsoft Telemetry provider group via \group_id\ for CUET/DiagTrack collection)

**Events emitted**:
- \MXC.Execution\: backend, exit_code, outcome, duration_ms, init_duration_ms, version, failure_reason
- \MXC.Error\: backend, error_type, error_message (sanitized), version

**Files** (16 files, +1031 lines):
- \src/wxc_common/src/telemetry/mod.rs\ — public API: init(), shutdown(), is_enabled(), version()
- \src/wxc_common/src/telemetry/events.rs\ — log_execution(), log_error(), ExecutionEvent, FailureReason, sanitize_error_message()
- \src/wxc_common/src/models.rs\ — TelemetryConfig in ExperimentalConfig
- \src/wxc_common/src/config_parser.rs\ — parse experimental.telemetry + 7 tests
- \src/wxc/src/main.rs\ — telemetry init/log/shutdown (gated by --experimental)
- \src/lxc/src/main.rs\ — same pattern (no-op on Linux)
- \sdk/src/types.ts\ — TelemetryConfig interface in experimental section
- \schemas/dev/mxc-config.schema.0.5.0-dev.json\ — telemetry under experimental
- \docs/schema.md\ — telemetry in schema example
- \Readme.md\ — Telemetry section
- \xamples/14_telemetry_enabled.json\ — example config
- \specs/001-add-observability/spec.md\ — feature specification

## Design decisions

- **Experimental**: requires \--experimental\ flag + \xperimental.telemetry.enabled: true\
- **Off by default**: telemetry requires explicit opt-in
- **No PII**: error messages sanitized, all fields are bounded enums or metrics
- **No consent prompts**: consent is the SDK consumer's responsibility
- **Pure Rust**: uses \	racelogging\ crate (no C/C++ FFI)
- **Microsoft Telemetry provider group**: for CUET/DiagTrack pipeline integration
- **Linux**: compiles as no-ops (P2 for LTTng support)

## Operational prerequisites (not code)

Before events flow end-to-end in production:
1. Register \Microsoft.MXC\ provider with Windows Telemetry team (OneSettings)
2. Register \MXC.Execution\ and \MXC.Error\ event schemas
3. Set up Kusto/dashboard access for querying ingested data

## Tests

16 telemetry tests covering: FailureReason enum, PII sanitization (Windows/Unix paths, truncation, safe passthrough), is_enabled resolution, version string, and config parser (7 tests for experimental.telemetry parsing).

## Validation

- \cargo fmt\ ✅
- \cargo clippy --workspace -D warnings\ ✅
- 222 workspace tests pass ✅
- 4 E2E test failures are pre-existing on main (STATUS_DLL_NOT_FOUND)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/233)