### PR TITLE
skip BFS and proxy wxc-exec e2e tests that require BFS changes

### DIFF
--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -136,6 +136,7 @@ fn appcontainer_proxy() {
 // ---------------------------------------------------------------------------
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_appcontainer_basic() {
     if !cached_has_wxc_exe() {
         return;
@@ -144,6 +145,7 @@ fn test_appcontainer_basic() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_appcontainer_lpac() {
     if !cached_has_wxc_exe() {
         return;
@@ -152,6 +154,7 @@ fn test_appcontainer_lpac() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs() {
     if !cached_has_wxc_exe() {
         return;
@@ -160,6 +163,7 @@ fn test_filesystem_bfs() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs_readonly() {
     if !cached_has_wxc_exe() {
         return;
@@ -168,6 +172,7 @@ fn test_filesystem_bfs_readonly() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs_spaces() {
     if !cached_has_wxc_exe() {
         return;
@@ -176,6 +181,7 @@ fn test_filesystem_bfs_spaces() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_pwsh_setlocation() {
     if !cached_has_wxc_exe() {
         return;
@@ -184,6 +190,7 @@ fn test_pwsh_setlocation() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_test_configs() {
     if !cached_has_test_driver() {
         return;
@@ -192,6 +199,7 @@ fn test_test_configs() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_examples() {
     if !cached_has_test_driver() {
         return;
@@ -236,6 +244,7 @@ fn test_microvm_suite() {
 }
 
 #[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled and elevation
 fn test_appcontainer_proxy() {
     if !cached_has_test_driver() {
         return;

--- a/test_scripts/README.md
+++ b/test_scripts/README.md
@@ -64,8 +64,29 @@ The `wxc_e2e_tests` crate runs executor E2E tests directly against
 ```powershell
 cd src
 cargo test -p wxc_e2e_tests              # Executor E2E tests (skips if prereqs missing)
-cargo test -p wxc_e2e_tests -- --ignored # Include stress tests
+cargo test -p wxc_e2e_tests -- --ignored # Include BFS, networking, and stress tests
 ```
+
+### Ignored tests
+
+The following tests are marked `#[ignore]` because they require velocity key
+61714527 (BFS deadlock fix) enabled on the machine. AppContainer process
+isolation with brokered filesystem or networking depends on this fix.
+Run them explicitly on capable machines with
+`cargo test -p wxc_e2e_tests -- --ignored`:
+
+| Test | Reason |
+|------|--------|
+| `test_appcontainer_basic` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_appcontainer_lpac` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_filesystem_bfs` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_filesystem_bfs_readonly` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_filesystem_bfs_spaces` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_pwsh_setlocation` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_test_configs` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_examples` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_appcontainer_proxy` | Requires velocity key 61714527 (BFS deadlock fix) and elevation |
+| `test_on_repeat` | Stress test (loops BFS tests) |
 
 ## MicroVM E2E
 


### PR DESCRIPTION
AppContainer tests using brokered filesystem (read/write/deny paths) require the BFS deadlock fix (velocity key 61714527) enabled on the machine. Proxy in 0.4.0 schema requires elevation.

If you run these tests on a machine that doesn't have the changes in  https://microsoft.visualstudio.com/OS/_git/os.2020/pullrequest/15258319 enabled these tests will dead lock your machine. 

For now we'll mark these as #[ignore] in Rust e2e tests and document the velocity key requirement. We need to do more work to see if there is a way we can check this without outright skipping in all cases.

<!-- To check a checkbox place an "x" between the brackets. e.g: [x] -->

- [ ] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/234)