### PR TITLE
[WSLC] Refactor WSLContainerRunner::run_internal into focused helpers

### DIFF
--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -804,12 +804,12 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetProcessSettingsCmdLine failed", hr, "");
         }
 
+        let env_cstrings: Vec<Vec<u8>> = request
+            .env
+            .iter()
+            .map(|e| format!("{}\0", e).into_bytes())
+            .collect();
         if !request.env.is_empty() {
-            let env_cstrings: Vec<Vec<u8>> = request
-                .env
-                .iter()
-                .map(|e| format!("{}\0", e).into_bytes())
-                .collect();
             let env_ptrs: Vec<PCSTR> = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
             let hr = (sdk.WslcSetProcessSettingsEnvVariables)(
                 &mut process_settings,

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -323,14 +323,9 @@ impl ScriptRunner for WSLContainerRunner {
     }
 }
 
-/// Result of the init phase: COM initialized and SDK loaded.
-struct InitResult {
-    sdk: WslcSdk,
-}
-
 impl WSLContainerRunner {
     /// Step 0: Initialize COM and load the WSLC SDK at runtime.
-    unsafe fn init_and_load_sdk(logger: &mut Logger) -> Result<InitResult, ScriptResponse> {
+    unsafe fn init_and_load_sdk(logger: &mut Logger) -> Result<WslcSdk, ScriptResponse> {
         let com_hr = windows::Win32::System::Com::CoInitializeEx(
             None,
             windows::Win32::System::Com::COINIT_MULTITHREADED,
@@ -364,7 +359,7 @@ impl WSLContainerRunner {
         }
         let _ = writeln!(logger, "[WSLC] Runtime check passed");
 
-        Ok(InitResult { sdk })
+        Ok(sdk)
     }
 
     /// Step 2-3: Configure session settings and create the session.
@@ -501,6 +496,11 @@ impl WSLContainerRunner {
         } else if let Some(tar_path) = &self.config.image_tar_path {
             Self::import_image_from_tar(sdk, session, image_name, tar_path, logger)?;
         } else {
+            // Pull from registry
+            // TODO: Move image pulling to a setup script (scripts/setup-wslc.ps1) as
+            // described in docs/wsl-container-support-plan.md Phase 5. MXC is an execution
+            // layer — image management should be handled externally. For now, auto-pull is
+            // used during development/testing.
             let _ = writeln!(
                 logger,
                 "[WSLC] Image '{}' not found locally, attempting pull...",
@@ -691,7 +691,7 @@ impl WSLContainerRunner {
         let mut exit_code: i32 = -1;
         let hr = (sdk.WslcGetProcessExitCode)(process_guard.as_raw(), &mut exit_code);
         if hr != S_OK && !timed_out {
-            let _ = writeln!(logger, "[WSLC] Warning: WslcGetProcessExitCode failed");
+            return Err(sdk_error("WslcGetProcessExitCode failed", hr, ""));
         }
         if timed_out {
             let _ = writeln!(logger, "[WSLC] Process killed after timeout");
@@ -744,7 +744,7 @@ impl WSLContainerRunner {
         let _ = writeln!(logger, "[WSLC] Starting WSL Container runner");
 
         // -- Init: COM + SDK + preflight --
-        let InitResult { sdk } = match Self::init_and_load_sdk(logger) {
+        let sdk = match Self::init_and_load_sdk(logger) {
             Ok(r) => r,
             Err(e) => return e,
         };
@@ -769,11 +769,19 @@ impl WSLContainerRunner {
             return sdk_error("WslcInitProcessSettings failed", hr, "");
         }
 
+        // Register I/O callbacks to capture stdout/stderr.
+        // We use Arc so the callback context stays alive even if the function
+        // returns early (e.g., container creation fails after callbacks are
+        // registered). The SDK may still invoke callbacks on its internal
+        // threads; Arc ensures the memory isn't freed until all references
+        // (including the one held by the SDK via raw pointer) are dropped.
         let io_ctx = Arc::new(IoContext {
             stdout: Arc::new(Mutex::new(Vec::new())),
             stderr: Arc::new(Mutex::new(Vec::new())),
             exited: Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new())),
         });
+        // Give the SDK an Arc reference via raw pointer. We must reconstruct
+        // the Arc later to avoid leaking the reference count.
         let io_ctx_for_sdk = Arc::clone(&io_ctx);
         let io_ctx_raw = Arc::into_raw(io_ctx_for_sdk) as *mut c_void;
         let _io_ctx_guard = IoCtxRawGuard::new(io_ctx_raw);
@@ -850,6 +858,9 @@ impl WSLContainerRunner {
             return sdk_error("WslcInitContainerSettings failed", hr, "");
         }
 
+        // TODO: Port mappings (WslcConfig.port_mappings) are parsed but not yet applied.
+        // Requires adding WslcSetContainerSettingsPortMappings and WslcContainerPortMapping
+        // bindings. See wslcsdk.h lines 120-128, 183-186.
         let (mounts, warnings) = policy_mapping::build_volume_mounts(
             &request.policy.readwrite_paths,
             &request.policy.readonly_paths,

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -323,43 +323,59 @@ impl ScriptRunner for WSLContainerRunner {
     }
 }
 
-impl WSLContainerRunner {
-    unsafe fn run_internal(&self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        let _ = writeln!(logger, "[WSLC] Starting WSL Container runner");
+/// Result of the init phase: COM initialized and SDK loaded.
+struct InitResult {
+    sdk: WslcSdk,
+}
 
-        // -- Step 0: COM initialization --
+impl WSLContainerRunner {
+    /// Step 0: Initialize COM and load the WSLC SDK at runtime.
+    unsafe fn init_and_load_sdk(logger: &mut Logger) -> Result<InitResult, ScriptResponse> {
         let com_hr = windows::Win32::System::Com::CoInitializeEx(
             None,
             windows::Win32::System::Com::COINIT_MULTITHREADED,
         );
         if com_hr.is_err() {
-            return ScriptResponse::error(&format!("COM initialization failed: {:?}", com_hr));
+            return Err(ScriptResponse::error(&format!(
+                "COM initialization failed: {:?}",
+                com_hr
+            )));
         }
         let _ = writeln!(logger, "[WSLC] COM initialized");
 
-        // -- Step 0b: Load WSLC SDK at runtime --
         let sdk = match WslcSdk::load() {
             Ok(s) => s,
-            Err(e) => return ScriptResponse::error(&e),
+            Err(e) => return Err(ScriptResponse::error(&e)),
         };
 
-        // -- Step 1: Prerequisites check --
+        // Prerequisites check
         let mut can_run: BOOL = 0;
         let mut missing = WslcComponentFlags::None;
         let hr = (sdk.WslcCanRun)(&mut can_run, &mut missing);
         if hr != S_OK {
-            return sdk_error("WslcCanRun failed", hr, "");
+            return Err(sdk_error("WslcCanRun failed", hr, ""));
         }
         if can_run == 0 {
-            return ScriptResponse::error(&format!(
+            return Err(ScriptResponse::error(&format!(
                 "WSLC runtime not available. Missing components: {:?}. \
                  Ensure WSL2 and the WSLC SDK are installed.",
                 missing
-            ));
+            )));
         }
         let _ = writeln!(logger, "[WSLC] Runtime check passed");
 
-        // -- Step 2: Session settings --
+        Ok(InitResult { sdk })
+    }
+
+    /// Step 2-3: Configure session settings and create the session.
+    /// Returns the session guard (RAII).
+    /// Keeps owned string data alive through session creation.
+    unsafe fn create_session(
+        &self,
+        sdk: &WslcSdk,
+        request: &CodexRequest,
+        logger: &mut Logger,
+    ) -> Result<WslcSessionGuard, ScriptResponse> {
         let session_name: Vec<u16> = format!("{}\0", request.container_id)
             .encode_utf16()
             .collect();
@@ -372,72 +388,83 @@ impl WSLContainerRunner {
         let storage_path_wide: Vec<u16> =
             format!("{}\0", storage_path_str).encode_utf16().collect();
 
-        let mut session_settings = std::mem::zeroed::<WslcSessionSettings>();
+        let mut settings = std::mem::zeroed::<WslcSessionSettings>();
         let hr = (sdk.WslcInitSessionSettings)(
             session_name.as_ptr(),
             storage_path_wide.as_ptr(),
-            &mut session_settings,
+            &mut settings,
         );
         if hr != S_OK {
-            return sdk_error("WslcInitSessionSettings failed", hr, "");
+            return Err(sdk_error("WslcInitSessionSettings failed", hr, ""));
         }
 
         if let Some(cpu) = self.config.cpu_count {
-            let hr = (sdk.WslcSetSessionSettingsCpuCount)(&mut session_settings, cpu);
+            let hr = (sdk.WslcSetSessionSettingsCpuCount)(&mut settings, cpu);
             if hr != S_OK {
-                return sdk_error("WslcSetSessionSettingsCpuCount failed", hr, "");
+                return Err(sdk_error("WslcSetSessionSettingsCpuCount failed", hr, ""));
             }
         }
         if let Some(mem_mb) = self.config.memory_mb {
             let mem_mb = match u32::try_from(mem_mb) {
                 Ok(v) => v,
                 Err(_) => {
-                    return ScriptResponse::error(&format!(
+                    return Err(ScriptResponse::error(&format!(
                         "Invalid config: memory_mb value {} exceeds maximum {} MB",
                         mem_mb,
                         u32::MAX
-                    ));
+                    )));
                 }
             };
-            let hr = (sdk.WslcSetSessionSettingsMemory)(&mut session_settings, mem_mb);
+            let hr = (sdk.WslcSetSessionSettingsMemory)(&mut settings, mem_mb);
             if hr != S_OK {
-                return sdk_error("WslcSetSessionSettingsMemory failed", hr, "");
+                return Err(sdk_error("WslcSetSessionSettingsMemory failed", hr, ""));
             }
         }
         if request.script_timeout > 0 {
-            let hr =
-                (sdk.WslcSetSessionSettingsTimeout)(&mut session_settings, request.script_timeout);
+            let hr = (sdk.WslcSetSessionSettingsTimeout)(&mut settings, request.script_timeout);
             if hr != S_OK {
-                return sdk_error("WslcSetSessionSettingsTimeout failed", hr, "");
+                return Err(sdk_error("WslcSetSessionSettingsTimeout failed", hr, ""));
             }
         }
         if self.config.gpu {
             let hr = (sdk.WslcSetSessionSettingsFeatureFlags)(
-                &mut session_settings,
+                &mut settings,
                 WslcSessionFeatureFlags::EnableGpu,
             );
             if hr != S_OK {
-                return sdk_error("WslcSetSessionSettingsFeatureFlags failed", hr, "");
+                return Err(sdk_error(
+                    "WslcSetSessionSettingsFeatureFlags failed",
+                    hr,
+                    "",
+                ));
             }
         }
 
-        // -- Step 3: Create session --
+        // Create session while string data is still alive
         let mut session: WslcSession = ptr::null_mut();
         let mut err_msg = CoTaskMemPWSTR::null();
-        let hr = (sdk.WslcCreateSession)(&mut session_settings, &mut session, err_msg.as_mut_ptr());
+        let hr = (sdk.WslcCreateSession)(&mut settings, &mut session, err_msg.as_mut_ptr());
         if hr != S_OK {
             let msg = err_msg.to_string_lossy();
-            return sdk_error("WslcCreateSession failed", hr, &msg);
+            return Err(sdk_error("WslcCreateSession failed", hr, &msg));
         }
-        let session_guard = WslcSessionGuard::from_raw(session, sdk.WslcReleaseSession);
         let _ = writeln!(logger, "[WSLC] Session created");
 
-        // -- Step 4: Image check --
+        Ok(WslcSessionGuard::from_raw(session, sdk.WslcReleaseSession))
+    }
+
+    /// Step 4: Check if image exists, import from tar, or pull from registry.
+    unsafe fn resolve_image(
+        &self,
+        sdk: &WslcSdk,
+        session: WslcSession,
+        logger: &mut Logger,
+    ) -> Result<(), ScriptResponse> {
         let mut images: *mut WslcImageInfo = ptr::null_mut();
         let mut image_count: u32 = 0;
-        let hr = (sdk.WslcListSessionImages)(session_guard.as_raw(), &mut images, &mut image_count);
+        let hr = (sdk.WslcListSessionImages)(session, &mut images, &mut image_count);
         if hr != S_OK {
-            return sdk_error("WslcListSessionImages failed", hr, "");
+            return Err(sdk_error("WslcListSessionImages failed", hr, ""));
         }
 
         let image_name = &self.config.image;
@@ -472,21 +499,8 @@ impl WSLContainerRunner {
                 let _ = writeln!(logger, "[WSLC] Image '{}' found", image_name);
             }
         } else if let Some(tar_path) = &self.config.image_tar_path {
-            if let Err(resp) = Self::import_image_from_tar(
-                &sdk,
-                session_guard.as_raw(),
-                image_name,
-                tar_path,
-                logger,
-            ) {
-                return resp;
-            }
+            Self::import_image_from_tar(sdk, session, image_name, tar_path, logger)?;
         } else {
-            // Pull from registry
-            // TODO: Move image pulling to a setup script (scripts/setup-wslc.ps1) as
-            // described in docs/wsl-container-support-plan.md Phase 5. MXC is an execution
-            // layer — image management should be handled externally. For now, auto-pull is
-            // used during development/testing.
             let _ = writeln!(
                 logger,
                 "[WSLC] Image '{}' not found locally, attempting pull...",
@@ -499,43 +513,265 @@ impl WSLContainerRunner {
                 progress_callback_context: ptr::null_mut(),
                 auth_info: ptr::null(),
             };
-            err_msg = CoTaskMemPWSTR::null();
-            let hr = (sdk.WslcPullSessionImage)(
-                session_guard.as_raw(),
-                &pull_opts,
-                err_msg.as_mut_ptr(),
-            );
+            let mut err_msg = CoTaskMemPWSTR::null();
+            let hr = (sdk.WslcPullSessionImage)(session, &pull_opts, err_msg.as_mut_ptr());
             if hr != S_OK {
                 let msg = err_msg.to_string_lossy();
-                return sdk_error(&format!("Failed to pull image '{}'", image_name), hr, &msg);
+                return Err(sdk_error(
+                    &format!("Failed to pull image '{}'", image_name),
+                    hr,
+                    &msg,
+                ));
             }
             let _ = writeln!(logger, "[WSLC] Image '{}' pulled successfully", image_name);
         }
 
-        // -- Step 5: Process settings --
+        Ok(())
+    }
+
+    /// Step 10b: Apply iptables rules inside a running container for host filtering.
+    unsafe fn apply_iptables_rules(
+        sdk: &WslcSdk,
+        container: WslcContainer,
+        ipt_cmd: &str,
+        logger: &mut Logger,
+    ) -> Result<(), ScriptResponse> {
+        let _ = writeln!(logger, "[WSLC] Applying iptables rules for host filtering");
+        let mut ipt_settings = std::mem::zeroed::<WslcProcessSettings>();
+        let hr = (sdk.WslcInitProcessSettings)(&mut ipt_settings);
+        if hr != S_OK {
+            return Err(sdk_error(
+                "WslcInitProcessSettings (iptables) failed",
+                hr,
+                "",
+            ));
+        }
+
+        let ipt_sh = b"/bin/sh\0";
+        let ipt_c = b"-c\0";
+        let ipt_script = format!("{}\0", ipt_cmd);
+        let ipt_script_bytes = ipt_script.as_bytes();
+        let ipt_argv: [PCSTR; 3] = [
+            ipt_sh.as_ptr() as PCSTR,
+            ipt_c.as_ptr() as PCSTR,
+            ipt_script_bytes.as_ptr() as PCSTR,
+        ];
+        let hr = (sdk.WslcSetProcessSettingsCmdLine)(
+            &mut ipt_settings,
+            ipt_argv.as_ptr(),
+            ipt_argv.len(),
+        );
+        if hr != S_OK {
+            return Err(sdk_error(
+                "WslcSetProcessSettingsCmdLine (iptables) failed",
+                hr,
+                "",
+            ));
+        }
+
+        let mut ipt_process: WslcProcess = ptr::null_mut();
+        let mut err_msg = CoTaskMemPWSTR::null();
+        let hr = (sdk.WslcCreateContainerProcess)(
+            container,
+            &mut ipt_settings,
+            &mut ipt_process,
+            err_msg.as_mut_ptr(),
+        );
+        if hr != S_OK {
+            let msg = err_msg.to_string_lossy();
+            return Err(sdk_error("Failed to exec iptables rules", hr, &msg));
+        }
+        let ipt_guard = WslcProcessGuard::from_raw(ipt_process, sdk.WslcReleaseProcess);
+
+        // Wait for iptables to complete
+        let mut ipt_exit_event: HANDLE = ptr::null_mut();
+        let hr = (sdk.WslcGetProcessExitEvent)(ipt_guard.as_raw(), &mut ipt_exit_event);
+        if hr != S_OK {
+            return Err(sdk_error(
+                "WslcGetProcessExitEvent (iptables) failed",
+                hr,
+                "",
+            ));
+        }
+        if !ipt_exit_event.is_null() {
+            windows::Win32::System::Threading::WaitForSingleObject(
+                windows::Win32::Foundation::HANDLE(ipt_exit_event),
+                30_000,
+            );
+        }
+
+        let mut ipt_exit_code: i32 = -1;
+        let hr = (sdk.WslcGetProcessExitCode)(ipt_guard.as_raw(), &mut ipt_exit_code);
+        if hr != S_OK {
+            return Err(sdk_error(
+                "WslcGetProcessExitCode (iptables) failed",
+                hr,
+                "",
+            ));
+        }
+        if ipt_exit_code != 0 {
+            return Err(ScriptResponse::error(&format!(
+                "iptables rules failed with exit code {} \
+                 (image may not have iptables installed)",
+                ipt_exit_code
+            )));
+        }
+        let _ = writeln!(logger, "[WSLC] iptables rules applied successfully");
+        Ok(())
+    }
+
+    /// Step 12: Wait for process exit with timeout enforcement.
+    /// Returns (exit_code, timed_out).
+    unsafe fn wait_for_process(
+        sdk: &WslcSdk,
+        process_guard: &WslcProcessGuard,
+        container_guard: &WslcContainerGuard,
+        io_ctx: &IoContext,
+        request: &CodexRequest,
+        logger: &mut Logger,
+    ) -> (i32, bool) {
+        let mut exit_event: HANDLE = ptr::null_mut();
+        let hr = (sdk.WslcGetProcessExitEvent)(process_guard.as_raw(), &mut exit_event);
+        if hr != S_OK {
+            let _ = writeln!(logger, "[WSLC] Warning: WslcGetProcessExitEvent failed");
+            return (-1, false);
+        }
+
+        let wait_ms = if request.script_timeout > 0 {
+            request.script_timeout
+        } else {
+            u32::MAX
+        };
+
+        let mut timed_out = false;
+        if !exit_event.is_null() {
+            let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
+                windows::Win32::Foundation::HANDLE(exit_event),
+                wait_ms,
+            );
+            if wait_result.0 == 258 {
+                timed_out = true;
+                let _ = writeln!(
+                    logger,
+                    "[WSLC] Execution timeout ({}ms) reached — stopping container",
+                    wait_ms
+                );
+                let mut err_msg = CoTaskMemPWSTR::null();
+                let _ = (sdk.WslcStopContainer)(
+                    container_guard.as_raw(),
+                    WslcSignal::SigTerm,
+                    2,
+                    err_msg.as_mut_ptr(),
+                );
+                drop(err_msg);
+            }
+        }
+
+        // Wait for exit callback to fire — guarantees all I/O is flushed.
+        {
+            let (lock, cvar) = &*io_ctx.exited;
+            let mut exited = lock.lock().unwrap_or_else(|e| e.into_inner());
+            if !*exited {
+                let result = cvar
+                    .wait_timeout(exited, std::time::Duration::from_secs(30))
+                    .unwrap_or_else(|e| e.into_inner());
+                exited = result.0;
+                if !*exited {
+                    let _ = writeln!(
+                        logger,
+                        "[WSLC] Warning: exit callback did not fire within 30s"
+                    );
+                }
+            }
+            drop(exited);
+        }
+
+        let mut exit_code: i32 = -1;
+        let hr = (sdk.WslcGetProcessExitCode)(process_guard.as_raw(), &mut exit_code);
+        if hr != S_OK && !timed_out {
+            let _ = writeln!(logger, "[WSLC] Warning: WslcGetProcessExitCode failed");
+        }
+        if timed_out {
+            let _ = writeln!(logger, "[WSLC] Process killed after timeout");
+        } else {
+            let _ = writeln!(logger, "[WSLC] Process exited with code {}", exit_code);
+        }
+
+        (exit_code, timed_out)
+    }
+
+    /// Step 13-14: Collect captured I/O and build the final ScriptResponse.
+    fn collect_output(
+        io_ctx: &IoContext,
+        exit_code: i32,
+        timed_out: bool,
+        wait_ms: u32,
+        logger: &mut Logger,
+    ) -> ScriptResponse {
+        let stdout =
+            String::from_utf8_lossy(&io_ctx.stdout.lock().unwrap_or_else(|e| e.into_inner()))
+                .to_string();
+        let stderr =
+            String::from_utf8_lossy(&io_ctx.stderr.lock().unwrap_or_else(|e| e.into_inner()))
+                .to_string();
+
+        if !stdout.is_empty() {
+            let _ = writeln!(logger, "[WSLC] Captured {} bytes stdout", stdout.len());
+        }
+        if !stderr.is_empty() {
+            let _ = writeln!(logger, "[WSLC] Captured {} bytes stderr", stderr.len());
+        }
+
+        ScriptResponse {
+            exit_code: if timed_out { -1 } else { exit_code },
+            standard_out: stdout,
+            standard_err: stderr,
+            error_message: if timed_out {
+                format!("Process timed out after {}ms and was terminated", wait_ms)
+            } else {
+                String::new()
+            },
+        }
+    }
+
+    /// Orchestrates the full WSLC lifecycle.
+    /// Helpers handle phases that don't involve dangling-pointer risks;
+    /// pointer-heavy SDK configuration stays inline to keep owned string
+    /// data alive for the duration needed.
+    unsafe fn run_internal(&self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+        let _ = writeln!(logger, "[WSLC] Starting WSL Container runner");
+
+        // -- Init: COM + SDK + preflight --
+        let InitResult { sdk } = match Self::init_and_load_sdk(logger) {
+            Ok(r) => r,
+            Err(e) => return e,
+        };
+
+        // -- Session (configure + create in one step to keep string data alive) --
+        let session_guard = match self.create_session(&sdk, request, logger) {
+            Ok(g) => g,
+            Err(e) => return e,
+        };
+
+        // -- Image resolution --
+        if let Err(e) = self.resolve_image(&sdk, session_guard.as_raw(), logger) {
+            return e;
+        }
+
+        // -- Process settings --
+        // String data (script_cstr, env_cstrings, _cwd_cstr) must stay alive
+        // until after WslcCreateContainer, so this stays inline.
         let mut process_settings = std::mem::zeroed::<WslcProcessSettings>();
         let hr = (sdk.WslcInitProcessSettings)(&mut process_settings);
         if hr != S_OK {
             return sdk_error("WslcInitProcessSettings failed", hr, "");
         }
 
-        // Register I/O callbacks to capture stdout/stderr.
-        // We use Arc so the callback context stays alive even if the function
-        // returns early (e.g., container creation fails after callbacks are
-        // registered). The SDK may still invoke callbacks on its internal
-        // threads; Arc ensures the memory isn't freed until all references
-        // (including the one held by the SDK via raw pointer) are dropped.
         let io_ctx = Arc::new(IoContext {
             stdout: Arc::new(Mutex::new(Vec::new())),
             stderr: Arc::new(Mutex::new(Vec::new())),
             exited: Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new())),
         });
-        let io_ctx_stdout = Arc::clone(&io_ctx.stdout);
-        let io_ctx_stderr = Arc::clone(&io_ctx.stderr);
-        let io_ctx_exited = Arc::clone(&io_ctx.exited);
-
-        // Give the SDK an Arc reference via raw pointer. We must reconstruct
-        // the Arc later to avoid leaking the reference count.
         let io_ctx_for_sdk = Arc::clone(&io_ctx);
         let io_ctx_raw = Arc::into_raw(io_ctx_for_sdk) as *mut c_void;
         let _io_ctx_guard = IoCtxRawGuard::new(io_ctx_raw);
@@ -551,7 +787,6 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetProcessSettingsCallbacks failed", hr, "");
         }
 
-        // Build command line: /bin/sh -c "<script_code>"
         let sh = b"/bin/sh\0";
         let dash_c = b"-c\0";
         let script_cstr = format!("{}\0", request.script_code);
@@ -567,13 +802,12 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetProcessSettingsCmdLine failed", hr, "");
         }
 
-        // Set environment variables
+        let env_cstrings: Vec<Vec<u8>> = request
+            .env
+            .iter()
+            .map(|e| format!("{}\0", e).into_bytes())
+            .collect();
         if !request.env.is_empty() {
-            let env_cstrings: Vec<Vec<u8>> = request
-                .env
-                .iter()
-                .map(|e| format!("{}\0", e).into_bytes())
-                .collect();
             let env_ptrs: Vec<PCSTR> = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
             let hr = (sdk.WslcSetProcessSettingsEnvVariables)(
                 &mut process_settings,
@@ -585,8 +819,7 @@ impl WSLContainerRunner {
             }
         }
 
-        // Set working directory
-        let _cwd_cstr; // kept alive for SDK pointer
+        let _cwd_cstr;
         if !request.working_directory.is_empty() {
             if let Some(container_cwd) =
                 policy_mapping::windows_path_to_container_path(&request.working_directory)
@@ -602,7 +835,9 @@ impl WSLContainerRunner {
             }
         }
 
-        // -- Step 6: Container settings --
+        // -- Container settings --
+        // Volume and image string data must stay alive until WslcCreateContainer.
+        let image_name = &self.config.image;
         let image_cstr = format!("{}\0", image_name);
         let mut container_settings = std::mem::zeroed::<WslcContainerSettings>();
         let hr = (sdk.WslcInitContainerSettings)(
@@ -613,10 +848,6 @@ impl WSLContainerRunner {
             return sdk_error("WslcInitContainerSettings failed", hr, "");
         }
 
-        // -- Step 7: Apply policy mapping --
-        // TODO: Port mappings (WslcConfig.port_mappings) are parsed but not yet applied.
-        // Requires adding WslcSetContainerSettingsPortMappings and WslcContainerPortMapping
-        // bindings. See wslcsdk.h lines 120-128, 183-186.
         let (mounts, warnings) = policy_mapping::build_volume_mounts(
             &request.policy.readwrite_paths,
             &request.policy.readonly_paths,
@@ -625,17 +856,17 @@ impl WSLContainerRunner {
             let _ = writeln!(logger, "[WSLC] Warning: {}", w);
         }
 
-        if !mounts.is_empty() {
-            // Build WslcContainerVolume array — keep owned data alive.
-            let wide_paths: Vec<(Vec<u16>, Vec<u8>)> = mounts
-                .iter()
-                .map(|m| {
-                    let win: Vec<u16> = format!("{}\0", m.windows_path).encode_utf16().collect();
-                    let ctr: Vec<u8> = format!("{}\0", m.container_path).into_bytes();
-                    (win, ctr)
-                })
-                .collect();
+        // Keep owned data alive for volume pointers
+        let wide_paths: Vec<(Vec<u16>, Vec<u8>)> = mounts
+            .iter()
+            .map(|m| {
+                let win: Vec<u16> = format!("{}\0", m.windows_path).encode_utf16().collect();
+                let ctr: Vec<u8> = format!("{}\0", m.container_path).into_bytes();
+                (win, ctr)
+            })
+            .collect();
 
+        if !mounts.is_empty() {
             let volumes: Vec<WslcContainerVolume> = wide_paths
                 .iter()
                 .zip(mounts.iter())
@@ -661,7 +892,6 @@ impl WSLContainerRunner {
             );
         }
 
-        // Network policy
         let is_default_block = request.policy.default_network_policy == NetworkPolicy::Block;
         let has_host_rules = policy_mapping::needs_host_filtering(
             is_default_block,
@@ -675,14 +905,12 @@ impl WSLContainerRunner {
         }
         let _ = writeln!(logger, "[WSLC] Networking mode: {:?}", net_mode);
 
-        // Build iptables rules (if per-host filtering is needed)
         let iptables_cmd = policy_mapping::build_iptables_rules(
             &request.policy.allowed_hosts,
             &request.policy.blocked_hosts,
             is_default_block,
         );
 
-        // Container flags
         let mut flags = WslcContainerFlags::None;
         if request.lifecycle.destroy_on_exit {
             flags = flags | WslcContainerFlags::AutoRemove;
@@ -691,7 +919,6 @@ impl WSLContainerRunner {
             flags = flags | WslcContainerFlags::EnableGpu;
         }
         if has_host_rules {
-            // Privileged needed for iptables inside the container
             flags = flags | WslcContainerFlags::Privileged;
         }
         let hr = (sdk.WslcSetContainerSettingsFlags)(&mut container_settings, flags);
@@ -699,7 +926,6 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetContainerSettingsFlags failed", hr, "");
         }
 
-        // Attach init process
         let hr = (sdk.WslcSetContainerSettingsInitProcess)(
             &mut container_settings,
             &mut process_settings,
@@ -708,9 +934,9 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetContainerSettingsInitProcess failed", hr, "");
         }
 
-        // -- Step 9: Create container --
+        // -- Create & start container --
         let mut container: WslcContainer = ptr::null_mut();
-        err_msg = CoTaskMemPWSTR::null();
+        let mut err_msg = CoTaskMemPWSTR::null();
         let hr = (sdk.WslcCreateContainer)(
             session_guard.as_raw(),
             &container_settings,
@@ -724,7 +950,6 @@ impl WSLContainerRunner {
         let container_guard = WslcContainerGuard::from_raw(container, sdk.WslcReleaseContainer);
         let _ = writeln!(logger, "[WSLC] Container created");
 
-        // -- Step 10: Start container --
         err_msg = CoTaskMemPWSTR::null();
         let hr = (sdk.WslcStartContainer)(
             container_guard.as_raw(),
@@ -737,76 +962,16 @@ impl WSLContainerRunner {
         }
         let _ = writeln!(logger, "[WSLC] Container started");
 
-        // -- Step 10b: Apply iptables rules (if per-host filtering) --
+        // -- Iptables (if needed) --
         if let Some(ref ipt_cmd) = iptables_cmd {
-            let _ = writeln!(logger, "[WSLC] Applying iptables rules for host filtering");
-            let mut ipt_settings = std::mem::zeroed::<WslcProcessSettings>();
-            let hr = (sdk.WslcInitProcessSettings)(&mut ipt_settings);
-            if hr != S_OK {
-                return sdk_error("WslcInitProcessSettings (iptables) failed", hr, "");
+            if let Err(e) =
+                Self::apply_iptables_rules(&sdk, container_guard.as_raw(), ipt_cmd, logger)
+            {
+                return e;
             }
-
-            let ipt_sh = b"/bin/sh\0";
-            let ipt_c = b"-c\0";
-            let ipt_script = format!("{}\0", ipt_cmd);
-            let ipt_script_bytes = ipt_script.as_bytes();
-            let ipt_argv: [PCSTR; 3] = [
-                ipt_sh.as_ptr() as PCSTR,
-                ipt_c.as_ptr() as PCSTR,
-                ipt_script_bytes.as_ptr() as PCSTR,
-            ];
-            let hr = (sdk.WslcSetProcessSettingsCmdLine)(
-                &mut ipt_settings,
-                ipt_argv.as_ptr(),
-                ipt_argv.len(),
-            );
-            if hr != S_OK {
-                return sdk_error("WslcSetProcessSettingsCmdLine (iptables) failed", hr, "");
-            }
-
-            let mut ipt_process: WslcProcess = ptr::null_mut();
-            err_msg = CoTaskMemPWSTR::null();
-            let hr = (sdk.WslcCreateContainerProcess)(
-                container_guard.as_raw(),
-                &mut ipt_settings,
-                &mut ipt_process,
-                err_msg.as_mut_ptr(),
-            );
-            if hr != S_OK {
-                let msg = err_msg.to_string_lossy();
-                return sdk_error("Failed to exec iptables rules", hr, &msg);
-            }
-            let ipt_guard = WslcProcessGuard::from_raw(ipt_process, sdk.WslcReleaseProcess);
-
-            // Wait for iptables to complete
-            let mut ipt_exit_event: HANDLE = ptr::null_mut();
-            let hr = (sdk.WslcGetProcessExitEvent)(ipt_guard.as_raw(), &mut ipt_exit_event);
-            if hr != S_OK {
-                return sdk_error("WslcGetProcessExitEvent (iptables) failed", hr, "");
-            }
-            if !ipt_exit_event.is_null() {
-                windows::Win32::System::Threading::WaitForSingleObject(
-                    windows::Win32::Foundation::HANDLE(ipt_exit_event),
-                    30_000, // 30s timeout for iptables
-                );
-            }
-
-            let mut ipt_exit_code: i32 = -1;
-            let hr = (sdk.WslcGetProcessExitCode)(ipt_guard.as_raw(), &mut ipt_exit_code);
-            if hr != S_OK {
-                return sdk_error("WslcGetProcessExitCode (iptables) failed", hr, "");
-            }
-            if ipt_exit_code != 0 {
-                return ScriptResponse::error(&format!(
-                    "iptables rules failed with exit code {} \
-                     (image may not have iptables installed)",
-                    ipt_exit_code
-                ));
-            }
-            let _ = writeln!(logger, "[WSLC] iptables rules applied successfully");
         }
 
-        // -- Step 11: Get init process handle --
+        // -- Get init process handle --
         let mut process: WslcProcess = ptr::null_mut();
         let hr = (sdk.WslcGetContainerInitProcess)(container_guard.as_raw(), &mut process);
         if hr != S_OK {
@@ -814,94 +979,17 @@ impl WSLContainerRunner {
         }
         let process_guard = WslcProcessGuard::from_raw(process, sdk.WslcReleaseProcess);
 
-        // -- Step 12: Wait for exit with timeout enforcement --
-        let mut exit_event: HANDLE = ptr::null_mut();
-        let hr = (sdk.WslcGetProcessExitEvent)(process_guard.as_raw(), &mut exit_event);
-        if hr != S_OK {
-            return sdk_error("WslcGetProcessExitEvent failed", hr, "");
-        }
+        // -- Wait for exit --
+        let (exit_code, timed_out) = Self::wait_for_process(
+            &sdk,
+            &process_guard,
+            &container_guard,
+            &io_ctx,
+            request,
+            logger,
+        );
 
-        // Use configured timeout, or wait indefinitely if not set.
-        let wait_ms = if request.script_timeout > 0 {
-            request.script_timeout
-        } else {
-            u32::MAX
-        };
-
-        let mut timed_out = false;
-        if !exit_event.is_null() {
-            let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
-                windows::Win32::Foundation::HANDLE(exit_event),
-                wait_ms,
-            );
-            // WAIT_TIMEOUT = 0x00000102 (258)
-            if wait_result.0 == 258 {
-                timed_out = true;
-                let _ = writeln!(
-                    logger,
-                    "[WSLC] Execution timeout ({}ms) reached — stopping container",
-                    wait_ms
-                );
-                // Send SIGTERM with 2-second grace period; the SDK escalates
-                // to SIGKILL automatically if the process doesn't exit.
-                err_msg = CoTaskMemPWSTR::null();
-                let _ = (sdk.WslcStopContainer)(
-                    container_guard.as_raw(),
-                    WslcSignal::SigTerm,
-                    2,
-                    err_msg.as_mut_ptr(),
-                );
-                drop(err_msg);
-            }
-        }
-
-        // Wait for exit callback to fire — this guarantees all I/O is flushed
-        // before we read the buffers (per SDK docs).
-        {
-            let (lock, cvar) = &*io_ctx_exited;
-            let mut exited = lock.lock().unwrap_or_else(|e| e.into_inner());
-            if !*exited {
-                let result = cvar
-                    .wait_timeout(exited, std::time::Duration::from_secs(30))
-                    .unwrap_or_else(|e| e.into_inner());
-                exited = result.0;
-                if !*exited {
-                    let _ = writeln!(
-                        logger,
-                        "[WSLC] Warning: exit callback did not fire within 30s"
-                    );
-                }
-            }
-            drop(exited);
-        }
-
-        let mut exit_code: i32 = -1;
-        let hr = (sdk.WslcGetProcessExitCode)(process_guard.as_raw(), &mut exit_code);
-        if hr != S_OK && !timed_out {
-            return sdk_error("WslcGetProcessExitCode failed", hr, "");
-        }
-        if timed_out {
-            let _ = writeln!(logger, "[WSLC] Process killed after timeout");
-        } else {
-            let _ = writeln!(logger, "[WSLC] Process exited with code {}", exit_code);
-        }
-
-        // -- Step 13: Collect captured I/O from callbacks (guaranteed flushed) --
-        let stdout =
-            String::from_utf8_lossy(&io_ctx_stdout.lock().unwrap_or_else(|e| e.into_inner()))
-                .to_string();
-        let stderr =
-            String::from_utf8_lossy(&io_ctx_stderr.lock().unwrap_or_else(|e| e.into_inner()))
-                .to_string();
-
-        if !stdout.is_empty() {
-            let _ = writeln!(logger, "[WSLC] Captured {} bytes stdout", stdout.len());
-        }
-        if !stderr.is_empty() {
-            let _ = writeln!(logger, "[WSLC] Captured {} bytes stderr", stderr.len());
-        }
-
-        // -- Step 14: Cleanup --
+        // -- Cleanup --
         if request.lifecycle.destroy_on_exit {
             err_msg = CoTaskMemPWSTR::null();
             let _ = (sdk.WslcStopContainer)(
@@ -924,23 +1012,12 @@ impl WSLContainerRunner {
         let _ = (sdk.WslcTerminateSession)(session_guard.as_raw());
         let _ = writeln!(logger, "[WSLC] Cleanup complete");
 
-        // IoCtxRawGuard drops here, reclaiming the Arc reference.
-        // All callbacks are guaranteed complete after the exit event wait.
-
-        // RAII guards will call Release on drop.
-        // CoUninitialize is not called explicitly — RAII guards need COM alive
-        // for the Release calls, and the process exits shortly after.
-
-        ScriptResponse {
-            exit_code: if timed_out { -1 } else { exit_code },
-            standard_out: stdout,
-            standard_err: stderr,
-            error_message: if timed_out {
-                format!("Process timed out after {}ms and was terminated", wait_ms)
-            } else {
-                String::new()
-            },
-        }
+        let wait_ms = if request.script_timeout > 0 {
+            request.script_timeout
+        } else {
+            u32::MAX
+        };
+        Self::collect_output(&io_ctx, exit_code, timed_out, wait_ms, logger)
     }
 }
 

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -594,10 +594,13 @@ impl WSLContainerRunner {
             ));
         }
         if !ipt_exit_event.is_null() {
-            windows::Win32::System::Threading::WaitForSingleObject(
+            let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
                 windows::Win32::Foundation::HANDLE(ipt_exit_event),
                 30_000,
             );
+            if wait_result == windows::Win32::Foundation::WAIT_TIMEOUT {
+                return Err(ScriptResponse::error("iptables rules timed out after 30s"));
+            }
         }
 
         let mut ipt_exit_code: i32 = -1;
@@ -629,12 +632,11 @@ impl WSLContainerRunner {
         io_ctx: &IoContext,
         request: &CodexRequest,
         logger: &mut Logger,
-    ) -> (i32, bool) {
+    ) -> Result<(i32, bool), ScriptResponse> {
         let mut exit_event: HANDLE = ptr::null_mut();
         let hr = (sdk.WslcGetProcessExitEvent)(process_guard.as_raw(), &mut exit_event);
         if hr != S_OK {
-            let _ = writeln!(logger, "[WSLC] Warning: WslcGetProcessExitEvent failed");
-            return (-1, false);
+            return Err(sdk_error("WslcGetProcessExitEvent failed", hr, ""));
         }
 
         let wait_ms = if request.script_timeout > 0 {
@@ -649,7 +651,7 @@ impl WSLContainerRunner {
                 windows::Win32::Foundation::HANDLE(exit_event),
                 wait_ms,
             );
-            if wait_result.0 == 258 {
+            if wait_result == windows::Win32::Foundation::WAIT_TIMEOUT {
                 timed_out = true;
                 let _ = writeln!(
                     logger,
@@ -697,7 +699,7 @@ impl WSLContainerRunner {
             let _ = writeln!(logger, "[WSLC] Process exited with code {}", exit_code);
         }
 
-        (exit_code, timed_out)
+        Ok((exit_code, timed_out))
     }
 
     /// Step 13-14: Collect captured I/O and build the final ScriptResponse.
@@ -802,12 +804,12 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetProcessSettingsCmdLine failed", hr, "");
         }
 
-        let env_cstrings: Vec<Vec<u8>> = request
-            .env
-            .iter()
-            .map(|e| format!("{}\0", e).into_bytes())
-            .collect();
         if !request.env.is_empty() {
+            let env_cstrings: Vec<Vec<u8>> = request
+                .env
+                .iter()
+                .map(|e| format!("{}\0", e).into_bytes())
+                .collect();
             let env_ptrs: Vec<PCSTR> = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
             let hr = (sdk.WslcSetProcessSettingsEnvVariables)(
                 &mut process_settings,
@@ -980,14 +982,17 @@ impl WSLContainerRunner {
         let process_guard = WslcProcessGuard::from_raw(process, sdk.WslcReleaseProcess);
 
         // -- Wait for exit --
-        let (exit_code, timed_out) = Self::wait_for_process(
+        let (exit_code, timed_out) = match Self::wait_for_process(
             &sdk,
             &process_guard,
             &container_guard,
             &io_ctx,
             request,
             logger,
-        );
+        ) {
+            Ok(r) => r,
+            Err(e) => return e,
+        };
 
         // -- Cleanup --
         if request.lifecycle.destroy_on_exit {

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -445,7 +445,11 @@ impl WSLContainerRunner {
         }
         let _ = writeln!(logger, "[WSLC] Session created");
 
-        Ok(WslcSessionGuard::from_raw(session, sdk.WslcReleaseSession))
+        Ok(WslcSessionGuard::from_raw(
+            session,
+            sdk.WslcTerminateSession,
+            sdk.WslcReleaseSession,
+        ))
     }
 
     /// Step 4: Check if image exists, import from tar, or pull from registry.
@@ -1025,7 +1029,7 @@ impl WSLContainerRunner {
             drop(err_msg);
         }
 
-        let _ = (sdk.WslcTerminateSession)(session_guard.as_raw());
+        // Session termination is handled by WslcSessionGuard's Drop impl.
         let _ = writeln!(logger, "[WSLC] Cleanup complete");
 
         let wait_ms = if request.script_timeout > 0 {

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 use wxc_common::logger::Logger;
 use wxc_common::models::{CodexRequest, NetworkPolicy, ScriptResponse, WslcConfig};
 use wxc_common::script_runner::ScriptRunner;
-use wxc_common::string_util::CoTaskMemPWSTR;
+use wxc_common::string_util::{to_wide, CoTaskMemPWSTR};
 
 use crate::policy_mapping;
 use crate::wslc_bindings::*;
@@ -212,7 +212,7 @@ impl WSLContainerRunner {
                 )));
             }
         };
-        let wide_path: Vec<u16> = tar_path.encode_utf16().chain(std::iter::once(0)).collect();
+        let wide_path: Vec<u16> = to_wide(&tar_path);
 
         match tar_format {
             TarFormat::DockerSave => {
@@ -324,7 +324,12 @@ impl ScriptRunner for WSLContainerRunner {
 }
 
 impl WSLContainerRunner {
-    /// Step 0: Initialize COM and load the WSLC SDK at runtime.
+    /// Initialize COM and load the WSLC SDK at runtime.
+    ///
+    /// # Safety
+    /// Must be called once per process before any other WSLC SDK functions.
+    /// The returned `WslcSdk` holds raw function pointers loaded from `wslcsdk.dll`;
+    /// callers must keep it alive for the duration of all SDK use.
     unsafe fn init_and_load_sdk(logger: &mut Logger) -> Result<WslcSdk, ScriptResponse> {
         let com_hr = windows::Win32::System::Com::CoInitializeEx(
             None,
@@ -362,26 +367,27 @@ impl WSLContainerRunner {
         Ok(sdk)
     }
 
-    /// Step 2-3: Configure session settings and create the session.
+    /// Configure session settings and create the session.
     /// Returns the session guard (RAII).
     /// Keeps owned string data alive through session creation.
+    ///
+    /// # Safety
+    /// `sdk` must contain valid, currently-loaded function pointers.
+    /// COM must already be initialized on this thread.
     unsafe fn create_session(
         &self,
         sdk: &WslcSdk,
         request: &CodexRequest,
         logger: &mut Logger,
     ) -> Result<WslcSessionGuard, ScriptResponse> {
-        let session_name: Vec<u16> = format!("{}\0", request.container_id)
-            .encode_utf16()
-            .collect();
+        let session_name: Vec<u16> = to_wide(&request.container_id);
         let storage_path_str = self.config.storage_path.clone().unwrap_or_else(|| {
             std::env::temp_dir()
                 .join("mxc-wslc-sessions")
                 .to_string_lossy()
                 .to_string()
         });
-        let storage_path_wide: Vec<u16> =
-            format!("{}\0", storage_path_str).encode_utf16().collect();
+        let storage_path_wide: Vec<u16> = to_wide(&storage_path_str);
 
         let mut settings = std::mem::zeroed::<WslcSessionSettings>();
         let hr = (sdk.WslcInitSessionSettings)(
@@ -452,7 +458,11 @@ impl WSLContainerRunner {
         ))
     }
 
-    /// Step 4: Check if image exists, import from tar, or pull from registry.
+    /// Check if image exists, import from tar, or pull from registry.
+    ///
+    /// # Safety
+    /// `sdk` must contain valid function pointers and `session` must be a
+    /// live session handle obtained from `WslcCreateSession`.
     unsafe fn resolve_image(
         &self,
         sdk: &WslcSdk,
@@ -533,7 +543,11 @@ impl WSLContainerRunner {
         Ok(())
     }
 
-    /// Step 10b: Apply iptables rules inside a running container for host filtering.
+    /// Apply iptables rules inside a running container for host filtering.
+    ///
+    /// # Safety
+    /// `sdk` must contain valid function pointers and `container` must be a
+    /// live container handle for a started container.
     unsafe fn apply_iptables_rules(
         sdk: &WslcSdk,
         container: WslcContainer,
@@ -627,8 +641,12 @@ impl WSLContainerRunner {
         Ok(())
     }
 
-    /// Step 12: Wait for process exit with timeout enforcement.
+    /// Wait for process exit with timeout enforcement.
     /// Returns (exit_code, timed_out).
+    ///
+    /// # Safety
+    /// `sdk` must contain valid function pointers. `process_guard` and
+    /// `container_guard` must hold live handles from this session.
     unsafe fn wait_for_process(
         sdk: &WslcSdk,
         process_guard: &WslcProcessGuard,
@@ -706,7 +724,7 @@ impl WSLContainerRunner {
         Ok((exit_code, timed_out))
     }
 
-    /// Step 13-14: Collect captured I/O and build the final ScriptResponse.
+    /// Collect captured I/O and build the final ScriptResponse.
     fn collect_output(
         io_ctx: &IoContext,
         exit_code: i32,
@@ -744,6 +762,14 @@ impl WSLContainerRunner {
     /// Helpers handle phases that don't involve dangling-pointer risks;
     /// pointer-heavy SDK configuration stays inline to keep owned string
     /// data alive for the duration needed.
+    ///
+    /// # Safety
+    /// Calls into the WSLC SDK via raw FFI. Owned buffers backing pointers
+    /// passed to the SDK (cmdline, env, mounts, etc.) must remain alive
+    /// until the SDK call that consumes them returns. RAII guards
+    /// (`WslcSessionGuard`, `WslcContainerGuard`, `WslcProcessGuard`,
+    /// `IoCtxRawGuard`) ensure handles and reference counts are released
+    /// on every exit path.
     unsafe fn run_internal(&self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
         let _ = writeln!(logger, "[WSLC] Starting WSL Container runner");
 
@@ -816,12 +842,12 @@ impl WSLContainerRunner {
             return sdk_error("WslcSetProcessSettingsCmdLine failed", hr, "");
         }
 
-        let env_cstrings: Vec<Vec<u8>> = request
-            .env
-            .iter()
-            .map(|e| format!("{}\0", e).into_bytes())
-            .collect();
         if !request.env.is_empty() {
+            let env_cstrings: Vec<Vec<u8>> = request
+                .env
+                .iter()
+                .map(|e| format!("{}\0", e).into_bytes())
+                .collect();
             let env_ptrs: Vec<PCSTR> = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
             let hr = (sdk.WslcSetProcessSettingsEnvVariables)(
                 &mut process_settings,
@@ -877,7 +903,7 @@ impl WSLContainerRunner {
         let wide_paths: Vec<(Vec<u16>, Vec<u8>)> = mounts
             .iter()
             .map(|m| {
-                let win: Vec<u16> = format!("{}\0", m.windows_path).encode_utf16().collect();
+                let win: Vec<u16> = to_wide(&m.windows_path);
                 let ctr: Vec<u8> = format!("{}\0", m.container_path).into_bytes();
                 (win, ctr)
             })

--- a/src/wslc_common/src/wslc_bindings.rs
+++ b/src/wslc_common/src/wslc_bindings.rs
@@ -507,9 +507,10 @@ impl WslcSdk {
 // RAII Guard types
 // ---------------------------------------------------------------------------
 
-/// RAII guard for a WSLC session handle. Calls the release function on drop.
+/// RAII guard for a WSLC session handle. Terminates and releases the session on drop.
 pub struct WslcSessionGuard {
     handle: WslcSession,
+    terminate_fn: ffi_types::WslcTerminateSessionFn,
     release_fn: ffi_types::WslcReleaseSessionFn,
 }
 
@@ -520,10 +521,15 @@ impl WslcSessionGuard {
     /// The handle must be a valid, non-null session returned by `WslcCreateSession`.
     pub unsafe fn from_raw(
         handle: WslcSession,
+        terminate_fn: ffi_types::WslcTerminateSessionFn,
         release_fn: ffi_types::WslcReleaseSessionFn,
     ) -> Self {
         debug_assert!(!handle.is_null());
-        Self { handle, release_fn }
+        Self {
+            handle,
+            terminate_fn,
+            release_fn,
+        }
     }
 
     /// Get the raw handle for passing to SDK functions.
@@ -536,7 +542,8 @@ impl Drop for WslcSessionGuard {
     fn drop(&mut self) {
         if !self.handle.is_null() {
             unsafe {
-                eprintln!("[WSLC][debug] WslcSessionGuard dropped -- releasing session");
+                eprintln!("[WSLC][debug] WslcSessionGuard dropped -- terminating and releasing session");
+                let _ = (self.terminate_fn)(self.handle);
                 (self.release_fn)(self.handle);
             }
         }

--- a/src/wslc_common/src/wslc_bindings.rs
+++ b/src/wslc_common/src/wslc_bindings.rs
@@ -542,7 +542,9 @@ impl Drop for WslcSessionGuard {
     fn drop(&mut self) {
         if !self.handle.is_null() {
             unsafe {
-                eprintln!("[WSLC][debug] WslcSessionGuard dropped -- terminating and releasing session");
+                eprintln!(
+                    "[WSLC][debug] WslcSessionGuard dropped -- terminating and releasing session"
+                );
                 let _ = (self.terminate_fn)(self.handle);
                 (self.release_fn)(self.handle);
             }

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -33,7 +33,7 @@ $ErrorActionPreference = "Stop"
 $RepoRoot = Split-Path -Parent $PSScriptRoot
 $TestConfigs = Join-Path $RepoRoot "test_configs"
 
-# Find binary — prefer explicit path, then probe target-specific and default dirs.
+# Find binary -- prefer explicit path, then probe target-specific and default dirs.
 $Target = "x86_64-pc-windows-msvc"
 $Profile = if ($Debug) { "debug" } else { "release" }
 
@@ -99,7 +99,7 @@ function Run-WslcTest {
     $isCrash = ($exitCode -lt -1000000000) -or ($exitCode -eq -2147483645)
     if ($isCrash) {
         Write-Host "" # newline before recovery message
-        Write-Host "    [recovery] Process crashed (exit $exitCode) — restarting WSL..." -ForegroundColor Yellow
+        Write-Host "    [recovery] Process crashed (exit $exitCode) -- restarting WSL..." -ForegroundColor Yellow
         $null = wsl --shutdown 2>&1
         Start-Sleep 15
     }
@@ -127,6 +127,10 @@ function Run-WslcTest {
             Write-Host "    > $($line.TrimEnd())" -ForegroundColor Gray
         }
     }
+
+    # Brief delay between tests to let the WSLC runtime fully release
+    # session resources (mounts, networking) before the next test starts.
+    Start-Sleep 2
 
     return @{ Name = $ConfigFile; Pass = $pass; Skipped = $false; Reason = $reason }
 }

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -93,6 +93,17 @@ function Run-WslcTest {
     $exitCode = $LASTEXITCODE
     $ErrorActionPreference = $prevPref
 
+    # Access violation (0xC0000005) or other hard crashes corrupt WSL runtime
+    # state, causing subsequent WslcCreateSession calls to fail with
+    # ERROR_SHARING_VIOLATION. Recover by restarting WSL.
+    $isCrash = ($exitCode -lt -1000000000) -or ($exitCode -eq -2147483645)
+    if ($isCrash) {
+        Write-Host "" # newline before recovery message
+        Write-Host "    [recovery] Process crashed (exit $exitCode) — restarting WSL..." -ForegroundColor Yellow
+        $null = wsl --shutdown 2>&1
+        Start-Sleep 15
+    }
+
     $pass = $true
     $reason = ""
 
@@ -154,9 +165,9 @@ Write-Host "`n--- Timeout Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_timeout.json" -ExpectedExit -1 -OutputContains "Starting long task"))
 
 # Summary
-$passed = ($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count
-$failed = ($results | Where-Object { -not $_.Pass -and -not $_.Skipped }).Count
-$skipped = ($results | Where-Object { $_.Skipped }).Count
+$passed = @($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count
+$failed = @($results | Where-Object { -not $_.Pass -and -not $_.Skipped }).Count
+$skipped = @($results | Where-Object { $_.Skipped }).Count
 $total = $results.Count
 $executed = $passed + $failed
 


### PR DESCRIPTION
Refactors the monolithic run_internal method in wsl_container_runner.rs into focused helper methods.

Fixes #167 