### PR TITLE
[IsolationSession] Add full TTY support for one-shot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ The Rust workspace (`src/`) implements multiple sandboxing backends behind the `
 | BaseContainer (OS sandbox API) | `wxc-exec.exe` | Windows | `base_container_runner.rs` — calls `Experimental_CreateProcessInSandbox` via FlatBuffer |
 | Windows Sandbox | `wxc-exec.exe` | Windows | `windows_sandbox_runner.rs` |
 | MicroVM (NanVix) | `wxc-exec.exe` | Windows | `nanvix_runner.rs` — feature-gated behind `microvm` |
-| IsolationSession | `wxc-exec.exe` | Windows | `isolation_session_runner.rs` — feature-gated behind `isolation_session`, experimental, uses the in-proc `Windows.AI.IsolationSession` `IsoSessionOps` API (loaded from `IsoSessionApp.dll`) |
+| IsolationSession | `wxc-exec.exe` | Windows | `isolation_session_runner.rs` — feature-gated behind `isolation_session`, experimental, uses the in-proc `Windows.AI.IsolationSession` `IsoSessionOps` API (loaded from `IsoSessionApp.dll`). Streams stdout/stderr, forwards stdin, and switches to ConPTY mode when wxc-exec's stdout is a TTY for `spawnSandbox` parity. |
 | LXC | `lxc-exec` | Linux | `lxc/src/main.rs` + `lxc_common/` |
 
 ### Config flow

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -14,19 +14,25 @@
 //!   the full lifecycle per invocation.
 
 use std::fmt::Write;
+use std::io::IsTerminal;
 
 use crate::logger::Logger;
 use crate::models::{CodexRequest, IsolationSessionConfigurationId, NetworkPolicy, ScriptResponse};
-use crate::process_util::{create_relay_thread, OwnedHandle, PipeRelayParams};
+use crate::process_util::{
+    create_relay_thread, create_relay_thread_with_stop, ConsoleModeRestorer, OwnedHandle,
+    PipeRelayParams, PipeRelayWithStopParams,
+};
 use crate::script_runner::ScriptRunner;
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
     IsoSessionProcessOptions, IsoSessionProcessResult, IsoSessionResult, IsoSessionUserResult,
 };
 use windows::Win32::Foundation::{CLASS_E_CLASSNOTAVAILABLE, HANDLE, REGDB_E_CLASSNOTREG};
-use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
-use windows::Win32::System::Threading::WaitForSingleObject;
-use windows_core::HSTRING;
+use windows::Win32::System::Console::{
+    GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
+use windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject};
+use windows_core::{HSTRING, PCWSTR};
 
 // -- Identifiers -------------------------------------------------------------
 
@@ -141,6 +147,28 @@ pub(crate) const REDIRECT_STDIN: u32 = 0x1;
 pub(crate) const REDIRECT_STDOUT: u32 = 0x2;
 pub(crate) const REDIRECT_STDERR: u32 = 0x4;
 
+/// Compute the canonical redirect-flags bitfield for the agent process I/O,
+/// given whether wxc-exec is running in interactive (ConPTY) mode.
+///
+/// Policy (Commit 2 — TTY support):
+/// - Stdin is always redirected. The runner spawns a relay so the parent's
+///   input reaches the agent (interactive shells need this; batch stdin works
+///   the same way).
+/// - Stdout is always redirected.
+/// - Stderr is redirected ONLY in non-interactive mode. In ConPTY mode the
+///   broker merges stderr into stdout and refuses to populate the stderr
+///   handle (predicate at `IsolationSessionWorkerProcess.cpp:309-310` in the
+///   OS repo: `optStderrHandleResult && !m_pseudoConsole && m_stderrPipeRead`).
+///   Setting `RedirectStandardError(true)` in ConPTY mode is benign but the
+///   handle returns 0 — so we just don't ask for it.
+pub(crate) fn compute_redirect_flags(interactive: bool) -> u32 {
+    let mut flags = REDIRECT_STDIN | REDIRECT_STDOUT;
+    if !interactive {
+        flags |= REDIRECT_STDERR;
+    }
+    flags
+}
+
 /// Intermediate representation of process creation options, decoupled from
 /// both `CodexRequest` (MXC-specific) and WinRT types (OS-specific).
 /// Built from `CodexRequest`, later converted to WinRT options.
@@ -158,6 +186,12 @@ pub(crate) struct ProcessOptions {
     pub env_vars: Vec<(String, String)>,
     /// Bitfield of I/O redirect flags (`REDIRECT_STDIN | REDIRECT_STDOUT | REDIRECT_STDERR`).
     pub redirect_flags: u32,
+    /// Whether to ask the broker to set up a ConPTY in the isolation session
+    /// (`InteractiveConsole = true`). Decided at runtime by the runner based
+    /// on `std::io::stdout().is_terminal()`. `build_process_options` returns
+    /// `false` as a safe default; the runner overwrites before passing to
+    /// `create_process`.
+    pub interactive: bool,
 }
 
 /// Builds `ProcessOptions` from a `CodexRequest`.
@@ -195,6 +229,7 @@ pub(crate) fn build_process_options(request: &CodexRequest) -> ProcessOptions {
         working_directory: request.working_directory.clone(),
         env_vars,
         redirect_flags: REDIRECT_STDOUT | REDIRECT_STDERR,
+        interactive: false,
     }
 }
 
@@ -389,29 +424,61 @@ impl IsolationSessionManager {
             ))
         })?;
 
-        // Streaming I/O via pipe relay threads. Output flows live to wxc-exec's stdio
-        // while the agent runs (replacing the prior batch-capture model).
+        // Streaming + interactive I/O via three pipe relay threads bridging
+        // wxc-exec's stdio with the broker's pipe handles. The relays cross
+        // the desktop-session boundary that kernel console-handle inheritance
+        // cannot (see `appcontainer_runner.rs:358-392` for the AppContainer
+        // comparison).
         //
-        // Handle ownership across three sources:
-        //   - Broker pipe handles (`OutputHandle()` / `ErrorHandle()`, returned as u64):
-        //     owned by `IsoSessionProcess`. Released by `process.Close()`
-        //     (`ApiProcess.cpp:131` in the OS repo). We do NOT close them.
-        //   - wxc-exec's std handles (`GetStdHandle(STD_*_HANDLE)`): owned by the OS
-        //     for the process lifetime. We do NOT close them.
-        //   - Relay thread handles (`OwnedHandle` from `create_relay_thread`): RAII-
-        //     closed when dropped, after `WaitForSingleObject` confirms thread exit.
+        // Handle ownership across four sources:
+        //   - Broker pipe handles (`OutputHandle()` / `ErrorHandle()` /
+        //     `InputHandle()`, returned as u64): owned by `IsoSessionProcess`.
+        //     Released by `process.Close()` (`ApiProcess.cpp:131` in the OS
+        //     repo). We do NOT close them.
+        //   - wxc-exec's std handles (`GetStdHandle(STD_*_HANDLE)`): owned by
+        //     the OS for the process lifetime. We do NOT close them.
+        //   - Stop event for stdin relay (`CreateEventW`): RAII-closed via
+        //     `OwnedHandle`.
+        //   - Relay thread handles: RAII-closed via `OwnedHandle` after we
+        //     `WaitForSingleObject` on each.
         //
-        // `PipeRelayParams` lifetime: stack-allocated. The relay thread holds a raw
-        // pointer to the params struct, so the struct must outlive the thread. We
-        // `WaitForSingleObject` on every spawned thread before this function returns,
-        // ensuring lifetime correctness.
+        // Lifetime: relay-param structs are stack-allocated; we wait on every
+        // spawned thread (INFINITE for stdout/stderr, bounded for stdin)
+        // before this function returns.
         let stdout_handle_val = process.OutputHandle().unwrap_or(0);
         let stderr_handle_val = process.ErrorHandle().unwrap_or(0);
+        let stdin_handle_val = process.InputHandle().unwrap_or(0);
 
         let wxc_stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }
             .map_err(|e| lifecycle_err(format!("GetStdHandle(stdout) failed: {}", e)))?;
         let wxc_stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) }
             .map_err(|e| lifecycle_err(format!("GetStdHandle(stderr) failed: {}", e)))?;
+        let wxc_stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) }
+            .map_err(|e| lifecycle_err(format!("GetStdHandle(stdin) failed: {}", e)))?;
+
+        // In interactive mode, switch wxc-exec's local console to raw VT mode
+        // so the agent's ConPTY does all the input echoing and rendering —
+        // otherwise both consoles render the same input twice (duplicate
+        // echos, doubled prompts, broken `\r\n` handling). RAII-restored on
+        // scope exit. No-op when stdio is not a console (the guard records
+        // itself as inactive).
+        let _console_guard = if options.interactive {
+            Some(ConsoleModeRestorer::install_raw_vt())
+        } else {
+            None
+        };
+
+        // Manual-reset stop event for the stdin relay. Effective for waitable
+        // `h_read` (console = TTY mode); for pipe handles (non-TTY) it has no
+        // effect on a blocked `ReadFile`, so we use a bounded
+        // `WaitForSingleObject` after process exit and rely on
+        // `process.Close()` invalidating the broker handle (next WriteFile
+        // fails) plus OS cleanup on wxc-exec exit.
+        let stdin_stop_event = unsafe {
+            CreateEventW(None, true, false, PCWSTR::null())
+                .map_err(|e| lifecycle_err(format!("CreateEventW(stdin stop): {}", e)))?
+        };
+        let stdin_stop_owned = OwnedHandle::new(stdin_stop_event);
 
         let mut stdout_params = PipeRelayParams {
             h_read: HANDLE(stdout_handle_val as *mut core::ffi::c_void),
@@ -420,6 +487,11 @@ impl IsolationSessionManager {
         let mut stderr_params = PipeRelayParams {
             h_read: HANDLE(stderr_handle_val as *mut core::ffi::c_void),
             h_write: wxc_stderr,
+        };
+        let mut stdin_params = PipeRelayWithStopParams {
+            h_read: wxc_stdin,
+            h_write: HANDLE(stdin_handle_val as *mut core::ffi::c_void),
+            h_stop_event: stdin_stop_owned.get(),
         };
 
         let stdout_relay: Option<OwnedHandle> = if stdout_handle_val != 0 {
@@ -438,30 +510,79 @@ impl IsolationSessionManager {
         } else {
             None
         };
+        let stdin_relay: Option<OwnedHandle> = if stdin_handle_val != 0 {
+            Some(
+                unsafe { create_relay_thread_with_stop(&mut stdin_params) }
+                    .map_err(|e| lifecycle_err(format!("create stdin relay: {}", e)))?,
+            )
+        } else {
+            None
+        };
 
-        // Reordering vs. previous batch-capture code: previously, `read_pipe_to_string`
-        // was the implicit wait — it blocked until EOF on the broker pipes, which only
-        // happens after the agent exits. With streaming relays, we wait explicitly here.
-        //
-        // `WaitForExit` is a Win32 `WaitForSingleObject` on a kernel handle owned by the
-        // in-proc DLL — no COM round-trip (`ApiProcess.cpp:76` in the OS repo).
+        // Wait for the agent process to exit. `WaitForExit` is a Win32
+        // `WaitForSingleObject` on a kernel handle (`ApiProcess.cpp:76` — no
+        // COM round-trip). On timeout it returns -1; otherwise the exit code.
         let _ = process
             .WaitForExit(options.timeout_ms)
             .map_err(|e| lifecycle_err(format!("WaitForExit failed: {}", e)))?;
-        let exit_code = process
+
+        // Detect timeout via `ExitCode()` returning `STILL_ACTIVE` (the agent
+        // is still running). Trigger the 3-tier graceful shutdown pattern from
+        // `CommandTty.cpp:226-263` in the OS repo. In the natural-exit path,
+        // none of the tiers fire.
+        const STILL_ACTIVE: i32 = 0x103;
+        let mut exit_code = process
             .ExitCode()
             .map_err(|e| lifecycle_err(format!("get ExitCode failed: {}", e)))?;
 
-        // Drain relay threads. They exit on broker-pipe EOF, which happens shortly
-        // after agent exit (the agent's write ends close on OS-level handle cleanup).
-        // INFINITE matches prior behaviour — `read_pipe_to_string` also blocked
-        // indefinitely on EOF, so the broker's own timeout is the safety net for a
-        // stuck agent (`IsolationSessionWorkerProcess.cpp:153-170` in the OS repo).
+        if exit_code == STILL_ACTIVE {
+            // Tier 1: close stdin — many REPLs (powershell, cmd, bash) exit
+            // on EOF alone.
+            let _ = process.CloseStandardInput();
+            let _ = process.WaitForExit(5000);
+            exit_code = process.ExitCode().unwrap_or(STILL_ACTIVE);
+
+            // Tier 2: `SendCtrlClose` is ConPTY-only (`E_NOTIMPL` otherwise
+            // per `IsolationSessionWorkerProcess.cpp:414-416`); benign call
+            // in non-ConPTY mode, just skips ahead.
+            if exit_code == STILL_ACTIVE {
+                let _ = process.SendCtrlClose();
+                let _ = process.WaitForExit(3000);
+                exit_code = process.ExitCode().unwrap_or(STILL_ACTIVE);
+            }
+
+            // Tier 3: force-terminate. Wait infinitely for the kill to land
+            // (timeout 0 == INFINITE per `ApiProcess.cpp:85`).
+            if exit_code == STILL_ACTIVE {
+                let _ = process.Terminate();
+                let _ = process.WaitForExit(0);
+                exit_code = process.ExitCode().unwrap_or(-1);
+            }
+        }
+
+        // Signal the stdin relay to exit. Effective for waitable (console)
+        // handles; for pipe handles the bounded wait below expires and we
+        // proceed.
+        unsafe {
+            let _ = SetEvent(stdin_stop_owned.get());
+        }
+
+        // Drain stdout / stderr relays (INFINITE — they exit on broker-pipe
+        // EOF once the agent's write ends close at OS-level handle cleanup;
+        // the broker's own timeout at
+        // `IsolationSessionWorkerProcess.cpp:153-170` is the safety net).
         if let Some(t) = stdout_relay {
             unsafe { WaitForSingleObject(t.get(), u32::MAX) };
         }
         if let Some(t) = stderr_relay {
             unsafe { WaitForSingleObject(t.get(), u32::MAX) };
+        }
+
+        // Drain stdin relay with a 1s bound. TTY mode exits via the stop
+        // event; non-TTY may still be in `ReadFile` — that's fine, the
+        // thread exits when wxc-exec exits and the OS cleans it up.
+        if let Some(t) = stdin_relay {
+            unsafe { WaitForSingleObject(t.get(), 1000) };
         }
 
         // Now safe to release the broker handles.
@@ -537,7 +658,7 @@ fn build_iso_process_options(
     }
 
     proc_options
-        .SetInteractiveConsole(false)
+        .SetInteractiveConsole(options.interactive)
         .map_err(|e| lifecycle_err(format!("SetInteractiveConsole: {}", e)))?;
 
     proc_options
@@ -595,13 +716,27 @@ impl ScriptRunner for IsolationSessionRunner {
     }
 
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        let options = build_process_options(request);
+        let mut options = build_process_options(request);
+
+        // Detect at runtime whether wxc-exec's stdout is a TTY. This flips the
+        // backend into ConPTY mode (`InteractiveConsole = true`) and adjusts
+        // the redirect flags (no separate stderr in ConPTY mode — the broker
+        // merges it into stdout). The check sees the handle wxc-exec was
+        // given by its immediate parent: ConPTY when launched by node-pty
+        // (`spawnSandbox`), pipe when launched by `child_process.spawn`
+        // (`spawnSandboxFromConfig({usePty: false})`), console when launched
+        // directly from a shell.
+        let interactive = std::io::stdout().is_terminal();
+        options.interactive = interactive;
+        options.redirect_flags = compute_redirect_flags(interactive);
+
         let _ = writeln!(
             logger,
             "Isolation Session: process={}",
             options.process_path
         );
         let _ = writeln!(logger, "Isolation Session: arguments={}", options.arguments);
+        let _ = writeln!(logger, "Isolation Session: interactive={}", interactive);
 
         // Read isolation_session config (configuration id).
         let session_cfg = request.experimental.isolation_session.as_ref();
@@ -876,6 +1011,32 @@ mod tests {
         };
         let opts = build_process_options(&request);
         assert_eq!(opts.redirect_flags, REDIRECT_STDOUT | REDIRECT_STDERR);
+    }
+
+    #[test]
+    fn compute_redirect_flags_interactive_omits_stderr() {
+        let flags = compute_redirect_flags(true);
+        assert!(
+            flags & REDIRECT_STDIN != 0,
+            "stdin should be redirected even in interactive mode"
+        );
+        assert!(flags & REDIRECT_STDOUT != 0, "stdout should be redirected");
+        assert!(
+            flags & REDIRECT_STDERR == 0,
+            "stderr should NOT be redirected in interactive (ConPTY) mode \
+             — broker won't populate ErrorHandle"
+        );
+    }
+
+    #[test]
+    fn compute_redirect_flags_noninteractive_includes_stderr() {
+        let flags = compute_redirect_flags(false);
+        assert!(flags & REDIRECT_STDIN != 0, "stdin should be redirected");
+        assert!(flags & REDIRECT_STDOUT != 0, "stdout should be redirected");
+        assert!(
+            flags & REDIRECT_STDERR != 0,
+            "stderr should be redirected in non-interactive (plain pipes) mode"
+        );
     }
 
     // ====== Service availability test ======

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -17,13 +17,15 @@ use std::fmt::Write;
 
 use crate::logger::Logger;
 use crate::models::{CodexRequest, IsolationSessionConfigurationId, NetworkPolicy, ScriptResponse};
+use crate::process_util::{create_relay_thread, OwnedHandle, PipeRelayParams};
 use crate::script_runner::ScriptRunner;
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
     IsoSessionProcessOptions, IsoSessionProcessResult, IsoSessionResult, IsoSessionUserResult,
 };
 use windows::Win32::Foundation::{CLASS_E_CLASSNOTAVAILABLE, HANDLE, REGDB_E_CLASSNOTREG};
-use windows::Win32::Storage::FileSystem::ReadFile;
+use windows::Win32::System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_OUTPUT_HANDLE};
+use windows::Win32::System::Threading::WaitForSingleObject;
 use windows_core::HSTRING;
 
 // -- Identifiers -------------------------------------------------------------
@@ -387,17 +389,62 @@ impl IsolationSessionManager {
             ))
         })?;
 
-        // Read stdout/stderr via the pipe handles owned by `IsoSessionProcess`.
-        // We do NOT close these handles here — `process.Close()` (or drop)
-        // does (`ApiProcess.cpp:131` in the OS repo).
-        let stdout_handle = process.OutputHandle().unwrap_or(0);
-        let stderr_handle = process.ErrorHandle().unwrap_or(0);
-        let stdout = read_pipe_to_string(stdout_handle);
-        let stderr = read_pipe_to_string(stderr_handle);
+        // Streaming I/O via pipe relay threads. Output flows live to wxc-exec's stdio
+        // while the agent runs (replacing the prior batch-capture model).
+        //
+        // Handle ownership across three sources:
+        //   - Broker pipe handles (`OutputHandle()` / `ErrorHandle()`, returned as u64):
+        //     owned by `IsoSessionProcess`. Released by `process.Close()`
+        //     (`ApiProcess.cpp:131` in the OS repo). We do NOT close them.
+        //   - wxc-exec's std handles (`GetStdHandle(STD_*_HANDLE)`): owned by the OS
+        //     for the process lifetime. We do NOT close them.
+        //   - Relay thread handles (`OwnedHandle` from `create_relay_thread`): RAII-
+        //     closed when dropped, after `WaitForSingleObject` confirms thread exit.
+        //
+        // `PipeRelayParams` lifetime: stack-allocated. The relay thread holds a raw
+        // pointer to the params struct, so the struct must outlive the thread. We
+        // `WaitForSingleObject` on every spawned thread before this function returns,
+        // ensuring lifetime correctness.
+        let stdout_handle_val = process.OutputHandle().unwrap_or(0);
+        let stderr_handle_val = process.ErrorHandle().unwrap_or(0);
 
-        // Wait for exit. `WaitForExit` is a Win32 `WaitForSingleObject` on
-        // a kernel handle owned by the in-proc DLL — no COM round-trip
-        // (`ApiProcess.cpp:76` in the OS repo).
+        let wxc_stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }
+            .map_err(|e| lifecycle_err(format!("GetStdHandle(stdout) failed: {}", e)))?;
+        let wxc_stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) }
+            .map_err(|e| lifecycle_err(format!("GetStdHandle(stderr) failed: {}", e)))?;
+
+        let mut stdout_params = PipeRelayParams {
+            h_read: HANDLE(stdout_handle_val as *mut core::ffi::c_void),
+            h_write: wxc_stdout,
+        };
+        let mut stderr_params = PipeRelayParams {
+            h_read: HANDLE(stderr_handle_val as *mut core::ffi::c_void),
+            h_write: wxc_stderr,
+        };
+
+        let stdout_relay: Option<OwnedHandle> = if stdout_handle_val != 0 {
+            Some(
+                unsafe { create_relay_thread(&mut stdout_params) }
+                    .map_err(|e| lifecycle_err(format!("create stdout relay: {}", e)))?,
+            )
+        } else {
+            None
+        };
+        let stderr_relay: Option<OwnedHandle> = if stderr_handle_val != 0 {
+            Some(
+                unsafe { create_relay_thread(&mut stderr_params) }
+                    .map_err(|e| lifecycle_err(format!("create stderr relay: {}", e)))?,
+            )
+        } else {
+            None
+        };
+
+        // Reordering vs. previous batch-capture code: previously, `read_pipe_to_string`
+        // was the implicit wait — it blocked until EOF on the broker pipes, which only
+        // happens after the agent exits. With streaming relays, we wait explicitly here.
+        //
+        // `WaitForExit` is a Win32 `WaitForSingleObject` on a kernel handle owned by the
+        // in-proc DLL — no COM round-trip (`ApiProcess.cpp:76` in the OS repo).
         let _ = process
             .WaitForExit(options.timeout_ms)
             .map_err(|e| lifecycle_err(format!("WaitForExit failed: {}", e)))?;
@@ -405,13 +452,25 @@ impl IsolationSessionManager {
             .ExitCode()
             .map_err(|e| lifecycle_err(format!("get ExitCode failed: {}", e)))?;
 
-        // Release the handles owned by the process object.
+        // Drain relay threads. They exit on broker-pipe EOF, which happens shortly
+        // after agent exit (the agent's write ends close on OS-level handle cleanup).
+        // INFINITE matches prior behaviour — `read_pipe_to_string` also blocked
+        // indefinitely on EOF, so the broker's own timeout is the safety net for a
+        // stuck agent (`IsolationSessionWorkerProcess.cpp:153-170` in the OS repo).
+        if let Some(t) = stdout_relay {
+            unsafe { WaitForSingleObject(t.get(), u32::MAX) };
+        }
+        if let Some(t) = stderr_relay {
+            unsafe { WaitForSingleObject(t.get(), u32::MAX) };
+        }
+
+        // Now safe to release the broker handles.
         let _ = process.Close();
 
         Ok(ProcessResult {
             exit_code,
-            stdout,
-            stderr,
+            stdout: String::new(),
+            stderr: String::new(),
         })
     }
 
@@ -502,33 +561,6 @@ fn build_iso_process_options(
     }
 
     Ok(proc_options)
-}
-
-// -- Pipe handle reading -----------------------------------------------------
-
-/// Reads all data from a pipe handle into a UTF-8-lossy string. Does NOT
-/// close the handle — ownership stays with the parent `IsoSessionProcess`,
-/// which closes it via `Close()` (or drop).
-fn read_pipe_to_string(handle_value: u64) -> String {
-    if handle_value == 0 {
-        return String::new();
-    }
-    let handle = HANDLE(handle_value as *mut core::ffi::c_void);
-    let mut output = Vec::new();
-    let mut buffer = [0u8; 4096];
-    loop {
-        let mut bytes_read = 0u32;
-        // SAFETY: `handle` is a kernel handle owned by the in-proc DLL's
-        // `IsoSessionProcess`. We only read; the DLL closes it on
-        // `IsoSessionProcess::Close()`. `buffer` and `bytes_read` are
-        // stack-allocated and live for the entire `ReadFile` call.
-        let ok = unsafe { ReadFile(handle, Some(&mut buffer), Some(&mut bytes_read), None) };
-        if ok.is_err() || bytes_read == 0 {
-            break;
-        }
-        output.extend_from_slice(&buffer[..bytes_read as usize]);
-    }
-    String::from_utf8_lossy(&output).to_string()
 }
 
 /// Result of a process execution in the isolation session.
@@ -634,11 +666,14 @@ impl ScriptRunner for IsolationSessionRunner {
             let _ = writeln!(logger, "Warning: unregister_client failed: {}", e);
         }
 
+        // Output already streamed live to wxc-exec's stdio via relay threads in
+        // `IsolationSessionManager::create_process` — captured fields are intentionally
+        // empty (matching the AppContainer pattern at `appcontainer_runner.rs:455-456`).
         ScriptResponse {
             exit_code: result.exit_code,
-            standard_out: result.stdout,
-            standard_err: result.stderr.clone(),
-            error_message: result.stderr,
+            standard_out: String::new(),
+            standard_err: String::new(),
+            error_message: String::new(),
         }
     }
 }
@@ -874,5 +909,35 @@ mod tests {
                 panic!("expected ServiceUnavailable variant, got: {:?}", other);
             }
         }
+    }
+
+    // ====== IsoSessionConfigId conversion tests ======
+    //
+    // The `From<IsolationSessionConfigurationId> for IsoSessionConfigId` impl is the
+    // sole bridge between MXC's internal enum and the WinRT enum. If a new variant is
+    // added to either side without updating the impl, these tests catch the drift.
+
+    #[test]
+    fn config_id_conversion_small() {
+        let iso_id: IsoSessionConfigId = IsolationSessionConfigurationId::Small.into();
+        assert_eq!(iso_id, IsoSessionConfigId::Small);
+    }
+
+    #[test]
+    fn config_id_conversion_medium() {
+        let iso_id: IsoSessionConfigId = IsolationSessionConfigurationId::Medium.into();
+        assert_eq!(iso_id, IsoSessionConfigId::Medium);
+    }
+
+    #[test]
+    fn config_id_conversion_large() {
+        let iso_id: IsoSessionConfigId = IsolationSessionConfigurationId::Large.into();
+        assert_eq!(iso_id, IsoSessionConfigId::Large);
+    }
+
+    #[test]
+    fn config_id_conversion_composable() {
+        let iso_id: IsoSessionConfigId = IsolationSessionConfigurationId::Composable.into();
+        assert_eq!(iso_id, IsoSessionConfigId::Composable);
     }
 }

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -12,8 +12,15 @@ use windows::Win32::Foundation::{
 };
 use windows::Win32::Security::{DeriveCapabilitySidsFromName, PSID, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::{FlushFileBuffers, ReadFile, WriteFile};
+use windows::Win32::System::Console::{
+    GetConsoleMode, GetStdHandle, SetConsoleMode, CONSOLE_MODE, DISABLE_NEWLINE_AUTO_RETURN,
+    ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, ENABLE_PROCESSED_INPUT, ENABLE_VIRTUAL_TERMINAL_INPUT,
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING, ENABLE_WINDOW_INPUT, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
 use windows::Win32::System::Pipes::CreatePipe;
-use windows::Win32::System::Threading::{CreateThread, WaitForSingleObject, THREAD_CREATION_FLAGS};
+use windows::Win32::System::Threading::{
+    CreateThread, WaitForMultipleObjects, WaitForSingleObject, THREAD_CREATION_FLAGS,
+};
 use windows_core::BOOL;
 use windows_core::PCWSTR;
 
@@ -92,6 +99,126 @@ pub unsafe fn create_relay_thread(params: *mut PipeRelayParams) -> Result<OwnedH
         None,
     )
     .map_err(|e| WxcError::Process(format!("CreateThread for pipe relay failed: {}", e)))?;
+
+    Ok(OwnedHandle::new(handle))
+}
+
+// ── Stop-event-aware pipe relay ────────────────────────────────────────────
+//
+// Used for the IsolationSession stdin relay in TTY (ConPTY) mode, where the
+// agent process can exit naturally while wxc-exec's stdin remains open (held
+// by the parent: node-pty, shell, etc.). Without an external signal the relay
+// sits in `ReadFile` forever.
+//
+// Pattern adopted from IsoSessionCLI's `ConsoleTtyRelay::WriteThread`
+// (`onecoreuap/windows/core/isoenvbroker/src/cli/ConsoleTtyRelay.cpp:188-263`
+// in the OS repo). `CancelSynchronousIo` was rejected because it has
+// documented edge cases on console handles, and wxc-exec's stdin is a console
+// handle in the dominant `spawnSandbox` (node-pty) and direct-cmd cases.
+//
+// `h_read` MUST be a waitable handle whose signal state correctly reflects
+// "input available" (a console input handle is the canonical case; events
+// also work). Anonymous pipe handles are NOT supported: they appear "always
+// signalled when open", so the wait returns immediately, the relay enters
+// `ReadFile`, and from there the stop event cannot interrupt it. For
+// pipe-backed stdin (the non-TTY case), use the simpler EOF-driven
+// `create_relay_thread` and rely on natural EOF or process exit for cleanup.
+
+/// Parameters for a stop-event-aware relay thread. The thread loops
+/// `WaitForMultipleObjects({h_stop_event, h_read})`; copies a chunk when
+/// `h_read` is ready; exits when `h_stop_event` is signalled, on read EOF,
+/// on read error, on write error, or on `WaitForMultipleObjects` failure.
+///
+/// `h_stop_event` should be a manual-reset event so the relay observes it
+/// even if signalled before the next loop iteration.
+///
+/// `h_read` must be a waitable handle (console input, event). Anonymous
+/// pipes are not supported — see module-level comment above.
+///
+/// # Safety
+/// All three handles must remain valid until the relay thread exits. The
+/// struct must outlive the thread (caller waits on the thread before dropping
+/// `params`).
+#[repr(C)]
+pub struct PipeRelayWithStopParams {
+    pub h_read: HANDLE,
+    pub h_write: HANDLE,
+    pub h_stop_event: HANDLE,
+}
+
+/// Thread procedure for a stop-event-aware relay.
+///
+/// # Safety
+/// `param` must point to a valid `PipeRelayWithStopParams` that outlives the
+/// thread.
+unsafe extern "system" fn pipe_relay_with_stop_thread_proc(param: *mut core::ffi::c_void) -> u32 {
+    let params = &*(param as *const PipeRelayWithStopParams);
+    let mut buffer = [0u8; BUFFER_SIZE as usize];
+    let wait_handles = [params.h_stop_event, params.h_read];
+
+    loop {
+        let wait_result = WaitForMultipleObjects(&wait_handles, false, u32::MAX);
+        // `WAIT_OBJECT_0 + 1` means `h_read` signalled (data available or EOF).
+        // Anything else (stop event = `WAIT_OBJECT_0`, `WAIT_FAILED`, etc.) → exit.
+        if wait_result.0 != WAIT_OBJECT_0.0 + 1 {
+            break;
+        }
+
+        let mut bytes_read = 0u32;
+        if ReadFile(
+            params.h_read,
+            Some(&mut buffer),
+            Some(&mut bytes_read),
+            None,
+        )
+        .is_err()
+            || bytes_read == 0
+        {
+            break;
+        }
+
+        let mut bytes_written = 0u32;
+        if WriteFile(
+            params.h_write,
+            Some(&buffer[..bytes_read as usize]),
+            Some(&mut bytes_written),
+            None,
+        )
+        .is_err()
+            || bytes_written != bytes_read
+        {
+            break;
+        }
+
+        let _ = FlushFileBuffers(params.h_write);
+    }
+
+    0
+}
+
+/// Create a stop-event-aware relay thread via `CreateThread`. Returns the
+/// thread HANDLE wrapped in `OwnedHandle`.
+///
+/// # Safety
+/// `params` must remain valid until the thread exits. The caller is
+/// responsible for joining (waiting on) the thread before `params` is dropped.
+pub unsafe fn create_relay_thread_with_stop(
+    params: *mut PipeRelayWithStopParams,
+) -> Result<OwnedHandle, WxcError> {
+    let handle = CreateThread(
+        None,
+        0,
+        Some(pipe_relay_with_stop_thread_proc),
+        Some(params as *const core::ffi::c_void),
+        THREAD_CREATION_FLAGS(0),
+        None,
+    )
+    .map_err(|e| {
+        WxcError::Process(format!(
+            "CreateThread for stop-aware pipe relay failed: {}",
+            e
+        ))
+    })?;
 
     Ok(OwnedHandle::new(handle))
 }
@@ -335,6 +462,128 @@ pub fn run_process_with_captured_output(
         stderr: stderr_output,
         exit_code: exit_code as i32,
     })
+}
+
+// ── Local console raw-VT-mode RAII guard ──────────────────────────────────
+//
+// When wxc-exec relays into an isolation session in interactive mode, there
+// are TWO consoles in series: wxc-exec's local console (where the user types)
+// and the agent's ConPTY in the isolation session. By default the local
+// console is in cooked-line mode with `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT |
+// ENABLE_PROCESSED_INPUT` — it line-buffers, echoes keystrokes, and processes
+// Ctrl-C locally. The agent's ConPTY *also* echoes (because it's a real PTY).
+// The two consoles render the same input twice, producing visible artifacts
+// (partial echos, doubled prompts, `\r\n` confusion).
+//
+// The fix mirrors IsoSessionCLI's `ConsoleRestorer::SetRawVtMode`
+// (`onecoreuap/windows/core/isoenvbroker/src/cli/ConsoleTtyRelay.cpp:69-93`
+// in the OS repo): switch the local console to raw VT mode for the relay
+// duration. Only the agent's ConPTY does input echo and command processing;
+// the local console is a transparent forwarder. On scope exit the original
+// modes are restored.
+
+/// RAII guard that switches the local console to raw VT mode. Only meaningful
+/// in interactive mode (`InteractiveConsole = true`). When wxc-exec's stdio
+/// is not a real console (redirected, piped), `GetConsoleMode` fails and the
+/// guard records itself as inactive — both `install` and `Drop` become
+/// no-ops, which is the right behavior for the non-TTY case.
+pub struct ConsoleModeRestorer {
+    h_stdin: HANDLE,
+    h_stdout: HANDLE,
+    original_stdin_mode: CONSOLE_MODE,
+    original_stdout_mode: CONSOLE_MODE,
+    active: bool,
+}
+
+impl ConsoleModeRestorer {
+    /// Save current console modes (for stdin and stdout) and switch to raw
+    /// VT mode. Returns the guard; original modes restored on drop.
+    ///
+    /// Stdin: enable VT input + window-resize events; disable line-input,
+    /// echo, and processed-input.
+    /// Stdout: enable VT processing; disable auto-newline-translation.
+    ///
+    /// On any failure (handles aren't real consoles, `SetConsoleMode` fails
+    /// because the handles are not console-mode handles, etc.), the guard
+    /// is constructed inactive — no mode is changed, no restore on drop.
+    pub fn install_raw_vt() -> Self {
+        let h_stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) }.unwrap_or_default();
+        let h_stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }.unwrap_or_default();
+
+        let mut original_stdin_mode = CONSOLE_MODE(0);
+        let mut original_stdout_mode = CONSOLE_MODE(0);
+
+        let stdin_ok = unsafe { GetConsoleMode(h_stdin, &mut original_stdin_mode) }.is_ok();
+        let stdout_ok = unsafe { GetConsoleMode(h_stdout, &mut original_stdout_mode) }.is_ok();
+
+        if !stdin_ok || !stdout_ok {
+            return Self {
+                h_stdin,
+                h_stdout,
+                original_stdin_mode,
+                original_stdout_mode,
+                active: false,
+            };
+        }
+
+        let raw_in = CONSOLE_MODE(
+            (original_stdin_mode.0 | ENABLE_VIRTUAL_TERMINAL_INPUT.0 | ENABLE_WINDOW_INPUT.0)
+                & !(ENABLE_PROCESSED_INPUT.0 | ENABLE_LINE_INPUT.0 | ENABLE_ECHO_INPUT.0),
+        );
+        let raw_out = CONSOLE_MODE(
+            original_stdout_mode.0
+                | ENABLE_VIRTUAL_TERMINAL_PROCESSING.0
+                | DISABLE_NEWLINE_AUTO_RETURN.0,
+        );
+
+        let in_set = unsafe { SetConsoleMode(h_stdin, raw_in) }.is_ok();
+        if !in_set {
+            return Self {
+                h_stdin,
+                h_stdout,
+                original_stdin_mode,
+                original_stdout_mode,
+                active: false,
+            };
+        }
+        let out_set = unsafe { SetConsoleMode(h_stdout, raw_out) }.is_ok();
+        if !out_set {
+            // Stdin succeeded; restore it so we don't leave a half-mutated state.
+            let _ = unsafe { SetConsoleMode(h_stdin, original_stdin_mode) };
+            return Self {
+                h_stdin,
+                h_stdout,
+                original_stdin_mode,
+                original_stdout_mode,
+                active: false,
+            };
+        }
+
+        Self {
+            h_stdin,
+            h_stdout,
+            original_stdin_mode,
+            original_stdout_mode,
+            active: true,
+        }
+    }
+
+    /// Whether the guard actually switched modes (true iff stdio is a real
+    /// console and both `SetConsoleMode` calls succeeded).
+    pub fn is_active(&self) -> bool {
+        self.active
+    }
+}
+
+impl Drop for ConsoleModeRestorer {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe {
+                let _ = SetConsoleMode(self.h_stdin, self.original_stdin_mode);
+                let _ = SetConsoleMode(self.h_stdout, self.original_stdout_mode);
+            }
+        }
+    }
 }
 
 // ── Capability SID helpers ────────────────────────────────────────────────
@@ -817,6 +1066,171 @@ mod tests {
             output.contains("relayed to child"),
             "Expected relayed input in child output, got: {:?}",
             output
+        );
+    }
+
+    // ── Tests for `create_relay_thread_with_stop` ──────────────────────────
+    //
+    // These exercise the stop-event-aware relay variant. Cancellation (test #1)
+    // is the load-bearing case: it's the reason this primitive exists and
+    // distinguishes it from the EOF-driven `create_relay_thread`.
+
+    use windows::Win32::System::Threading::{CreateEventW, SetEvent};
+
+    /// Helper: create a manual-reset, initially-unsignalled event for tests.
+    fn create_test_stop_event() -> OwnedHandle {
+        unsafe {
+            let h = CreateEventW(None, true, false, PCWSTR::null()).unwrap();
+            OwnedHandle::new(h)
+        }
+    }
+
+    #[test]
+    fn test_pipe_relay_with_stop_exits_on_stop_event() {
+        // Core cancellation case: relay is blocked in WaitForMultipleObjects
+        // (no data on h_read, h_read not closed). Signal the stop event;
+        // verify the relay exits within a short timeout.
+        let (source_read, _source_write) = create_test_pipes();
+        let (mut dest_read, dest_write) = create_test_pipes();
+        let stop_event = create_test_stop_event();
+
+        let mut params = PipeRelayWithStopParams {
+            h_read: source_read.get(),
+            h_write: dest_write.get(),
+            h_stop_event: stop_event.get(),
+        };
+        let relay_thread = unsafe { create_relay_thread_with_stop(&mut params).unwrap() };
+
+        // Source has no data and is not closed → relay sits in
+        // WaitForMultipleObjects. Without the stop event it would hang.
+        unsafe {
+            SetEvent(stop_event.get()).unwrap();
+        }
+
+        let wait_result = unsafe { WaitForSingleObject(relay_thread.get(), 5000) };
+        assert_eq!(
+            wait_result, WAIT_OBJECT_0,
+            "Relay did not exit within 5s of stop event"
+        );
+
+        // Drain the dest pipe so its handles can drop cleanly.
+        drop(dest_write);
+        let dest_send = SendOwnedHandle::take(&mut dest_read);
+        let _ = std::thread::spawn(move || read_from_pipe(dest_send.get())).join();
+    }
+
+    #[test]
+    fn test_pipe_relay_with_stop_exits_on_read_eof() {
+        // Stop event never signalled; source closed → read EOF → relay exits.
+        let (source_read, source_write) = create_test_pipes();
+        let (mut dest_read, dest_write) = create_test_pipes();
+        let stop_event = create_test_stop_event();
+
+        let mut params = PipeRelayWithStopParams {
+            h_read: source_read.get(),
+            h_write: dest_write.get(),
+            h_stop_event: stop_event.get(),
+        };
+        let relay_thread = unsafe { create_relay_thread_with_stop(&mut params).unwrap() };
+
+        // Concurrent reader (no-op here, but defensive in case data flows on
+        // any FlushFileBuffers iteration; avoids any pipe-buffer deadlock).
+        let dest_send = SendOwnedHandle::take(&mut dest_read);
+        let reader = std::thread::spawn(move || read_from_pipe(dest_send.get()));
+
+        // Close source write end → relay's read returns EOF → break.
+        drop(source_write);
+
+        let wait_result = unsafe { WaitForSingleObject(relay_thread.get(), 5000) };
+        assert_eq!(wait_result, WAIT_OBJECT_0, "Relay did not exit on read EOF");
+
+        drop(dest_write);
+        let _ = reader.join();
+    }
+
+    #[test]
+    fn test_pipe_relay_with_stop_copies_data_before_exit() {
+        // Stop event never signalled; data is written; verify it is copied.
+        let (source_read, source_write) = create_test_pipes();
+        let (mut dest_read, dest_write) = create_test_pipes();
+        let stop_event = create_test_stop_event();
+
+        let mut params = PipeRelayWithStopParams {
+            h_read: source_read.get(),
+            h_write: dest_write.get(),
+            h_stop_event: stop_event.get(),
+        };
+        let relay_thread = unsafe { create_relay_thread_with_stop(&mut params).unwrap() };
+
+        // Concurrent reader to avoid FlushFileBuffers deadlock.
+        let dest_send = SendOwnedHandle::take(&mut dest_read);
+        let reader = std::thread::spawn(move || read_from_pipe(dest_send.get()));
+
+        let test_data = b"hello via stop-aware relay";
+        let mut bytes_written = 0u32;
+        unsafe {
+            WriteFile(
+                source_write.get(),
+                Some(test_data),
+                Some(&mut bytes_written),
+                None,
+            )
+            .unwrap();
+        }
+        drop(source_write); // EOF → relay exits.
+
+        let wait_result = unsafe { WaitForSingleObject(relay_thread.get(), 5000) };
+        assert_eq!(wait_result, WAIT_OBJECT_0);
+
+        drop(dest_write);
+        let output = reader.join().unwrap();
+        assert_eq!(output, "hello via stop-aware relay");
+    }
+
+    // Note: a "signal-stop-mid-data" test using anonymous pipes is not viable —
+    // anonymous pipe handles appear always-signalled to WaitForMultipleObjects,
+    // so once the relay returns from the wait into ReadFile, the stop event
+    // cannot interrupt the blocked read. The intended production usage is with
+    // a console input handle (or other waitable handle) where signal state
+    // accurately reflects data-available. The "stop-event-only" path
+    // (test_pipe_relay_with_stop_exits_on_stop_event) and the "EOF-after-data"
+    // path (test_pipe_relay_with_stop_copies_data_before_exit) together cover
+    // the invariants that matter for the production case.
+
+    #[test]
+    fn test_console_mode_restorer_handles_non_console() {
+        // `cargo test` typically runs with stdio as pipes, not a real console.
+        // Verify the restorer constructs and drops without panicking, and
+        // reports `active == false` since `GetConsoleMode` fails on pipes.
+        // The `active == true` path is exercised by manual smoke testing on a
+        // real console — covered by the `isolation_session_powershell_interactive`
+        // smoke config.
+        let restorer = ConsoleModeRestorer::install_raw_vt();
+        // Either active or inactive is acceptable here — what matters is no
+        // panic and clean drop. On CI / cargo test, `active` should be false.
+        let _ = restorer.is_active();
+        // Drop happens at end of scope.
+    }
+
+    #[test]
+    fn test_pipe_relay_with_stop_exits_on_invalid_handle() {
+        // Defensive path: pass a default (invalid) HANDLE for h_read.
+        // WaitForMultipleObjects returns WAIT_FAILED → relay loop breaks →
+        // thread exits cleanly. No panic, no hang.
+        let (_, dest_write) = create_test_pipes();
+        let stop_event = create_test_stop_event();
+
+        let mut params = PipeRelayWithStopParams {
+            h_read: HANDLE::default(), // invalid — not a kernel handle
+            h_write: dest_write.get(),
+            h_stop_event: stop_event.get(),
+        };
+        let relay_thread = unsafe { create_relay_thread_with_stop(&mut params).unwrap() };
+
+        let wait_result = unsafe { WaitForSingleObject(relay_thread.get(), 5000) };
+        assert_eq!(
+            wait_result, WAIT_OBJECT_0,
+            "Relay did not exit on invalid h_read"
         );
     }
 }

--- a/test_configs/isolation_session_powershell_interactive.json
+++ b/test_configs/isolation_session_powershell_interactive.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-powershell-interactive",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "powershell.exe -NoLogo",
+    "timeout": 0
+  }
+}

--- a/test_configs/isolation_session_stderr.json
+++ b/test_configs/isolation_session_stderr.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-stderr",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "echo MARKER_STDOUT & echo MARKER_STDERR 1>&2",
+    "timeout": 30000
+  }
+}

--- a/test_configs/isolation_session_stdout_stderr_interleaved.json
+++ b/test_configs/isolation_session_stdout_stderr_interleaved.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-interleaved",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "echo OUT_A & echo ERR_A 1>&2 & echo OUT_B & echo ERR_B 1>&2 & echo OUT_C",
+    "timeout": 30000
+  }
+}

--- a/test_configs/isolation_session_streaming_smoke.json
+++ b/test_configs/isolation_session_streaming_smoke.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-streaming-smoke",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "echo line_1 & ping -n 2 127.0.0.1 >nul & echo line_2 & ping -n 2 127.0.0.1 >nul & echo line_3",
+    "timeout": 30000
+  }
+}

--- a/test_configs/isolation_session_timeout.json
+++ b/test_configs/isolation_session_timeout.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-timeout",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "ping -n 30 127.0.0.1 >nul",
+    "timeout": 1500
+  }
+}

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -151,6 +151,11 @@ $null = $results.Add((Run-IsolationSessionTest "isolation_session_hello.json" `
     -OutputContains @("MYVAR=IsolationSessionTest", "CWD=C:\mxc_workdir_test", "-IEB-")))
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_exit42.json" `
     -ExpectedExit 42))
+# stderr separation: agent writes MARKER_STDOUT to stdout and MARKER_STDERR to stderr.
+# Both reach this script's captured output via wxc-exec's `2>&1` merge above; the assertion
+# proves stderr is being relayed (not dropped) on the non-ConPTY plain-pipes path.
+$null = $results.Add((Run-IsolationSessionTest "isolation_session_stderr.json" `
+    -OutputContains @("MARKER_STDOUT", "MARKER_STDERR")))
 
 # Summary
 $passed = ($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -11,8 +11,8 @@
 
 .DESCRIPTION
     - Locates wxc-exec.exe (built with --features isolation_session)
-    - Runs each test config via wxc-exec, validates exit codes and stdout
-      content
+    - Runs each automated test config via wxc-exec, validates exit codes
+      and stdout content
     - Reports pass/fail summary
 
     This script must run INTERACTIVELY on the test host. The IsoEnvBroker
@@ -20,6 +20,25 @@
     invocations fail with Access Denied. Copy wxc-exec.exe, the test
     configs, and this script to the host, then run it directly in
     cmd.exe or PowerShell on that host.
+
+    Automated configs (asserted by this script):
+      - isolation_session_hello.json — env vars + working dir + agent name
+      - isolation_session_exit42.json — exit code propagation
+      - isolation_session_stderr.json — separate stderr in non-ConPTY mode
+      - isolation_session_stdout_stderr_interleaved.json — interleaved streams
+      - isolation_session_timeout.json — broker terminates with exit code 1
+
+    Manual smoke configs (NOT asserted — observe the output yourself):
+      - isolation_session_streaming_smoke.json — output appears with delays
+        rather than a burst at exit; verifies Commit 1 streaming.
+        Run from cmd.exe directly (not redirected) so wxc-exec sees a TTY:
+            wxc-exec.exe --experimental isolation_session_streaming_smoke.json
+      - isolation_session_powershell_interactive.json — launches
+        powershell.exe in the isolation session; type commands at the prompt
+        (e.g. `Get-Date`, `whoami`, `exit 7`) and verify input forwarding +
+        ConPTY rendering + exit-code propagation. Requires a real cmd.exe
+        console (interactive on the VM desktop):
+            wxc-exec.exe --experimental isolation_session_powershell_interactive.json
 
 .PARAMETER WxcExePath
     Path to wxc-exec.exe. Default probes target-specific then default
@@ -156,6 +175,14 @@ $null = $results.Add((Run-IsolationSessionTest "isolation_session_exit42.json" `
 # proves stderr is being relayed (not dropped) on the non-ConPTY plain-pipes path.
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_stderr.json" `
     -OutputContains @("MARKER_STDOUT", "MARKER_STDERR")))
+# Interleaved streams: agent writes alternating stdout/stderr lines. All five markers
+# must appear in the captured output (proves streams aren't crossed or dropped mid-run).
+$null = $results.Add((Run-IsolationSessionTest "isolation_session_stdout_stderr_interleaved.json" `
+    -OutputContains @("OUT_A", "ERR_A", "OUT_B", "ERR_B", "OUT_C")))
+# Timeout: ping runs ~30s; broker timer set to 1500ms forces TerminateProcess(handle, 1)
+# (verified at IsolationSessionWorkerProcess.cpp:153-170 in the OS repo). Exit code = 1.
+$null = $results.Add((Run-IsolationSessionTest "isolation_session_timeout.json" `
+    -ExpectedExit 1))
 
 # Summary
 $passed = ($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Closes #240. Adds full interactive (TTY) parity for the IsolationSession backend, closing the gap between IsolationSession and the process container in `spawnSandbox` consumer scenarios. Streaming stdout/stderr, stdin forwarding, ConPTY mode, and 3-tier graceful shutdown — all runtime-conditional on `std::io::stdout().is_terminal()` so non-TTY callers (`spawnSandboxFromConfig({usePty: false})`, redirected stdio) are unchanged.

## What's in this PR

Two commits, structured for review:

**Commit 1 — `[IsolationSession] Stream stdout/stderr via pipe relay threads`**

Replaces the batch-capture model in `IsolationSessionManager::create_process` (read pipes to `String`, return at exit) with stdout/stderr relay threads using `process_util::create_relay_thread`. Output now flows live to wxc-exec's stdio while the agent runs. `InteractiveConsole` stays `false` (plain-pipes mode preserved); no observable change for existing automated tests, which assert final output content + exit code only. Adds `isolation_session_stderr.json` integration config and 4 new unit tests for `From<IsolationSessionConfigurationId> for IsoSessionConfigId` (gap-fill from PR #239 — catches enum drift).

**Commit 2 — `[IsolationSession] Add interactive ConPTY mode and stdin relay`**

Detects at runtime via `std::io::stdout().is_terminal()` whether wxc-exec was launched with TTY-bearing stdio (node-pty's ConPTY for SDK `spawnSandbox`, or direct cmd.exe). When true, sets `InteractiveConsole = true` so the broker creates a ConPTY in the isolation session. Adds:

- `process_util::create_relay_thread_with_stop` + `PipeRelayWithStopParams` — stop-event-aware stdin relay using `WaitForMultipleObjects({stop, h_read})` (pattern from IsoSessionCLI's `ConsoleTtyRelay::WriteThread`; avoids `CancelSynchronousIo`'s known console-handle edge cases).
- `process_util::ConsoleModeRestorer` — RAII guard switching the local console to raw VT mode for the relay duration (mirrors IsoSessionCLI's `ConsoleRestorer::SetRawVtMode`). Without this, both the local cmd.exe and the agent's ConPTY echo input independently — visible double-rendering, doubled prompts, `\r\n` artifacts.
- 3-tier graceful shutdown (`CloseStandardInput` → `WaitForExit(5000)` → `SendCtrlClose` → `WaitForExit(3000)` → `Terminate` → `WaitForExit(INFINITE)`) for the timeout / cancellation path; pattern from IsoSessionCLI's `CommandTty.cpp:226-263`. In the natural-exit path, tiers don't fire.
- Pure helper `compute_redirect_flags(interactive)` for testable `RedirectStandardError = !interactive` policy. The broker doesn't populate `ErrorHandle` in ConPTY mode (predicate at `IsolationSessionWorkerProcess.cpp:309-310`), so we don't ask for it.
- Two new automated test configs (`isolation_session_stdout_stderr_interleaved.json`, `isolation_session_timeout.json`) and two manual smokes (`isolation_session_streaming_smoke.json`, `isolation_session_powershell_interactive.json`) excluded from the auto-runner; manual procedure documented in `run_isolation_session_tests.ps1`.

## Testing

**Automated** (release + debug, x86_64-pc-windows-msvc, with and without `--features isolation_session`):

- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 lint warnings.
- `cargo build`: 0 warnings.
- `cargo test --workspace --exclude wxc_e2e_tests`: 279 / 0 / 0 without; 300 / 0 / 0 with. Delta from `main`: +5 unconditional (process_util tests for stop-aware relay + console-mode restorer) and +6 feature-gated (4 config-id conversion + 2 redirect-flags).

**VM integration** (Hyper-V VM at OS build `26611.260501-1700`, `Composable` config, both release and debug builds):

- 5/5 automated PASS (`hello`, `exit42`, `stderr`, `interleaved`, `timeout`). No leftover `IsolationProxy.exe`.

**Manual smokes** (run interactively on the VM desktop in cmd.exe; PSSession-driven invocations fail per the IsoEnvBroker cohort check — same constraint as #217 / #239):

- Streaming smoke: output appears with delays matching the `ping` sleeps.
- Powershell interactive: prompt appears, typed `Get-Date` / `whoami` / `exit <N>` work — input forwarded, output rendered, exit code propagated.

**`build.bat` presence / absence verified on dev host**:

- `--with-isolation-session`: ServiceUnavailable error (no `IsoSessionApp.dll` on dev host; HRESULT `0x80040154` / `REGDB_E_CLASSNOTREG`).
- Without: `Error: IsolationSession backend not compiled. Rebuild with --features isolation_session.` + exit 1.

## Scope notes

Deliberately deferred — see issue #240's "Additional context" section:

- Streaming-during-execution as an automated e2e test. Cross-cutting test infrastructure that would benefit all backends; fast-follow.
- PTY-driven interactive shell automation. Substantial new infrastructure.
- IDL extension request for `SendCtrlC` / `SendCtrlBreak` exposure on `IsoSessionProcess`. Broker supports both; in-proc IDL only exposes `SendCtrlClose`. Not blocking; OS team request.

Closes #240.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/241)