### PR TITLE
Add In-PR label policy for issue tracking

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -268,3 +268,37 @@ This section is **required**.
 - For feature requests, explain the *why* (user problem) before the *how* (implementation)
 - Reference relevant source files, config fields, or docs when applicable
 - If any required field is unknown, **ask for the information rather than fabricating content**
+
+## Creating Pull Requests
+
+Pull requests must follow the template in `.github/PULL_REQUEST_TEMPLATE.md`. Complete all checklist items and add content below the separator (`-----`).
+
+### Required structure
+
+Every PR body should include:
+
+1. **Template checklist** — check the boxes that apply (CLA, related issue, copilot-instructions update).
+2. **Summary** — a brief description of what the PR does and why.
+3. **Issue references** — if the PR is intended to close an issue, use GitHub closing keywords (`Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN`). If the PR is related but does not close an issue, use an unordered list under a "Related Issues" heading (`- #NNN`).
+
+### Example
+
+```markdown
+- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
+- [x] This pull request is related to an issue.
+- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+-----
+
+## Summary
+
+Brief description of the change.
+
+Closes #42
+```
+
+### Guidelines
+
+- One PR should address one issue or concern. Avoid bundling unrelated changes.
+- If the PR updates build commands, project architecture, or key conventions, update `.github/copilot-instructions.md` in the same PR.
+- Draft PRs are appropriate for work-in-progress that needs early feedback.

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -46,6 +46,9 @@ configuration:
           - hasLabel:
               label: Needs-Author-Feedback
           - not:
+              hasLabel:
+                label: Needs-Attention
+          - not:
               isAction:
                 action: Synchronize
         then:
@@ -63,6 +66,9 @@ configuration:
               action: Submitted
           - isReviewState:
               reviewState: Changes_requested
+          - not:
+              hasLabel:
+                label: Needs-Author-Feedback
         then:
           - assignTo:
               author: True

--- a/.github/policies/labelManagement.issueUpdated.yml
+++ b/.github/policies/labelManagement.issueUpdated.yml
@@ -1,0 +1,84 @@
+id: labelManagement.issueUpdated
+name: GitOps.PullRequestIssueManagement
+description: >-
+  Handlers for when an issue is updated and not closed.
+  This primarily includes handlers for comments, reviews, and re-runs.
+owner:
+resource: repository
+disabled: false
+where:
+configuration:
+  resourceManagementConfiguration:
+    eventResponderTasks:
+      - description: Remove "No-Recent-Activity" when a pull request or issue is updated
+        if:
+          - or:
+              - payloadType: Pull_Request
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
+              - payloadType: Issue_Comment
+              - payloadType: Issues
+          - not:
+              isAction:
+                action: Closed
+          - hasLabel:
+              label: No-Recent-Activity
+        then:
+          - removeLabel:
+              label: No-Recent-Activity
+        triggerOnOwnActions: False
+      - description: Clean email replies on every comment
+        if:
+          - payloadType: Issue_Comment
+        then:
+          - cleanEmailReply
+      - description: >-
+          If an author responds to an issue which needs author feedback
+          * Remove the Needs-Author-Feedback Label
+          * Add the Needs-Attention Label
+        if:
+          - or:
+              - payloadType: Pull_Request_Review
+              - payloadType: Pull_Request_Review_Comment
+              - payloadType: Issue_Comment
+          - isActivitySender:
+              issueAuthor: True
+          - hasLabel:
+              label: Needs-Author-Feedback
+          - not:
+              isAction:
+                action: Synchronize
+        then:
+          - removeLabel:
+              label: Needs-Author-Feedback
+          - addLabel:
+              label: Needs-Attention
+      - description: >-
+          When changes are requested on a pull request
+          * Assign to the author
+          * Label with Needs-Author-Feedback
+        if:
+          - payloadType: Pull_Request_Review
+          - isAction:
+              action: Submitted
+          - isReviewState:
+              reviewState: Changes_requested
+        then:
+          - assignTo:
+              author: True
+          - addLabel:
+              label: Needs-Author-Feedback
+      - description: Sync labels from issues on all pull request events
+        if:
+          - payloadType: Pull_Request
+        then:
+          - labelSync:
+              pattern: Issue-
+          - labelSync:
+              pattern: Area-
+          - labelSync:
+              pattern: Priority-
+          - inPrLabel:
+              label: In-PR
+onFailure:
+onSuccess:


### PR DESCRIPTION
## 📖 Description
Created with GitHub Copilot assistance.

Add `.github/policies/labelManagement.issueUpdated.yml` so issues referenced by pull requests automatically receive the `In-PR` label, and document the related pull request conventions in `.github/copilot-instructions.md`.

## 🔗 References
Resolves #243

## 🔍 Validation
- Reviewed `.github/policies/labelManagement.issueUpdated.yml` against the equivalent policy in `microsoft/winget-cli`.
- Reviewed `.github/copilot-instructions.md` for the updated pull request guidance.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
