### PR TITLE
[IsolationSession] Add state-aware lifecycle support to wxc-exec

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -72,7 +72,8 @@ node --test dist/cli.test.js
 # Local PowerShell helpers — run from repo root, require built binaries
 test_scripts\run_test_configs.ps1            # All test configs via wxc_test_driver
 test_scripts\run_basicac_test.ps1            # Single AppContainer test
-test_scripts\run_isolation_session_tests.ps1 # IsolationSession E2E (requires IsoEnvBroker host)
+test_scripts\run_isolation_session_tests.ps1                # IsolationSession one-shot E2E (requires host with the OS-side IsoSessionOps service)
+test_scripts\run_isolation_session_state_aware_tests.ps1    # IsolationSession state-aware lifecycle E2E (multi-invocation provision/start/exec/stop/deprovision, same host requirements)
 test_scripts\run_lxc_all_tests.sh            # All LXC tests (Linux)
 
 # E2E test crate — Rust executor integration tests (from src/)
@@ -94,7 +95,7 @@ The Rust workspace (`src/`) implements multiple sandboxing backends behind the `
 | BaseContainer (OS sandbox API) | `wxc-exec.exe` | Windows | `base_container_runner.rs` — calls `Experimental_CreateProcessInSandbox` via FlatBuffer |
 | Windows Sandbox | `wxc-exec.exe` | Windows | `windows_sandbox_runner.rs` |
 | MicroVM (NanVix) | `wxc-exec.exe` | Windows | `nanvix_runner.rs` — feature-gated behind `microvm` |
-| IsolationSession | `wxc-exec.exe` | Windows | `isolation_session_runner.rs` — feature-gated behind `isolation_session`, experimental, uses the in-proc `Windows.AI.IsolationSession` `IsoSessionOps` API (loaded from `IsoSessionApp.dll`). Streams stdout/stderr, forwards stdin, and switches to ConPTY mode when wxc-exec's stdout is a TTY for `spawnSandbox` parity. |
+| IsolationSession | `wxc-exec.exe` | Windows | `isolation_session_runner.rs` — feature-gated behind `isolation_session`, experimental, uses the in-proc `Windows.AI.IsolationSession` `IsoSessionOps` API (loaded from `IsoSessionApp.dll`). Supports both one-shot (single-invocation lifecycle, via `ScriptRunner`) and state-aware (multi-invocation provision/start/exec/stop/deprovision, via `StatefulSandboxBackend`) modes. Streams stdout/stderr, forwards stdin, and switches to ConPTY mode when wxc-exec's stdout is a TTY for `spawnSandbox` parity. |
 | LXC | `lxc-exec` | Linux | `lxc/src/main.rs` + `lxc_common/` |
 
 ### Config flow
@@ -124,7 +125,10 @@ The SDK auto-discovers native binaries by checking `sdk/bin/<target-triple>/` (n
 - `docs/authoring-a-new-feature.md` — step-by-step guide for adding experimental features (which files to touch, in what order)
 - `docs/lxc-backend.md` — LXC container backend details
 - `docs/windows-sandbox.md` / `docs/windows-sandbox-reference.md` — Windows Sandbox backend
-- `docs/isolation-session/initial-bringup-plan.md` — IsolationSession backend (experimental, isolated user account per execution via the OS-side IsoEnvBroker)
+- `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md` — state-aware sandbox lifecycle API (cross-backend wire format, Rust `StatefulSandboxBackend` trait, and dispatcher contract)
+- `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md` — companion overview to the full state-aware design
+- `docs/isolation-session/initial-bringup-plan.md` — IsolationSession backend, one-shot bringup (experimental, isolated user account per execution via the OS-side service)
+- `docs/isolation-session/state-aware-rust-initial-plan.md` — IsolationSession state-aware lifecycle, Rust-layer initial plan (per-phase config / metadata, policy honor matrix, idempotence, concurrency, error mapping)
 - `docs/examples.md` — annotated configuration examples (see also `examples/` and `test_configs/`)
 
 ## Key Conventions

--- a/docs/isolation-session/initial-bringup-plan.md
+++ b/docs/isolation-session/initial-bringup-plan.md
@@ -279,9 +279,10 @@ expected output substrings, and reports a pass/fail summary. Pattern
 follows the existing per-backend integration scripts (e.g.
 `run_microvm_tests.ps1`, `run_wslc_all_tests.ps1`).
 
-The script must run **interactively** on the test host. The IsoEnvBroker's
-cohort check rejects network-logon tokens, so PSSession-driven
-invocations fail with `Access Denied`. Intended workflow: build a release
+The script must run **interactively** on the test host. The OS-side service's
+calling-process identity check rejects network-logon tokens, so
+PSSession-driven invocations fail with `Access Denied`. Intended workflow:
+build a release
 `wxc-exec.exe` (the repo's `.cargo/config.toml` already configures
 `+crt-static` for Windows MSVC, so the binary has no `vcruntime140.dll`
 dependency on the test host), copy it plus the two test configs and the

--- a/docs/isolation-session/initial-bringup-plan.md
+++ b/docs/isolation-session/initial-bringup-plan.md
@@ -9,7 +9,7 @@ cases that need this — per the broader claw-on-MXC scenario — call for:
 
 - **per-execution OS-isolated identity** so the workload's actions cannot
   pollute the calling user's NTFS / registry / token state,
-- **OS-managed session lifecycle** that the broker tears down cleanly when
+- **OS-managed session lifecycle** that the OS-side service tears down cleanly when
   the calling process exits, and
 - a **path toward stateful execution** where one provisioned user and session
   can host multiple sequential exec calls without re-paying the registration /
@@ -44,7 +44,7 @@ User: wxc-exec.exe --experimental config.json
 wxc-exec.exe (Rust — single binary, multiple backends)
    ├── Parses JSON config → sees containment = "isolation_session"
    ├── Checks --experimental flag → instantiates IsolationSessionRunner
-   ├── Calls IsolationSessionManager methods 1:1 with the broker:
+   ├── Calls IsolationSessionManager methods 1:1 with the OS-side service:
    │     register_client(regId)              → Step 0
    │     provision_agent_user(...)           → Step 1 — creates agent user
    │     start_session(..., configId)        → Step 2 — boots session
@@ -57,7 +57,7 @@ wxc-exec.exe (Rust — single binary, multiple backends)
    └── Returns ScriptResponse with stdout, stderr, exit_code
 ```
 
-The broker does the heavy lifting: it provisions a Windows agent user account
+The OS-side service does the heavy lifting: it provisions a Windows agent user account
 (named `<CallingUser>-IEB-<NNN>`), launches an `IsolationProxy.exe` per
 session, and exposes the running script as an `IIsolationSessionWorkerProcess`
 from which the runner reads pipe handles for I/O.
@@ -84,7 +84,7 @@ let mut runner: Box<dyn ScriptRunner> = match request.containment {
 The runner is split into two layers:
 
 - **`IsolationSessionManager`** — reusable, lifecycle methods that map 1:1
-  to the broker API. Methods: `new`, `register_client`,
+  to the OS-side API. Methods: `new`, `register_client`,
   `provision_agent_user`, `start_session`, `create_process`, `stop_session`,
   `deprovision_agent_user`, `unregister_client`.
 - **`IsolationSessionRunner`** — thin one-shot `ScriptRunner` impl that
@@ -146,7 +146,7 @@ interface.
 ```
 
 The only `experimental.isolation_session` knob is `configurationId`, which
-selects the broker-side session size: `"small"` (1, default), `"medium"` (2),
+selects the OS-side session size: `"small"` (1, default), `"medium"` (2),
 `"large"` (3), or `"commandline"` (4). Other process options (`cwd`, `env`,
 `timeout`) read from the existing top-level `process` section, matching the
 contract every other backend honors.
@@ -223,11 +223,11 @@ matching `windows` crate version").
 - `process.cwd` (working directory inside the session).
 - `process.env` (environment variables forwarded via
   `IIsolationSessionWorkerProcessCreateOptions::SetEnvironmentVariables`).
-- `process.timeout` (forwarded to the broker's per-process timeout
+- `process.timeout` (forwarded to the OS-side per-process timeout
   enforcement).
 - `experimental.isolation_session.configurationId`
   (Small / Medium / Large / CommandLine).
-- `lifecycle.destroyOnExit` (mapped to broker `LifetimePolicy`: `true` →
+- `lifecycle.destroyOnExit` (mapped to the OS-side `LifetimePolicy`: `true` →
   `CallerProcess`, `false` → `Indefinite`; matches how other backends
   interpret this field).
 - Stdout / stderr capture and exit code propagation into `ScriptResponse`.
@@ -241,7 +241,7 @@ matching `windows` crate version").
 - **TypeScript SDK exposure.** Lifting `experimental.isolation_session`
   into `SandboxSpawnOptions` so the SDK can spawn isolation-session
   workloads programmatically. Today the backend works only via JSON.
-- **Interactive ConPTY** (no plans currently). The broker-side
+- **Interactive ConPTY** (no plans currently). The OS-side
   `InteractiveConsole` flag, console resize, and control signals
   (CtrlC / CtrlBreak / CtrlClose) are not used by fire-and-forget script
   execution.
@@ -303,7 +303,7 @@ The following were observed during VM testing and are accepted for v0.1.
   `ScriptResponse` ahead of teardown.
 - **`DeprovisionAgentUserAsync` returning status 1.** Initially observed as
   a stderr warning on an earlier OS build. No longer surfacing on the
-  current OS build. Cleanup proceeds via the broker's process-exit callback
+  current OS build. Cleanup proceeds via the OS-side process-exit callback
   when `LifetimePolicy: CallerProcess` is used, so the warning was
   non-functional even when present.
 - **Intermittent `IdentityNotFound` (status 4) immediately after VM boot.**
@@ -318,18 +318,18 @@ The following were observed during VM testing and are accepted for v0.1.
 | Bindings tied to a specific OS API version | `GENERATION_INFO.toml` records the OS branch + commit; `build.rs` version-checks the `windows` crate; regeneration is one command |
 | OS API not present on older Windows builds | `Feature_IsoBrokerSessionApis` is OS-side; runner reports a clean error when the activation factory fails. Feature-unavailable test exercises this on CI |
 | New Cargo feature increases coupling | The `isolation_session` feature is off by default in the workspace; default builds and existing CI are unaffected |
-| Manual VM testing required | The OS-side service has the same constraint for any consumer (broker rejects network-logon tokens). Automated suite covers what it can without the broker |
+| Manual VM testing required | The OS-side service has the same constraint for any consumer (it rejects network-logon tokens). Automated suite covers what it can without the OS-side service |
 | One-shot lifecycle is heavy (full register → provision → start per call) | Accepted for v0.1; experimental flag indicates rough edges. Stateful API is the planned mitigation |
 | `ProvisionAgentUserAsync` re-provision hang under `Indefinite` lifetime | Manager calls `GetAgentUser` first and skips a redundant provision when the user already exists |
-| `DeprovisionAgentUserAsync` failure under `Indefinite` lifetime | Manager re-provisions with `CallerProcess` lifetime as part of teardown so the broker's process-exit callback handles cleanup naturally |
+| `DeprovisionAgentUserAsync` failure under `Indefinite` lifetime | Manager re-provisions with `CallerProcess` lifetime as part of teardown so the OS-side process-exit callback handles cleanup naturally |
 
 ## Prerequisites
 
 **For end users:**
 
 - A Windows build with `Feature_IsoBrokerSessionApis` enabled.
-- `IsolationProxy.exe` present in `%SystemRoot%\System32\` (ships with the
-  broker).
+- `IsolationProxy.exe` present in `%SystemRoot%\System32\` (ships with
+  Windows as part of the OS-side service).
 - WinRT initialized as MTA (handled by `wxc-exec`).
 
 **For developers:**

--- a/docs/isolation-session/state-aware-rust-initial-plan.md
+++ b/docs/isolation-session/state-aware-rust-initial-plan.md
@@ -1,0 +1,242 @@
+# MXC IsolationSession Backend — State-Aware Rust Initial Plan
+
+This document describes the IsolationSession backend's behaviour under the
+state-aware lifecycle API ([design](../state-aware-lifecycle/mxc-state-aware-sandbox-api.md)).
+It is the per-backend plan required by §11.6 of that design and covers the
+five state-aware phases — provision, start, exec, stop, deprovision —
+plus the cross-cutting policy honor matrix, idempotence behaviour,
+concurrency story, and error mapping.
+
+## Scope
+
+### In scope
+
+- The Rust layer of state-aware IsolationSession in `wxc-exec.exe`, behind
+  the `--features isolation_session` Cargo feature and the `--experimental`
+  CLI flag.
+- The wire format consumed by `wxc-exec.exe` for state-aware requests
+  (top-level `phase` discriminator, `sandboxId`,
+  `experimental.isolation_session.<phase>` typed config blocks).
+- Mapping from the OS-side service's HRESULTs to the wire-format `MxcError`
+  codes.
+
+### Out of scope (for this initial plan)
+
+- **TypeScript SDK exposure.** State-aware lands in `wxc-exec.exe` only.
+  SDK exposure (the `provisionSandbox` / `startSandbox` / `execInSandbox` /
+  etc. surface) is a separate work item — same staging as the original
+  IsolationSession bringup (one-shot wire-format first, SDK exposure later).
+  When SDK exposure lands, a companion plan doc covers the TypeScript layer
+  and its exception classes.
+- **Explicit `AbortSignal` plumbing.** v1 cancellation is OS-level: the
+  caller kills `wxc-exec.exe`, the OS-side service's per-process timer or
+  the existing 3-tier shutdown (close stdin → `SendCtrlClose` → `Terminate`)
+  reaps the agent. See [Cancellation](#cancellation) below.
+- **Concurrent state-aware sessions.** v1 supports a single state-aware
+  sandbox per consumer. See [Concurrency](#concurrency) for the constraint.
+
+## Per-phase config and metadata shapes
+
+The `StatefulSandboxBackend` impl on `IsolationSessionRunner` declares
+associated types for each phase. Phases without a config use `()`; phases
+without metadata use `()`.
+
+| Phase | `*Config` | `*Metadata` |
+|---|---|---|
+| provision | `()` | `IsolationSessionProvisionMetadata` |
+| start | `IsolationSessionConfig` | `()` |
+| exec | `()` | (n/a — exec returns an exit code, not metadata) |
+| stop | `()` | `()` |
+| deprovision | `()` | `()` |
+
+### Provision
+
+**Config (none).** Provision takes no per-phase config. The agent user
+account name is OS-assigned (`<CallingUser>-IEB-<NNN>`).
+
+**Metadata (`IsolationSessionProvisionMetadata`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `agentUserName` | string | The OS-assigned agent account name returned by `AddUserAsync`. Diagnostic only — not used as an addressing key. |
+
+The provisioned `sandboxId` shape is `iso:wxc-<8-hex>`, where the 8-hex
+suffix is `mint_random_token()`. Example: `iso:wxc-1b65bd11`.
+
+### Start
+
+**Config (`IsolationSessionConfig`):**
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `configurationId` | `"small" \| "medium" \| "large" \| "composable"` | `"composable"` | Maps to the OS-side `IsoSessionConfigId`. `composable` is the lightweight, ConPTY-friendly default; `small` triggers a known cache-teardown bug on the current OS build (see [Known issues](#known-issues)) and is not recommended. |
+
+This is the same `IsolationSessionConfig` shape used by the one-shot
+`experimental.isolation_session` block — there is no separate state-aware
+type. The wire path is `experimental.isolation_session.start.configurationId`.
+
+**Metadata (none).** Start returns an empty `result: {}` envelope on success.
+
+### Exec
+
+**Config (none).** Exec uses only the cross-cutting `process` block on the
+top-level wire envelope (`commandLine`, `cwd`, `env`, `timeout`).
+
+**Output.** Stdout is the agent process's live-streamed output (the SDK
+discriminates this from a JSON envelope by exit code + stdout-parseability;
+the dispatcher never emits a JSON envelope on stdout for exec on success).
+The wxc-exec process exit code is the agent process's exit code.
+
+### Stop
+
+**Config (none).** Stop terminates the active session. Idempotent semantics
+described in [Idempotence](#idempotence-per-phase).
+
+**Metadata (none).** Empty `result: {}` envelope.
+
+### Deprovision
+
+**Config (none).** Deprovision removes the agent user *and* unregisters the
+client app. After this returns, `sandboxId` is no longer addressable — any
+subsequent op against it surfaces `stale_id`.
+
+**Metadata (none).** Empty `result: {}` envelope.
+
+## Cross-cutting policy honor matrix
+
+IsolationSession's underlying OS-side service does not expose filesystem,
+network, or UI policy knobs. Every state-aware phase rejects these fields
+up-front via the trait's `validate_<phase>` hooks, mirroring the one-shot
+path's `validate_runner` rejection.
+
+| Field | provision | start | exec | stop | deprovision |
+|---|---|---|---|---|---|
+| `policy.filesystem.{readwritePaths,readonlyPaths,deniedPaths}` | rejected | rejected | rejected | rejected | rejected |
+| `policy.network.{allowedHosts,blockedHosts,defaultPolicy}` | rejected | rejected | rejected | rejected | rejected |
+| `policy.network.proxy` | rejected | rejected | rejected | rejected | rejected |
+| `policy.ui` | rejected | rejected | rejected | rejected | rejected |
+
+Rejection surfaces as wire-format `error.code = "policy_validation"`.
+
+## Mode-specific fields
+
+### Fields valid in both modes
+
+- `process.commandLine` — required for one-shot and for state-aware exec;
+  ignored at non-exec state-aware phases (the parser allows `process` to be
+  absent for non-exec phases).
+- `process.cwd`, `process.env`, `process.timeout` — optional in both modes,
+  honoured per-process (each exec receives its own block).
+- `experimental.isolation_session.configurationId` (one-shot) /
+  `experimental.isolation_session.start.configurationId` (state-aware) —
+  same enum (`small` / `medium` / `large` / `composable`).
+
+### Fields valid in one-shot only
+
+- `policy.filesystem`, `policy.network`, `policy.ui`, `policy.network.proxy`
+  — rejected by both modes (one-shot via `ScriptRunner::validate_runner`;
+  state-aware via `validate_<phase>` hooks).
+
+### Fields valid in state-aware only
+
+- `phase` — the discriminator. Required for state-aware; absent for one-shot.
+- `sandboxId` — required for non-provision phases.
+- `experimental.isolation_session.<phase>` — typed per-phase config blocks
+  (only `start` is populated in v1; the others use `()`).
+
+## Idempotence per phase
+
+| Phase | Repeated call | Notes |
+|---|---|---|
+| provision | non-idempotent | Each provision mints a fresh `provisionId` / agent user. Two provision calls produce two distinct sandboxes. Acceptable: callers manage `sandboxId` state themselves. |
+| start | OS-side dependent | Starting an already-started session surfaces an HRESULT from `StartSessionAsync`; mapped to `backend_error` (no specific MXC code). Callers should not call start twice; if they do, the second call's failure does not corrupt the first session. |
+| exec | per-call | Each exec creates a fresh agent process via `RunProcessWithOptionsAsync`. No deduplication — repeated `commandLine` runs the command repeatedly. |
+| stop | OS-side dependent | Stopping an already-stopped session surfaces an HRESULT from `StopSessionAsync`; mapped to `backend_error`. The cohort registration and agent user remain — only the running session is gone. |
+| deprovision | becomes `stale_id` | After a successful deprovision, the agent user and registration are gone. A second deprovision on the same `sandboxId` triggers the OS-side `FindActiveAgentUserByProvisionId` lookup failure (`HRESULT_FROM_WIN32(ERROR_NOT_FOUND)`), which the runner maps to `MxcError::StaleId`. |
+
+## Concurrency
+
+### Multiple sandboxes
+
+Distinct `sandboxId`s have distinct `provisionId`s (each minted by
+`mint_random_token`). They share a single registration string (`"regid"`,
+hardcoded by the `IsoSessionOps` wrapper). The OS-side service's
+`RegisterApp` is idempotent for duplicate calls (returns
+`ALREADY_REGISTERED` as success), so concurrent provisions all succeed.
+
+### Multiple exec calls against the same sandbox
+
+The runner's `exec` impl reuses the existing one-shot `create_process` path
+synchronously: `manager.create_process(&options)` blocks until the agent
+process exits and the relay drains. Two concurrent exec calls against the
+same `sandboxId` from two `wxc-exec` processes are not coordinated by MXC;
+the OS-side service serialises (or rejects, depending on session state) at
+its own layer.
+
+### Deprovision side-effect on concurrent sandboxes
+
+`deprovision` calls both `deprovision_agent_user` and `unregister_client`.
+The second call tears down the *shared* registration, so any other
+concurrent state-aware sandbox using the same registration breaks at its
+next op (sees `stale_id` from `FindClientIdentity` lookup failure). v1 does
+not target concurrent state-aware sandboxes; if that becomes a real
+requirement, this needs either reference-counting on the registration or a
+"leave-registration-alone" deprovision mode.
+
+## Error mapping
+
+`IsolationSessionError` (the runner's internal categorisation) maps 1:1 to
+wire-format `MxcError` codes via `map_lifecycle_error`:
+
+| `IsolationSessionError` variant | Wire `error.code` | Trigger |
+|---|---|---|
+| `Policy(...)` | `policy_validation` | Caller-supplied `policy.filesystem` / `policy.network` / `policy.ui` / `policy.network_proxy` at any phase (rejected by `validate_<phase>` hooks). |
+| `ServiceUnavailable(...)` | `backend_unavailable` | `IsoSessionOps` activation failure: `IsoSessionApp.dll` not registered, or `Feature_IsoBrokerSessionApis` disabled at the OS-side. HRESULTs `CLASS_E_CLASSNOTAVAILABLE` (`0x80040111`) or `REGDB_E_CLASSNOTREG` (`0x80040154`). |
+| `Stale(...)` | `stale_id` | OS-side `AgentManager::FindActiveAgentUserByProvisionId` returns `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` (`0x80070490`) — the `provisionId` is missing from both the in-memory cache and the persisted registry. After `deprovision`, every non-provision op against the dead `sandboxId` triggers this. |
+| `Lifecycle(...)` | `backend_error` | Any other HRESULT from a lifecycle op. The error message embeds the operation name, HRESULT, OS-side message, and remediation hint where present. |
+
+`error.details` is empty in v1. The HRESULT and OS-side message live inside
+`error.message` rather than as a structured field.
+
+## Cancellation
+
+State-aware exec (and other phases) use OS-level cancellation in v1:
+
+- The SDK kills the `wxc-exec` process via process termination.
+- The agent process's pipes EOF, the relay threads exit.
+- The OS-side service's per-process timer (set from
+  `process.timeout`) reaps the agent if the runner does not.
+- The runner's existing 3-tier shutdown (`CloseStandardInput` →
+  `SendCtrlClose` → `Terminate`) handles the timeout case from inside the
+  agent process before returning.
+
+`ExecHandle.terminator` is currently a no-op closure on the
+IsolationSession path because the backend reuses the one-shot
+`create_process` synchronously and there is no mid-flight cancellation
+seam. Future work — explicit Rust-layer `AbortSignal` plumbing — would
+require splitting `create_process` into a non-blocking start + a separate
+waiter, with `terminator` invoking `IsoSessionProcess::Terminate()`.
+
+## Known issues
+
+### `Small` configurationId
+
+Selecting `configurationId: "small"` triggers a cache-teardown bug in the
+OS-side service: the `RemoveUserAsync` call against a cached `Small` agent
+user causes the service's RPC endpoint to disconnect with `0x800706be`
+(`RPC_S_CALL_FAILED`), and subsequent calls fail until the service
+restarts. `Composable` is unaffected. Use `composable` (the default).
+
+### Concurrent state-aware sandboxes
+
+See [Concurrency](#concurrency) — `deprovision` tears down the shared
+registration and breaks any other in-flight state-aware sandbox. v1's
+single-sandbox-per-consumer model is the workaround.
+
+## References
+
+- [State-aware design (full)](../state-aware-lifecycle/mxc-state-aware-sandbox-api.md)
+- [State-aware design (overview)](../state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md)
+- [Initial bringup plan (one-shot)](initial-bringup-plan.md) — the
+  predecessor doc for IsolationSession's first integration; this doc
+  covers state-aware on top of that foundation.

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -56,8 +56,8 @@ on the response, and neither shape carries `containerId`.
 | `stop` | running | provisioned | optional metadata |
 | `deprovision` | provisioned | (not provisioned) | optional metadata |
 
-A backend that has no native equivalent for a phase implements it as a no-op. Every
-state-aware backend implements all five.
+Phases without native equivalents fall through to the trait's default no-op bodies; only
+`exec` is required. Reference §4 has the per-phase rule.
 
 ## TypeScript SDK
 
@@ -183,17 +183,19 @@ type MxcRequest = OneShotRequest | StateAwareRequest;
 
 The two shapes do not coexist in a single call — `phase` fully discriminates.
 
-**Response convention** is phase-aware. Non-exec phases (provision/start/stop/deprovision):
-single JSON envelope on stdout — `{ result: ... }` or `{ error: ... }` — exit 0 / non-zero.
-Exec phase, dispatch succeeded: raw stdout/stderr stream live (matching ProcessContainer);
-the script's exit code is the executor's exit code; SDK constructs `{stdout, stderr,
-exitCode}` from PTY events. Exec phase, dispatch failed: `{ error: ... }` envelope on
-stdout, exit non-zero.
+**Response convention** is phase-aware. `stdout` is reserved for the structured
+response: a single JSON envelope (`{result}` or `{error}`) for non-exec phases, the
+script's raw stream for exec succeeded, or one `{error}` envelope for exec
+dispatch-failure. `stderr` carries MXC diagnostic output (when `--debug` is passed) and,
+in exec, the script's stderr. See main doc §7.3 for the full stream-usage table and
+SDK parsing rules.
 
 ## Rust trait
 
 ```rust
 pub trait StatefulSandboxBackend {
+    const ID_PREFIX: &'static str;
+
     type ProvisionConfig: serde::de::DeserializeOwned;
     type StartConfig: serde::de::DeserializeOwned;
     type ExecConfig: serde::de::DeserializeOwned;
@@ -204,25 +206,34 @@ pub trait StatefulSandboxBackend {
     type StopMetadata: serde::Serialize;
     type DeprovisionMetadata: serde::Serialize;
 
-    fn provision(&mut self, policy: Option<&SandboxPolicy>, config: Option<&Self::ProvisionConfig>)
-        -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError>;
-    fn start(&mut self, sandbox_id: &str, policy: Option<&SandboxPolicy>, config: Option<&Self::StartConfig>)
-        -> Result<StartResult<Self::StartMetadata>, MxcError>;
-    fn exec(&mut self, sandbox_id: &str, policy: Option<&SandboxPolicy>, config: Option<&Self::ExecConfig>, process: &ProcessConfig)
+    // Default body mints `<ID_PREFIX>:<random-token>`; override for native provision.
+    fn provision(&mut self, request: &ProvisionRequest<Self::ProvisionConfig>)
+        -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> { /* ... */ }
+
+    // Default body returns Ok with no metadata.
+    fn start(&mut self, request: &StartRequest<Self::StartConfig>)
+        -> Result<StartResult<Self::StartMetadata>, MxcError> { /* ... */ }
+
+    // Required.
+    fn exec(&mut self, request: &ExecRequest<Self::ExecConfig>)
         -> Result<ExecHandle, MxcError>;
-    fn stop(&mut self, sandbox_id: &str, policy: Option<&SandboxPolicy>, config: Option<&Self::StopConfig>)
-        -> Result<StopResult<Self::StopMetadata>, MxcError>;
-    fn deprovision(&mut self, sandbox_id: &str, policy: Option<&SandboxPolicy>, config: Option<&Self::DeprovisionConfig>)
-        -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError>;
+
+    fn stop(&mut self, request: &StopRequest<Self::StopConfig>)
+        -> Result<StopResult<Self::StopMetadata>, MxcError> { /* ... */ }
+
+    fn deprovision(&mut self, request: &DeprovisionRequest<Self::DeprovisionConfig>)
+        -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> { /* ... */ }
+
+    // Per-phase validate_<phase> hooks (default Ok). See main doc §9.2.
 }
 ```
 
-Backends declare per-phase config and metadata as associated types (use `()` for
-phases that don't need either). The dispatch layer deserialises configs into the typed
-shape before invoking the trait method; result structs (`StartResult<M>`,
-`StopResult<M>`, `DeprovisionResult<M>`) carry an optional metadata payload, parallel
-to `ProvisionResult<M>`. `SandboxPolicy` is the typed Rust mirror of the SDK type;
-`ProcessConfig` is reused from the existing one-shot wire format.
+Backends declare a const id prefix, per-phase config and metadata as associated types
+(use `()` for phases that don't need either), and override only the methods they care
+about — `exec` is the only required method. Per-phase `<Phase>Request<C>` structs bundle
+the cross-cutting wire-shape configs (`FilesystemConfig`, `NetworkConfig`, `UiConfig`)
+with the backend-specific typed per-phase config; there is no unified Rust "policy"
+type. `ProcessConfig` is reused from the existing one-shot wire format.
 
 A backend's participation mode (ephemeral-only, state-aware-only, both) is declared by
 which traits it implements. State-aware backends additionally register an id prefix
@@ -257,7 +268,12 @@ const { sandboxId } = await provisionSandbox('isolation_session', { policy });
 ```
 
 ```rust
-backend.provision(Some(&policy), None)
+// Dispatcher converts the JSON above into ProvisionRequest<()> {
+//   filesystem: Some(FilesystemConfig { readwrite_paths: ["C:\\workspace"] }),
+//   network: Some(NetworkConfig { default_policy: Allow, allowed_hosts: ["api.anthropic.com"] }),
+//   ui: None, config: None,
+// } and calls:
+backend.provision(&prov_req)
 // returns Ok(ProvisionResult {
 //     sandbox_id: "iso:reg-abc:prov-123".into(),
 //     metadata: Some(IsolationSessionProvisionMetadata {
@@ -289,7 +305,12 @@ const r = await execInSandboxAsync(sandboxId, {
 ```
 
 ```rust
-backend.exec("iso:reg-abc:prov-123", None, None, &ProcessConfig { command_line: "echo hello".into(), ..Default::default() })
+// Dispatcher constructs ExecRequest<()> {
+//   sandbox_id: "iso:reg-abc:prov-123".into(),
+//   filesystem: None, network: None, ui: None, config: None,
+//   process: ProcessConfig { command_line: "echo hello".into(), ..Default::default() },
+// }
+backend.exec(&exec_req)
 // returns Ok(ExecHandle { stdout, stderr, stdin, waiter, terminator })
 ```
 
@@ -340,7 +361,8 @@ Reference §11 has the full guide. Operational checklist:
 5. Add `Raw*` intermediate structs in `config_parser.rs` for the backend's wire-format
    block.
 6. Document policy-honor matrix, idempotence, concurrency, and error mapping in
-   `docs/<backend>-plan.md`.
+   `docs/<backend-or-feature>/<plan-name>.md` (e.g.,
+   `docs/isolation-session/state-aware-plan.md`).
 7. Add a feature-unavailable test (CI-runnable) and an integration test.
 8. Update `.github/copilot-instructions.md`.
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -207,22 +207,41 @@ pub trait StatefulSandboxBackend {
     type DeprovisionMetadata: serde::Serialize;
 
     // Default body mints `<ID_PREFIX>:<random-token>`; override for native provision.
-    fn provision(&mut self, request: &ProvisionRequest<Self::ProvisionConfig>)
-        -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> { /* ... */ }
+    fn provision(
+        &mut self,
+        request: &CodexRequest,
+        config: Option<Self::ProvisionConfig>,
+    ) -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> { /* ... */ }
 
     // Default body returns Ok with no metadata.
-    fn start(&mut self, request: &StartRequest<Self::StartConfig>)
-        -> Result<StartResult<Self::StartMetadata>, MxcError> { /* ... */ }
+    fn start(
+        &mut self,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::StartConfig>,
+    ) -> Result<StartResult<Self::StartMetadata>, MxcError> { /* ... */ }
 
     // Required.
-    fn exec(&mut self, request: &ExecRequest<Self::ExecConfig>)
-        -> Result<ExecHandle, MxcError>;
+    fn exec(
+        &mut self,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::ExecConfig>,
+    ) -> Result<ExecHandle, MxcError>;
 
-    fn stop(&mut self, request: &StopRequest<Self::StopConfig>)
-        -> Result<StopResult<Self::StopMetadata>, MxcError> { /* ... */ }
+    fn stop(
+        &mut self,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::StopConfig>,
+    ) -> Result<StopResult<Self::StopMetadata>, MxcError> { /* ... */ }
 
-    fn deprovision(&mut self, request: &DeprovisionRequest<Self::DeprovisionConfig>)
-        -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> { /* ... */ }
+    fn deprovision(
+        &mut self,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::DeprovisionConfig>,
+    ) -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> { /* ... */ }
 
     // Per-phase validate_<phase> hooks (default Ok). See main doc §9.2.
 }
@@ -230,10 +249,15 @@ pub trait StatefulSandboxBackend {
 
 Backends declare a const id prefix, per-phase config and metadata as associated types
 (use `()` for phases that don't need either), and override only the methods they care
-about — `exec` is the only required method. Per-phase `<Phase>Request<C>` structs bundle
-the cross-cutting wire-shape configs (`FilesystemConfig`, `NetworkConfig`, `UiConfig`)
-with the backend-specific typed per-phase config; there is no unified Rust "policy"
-type. `ProcessConfig` is reused from the existing one-shot wire format.
+about — `exec` is the only required method. Trait methods take `&CodexRequest` (the
+existing one-shot domain model from `wxc_common::models`) plus `sandbox_id` for
+non-provision phases and an optional backend-specific typed config; cross-cutting
+policy fields flow through `request.policy` (a `ContainerPolicy`) and per-exec process
+info flows through `request.script_code` / `request.working_directory` /
+`request.script_timeout` / `request.env`. There is no unified Rust "policy" type and
+no Rust `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` wrapper
+struct — those names exist as TypeScript SDK interfaces only. See "Why the trait
+reuses `CodexRequest`" in main doc §9.2 for the rationale.
 
 A backend's participation mode (ephemeral-only, state-aware-only, both) is declared by
 which traits it implements. State-aware backends additionally register an id prefix
@@ -268,12 +292,12 @@ const { sandboxId } = await provisionSandbox('isolation_session', { policy });
 ```
 
 ```rust
-// Dispatcher converts the JSON above into ProvisionRequest<()> {
-//   filesystem: Some(FilesystemConfig { readwrite_paths: ["C:\\workspace"] }),
-//   network: Some(NetworkConfig { default_policy: Allow, allowed_hosts: ["api.anthropic.com"] }),
-//   ui: None, config: None,
-// } and calls:
-backend.provision(&prov_req)
+// Parser deserializes the JSON above into a CodexRequest with
+//   request.policy.readwrite_paths = ["C:\\workspace"]
+//   request.policy.default_network_policy = NetworkPolicy::Allow
+//   request.policy.allowed_hosts = ["api.anthropic.com"]
+// (the same one-shot path the parser already uses). The dispatcher then calls:
+backend.provision(&request, /* config */ None)
 // returns Ok(ProvisionResult {
 //     sandbox_id: "iso:reg-abc:prov-123".into(),
 //     metadata: Some(IsolationSessionProvisionMetadata {
@@ -305,12 +329,9 @@ const r = await execInSandboxAsync(sandboxId, {
 ```
 
 ```rust
-// Dispatcher constructs ExecRequest<()> {
-//   sandbox_id: "iso:reg-abc:prov-123".into(),
-//   filesystem: None, network: None, ui: None, config: None,
-//   process: ProcessConfig { command_line: "echo hello".into(), ..Default::default() },
-// }
-backend.exec(&exec_req)
+// Parser populates request.script_code = "echo hello" from the wire-format `process`
+// block (same path as one-shot). The dispatcher then calls:
+backend.exec("iso:reg-abc:prov-123", &request, /* config */ None)
 // returns Ok(ExecHandle { stdout, stderr, stdin, waiter, terminator })
 ```
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -49,11 +49,11 @@ The mental model: `spawnSandbox` is the composition of the five phases into one 
 State-aware exposes them individually so callers can hold a sandbox between calls, run
 multiple workloads inside it, and tear it down explicitly.
 
-Sandbox state is owned by the backend (e.g., IsoEnvBroker for IsolationSession). The
-`SandboxId` is the only handle the caller gets; persisting it between calls is the
-caller's responsibility. MXC retains no state between calls and does not become a sandbox
-orchestrator. Backends with no meaningful state continue to expose only the one-shot
-surface; state-aware participation is fully opt-in.
+Sandbox state is owned by the backend's underlying service. The `SandboxId` is the only
+handle the caller gets; persisting it between calls is the caller's responsibility. MXC
+retains no state between calls and does not become a sandbox orchestrator. Backends with
+no meaningful state continue to expose only the one-shot surface; state-aware
+participation is fully opt-in.
 
 The proposal adds artefacts at five layers of MXC. Each row points into the section that
 elaborates.
@@ -88,8 +88,8 @@ first-class concept. IsolationSession is the first such backend.
 The design holds three constraints throughout:
 
 - MXC does not take on responsibility for any persistent storage. The durable identifier
-  of a stateful sandbox belongs to the backend's API surface (IsoEnvBroker, in the
-  IsolationSession case); persisting it across calls is the caller's responsibility.
+  of a stateful sandbox belongs to the backend's underlying service; persisting it
+  across calls is the caller's responsibility.
 - The contract supports easy plug-in by backend developers. Per-phase configuration is
   typed per-backend in a way that backends with different native lifecycle models can map
   cleanly.
@@ -136,11 +136,14 @@ The five phases form a small state machine over three states: not-provisioned,
 provisioned, and running. The `SandboxId` is valid from provision through deprovision;
 once deprovision returns, the id is assumed to no longer route to any backend resource.
 
-Every stateful backend implements all five phases. A backend whose underlying API has
-no meaningful equivalent for a particular phase implements that phase as a no-op (returns
-success without side effects). The backend's documentation states which phases are
-no-ops. The MXC dispatch layer treats substantive and no-op implementations identically;
-SDK signatures do not differentiate them.
+A backend whose underlying API has no meaningful equivalent for `provision`, `start`,
+`stop`, or `deprovision` can omit the implementation entirely; the trait provides
+default no-op bodies for those four (§9.2). The default `provision` mints a synthetic
+`sandbox_id` of the form `<ID_PREFIX>:<random-token>` that subsequent calls echo back.
+`exec` is always required — every state-aware backend must execute the workload to be
+useful. The backend's documentation states which phases are no-ops. The MXC dispatch
+layer treats substantive and no-op implementations identically; SDK signatures do not
+differentiate them.
 
 Each backend declares one of three participation modes:
 
@@ -163,10 +166,10 @@ the provisioned sandbox in later calls. It is an opaque string at every observab
 (TS SDK, JSON wire format, CLI output).
 
 The backend generates the `SandboxId` during `provision`. A backend whose underlying API
-requires caller-supplied identifiers (e.g., IsoEnvBroker, which uses registration and
-provisioning IDs) mints them inside the backend implementation and encodes them into the
-id string. A backend whose underlying API generates identifiers itself (Docker, future
-Hyper-V) captures the generated value and encodes it. The first segment is a
+requires caller-supplied identifiers (e.g., one that uses registration and provisioning
+IDs) mints them inside the backend implementation and encodes them into the id string.
+A backend whose underlying API generates identifiers itself (Docker, future Hyper-V)
+captures the generated value and encodes it. The first segment is a
 backend-specific prefix (e.g., `iso:`, `docker:`); past the prefix, the encoding is
 opaque to MXC.
 
@@ -174,7 +177,10 @@ The prefix is required: backend authors register their tag alongside the backend
 `ContainmentBackend` variant, and the dispatcher uses it to route non-provision calls
 without a separate `containment` field on the wire (§7.1). An unrecognised prefix
 surfaces as `unsupported_containment`; a recognised prefix with a malformed body surfaces
-as `malformed_id` (§8).
+as `malformed_id` (§8). The same prefix is exposed on the `StatefulSandboxBackend` trait
+as `const ID_PREFIX: &'static str` (§9.2) so the default `provision` body can mint
+synthetic ids with the right prefix; the trait const and the dispatcher's routing table
+read from the same source, eliminating drift.
 
 The SDK exposes the id as a branded TypeScript string parameterised by backend:
 
@@ -194,6 +200,12 @@ storage mechanism. MXC neither tracks the id after `provision` returns nor verif
 validity until the caller passes it back. If an id refers to a resource that no longer
 exists, the next call returns `error.code: "stale_id"` (§8); the caller decides whether
 to re-provision or treat the failure terminally.
+
+MXC detects `stale_id` by translating the backend's native lookup-failure error —
+returned when the underlying service no longer recognises the resource — into the typed
+MXC error code. MXC itself retains no caller-side state and performs no validity check
+before the call reaches the backend. Each backend's plan doc (§11.6) documents which
+native errors map to `stale_id`.
 
 **Disambiguation: `sandboxId` vs `containerId`.** Two different identifiers exist on the
 wire format and have different roles:
@@ -481,6 +493,23 @@ The existing policy-discovery helpers (`getAvailableToolsPolicy`,
 unchanged. They produce `FilesystemPolicyResult` fragments that callers merge into
 `SandboxPolicy.filesystem` (as in the §6.3 example), then pass via the `policy` field.
 
+### 6.6 Why `SandboxPolicy` is retained at the SDK layer
+
+The SDK's existing `spawnSandbox(script, policy, ...)` entry point takes `SandboxPolicy`,
+and the three policy-discovery helpers (`getAvailableToolsPolicy`,
+`getUserProfilePolicy`, `getTemporaryFilesPolicy`) produce `FilesystemPolicyResult`
+fragments designed to merge into `SandboxPolicy.filesystem`. Keeping
+`policy?: SandboxPolicy` on every state-aware options interface preserves both ergonomic
+compositions and a consistent SDK surface across one-shot and state-aware lifecycle
+modes.
+
+The Rust trait remains policy-agnostic regardless: the SDK serialises both `policy` and
+`config` into the wire format (top-level `filesystem` / `network` / `ui` plus
+`experimental.<backend>.<phase>`), and the Rust trait sees only wire-shape configs
+(§9.2). No "policy" abstraction crosses the SDK-Rust boundary. Future SDK-level
+evolution of the policy concept will be contained to the SDK and will not propagate
+into backend trait implementations.
+
 ## 7. Wire contract
 
 The wire contract is a typed envelope, JSON-serialised, that flows from the SDK to the
@@ -599,10 +628,30 @@ one-shot config object (e.g., `experimental.wslc?: WslcConfig`), as documented i
 
 ### 7.3 Response convention
 
-The response convention is phase-aware.
+The response convention is phase-aware and uses the executor process's stdout and
+stderr streams distinctly.
 
-**Non-exec phases** (provision / start / stop / deprovision): the executor emits a single
-JSON envelope on stdout, then exits with 0 on success or non-zero on failure.
+**Stream usage (state-aware):**
+
+| Phase / outcome | stdout | stderr |
+|---|---|---|
+| Non-exec (provision, start, stop, deprovision), success or failure | Single JSON envelope (`{result}` or `{error}`) | MXC diagnostic output (when `--debug`); empty otherwise |
+| Exec, dispatch succeeded | Script's stdout (via PTY or pipe) | Script's stderr (pipe mode) or merged with stdout (PTY mode); MXC diagnostic also lands here when `--debug` is passed |
+| Exec, dispatch failed | Single JSON envelope (`{error}`) | MXC diagnostic output (when `--debug`); empty otherwise |
+
+`stdout` is authoritative: for non-exec phases it carries exactly one envelope; for exec
+it carries either the script's output (success) or exactly one envelope (failure).
+`stderr` is informational. MXC routes its diagnostic logger output to `stderr` in
+state-aware mode so `stdout` remains parseable without sentinels. (One-shot dispatch
+keeps its existing `stdout` logger behaviour — the stricter routing applies to
+state-aware only.)
+
+For exec specifically, MXC diagnostic output mixes with the script's own stderr when
+`--debug` is passed. This is a small amount of pre- and post-dispatch noise; consumers
+wanting clean separation should use `--log-file <path>` instead, which routes diagnostic
+output to a file and leaves stderr as pure script content.
+
+**Envelope shape:**
 
 ```typescript
 interface ErrorEnvelope {
@@ -621,26 +670,26 @@ type NonExecResponseEnvelope<TResult> = { result: TResult } | { error: ErrorEnve
 | `stop` | `{ metadata?: object }` |
 | `deprovision` | `{ metadata?: object }` |
 
-**Exec phase, dispatch succeeded**: the script's stdout/stderr stream live, matching
-ProcessContainer's existing behaviour. The executor's stdout/stderr inherit through to
-the SDK (PTY by default; piped via `child_process` in non-PTY mode). Process exit code is
-the script's exit code. No JSON envelope is emitted in this case — the SDK constructs
-`{ stdout, stderr, exitCode }` from PTY/process events, exactly as `spawnSandboxAsync`
-does.
+**Distinguishing exec dispatch-failure from script execution:**
 
-**Exec phase, dispatch failed**: the executor emits a JSON envelope on stdout (same shape
-as non-exec phases) and exits non-zero. No script ever runs, so stdout otherwise is empty
-and the envelope is unambiguous.
+The SDK uses exit code plus stdout content:
 
-The SDK distinguishes for exec by inspecting stdout: if exit is non-zero AND stdout's
-entire content parses as a complete `{ error: { ... } }` envelope, treat it as a typed
-dispatch error; otherwise it's a script failure and the SDK reports `exitCode` directly.
+- `exitCode == 0`: the script ran and exited successfully. SDK constructs
+  `{stdout, stderr, exitCode}` from PTY / pipe events.
+- `exitCode != 0` AND stdout's entire content parses as a complete `{error: {...}}`
+  envelope: dispatch failed before the script ran; SDK surfaces the typed error.
+- `exitCode != 0` AND stdout does NOT parse as an envelope: the script ran and exited
+  non-zero. SDK constructs `{stdout, stderr, exitCode}`.
+
+Because MXC diagnostic output is routed to `stderr` in state-aware mode, this
+stdout-based discrimination has no false positives or negatives — the content is always
+either pure envelope or pure script output.
 
 `ErrorEnvelope.details` is the only `Record<string, unknown>` in the contract. It's the
 escape hatch backends use to convey structured failure information that's
-genuinely-per-error-code (a backend's native HRESULT, partial output captured before a
-timeout, etc.). Each backend's plan doc (§11) specifies what `details` contains for which
-error codes.
+per-error-code (a backend's native HRESULT, partial output captured before a timeout,
+etc.). Each backend's plan doc (§11) specifies what `details` contains for which error
+codes.
 
 ### 7.4 Worked example: IsolationSession end-to-end
 
@@ -671,7 +720,12 @@ const { sandboxId } = await provisionSandbox('isolation_session', { policy });
 ```
 
 ```rust
-backend.provision(Some(&policy), None)
+// Dispatcher converts the JSON above into ProvisionRequest<()> {
+//   filesystem: Some(FilesystemConfig { readwrite_paths: ["C:\\workspace"] }),
+//   network: Some(NetworkConfig { default_policy: Allow, allowed_hosts: ["api.anthropic.com"] }),
+//   ui: None, config: None,
+// } and calls:
+backend.provision(&prov_req)
 // returns Ok(ProvisionResult {
 //     sandbox_id: "iso:reg-abc:prov-123".into(),
 //     metadata: Some(IsolationSessionProvisionMetadata {
@@ -702,9 +756,12 @@ await startSandbox(sandboxId, {
 ```
 
 ```rust
-backend.start("iso:reg-abc:prov-123", None, Some(&IsolationSessionStartConfig {
-    configuration_id: IsolationSessionConfigurationId::Small,
-}))
+// Dispatcher constructs StartRequest<IsolationSessionStartConfig> {
+//   sandbox_id: "iso:reg-abc:prov-123".into(),
+//   filesystem: None, network: None, ui: None,
+//   config: Some(IsolationSessionStartConfig { configuration_id: Small }),
+// }
+backend.start(&start_req)
 // returns Ok(StartResult { metadata: None })
 ```
 
@@ -732,11 +789,12 @@ const r = await execInSandboxAsync(sandboxId, {
 ```
 
 ```rust
-backend.exec("iso:reg-abc:prov-123", None, None, &ProcessConfig {
-    command_line: "echo hello".into(),
-    timeout: Some(5000),
-    ..Default::default()
-})
+// Dispatcher constructs ExecRequest<()> {
+//   sandbox_id: "iso:reg-abc:prov-123".into(),
+//   filesystem: None, network: None, ui: None, config: None,
+//   process: ProcessConfig { command_line: "echo hello".into(), timeout: Some(5000), ..Default::default() },
+// }
+backend.exec(&exec_req)
 // returns Ok(ExecHandle { ... pipe handles + waiter ... })
 ```
 
@@ -763,7 +821,11 @@ await stopSandbox(sandboxId);
 ```
 
 ```rust
-backend.stop("iso:reg-abc:prov-123", None, None)
+// Dispatcher constructs StopRequest<()> {
+//   sandbox_id: "iso:reg-abc:prov-123".into(),
+//   filesystem: None, network: None, ui: None, config: None,
+// }
+backend.stop(&stop_req)
 // returns Ok(StopResult { metadata: None })
 ```
 
@@ -786,7 +848,11 @@ await deprovisionSandbox(sandboxId);
 ```
 
 ```rust
-backend.deprovision("iso:reg-abc:prov-123", None, None)
+// Dispatcher constructs DeprovisionRequest<()> {
+//   sandbox_id: "iso:reg-abc:prov-123".into(),
+//   filesystem: None, network: None, ui: None, config: None,
+// }
+backend.deprovision(&deprov_req)
 // returns Ok(DeprovisionResult { metadata: None })
 ```
 
@@ -945,19 +1011,26 @@ than at the deserialiser; the `Raw*` struct accepts both fields as optional.
 
 Conversion from `Raw*` into typed domain models happens in `convert_*` helpers analogous
 to the existing `convert_raw_config` → `CodexRequest`. The cross-cutting wire fields
-(`filesystem`, `network`, `ui`) are folded into a single `SandboxPolicy` on the typed
-domain model, so the dispatch layer (§9.3) and trait methods receive the policy as one
-value. Domain models are exposed to the dispatch layer; the `Raw*` types stay private
-to the parser.
+(`filesystem`, `network`, `ui`) are converted into typed wire-shape configs
+(`FilesystemConfig`, `NetworkConfig`, `UiConfig`) and bundled into the per-phase request
+struct passed to the trait method (§9.2). There is no unified Rust "policy" type —
+`SandboxPolicy` is an SDK-only abstraction (§6.6). Domain models are exposed to the
+dispatch layer; the `Raw*` types stay private to the parser.
 
 ### 9.2 The trait
 
-Backends implement the trait with associated types for each phase's config and for
-each phase's return metadata. Use `()` for any associated type the backend does not
-need.
+Backends implement the trait with a const for the id prefix, associated types for each
+phase's config and metadata, and method overrides where they have substantive work.
+Most methods have default no-op bodies; only `exec` is strictly required. Use `()` for
+any associated type the backend does not need.
 
 ```rust
 pub trait StatefulSandboxBackend {
+    /// Backend identifier prefix. Used as the leading `<tag>:` segment of every
+    /// `sandbox_id` minted by the default `provision` body, and read by the
+    /// dispatcher to route non-provision calls to this backend (§5).
+    const ID_PREFIX: &'static str;
+
     type ProvisionConfig: serde::de::DeserializeOwned;
     type StartConfig: serde::de::DeserializeOwned;
     type ExecConfig: serde::de::DeserializeOwned;
@@ -968,40 +1041,129 @@ pub trait StatefulSandboxBackend {
     type StopMetadata: serde::Serialize;
     type DeprovisionMetadata: serde::Serialize;
 
+    /// Optional. Default mints `<ID_PREFIX>:<random-token>` for a stateless-
+    /// underneath backend; override when the backend has native provision work
+    /// (e.g., allocating a session, registering with the underlying service).
     fn provision(
         &mut self,
-        policy: Option<&SandboxPolicy>,
-        config: Option<&Self::ProvisionConfig>,
-    ) -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError>;
+        _request: &ProvisionRequest<Self::ProvisionConfig>,
+    ) -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> {
+        Ok(ProvisionResult {
+            sandbox_id: format!("{}:{}", Self::ID_PREFIX, mint_random_token()),
+            metadata: None,
+        })
+    }
 
+    /// Optional. Default returns success with no metadata. Override when the
+    /// backend has substantive work to do at start.
     fn start(
         &mut self,
-        sandbox_id: &str,
-        policy: Option<&SandboxPolicy>,
-        config: Option<&Self::StartConfig>,
-    ) -> Result<StartResult<Self::StartMetadata>, MxcError>;
+        _request: &StartRequest<Self::StartConfig>,
+    ) -> Result<StartResult<Self::StartMetadata>, MxcError> {
+        Ok(StartResult { metadata: None })
+    }
 
+    /// Required. Must execute the workload and return a handle.
     fn exec(
         &mut self,
-        sandbox_id: &str,
-        policy: Option<&SandboxPolicy>,
-        config: Option<&Self::ExecConfig>,
-        process: &ProcessConfig,
+        request: &ExecRequest<Self::ExecConfig>,
     ) -> Result<ExecHandle, MxcError>;
 
+    /// Optional. Default returns success with no metadata.
     fn stop(
         &mut self,
-        sandbox_id: &str,
-        policy: Option<&SandboxPolicy>,
-        config: Option<&Self::StopConfig>,
-    ) -> Result<StopResult<Self::StopMetadata>, MxcError>;
+        _request: &StopRequest<Self::StopConfig>,
+    ) -> Result<StopResult<Self::StopMetadata>, MxcError> {
+        Ok(StopResult { metadata: None })
+    }
 
+    /// Optional. Default returns success with no metadata.
     fn deprovision(
         &mut self,
-        sandbox_id: &str,
-        policy: Option<&SandboxPolicy>,
-        config: Option<&Self::DeprovisionConfig>,
-    ) -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError>;
+        _request: &DeprovisionRequest<Self::DeprovisionConfig>,
+    ) -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> {
+        Ok(DeprovisionResult { metadata: None })
+    }
+
+    /// Per-phase validation hooks. Called by the dispatch layer before the
+    /// corresponding phase method. Default: accept all requests. Override to
+    /// add backend-specific checks (config field semantics, policy honor
+    /// enforcement, id format checks beyond the prefix). Failures surface as
+    /// the chosen `MxcError` code.
+    fn validate_provision(
+        &self,
+        _request: &ProvisionRequest<Self::ProvisionConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_start(
+        &self,
+        _request: &StartRequest<Self::StartConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_exec(
+        &self,
+        _request: &ExecRequest<Self::ExecConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_stop(
+        &self,
+        _request: &StopRequest<Self::StopConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_deprovision(
+        &self,
+        _request: &DeprovisionRequest<Self::DeprovisionConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+}
+
+pub struct ProvisionRequest<C> {
+    pub filesystem: Option<FilesystemConfig>,
+    pub network: Option<NetworkConfig>,
+    pub ui: Option<UiConfig>,
+    pub config: Option<C>,
+}
+
+pub struct StartRequest<C> {
+    pub sandbox_id: String,
+    pub filesystem: Option<FilesystemConfig>,
+    pub network: Option<NetworkConfig>,
+    pub ui: Option<UiConfig>,
+    pub config: Option<C>,
+}
+
+pub struct ExecRequest<C> {
+    pub sandbox_id: String,
+    pub filesystem: Option<FilesystemConfig>,
+    pub network: Option<NetworkConfig>,
+    pub ui: Option<UiConfig>,
+    pub config: Option<C>,
+    pub process: ProcessConfig,
+}
+
+pub struct StopRequest<C> {
+    pub sandbox_id: String,
+    pub filesystem: Option<FilesystemConfig>,
+    pub network: Option<NetworkConfig>,
+    pub ui: Option<UiConfig>,
+    pub config: Option<C>,
+}
+
+pub struct DeprovisionRequest<C> {
+    pub sandbox_id: String,
+    pub filesystem: Option<FilesystemConfig>,
+    pub network: Option<NetworkConfig>,
+    pub ui: Option<UiConfig>,
+    pub config: Option<C>,
 }
 
 pub struct ProvisionResult<M> {
@@ -1035,12 +1197,21 @@ pub struct ExecHandle {
 }
 ```
 
-`SandboxPolicy` is the typed Rust equivalent of the SDK type from `sdk/src/types.ts`,
-with serde renames to camelCase. `ProcessConfig` and `MxcError` are similarly typed.
-`PipeHandle` is a platform-abstracted pipe-handle wrapper — a kernel `HANDLE` on Windows,
-a file descriptor on Linux. `ExecHandle` exposes the running process's pipe handles for
-relay; the executor's outer driver reads from `stdout`/`stderr` and writes to `stdin`,
+Per-phase `<Phase>Request<C>` structs bundle the cross-cutting wire-shape configs
+(`FilesystemConfig`, `NetworkConfig`, `UiConfig` — typed Rust mirrors of the wire
+format's `filesystem`, `network`, `ui` fields) with the backend-specific typed per-phase
+config. There is no unified Rust "policy" type — `SandboxPolicy` is an SDK-only
+abstraction (§6.6). The SDK serialises both `policy` and `config` into the wire format,
+and the trait sees only the resulting wire-shape values. `ProcessConfig` and `MxcError`
+are the typed Rust equivalents of their SDK counterparts. `PipeHandle` is a
+platform-abstracted pipe-handle wrapper — a kernel `HANDLE` on Windows, a file
+descriptor on Linux. `ExecHandle` exposes the running process's pipe handles for relay;
+the executor's outer driver reads from `stdout` / `stderr` and writes to `stdin`,
 awaits exit via `waiter`, and calls `terminator` on cancellation signals.
+
+`mint_random_token()` is a small helper in `wxc_common` that produces a short hex string
+(mirroring the SDK's `randomBytes`-based id minting in `sandbox.ts`); it is used by the
+default `provision` body to construct synthetic ids for stateless-underneath backends.
 
 Methods take `&mut self`, matching the existing `ScriptRunner::run` signature. Backends
 do not need to accumulate state between calls within a backend instance — within a
@@ -1058,14 +1229,14 @@ enum DispatchOutcome {
     ExecCompleted { exit_code: i32 },
 }
 
-fn run(req: MxcRequest) -> Result<DispatchOutcome, MxcError> {
+fn run(req: MxcRequest, dry_run: bool) -> Result<DispatchOutcome, MxcError> {
     match req {
         MxcRequest::OneShot(r) => Ok(DispatchOutcome::Envelope(run_one_shot(r))),
 
         MxcRequest::StateAware(r) => match resolve_backend(&r)? {
             ContainmentBackend::IsolationSession => {
                 let mut backend = IsolationSessionRunner::new();
-                dispatch_state_aware::<IsolationSessionRunner>(&mut backend, r)
+                dispatch_state_aware::<IsolationSessionRunner>(&mut backend, r, dry_run)
             }
             // additional state-aware backends added here
             _ => Err(MxcError::UnsupportedPhase),
@@ -1076,41 +1247,46 @@ fn run(req: MxcRequest) -> Result<DispatchOutcome, MxcError> {
 fn dispatch_state_aware<B: StatefulSandboxBackend>(
     backend: &mut B,
     req: StateAwareRequest,
+    dry_run: bool,
 ) -> Result<DispatchOutcome, MxcError> {
-    let policy = req.policy.as_ref();
-
     match req.phase {
         Phase::Provision => {
-            let config = req.deserialize_provision_config::<B::ProvisionConfig>()?;
-            let result = backend.provision(policy, config.as_ref())?;
+            let prov_req = req.into_provision_request::<B::ProvisionConfig>()?;
+            backend.validate_provision(&prov_req)?;
+            if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
+            let result = backend.provision(&prov_req)?;
             Ok(DispatchOutcome::Envelope(provision_envelope(result)))
         }
         Phase::Start => {
-            let id = req.require_sandbox_id()?;
-            let config = req.deserialize_start_config::<B::StartConfig>()?;
-            let result = backend.start(&id, policy, config.as_ref())?;
+            let start_req = req.into_start_request::<B::StartConfig>()?;
+            backend.validate_start(&start_req)?;
+            if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
+            let result = backend.start(&start_req)?;
             Ok(DispatchOutcome::Envelope(start_envelope(result)))
         }
         Phase::Exec => {
-            let id = req.require_sandbox_id()?;
-            let process = req.require_process()?;
-            let config = req.deserialize_exec_config::<B::ExecConfig>()?;
-            let handle = backend.exec(&id, policy, config.as_ref(), &process)?;
+            let exec_req = req.into_exec_request::<B::ExecConfig>()?;
+            validate_exec_common(&exec_req)?;
+            backend.validate_exec(&exec_req)?;
+            if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
+            let handle = backend.exec(&exec_req)?;
             // relay_exec_to_stdio streams the script's pipes to the executor's
             // stdout/stderr/stdin live, awaits exit, and returns the script's exit code.
             let exit_code = relay_exec_to_stdio(handle)?;
             Ok(DispatchOutcome::ExecCompleted { exit_code })
         }
         Phase::Stop => {
-            let id = req.require_sandbox_id()?;
-            let config = req.deserialize_stop_config::<B::StopConfig>()?;
-            let result = backend.stop(&id, policy, config.as_ref())?;
+            let stop_req = req.into_stop_request::<B::StopConfig>()?;
+            backend.validate_stop(&stop_req)?;
+            if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
+            let result = backend.stop(&stop_req)?;
             Ok(DispatchOutcome::Envelope(stop_envelope(result)))
         }
         Phase::Deprovision => {
-            let id = req.require_sandbox_id()?;
-            let config = req.deserialize_deprovision_config::<B::DeprovisionConfig>()?;
-            let result = backend.deprovision(&id, policy, config.as_ref())?;
+            let deprov_req = req.into_deprovision_request::<B::DeprovisionConfig>()?;
+            backend.validate_deprovision(&deprov_req)?;
+            if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
+            let result = backend.deprovision(&deprov_req)?;
             Ok(DispatchOutcome::Envelope(deprovision_envelope(result)))
         }
     }
@@ -1122,9 +1298,18 @@ phases it reads the prefix from `r.sandbox_id` and looks it up in the registered
 table. Mismatches surface as `unsupported_containment` (unrecognised prefix) or
 `malformed_id` (no prefix structure) per §8.
 
-Helper functions for handle-validation, config deserialisation, and envelope wrapping
-are mechanical and elided. The executor's outer driver invokes `run` and handles each
-outcome:
+The `into_<phase>_request` helpers convert the parsed `StateAwareRequest` into the
+typed per-phase request struct (§9.2), enforcing envelope-shape invariants —
+`sandbox_id` required for non-provision phases, `process` required for exec — and
+deserialising the backend-specific typed config from JSON. Failures surface as
+`malformed_request`. `validate_exec_common` is a free function in `validator.rs` that
+checks cross-backend per-phase invariants (e.g., `process.commandLine` non-empty); other
+phases have no cross-backend common checks today and skip directly to the backend's
+`validate_<phase>` hook.
+
+Helper functions for handle-validation, config deserialisation, envelope wrapping, and
+empty-envelope construction are mechanical and elided. The executor's outer driver
+invokes `run` and handles each outcome:
 
 - `Ok(DispatchOutcome::Envelope(env))` — write the envelope's JSON to stdout, exit 0.
 - `Ok(DispatchOutcome::ExecCompleted { exit_code })` — exec already streamed live; the
@@ -1159,8 +1344,9 @@ shapes.
 | Layer | Validates | Failure surfaces as |
 |---|---|---|
 | SDK (TypeScript) | Recognised `containment` (provision); branded `SandboxId<C>` (other phases); required cross-backend fields (`process.commandLine` for exec); typed config shape (autocompletion + compile-time check) | Thrown at the call site, before any subprocess runs |
-| MXC dispatch (Rust, in the executor) | Re-validates envelope; verifies the backend supports the requested phase; deserialises typed configs from JSON | `error.code: malformed_request`, `unsupported_phase`, `unsupported_containment`, `backend_unavailable`, `policy_validation` (config shape) |
-| Backend implementation | Validates config field values against backend-specific rules; deserialises `sandboxId` into the backend's native form; honors cross-cutting policy per backend's matrix (§10.3) | `error.code: policy_validation` (semantic), `malformed_id`, `stale_id`, `backend_error` |
+| MXC parser (Rust) | Envelope shape: `phase` present; `sandbox_id` present for non-provision; `process` present for exec; typed config deserialisation from JSON | `error.code: malformed_request`, `unsupported_phase`, `unsupported_containment` |
+| MXC dispatch common (Rust) | Cross-backend per-phase invariants (e.g., `validate_exec_common` checks `process.commandLine` non-empty) | `error.code: malformed_request`, `policy_validation` |
+| Backend `validate_<phase>` hooks (Rust) | Per-backend per-phase invariants: config field values, cross-cutting policy honor (per the matrix in §10.3), id format checks beyond prefix matching | `error.code: policy_validation`, `malformed_id`, `stale_id`, `backend_error`, `backend_unavailable` |
 
 Each layer validates only what it cheaply can. The SDK's typed config catches structural
 errors at compile time. The dispatch layer catches structural errors that escaped the
@@ -1213,6 +1399,26 @@ documented in the backend's plan doc):
 fields evolve, all backends inherit them automatically). Per-phase honor is the
 backend's choice and must be documented.
 
+**Why runtime rejection rather than compile-time type narrowing.** A plausible
+alternative is to narrow each backend's per-phase options at the TypeScript type level,
+removing unsupported cross-cutting fields from the type entirely. Runtime rejection via
+this matrix was chosen instead:
+
+- Existing one-shot dispatch already validates unsupported combinations at runtime
+  (e.g., `network.proxy` is AppContainer-only and rejected by the parser for other
+  backends). State-aware matches that pattern.
+- Cross-cutting fields are intentionally shared across backends; splitting them into
+  per-backend typed bundles fragments the abstraction and breaks generic code that
+  targets "any state-aware backend".
+- Compile-time narrowing requires conditional types parameterised by `(backend, phase)`,
+  which are slow to type-check and brittle to extend.
+
+If a specific backend's policy-honor mismatch becomes a real usability problem, narrowing
+that backend's options for that phase is a localised future fix that does not require
+changing the framework. The closed `ErrorCode` enum and typed `MxcPolicyValidationError`
+exception class give callers the same caught-at-the-call-site experience as compile-time
+errors, just at runtime.
+
 ## 11. Plug-in guide for new backends
 
 A backend author adding a new state-aware backend (or extending an existing ephemeral
@@ -1225,15 +1431,26 @@ Pick one of the three modes from §4: ephemeral-only, state-aware-only, or both.
 
 ### 11.2 Implement the trait
 
-The `StatefulSandboxBackend` trait signatures are in §9.2. Define associated types: per-phase
-configs (`ProvisionConfig`, `StartConfig`, `ExecConfig`, `StopConfig`, `DeprovisionConfig`)
-and per-phase metadata (`ProvisionMetadata`, `StartMetadata`, `StopMetadata`,
-`DeprovisionMetadata`). Use `()` for any associated type the backend does not need.
+The `StatefulSandboxBackend` trait signatures are in §9.2. Declare:
 
-Identifier generation happens inside the backend's `provision` method. Use the
-registered prefix from §11.4 as the leading `<tag>:` segment; encoding past the prefix
-(UUID, structured payload, etc.) is the backend's choice. Serialise the result into the
-`sandbox_id: String` field of `ProvisionResult`.
+- `const ID_PREFIX: &'static str` — the leading `<tag>:` segment for this backend's
+  `sandbox_id` values; also used by the dispatcher for non-provision routing (§5).
+- Per-phase config associated types (`ProvisionConfig`, ..., `DeprovisionConfig`).
+- Per-phase metadata associated types (`ProvisionMetadata`, ..., `DeprovisionMetadata`).
+  Use `()` for any associated type the backend does not need.
+
+Implement `exec` — the only required method. Override `provision`, `start`, `stop`, or
+`deprovision` only when the backend has substantive work to do in that phase; the trait
+provides default no-op bodies otherwise. The default `provision` mints a synthetic
+`sandbox_id` of the form `<ID_PREFIX>:<random-token>`; backends with native provision
+(allocating a session, registering with the underlying service) override and produce
+their own structured id.
+
+Override `validate_<phase>` hooks for backend-specific pre-execution checks (config
+field semantics, policy honor enforcement, id format verification beyond prefix
+matching). Defaults are no-ops; only override the phases the backend has checks for.
+Validation runs before the phase method; failures short-circuit and surface as typed
+`MxcError` codes without invoking the backend.
 
 ### 11.3 Define typed `*Config` interfaces in the SDK
 
@@ -1282,8 +1499,9 @@ dispatch layer consumes.
 
 ### 11.6 Document the backend
 
-A per-backend document at `docs/<backend>-plan.md` (or equivalent) is required. It must
-cover:
+A per-backend document at `docs/<backend-or-feature>/<plan-name>.md` is required (e.g.,
+`docs/isolation-session/state-aware-plan.md` for IsolationSession's state-aware support
+— mirroring the directory pattern used elsewhere in MXC docs). It must cover:
 
 - **Per-phase config shapes.** The fields of each `*Config` interface, with allowed
   values and defaults.
@@ -1456,8 +1674,8 @@ The following items are explicitly deferred. Each has a brief rationale and a li
 path forward.
 
 - **Detached or long-running execs.** A model where `exec` returns a process id and
-  the spawned process outlives the SDK call (analogous to `IsoSessionCli`'s
-  fire-and-forget `create-process`). The JS-async fire-and-forget pattern (don't `await`
+  the spawned process outlives the SDK call. The JS-async fire-and-forget pattern
+  (don't `await`
   `execInSandboxAsync`) IS supported via the existing functions — the spawned process
   is tethered to the SDK consumer's lifetime, but the caller can move on without
   awaiting. True OS-level detachment (process owned by the OS service, independent of any

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -720,12 +720,13 @@ const { sandboxId } = await provisionSandbox('isolation_session', { policy });
 ```
 
 ```rust
-// Dispatcher converts the JSON above into ProvisionRequest<()> {
-//   filesystem: Some(FilesystemConfig { readwrite_paths: ["C:\\workspace"] }),
-//   network: Some(NetworkConfig { default_policy: Allow, allowed_hosts: ["api.anthropic.com"] }),
-//   ui: None, config: None,
-// } and calls:
-backend.provision(&prov_req)
+// Parser deserializes the JSON above into a CodexRequest with
+//   request.policy.readwrite_paths = ["C:\\workspace"]
+//   request.policy.default_network_policy = NetworkPolicy::Allow
+//   request.policy.allowed_hosts = ["api.anthropic.com"]
+// (and the other top-level wire fields populated as today's one-shot path
+// already populates them). The dispatcher then calls:
+backend.provision(&request, /* config */ None)
 // returns Ok(ProvisionResult {
 //     sandbox_id: "iso:reg-abc:prov-123".into(),
 //     metadata: Some(IsolationSessionProvisionMetadata {
@@ -756,12 +757,13 @@ await startSandbox(sandboxId, {
 ```
 
 ```rust
-// Dispatcher constructs StartRequest<IsolationSessionStartConfig> {
-//   sandbox_id: "iso:reg-abc:prov-123".into(),
-//   filesystem: None, network: None, ui: None,
-//   config: Some(IsolationSessionStartConfig { configuration_id: Small }),
-// }
-backend.start(&start_req)
+// Dispatcher deserializes `experimental.isolation_session.start` into
+// IsolationSessionStartConfig { configuration_id: Small }, then calls:
+backend.start(
+    "iso:reg-abc:prov-123",
+    &request,
+    Some(IsolationSessionStartConfig { configuration_id: Small }),
+)
 // returns Ok(StartResult { metadata: None })
 ```
 
@@ -789,12 +791,10 @@ const r = await execInSandboxAsync(sandboxId, {
 ```
 
 ```rust
-// Dispatcher constructs ExecRequest<()> {
-//   sandbox_id: "iso:reg-abc:prov-123".into(),
-//   filesystem: None, network: None, ui: None, config: None,
-//   process: ProcessConfig { command_line: "echo hello".into(), timeout: Some(5000), ..Default::default() },
-// }
-backend.exec(&exec_req)
+// Parser populates request.script_code = "echo hello", request.script_timeout =
+// 5000 from the wire-format `process` block (same path as one-shot). The
+// dispatcher then calls:
+backend.exec("iso:reg-abc:prov-123", &request, /* config */ None)
 // returns Ok(ExecHandle { ... pipe handles + waiter ... })
 ```
 
@@ -821,11 +821,7 @@ await stopSandbox(sandboxId);
 ```
 
 ```rust
-// Dispatcher constructs StopRequest<()> {
-//   sandbox_id: "iso:reg-abc:prov-123".into(),
-//   filesystem: None, network: None, ui: None, config: None,
-// }
-backend.stop(&stop_req)
+backend.stop("iso:reg-abc:prov-123", &request, /* config */ None)
 // returns Ok(StopResult { metadata: None })
 ```
 
@@ -848,11 +844,7 @@ await deprovisionSandbox(sandboxId);
 ```
 
 ```rust
-// Dispatcher constructs DeprovisionRequest<()> {
-//   sandbox_id: "iso:reg-abc:prov-123".into(),
-//   filesystem: None, network: None, ui: None, config: None,
-// }
-backend.deprovision(&deprov_req)
+backend.deprovision("iso:reg-abc:prov-123", &request, /* config */ None)
 // returns Ok(DeprovisionResult { metadata: None })
 ```
 
@@ -1009,13 +1001,20 @@ falls through to the one-shot branch. Per-phase requirements (`containment` for
 `provision`, `sandboxId` for the others) are enforced in the conversion step rather
 than at the deserialiser; the `Raw*` struct accepts both fields as optional.
 
-Conversion from `Raw*` into typed domain models happens in `convert_*` helpers analogous
-to the existing `convert_raw_config` → `CodexRequest`. The cross-cutting wire fields
-(`filesystem`, `network`, `ui`) are converted into typed wire-shape configs
-(`FilesystemConfig`, `NetworkConfig`, `UiConfig`) and bundled into the per-phase request
-struct passed to the trait method (§9.2). There is no unified Rust "policy" type —
-`SandboxPolicy` is an SDK-only abstraction (§6.6). Domain models are exposed to the
-dispatch layer; the `Raw*` types stay private to the parser.
+Conversion from `Raw*` into the typed domain model is the existing
+`convert_raw_config` → `CodexRequest` path, used for both one-shot and state-aware
+requests. The cross-cutting wire fields (`filesystem`, `network`, `ui`) populate
+`CodexRequest.policy` (a `ContainerPolicy`) exactly as the one-shot path does today,
+and `process` populates `CodexRequest`'s flat `script_code` / `working_directory` /
+`script_timeout` / `env` fields via the existing `RawProcess` intermediate. The
+state-aware-only fields (`phase`, `sandboxId`, `experimental.<backend>.<phase>`) are
+extracted alongside the `CodexRequest` and bundled into a `ParsedStateAwareRequest`
+domain model — `{ request: CodexRequest, phase: Phase, containment:
+Option<ContainmentBackend>, sandbox_id: Option<String>, experimental_raw: ... }` —
+that the dispatcher consumes (§9.3). The bundling does not modify `CodexRequest`'s
+shape. There is no unified Rust "policy" type — `SandboxPolicy` is an SDK-only
+abstraction (§6.6). Domain models are exposed to the dispatch layer; the `Raw*` types
+stay private to the parser.
 
 ### 9.2 The trait
 
@@ -1046,7 +1045,8 @@ pub trait StatefulSandboxBackend {
     /// (e.g., allocating a session, registering with the underlying service).
     fn provision(
         &mut self,
-        _request: &ProvisionRequest<Self::ProvisionConfig>,
+        _request: &CodexRequest,
+        _config: Option<Self::ProvisionConfig>,
     ) -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> {
         Ok(ProvisionResult {
             sandbox_id: format!("{}:{}", Self::ID_PREFIX, mint_random_token()),
@@ -1058,7 +1058,9 @@ pub trait StatefulSandboxBackend {
     /// backend has substantive work to do at start.
     fn start(
         &mut self,
-        _request: &StartRequest<Self::StartConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::StartConfig>,
     ) -> Result<StartResult<Self::StartMetadata>, MxcError> {
         Ok(StartResult { metadata: None })
     }
@@ -1066,13 +1068,17 @@ pub trait StatefulSandboxBackend {
     /// Required. Must execute the workload and return a handle.
     fn exec(
         &mut self,
-        request: &ExecRequest<Self::ExecConfig>,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::ExecConfig>,
     ) -> Result<ExecHandle, MxcError>;
 
     /// Optional. Default returns success with no metadata.
     fn stop(
         &mut self,
-        _request: &StopRequest<Self::StopConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::StopConfig>,
     ) -> Result<StopResult<Self::StopMetadata>, MxcError> {
         Ok(StopResult { metadata: None })
     }
@@ -1080,7 +1086,9 @@ pub trait StatefulSandboxBackend {
     /// Optional. Default returns success with no metadata.
     fn deprovision(
         &mut self,
-        _request: &DeprovisionRequest<Self::DeprovisionConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::DeprovisionConfig>,
     ) -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> {
         Ok(DeprovisionResult { metadata: None })
     }
@@ -1092,78 +1100,47 @@ pub trait StatefulSandboxBackend {
     /// the chosen `MxcError` code.
     fn validate_provision(
         &self,
-        _request: &ProvisionRequest<Self::ProvisionConfig>,
+        _request: &CodexRequest,
+        _config: Option<&Self::ProvisionConfig>,
     ) -> Result<(), MxcError> {
         Ok(())
     }
 
     fn validate_start(
         &self,
-        _request: &StartRequest<Self::StartConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::StartConfig>,
     ) -> Result<(), MxcError> {
         Ok(())
     }
 
     fn validate_exec(
         &self,
-        _request: &ExecRequest<Self::ExecConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::ExecConfig>,
     ) -> Result<(), MxcError> {
         Ok(())
     }
 
     fn validate_stop(
         &self,
-        _request: &StopRequest<Self::StopConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::StopConfig>,
     ) -> Result<(), MxcError> {
         Ok(())
     }
 
     fn validate_deprovision(
         &self,
-        _request: &DeprovisionRequest<Self::DeprovisionConfig>,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::DeprovisionConfig>,
     ) -> Result<(), MxcError> {
         Ok(())
     }
-}
-
-pub struct ProvisionRequest<C> {
-    pub filesystem: Option<FilesystemConfig>,
-    pub network: Option<NetworkConfig>,
-    pub ui: Option<UiConfig>,
-    pub config: Option<C>,
-}
-
-pub struct StartRequest<C> {
-    pub sandbox_id: String,
-    pub filesystem: Option<FilesystemConfig>,
-    pub network: Option<NetworkConfig>,
-    pub ui: Option<UiConfig>,
-    pub config: Option<C>,
-}
-
-pub struct ExecRequest<C> {
-    pub sandbox_id: String,
-    pub filesystem: Option<FilesystemConfig>,
-    pub network: Option<NetworkConfig>,
-    pub ui: Option<UiConfig>,
-    pub config: Option<C>,
-    pub process: ProcessConfig,
-}
-
-pub struct StopRequest<C> {
-    pub sandbox_id: String,
-    pub filesystem: Option<FilesystemConfig>,
-    pub network: Option<NetworkConfig>,
-    pub ui: Option<UiConfig>,
-    pub config: Option<C>,
-}
-
-pub struct DeprovisionRequest<C> {
-    pub sandbox_id: String,
-    pub filesystem: Option<FilesystemConfig>,
-    pub network: Option<NetworkConfig>,
-    pub ui: Option<UiConfig>,
-    pub config: Option<C>,
 }
 
 pub struct ProvisionResult<M> {
@@ -1197,17 +1174,23 @@ pub struct ExecHandle {
 }
 ```
 
-Per-phase `<Phase>Request<C>` structs bundle the cross-cutting wire-shape configs
-(`FilesystemConfig`, `NetworkConfig`, `UiConfig` — typed Rust mirrors of the wire
-format's `filesystem`, `network`, `ui` fields) with the backend-specific typed per-phase
-config. There is no unified Rust "policy" type — `SandboxPolicy` is an SDK-only
-abstraction (§6.6). The SDK serialises both `policy` and `config` into the wire format,
-and the trait sees only the resulting wire-shape values. `ProcessConfig` and `MxcError`
-are the typed Rust equivalents of their SDK counterparts. `PipeHandle` is a
+Trait methods take `&CodexRequest` (the existing one-shot domain model from
+`wxc_common::models`, populated by the same `convert_raw_config` parser path that
+serves one-shot calls), plus `sandbox_id` for non-provision phases and an optional
+backend-specific typed config (`Self::<Phase>Config`). Cross-cutting policy fields
+flow through `request.policy` (a `ContainerPolicy`); per-exec process info flows
+through `request.script_code` / `request.working_directory` / `request.script_timeout`
+/ `request.env`; backend-specific per-phase typed config is deserialised by the
+dispatcher from `experimental.<backend>.<phase>` and passed as the `config` parameter
+(§9.3). Per-phase result types (`ProvisionResult<M>`, `StartResult<M>`,
+`StopResult<M>`, `DeprovisionResult<M>`) carry the typed metadata return value;
+`ExecHandle` exposes the running process's pipe handles for relay. There is no
+unified Rust "policy" type — `SandboxPolicy` is an SDK-only abstraction (§6.6).
+`MxcError` is the typed Rust equivalent of its SDK counterpart. `PipeHandle` is a
 platform-abstracted pipe-handle wrapper — a kernel `HANDLE` on Windows, a file
-descriptor on Linux. `ExecHandle` exposes the running process's pipe handles for relay;
-the executor's outer driver reads from `stdout` / `stderr` and writes to `stdin`,
-awaits exit via `waiter`, and calls `terminator` on cancellation signals.
+descriptor on Linux. The executor's outer driver reads from `ExecHandle.stdout` /
+`stderr` and writes to `stdin`, awaits exit via `waiter`, and calls `terminator` on
+cancellation signals.
 
 `mint_random_token()` is a small helper in `wxc_common` that produces a short hex string
 (mirroring the SDK's `randomBytes`-based id minting in `sandbox.ts`); it is used by the
@@ -1217,6 +1200,68 @@ Methods take `&mut self`, matching the existing `ScriptRunner::run` signature. B
 do not need to accumulate state between calls within a backend instance — within a
 single call a backend may use mutability to hold open service connections, but no state
 needs to survive across phase calls.
+
+#### Why the trait reuses `CodexRequest`
+
+The trait could plausibly require its own per-phase request types (e.g., an
+`ExecRequest<C>` containing typed `ProcessConfig`, `FilesystemConfig`, `NetworkConfig`,
+and `UiConfig` fields) instead of taking `&CodexRequest` directly. The design rejects
+that shape and reuses `CodexRequest` for five concrete reasons:
+
+1. **The field-ignore precedent is established across every existing backend.** Every
+   `ScriptRunner` impl in the workspace today (`AppContainer`, `BaseContainer`,
+   `NanVix`, `WindowsSandbox`, `IsolationSession`, `Lxc`, `Wslc`) takes
+   `&CodexRequest` and reads only the fields it needs. `NanVix` and
+   `IsolationSession` go further and actively reject fields they cannot honor (e.g.,
+   `NanVixScriptRunner::validate_runner` rejects filesystem paths, network rules,
+   network proxy, and a non-empty working directory). State-aware follows the same
+   pattern, so the trait ergonomic stays consistent across one-shot and state-aware
+   surfaces.
+
+2. **Process info is already typed on `CodexRequest`.** The wire-format `process`
+   block (`commandLine`, `cwd`, `env`, `timeout`) deserialises into `CodexRequest`'s
+   flat fields (`script_code`, `working_directory`, `script_timeout`, `env`) via the
+   existing `RawProcess` intermediate in `config_parser.rs`. Wrapping these four
+   typed fields into a Rust `ProcessConfig` struct adds no type safety the compiler
+   does not already provide on the flat fields. The TypeScript-side `ProcessConfig`
+   in `sdk/src/types.ts` is unchanged regardless.
+
+3. **Cross-cutting policy is already typed on `CodexRequest`.** Existing backends read
+   `request.policy.readwrite_paths`, `request.policy.allowed_hosts`,
+   `request.policy.network_proxy`, `request.policy.ui`, etc. directly today.
+   State-aware `provision` and `validate_<phase>` hooks read the same fields.
+   Splitting `ContainerPolicy` into separate `FilesystemConfig` / `NetworkConfig` /
+   `UiConfig` Rust types would force a mechanical refactor across every backend
+   without changing what any of them does.
+
+4. **The existing extraction helpers already work for state-aware exec.** The
+   `IsolationSessionRunner::build_process_options(&CodexRequest)` function in
+   `wxc_common::isolation_session_runner` extracts process info into the runner's
+   internal `ProcessOptions` struct used to populate `IsoSessionProcessOptions` for
+   `RunProcessWithOptionsAsync`. State-aware `exec` calls the same function with the
+   same `&CodexRequest` argument; no new public Rust type closes a semantic gap that
+   does not exist.
+
+5. **No SDK or wire-format change is required.** The TypeScript `ProcessConfig`,
+   `FilesystemConfig`, `NetworkConfig`, and `UiConfig` interfaces in
+   `sdk/src/types.ts` are public consumer-facing types and remain unchanged. The
+   wire JSON shape is unchanged. The Rust trait reading `request.script_code`,
+   `request.policy.allowed_hosts`, etc. is an internal implementation choice
+   invisible above the Rust layer.
+
+What would justify deviating from `CodexRequest` reuse — none of which apply to the v1
+surface in this proposal:
+
+- A fundamentally new state-aware-only field that does not fit any existing
+  `CodexRequest` shape (e.g., a snapshot id for a hypothetical `restore` phase).
+- A type-system invariant only expressible via a wrapper struct (e.g., enforcing at
+  compile time that exec requests always carry a non-empty command line —
+  `validate_exec_common` checks this at runtime instead per §10.1).
+- An SDK-API evolution that introduces a new typed shape the Rust trait must mirror
+  across the SDK-Rust boundary.
+
+If any of these emerges, the trait gains the necessary type at that point. The v1
+surface introduces none, so the trait stays minimal and reuses `CodexRequest`.
 
 ### 9.3 Dispatch
 
@@ -1233,10 +1278,10 @@ fn run(req: MxcRequest, dry_run: bool) -> Result<DispatchOutcome, MxcError> {
     match req {
         MxcRequest::OneShot(r) => Ok(DispatchOutcome::Envelope(run_one_shot(r))),
 
-        MxcRequest::StateAware(r) => match resolve_backend(&r)? {
+        MxcRequest::StateAware(parsed) => match resolve_backend(&parsed)? {
             ContainmentBackend::IsolationSession => {
                 let mut backend = IsolationSessionRunner::new();
-                dispatch_state_aware::<IsolationSessionRunner>(&mut backend, r, dry_run)
+                dispatch_state_aware::<IsolationSessionRunner>(&mut backend, parsed, dry_run)
             }
             // additional state-aware backends added here
             _ => Err(MxcError::UnsupportedPhase),
@@ -1246,66 +1291,76 @@ fn run(req: MxcRequest, dry_run: bool) -> Result<DispatchOutcome, MxcError> {
 
 fn dispatch_state_aware<B: StatefulSandboxBackend>(
     backend: &mut B,
-    req: StateAwareRequest,
+    parsed: ParsedStateAwareRequest,
     dry_run: bool,
 ) -> Result<DispatchOutcome, MxcError> {
-    match req.phase {
+    // `parsed` carries the typed `CodexRequest`, the parsed `Phase`, the optional
+    // `sandbox_id`, and the raw JSON value for `experimental.<backend>.<phase>` (if
+    // present). The dispatcher deserialises that raw JSON into the backend's
+    // `Self::<Phase>Config` associated type before calling the trait method.
+    let request = &parsed.request;
+    match parsed.phase {
         Phase::Provision => {
-            let prov_req = req.into_provision_request::<B::ProvisionConfig>()?;
-            backend.validate_provision(&prov_req)?;
+            let config = parsed.deserialize_config::<B::ProvisionConfig>("provision")?;
+            backend.validate_provision(request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let result = backend.provision(&prov_req)?;
+            let result = backend.provision(request, config)?;
             Ok(DispatchOutcome::Envelope(provision_envelope(result)))
         }
         Phase::Start => {
-            let start_req = req.into_start_request::<B::StartConfig>()?;
-            backend.validate_start(&start_req)?;
+            let sandbox_id = parsed.sandbox_id_required()?;
+            let config = parsed.deserialize_config::<B::StartConfig>("start")?;
+            backend.validate_start(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let result = backend.start(&start_req)?;
+            let result = backend.start(sandbox_id, request, config)?;
             Ok(DispatchOutcome::Envelope(start_envelope(result)))
         }
         Phase::Exec => {
-            let exec_req = req.into_exec_request::<B::ExecConfig>()?;
-            validate_exec_common(&exec_req)?;
-            backend.validate_exec(&exec_req)?;
+            let sandbox_id = parsed.sandbox_id_required()?;
+            let config = parsed.deserialize_config::<B::ExecConfig>("exec")?;
+            validate_exec_common(request)?;
+            backend.validate_exec(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let handle = backend.exec(&exec_req)?;
+            let handle = backend.exec(sandbox_id, request, config)?;
             // relay_exec_to_stdio streams the script's pipes to the executor's
             // stdout/stderr/stdin live, awaits exit, and returns the script's exit code.
             let exit_code = relay_exec_to_stdio(handle)?;
             Ok(DispatchOutcome::ExecCompleted { exit_code })
         }
         Phase::Stop => {
-            let stop_req = req.into_stop_request::<B::StopConfig>()?;
-            backend.validate_stop(&stop_req)?;
+            let sandbox_id = parsed.sandbox_id_required()?;
+            let config = parsed.deserialize_config::<B::StopConfig>("stop")?;
+            backend.validate_stop(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let result = backend.stop(&stop_req)?;
+            let result = backend.stop(sandbox_id, request, config)?;
             Ok(DispatchOutcome::Envelope(stop_envelope(result)))
         }
         Phase::Deprovision => {
-            let deprov_req = req.into_deprovision_request::<B::DeprovisionConfig>()?;
-            backend.validate_deprovision(&deprov_req)?;
+            let sandbox_id = parsed.sandbox_id_required()?;
+            let config = parsed.deserialize_config::<B::DeprovisionConfig>("deprovision")?;
+            backend.validate_deprovision(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let result = backend.deprovision(&deprov_req)?;
+            let result = backend.deprovision(sandbox_id, request, config)?;
             Ok(DispatchOutcome::Envelope(deprovision_envelope(result)))
         }
     }
 }
 ```
 
-`resolve_backend(&r)` reads `r.containment` when `phase == Provision`; for the other
-phases it reads the prefix from `r.sandbox_id` and looks it up in the registered prefix
-table. Mismatches surface as `unsupported_containment` (unrecognised prefix) or
-`malformed_id` (no prefix structure) per §8.
+`resolve_backend(&parsed)` reads `parsed.containment` when `phase == Provision`; for the
+other phases it reads the prefix from `parsed.sandbox_id` and looks it up in the
+registered prefix table. Mismatches surface as `unsupported_containment` (unrecognised
+prefix) or `malformed_id` (no prefix structure) per §8.
 
-The `into_<phase>_request` helpers convert the parsed `StateAwareRequest` into the
-typed per-phase request struct (§9.2), enforcing envelope-shape invariants —
-`sandbox_id` required for non-provision phases, `process` required for exec — and
-deserialising the backend-specific typed config from JSON. Failures surface as
-`malformed_request`. `validate_exec_common` is a free function in `validator.rs` that
-checks cross-backend per-phase invariants (e.g., `process.commandLine` non-empty); other
-phases have no cross-backend common checks today and skip directly to the backend's
-`validate_<phase>` hook.
+`ParsedStateAwareRequest::deserialize_config::<C>(phase_name)` returns
+`Result<Option<C>, MxcError>`: it deserialises the
+`experimental.<backend>.<phase>` JSON value into `C` when present, returns `Ok(None)`
+when absent, and surfaces malformed JSON as `malformed_request`.
+`sandbox_id_required()` enforces that non-provision phases carry a `sandboxId`,
+returning `&str` on success or `malformed_request` on absence. `validate_exec_common`
+is a free function in `validator.rs` that checks cross-backend per-phase invariants
+(e.g., `request.script_code` non-empty); other phases have no cross-backend common
+checks today and skip directly to the backend's `validate_<phase>` hook.
 
 Helper functions for handle-validation, config deserialisation, envelope wrapping, and
 empty-envelope construction are mechanical and elided. The executor's outer driver

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -821,7 +821,7 @@ caller error-handling code is portable across backends.
 | `malformed_request` | Envelope-level error: missing required field, unknown phase, malformed JSON |
 | `unsupported_containment` | The backend named by `containment` (provision) or implied by the `sandboxId` prefix (non-provision) is not a recognised backend in this build |
 | `unsupported_phase` | The backend does not support the requested call mode (state-aware call against an ephemeral-only backend, or one-shot call against a state-aware-only backend) |
-| `backend_unavailable` | The backend's runtime dependency is missing or unreachable (broker not running, daemon stopped) |
+| `backend_unavailable` | The backend's runtime dependency is missing or unreachable (service not running, daemon stopped) |
 | `malformed_id` | The `sandboxId` does not have a recognised backend prefix, or has a recognised prefix but does not deserialise into the backend's native form |
 | `stale_id` | The `sandboxId` deserialised but refers to a resource the backend no longer recognises |
 | `not_provisioned` | Phase requires a provisioned sandbox; none provided, or the id is in a pre-provision state |
@@ -1044,7 +1044,7 @@ awaits exit via `waiter`, and calls `terminator` on cancellation signals.
 
 Methods take `&mut self`, matching the existing `ScriptRunner::run` signature. Backends
 do not need to accumulate state between calls within a backend instance — within a
-single call a backend may use mutability to hold open broker connections, but no state
+single call a backend may use mutability to hold open service connections, but no state
 needs to survive across phase calls.
 
 ### 9.3 Dispatch
@@ -1312,7 +1312,7 @@ cover:
 Two categories:
 
 - **Feature-unavailable test (CI-runnable).** The backend is exercised on a machine
-  without its runtime dependency (no broker, no daemon, no kernel feature). The
+  without its runtime dependency (no service, no daemon, no kernel feature). The
   expected result is a clean `backend_unavailable` error rather than a panic or hang.
 - **Integration test on real infrastructure.** The full lifecycle (provision, start,
   exec, stop, deprovision) plus a few exec variants. May be runner-script-driven and
@@ -1460,7 +1460,7 @@ path forward.
   fire-and-forget `create-process`). The JS-async fire-and-forget pattern (don't `await`
   `execInSandboxAsync`) IS supported via the existing functions — the spawned process
   is tethered to the SDK consumer's lifetime, but the caller can move on without
-  awaiting. True OS-level detachment (process owned by the broker, independent of any
+  awaiting. True OS-level detachment (process owned by the OS service, independent of any
   caller) needs a different SDK contract (e.g., a future `execInSandboxDetached`
   returning a process id, no waiting for exit). Deferred to a later version with that
   dedicated function.

--- a/external/windows-sdk/isolation-session/README.md
+++ b/external/windows-sdk/isolation-session/README.md
@@ -1,4 +1,4 @@
-# IsoEnvBroker Session API — WinMD Provenance
+# Windows.AI.IsolationSession — WinMD Provenance
 
 This directory tracks provenance for the generated Rust bindings in
 `src/isolation_session_bindings/`. The WinMD file itself is NOT checked in.
@@ -28,7 +28,7 @@ After regeneration:
    - `os_official_branch` — the `official/...` rolling branch (development lineage).
    - `os_commit` — full 40-char commit SHA.
    - `winmd_sha256` — SHA-256 of the WinMD file.
-   - `windows_bindgen_version` — version reported on line 1 of the generated `bindings.rs`.
+   - `windows_bindgen_version` — version reported in the header comment of the generated `bindings.rs`.
    - `target_windows_crate` — major.minor of the `windows` crate in `src/Cargo.lock`.
    - `generated_date` — ISO date.
 3. Build and test: `cd src && cargo test --workspace`

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -438,6 +438,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -1777,6 +1788,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "flatbuffers",
+ "getrandom 0.2.17",
  "isolation_session_bindings",
  "sandbox_spec",
  "semver",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "isolation_session_bindings",
  "nanvix_binaries",
  "nanvix_common",
+ "serde_json",
  "windows",
  "wslc_common",
  "wxc_common",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -52,6 +52,7 @@ clap = { version = "4", features = ["derive"] }
 wxc_common = { path = "wxc_common" }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
+getrandom = "0.2"
 libc = "0.2"
 nix = { version = "0.29", features = ["mount", "sched", "signal", "net", "process", "user"] }
 lxc_common = { path = "lxc_common" }

--- a/src/wxc/Cargo.toml
+++ b/src/wxc/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 wxc_common.workspace = true
 anyhow.workspace = true
 clap.workspace = true
+serde_json.workspace = true
 windows.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -9,14 +9,17 @@ use clap::Parser;
 use windows::Win32::Security::Isolation::DeleteAppContainerProfile;
 use wxc_common::appcontainer_runner::AppContainerScriptRunner;
 use wxc_common::base_container_runner::BaseContainerRunner;
-use wxc_common::config_parser::{is_base_container_version, load_request};
+use wxc_common::config_parser::{is_base_container_version, load_mxc_request, ParseError};
 use wxc_common::filesystem_bfs::FileSystemBfsManager;
 #[cfg(feature = "isolation_session")]
 use wxc_common::isolation_session_runner::IsolationSessionRunner;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{CodexRequest, ContainmentBackend, ScriptResponse};
+use wxc_common::mxc_error::{MxcError, ResponseEnvelope};
 use wxc_common::nanvix_runner::NanVixScriptRunner;
 use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
+use wxc_common::state_aware_dispatch::{run_state_aware, DispatchOutcome};
+use wxc_common::state_aware_request::{MxcRequest, ParsedStateAwareRequest};
 use wxc_common::windows_sandbox_runner::WindowsSandboxScriptRunner;
 
 #[derive(Parser)]
@@ -82,6 +85,48 @@ fn display_script_results(response: &ScriptResponse, logger: &mut Logger) {
     let _ = writeln!(logger, "Exit code: {}", response.exit_code);
     if !response.error_message.is_empty() {
         let _ = writeln!(logger, "Error: {}", response.error_message);
+    }
+}
+
+/// Drives the state-aware dispatch flow. On envelope success, writes the
+/// JSON to stdout and exits 0. On exec success, exits with the script's
+/// exit code (output already streamed). On failure, writes a JSON error
+/// envelope to stdout and exits 1. Diagnostic logger output goes to stderr
+/// regardless of mode (per design §7.3 stream protocol — stdout reserved
+/// for the response envelope).
+fn run_state_aware_main(parsed: ParsedStateAwareRequest, dry_run: bool, logger: &mut Logger) -> ! {
+    let outcome = run_state_aware(parsed, dry_run);
+    // Diagnostic buffer flushes to stderr regardless of success/failure so it
+    // never interleaves with the stdout envelope.
+    let buffered = logger.get_buffer().to_string();
+    if !buffered.is_empty() {
+        eprint!("{}", buffered);
+    }
+    match outcome {
+        Ok(DispatchOutcome::Envelope(value)) => {
+            println!("{}", value);
+            process::exit(0);
+        }
+        Ok(DispatchOutcome::ExecCompleted { exit_code }) => process::exit(exit_code),
+        Err(e) => {
+            print_error_envelope(&e);
+            process::exit(1);
+        }
+    }
+}
+
+fn print_error_envelope(error: &MxcError) {
+    let envelope: ResponseEnvelope<()> = ResponseEnvelope::from_error(error);
+    match serde_json::to_string(&envelope) {
+        Ok(s) => println!("{}", s),
+        Err(_) => {
+            // Last-resort path: serialisation of the envelope itself failed —
+            // emit a minimal structurally-valid envelope so consumers that
+            // require `error.code` still parse something.
+            println!(
+                r#"{{"error":{{"code":"backend_error","message":"failed to serialise error envelope"}}}}"#
+            );
+        }
     }
 }
 
@@ -165,15 +210,27 @@ fn main() {
         process::exit(if success { 0 } else { 1 });
     }
 
-    // Load request
-    let mut request = match load_request(&config_data, &mut logger, is_base64) {
-        Ok(r) => r,
-        Err(_) => {
+    // Load request — discriminates state-aware (top-level `phase` field) from
+    // one-shot. State-aware failures emit a JSON envelope on stdout; one-shot
+    // and pre-discrimination failures keep the existing diagnostic-on-stderr
+    // convention.
+    let request = match load_mxc_request(&config_data, &mut logger, is_base64) {
+        Ok(MxcRequest::OneShot(req)) => req,
+        Ok(MxcRequest::StateAware(parsed)) => {
+            run_state_aware_main(parsed, cli.dry_run, &mut logger)
+        }
+        Err(ParseError::OneShot(_)) | Err(ParseError::Decode(_)) => {
             eprint!("Request error\n{}", logger.get_buffer());
+            process::exit(1);
+        }
+        Err(ParseError::StateAware(e)) => {
+            print_error_envelope(&e);
+            eprint!("{}", logger.get_buffer());
             process::exit(1);
         }
     };
 
+    let mut request = request;
     request.experimental_enabled = cli.experimental;
     request.dry_run = cli.dry_run;
 

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }
+getrandom = { workspace = true }
 semver = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -15,7 +15,24 @@ use crate::models::{
     PortMapping, ProxyAddress, ProxyConfig, TestFeatureConfig, UiPolicy, WindowsSandboxConfig,
     WslcConfig,
 };
+use crate::mxc_error::MxcError;
 use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
+
+/// Categorised error from `load_mxc_request`. The `wxc-exec` driver uses the
+/// variant to choose the failure-output convention: state-aware failures
+/// emit a JSON `{"error": ...}` envelope on stdout, while one-shot and
+/// pre-discrimination failures keep the existing diagnostic-on-stderr path.
+#[derive(Debug)]
+pub enum ParseError {
+    /// I/O, base64-decode, or top-level JSON parse failure — the input could
+    /// not be discriminated as state-aware vs one-shot.
+    Decode(WxcError),
+    /// Discriminated as one-shot; conversion to `CodexRequest` failed.
+    OneShot(WxcError),
+    /// Discriminated as state-aware; conversion to `ParsedStateAwareRequest`
+    /// failed. Carries an `MxcError` so the driver can emit a typed envelope.
+    StateAware(MxcError),
+}
 
 // ---------- Intermediate serde structs matching the JSON schema ----------
 
@@ -316,31 +333,7 @@ pub fn load_request(
     logger: &mut Logger,
     is_base64: bool,
 ) -> Result<CodexRequest, WxcError> {
-    let json_str = if is_base64 {
-        let bytes = base64_decode(input).map_err(|_| {
-            let msg = "Failed to decode base64 configuration";
-            logger.log_line(msg);
-            WxcError::ConfigParse(msg.to_string())
-        })?;
-        String::from_utf8(bytes).map_err(|_| {
-            let msg = "Base64 decoded content is not valid UTF-8";
-            logger.log_line(msg);
-            WxcError::ConfigParse(msg.to_string())
-        })?
-    } else {
-        // Treat input as a file path
-        if !std::path::Path::new(input).exists() {
-            let _ = write!(logger, "Configuration file not found: {}", input);
-            return Err(WxcError::ConfigParse(format!(
-                "Configuration file not found: {}",
-                input
-            )));
-        }
-        fs::read_to_string(input).map_err(|e| {
-            let _ = write!(logger, "Failed to open configuration file: {}", input);
-            WxcError::ConfigParse(format!("Failed to read configuration file: {}", e))
-        })?
-    };
+    let json_str = decode_request_input(input, logger, is_base64)?;
 
     let raw: RawConfig = serde_json::from_str(&json_str).map_err(|e| {
         logger.log_line("Error parsing JSON");
@@ -351,14 +344,41 @@ pub fn load_request(
 }
 
 /// Loads a request and routes to the one-shot or state-aware path based on
-/// presence of the wire-format `phase` field. The dispatcher consumes the
-/// returned `MxcRequest` directly.
+/// presence of the wire-format `phase` field. Errors are categorised so the
+/// driver can pick the right output convention per path (envelope on stdout
+/// for state-aware, diagnostic on stderr for one-shot and pre-discrimination
+/// failures).
 pub fn load_mxc_request(
     input: &str,
     logger: &mut Logger,
     is_base64: bool,
-) -> Result<MxcRequest, WxcError> {
-    let json_str = if is_base64 {
+) -> Result<MxcRequest, ParseError> {
+    let json_str = decode_request_input(input, logger, is_base64).map_err(ParseError::Decode)?;
+
+    let raw: RawMxcRequest = serde_json::from_str(&json_str).map_err(|e| {
+        logger.log_line("Error parsing JSON");
+        ParseError::Decode(WxcError::ConfigParse(format!("JSON parse error: {}", e)))
+    })?;
+
+    match raw {
+        RawMxcRequest::StateAware(state_aware) => convert_raw_state_aware(*state_aware, logger)
+            .map(MxcRequest::StateAware)
+            .map_err(|e| ParseError::StateAware(MxcError::malformed_request(e.to_string()))),
+        RawMxcRequest::OneShot(one_shot) => convert_raw_config(*one_shot, logger)
+            .map(MxcRequest::OneShot)
+            .map_err(ParseError::OneShot),
+    }
+}
+
+/// Reads a request from disk or decodes it from base64. Public so the driver
+/// can decode once and reuse the JSON across multiple parse attempts; the
+/// internal `load_request` and `load_mxc_request` use it too.
+pub fn decode_request_input(
+    input: &str,
+    logger: &mut Logger,
+    is_base64: bool,
+) -> Result<String, WxcError> {
+    if is_base64 {
         let bytes = base64_decode(input).map_err(|_| {
             let msg = "Failed to decode base64 configuration";
             logger.log_line(msg);
@@ -368,7 +388,7 @@ pub fn load_mxc_request(
             let msg = "Base64 decoded content is not valid UTF-8";
             logger.log_line(msg);
             WxcError::ConfigParse(msg.to_string())
-        })?
+        })
     } else {
         if !std::path::Path::new(input).exists() {
             let _ = write!(logger, "Configuration file not found: {}", input);
@@ -380,21 +400,7 @@ pub fn load_mxc_request(
         fs::read_to_string(input).map_err(|e| {
             let _ = write!(logger, "Failed to open configuration file: {}", input);
             WxcError::ConfigParse(format!("Failed to read configuration file: {}", e))
-        })?
-    };
-
-    let raw: RawMxcRequest = serde_json::from_str(&json_str).map_err(|e| {
-        logger.log_line("Error parsing JSON");
-        WxcError::ConfigParse(format!("JSON parse error: {}", e))
-    })?;
-
-    match raw {
-        RawMxcRequest::StateAware(state_aware) => {
-            convert_raw_state_aware(*state_aware, logger).map(MxcRequest::StateAware)
-        }
-        RawMxcRequest::OneShot(one_shot) => {
-            convert_raw_config(*one_shot, logger).map(MxcRequest::OneShot)
-        }
+        })
     }
 }
 
@@ -892,7 +898,7 @@ mod tests {
         Logger::new(Mode::Buffer)
     }
 
-    fn load_mxc(json: &str) -> Result<MxcRequest, WxcError> {
+    fn load_mxc(json: &str) -> Result<MxcRequest, ParseError> {
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
         load_mxc_request(&encoded, &mut logger, true)
@@ -968,21 +974,21 @@ mod tests {
         // Exec phase still requires the process.commandLine wire field.
         let json = r#"{ "phase": "exec", "sandboxId": "iso:abcd1234" }"#;
         let r = load_mxc(json);
-        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+        assert!(matches!(r, Err(ParseError::StateAware(_))), "got {:?}", r);
     }
 
     #[test]
     fn state_aware_unknown_phase_is_rejected() {
         let json = r#"{"phase": "teleport"}"#;
         let r = load_mxc(json);
-        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+        assert!(matches!(r, Err(ParseError::StateAware(_))), "got {:?}", r);
     }
 
     #[test]
     fn state_aware_unknown_containment_is_rejected() {
         let json = r#"{"phase": "provision", "containment": "totally_made_up"}"#;
         let r = load_mxc(json);
-        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+        assert!(matches!(r, Err(ParseError::StateAware(_))), "got {:?}", r);
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -15,6 +15,7 @@ use crate::models::{
     PortMapping, ProxyAddress, ProxyConfig, TestFeatureConfig, UiPolicy, WindowsSandboxConfig,
     WslcConfig,
 };
+use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
 
 // ---------- Intermediate serde structs matching the JSON schema ----------
 
@@ -182,6 +183,44 @@ struct RawConfig {
     experimental: Option<RawExperimental>,
 }
 
+// State-aware request shape. `phase` is required (no `#[serde(default)]` on
+// the struct, no field-level default) and acts as the discriminator against
+// `RawConfig`; the other fields mirror `RawConfig`'s wire shape so
+// cross-cutting fields (filesystem/network/ui/process) populate the inner
+// `CodexRequest` via the same conversion path. The `experimental` block stays
+// raw — typed deserialisation happens at dispatch time keyed by backend.
+#[derive(Deserialize)]
+struct RawStateAwareRequest {
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    containment: Option<String>,
+    phase: String,
+    #[serde(rename = "sandboxId", default)]
+    sandbox_id: Option<String>,
+    #[serde(default)]
+    process: Option<RawProcess>,
+    #[serde(default)]
+    filesystem: Option<RawFilesystem>,
+    #[serde(default)]
+    network: Option<RawNetwork>,
+    #[serde(default)]
+    ui: Option<RawUi>,
+    #[serde(default)]
+    experimental: Option<serde_json::Value>,
+}
+
+// Untagged enum: serde tries `StateAware` first (requires `phase`), falls
+// through to `OneShot` when `phase` is absent. Order matters — `OneShot` is
+// permissive enough to accept arbitrary wire shapes. Both variants are boxed
+// so the enum stays a single tagged pointer regardless of inner growth.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawMxcRequest {
+    StateAware(Box<RawStateAwareRequest>),
+    OneShot(Box<RawConfig>),
+}
+
 // ---------- Public API ----------
 
 /// Parse the `proxy` field.
@@ -311,6 +350,54 @@ pub fn load_request(
     convert_raw_config(raw, logger)
 }
 
+/// Loads a request and routes to the one-shot or state-aware path based on
+/// presence of the wire-format `phase` field. The dispatcher consumes the
+/// returned `MxcRequest` directly.
+pub fn load_mxc_request(
+    input: &str,
+    logger: &mut Logger,
+    is_base64: bool,
+) -> Result<MxcRequest, WxcError> {
+    let json_str = if is_base64 {
+        let bytes = base64_decode(input).map_err(|_| {
+            let msg = "Failed to decode base64 configuration";
+            logger.log_line(msg);
+            WxcError::ConfigParse(msg.to_string())
+        })?;
+        String::from_utf8(bytes).map_err(|_| {
+            let msg = "Base64 decoded content is not valid UTF-8";
+            logger.log_line(msg);
+            WxcError::ConfigParse(msg.to_string())
+        })?
+    } else {
+        if !std::path::Path::new(input).exists() {
+            let _ = write!(logger, "Configuration file not found: {}", input);
+            return Err(WxcError::ConfigParse(format!(
+                "Configuration file not found: {}",
+                input
+            )));
+        }
+        fs::read_to_string(input).map_err(|e| {
+            let _ = write!(logger, "Failed to open configuration file: {}", input);
+            WxcError::ConfigParse(format!("Failed to read configuration file: {}", e))
+        })?
+    };
+
+    let raw: RawMxcRequest = serde_json::from_str(&json_str).map_err(|e| {
+        logger.log_line("Error parsing JSON");
+        WxcError::ConfigParse(format!("JSON parse error: {}", e))
+    })?;
+
+    match raw {
+        RawMxcRequest::StateAware(state_aware) => {
+            convert_raw_state_aware(*state_aware, logger).map(MxcRequest::StateAware)
+        }
+        RawMxcRequest::OneShot(one_shot) => {
+            convert_raw_config(*one_shot, logger).map(MxcRequest::OneShot)
+        }
+    }
+}
+
 // ---------- Cross-field validation ----------
 
 /// Maximum supported schema version (major.minor). Configs with a higher major.minor are rejected.
@@ -403,43 +490,65 @@ fn validate_paths(paths: &[String], logger: &mut Logger) -> Result<(), WxcError>
 // ---------- Conversion from raw JSON to domain model ----------
 
 fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexRequest, WxcError> {
+    convert_raw_config_inner(raw, logger, true)
+}
+
+// `require_process = false` allows state-aware non-exec phases to omit the
+// `process` block entirely; those phases leave `script_code` / `working_directory`
+// / `script_timeout` / `env` at their defaults and never read them.
+fn convert_raw_config_inner(
+    raw: RawConfig,
+    logger: &mut Logger,
+    require_process: bool,
+) -> Result<CodexRequest, WxcError> {
     // New top-level fields
     let schema_version = raw.version.unwrap_or_default();
     let container_id = raw.container_id.unwrap_or_default();
     let platform = raw.platform.unwrap_or_else(|| "windows".to_string());
 
-    // Process section is required
-    let process = raw
-        .process
-        .ok_or_else(|| WxcError::ConfigParse("'process' section is required".into()))?;
+    // Process section: required for one-shot and for state-aware exec; absent
+    // is allowed for state-aware non-exec phases (require_process == false).
+    let (script_code, working_directory, script_timeout, env) = match raw.process {
+        Some(process) => {
+            let script_code = match process.command_line {
+                Some(s) if !s.is_empty() => s,
+                Some(_) if require_process => {
+                    logger.log_line("process.commandLine cannot be empty");
+                    return Err(WxcError::ConfigParse(
+                        "process.commandLine cannot be empty".to_string(),
+                    ));
+                }
+                None if require_process => {
+                    logger.log_line("Missing required field: process.commandLine");
+                    return Err(WxcError::ConfigParse(
+                        "Missing required field: process.commandLine".to_string(),
+                    ));
+                }
+                _ => String::new(),
+            };
 
-    let script_code = match process.command_line {
-        Some(s) if !s.is_empty() => s,
-        Some(_) => {
-            logger.log_line("process.commandLine cannot be empty");
+            // Null bytes can be used to hide malicious payloads from audit logs or
+            // other inspection.
+            if script_code.contains('\0') {
+                return Err(WxcError::ConfigParse(
+                    "process.commandLine must not contain null bytes".to_string(),
+                ));
+            }
+
+            (
+                script_code,
+                process.cwd.unwrap_or_default(),
+                process.timeout.unwrap_or(0),
+                process.env.unwrap_or_default(),
+            )
+        }
+        None if require_process => {
             return Err(WxcError::ConfigParse(
-                "process.commandLine cannot be empty".to_string(),
+                "'process' section is required".into(),
             ));
         }
-        None => {
-            logger.log_line("Missing required field: process.commandLine");
-            return Err(WxcError::ConfigParse(
-                "Missing required field: process.commandLine".to_string(),
-            ));
-        }
+        None => (String::new(), String::new(), 0, Vec::new()),
     };
-
-    // Script should not have embedded null bytes
-    // Null bytes can be used to hide malicious payloads from audit logs or other inspection
-    if script_code.contains('\0') {
-        return Err(WxcError::ConfigParse(
-            "process.commandLine must not contain null bytes".to_string(),
-        ));
-    }
-
-    let working_directory = process.cwd.unwrap_or_default();
-    let script_timeout = process.timeout.unwrap_or(0);
-    let env = process.env.unwrap_or_default();
 
     // Containment backend selection
     let containment = match raw.containment.as_deref() {
@@ -706,6 +815,73 @@ fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexReques
     })
 }
 
+fn convert_raw_state_aware(
+    raw: RawStateAwareRequest,
+    logger: &mut Logger,
+) -> Result<ParsedStateAwareRequest, WxcError> {
+    let phase = Phase::from_wire(&raw.phase).map_err(|e| {
+        let msg = e.message.clone();
+        logger.log_line(&msg);
+        WxcError::ConfigParse(msg)
+    })?;
+
+    let containment = match raw.containment.as_deref() {
+        None => None,
+        Some(s) => Some(parse_containment_str(s, logger)?),
+    };
+
+    // Build a RawConfig surrogate so the inner CodexRequest is populated by the
+    // same conversion path one-shot uses for cross-cutting wire fields.
+    let surrogate = RawConfig {
+        version: raw.version,
+        container_id: None,
+        platform: None,
+        process: raw.process,
+        lifecycle: None,
+        containment: raw.containment,
+        app_container: None,
+        lxc: None,
+        filesystem: raw.filesystem,
+        network: raw.network,
+        ui: raw.ui,
+        // The state-aware experimental block has a different shape from the
+        // one-shot RawExperimental; it is preserved separately on
+        // ParsedStateAwareRequest as raw JSON.
+        experimental: None,
+    };
+
+    let require_process = phase == Phase::Exec;
+    let request = convert_raw_config_inner(surrogate, logger, require_process)?;
+
+    Ok(ParsedStateAwareRequest {
+        request,
+        phase,
+        containment,
+        sandbox_id: raw.sandbox_id,
+        experimental_raw: raw.experimental,
+    })
+}
+
+fn parse_containment_str(s: &str, logger: &mut Logger) -> Result<ContainmentBackend, WxcError> {
+    match s {
+        "appcontainer" => Ok(ContainmentBackend::AppContainer),
+        "windows_sandbox" => Ok(ContainmentBackend::WindowsSandbox),
+        "wslc" => Ok(ContainmentBackend::Wslc),
+        "lxc" => Ok(ContainmentBackend::Lxc),
+        "vm" => Ok(ContainmentBackend::Vm),
+        "microvm" => Ok(ContainmentBackend::MicroVm),
+        "isolation_session" => Ok(ContainmentBackend::IsolationSession),
+        other => {
+            let msg = format!(
+                "Invalid containment value '{}' (must be 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', or 'microvm')",
+                other
+            );
+            logger.log_line(&msg);
+            Err(WxcError::ConfigParse(msg))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -714,6 +890,113 @@ mod tests {
 
     fn test_logger() -> Logger {
         Logger::new(Mode::Buffer)
+    }
+
+    fn load_mxc(json: &str) -> Result<MxcRequest, WxcError> {
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        load_mxc_request(&encoded, &mut logger, true)
+    }
+
+    #[test]
+    fn one_shot_routes_via_load_mxc_request() {
+        let json = r#"{"process": {"commandLine": "echo hello"}}"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::OneShot(req) => assert_eq!(req.script_code, "echo hello"),
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        }
+    }
+
+    #[test]
+    fn state_aware_provision_request_routes_to_state_aware_arm() {
+        let json = r#"{
+            "phase": "provision",
+            "containment": "isolation_session",
+            "filesystem": {"readwritePaths": ["C:\\workspace"]}
+        }"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Provision);
+                assert_eq!(p.containment, Some(ContainmentBackend::IsolationSession));
+                assert!(p.sandbox_id.is_none());
+                assert!(p.experimental_raw.is_none());
+                assert_eq!(p.request.policy.readwrite_paths, vec!["C:\\workspace"]);
+                // Non-exec phase: process-related fields stay default.
+                assert!(p.request.script_code.is_empty());
+            }
+            MxcRequest::OneShot(_) => panic!("expected state-aware"),
+        }
+    }
+
+    #[test]
+    fn state_aware_start_request_carries_sandbox_id_and_experimental() {
+        let json = r#"{
+            "phase": "start",
+            "sandboxId": "iso:abcd1234",
+            "experimental": {
+                "isolation_session": {"start": {"configurationId": "small"}}
+            }
+        }"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Start);
+                assert_eq!(p.sandbox_id.as_deref(), Some("iso:abcd1234"));
+                assert!(p.experimental_raw.is_some());
+            }
+            MxcRequest::OneShot(_) => panic!("expected state-aware"),
+        }
+    }
+
+    #[test]
+    fn state_aware_exec_request_requires_command_line() {
+        let json = r#"{
+            "phase": "exec",
+            "sandboxId": "iso:abcd1234",
+            "process": {"commandLine": "echo hello"}
+        }"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Exec);
+                assert_eq!(p.request.script_code, "echo hello");
+            }
+            MxcRequest::OneShot(_) => panic!("expected state-aware"),
+        }
+    }
+
+    #[test]
+    fn state_aware_exec_without_process_is_rejected() {
+        // Exec phase still requires the process.commandLine wire field.
+        let json = r#"{ "phase": "exec", "sandboxId": "iso:abcd1234" }"#;
+        let r = load_mxc(json);
+        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+    }
+
+    #[test]
+    fn state_aware_unknown_phase_is_rejected() {
+        let json = r#"{"phase": "teleport"}"#;
+        let r = load_mxc(json);
+        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+    }
+
+    #[test]
+    fn state_aware_unknown_containment_is_rejected() {
+        let json = r#"{"phase": "provision", "containment": "totally_made_up"}"#;
+        let r = load_mxc(json);
+        assert!(matches!(r, Err(WxcError::ConfigParse(_))), "got {:?}", r);
+    }
+
+    #[test]
+    fn state_aware_provision_works_with_no_containment() {
+        // Containment is optional at parse time; the dispatcher enforces it
+        // (provision needs containment, non-provision uses sandbox_id prefix).
+        let json = r#"{"phase": "provision"}"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Provision);
+                assert!(p.containment.is_none());
+            }
+            MxcRequest::OneShot(_) => panic!("expected state-aware"),
+        }
     }
 
     #[test]

--- a/src/wxc_common/src/id.rs
+++ b/src/wxc_common/src/id.rs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Sandbox-id helpers for state-aware backends.
+//!
+//! `mint_random_token` is the Rust-side mirror of the SDK's
+//! `randomBytes(4).toString("hex")` pattern: 4 bytes of OS randomness rendered as
+//! 8 lowercase hex chars. The default `StatefulSandboxBackend::provision` body
+//! composes it with the backend's `ID_PREFIX` to mint synthetic sandbox ids for
+//! stateless-underneath backends. Future helpers (e.g. prefix parsing) live in
+//! this module too.
+
+/// Returns a fresh 8-character lowercase-hex token derived from 4 bytes of
+/// OS randomness.
+///
+/// Panics if the OS RNG is unavailable, which on modern desktop targets does
+/// not occur outside catastrophic system failure.
+pub fn mint_random_token() -> String {
+    let mut buf = [0u8; 4];
+    getrandom::getrandom(&mut buf).expect("OS getrandom call failed");
+    format!("{:08x}", u32::from_be_bytes(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn token_is_eight_lowercase_hex_chars() {
+        for _ in 0..64 {
+            let t = mint_random_token();
+            assert_eq!(t.len(), 8, "token {:?} not 8 chars", t);
+            assert!(
+                t.chars()
+                    .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+                "token {:?} contains non-lowercase-hex chars",
+                t,
+            );
+        }
+    }
+
+    #[test]
+    fn token_can_render_a_full_zero_byte_run() {
+        // {:08x} must zero-pad: u32::from_be_bytes([0,0,0,0]) renders to "00000000".
+        let s = format!("{:08x}", u32::from_be_bytes([0, 0, 0, 0]));
+        assert_eq!(s, "00000000");
+    }
+
+    #[test]
+    fn token_is_parseable_as_hex_u32() {
+        for _ in 0..16 {
+            let t = mint_random_token();
+            u32::from_str_radix(&t, 16).expect("token must be valid hex");
+        }
+    }
+
+    #[test]
+    fn distinct_calls_produce_distinct_tokens() {
+        // 4 bytes of randomness -> 32-bit space; 1024 draws have a birthday-paradox
+        // collision probability of roughly 1024^2 / 2^33 ~= 1.2e-4. The bound below
+        // tolerates a couple of collisions to avoid flake without losing the
+        // property we care about (the source is genuinely random, not constant).
+        let n = 1024;
+        let mut set = HashSet::with_capacity(n);
+        for _ in 0..n {
+            set.insert(mint_random_token());
+        }
+        assert!(
+            set.len() >= n - 4,
+            "{} collisions in {} draws — RNG output not random",
+            n - set.len(),
+            n,
+        );
+    }
+}

--- a/src/wxc_common/src/id.rs
+++ b/src/wxc_common/src/id.rs
@@ -10,6 +10,8 @@
 //! stateless-underneath backends. Future helpers (e.g. prefix parsing) live in
 //! this module too.
 
+use crate::mxc_error::MxcError;
+
 /// Returns a fresh 8-character lowercase-hex token derived from 4 bytes of
 /// OS randomness.
 ///
@@ -21,9 +23,25 @@ pub fn mint_random_token() -> String {
     format!("{:08x}", u32::from_be_bytes(buf))
 }
 
+/// Returns the prefix portion of a state-aware `sandbox_id` — the substring
+/// before the first `:`. Used by the dispatcher to resolve a non-provision
+/// request to the backend that minted the id.
+///
+/// Surfaces a missing `:` or empty prefix as `MxcError::MalformedId`.
+pub fn parse_sandbox_id_prefix(sandbox_id: &str) -> Result<&str, MxcError> {
+    match sandbox_id.split_once(':') {
+        Some((prefix, _)) if !prefix.is_empty() => Ok(prefix),
+        _ => Err(MxcError::malformed_id(format!(
+            "sandbox_id {:?} is missing the `<prefix>:...` form",
+            sandbox_id
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mxc_error::MxcErrorCode;
     use std::collections::HashSet;
 
     #[test]
@@ -53,6 +71,30 @@ mod tests {
             let t = mint_random_token();
             u32::from_str_radix(&t, 16).expect("token must be valid hex");
         }
+    }
+
+    #[test]
+    fn parse_prefix_returns_segment_before_colon() {
+        assert_eq!(parse_sandbox_id_prefix("iso:wxc-abcd1234").unwrap(), "iso");
+        assert_eq!(parse_sandbox_id_prefix("wsb:abc:def").unwrap(), "wsb");
+    }
+
+    #[test]
+    fn parse_prefix_rejects_missing_colon() {
+        let err = parse_sandbox_id_prefix("no-colon-here").unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedId);
+    }
+
+    #[test]
+    fn parse_prefix_rejects_empty_prefix() {
+        let err = parse_sandbox_id_prefix(":no-prefix").unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedId);
+    }
+
+    #[test]
+    fn parse_prefix_rejects_empty_string() {
+        let err = parse_sandbox_id_prefix("").unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedId);
     }
 
     #[test]

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -88,6 +88,11 @@ pub enum IsolationSessionError {
     /// An OS-side lifecycle step (register / provision / start / exec /
     /// stop / deprovision / unregister) returned a failure.
     Lifecycle(String),
+    /// The OS-side service could not find the provisionId — the sandbox
+    /// has been deprovisioned (or never provisioned in this user's
+    /// session) and any further state-aware op against it is a stale-id
+    /// reference. Surfaces as `MxcError::StaleId` at the dispatch boundary.
+    Stale(String),
 }
 
 impl std::fmt::Display for IsolationSessionError {
@@ -98,6 +103,7 @@ impl std::fmt::Display for IsolationSessionError {
                 write!(f, "Isolation Session service unavailable: {}", msg)
             }
             Self::Lifecycle(msg) => write!(f, "Isolation Session lifecycle error: {}", msg),
+            Self::Stale(msg) => write!(f, "Isolation Session stale id: {}", msg),
         }
     }
 }
@@ -273,8 +279,18 @@ pub(crate) fn check_service_available_and_activate() -> Result<IsoSessionOps, Is
 
 // -- Helper: structured error checks -----------------------------------------
 
-/// Formats an `IsoSessionError` (the WinRT result type) into a lifecycle
-/// error string with HRESULT, message, and remediation hint where present.
+/// `HRESULT_FROM_WIN32(ERROR_NOT_FOUND)` — returned by the OS-side service's
+/// `AgentManager::FindActiveAgentUserByProvisionId` when the provisionId is
+/// missing from both the in-memory cache and the persisted registry. Every
+/// non-provision lifecycle op (start / exec / stop / deprovision) goes
+/// through this lookup, so a `0x80070490` from any of them means the
+/// sandbox_id is stale.
+const ERROR_NOT_FOUND_HRESULT: u32 = 0x80070490;
+
+/// Formats an `IsoSessionError` (the WinRT result type) into a typed
+/// `IsolationSessionError`. Detects the ERROR_NOT_FOUND HRESULT and
+/// promotes it to `Stale` so callers (and ultimately the wire envelope)
+/// can return `MxcError::StaleId` for a deprovisioned sandbox_id.
 fn format_iso_error(op: &str, err: &IsoSessionError) -> IsolationSessionError {
     let msg = err.Message().map(|h| h.to_string()).unwrap_or_default();
     let code = err.Code().map(|h| h.0 as u32).unwrap_or(0);
@@ -282,12 +298,14 @@ fn format_iso_error(op: &str, err: &IsoSessionError) -> IsolationSessionError {
     let suffix = if remediation.is_empty() {
         String::new()
     } else {
-        format!(" — remediation: {}", remediation)
+        format!(" -- remediation: {}", remediation)
     };
-    lifecycle_err(format!(
-        "{} failed: {} (HRESULT: {:#010x}){}",
-        op, msg, code, suffix
-    ))
+    let formatted = format!("{} failed: {} (HRESULT: {:#010x}){}", op, msg, code, suffix);
+    if code == ERROR_NOT_FOUND_HRESULT {
+        IsolationSessionError::Stale(formatted)
+    } else {
+        IsolationSessionError::Lifecycle(formatted)
+    }
 }
 
 /// Checks the `Error` property of an `IsoSessionResult` and returns
@@ -988,6 +1006,7 @@ fn map_lifecycle_error(err: IsolationSessionError) -> MxcError {
         IsolationSessionError::Policy(_) => MxcError::policy_validation(message),
         IsolationSessionError::ServiceUnavailable(_) => MxcError::backend_unavailable(message),
         IsolationSessionError::Lifecycle(_) => MxcError::backend_error(message),
+        IsolationSessionError::Stale(_) => MxcError::stale_id(message),
     }
 }
 
@@ -1046,6 +1065,23 @@ mod tests {
             map_lifecycle_error(IsolationSessionError::Lifecycle("x".into())).code,
             MxcErrorCode::BackendError,
         );
+        assert_eq!(
+            map_lifecycle_error(IsolationSessionError::Stale("x".into())).code,
+            MxcErrorCode::StaleId,
+        );
+    }
+
+    #[test]
+    fn error_not_found_hresult_constant_matches_win32() {
+        // Sanity check: HRESULT_FROM_WIN32(ERROR_NOT_FOUND) =
+        //   0x80070000 | (1168 & 0xFFFF) = 0x80070490.
+        // The OS-side AgentManager::FindActiveAgentUserByProvisionId returns
+        // exactly this when the provisionId is gone, so a regression in the
+        // constant would silently downgrade stale-id detection to backend_error.
+        const ERROR_NOT_FOUND: u32 = 1168;
+        let expected = 0x8007_0000u32 | (ERROR_NOT_FOUND & 0xFFFF);
+        assert_eq!(ERROR_NOT_FOUND_HRESULT, expected);
+        assert_eq!(ERROR_NOT_FOUND_HRESULT, 0x80070490);
     }
 
     #[test]

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -38,18 +38,17 @@ use windows_core::{HSTRING, PCWSTR};
 
 /// Cohort registration ID used with the `IsoSessionOps` wrapper.
 ///
-/// The wrapper hardcodes `L"regid"` internally for every agent-name-keyed op
-/// (`ApiIsoSessionOps.cpp` lines 80, 90, 106, 115, 132, 187 in the OS repo),
-/// so callers must register with the literal `"regid"` or subsequent calls
-/// hit the wrong cohort.
+/// The `IsoSessionOps` wrapper hardcodes `L"regid"` internally for every
+/// agent-name-keyed op, so callers must register with this exact literal
+/// or subsequent calls hit the wrong cohort.
 const REGISTRATION_ID: &str = "regid";
 
 /// Provision identifier scoping the agent user across the lifecycle.
 ///
-/// Reused as the `agentName` parameter on every subsequent op — the wrapper
-/// aliases agentName to provisionId at the COM layer (per the comment in
-/// `CommandSession.cpp:64` in the OS repo, `IsoSessionOps` callers pass
-/// `provisionId` where the IDL says `agentName`).
+/// Reused as the `agentName` parameter on every subsequent op — the
+/// `IsoSessionOps` wrapper aliases `agentName` to this `provisionId` at
+/// the COM layer, so callers pass `provisionId` where the IDL says
+/// `agentName`.
 const PROVISION_ID: &str = "wxc-provid";
 
 impl From<IsolationSessionConfigurationId> for IsoSessionConfigId {
@@ -75,7 +74,7 @@ pub enum IsolationSessionError {
     /// not available on this host (DLL not registered or
     /// `Feature_IsoBrokerSessionApis` disabled).
     ServiceUnavailable(String),
-    /// A broker-side lifecycle step (register / provision / start / exec /
+    /// An OS-side lifecycle step (register / provision / start / exec /
     /// stop / deprovision / unregister) returned a failure.
     Lifecycle(String),
 }
@@ -156,11 +155,9 @@ pub(crate) const REDIRECT_STDERR: u32 = 0x4;
 ///   the same way).
 /// - Stdout is always redirected.
 /// - Stderr is redirected ONLY in non-interactive mode. In ConPTY mode the
-///   broker merges stderr into stdout and refuses to populate the stderr
-///   handle (predicate at `IsolationSessionWorkerProcess.cpp:309-310` in the
-///   OS repo: `optStderrHandleResult && !m_pseudoConsole && m_stderrPipeRead`).
-///   Setting `RedirectStandardError(true)` in ConPTY mode is benign but the
-///   handle returns 0 — so we just don't ask for it.
+///   OS-side service merges stderr into stdout and does not populate the
+///   stderr handle. Setting `RedirectStandardError(true)` in ConPTY mode
+///   is benign but the handle returns 0 — so we just don't ask for it.
 pub(crate) fn compute_redirect_flags(interactive: bool) -> u32 {
     let mut flags = REDIRECT_STDIN | REDIRECT_STDOUT;
     if !interactive {
@@ -186,11 +183,11 @@ pub(crate) struct ProcessOptions {
     pub env_vars: Vec<(String, String)>,
     /// Bitfield of I/O redirect flags (`REDIRECT_STDIN | REDIRECT_STDOUT | REDIRECT_STDERR`).
     pub redirect_flags: u32,
-    /// Whether to ask the broker to set up a ConPTY in the isolation session
-    /// (`InteractiveConsole = true`). Decided at runtime by the runner based
-    /// on `std::io::stdout().is_terminal()`. `build_process_options` returns
-    /// `false` as a safe default; the runner overwrites before passing to
-    /// `create_process`.
+    /// Whether to ask the OS-side service to set up a ConPTY in the
+    /// isolation session (`InteractiveConsole = true`). Decided at runtime
+    /// by the runner based on `std::io::stdout().is_terminal()`.
+    /// `build_process_options` returns `false` as a safe default; the
+    /// runner overwrites before passing to `create_process`.
     pub interactive: bool,
 }
 
@@ -329,7 +326,7 @@ impl IsolationSessionManager {
         })
     }
 
-    /// Step 0: Register the app with the broker.
+    /// Step 0: Register the app with the OS-side service.
     pub fn register_client(&self) -> Result<(), IsolationSessionError> {
         let result = self
             .ops
@@ -339,13 +336,12 @@ impl IsolationSessionManager {
     }
 
     /// Step 1: Provision an agent user. Returns the OS-assigned agent
-    /// account name (e.g., `Adib-IEB-000`) for logging only — addressing
+    /// account name (e.g., `RealUser-IEB-000`) for logging only — addressing
     /// for subsequent ops continues to use the configured `provision_id`.
     ///
     /// Note: `lifecycle.destroyOnExit` is silently ignored on this backend.
-    /// The in-proc API hardcodes `Indefinite` lifetime in `AddUserAsync`
-    /// (`IsoSessionServerClient.cpp:147` in the OS repo) and the wrapper's
-    /// `RemoveUserAsync` papers over the Indefinite-deprovision bug.
+    /// The in-proc API hardcodes `Indefinite` lifetime in `AddUserAsync`,
+    /// and `RemoveUserAsync` papers over the Indefinite-deprovision bug.
     pub fn provision_agent_user(&self) -> Result<String, IsolationSessionError> {
         let async_op = self
             .ops
@@ -425,16 +421,14 @@ impl IsolationSessionManager {
         })?;
 
         // Streaming + interactive I/O via three pipe relay threads bridging
-        // wxc-exec's stdio with the broker's pipe handles. The relays cross
-        // the desktop-session boundary that kernel console-handle inheritance
-        // cannot (see `appcontainer_runner.rs:358-392` for the AppContainer
-        // comparison).
+        // wxc-exec's stdio with the pipe handles owned by `IsoSessionProcess`.
+        // The relays cross the desktop-session boundary that kernel
+        // console-handle inheritance cannot.
         //
         // Handle ownership across four sources:
-        //   - Broker pipe handles (`OutputHandle()` / `ErrorHandle()` /
-        //     `InputHandle()`, returned as u64): owned by `IsoSessionProcess`.
-        //     Released by `process.Close()` (`ApiProcess.cpp:131` in the OS
-        //     repo). We do NOT close them.
+        //   - Pipe handles owned by `IsoSessionProcess` (`OutputHandle()` /
+        //     `ErrorHandle()` / `InputHandle()`, returned as u64): released
+        //     by `process.Close()`. We do NOT close them.
         //   - wxc-exec's std handles (`GetStdHandle(STD_*_HANDLE)`): owned by
         //     the OS for the process lifetime. We do NOT close them.
         //   - Stop event for stdin relay (`CreateEventW`): RAII-closed via
@@ -472,8 +466,8 @@ impl IsolationSessionManager {
         // `h_read` (console = TTY mode); for pipe handles (non-TTY) it has no
         // effect on a blocked `ReadFile`, so we use a bounded
         // `WaitForSingleObject` after process exit and rely on
-        // `process.Close()` invalidating the broker handle (next WriteFile
-        // fails) plus OS cleanup on wxc-exec exit.
+        // `process.Close()` invalidating the `IsoSessionProcess` handle
+        // (next WriteFile fails) plus OS cleanup on wxc-exec exit.
         let stdin_stop_event = unsafe {
             CreateEventW(None, true, false, PCWSTR::null())
                 .map_err(|e| lifecycle_err(format!("CreateEventW(stdin stop): {}", e)))?
@@ -520,16 +514,16 @@ impl IsolationSessionManager {
         };
 
         // Wait for the agent process to exit. `WaitForExit` is a Win32
-        // `WaitForSingleObject` on a kernel handle (`ApiProcess.cpp:76` — no
-        // COM round-trip). On timeout it returns -1; otherwise the exit code.
+        // `WaitForSingleObject` on a kernel handle — no COM round-trip. On
+        // timeout it returns -1; otherwise the exit code.
         let _ = process
             .WaitForExit(options.timeout_ms)
             .map_err(|e| lifecycle_err(format!("WaitForExit failed: {}", e)))?;
 
         // Detect timeout via `ExitCode()` returning `STILL_ACTIVE` (the agent
-        // is still running). Trigger the 3-tier graceful shutdown pattern from
-        // `CommandTty.cpp:226-263` in the OS repo. In the natural-exit path,
-        // none of the tiers fire.
+        // is still running). Run a 3-tier graceful shutdown — escalating from
+        // stdin-close to control signal to terminate — so well-behaved agents
+        // exit cleanly. In the natural-exit path none of the tiers fire.
         const STILL_ACTIVE: i32 = 0x103;
         let mut exit_code = process
             .ExitCode()
@@ -542,9 +536,8 @@ impl IsolationSessionManager {
             let _ = process.WaitForExit(5000);
             exit_code = process.ExitCode().unwrap_or(STILL_ACTIVE);
 
-            // Tier 2: `SendCtrlClose` is ConPTY-only (`E_NOTIMPL` otherwise
-            // per `IsolationSessionWorkerProcess.cpp:414-416`); benign call
-            // in non-ConPTY mode, just skips ahead.
+            // Tier 2: `SendCtrlClose` is ConPTY-only — `E_NOTIMPL` in
+            // non-ConPTY mode, which is benign and skips ahead.
             if exit_code == STILL_ACTIVE {
                 let _ = process.SendCtrlClose();
                 let _ = process.WaitForExit(3000);
@@ -552,7 +545,7 @@ impl IsolationSessionManager {
             }
 
             // Tier 3: force-terminate. Wait infinitely for the kill to land
-            // (timeout 0 == INFINITE per `ApiProcess.cpp:85`).
+            // (`WaitForExit(0)` = INFINITE).
             if exit_code == STILL_ACTIVE {
                 let _ = process.Terminate();
                 let _ = process.WaitForExit(0);
@@ -567,10 +560,10 @@ impl IsolationSessionManager {
             let _ = SetEvent(stdin_stop_owned.get());
         }
 
-        // Drain stdout / stderr relays (INFINITE — they exit on broker-pipe
-        // EOF once the agent's write ends close at OS-level handle cleanup;
-        // the broker's own timeout at
-        // `IsolationSessionWorkerProcess.cpp:153-170` is the safety net).
+        // Drain stdout / stderr relays (INFINITE — they exit when the
+        // `IsoSessionProcess` pipe-read EOFs once the agent's write ends
+        // close at OS-level cleanup. The OS-side per-process timeout is
+        // the safety net.
         if let Some(t) = stdout_relay {
             unsafe { WaitForSingleObject(t.get(), u32::MAX) };
         }
@@ -585,7 +578,7 @@ impl IsolationSessionManager {
             unsafe { WaitForSingleObject(t.get(), 1000) };
         }
 
-        // Now safe to release the broker handles.
+        // Now safe to release the `IsoSessionProcess` handles.
         let _ = process.Close();
 
         Ok(ProcessResult {
@@ -609,10 +602,9 @@ impl IsolationSessionManager {
 
     /// Step 5: Deprovision the agent user.
     ///
-    /// The wrapper's `RemoveUserAsync` internally re-provisions as
-    /// `CallerProcess` first then deprovisions, papering over the
-    /// Indefinite-deprovision broker bug
-    /// (`IsoSessionServerClient.cpp:184` in the OS repo).
+    /// `RemoveUserAsync` internally re-provisions as `CallerProcess` first
+    /// then deprovisions, papering over the Indefinite-deprovision bug in
+    /// the OS-side service.
     pub fn deprovision_agent_user(&self) -> Result<(), IsolationSessionError> {
         let async_op = self
             .ops
@@ -720,9 +712,9 @@ impl ScriptRunner for IsolationSessionRunner {
 
         // Detect at runtime whether wxc-exec's stdout is a TTY. This flips the
         // backend into ConPTY mode (`InteractiveConsole = true`) and adjusts
-        // the redirect flags (no separate stderr in ConPTY mode — the broker
-        // merges it into stdout). The check sees the handle wxc-exec was
-        // given by its immediate parent: ConPTY when launched by node-pty
+        // the redirect flags (no separate stderr in ConPTY mode — the OS-side
+        // service merges it into stdout). The check sees the handle wxc-exec
+        // was given by its immediate parent: ConPTY when launched by node-pty
         // (`spawnSandbox`), pipe when launched by `child_process.spawn`
         // (`spawnSandboxFromConfig({usePty: false})`), console when launched
         // directly from a shell.
@@ -761,10 +753,10 @@ impl ScriptRunner for IsolationSessionRunner {
             }
             Err(e) => {
                 // provision_agent_user may return Err *after* a successful
-                // broker-side provision (e.g., the AgentUserName fetch
-                // fails on a non-error result). Defensively deprovision so
-                // an Indefinite-lifetime agent user does not leak. The
-                // wrapper no-ops these on absent state.
+                // OS-side provision (e.g., the AgentUserName fetch fails on
+                // a non-error result). Defensively deprovision so an
+                // Indefinite-lifetime agent user does not leak.
+                // `IsoSessionOps` no-ops these on absent state.
                 let _ = manager.deprovision_agent_user();
                 let _ = manager.unregister_client();
                 return e.into();
@@ -803,7 +795,7 @@ impl ScriptRunner for IsolationSessionRunner {
 
         // Output already streamed live to wxc-exec's stdio via relay threads in
         // `IsolationSessionManager::create_process` — captured fields are intentionally
-        // empty (matching the AppContainer pattern at `appcontainer_runner.rs:455-456`).
+        // empty (same pattern as AppContainer).
         ScriptResponse {
             exit_code: result.exit_code,
             standard_out: String::new(),
@@ -1024,7 +1016,7 @@ mod tests {
         assert!(
             flags & REDIRECT_STDERR == 0,
             "stderr should NOT be redirected in interactive (ConPTY) mode \
-             — broker won't populate ErrorHandle"
+             — ErrorHandle is not populated by the OS-side service"
         );
     }
 

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -31,7 +31,7 @@ use crate::process_util::{
 };
 use crate::script_runner::ScriptRunner;
 use crate::state_aware_backend::{
-    ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
+    DeprovisionResult, ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
 };
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
@@ -46,11 +46,11 @@ use windows_core::{HSTRING, PCWSTR};
 
 // -- Identifiers -------------------------------------------------------------
 
-/// Cohort registration ID used with the `IsoSessionOps` wrapper.
+/// Registration ID used with the `IsoSessionOps` wrapper.
 ///
 /// The `IsoSessionOps` wrapper hardcodes `L"regid"` internally for every
 /// agent-name-keyed op, so callers must register with this exact literal
-/// or subsequent calls hit the wrong cohort.
+/// or subsequent calls hit the wrong registration.
 const REGISTRATION_ID: &str = "regid";
 
 /// Default provisionId used by the one-shot backend path. State-aware
@@ -312,7 +312,7 @@ fn check_result(result: &IsoSessionResult, op: &str) -> Result<(), IsolationSess
 /// Manages the `IsoSessionOps` lifecycle. Methods map 1:1 to the granular
 /// API steps.
 pub struct IsolationSessionManager {
-    /// Cohort/registration identifier used in `RegisterApp` / `AddUserAsync`
+    /// Registration identifier used in `RegisterApp` / `AddUserAsync`
     /// / `UnregisterAppAsync`. Pegged to the literal `"regid"` per the
     /// wrapper's internal hardcode.
     registration_id: HSTRING,
@@ -916,6 +916,30 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         let manager = IsolationSessionManager::new(provision_id).map_err(map_lifecycle_error)?;
         manager.stop_session().map_err(map_lifecycle_error)?;
         Ok(StopResult { metadata: None })
+    }
+
+    /// Removes the agent user, then unregisters the client. Mirrors the
+    /// one-shot teardown sequence so a state-aware lifecycle leaves the
+    /// OS-side service in the same end state as a one-shot run.
+    ///
+    /// `unregister_client` tears down the client registration that
+    /// `provision` set up via `register_client`. v1 does not target
+    /// concurrent state-aware sessions, which would share that
+    /// registration -- if that becomes a real requirement, this will
+    /// need either a refcount or a "leave-registration-alone" mode.
+    fn deprovision(
+        &mut self,
+        sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<()>,
+    ) -> Result<DeprovisionResult<()>, MxcError> {
+        let provision_id = extract_provision_id(sandbox_id)?;
+        let manager = IsolationSessionManager::new(provision_id).map_err(map_lifecycle_error)?;
+        manager
+            .deprovision_agent_user()
+            .map_err(map_lifecycle_error)?;
+        manager.unregister_client().map_err(map_lifecycle_error)?;
+        Ok(DeprovisionResult { metadata: None })
     }
 
     /// Reuses `IsolationSessionManager::create_process` — the same path the

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -960,6 +960,60 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         Ok(DeprovisionResult { metadata: None })
     }
 
+    // -- Validation hooks ----------------------------------------------------
+    //
+    // Cross-cutting policy fields (filesystem, network, ui, network proxy)
+    // are not honoured by IsolationSession at any phase: the OS-side service
+    // does not expose these knobs. Mirroring the one-shot path's
+    // `validate_runner` rejection, every state-aware phase rejects these
+    // fields up-front rather than silently ignoring them. This produces
+    // `policy_validation` per design 10.3 instead of letting unsupported
+    // fields slip through unnoticed.
+
+    fn validate_provision(
+        &self,
+        request: &CodexRequest,
+        _config: Option<&()>,
+    ) -> Result<(), MxcError> {
+        validate_policy(request).map_err(map_lifecycle_error)
+    }
+
+    fn validate_start(
+        &self,
+        _sandbox_id: &str,
+        request: &CodexRequest,
+        _config: Option<&IsolationSessionConfig>,
+    ) -> Result<(), MxcError> {
+        validate_policy(request).map_err(map_lifecycle_error)
+    }
+
+    fn validate_exec(
+        &self,
+        _sandbox_id: &str,
+        request: &CodexRequest,
+        _config: Option<&()>,
+    ) -> Result<(), MxcError> {
+        validate_policy(request).map_err(map_lifecycle_error)
+    }
+
+    fn validate_stop(
+        &self,
+        _sandbox_id: &str,
+        request: &CodexRequest,
+        _config: Option<&()>,
+    ) -> Result<(), MxcError> {
+        validate_policy(request).map_err(map_lifecycle_error)
+    }
+
+    fn validate_deprovision(
+        &self,
+        _sandbox_id: &str,
+        request: &CodexRequest,
+        _config: Option<&()>,
+    ) -> Result<(), MxcError> {
+        validate_policy(request).map_err(map_lifecycle_error)
+    }
+
     /// Reuses `IsolationSessionManager::create_process` — the same path the
     /// one-shot runner uses. Output streams to wxc-exec's stdout/stderr via
     /// internal relay threads while the call is in flight; the call returns
@@ -1069,6 +1123,52 @@ mod tests {
             map_lifecycle_error(IsolationSessionError::Stale("x".into())).code,
             MxcErrorCode::StaleId,
         );
+    }
+
+    fn request_with_filesystem_policy() -> CodexRequest {
+        CodexRequest {
+            policy: ContainerPolicy {
+                readwrite_paths: vec!["C:\\workspace".into()],
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_phase_hooks_reject_unsupported_filesystem_policy() {
+        use crate::mxc_error::MxcErrorCode;
+        let runner = IsolationSessionRunner::new();
+        let req = request_with_filesystem_policy();
+
+        let p = runner.validate_provision(&req, None).unwrap_err();
+        assert_eq!(p.code, MxcErrorCode::PolicyValidation);
+
+        let s = runner.validate_start("iso:abc", &req, None).unwrap_err();
+        assert_eq!(s.code, MxcErrorCode::PolicyValidation);
+
+        let e = runner.validate_exec("iso:abc", &req, None).unwrap_err();
+        assert_eq!(e.code, MxcErrorCode::PolicyValidation);
+
+        let st = runner.validate_stop("iso:abc", &req, None).unwrap_err();
+        assert_eq!(st.code, MxcErrorCode::PolicyValidation);
+
+        let d = runner
+            .validate_deprovision("iso:abc", &req, None)
+            .unwrap_err();
+        assert_eq!(d.code, MxcErrorCode::PolicyValidation);
+    }
+
+    #[test]
+    fn validate_phase_hooks_accept_clean_request() {
+        let runner = IsolationSessionRunner::new();
+        let req = CodexRequest::default();
+
+        runner.validate_provision(&req, None).unwrap();
+        runner.validate_start("iso:abc", &req, None).unwrap();
+        runner.validate_exec("iso:abc", &req, None).unwrap();
+        runner.validate_stop("iso:abc", &req, None).unwrap();
+        runner.validate_deprovision("iso:abc", &req, None).unwrap();
     }
 
     #[test]

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -16,13 +16,21 @@
 use std::fmt::Write;
 use std::io::IsTerminal;
 
+use serde::Serialize;
+
+use crate::id::mint_random_token;
 use crate::logger::Logger;
-use crate::models::{CodexRequest, IsolationSessionConfigurationId, NetworkPolicy, ScriptResponse};
+use crate::models::{
+    CodexRequest, IsolationSessionConfig, IsolationSessionConfigurationId, NetworkPolicy,
+    ScriptResponse,
+};
+use crate::mxc_error::MxcError;
 use crate::process_util::{
     create_relay_thread, create_relay_thread_with_stop, ConsoleModeRestorer, OwnedHandle,
     PipeRelayParams, PipeRelayWithStopParams,
 };
 use crate::script_runner::ScriptRunner;
+use crate::state_aware_backend::{ExecHandle, ProvisionResult, StatefulSandboxBackend};
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
     IsoSessionProcessOptions, IsoSessionProcessResult, IsoSessionResult, IsoSessionUserResult,
@@ -43,13 +51,14 @@ use windows_core::{HSTRING, PCWSTR};
 /// or subsequent calls hit the wrong cohort.
 const REGISTRATION_ID: &str = "regid";
 
-/// Provision identifier scoping the agent user across the lifecycle.
+/// Default provisionId used by the one-shot backend path. State-aware
+/// callers mint their own dynamic ids (e.g. `wxc-<8-hex>`) instead.
 ///
-/// Reused as the `agentName` parameter on every subsequent op — the
-/// `IsoSessionOps` wrapper aliases `agentName` to this `provisionId` at
-/// the COM layer, so callers pass `provisionId` where the IDL says
-/// `agentName`.
-const PROVISION_ID: &str = "wxc-provid";
+/// `provisionId` scopes the agent user across the lifecycle and is reused as
+/// the `agentName` parameter on every subsequent op — the `IsoSessionOps`
+/// wrapper aliases `agentName` to this `provisionId` at the COM layer, so
+/// callers pass `provisionId` where the IDL says `agentName`.
+pub const DEFAULT_PROVISION_ID: &str = "wxc-provid";
 
 impl From<IsolationSessionConfigurationId> for IsoSessionConfigId {
     fn from(value: IsolationSessionConfigurationId) -> Self {
@@ -315,13 +324,15 @@ pub struct IsolationSessionManager {
 }
 
 impl IsolationSessionManager {
-    /// Activates the `IsoSessionOps` factory and verifies the service is
-    /// available.
-    pub fn new() -> Result<Self, IsolationSessionError> {
+    /// Activates the `IsoSessionOps` factory, verifies the service is
+    /// available, and pegs the manager to the supplied `provisionId`.
+    /// One-shot callers pass `DEFAULT_PROVISION_ID`; state-aware callers
+    /// mint a dynamic id per provision (e.g. `wxc-<8-hex>`).
+    pub fn new(provision_id: &str) -> Result<Self, IsolationSessionError> {
         let ops = check_service_available_and_activate()?;
         Ok(Self {
             registration_id: HSTRING::from(REGISTRATION_ID),
-            provision_id: HSTRING::from(PROVISION_ID),
+            provision_id: HSTRING::from(provision_id),
             ops,
         })
     }
@@ -736,8 +747,9 @@ impl ScriptRunner for IsolationSessionRunner {
             .map(|cfg| cfg.configuration_id)
             .unwrap_or_default();
 
-        // Activate the in-proc IsoSessionOps factory.
-        let manager = match IsolationSessionManager::new() {
+        // Activate the in-proc IsoSessionOps factory. One-shot uses the
+        // hardcoded default provisionId; state-aware mints a dynamic one.
+        let manager = match IsolationSessionManager::new(DEFAULT_PROVISION_ID) {
             Ok(m) => m,
             Err(e) => return e.into(),
         };
@@ -805,6 +817,84 @@ impl ScriptRunner for IsolationSessionRunner {
     }
 }
 
+// -- StatefulSandboxBackend impl --------------------------------------------
+
+/// Provision-phase metadata. Carries the OS-assigned agent account name
+/// (e.g. `<CallingUser>-IEB-NNN`) for diagnostics; the SID is omitted (can
+/// be added later when a caller needs it).
+#[derive(Debug, Clone, Serialize)]
+pub struct IsolationSessionProvisionMetadata {
+    #[serde(rename = "agentUserName")]
+    pub agent_user_name: String,
+}
+
+impl StatefulSandboxBackend for IsolationSessionRunner {
+    const ID_PREFIX: &'static str = "iso";
+    const BACKEND_KEY: &'static str = "isolation_session";
+
+    type ProvisionConfig = ();
+    /// `experimental.isolation_session.start` mirrors the one-shot
+    /// `experimental.isolation_session` shape — same `IsolationSessionConfig`
+    /// type, same wire keys.
+    type StartConfig = IsolationSessionConfig;
+    type ExecConfig = ();
+    type StopConfig = ();
+    type DeprovisionConfig = ();
+    type ProvisionMetadata = IsolationSessionProvisionMetadata;
+    type StartMetadata = ();
+    type StopMetadata = ();
+    type DeprovisionMetadata = ();
+
+    fn provision(
+        &mut self,
+        _request: &CodexRequest,
+        _config: Option<()>,
+    ) -> Result<ProvisionResult<IsolationSessionProvisionMetadata>, MxcError> {
+        let provision_id = format!("wxc-{}", mint_random_token());
+        let manager = IsolationSessionManager::new(&provision_id).map_err(map_lifecycle_error)?;
+        manager.register_client().map_err(map_lifecycle_error)?;
+        let agent_user_name = match manager.provision_agent_user() {
+            Ok(name) => name,
+            Err(e) => {
+                // Defensive cleanup mirrors the one-shot path: provision_agent_user
+                // can fail after the OS-side provision succeeded, leaving an
+                // Indefinite-lifetime agent user. Calls no-op on absent state.
+                let _ = manager.deprovision_agent_user();
+                let _ = manager.unregister_client();
+                return Err(map_lifecycle_error(e));
+            }
+        };
+
+        Ok(ProvisionResult {
+            sandbox_id: format!("{}:{}", Self::ID_PREFIX, provision_id),
+            metadata: Some(IsolationSessionProvisionMetadata { agent_user_name }),
+        })
+    }
+
+    /// `exec` lands in a follow-up commit. Returning a typed error rather
+    /// than panicking keeps a misrouted dispatcher path observable in tests
+    /// instead of aborting the test binary.
+    fn exec(
+        &mut self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<()>,
+    ) -> Result<ExecHandle, MxcError> {
+        Err(MxcError::backend_error(
+            "IsolationSession state-aware exec not yet implemented",
+        ))
+    }
+}
+
+fn map_lifecycle_error(err: IsolationSessionError) -> MxcError {
+    let message = err.to_string();
+    match err {
+        IsolationSessionError::Policy(_) => MxcError::policy_validation(message),
+        IsolationSessionError::ServiceUnavailable(_) => MxcError::backend_unavailable(message),
+        IsolationSessionError::Lifecycle(_) => MxcError::backend_error(message),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -817,6 +907,23 @@ mod tests {
             }
             other => panic!("expected Policy variant, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn map_lifecycle_error_categorises_each_variant() {
+        use crate::mxc_error::MxcErrorCode;
+        assert_eq!(
+            map_lifecycle_error(IsolationSessionError::Policy("x".into())).code,
+            MxcErrorCode::PolicyValidation,
+        );
+        assert_eq!(
+            map_lifecycle_error(IsolationSessionError::ServiceUnavailable("x".into())).code,
+            MxcErrorCode::BackendUnavailable,
+        );
+        assert_eq!(
+            map_lifecycle_error(IsolationSessionError::Lifecycle("x".into())).code,
+            MxcErrorCode::BackendError,
+        );
     }
 
     #[test]

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -31,7 +31,7 @@ use crate::process_util::{
 };
 use crate::script_runner::ScriptRunner;
 use crate::state_aware_backend::{
-    ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend,
+    ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
 };
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
@@ -904,6 +904,18 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
             .start_session(configuration_id)
             .map_err(map_lifecycle_error)?;
         Ok(StartResult { metadata: None })
+    }
+
+    fn stop(
+        &mut self,
+        sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<()>,
+    ) -> Result<StopResult<()>, MxcError> {
+        let provision_id = extract_provision_id(sandbox_id)?;
+        let manager = IsolationSessionManager::new(provision_id).map_err(map_lifecycle_error)?;
+        manager.stop_session().map_err(map_lifecycle_error)?;
+        Ok(StopResult { metadata: None })
     }
 
     /// Reuses `IsolationSessionManager::create_process` — the same path the

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -30,7 +30,9 @@ use crate::process_util::{
     PipeRelayParams, PipeRelayWithStopParams,
 };
 use crate::script_runner::ScriptRunner;
-use crate::state_aware_backend::{ExecHandle, ProvisionResult, StatefulSandboxBackend};
+use crate::state_aware_backend::{
+    ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend,
+};
 use isolation_session_bindings::bindings::{
     IsoSessionConfigId, IsoSessionError, IsoSessionOps, IsoSessionProcess,
     IsoSessionProcessOptions, IsoSessionProcessResult, IsoSessionResult, IsoSessionUserResult,
@@ -828,6 +830,21 @@ pub struct IsolationSessionProvisionMetadata {
     pub agent_user_name: String,
 }
 
+/// Parses the `iso:<provisionId>` form of a state-aware sandbox_id and
+/// returns the inner `provisionId` segment. Surfaces format mismatches as
+/// `MxcError::MalformedId` so callers can return the right wire-format
+/// error code.
+fn extract_provision_id(sandbox_id: &str) -> Result<&str, MxcError> {
+    let prefix = <IsolationSessionRunner as StatefulSandboxBackend>::ID_PREFIX;
+    match sandbox_id.split_once(':') {
+        Some((p, rest)) if p == prefix && !rest.is_empty() => Ok(rest),
+        _ => Err(MxcError::malformed_id(format!(
+            "expected {}:<provisionId>, got {:?}",
+            prefix, sandbox_id
+        ))),
+    }
+}
+
 impl StatefulSandboxBackend for IsolationSessionRunner {
     const ID_PREFIX: &'static str = "iso";
     const BACKEND_KEY: &'static str = "isolation_session";
@@ -871,6 +888,24 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         })
     }
 
+    fn start(
+        &mut self,
+        sandbox_id: &str,
+        _request: &CodexRequest,
+        config: Option<IsolationSessionConfig>,
+    ) -> Result<StartResult<()>, MxcError> {
+        let provision_id = extract_provision_id(sandbox_id)?;
+        let manager = IsolationSessionManager::new(provision_id).map_err(map_lifecycle_error)?;
+        // Config absent → Composable, mirroring the one-shot default. The
+        // OS-side service does not call back into MXC after start, so a
+        // return here means the session is ready to host process launches.
+        let configuration_id = config.map(|c| c.configuration_id).unwrap_or_default();
+        manager
+            .start_session(configuration_id)
+            .map_err(map_lifecycle_error)?;
+        Ok(StartResult { metadata: None })
+    }
+
     /// `exec` lands in a follow-up commit. Returning a typed error rather
     /// than panicking keeps a misrouted dispatcher path observable in tests
     /// instead of aborting the test binary.
@@ -907,6 +942,32 @@ mod tests {
             }
             other => panic!("expected Policy variant, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn extract_provision_id_unwraps_iso_prefix() {
+        assert_eq!(
+            extract_provision_id("iso:wxc-abcd1234").unwrap(),
+            "wxc-abcd1234"
+        );
+    }
+
+    #[test]
+    fn extract_provision_id_rejects_other_prefix() {
+        let err = extract_provision_id("wsb:abc").unwrap_err();
+        assert_eq!(err.code, crate::mxc_error::MxcErrorCode::MalformedId);
+    }
+
+    #[test]
+    fn extract_provision_id_rejects_missing_colon() {
+        let err = extract_provision_id("no-colon").unwrap_err();
+        assert_eq!(err.code, crate::mxc_error::MxcErrorCode::MalformedId);
+    }
+
+    #[test]
+    fn extract_provision_id_rejects_empty_payload() {
+        let err = extract_provision_id("iso:").unwrap_err();
+        assert_eq!(err.code, crate::mxc_error::MxcErrorCode::MalformedId);
     }
 
     #[test]

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -906,18 +906,43 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         Ok(StartResult { metadata: None })
     }
 
-    /// `exec` lands in a follow-up commit. Returning a typed error rather
-    /// than panicking keeps a misrouted dispatcher path observable in tests
-    /// instead of aborting the test binary.
+    /// Reuses `IsolationSessionManager::create_process` — the same path the
+    /// one-shot runner uses. Output streams to wxc-exec's stdout/stderr via
+    /// internal relay threads while the call is in flight; the call returns
+    /// once the process has exited and the relays have drained. The
+    /// resulting `ExecHandle` carries sentinel pipe handles plus a waiter
+    /// closure that yields the already-captured exit code, so the
+    /// dispatcher's `relay_exec_to_stdio` is a thin call-through.
     fn exec(
         &mut self,
-        _sandbox_id: &str,
-        _request: &CodexRequest,
+        sandbox_id: &str,
+        request: &CodexRequest,
         _config: Option<()>,
     ) -> Result<ExecHandle, MxcError> {
-        Err(MxcError::backend_error(
-            "IsolationSession state-aware exec not yet implemented",
-        ))
+        let provision_id = extract_provision_id(sandbox_id)?;
+        let manager = IsolationSessionManager::new(provision_id).map_err(map_lifecycle_error)?;
+
+        let mut options = build_process_options(request);
+        let interactive = std::io::stdout().is_terminal();
+        options.interactive = interactive;
+        options.redirect_flags = compute_redirect_flags(interactive);
+
+        let result = manager
+            .create_process(&options)
+            .map_err(map_lifecycle_error)?;
+        let exit_code = result.exit_code;
+
+        // The output relay completed inside `create_process`. The dispatcher
+        // sees zero pipe handles, skips its own relay setup, and gets the
+        // exit code from the waiter closure.
+        let null = HANDLE(std::ptr::null_mut());
+        Ok(ExecHandle {
+            stdout: null,
+            stderr: null,
+            stdin: null,
+            waiter: Box::new(move || Ok(exit_code)),
+            terminator: Box::new(|| {}),
+        })
     }
 }
 

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mxc_error;
 #[cfg(target_os = "windows")]
 pub mod nanvix_runner;
 pub mod script_runner;
+pub mod state_aware_backend;
 pub mod validator;
 
 // Windows-specific modules

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod mxc_error;
 pub mod nanvix_runner;
 pub mod script_runner;
 pub mod state_aware_backend;
+pub mod state_aware_dispatch;
 pub mod state_aware_request;
 pub mod validator;
 

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod config_parser;
 pub mod encoding;
 pub mod error;
+pub mod id;
 pub mod logger;
 pub mod models;
 pub mod mxc_error;

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -13,6 +13,7 @@ pub mod mxc_error;
 pub mod nanvix_runner;
 pub mod script_runner;
 pub mod state_aware_backend;
+pub mod state_aware_request;
 pub mod validator;
 
 // Windows-specific modules

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod encoding;
 pub mod error;
 pub mod logger;
 pub mod models;
+pub mod mxc_error;
 #[cfg(target_os = "windows")]
 pub mod nanvix_runner;
 pub mod script_runner;

--- a/src/wxc_common/src/mxc_error.rs
+++ b/src/wxc_common/src/mxc_error.rs
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! State-aware wire-format error model and response envelope.
+//!
+//! `MxcError` is the typed Rust value returned from `StatefulSandboxBackend`
+//! trait methods and dispatch. Backends construct it with a closed `MxcErrorCode`
+//! plus a free-form message and optional `details`. The dispatcher serialises an
+//! `Err(MxcError)` to the JSON `{"error": {...}}` envelope on stdout; success
+//! values from non-exec phases serialise to `{"result": {...}}`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+/// Closed set of wire-format error codes. Matches the SDK's `ErrorCode` string
+/// union one-for-one; serialised as snake_case strings on the wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MxcErrorCode {
+    MalformedRequest,
+    UnsupportedContainment,
+    UnsupportedPhase,
+    BackendUnavailable,
+    MalformedId,
+    StaleId,
+    NotProvisioned,
+    NotStarted,
+    AlreadyStarted,
+    AlreadyStopped,
+    PolicyValidation,
+    BackendError,
+}
+
+impl MxcErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MalformedRequest => "malformed_request",
+            Self::UnsupportedContainment => "unsupported_containment",
+            Self::UnsupportedPhase => "unsupported_phase",
+            Self::BackendUnavailable => "backend_unavailable",
+            Self::MalformedId => "malformed_id",
+            Self::StaleId => "stale_id",
+            Self::NotProvisioned => "not_provisioned",
+            Self::NotStarted => "not_started",
+            Self::AlreadyStarted => "already_started",
+            Self::AlreadyStopped => "already_stopped",
+            Self::PolicyValidation => "policy_validation",
+            Self::BackendError => "backend_error",
+        }
+    }
+}
+
+impl std::fmt::Display for MxcErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Typed Rust equivalent of the SDK `MxcError` class hierarchy.
+///
+/// Constructed via `MxcError::new(code, message)` or one of the per-code
+/// convenience constructors (e.g. `MxcError::stale_id("...")`); attach
+/// structured failure information with `.with_details(json!({...}))`.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{code}: {message}")]
+pub struct MxcError {
+    pub code: MxcErrorCode,
+    pub message: String,
+    pub details: Option<Value>,
+}
+
+impl MxcError {
+    pub fn new(code: MxcErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
+    }
+
+    pub fn to_envelope(&self) -> ErrorEnvelope {
+        ErrorEnvelope {
+            code: self.code.as_str().to_string(),
+            message: self.message.clone(),
+            details: self.details.clone(),
+        }
+    }
+}
+
+// Per-code convenience constructors. One per `MxcErrorCode` variant.
+impl MxcError {
+    pub fn malformed_request(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::MalformedRequest, message)
+    }
+    pub fn unsupported_containment(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::UnsupportedContainment, message)
+    }
+    pub fn unsupported_phase(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::UnsupportedPhase, message)
+    }
+    pub fn backend_unavailable(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::BackendUnavailable, message)
+    }
+    pub fn malformed_id(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::MalformedId, message)
+    }
+    pub fn stale_id(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::StaleId, message)
+    }
+    pub fn not_provisioned(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::NotProvisioned, message)
+    }
+    pub fn not_started(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::NotStarted, message)
+    }
+    pub fn already_started(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::AlreadyStarted, message)
+    }
+    pub fn already_stopped(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::AlreadyStopped, message)
+    }
+    pub fn policy_validation(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::PolicyValidation, message)
+    }
+    pub fn backend_error(message: impl Into<String>) -> Self {
+        Self::new(MxcErrorCode::BackendError, message)
+    }
+}
+
+/// Wire shape of the `error` arm. `code` is a snake_case string from
+/// `MxcErrorCode::as_str`; `details` is omitted from JSON when absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorEnvelope {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub details: Option<Value>,
+}
+
+/// Top-level non-exec response envelope: `{"result": <T>}` on success, or
+/// `{"error": {...}}` on failure. `T` is per-phase (e.g. provision metadata,
+/// or `()` for phases without a return body).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseEnvelope<T> {
+    Result(T),
+    Error(ErrorEnvelope),
+}
+
+impl<T> ResponseEnvelope<T> {
+    pub fn from_error(err: &MxcError) -> Self {
+        Self::Error(err.to_envelope())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn every_code_serialises_to_its_wire_string() {
+        let cases = [
+            (MxcErrorCode::MalformedRequest, "malformed_request"),
+            (
+                MxcErrorCode::UnsupportedContainment,
+                "unsupported_containment",
+            ),
+            (MxcErrorCode::UnsupportedPhase, "unsupported_phase"),
+            (MxcErrorCode::BackendUnavailable, "backend_unavailable"),
+            (MxcErrorCode::MalformedId, "malformed_id"),
+            (MxcErrorCode::StaleId, "stale_id"),
+            (MxcErrorCode::NotProvisioned, "not_provisioned"),
+            (MxcErrorCode::NotStarted, "not_started"),
+            (MxcErrorCode::AlreadyStarted, "already_started"),
+            (MxcErrorCode::AlreadyStopped, "already_stopped"),
+            (MxcErrorCode::PolicyValidation, "policy_validation"),
+            (MxcErrorCode::BackendError, "backend_error"),
+        ];
+        for (code, wire) in cases {
+            assert_eq!(code.as_str(), wire);
+            assert_eq!(code.to_string(), wire);
+            let json = serde_json::to_value(code).unwrap();
+            assert_eq!(json, Value::String(wire.to_string()));
+            let parsed: MxcErrorCode = serde_json::from_value(json).unwrap();
+            assert_eq!(parsed, code);
+        }
+    }
+
+    #[test]
+    fn convenience_constructors_set_correct_codes() {
+        assert_eq!(
+            MxcError::malformed_request("x").code,
+            MxcErrorCode::MalformedRequest
+        );
+        assert_eq!(
+            MxcError::unsupported_containment("x").code,
+            MxcErrorCode::UnsupportedContainment
+        );
+        assert_eq!(
+            MxcError::unsupported_phase("x").code,
+            MxcErrorCode::UnsupportedPhase
+        );
+        assert_eq!(
+            MxcError::backend_unavailable("x").code,
+            MxcErrorCode::BackendUnavailable
+        );
+        assert_eq!(MxcError::malformed_id("x").code, MxcErrorCode::MalformedId);
+        assert_eq!(MxcError::stale_id("x").code, MxcErrorCode::StaleId);
+        assert_eq!(
+            MxcError::not_provisioned("x").code,
+            MxcErrorCode::NotProvisioned
+        );
+        assert_eq!(MxcError::not_started("x").code, MxcErrorCode::NotStarted);
+        assert_eq!(
+            MxcError::already_started("x").code,
+            MxcErrorCode::AlreadyStarted
+        );
+        assert_eq!(
+            MxcError::already_stopped("x").code,
+            MxcErrorCode::AlreadyStopped
+        );
+        assert_eq!(
+            MxcError::policy_validation("x").code,
+            MxcErrorCode::PolicyValidation
+        );
+        assert_eq!(
+            MxcError::backend_error("x").code,
+            MxcErrorCode::BackendError
+        );
+    }
+
+    #[test]
+    fn error_to_envelope_carries_code_and_message() {
+        let env = MxcError::stale_id("session expired").to_envelope();
+        let json = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            json,
+            json!({"code": "stale_id", "message": "session expired"})
+        );
+    }
+
+    #[test]
+    fn error_with_details_includes_details_in_envelope() {
+        let err = MxcError::backend_error("hresult failure")
+            .with_details(json!({"hresult": "0x80004005"}));
+        let env = err.to_envelope();
+        let json = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "code": "backend_error",
+                "message": "hresult failure",
+                "details": {"hresult": "0x80004005"},
+            })
+        );
+    }
+
+    #[test]
+    fn error_envelope_round_trips_via_json() {
+        let env = ErrorEnvelope {
+            code: "stale_id".into(),
+            message: "session expired".into(),
+            details: Some(json!({"k": "v"})),
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        let back: ErrorEnvelope = serde_json::from_str(&s).unwrap();
+        assert_eq!(env, back);
+    }
+
+    #[test]
+    fn error_envelope_omits_details_when_none() {
+        let env = ErrorEnvelope {
+            code: "stale_id".into(),
+            message: "x".into(),
+            details: None,
+        };
+        let s = serde_json::to_string(&env).unwrap();
+        assert!(!s.contains("details"));
+    }
+
+    #[test]
+    fn response_envelope_result_serialises_with_result_key() {
+        let env: ResponseEnvelope<&str> = ResponseEnvelope::Result("hello");
+        let json = serde_json::to_value(&env).unwrap();
+        assert_eq!(json, json!({"result": "hello"}));
+    }
+
+    #[test]
+    fn response_envelope_error_serialises_with_error_key() {
+        let inner = ErrorEnvelope {
+            code: "stale_id".into(),
+            message: "x".into(),
+            details: None,
+        };
+        let env: ResponseEnvelope<()> = ResponseEnvelope::Error(inner.clone());
+        let json = serde_json::to_value(&env).unwrap();
+        assert_eq!(json, json!({"error": {"code": "stale_id", "message": "x"}}));
+    }
+
+    #[test]
+    fn response_envelope_round_trips_via_json() {
+        let inner = ErrorEnvelope {
+            code: "backend_error".into(),
+            message: "boom".into(),
+            details: Some(json!({"x": 1})),
+        };
+        let env: ResponseEnvelope<()> = ResponseEnvelope::Error(inner);
+        let s = serde_json::to_string(&env).unwrap();
+        let back: ResponseEnvelope<()> = serde_json::from_str(&s).unwrap();
+        assert_eq!(env, back);
+    }
+
+    #[test]
+    fn response_envelope_from_error_wraps_via_to_envelope() {
+        let err = MxcError::policy_validation("nope").with_details(json!({"field": "containment"}));
+        let env: ResponseEnvelope<()> = ResponseEnvelope::from_error(&err);
+        let json = serde_json::to_value(&env).unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "error": {
+                    "code": "policy_validation",
+                    "message": "nope",
+                    "details": {"field": "containment"},
+                }
+            })
+        );
+    }
+}

--- a/src/wxc_common/src/process_util.rs
+++ b/src/wxc_common/src/process_util.rs
@@ -110,11 +110,9 @@ pub unsafe fn create_relay_thread(params: *mut PipeRelayParams) -> Result<OwnedH
 // by the parent: node-pty, shell, etc.). Without an external signal the relay
 // sits in `ReadFile` forever.
 //
-// Pattern adopted from IsoSessionCLI's `ConsoleTtyRelay::WriteThread`
-// (`onecoreuap/windows/core/isoenvbroker/src/cli/ConsoleTtyRelay.cpp:188-263`
-// in the OS repo). `CancelSynchronousIo` was rejected because it has
-// documented edge cases on console handles, and wxc-exec's stdin is a console
-// handle in the dominant `spawnSandbox` (node-pty) and direct-cmd cases.
+// `CancelSynchronousIo` is the obvious alternative but has documented edge
+// cases on console handles, and wxc-exec's stdin is a console handle in the
+// dominant `spawnSandbox` (node-pty) and direct-cmd cases.
 //
 // `h_read` MUST be a waitable handle whose signal state correctly reflects
 // "input available" (a console input handle is the canonical case; events
@@ -475,12 +473,10 @@ pub fn run_process_with_captured_output(
 // The two consoles render the same input twice, producing visible artifacts
 // (partial echos, doubled prompts, `\r\n` confusion).
 //
-// The fix mirrors IsoSessionCLI's `ConsoleRestorer::SetRawVtMode`
-// (`onecoreuap/windows/core/isoenvbroker/src/cli/ConsoleTtyRelay.cpp:69-93`
-// in the OS repo): switch the local console to raw VT mode for the relay
-// duration. Only the agent's ConPTY does input echo and command processing;
-// the local console is a transparent forwarder. On scope exit the original
-// modes are restored.
+// Fix: switch the local console to raw VT mode for the relay duration. Only
+// the agent's ConPTY does input echo and command processing; the local
+// console is a transparent forwarder. On scope exit the original modes are
+// restored.
 
 /// RAII guard that switches the local console to raw VT mode. Only meaningful
 /// in interactive mode (`InteractiveConsole = true`). When wxc-exec's stdio

--- a/src/wxc_common/src/state_aware_backend.rs
+++ b/src/wxc_common/src/state_aware_backend.rs
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! State-aware backend trait and supporting types.
+//!
+//! Backends opt into state-aware dispatch by implementing
+//! `StatefulSandboxBackend` alongside (or instead of) `ScriptRunner`. The trait
+//! exposes the five lifecycle phases — provision, start, exec, stop,
+//! deprovision — plus per-phase validation hooks.
+//!
+//! Methods take `&CodexRequest` (the same one-shot domain model used by every
+//! existing backend) plus the typed `sandbox_id` for non-provision phases and
+//! an optional backend-specific config object. Cross-cutting policy fields
+//! flow through `request.policy`; per-exec process info flows through
+//! `request.script_code` / `working_directory` / `script_timeout` / `env`.
+//!
+//! Most phase methods have default no-op bodies — only `exec` is strictly
+//! required. The default `provision` body mints `<ID_PREFIX>:<token>` for
+//! stateless-underneath backends; backends with native session work override
+//! it.
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::id::mint_random_token;
+use crate::models::CodexRequest;
+use crate::mxc_error::MxcError;
+
+/// Platform pipe-handle wrapper used by `ExecHandle`. On Windows this is a
+/// kernel `HANDLE`; on Unix-like targets it is a raw file descriptor.
+#[cfg(target_os = "windows")]
+pub type PipeHandle = windows::Win32::Foundation::HANDLE;
+
+#[cfg(not(target_os = "windows"))]
+pub type PipeHandle = i32;
+
+/// Provision-phase result. Carries the freshly-minted `sandbox_id` and
+/// optional backend-typed metadata.
+#[derive(Debug)]
+pub struct ProvisionResult<M> {
+    pub sandbox_id: String,
+    pub metadata: Option<M>,
+}
+
+/// Start-phase result. Backends with no useful metadata return `None`.
+#[derive(Debug)]
+pub struct StartResult<M> {
+    pub metadata: Option<M>,
+}
+
+/// Stop-phase result.
+#[derive(Debug)]
+pub struct StopResult<M> {
+    pub metadata: Option<M>,
+}
+
+/// Deprovision-phase result.
+#[derive(Debug)]
+pub struct DeprovisionResult<M> {
+    pub metadata: Option<M>,
+}
+
+/// Streaming exec handle. The dispatcher relays `stdout` / `stderr` to the
+/// executor's own streams, forwards executor stdin into `stdin`, awaits exit
+/// via `waiter`, and calls `terminator` on cancellation signals. Pipe-handle
+/// ownership stays with the underlying process object; the relay does not
+/// close them.
+pub struct ExecHandle {
+    pub stdout: PipeHandle,
+    pub stderr: PipeHandle,
+    pub stdin: PipeHandle,
+    pub waiter: Box<dyn FnOnce() -> Result<i32, MxcError> + Send>,
+    pub terminator: Box<dyn FnOnce() + Send>,
+}
+
+// Manual Debug impl: the boxed closures can't derive Debug. Pipe handles are
+// printed; the closures render as opaque markers.
+impl std::fmt::Debug for ExecHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExecHandle")
+            .field("stdout", &self.stdout)
+            .field("stderr", &self.stderr)
+            .field("stdin", &self.stdin)
+            .field("waiter", &"<fn>")
+            .field("terminator", &"<fn>")
+            .finish()
+    }
+}
+
+/// State-aware backend trait. Backends declare their `ID_PREFIX` and the
+/// per-phase typed config / metadata associated types, then override only
+/// the phase methods where they have substantive work.
+pub trait StatefulSandboxBackend {
+    /// Backend identifier prefix. Forms the leading `<tag>:` segment of every
+    /// `sandbox_id` minted by the default `provision` body, and is the routing
+    /// key the dispatcher uses to resolve non-provision calls to this backend.
+    const ID_PREFIX: &'static str;
+
+    type ProvisionConfig: DeserializeOwned;
+    type StartConfig: DeserializeOwned;
+    type ExecConfig: DeserializeOwned;
+    type StopConfig: DeserializeOwned;
+    type DeprovisionConfig: DeserializeOwned;
+    type ProvisionMetadata: Serialize;
+    type StartMetadata: Serialize;
+    type StopMetadata: Serialize;
+    type DeprovisionMetadata: Serialize;
+
+    /// Optional. Default mints `<ID_PREFIX>:<random-token>` and returns no
+    /// metadata. Override when the backend has native provision work.
+    fn provision(
+        &mut self,
+        _request: &CodexRequest,
+        _config: Option<Self::ProvisionConfig>,
+    ) -> Result<ProvisionResult<Self::ProvisionMetadata>, MxcError> {
+        Ok(ProvisionResult {
+            sandbox_id: format!("{}:{}", Self::ID_PREFIX, mint_random_token()),
+            metadata: None,
+        })
+    }
+
+    /// Optional. Default returns success with no metadata.
+    fn start(
+        &mut self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::StartConfig>,
+    ) -> Result<StartResult<Self::StartMetadata>, MxcError> {
+        Ok(StartResult { metadata: None })
+    }
+
+    /// Required. Executes the workload and returns a streaming handle.
+    fn exec(
+        &mut self,
+        sandbox_id: &str,
+        request: &CodexRequest,
+        config: Option<Self::ExecConfig>,
+    ) -> Result<ExecHandle, MxcError>;
+
+    /// Optional. Default returns success with no metadata.
+    fn stop(
+        &mut self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::StopConfig>,
+    ) -> Result<StopResult<Self::StopMetadata>, MxcError> {
+        Ok(StopResult { metadata: None })
+    }
+
+    /// Optional. Default returns success with no metadata.
+    fn deprovision(
+        &mut self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<Self::DeprovisionConfig>,
+    ) -> Result<DeprovisionResult<Self::DeprovisionMetadata>, MxcError> {
+        Ok(DeprovisionResult { metadata: None })
+    }
+
+    /// Per-phase validation hooks. The dispatcher calls these before the
+    /// corresponding phase method. Default: accept all requests. Override to
+    /// add backend-specific checks (config field semantics, policy honor
+    /// enforcement, id format checks beyond the prefix).
+    fn validate_provision(
+        &self,
+        _request: &CodexRequest,
+        _config: Option<&Self::ProvisionConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_start(
+        &self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::StartConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_exec(
+        &self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::ExecConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_stop(
+        &self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::StopConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+
+    fn validate_deprovision(
+        &self,
+        _sandbox_id: &str,
+        _request: &CodexRequest,
+        _config: Option<&Self::DeprovisionConfig>,
+    ) -> Result<(), MxcError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mxc_error::MxcErrorCode;
+
+    /// Minimal trait fixture exercising every default body. Uses `()` for all
+    /// associated types; `exec` is the only required method — wired to a
+    /// recognisable error so accidental calls show up in test output rather
+    /// than panicking.
+    struct StubBackend;
+
+    impl StatefulSandboxBackend for StubBackend {
+        const ID_PREFIX: &'static str = "stub";
+        type ProvisionConfig = ();
+        type StartConfig = ();
+        type ExecConfig = ();
+        type StopConfig = ();
+        type DeprovisionConfig = ();
+        type ProvisionMetadata = ();
+        type StartMetadata = ();
+        type StopMetadata = ();
+        type DeprovisionMetadata = ();
+
+        fn exec(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<ExecHandle, MxcError> {
+            Err(MxcError::backend_error("StubBackend::exec not implemented"))
+        }
+    }
+
+    #[test]
+    fn default_provision_mints_id_with_prefix_and_token() {
+        let mut b = StubBackend;
+        let r = b.provision(&CodexRequest::default(), None).unwrap();
+        // Expected shape: "stub:" followed by 8 lowercase hex chars.
+        assert!(r.sandbox_id.starts_with("stub:"), "got {:?}", r.sandbox_id);
+        let token = &r.sandbox_id["stub:".len()..];
+        assert_eq!(
+            token.len(),
+            8,
+            "token portion should be 8 chars: {:?}",
+            token
+        );
+        assert!(
+            token
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "token portion should be lowercase hex: {:?}",
+            token,
+        );
+        assert!(r.metadata.is_none());
+    }
+
+    #[test]
+    fn default_provision_produces_distinct_ids() {
+        let mut b = StubBackend;
+        let a = b.provision(&CodexRequest::default(), None).unwrap();
+        let c = b.provision(&CodexRequest::default(), None).unwrap();
+        assert_ne!(a.sandbox_id, c.sandbox_id);
+    }
+
+    #[test]
+    fn default_start_returns_no_metadata() {
+        let mut b = StubBackend;
+        let r = b
+            .start("stub:abcd1234", &CodexRequest::default(), None)
+            .unwrap();
+        assert!(r.metadata.is_none());
+    }
+
+    #[test]
+    fn default_stop_returns_no_metadata() {
+        let mut b = StubBackend;
+        let r = b
+            .stop("stub:abcd1234", &CodexRequest::default(), None)
+            .unwrap();
+        assert!(r.metadata.is_none());
+    }
+
+    #[test]
+    fn default_deprovision_returns_no_metadata() {
+        let mut b = StubBackend;
+        let r = b
+            .deprovision("stub:abcd1234", &CodexRequest::default(), None)
+            .unwrap();
+        assert!(r.metadata.is_none());
+    }
+
+    #[test]
+    fn default_validate_hooks_all_pass() {
+        let b = StubBackend;
+        let req = CodexRequest::default();
+        b.validate_provision(&req, None).unwrap();
+        b.validate_start("stub:abcd1234", &req, None).unwrap();
+        b.validate_exec("stub:abcd1234", &req, None).unwrap();
+        b.validate_stop("stub:abcd1234", &req, None).unwrap();
+        b.validate_deprovision("stub:abcd1234", &req, None).unwrap();
+    }
+
+    #[test]
+    fn required_exec_returns_error_on_stub() {
+        // Confirms `exec` is wired and reachable; the stub returns a typed
+        // error rather than panicking so a misrouted dispatcher test would
+        // surface this code rather than aborting the test binary.
+        let mut b = StubBackend;
+        let err = b
+            .exec("stub:abcd1234", &CodexRequest::default(), None)
+            .unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+    }
+}

--- a/src/wxc_common/src/state_aware_backend.rs
+++ b/src/wxc_common/src/state_aware_backend.rs
@@ -95,6 +95,13 @@ pub trait StatefulSandboxBackend {
     /// key the dispatcher uses to resolve non-provision calls to this backend.
     const ID_PREFIX: &'static str;
 
+    /// Wire-format `containment` value for this backend, matching the SDK's
+    /// `StateAwareSandboxingMethod` member name (e.g. `"isolation_session"`).
+    /// Used by the dispatcher to navigate
+    /// `experimental.<BACKEND_KEY>.<phase>` in the request envelope and to
+    /// resolve provision-phase requests to the right backend implementation.
+    const BACKEND_KEY: &'static str;
+
     type ProvisionConfig: DeserializeOwned;
     type StartConfig: DeserializeOwned;
     type ExecConfig: DeserializeOwned;
@@ -218,6 +225,7 @@ mod tests {
 
     impl StatefulSandboxBackend for StubBackend {
         const ID_PREFIX: &'static str = "stub";
+        const BACKEND_KEY: &'static str = "stub_backend";
         type ProvisionConfig = ();
         type StartConfig = ();
         type ExecConfig = ();

--- a/src/wxc_common/src/state_aware_dispatch.rs
+++ b/src/wxc_common/src/state_aware_dispatch.rs
@@ -161,16 +161,16 @@ fn backend_from_prefix(prefix: &str) -> Result<ContainmentBackend, MxcError> {
 }
 
 /// Streams the running process's pipes to executor stdio and waits for exit.
-/// At this stage no backend produces an `ExecHandle`, but the function is
-/// defined so `dispatch_state_aware` compiles and so I-commits drop their
-/// real impls into a stable seam.
 ///
-/// TODO: once an exec-capable backend lands, replace the placeholder with a
-/// `process_util`-driven 3-pipe relay and waiter join.
-fn relay_exec_to_stdio(_handle: ExecHandle) -> Result<i32, MxcError> {
-    Err(MxcError::backend_error(
-        "state-aware exec relay is not yet wired",
-    ))
+/// Backends that perform their own internal relay (e.g. IsolationSession,
+/// which reuses the one-shot path's relay threads) hand back zero pipe
+/// handles plus a waiter closure that yields the already-captured exit code
+/// — this function is a thin call-through in that case. When a backend
+/// surfaces live pipe handles, this function will gain `process_util`-driven
+/// relay threads and a waiter join; that path lands when the first such
+/// backend appears.
+fn relay_exec_to_stdio(handle: ExecHandle) -> Result<i32, MxcError> {
+    (handle.waiter)()
 }
 
 // ---------- Wire-format envelope construction ----------

--- a/src/wxc_common/src/state_aware_dispatch.rs
+++ b/src/wxc_common/src/state_aware_dispatch.rs
@@ -1,0 +1,698 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! State-aware dispatcher: routes a parsed state-aware request to the right
+//! backend's `StatefulSandboxBackend` impl, runs the per-phase typed flow, and
+//! produces either a JSON response envelope (non-exec phases or dispatch
+//! failure) or an exit code (exec phase, which streams its output live).
+//!
+//! `run_state_aware` is the entry point invoked from `wxc-exec`'s main flow.
+//! It resolves the backend (by `containment` for provision, by `sandbox_id`
+//! prefix for non-provision phases) and either dispatches to the registered
+//! state-aware backend or surfaces `unsupported_phase` for backends without a
+//! state-aware impl.
+//!
+//! `dispatch_state_aware<B>` is the per-backend phase router, generic over the
+//! `StatefulSandboxBackend` impl. It validates, calls the right phase method,
+//! and wraps the typed result into a wire-format response envelope.
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::id::parse_sandbox_id_prefix;
+use crate::models::ContainmentBackend;
+use crate::mxc_error::{MxcError, ResponseEnvelope};
+use crate::state_aware_backend::{
+    DeprovisionResult, ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
+};
+use crate::state_aware_request::{ParsedStateAwareRequest, Phase};
+use crate::validator::validate_exec_common;
+
+/// Outcome of dispatching one state-aware request. Distinguishes the two
+/// success modes: non-exec phases produce a JSON envelope; exec phases stream
+/// their output live and exit with the script's exit code.
+#[derive(Debug)]
+pub enum DispatchOutcome {
+    /// JSON envelope to write to stdout (non-exec phases or dispatch failure).
+    Envelope(Value),
+    /// Exec phase completed; the executor process should exit with this code.
+    /// Stdout already carried the script's output; no JSON envelope is emitted.
+    ExecCompleted { exit_code: i32 },
+}
+
+/// Maps a parsed state-aware request to its target backend's state-aware
+/// dispatch arm, or surfaces a typed error.
+///
+/// At this stage no backend implements `StatefulSandboxBackend` yet, so every
+/// recognised backend yields `unsupported_phase`. Subsequent commits add an
+/// arm per participating backend.
+pub fn run_state_aware(
+    parsed: ParsedStateAwareRequest,
+    _dry_run: bool,
+) -> Result<DispatchOutcome, MxcError> {
+    let backend = resolve_backend(&parsed)?;
+    Err(MxcError::unsupported_phase(format!(
+        "backend {:?} does not implement state-aware lifecycle",
+        backend
+    )))
+}
+
+/// Per-backend phase router. The `run_state_aware` arm for a participating
+/// backend constructs `B` and delegates here.
+pub fn dispatch_state_aware<B: StatefulSandboxBackend>(
+    backend: &mut B,
+    parsed: ParsedStateAwareRequest,
+    dry_run: bool,
+) -> Result<DispatchOutcome, MxcError> {
+    let request = parsed.request.clone();
+    let phase = parsed.phase;
+    match phase {
+        Phase::Provision => {
+            let config =
+                parsed.deserialize_config::<B::ProvisionConfig>(B::BACKEND_KEY, "provision")?;
+            backend.validate_provision(&request, config.as_ref())?;
+            if dry_run {
+                return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
+            }
+            let result = backend.provision(&request, config)?;
+            Ok(DispatchOutcome::Envelope(provision_envelope(result)?))
+        }
+        Phase::Start => {
+            let sandbox_id = parsed.sandbox_id_required()?.to_string();
+            let config = parsed.deserialize_config::<B::StartConfig>(B::BACKEND_KEY, "start")?;
+            backend.validate_start(&sandbox_id, &request, config.as_ref())?;
+            if dry_run {
+                return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
+            }
+            let result = backend.start(&sandbox_id, &request, config)?;
+            Ok(DispatchOutcome::Envelope(metadata_envelope(result)?))
+        }
+        Phase::Exec => {
+            let sandbox_id = parsed.sandbox_id_required()?.to_string();
+            let config = parsed.deserialize_config::<B::ExecConfig>(B::BACKEND_KEY, "exec")?;
+            validate_exec_common(&request)?;
+            backend.validate_exec(&sandbox_id, &request, config.as_ref())?;
+            if dry_run {
+                return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
+            }
+            let handle = backend.exec(&sandbox_id, &request, config)?;
+            let exit_code = relay_exec_to_stdio(handle)?;
+            Ok(DispatchOutcome::ExecCompleted { exit_code })
+        }
+        Phase::Stop => {
+            let sandbox_id = parsed.sandbox_id_required()?.to_string();
+            let config = parsed.deserialize_config::<B::StopConfig>(B::BACKEND_KEY, "stop")?;
+            backend.validate_stop(&sandbox_id, &request, config.as_ref())?;
+            if dry_run {
+                return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
+            }
+            let result = backend.stop(&sandbox_id, &request, config)?;
+            Ok(DispatchOutcome::Envelope(metadata_envelope(result)?))
+        }
+        Phase::Deprovision => {
+            let sandbox_id = parsed.sandbox_id_required()?.to_string();
+            let config =
+                parsed.deserialize_config::<B::DeprovisionConfig>(B::BACKEND_KEY, "deprovision")?;
+            backend.validate_deprovision(&sandbox_id, &request, config.as_ref())?;
+            if dry_run {
+                return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
+            }
+            let result = backend.deprovision(&sandbox_id, &request, config)?;
+            Ok(DispatchOutcome::Envelope(metadata_envelope(result)?))
+        }
+    }
+}
+
+/// Resolves the target backend: from `containment` for provision, from the
+/// `sandbox_id` prefix for non-provision phases.
+pub fn resolve_backend(parsed: &ParsedStateAwareRequest) -> Result<ContainmentBackend, MxcError> {
+    if parsed.phase == Phase::Provision {
+        return parsed.containment.clone().ok_or_else(|| {
+            MxcError::malformed_request("provision phase requires a containment field")
+        });
+    }
+    let sandbox_id = parsed.sandbox_id_required()?;
+    let prefix = parse_sandbox_id_prefix(sandbox_id)?;
+    backend_from_prefix(prefix)
+}
+
+/// Maps a state-aware sandbox-id prefix to its `ContainmentBackend`.
+/// Subsequent state-aware backends register their prefix here.
+fn backend_from_prefix(prefix: &str) -> Result<ContainmentBackend, MxcError> {
+    match prefix {
+        "iso" => Ok(ContainmentBackend::IsolationSession),
+        // Future state-aware backends extend this list.
+        other => Err(MxcError::unsupported_containment(format!(
+            "no state-aware backend registered for prefix {:?}",
+            other
+        ))),
+    }
+}
+
+/// Streams the running process's pipes to executor stdio and waits for exit.
+/// At this stage no backend produces an `ExecHandle`, but the function is
+/// defined so `dispatch_state_aware` compiles and so I-commits drop their
+/// real impls into a stable seam.
+///
+/// TODO: once an exec-capable backend lands, replace the placeholder with a
+/// `process_util`-driven 3-pipe relay and waiter join.
+fn relay_exec_to_stdio(_handle: ExecHandle) -> Result<i32, MxcError> {
+    Err(MxcError::backend_error(
+        "state-aware exec relay is not yet wired",
+    ))
+}
+
+// ---------- Wire-format envelope construction ----------
+
+/// `{ "result": { "sandboxId": "...", "metadata": {...}? } }`
+#[derive(Serialize)]
+struct ProvisionWireBody<M: Serialize> {
+    #[serde(rename = "sandboxId")]
+    sandbox_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<M>,
+}
+
+/// `{ "metadata": {...}? }` — used by start / stop / deprovision phases.
+#[derive(Serialize)]
+struct MetadataWireBody<M: Serialize> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<M>,
+}
+
+fn provision_envelope<M: Serialize>(r: ProvisionResult<M>) -> Result<Value, MxcError> {
+    let body = ProvisionWireBody {
+        sandbox_id: r.sandbox_id,
+        metadata: r.metadata,
+    };
+    let envelope = ResponseEnvelope::Result(body);
+    serde_json::to_value(&envelope).map_err(|e| {
+        MxcError::backend_error(format!("provision envelope serialisation failed: {}", e))
+    })
+}
+
+fn metadata_envelope<R: HasMetadata>(r: R) -> Result<Value, MxcError> {
+    let body = MetadataWireBody {
+        metadata: r.into_metadata(),
+    };
+    let envelope = ResponseEnvelope::Result(body);
+    serde_json::to_value(&envelope).map_err(|e| {
+        MxcError::backend_error(format!("metadata envelope serialisation failed: {}", e))
+    })
+}
+
+fn empty_result_envelope() -> Value {
+    serde_json::json!({"result": {}})
+}
+
+// Lets `metadata_envelope` accept any of the per-phase result types without a
+// long manual match.
+trait HasMetadata {
+    type Metadata: Serialize;
+    fn into_metadata(self) -> Option<Self::Metadata>;
+}
+
+impl<M: Serialize> HasMetadata for StartResult<M> {
+    type Metadata = M;
+    fn into_metadata(self) -> Option<M> {
+        self.metadata
+    }
+}
+impl<M: Serialize> HasMetadata for StopResult<M> {
+    type Metadata = M;
+    fn into_metadata(self) -> Option<M> {
+        self.metadata
+    }
+}
+impl<M: Serialize> HasMetadata for DeprovisionResult<M> {
+    type Metadata = M;
+    fn into_metadata(self) -> Option<M> {
+        self.metadata
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::CodexRequest;
+    use crate::mxc_error::MxcErrorCode;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use std::cell::Cell;
+
+    /// Fully-configurable backend stub for dispatcher tests.
+    /// Each phase is wired to either succeed (the default — empty result with
+    /// no metadata) or fail with a typed `MxcError` (set via the `*_error`
+    /// fields). Calls to each phase method are counted on `*_calls` so tests
+    /// can assert the routing landed on the right method.
+    struct StubBackend {
+        provision_calls: Cell<u32>,
+        start_calls: Cell<u32>,
+        exec_calls: Cell<u32>,
+        stop_calls: Cell<u32>,
+        deprovision_calls: Cell<u32>,
+        validate_provision_calls: Cell<u32>,
+        validate_start_calls: Cell<u32>,
+        validate_exec_calls: Cell<u32>,
+        validate_stop_calls: Cell<u32>,
+        validate_deprovision_calls: Cell<u32>,
+        provision_error: Option<MxcError>,
+        validate_provision_error: Option<MxcError>,
+    }
+
+    impl StubBackend {
+        fn new() -> Self {
+            Self {
+                provision_calls: Cell::new(0),
+                start_calls: Cell::new(0),
+                exec_calls: Cell::new(0),
+                stop_calls: Cell::new(0),
+                deprovision_calls: Cell::new(0),
+                validate_provision_calls: Cell::new(0),
+                validate_start_calls: Cell::new(0),
+                validate_exec_calls: Cell::new(0),
+                validate_stop_calls: Cell::new(0),
+                validate_deprovision_calls: Cell::new(0),
+                provision_error: None,
+                validate_provision_error: None,
+            }
+        }
+    }
+
+    impl StatefulSandboxBackend for StubBackend {
+        const ID_PREFIX: &'static str = "stubd";
+        const BACKEND_KEY: &'static str = "stub_dispatch";
+        type ProvisionConfig = ();
+        type StartConfig = ();
+        type ExecConfig = ();
+        type StopConfig = ();
+        type DeprovisionConfig = ();
+        type ProvisionMetadata = ();
+        type StartMetadata = ();
+        type StopMetadata = ();
+        type DeprovisionMetadata = ();
+
+        fn provision(
+            &mut self,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<ProvisionResult<()>, MxcError> {
+            self.provision_calls.set(self.provision_calls.get() + 1);
+            if let Some(e) = self.provision_error.clone() {
+                return Err(e);
+            }
+            Ok(ProvisionResult {
+                sandbox_id: format!("{}:fixed-token", Self::ID_PREFIX),
+                metadata: None,
+            })
+        }
+        fn start(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<StartResult<()>, MxcError> {
+            self.start_calls.set(self.start_calls.get() + 1);
+            Ok(StartResult { metadata: None })
+        }
+        fn exec(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<ExecHandle, MxcError> {
+            self.exec_calls.set(self.exec_calls.get() + 1);
+            Err(MxcError::backend_error("stub exec not wired"))
+        }
+        fn stop(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<StopResult<()>, MxcError> {
+            self.stop_calls.set(self.stop_calls.get() + 1);
+            Ok(StopResult { metadata: None })
+        }
+        fn deprovision(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<DeprovisionResult<()>, MxcError> {
+            self.deprovision_calls.set(self.deprovision_calls.get() + 1);
+            Ok(DeprovisionResult { metadata: None })
+        }
+
+        fn validate_provision(
+            &self,
+            _request: &CodexRequest,
+            _config: Option<&()>,
+        ) -> Result<(), MxcError> {
+            self.validate_provision_calls
+                .set(self.validate_provision_calls.get() + 1);
+            if let Some(e) = self.validate_provision_error.clone() {
+                return Err(e);
+            }
+            Ok(())
+        }
+        fn validate_start(
+            &self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<&()>,
+        ) -> Result<(), MxcError> {
+            self.validate_start_calls
+                .set(self.validate_start_calls.get() + 1);
+            Ok(())
+        }
+        fn validate_exec(
+            &self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<&()>,
+        ) -> Result<(), MxcError> {
+            self.validate_exec_calls
+                .set(self.validate_exec_calls.get() + 1);
+            Ok(())
+        }
+        fn validate_stop(
+            &self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<&()>,
+        ) -> Result<(), MxcError> {
+            self.validate_stop_calls
+                .set(self.validate_stop_calls.get() + 1);
+            Ok(())
+        }
+        fn validate_deprovision(
+            &self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<&()>,
+        ) -> Result<(), MxcError> {
+            self.validate_deprovision_calls
+                .set(self.validate_deprovision_calls.get() + 1);
+            Ok(())
+        }
+    }
+
+    /// Backend that exercises typed-config deserialisation via
+    /// `ParsedStateAwareRequest::deserialize_config`. The dispatcher's start
+    /// phase must extract `experimental.<BACKEND_KEY>.start` into this type
+    /// and pass it through to `start()`.
+    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Default)]
+    struct TypedStartConfig {
+        configuration_id: String,
+    }
+
+    struct TypedConfigStubBackend {
+        captured_start_config: Cell<Option<TypedStartConfig>>,
+    }
+
+    impl TypedConfigStubBackend {
+        fn new() -> Self {
+            Self {
+                captured_start_config: Cell::new(None),
+            }
+        }
+    }
+
+    impl StatefulSandboxBackend for TypedConfigStubBackend {
+        const ID_PREFIX: &'static str = "typed";
+        const BACKEND_KEY: &'static str = "typed_stub";
+        type ProvisionConfig = ();
+        type StartConfig = TypedStartConfig;
+        type ExecConfig = ();
+        type StopConfig = ();
+        type DeprovisionConfig = ();
+        type ProvisionMetadata = ();
+        type StartMetadata = ();
+        type StopMetadata = ();
+        type DeprovisionMetadata = ();
+
+        fn exec(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            _config: Option<()>,
+        ) -> Result<ExecHandle, MxcError> {
+            Err(MxcError::backend_error("typed stub exec not wired"))
+        }
+
+        fn start(
+            &mut self,
+            _sandbox_id: &str,
+            _request: &CodexRequest,
+            config: Option<TypedStartConfig>,
+        ) -> Result<StartResult<()>, MxcError> {
+            self.captured_start_config.set(config);
+            Ok(StartResult { metadata: None })
+        }
+    }
+
+    fn parsed(
+        phase: Phase,
+        sandbox_id: Option<&str>,
+        exp: Option<Value>,
+    ) -> ParsedStateAwareRequest {
+        ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase,
+            containment: Some(ContainmentBackend::IsolationSession),
+            sandbox_id: sandbox_id.map(String::from),
+            experimental_raw: exp,
+        }
+    }
+
+    fn assert_envelope(outcome: DispatchOutcome) -> Value {
+        match outcome {
+            DispatchOutcome::Envelope(v) => v,
+            DispatchOutcome::ExecCompleted { exit_code } => {
+                panic!(
+                    "expected envelope, got ExecCompleted {{ exit_code: {} }}",
+                    exit_code
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn dispatch_provision_calls_validate_then_provision() {
+        let mut b = StubBackend::new();
+        let env = assert_envelope(
+            dispatch_state_aware(&mut b, parsed(Phase::Provision, None, None), false).unwrap(),
+        );
+        assert_eq!(b.validate_provision_calls.get(), 1);
+        assert_eq!(b.provision_calls.get(), 1);
+        assert_eq!(env, json!({"result": {"sandboxId": "stubd:fixed-token"}}));
+    }
+
+    #[test]
+    fn dispatch_provision_dry_run_skips_provision_call_but_runs_validate() {
+        let mut b = StubBackend::new();
+        let env = assert_envelope(
+            dispatch_state_aware(&mut b, parsed(Phase::Provision, None, None), true).unwrap(),
+        );
+        assert_eq!(b.validate_provision_calls.get(), 1);
+        assert_eq!(b.provision_calls.get(), 0);
+        assert_eq!(env, json!({"result": {}}));
+    }
+
+    #[test]
+    fn dispatch_provision_returns_validate_error_without_calling_provision() {
+        let mut b = StubBackend::new();
+        b.validate_provision_error = Some(MxcError::policy_validation("nope"));
+        let err =
+            dispatch_state_aware(&mut b, parsed(Phase::Provision, None, None), false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::PolicyValidation);
+        assert_eq!(b.validate_provision_calls.get(), 1);
+        assert_eq!(b.provision_calls.get(), 0);
+    }
+
+    #[test]
+    fn dispatch_provision_propagates_provision_error() {
+        let mut b = StubBackend::new();
+        b.provision_error = Some(MxcError::backend_error("boom"));
+        let err =
+            dispatch_state_aware(&mut b, parsed(Phase::Provision, None, None), false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+        assert_eq!(b.provision_calls.get(), 1);
+    }
+
+    #[test]
+    fn dispatch_start_requires_sandbox_id() {
+        let mut b = StubBackend::new();
+        let err =
+            dispatch_state_aware(&mut b, parsed(Phase::Start, None, None), false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert_eq!(b.start_calls.get(), 0);
+    }
+
+    #[test]
+    fn dispatch_start_calls_validate_then_start() {
+        let mut b = StubBackend::new();
+        let env = assert_envelope(
+            dispatch_state_aware(&mut b, parsed(Phase::Start, Some("stubd:abc"), None), false)
+                .unwrap(),
+        );
+        assert_eq!(b.validate_start_calls.get(), 1);
+        assert_eq!(b.start_calls.get(), 1);
+        assert_eq!(env, json!({"result": {}}));
+    }
+
+    #[test]
+    fn dispatch_exec_validate_common_rejects_empty_command_line() {
+        let mut b = StubBackend::new();
+        let err = dispatch_state_aware(&mut b, parsed(Phase::Exec, Some("stubd:abc"), None), false)
+            .unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert_eq!(b.validate_exec_calls.get(), 0);
+        assert_eq!(b.exec_calls.get(), 0);
+    }
+
+    #[test]
+    fn dispatch_exec_dry_run_skips_exec_call() {
+        let mut b = StubBackend::new();
+        let mut p = parsed(Phase::Exec, Some("stubd:abc"), None);
+        p.request.script_code = "echo".into();
+        let env = assert_envelope(dispatch_state_aware(&mut b, p, true).unwrap());
+        assert_eq!(b.validate_exec_calls.get(), 1);
+        assert_eq!(b.exec_calls.get(), 0);
+        assert_eq!(env, json!({"result": {}}));
+    }
+
+    #[test]
+    fn dispatch_stop_routes_correctly() {
+        let mut b = StubBackend::new();
+        assert_envelope(
+            dispatch_state_aware(&mut b, parsed(Phase::Stop, Some("stubd:abc"), None), false)
+                .unwrap(),
+        );
+        assert_eq!(b.validate_stop_calls.get(), 1);
+        assert_eq!(b.stop_calls.get(), 1);
+    }
+
+    #[test]
+    fn dispatch_deprovision_routes_correctly() {
+        let mut b = StubBackend::new();
+        assert_envelope(
+            dispatch_state_aware(
+                &mut b,
+                parsed(Phase::Deprovision, Some("stubd:abc"), None),
+                false,
+            )
+            .unwrap(),
+        );
+        assert_eq!(b.validate_deprovision_calls.get(), 1);
+        assert_eq!(b.deprovision_calls.get(), 1);
+    }
+
+    #[test]
+    fn typed_config_stub_receives_typed_start_config() {
+        let mut b = TypedConfigStubBackend::new();
+        let exp = json!({
+            "typed_stub": { "start": {"configuration_id": "small"} }
+        });
+        let p = parsed(Phase::Start, Some("typed:abc"), Some(exp));
+        assert_envelope(dispatch_state_aware(&mut b, p, false).unwrap());
+        let captured = b.captured_start_config.into_inner();
+        assert_eq!(
+            captured,
+            Some(TypedStartConfig {
+                configuration_id: "small".into()
+            })
+        );
+    }
+
+    #[test]
+    fn typed_config_stub_receives_none_when_experimental_block_absent() {
+        let mut b = TypedConfigStubBackend::new();
+        let p = parsed(Phase::Start, Some("typed:abc"), None);
+        assert_envelope(dispatch_state_aware(&mut b, p, false).unwrap());
+        assert_eq!(b.captured_start_config.into_inner(), None);
+    }
+
+    #[test]
+    fn typed_config_stub_surfaces_shape_mismatch_as_malformed_request() {
+        let mut b = TypedConfigStubBackend::new();
+        // Wrong shape — missing required `configuration_id`.
+        let exp = json!({
+            "typed_stub": { "start": {"wrong_field": 1} }
+        });
+        let p = parsed(Phase::Start, Some("typed:abc"), Some(exp));
+        let err = dispatch_state_aware(&mut b, p, false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+
+    // ---------- run_state_aware / resolve_backend ----------
+
+    #[test]
+    fn run_state_aware_provision_for_recognized_backend_returns_unsupported_phase() {
+        // No state-aware impls registered yet — every recognized backend is
+        // unsupported. Smoke-test scenario #2 from decision 6.
+        let p = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Provision,
+            containment: Some(ContainmentBackend::Wslc),
+            sandbox_id: None,
+            experimental_raw: None,
+        };
+        let err = run_state_aware(p, false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::UnsupportedPhase);
+    }
+
+    #[test]
+    fn run_state_aware_provision_without_containment_is_malformed() {
+        let p = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Provision,
+            containment: None,
+            sandbox_id: None,
+            experimental_raw: None,
+        };
+        let err = run_state_aware(p, false).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+
+    #[test]
+    fn resolve_backend_for_iso_prefix_returns_isolation_session() {
+        let p = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Start,
+            containment: None,
+            sandbox_id: Some("iso:wxc-abcd1234".into()),
+            experimental_raw: None,
+        };
+        assert_eq!(
+            resolve_backend(&p).unwrap(),
+            ContainmentBackend::IsolationSession
+        );
+    }
+
+    #[test]
+    fn resolve_backend_for_unknown_prefix_returns_unsupported_containment() {
+        let p = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Start,
+            containment: None,
+            sandbox_id: Some("unknownxyz:abc".into()),
+            experimental_raw: None,
+        };
+        let err = resolve_backend(&p).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::UnsupportedContainment);
+    }
+
+    #[test]
+    fn resolve_backend_for_malformed_id_surfaces_malformed_id() {
+        let p = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Start,
+            containment: None,
+            sandbox_id: Some("no-colon".into()),
+            experimental_raw: None,
+        };
+        let err = resolve_backend(&p).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedId);
+    }
+}

--- a/src/wxc_common/src/state_aware_dispatch.rs
+++ b/src/wxc_common/src/state_aware_dispatch.rs
@@ -41,20 +41,31 @@ pub enum DispatchOutcome {
 }
 
 /// Maps a parsed state-aware request to its target backend's state-aware
-/// dispatch arm, or surfaces a typed error.
-///
-/// At this stage no backend implements `StatefulSandboxBackend` yet, so every
-/// recognised backend yields `unsupported_phase`. Subsequent commits add an
-/// arm per participating backend.
+/// dispatch arm, or surfaces a typed error. Subsequent commits add an arm
+/// per participating backend; backends without a state-aware impl (or
+/// compiled out via feature flag) fall through to `unsupported_phase`.
 pub fn run_state_aware(
     parsed: ParsedStateAwareRequest,
-    _dry_run: bool,
+    dry_run: bool,
 ) -> Result<DispatchOutcome, MxcError> {
+    // `dry_run` is consumed by per-backend arms below. When no state-aware
+    // arms are compiled in (no participating backends behind active feature
+    // flags), the value is unused — silence the warning rather than
+    // shape-shifting the parameter list per build configuration.
+    let _ = dry_run;
+
     let backend = resolve_backend(&parsed)?;
-    Err(MxcError::unsupported_phase(format!(
-        "backend {:?} does not implement state-aware lifecycle",
-        backend
-    )))
+    match backend {
+        #[cfg(all(target_os = "windows", feature = "isolation_session"))]
+        ContainmentBackend::IsolationSession => {
+            let mut runner = crate::isolation_session_runner::IsolationSessionRunner::new();
+            dispatch_state_aware(&mut runner, parsed, dry_run)
+        }
+        other => Err(MxcError::unsupported_phase(format!(
+            "backend {:?} does not implement state-aware lifecycle",
+            other
+        ))),
+    }
 }
 
 /// Per-backend phase router. The `run_state_aware` arm for a participating

--- a/src/wxc_common/src/state_aware_request.rs
+++ b/src/wxc_common/src/state_aware_request.rs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! State-aware request types — public domain output of the parser.
+//!
+//! `MxcRequest` is the bridge between parser and dispatcher: a one-shot call
+//! produces `MxcRequest::OneShot(CodexRequest)`, a state-aware call produces
+//! `MxcRequest::StateAware(ParsedStateAwareRequest)`. The parser narrows the
+//! discriminator by presence of the wire-format `phase` field.
+//!
+//! `ParsedStateAwareRequest` bundles the inner `CodexRequest` (populated by
+//! the same parser path one-shot uses for cross-cutting fields) with the
+//! state-aware-only fields: `phase`, optional `containment`, optional
+//! `sandbox_id`, and the raw JSON `experimental` block. The dispatcher
+//! resolves the backend, deserialises the per-backend per-phase config from
+//! `experimental_raw` via `deserialize_config<C>`, and asserts
+//! `sandbox_id_required` for non-provision phases.
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::models::{CodexRequest, ContainmentBackend};
+use crate::mxc_error::MxcError;
+
+/// Lifecycle phase in a state-aware request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Phase {
+    Provision,
+    Start,
+    Exec,
+    Stop,
+    Deprovision,
+}
+
+impl Phase {
+    /// Wire-format string for the phase, matching the SDK's `Phase` union.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Provision => "provision",
+            Self::Start => "start",
+            Self::Exec => "exec",
+            Self::Stop => "stop",
+            Self::Deprovision => "deprovision",
+        }
+    }
+
+    /// Parses the wire-format phase string. Unknown values produce
+    /// `MxcError::MalformedRequest`.
+    pub fn from_wire(s: &str) -> Result<Self, MxcError> {
+        match s {
+            "provision" => Ok(Self::Provision),
+            "start" => Ok(Self::Start),
+            "exec" => Ok(Self::Exec),
+            "stop" => Ok(Self::Stop),
+            "deprovision" => Ok(Self::Deprovision),
+            other => Err(MxcError::malformed_request(format!(
+                "unknown phase {:?} (expected provision/start/exec/stop/deprovision)",
+                other
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Parsed state-aware request. Pairs the inner `CodexRequest` with the
+/// state-aware-only wire fields the dispatcher consumes.
+#[derive(Debug, Clone)]
+pub struct ParsedStateAwareRequest {
+    /// Domain model populated from the request's cross-cutting wire fields
+    /// (`process`, `filesystem`, `network`, `ui`) — same path one-shot calls use.
+    /// For non-exec phases the process-related fields (`script_code`,
+    /// `working_directory`, `script_timeout`, `env`) are left at their default
+    /// values; only exec carries process info on the wire.
+    pub request: CodexRequest,
+    pub phase: Phase,
+    /// Present iff the request carried a `containment` field. Required for
+    /// `provision`; for non-provision phases the dispatcher resolves the
+    /// backend from the `sandbox_id` prefix instead.
+    pub containment: Option<ContainmentBackend>,
+    /// Present iff the request carried a `sandboxId` field. Required for all
+    /// non-provision phases; absent for `provision`.
+    pub sandbox_id: Option<String>,
+    /// Raw `experimental` JSON object (un-narrowed). Shape:
+    /// `{ <backend_key>: { <phase_name>: <typed-config>, ... }, ... }`.
+    /// `deserialize_config<C>` navigates the two layers.
+    pub experimental_raw: Option<Value>,
+}
+
+impl ParsedStateAwareRequest {
+    /// Returns the typed per-phase config for the given backend, or `None` if
+    /// the wire request does not carry one. Surfaces shape mismatches as
+    /// `MxcError::MalformedRequest`.
+    ///
+    /// `backend_key` is the wire-format backend name (the `containment`
+    /// string, e.g. "isolation_session") — typically pulled from a trait const
+    /// at the dispatcher.
+    pub fn deserialize_config<C: DeserializeOwned>(
+        &self,
+        backend_key: &str,
+        phase_name: &str,
+    ) -> Result<Option<C>, MxcError> {
+        let Some(exp) = self.experimental_raw.as_ref() else {
+            return Ok(None);
+        };
+        let Some(backend_obj) = exp.get(backend_key) else {
+            return Ok(None);
+        };
+        let Some(phase_value) = backend_obj.get(phase_name) else {
+            return Ok(None);
+        };
+        serde_json::from_value::<C>(phase_value.clone())
+            .map(Some)
+            .map_err(|e| {
+                MxcError::malformed_request(format!(
+                    "invalid config at experimental.{}.{}: {}",
+                    backend_key, phase_name, e
+                ))
+            })
+    }
+
+    /// Returns the `sandbox_id` for non-provision phases. Surfaces a missing
+    /// id as `MxcError::MalformedRequest` — the caller typically only invokes
+    /// this on phases where the wire format requires it.
+    pub fn sandbox_id_required(&self) -> Result<&str, MxcError> {
+        self.sandbox_id.as_deref().ok_or_else(|| {
+            MxcError::malformed_request(format!("phase {} requires a sandboxId", self.phase))
+        })
+    }
+}
+
+/// Public bridge between parser and dispatcher.
+#[derive(Debug, Clone)]
+pub enum MxcRequest {
+    OneShot(CodexRequest),
+    StateAware(ParsedStateAwareRequest),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mxc_error::MxcErrorCode;
+    use serde::Deserialize;
+    use serde_json::json;
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    struct DummyStartConfig {
+        configuration_id: String,
+    }
+
+    fn parsed_with_experimental(exp: Option<Value>, phase: Phase) -> ParsedStateAwareRequest {
+        ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase,
+            containment: None,
+            sandbox_id: None,
+            experimental_raw: exp,
+        }
+    }
+
+    #[test]
+    fn phase_from_wire_round_trip_for_all_variants() {
+        for p in [
+            Phase::Provision,
+            Phase::Start,
+            Phase::Exec,
+            Phase::Stop,
+            Phase::Deprovision,
+        ] {
+            let parsed = Phase::from_wire(p.as_str()).unwrap();
+            assert_eq!(parsed, p);
+        }
+    }
+
+    #[test]
+    fn phase_from_wire_rejects_unknown() {
+        let err = Phase::from_wire("nope").unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+
+    #[test]
+    fn deserialize_config_returns_none_when_no_experimental_block() {
+        let p = parsed_with_experimental(None, Phase::Start);
+        let r = p
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn deserialize_config_returns_none_when_backend_key_absent() {
+        let p = parsed_with_experimental(Some(json!({})), Phase::Start);
+        let r = p
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn deserialize_config_returns_none_when_phase_absent() {
+        let exp = json!({"isolation_session": {}});
+        let p = parsed_with_experimental(Some(exp), Phase::Start);
+        let r = p
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap();
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn deserialize_config_round_trips_typed_config() {
+        let exp = json!({
+            "isolation_session": {
+                "start": { "configuration_id": "small" }
+            }
+        });
+        let p = parsed_with_experimental(Some(exp), Phase::Start);
+        let r = p
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap()
+            .expect("config should be present");
+        assert_eq!(
+            r,
+            DummyStartConfig {
+                configuration_id: "small".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_config_rejects_shape_mismatch_as_malformed_request() {
+        // Missing `configuration_id` — DummyStartConfig requires it.
+        let exp = json!({
+            "isolation_session": { "start": { "wrong_field": 42 } }
+        });
+        let p = parsed_with_experimental(Some(exp), Phase::Start);
+        let err = p
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+
+    #[test]
+    fn sandbox_id_required_returns_id_when_present() {
+        let mut p = parsed_with_experimental(None, Phase::Start);
+        p.sandbox_id = Some("iso:abcd1234".into());
+        assert_eq!(p.sandbox_id_required().unwrap(), "iso:abcd1234");
+    }
+
+    #[test]
+    fn sandbox_id_required_errors_when_absent() {
+        let p = parsed_with_experimental(None, Phase::Start);
+        let err = p.sandbox_id_required().unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+}

--- a/src/wxc_common/src/validator.rs
+++ b/src/wxc_common/src/validator.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::models::{CodexRequest, ScriptResponse};
+use crate::mxc_error::MxcError;
 
 /// Validates non-backend-specific parts of the request (e.g. non-empty script).
 pub fn validate_common(request: &CodexRequest) -> Result<(), ScriptResponse> {
@@ -11,10 +12,23 @@ pub fn validate_common(request: &CodexRequest) -> Result<(), ScriptResponse> {
     Ok(())
 }
 
+/// Cross-backend invariants for state-aware `exec`. The dispatcher calls this
+/// before the backend's own `validate_exec` hook. Only the exec phase has a
+/// common-check today (a non-empty `process.commandLine`).
+pub fn validate_exec_common(request: &CodexRequest) -> Result<(), MxcError> {
+    if request.script_code.is_empty() {
+        return Err(MxcError::malformed_request(
+            "exec phase requires a non-empty process.commandLine",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::validate_common;
+    use super::*;
     use crate::models::CodexRequest;
+    use crate::mxc_error::MxcErrorCode;
 
     #[test]
     fn rejects_empty_script() {
@@ -55,5 +69,21 @@ mod tests {
             "Error should mention empty: {}",
             err.error_message
         );
+    }
+
+    #[test]
+    fn validate_exec_common_rejects_empty_command_line() {
+        let req = CodexRequest::default();
+        let err = validate_exec_common(&req).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+    }
+
+    #[test]
+    fn validate_exec_common_accepts_non_empty_command_line() {
+        let req = CodexRequest {
+            script_code: "echo hello".to_string(),
+            ..Default::default()
+        };
+        assert!(validate_exec_common(&req).is_ok());
     }
 }

--- a/src/wxc_e2e_tests/src/lib.rs
+++ b/src/wxc_e2e_tests/src/lib.rs
@@ -67,11 +67,14 @@ fn current_triple() -> &'static str {
 
 /// Search for a binary in the target directory, checking multiple locations.
 ///
-/// Search order prefers the profile matching the current build mode, then falls
-/// back to the other profile. For each profile, the triple-prefixed
-/// `target/<triple>/<profile>/` path is checked before the plain
-/// `target/<profile>/` path so explicit target builds win over stale local
-/// builds.
+/// Two profile directories may both contain the binary on a given dev host —
+/// the triple-prefixed `target/<triple>/<profile>/` from explicit-target
+/// builds, and the plain `target/<profile>/` that `cargo build` /
+/// `cargo test` write by default. Returning the *most recently modified*
+/// candidate keeps tests aligned with the build the user just ran, instead
+/// of latching onto a stale triple-prefixed copy from a previous session.
+/// Profile preference (debug-vs-release) only resolves ties when neither
+/// candidate has been built more recently than the other.
 pub fn find_binary(name: &str) -> Option<PathBuf> {
     let src = src_dir();
     let (primary, fallback) = if is_release_mode() {
@@ -91,7 +94,12 @@ pub fn find_binary(name: &str) -> Option<PathBuf> {
     }
     candidates.push(src.join("target").join(fallback).join(name));
 
-    candidates.into_iter().find(|p| p.exists())
+    // Pick the most recently modified candidate that exists. Falls back to
+    // existence-order when mtimes are unavailable (read errors).
+    candidates
+        .into_iter()
+        .filter(|p| p.exists())
+        .max_by_key(|p| std::fs::metadata(p).and_then(|m| m.modified()).ok())
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +299,25 @@ pub fn run_wxc_config(config_file: &str, extra_args: &[&str]) -> CommandResult {
     args.push(config.display().to_string());
 
     run_executable(config_file, &exe, args)
+}
+
+/// Run `wxc-exec.exe` with a state-aware request envelope. The JSON value is
+/// serialised, base64-encoded, and passed via `--config-base64`. Used by the
+/// state-aware smoke tests.
+pub fn run_wxc_state_aware(
+    label: &str,
+    request: &serde_json::Value,
+    extra_args: &[&str],
+) -> CommandResult {
+    let exe = find_binary("wxc-exec.exe").expect("wxc-exec.exe should be available");
+    let json = request.to_string();
+    let encoded = STANDARD.encode(json.as_bytes());
+
+    let mut args: Vec<String> = extra_args.iter().map(|s| (*s).to_string()).collect();
+    args.push("--config-base64".to_string());
+    args.push(encoded);
+
+    run_executable(label, &exe, args)
 }
 
 /// Run `wxc-test-driver.exe` against a directory or a single config file.

--- a/src/wxc_e2e_tests/tests/e2e_state_aware.rs
+++ b/src/wxc_e2e_tests/tests/e2e_state_aware.rs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! State-aware dispatcher smoke tests.
+//!
+//! These tests exercise the wire-format invariant that `wxc-exec` reserves
+//! stdout for a single JSON envelope on every state-aware request — even
+//! when no state-aware backend implementation is present yet. They run on
+//! any Windows host that can build `wxc-exec.exe`; no OS-side service
+//! prerequisites are required.
+
+use std::sync::OnceLock;
+
+use serde_json::{json, Value};
+use wxc_e2e_tests::{has_wxc_exe, run_wxc_state_aware, CommandResult};
+
+static HAS_WXC_EXE: OnceLock<bool> = OnceLock::new();
+
+fn cached_has_wxc_exe() -> bool {
+    *HAS_WXC_EXE.get_or_init(has_wxc_exe)
+}
+
+/// Asserts that stdout is exactly one parseable JSON object with an
+/// `error.code` string field, returns that code, and panics with the full
+/// stdout/stderr payload on failure. Stdout content other than the envelope
+/// would invalidate the SDK's stdout-as-envelope assumption.
+fn assert_error_envelope_on_stdout(result: &CommandResult) -> String {
+    let stdout = result.stdout.trim();
+    let parsed: Value = serde_json::from_str(stdout).unwrap_or_else(|e| {
+        panic!(
+            "{} stdout did not parse as JSON: {}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            result.label, e, result.stdout, result.stderr,
+        )
+    });
+    let code = parsed
+        .get("error")
+        .and_then(|e| e.get("code"))
+        .and_then(|c| c.as_str())
+        .unwrap_or_else(|| {
+            panic!(
+                "{} envelope missing error.code\n--- stdout ---\n{}\n--- stderr ---\n{}",
+                result.label, result.stdout, result.stderr,
+            )
+        });
+    code.to_string()
+}
+
+#[test]
+fn state_aware_unknown_containment_emits_error_envelope_on_stdout() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+
+    // The parser rejects an unrecognised `containment` string when discriminating
+    // a state-aware request — exercises the parser-level rejection branch of
+    // the wire-format error contract.
+    let request = json!({
+        "containment": "totally_made_up",
+        "phase": "provision"
+    });
+    let result = run_wxc_state_aware("state-aware unknown containment", &request, &[]);
+    let code = assert_error_envelope_on_stdout(&result);
+    // Parser-level rejection surfaces as malformed_request per the design's
+    // wire-format error model.
+    assert_eq!(
+        code, "malformed_request",
+        "expected malformed_request for unknown containment, got {:?}; stdout={:?}",
+        code, result.stdout
+    );
+    assert_ne!(result.code, Some(0), "non-zero exit expected on error");
+}
+
+#[test]
+fn state_aware_recognized_but_non_state_aware_backend_emits_unsupported_phase() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+
+    // `wslc` is a recognised backend but does not implement the state-aware
+    // trait. The dispatcher should emit `unsupported_phase` per design §8 and
+    // §10. This is the smoke-test scenario that protects the contract once
+    // I-commits land state-aware impls — the assertion will keep working
+    // because `wslc` will remain a non-state-aware backend.
+    let request = json!({
+        "containment": "wslc",
+        "phase": "provision"
+    });
+    let result = run_wxc_state_aware("state-aware non-stateful backend", &request, &[]);
+    let code = assert_error_envelope_on_stdout(&result);
+    assert_eq!(
+        code, "unsupported_phase",
+        "expected unsupported_phase for non-stateful backend, got {:?}; stdout={:?}",
+        code, result.stdout
+    );
+    assert_ne!(result.code, Some(0), "non-zero exit expected on error");
+}

--- a/test_configs/isolation_session_state_aware_deprovision.json
+++ b/test_configs/isolation_session_state_aware_deprovision.json
@@ -1,0 +1,4 @@
+{
+    "phase": "deprovision",
+    "sandboxId": "{{SANDBOX_ID}}"
+}

--- a/test_configs/isolation_session_state_aware_exec_basic.json
+++ b/test_configs/isolation_session_state_aware_exec_basic.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo state-aware-exec-marker",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_cwd.json
+++ b/test_configs/isolation_session_state_aware_exec_cwd.json
@@ -1,0 +1,9 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "cd",
+        "cwd": "C:\\Windows",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_env_absent.json
+++ b/test_configs/isolation_session_state_aware_exec_env_absent.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo %MY_SA_ENV%",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_env_initial.json
+++ b/test_configs/isolation_session_state_aware_exec_env_initial.json
@@ -1,0 +1,9 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo %MY_SA_ENV%",
+        "env": ["MY_SA_ENV=initial-value"],
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_env_modified.json
+++ b/test_configs/isolation_session_state_aware_exec_env_modified.json
@@ -1,0 +1,9 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo %MY_SA_ENV%",
+        "env": ["MY_SA_ENV=modified-value"],
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_exit_0.json
+++ b/test_configs/isolation_session_state_aware_exec_exit_0.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "exit 0",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_exit_1.json
+++ b/test_configs/isolation_session_state_aware_exec_exit_1.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "exit 1",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_exit_2.json
+++ b/test_configs/isolation_session_state_aware_exec_exit_2.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "exit 2",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_read_marker.json
+++ b/test_configs/isolation_session_state_aware_exec_read_marker.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "type %TEMP%\\sa-multi-exec.txt",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_read_persist.json
+++ b/test_configs/isolation_session_state_aware_exec_read_persist.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo %MY_SA_PERSIST%",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_setx_initial.json
+++ b/test_configs/isolation_session_state_aware_exec_setx_initial.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "setx MY_SA_PERSIST initial-persist",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_setx_modified.json
+++ b/test_configs/isolation_session_state_aware_exec_setx_modified.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "setx MY_SA_PERSIST modified-persist",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_exec_write_marker.json
+++ b/test_configs/isolation_session_state_aware_exec_write_marker.json
@@ -1,0 +1,8 @@
+{
+    "phase": "exec",
+    "sandboxId": "{{SANDBOX_ID}}",
+    "process": {
+        "commandLine": "echo multi-exec-marker-content > %TEMP%\\sa-multi-exec.txt",
+        "timeout": 30000
+    }
+}

--- a/test_configs/isolation_session_state_aware_provision.json
+++ b/test_configs/isolation_session_state_aware_provision.json
@@ -1,0 +1,4 @@
+{
+    "phase": "provision",
+    "containment": "isolation_session"
+}

--- a/test_configs/isolation_session_state_aware_provision_rejected_filesystem.json
+++ b/test_configs/isolation_session_state_aware_provision_rejected_filesystem.json
@@ -1,0 +1,7 @@
+{
+    "phase": "provision",
+    "containment": "isolation_session",
+    "filesystem": {
+        "readwritePaths": ["C:\\workspace"]
+    }
+}

--- a/test_configs/isolation_session_state_aware_start.json
+++ b/test_configs/isolation_session_state_aware_start.json
@@ -1,0 +1,4 @@
+{
+    "phase": "start",
+    "sandboxId": "{{SANDBOX_ID}}"
+}

--- a/test_configs/isolation_session_state_aware_stop.json
+++ b/test_configs/isolation_session_state_aware_stop.json
@@ -1,0 +1,4 @@
+{
+    "phase": "stop",
+    "sandboxId": "{{SANDBOX_ID}}"
+}

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -208,6 +208,7 @@ if ($arm -ne 'result') {
 # multi-invocation pattern — provision was a separate wxc-exec process; this
 # is a fresh wxc-exec process consuming the same sandbox_id. Skipped if
 # provision did not return a usable id.
+$startedOk = $false
 if ($null -ne $sandboxId) {
     Write-Host "[start] provision + start sequence" -ForegroundColor Cyan
     $startRequest = @{
@@ -227,7 +228,35 @@ if ($null -ne $sandboxId) {
         Assert-True ($startResult.ExitCode -eq 0) "exit code = 0 on success"
         # Start has no metadata in v1 — `result` should be an empty object.
         Assert-True ($null -eq $startEnv.result.metadata) "result.metadata is absent (no start metadata in v1)"
+        $startedOk = ($startResult.ExitCode -eq 0)
     }
+}
+
+# Test 3: exec runs a command in the started session. Output streams live
+# (the backend reuses the one-shot relay path) so stdout from this
+# wxc-exec invocation is the script's output rather than a JSON envelope.
+# Skipped unless start succeeded.
+if ($startedOk) {
+    Write-Host "[exec] provision + start + exec sequence" -ForegroundColor Cyan
+    $execRequest = @{
+        phase     = 'exec'
+        sandboxId = $sandboxId
+        process   = @{
+            commandLine = 'echo state-aware-exec-marker'
+            timeout     = 30000
+        }
+    }
+    $execResult = Invoke-StateAware -Request $execRequest -Experimental
+
+    Assert-True ($execResult.ExitCode -eq 0) "exit code = 0 on success"
+    Assert-True ($execResult.Stdout -match 'state-aware-exec-marker') `
+        "stdout contains the script's output (streamed live, not enveloped)"
+    # Exec on success does not emit a JSON envelope on stdout — the SDK
+    # discriminates between exec success (raw stdout) and dispatch failure
+    # (JSON envelope) using exit code + envelope-parseability.
+    $maybeEnv = Parse-Envelope -Stdout $execResult.Stdout
+    Assert-True ($null -eq $maybeEnv -or $null -eq $maybeEnv.error) `
+        "stdout is not a state-aware error envelope on success"
 }
 
 # ---------------- Summary ----------------

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -236,6 +236,7 @@ if ($null -ne $sandboxId) {
 # (the backend reuses the one-shot relay path) so stdout from this
 # wxc-exec invocation is the script's output rather than a JSON envelope.
 # Skipped unless start succeeded.
+$execedOk = $false
 if ($startedOk) {
     Write-Host "[exec] provision + start + exec sequence" -ForegroundColor Cyan
     $execRequest = @{
@@ -257,6 +258,31 @@ if ($startedOk) {
     $maybeEnv = Parse-Envelope -Stdout $execResult.Stdout
     Assert-True ($null -eq $maybeEnv -or $null -eq $maybeEnv.error) `
         "stdout is not a state-aware error envelope on success"
+    $execedOk = ($execResult.ExitCode -eq 0)
+}
+
+# Test 4: stop closes the started session. Asserts a clean result envelope
+# with no metadata. Skipped unless exec succeeded (so we know we have a
+# truly running session to stop, not a half-set-up one).
+if ($execedOk) {
+    Write-Host "[stop] full lifecycle through stop" -ForegroundColor Cyan
+    $stopRequest = @{
+        phase     = 'stop'
+        sandboxId = $sandboxId
+    }
+    $stopResult = Invoke-StateAware -Request $stopRequest -Experimental
+    $stopEnv = Parse-Envelope -Stdout $stopResult.Stdout
+    $stopArm = Envelope-Arm $stopEnv
+
+    if ($stopArm -ne 'result') {
+        Write-Host "  Envelope arm: $stopArm" -ForegroundColor Red
+        Write-Host "  Stdout: $($stopResult.Stdout)" -ForegroundColor Gray
+        Write-Host "  Stderr: $($stopResult.Stderr)" -ForegroundColor Gray
+        Assert-True $false "stop returned a result envelope"
+    } else {
+        Assert-True ($stopResult.ExitCode -eq 0) "exit code = 0 on success"
+        Assert-True ($null -eq $stopEnv.result.metadata) "result.metadata is absent (no stop metadata in v1)"
+    }
 }
 
 # ---------------- Summary ----------------

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -1,0 +1,214 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Runs IsolationSession state-aware lifecycle E2E tests. Companion to
+    run_isolation_session_tests.ps1 — that script asserts the one-shot path;
+    this script asserts the state-aware path (`phase` / `sandboxId` envelope
+    style, multi-invocation lifecycle).
+
+.DESCRIPTION
+    Each test invokes wxc-exec.exe with a base64-encoded state-aware request
+    envelope, parses the JSON response on stdout, and asserts on the
+    envelope's `result` or `error` fields. Subsequent commits extend the
+    skeleton with start, exec, stop, and deprovision tests; this revision
+    asserts only the provision phase.
+
+    This script must run INTERACTIVELY on the test host. The OS-side service
+    cohort check rejects network-logon tokens, so PSSession-driven
+    invocations fail with Access Denied. Copy wxc-exec.exe and this script
+    to the host, then run it directly in cmd.exe or PowerShell on that host.
+
+    Prerequisite probes (skip if missing — not a failure):
+      - IsoSessionApp.dll present in System32
+      - WinRT activatable class IsoSessionOps registered
+      - wxc-exec.exe responds to a state-aware request without
+        backend_unavailable (catches feature-flag-off builds)
+
+.PARAMETER WxcExePath
+    Path to wxc-exec.exe. Default probes the host-arch target dir, then
+    other-arch target dir, then the default release/debug dirs.
+
+.EXAMPLE
+    .\run_isolation_session_state_aware_tests.ps1
+    .\run_isolation_session_state_aware_tests.ps1 -WxcExePath C:\test\wxc-exec.exe
+#>
+
+param(
+    [string]$WxcExePath
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+# ---------------- Locate wxc-exec.exe ----------------
+
+$HostTarget = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+    'aarch64-pc-windows-msvc'
+} else {
+    'x86_64-pc-windows-msvc'
+}
+$OtherTarget = if ($HostTarget -eq 'aarch64-pc-windows-msvc') {
+    'x86_64-pc-windows-msvc'
+} else {
+    'aarch64-pc-windows-msvc'
+}
+
+if ($WxcExePath) {
+    $WxcExec = $WxcExePath
+} else {
+    $CandidatePaths = @(
+        (Join-Path $RepoRoot "src\target\$HostTarget\release\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\$OtherTarget\release\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\release\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\$HostTarget\debug\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\$OtherTarget\debug\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\debug\wxc-exec.exe")
+    )
+    $WxcExec = $CandidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
+if (-not $WxcExec -or -not (Test-Path $WxcExec)) {
+    Write-Host "ERROR: wxc-exec.exe not found." -ForegroundColor Red
+    Write-Host "Build with: cargo build --release --features isolation_session --target $HostTarget" -ForegroundColor Yellow
+    Write-Host "Or pass -WxcExePath explicitly." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "`nIsolationSession State-Aware E2E Tests" -ForegroundColor Cyan
+Write-Host "=======================================" -ForegroundColor Cyan
+Write-Host "Binary: $WxcExec`n" -ForegroundColor Gray
+
+# ---------------- Prerequisite probes ----------------
+
+if (-not (Test-Path 'C:\Windows\System32\IsoSessionApp.dll')) {
+    Write-Host "SKIPPED: IsoSessionApp.dll not present in System32" -ForegroundColor Yellow
+    exit 0
+}
+
+$IsoSessionOpsKey = "HKLM:\SOFTWARE\Microsoft\WindowsRuntime\ActivatableClassId\Windows.AI.IsolationSession.IsoSessionOps"
+if (-not (Test-Path $IsoSessionOpsKey)) {
+    Write-Host "SKIPPED: Windows.AI.IsolationSession.IsoSessionOps WinRT class not registered" -ForegroundColor Yellow
+    exit 0
+}
+
+# ---------------- Helpers ----------------
+
+# Encode a state-aware request envelope and run wxc-exec against it. Returns
+# a hashtable with stdout / stderr / exitCode for the caller to assert on.
+function Invoke-StateAware {
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$Request,
+        [switch]$Experimental
+    )
+    $json = $Request | ConvertTo-Json -Compress -Depth 12
+    $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($json))
+
+    $argList = @()
+    if ($Experimental.IsPresent) { $argList += '--experimental' }
+    $argList += @('--config-base64', $b64)
+
+    $stdoutFile = [System.IO.Path]::GetTempFileName()
+    $stderrFile = [System.IO.Path]::GetTempFileName()
+    try {
+        # Start-Process redirects to file so we can capture both streams without
+        # ConPTY interleaving — wxc-exec's stdout must be a single envelope.
+        $proc = Start-Process -FilePath $WxcExec -ArgumentList $argList `
+            -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile `
+            -NoNewWindow -PassThru -Wait
+        @{
+            ExitCode = $proc.ExitCode
+            Stdout   = (Get-Content $stdoutFile -Raw -ErrorAction SilentlyContinue)
+            Stderr   = (Get-Content $stderrFile -Raw -ErrorAction SilentlyContinue)
+        }
+    } finally {
+        Remove-Item $stdoutFile -ErrorAction SilentlyContinue
+        Remove-Item $stderrFile -ErrorAction SilentlyContinue
+    }
+}
+
+# Parses the wxc-exec stdout envelope and returns the parsed object, or
+# $null if the stdout is not valid JSON.
+function Parse-Envelope {
+    param([string]$Stdout)
+    if ([string]::IsNullOrWhiteSpace($Stdout)) { return $null }
+    try { $Stdout | ConvertFrom-Json } catch { $null }
+}
+
+# Returns "result" / "error" / "<empty>" describing which arm of the envelope
+# is present. Useful for failure messages.
+function Envelope-Arm {
+    param($Envelope)
+    if ($null -eq $Envelope) { return '<empty>' }
+    if ($Envelope.PSObject.Properties.Name -contains 'result') { return 'result' }
+    if ($Envelope.PSObject.Properties.Name -contains 'error') { return 'error' }
+    '<unknown>'
+}
+
+# ---------------- Backend-availability probe ----------------
+
+# Sends a state-aware provision request and surfaces a `backend_unavailable`
+# envelope as a SKIP. This catches feature-flag-off builds without raising
+# false test failures.
+$probeRequest = @{
+    phase       = 'provision'
+    containment = 'isolation_session'
+}
+$probe = Invoke-StateAware -Request $probeRequest -Experimental
+$probeEnv = Parse-Envelope -Stdout $probe.Stdout
+if ($null -ne $probeEnv -and $probeEnv.error.code -eq 'backend_unavailable') {
+    Write-Host "SKIPPED: wxc-exec reports backend_unavailable (likely built without --features isolation_session)" -ForegroundColor Yellow
+    exit 0
+}
+
+# ---------------- Tests ----------------
+
+$TestsRun = 0
+$TestsFailed = 0
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    $script:TestsRun++
+    if ($Condition) {
+        Write-Host "  PASS: $Message" -ForegroundColor Green
+    } else {
+        Write-Host "  FAIL: $Message" -ForegroundColor Red
+        $script:TestsFailed++
+    }
+}
+
+# Test 1: provision returns iso:wxc-<8-hex> and a backend_unavailable-free
+# envelope.
+Write-Host "[provision] sandbox_id format" -ForegroundColor Cyan
+$provisionResult = Invoke-StateAware -Request $probeRequest -Experimental
+$provisionEnv = Parse-Envelope -Stdout $provisionResult.Stdout
+$arm = Envelope-Arm $provisionEnv
+
+if ($arm -ne 'result') {
+    Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+    Write-Host "  Stdout: $($provisionResult.Stdout)" -ForegroundColor Gray
+    Write-Host "  Stderr: $($provisionResult.Stderr)" -ForegroundColor Gray
+    Assert-True $false "provision returned a result envelope"
+} else {
+    Assert-True ($provisionResult.ExitCode -eq 0) "exit code = 0 on success"
+    $sandboxId = $provisionEnv.result.sandboxId
+    $agentUserName = $provisionEnv.result.metadata.agentUserName
+    Assert-True ($sandboxId -match '^iso:wxc-[0-9a-f]{8}$') "sandbox_id matches iso:wxc-<8-hex> ($sandboxId)"
+    Assert-True ($null -ne $agentUserName) "metadata.agentUserName is present ($agentUserName)"
+    # TODO(I5): once deprovision lands, wrap this test body in try-finally and
+    # call deprovision on $sandboxId to avoid leaking the agent user across
+    # test runs. Until then, the OS-side service retains the registration —
+    # acceptable while we are validating early phases only.
+}
+
+# ---------------- Summary ----------------
+
+Write-Host ""
+if ($TestsFailed -eq 0) {
+    Write-Host "ALL $TestsRun TESTS PASSED" -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "$TestsFailed of $TestsRun TESTS FAILED" -ForegroundColor Red
+    exit 1
+}

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -453,7 +453,22 @@ try {
         if ($deprovPassed) { $deprovisionedOk = $true }
     }
 
-    # Test 11: stale_id detection. The just-deprovisioned $sandboxId is now
+    # Test 11: policy_validation rejects unsupported cross-cutting fields.
+    # IsolationSession does not honour filesystem / network / ui / proxy at
+    # any phase (per the plan-doc honor matrix). validate_<phase> hooks must
+    # surface a `policy_validation` error envelope for any request that
+    # carries these fields. Runs as its own provision attempt -- no sandbox
+    # is created, so no cleanup is required.
+    Run-StateAwareTest "policy_validation (unsupported filesystem field rejected)" {
+        $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision_rejected_filesystem.json' -Experimental
+        Assert-True ($r.ExitCode -ne 0) "exit code is non-zero (policy rejected)"
+        $envObj = Parse-Envelope -Stdout $r.Stdout
+        Assert-True ($null -ne $envObj) "stdout is a parseable envelope"
+        $code = if ($envObj) { $envObj.error.code } else { '<no envelope>' }
+        Assert-True ($code -eq 'policy_validation') "error.code is 'policy_validation' (got '$code')"
+    } | Out-Null
+
+    # Test 12: stale_id detection. The just-deprovisioned $sandboxId is now
     # unknown to the OS-side service. Calling stop against it must surface
     # `MxcError::StaleId` (wire `error.code = "stale_id"`), proving the
     # Rust-layer ERROR_NOT_FOUND HRESULT detection is wired through the

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -4,7 +4,7 @@
 <#
 .SYNOPSIS
     Runs IsolationSession state-aware lifecycle E2E tests. Companion to
-    run_isolation_session_tests.ps1 — that script asserts the one-shot path;
+    run_isolation_session_tests.ps1 --that script asserts the one-shot path;
     this script asserts the state-aware path (`phase` / `sandboxId` envelope
     style, multi-invocation lifecycle).
 
@@ -16,11 +16,12 @@
     asserts only the provision phase.
 
     This script must run INTERACTIVELY on the test host. The OS-side service
-    cohort check rejects network-logon tokens, so PSSession-driven
-    invocations fail with Access Denied. Copy wxc-exec.exe and this script
-    to the host, then run it directly in cmd.exe or PowerShell on that host.
+    calling-process identity check rejects network-logon tokens, so
+    PSSession-driven invocations fail with Access Denied. Copy wxc-exec.exe
+    and this script to the host, then run it directly in cmd.exe or
+    PowerShell on that host.
 
-    Prerequisite probes (skip if missing — not a failure):
+    Prerequisite probes (skip if missing --not a failure):
       - IsoSessionApp.dll present in System32
       - WinRT activatable class IsoSessionOps registered
       - wxc-exec.exe responds to a state-aware request without
@@ -113,7 +114,7 @@ function Invoke-StateAware {
     $stderrFile = [System.IO.Path]::GetTempFileName()
     try {
         # Start-Process redirects to file so we can capture both streams without
-        # ConPTY interleaving — wxc-exec's stdout must be a single envelope.
+        # ConPTY interleaving --wxc-exec's stdout must be a single envelope.
         $proc = Start-Process -FilePath $WxcExec -ArgumentList $argList `
             -RedirectStandardOutput $stdoutFile -RedirectStandardError $stderrFile `
             -NoNewWindow -PassThru -Wait
@@ -178,14 +179,19 @@ function Assert-True {
     }
 }
 
+# try-finally wraps the lifecycle so any mid-flow failure still triggers a
+# best-effort deprovision. Mirrors the defensive cleanup in
+# IsolationSessionRunner::execute -- failed runs do not leak Indefinite-
+# lifetime agent users across test runs.
+$sandboxId = $null
+try {
+
 # Test 1: provision returns iso:wxc-<8-hex> and a backend_unavailable-free
 # envelope.
 Write-Host "[provision] sandbox_id format" -ForegroundColor Cyan
 $provisionResult = Invoke-StateAware -Request $probeRequest -Experimental
 $provisionEnv = Parse-Envelope -Stdout $provisionResult.Stdout
 $arm = Envelope-Arm $provisionEnv
-
-$sandboxId = $null
 
 if ($arm -ne 'result') {
     Write-Host "  Envelope arm: $arm" -ForegroundColor Red
@@ -198,14 +204,10 @@ if ($arm -ne 'result') {
     $agentUserName = $provisionEnv.result.metadata.agentUserName
     Assert-True ($sandboxId -match '^iso:wxc-[0-9a-f]{8}$') "sandbox_id matches iso:wxc-<8-hex> ($sandboxId)"
     Assert-True ($null -ne $agentUserName) "metadata.agentUserName is present ($agentUserName)"
-    # TODO(I5): once deprovision lands, wrap this test body in try-finally and
-    # call deprovision on $sandboxId to avoid leaking the agent user across
-    # test runs. Until then, the OS-side service retains the registration —
-    # acceptable while we are validating early phases only.
 }
 
 # Test 2: start succeeds against the provisioned sandbox. Exercises the
-# multi-invocation pattern — provision was a separate wxc-exec process; this
+# multi-invocation pattern --provision was a separate wxc-exec process; this
 # is a fresh wxc-exec process consuming the same sandbox_id. Skipped if
 # provision did not return a usable id.
 $startedOk = $false
@@ -226,7 +228,7 @@ if ($null -ne $sandboxId) {
         Assert-True $false "start returned a result envelope"
     } else {
         Assert-True ($startResult.ExitCode -eq 0) "exit code = 0 on success"
-        # Start has no metadata in v1 — `result` should be an empty object.
+        # Start has no metadata in v1 --`result` should be an empty object.
         Assert-True ($null -eq $startEnv.result.metadata) "result.metadata is absent (no start metadata in v1)"
         $startedOk = ($startResult.ExitCode -eq 0)
     }
@@ -252,7 +254,7 @@ if ($startedOk) {
     Assert-True ($execResult.ExitCode -eq 0) "exit code = 0 on success"
     Assert-True ($execResult.Stdout -match 'state-aware-exec-marker') `
         "stdout contains the script's output (streamed live, not enveloped)"
-    # Exec on success does not emit a JSON envelope on stdout — the SDK
+    # Exec on success does not emit a JSON envelope on stdout --the SDK
     # discriminates between exec success (raw stdout) and dispatch failure
     # (JSON envelope) using exit code + envelope-parseability.
     $maybeEnv = Parse-Envelope -Stdout $execResult.Stdout
@@ -264,6 +266,7 @@ if ($startedOk) {
 # Test 4: stop closes the started session. Asserts a clean result envelope
 # with no metadata. Skipped unless exec succeeded (so we know we have a
 # truly running session to stop, not a half-set-up one).
+$stoppedOk = $false
 if ($execedOk) {
     Write-Host "[stop] full lifecycle through stop" -ForegroundColor Cyan
     $stopRequest = @{
@@ -282,6 +285,58 @@ if ($execedOk) {
     } else {
         Assert-True ($stopResult.ExitCode -eq 0) "exit code = 0 on success"
         Assert-True ($null -eq $stopEnv.result.metadata) "result.metadata is absent (no stop metadata in v1)"
+        $stoppedOk = ($stopResult.ExitCode -eq 0)
+    }
+}
+
+# Test 5: deprovision tears down the agent user and unregisters the client.
+# After this test, $sandboxId is no longer addressable -- the finally block
+# below skips its cleanup pass when this test ran.
+$deprovisionedOk = $false
+if ($stoppedOk) {
+    Write-Host "[deprovision] full lifecycle through deprovision" -ForegroundColor Cyan
+    $deprovRequest = @{
+        phase     = 'deprovision'
+        sandboxId = $sandboxId
+    }
+    $deprovResult = Invoke-StateAware -Request $deprovRequest -Experimental
+    $deprovEnv = Parse-Envelope -Stdout $deprovResult.Stdout
+    $deprovArm = Envelope-Arm $deprovEnv
+
+    if ($deprovArm -ne 'result') {
+        Write-Host "  Envelope arm: $deprovArm" -ForegroundColor Red
+        Write-Host "  Stdout: $($deprovResult.Stdout)" -ForegroundColor Gray
+        Write-Host "  Stderr: $($deprovResult.Stderr)" -ForegroundColor Gray
+        Assert-True $false "deprovision returned a result envelope"
+    } else {
+        Assert-True ($deprovResult.ExitCode -eq 0) "exit code = 0 on success"
+        Assert-True ($null -eq $deprovEnv.result.metadata) "result.metadata is absent (no deprovision metadata in v1)"
+        $deprovisionedOk = $true
+    }
+}
+
+} finally {
+    # Best-effort cleanup. If the suite reached the deprovision test and it
+    # succeeded, the agent user is already torn down -- nothing to do. If
+    # the suite failed mid-flow, this still runs so a leaked Indefinite-
+    # lifetime agent user does not survive across test runs.
+    if ($null -ne $sandboxId -and -not $deprovisionedOk) {
+        Write-Host "" -ForegroundColor Gray
+        Write-Host "[cleanup] best-effort deprovision of $sandboxId" -ForegroundColor DarkGray
+        $cleanupRequest = @{
+            phase     = 'deprovision'
+            sandboxId = $sandboxId
+        }
+        try {
+            $cleanupResult = Invoke-StateAware -Request $cleanupRequest -Experimental
+            if ($cleanupResult.ExitCode -eq 0) {
+                Write-Host "  cleanup deprovision succeeded" -ForegroundColor DarkGray
+            } else {
+                Write-Host "  cleanup deprovision exit $($cleanupResult.ExitCode); stdout: $($cleanupResult.Stdout)" -ForegroundColor DarkGray
+            }
+        } catch {
+            Write-Host "  cleanup deprovision threw: $($_.Exception.Message)" -ForegroundColor DarkGray
+        }
     }
 }
 

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -185,6 +185,8 @@ $provisionResult = Invoke-StateAware -Request $probeRequest -Experimental
 $provisionEnv = Parse-Envelope -Stdout $provisionResult.Stdout
 $arm = Envelope-Arm $provisionEnv
 
+$sandboxId = $null
+
 if ($arm -ne 'result') {
     Write-Host "  Envelope arm: $arm" -ForegroundColor Red
     Write-Host "  Stdout: $($provisionResult.Stdout)" -ForegroundColor Gray
@@ -200,6 +202,32 @@ if ($arm -ne 'result') {
     # call deprovision on $sandboxId to avoid leaking the agent user across
     # test runs. Until then, the OS-side service retains the registration —
     # acceptable while we are validating early phases only.
+}
+
+# Test 2: start succeeds against the provisioned sandbox. Exercises the
+# multi-invocation pattern — provision was a separate wxc-exec process; this
+# is a fresh wxc-exec process consuming the same sandbox_id. Skipped if
+# provision did not return a usable id.
+if ($null -ne $sandboxId) {
+    Write-Host "[start] provision + start sequence" -ForegroundColor Cyan
+    $startRequest = @{
+        phase     = 'start'
+        sandboxId = $sandboxId
+    }
+    $startResult = Invoke-StateAware -Request $startRequest -Experimental
+    $startEnv = Parse-Envelope -Stdout $startResult.Stdout
+    $startArm = Envelope-Arm $startEnv
+
+    if ($startArm -ne 'result') {
+        Write-Host "  Envelope arm: $startArm" -ForegroundColor Red
+        Write-Host "  Stdout: $($startResult.Stdout)" -ForegroundColor Gray
+        Write-Host "  Stderr: $($startResult.Stderr)" -ForegroundColor Gray
+        Assert-True $false "start returned a result envelope"
+    } else {
+        Assert-True ($startResult.ExitCode -eq 0) "exit code = 0 on success"
+        # Start has no metadata in v1 — `result` should be an empty object.
+        Assert-True ($null -eq $startEnv.result.metadata) "result.metadata is absent (no start metadata in v1)"
+    }
 }
 
 # ---------------- Summary ----------------

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -453,6 +453,22 @@ try {
         if ($deprovPassed) { $deprovisionedOk = $true }
     }
 
+    # Test 11: stale_id detection. The just-deprovisioned $sandboxId is now
+    # unknown to the OS-side service. Calling stop against it must surface
+    # `MxcError::StaleId` (wire `error.code = "stale_id"`), proving the
+    # Rust-layer ERROR_NOT_FOUND HRESULT detection is wired through the
+    # backend impl all the way to the wire envelope.
+    if ($deprovisionedOk) {
+        Run-StateAwareTest "stale_id (stop on previously-deprovisioned sandbox)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($r.ExitCode -ne 0) "exit code is non-zero (stop on stale sandbox failed as expected)"
+            $envObj = Parse-Envelope -Stdout $r.Stdout
+            Assert-True ($null -ne $envObj) "stdout is a parseable envelope"
+            $code = if ($envObj) { $envObj.error.code } else { '<no envelope>' }
+            Assert-True ($code -eq 'stale_id') "error.code is 'stale_id' (got '$code')"
+        } | Out-Null
+    }
+
 } finally {
     # Best-effort cleanup. If the suite reached the deprovision test and it
     # succeeded, the agent user is already torn down -- nothing to do. If

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -31,13 +31,19 @@
     Path to wxc-exec.exe. Default probes the host-arch target dir, then
     other-arch target dir, then the default release/debug dirs.
 
+.PARAMETER ConfigDir
+    Directory holding the state-aware request fixture JSON files. Defaults
+    to <repo>/test_configs. Override on the VM where the deployed layout
+    differs from the repo layout.
+
 .EXAMPLE
     .\run_isolation_session_state_aware_tests.ps1
-    .\run_isolation_session_state_aware_tests.ps1 -WxcExePath C:\test\wxc-exec.exe
+    .\run_isolation_session_state_aware_tests.ps1 -WxcExePath C:\test\wxc-exec.exe -ConfigDir C:\test\test_configs
 #>
 
 param(
-    [string]$WxcExePath
+    [string]$WxcExePath,
+    [string]$ConfigDir
 )
 
 $ErrorActionPreference = "Stop"
@@ -96,14 +102,46 @@ if (-not (Test-Path $IsoSessionOpsKey)) {
 
 # ---------------- Helpers ----------------
 
-# Encode a state-aware request envelope and run wxc-exec against it. Returns
-# a hashtable with stdout / stderr / exitCode for the caller to assert on.
+# Resolve the directory holding state-aware request fixtures. The -ConfigDir
+# CLI parameter wins when supplied; otherwise default to <repo>/test_configs
+# computed from $RepoRoot.
+if (-not $ConfigDir) {
+    $ConfigDir = Join-Path $RepoRoot "test_configs"
+}
+
+# Encode a state-aware request envelope and run wxc-exec against it. The
+# request comes either from an in-line hashtable or from a static JSON
+# fixture file under test_configs/ (for the project-wide "test scenarios are
+# version-controlled JSON" pattern). When the fixture contains the
+# placeholder `{{SANDBOX_ID}}`, the caller must supply -SandboxId so it can
+# be substituted before the request is base64-encoded. Returns a hashtable
+# with stdout / stderr / exitCode for the caller to assert on.
 function Invoke-StateAware {
     param(
-        [Parameter(Mandatory = $true)] [hashtable]$Request,
+        [hashtable]$Request,
+        [string]$ConfigFile,
+        [string]$SandboxId,
         [switch]$Experimental
     )
-    $json = $Request | ConvertTo-Json -Compress -Depth 12
+
+    if ($ConfigFile) {
+        $path = Join-Path $ConfigDir $ConfigFile
+        if (-not (Test-Path $path)) {
+            throw "Config fixture not found: $path"
+        }
+        $json = Get-Content $path -Raw
+        if ($json -match '\{\{SANDBOX_ID\}\}') {
+            if (-not $SandboxId) {
+                throw "Fixture $ConfigFile contains {{SANDBOX_ID}} but -SandboxId was not supplied"
+            }
+            $json = $json -replace '\{\{SANDBOX_ID\}\}', $SandboxId
+        }
+    } elseif ($Request) {
+        $json = $Request | ConvertTo-Json -Compress -Depth 12
+    } else {
+        throw "Invoke-StateAware requires either -Request or -ConfigFile"
+    }
+
     $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($json))
 
     $argList = @()
@@ -152,11 +190,7 @@ function Envelope-Arm {
 # Sends a state-aware provision request and surfaces a `backend_unavailable`
 # envelope as a SKIP. This catches feature-flag-off builds without raising
 # false test failures.
-$probeRequest = @{
-    phase       = 'provision'
-    containment = 'isolation_session'
-}
-$probe = Invoke-StateAware -Request $probeRequest -Experimental
+$probe = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision.json' -Experimental
 $probeEnv = Parse-Envelope -Stdout $probe.Stdout
 if ($null -ne $probeEnv -and $probeEnv.error.code -eq 'backend_unavailable') {
     Write-Host "SKIPPED: wxc-exec reports backend_unavailable (likely built without --features isolation_session)" -ForegroundColor Yellow
@@ -165,170 +199,270 @@ if ($null -ne $probeEnv -and $probeEnv.error.code -eq 'backend_unavailable') {
 
 # ---------------- Tests ----------------
 
-$TestsRun = 0
-$TestsFailed = 0
+$script:TestResults = @()
+$script:currentTestPassed = $true
+$script:currentTestFirstFailReason = $null
 
+# Records assertion outcomes for the active Run-StateAwareTest. Per-assertion
+# detail is still printed inline so failures show exactly which dimension
+# broke; the test as a whole passes iff every assertion in its body passed.
 function Assert-True {
     param([bool]$Condition, [string]$Message)
-    $script:TestsRun++
     if ($Condition) {
         Write-Host "  PASS: $Message" -ForegroundColor Green
     } else {
         Write-Host "  FAIL: $Message" -ForegroundColor Red
-        $script:TestsFailed++
+        if ($script:currentTestPassed) {
+            $script:currentTestFirstFailReason = $Message
+        }
+        $script:currentTestPassed = $false
     }
+}
+
+# Wraps a logical test (one phase, one phase-pair, or one multi-exec
+# scenario). Prints the test name as a section header, runs the body
+# (which uses Assert-True for per-dimension checks), and records one
+# pass/fail entry in TestResults so the final summary can match the
+# project's other PowerShell runners. Returns the overall pass state so
+# callers can gate subsequent tests.
+function Run-StateAwareTest {
+    param(
+        [string]$Name,
+        [scriptblock]$Body
+    )
+    Write-Host ""
+    Write-Host "[$Name]" -ForegroundColor Cyan
+    $script:currentTestPassed = $true
+    $script:currentTestFirstFailReason = $null
+    & $Body
+    $script:TestResults += [pscustomobject]@{
+        Name   = $Name
+        Passed = $script:currentTestPassed
+        Reason = $script:currentTestFirstFailReason
+    }
+    return $script:currentTestPassed
 }
 
 # try-finally wraps the lifecycle so any mid-flow failure still triggers a
 # best-effort deprovision. Mirrors the defensive cleanup in
 # IsolationSessionRunner::execute -- failed runs do not leak Indefinite-
 # lifetime agent users across test runs.
-$sandboxId = $null
+$script:sandboxId = $null
+$deprovisionedOk = $false
 try {
 
-# Test 1: provision returns iso:wxc-<8-hex> and a backend_unavailable-free
-# envelope.
-Write-Host "[provision] sandbox_id format" -ForegroundColor Cyan
-$provisionResult = Invoke-StateAware -Request $probeRequest -Experimental
-$provisionEnv = Parse-Envelope -Stdout $provisionResult.Stdout
-$arm = Envelope-Arm $provisionEnv
+    # Test 1: provision returns iso:wxc-<8-hex> and a backend_unavailable-free
+    # envelope.
+    Run-StateAwareTest "provision (sandbox_id format)" {
+        $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision.json' -Experimental
+        $envObj = Parse-Envelope -Stdout $r.Stdout
+        $arm = Envelope-Arm $envObj
+        if ($arm -ne 'result') {
+            Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+            Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+            Write-Host "  Stderr: $($r.Stderr)" -ForegroundColor Gray
+            Assert-True $false "provision returned a result envelope"
+        } else {
+            Assert-True ($r.ExitCode -eq 0) "exit code = 0 on success"
+            $script:sandboxId = $envObj.result.sandboxId
+            $agentUserName = $envObj.result.metadata.agentUserName
+            Assert-True ($script:sandboxId -match '^iso:wxc-[0-9a-f]{8}$') "sandbox_id matches iso:wxc-<8-hex> ($script:sandboxId)"
+            Assert-True ($null -ne $agentUserName) "metadata.agentUserName is present ($agentUserName)"
+        }
+    } | Out-Null
 
-if ($arm -ne 'result') {
-    Write-Host "  Envelope arm: $arm" -ForegroundColor Red
-    Write-Host "  Stdout: $($provisionResult.Stdout)" -ForegroundColor Gray
-    Write-Host "  Stderr: $($provisionResult.Stderr)" -ForegroundColor Gray
-    Assert-True $false "provision returned a result envelope"
-} else {
-    Assert-True ($provisionResult.ExitCode -eq 0) "exit code = 0 on success"
-    $sandboxId = $provisionEnv.result.sandboxId
-    $agentUserName = $provisionEnv.result.metadata.agentUserName
-    Assert-True ($sandboxId -match '^iso:wxc-[0-9a-f]{8}$') "sandbox_id matches iso:wxc-<8-hex> ($sandboxId)"
-    Assert-True ($null -ne $agentUserName) "metadata.agentUserName is present ($agentUserName)"
-}
-
-# Test 2: start succeeds against the provisioned sandbox. Exercises the
-# multi-invocation pattern --provision was a separate wxc-exec process; this
-# is a fresh wxc-exec process consuming the same sandbox_id. Skipped if
-# provision did not return a usable id.
-$startedOk = $false
-if ($null -ne $sandboxId) {
-    Write-Host "[start] provision + start sequence" -ForegroundColor Cyan
-    $startRequest = @{
-        phase     = 'start'
-        sandboxId = $sandboxId
-    }
-    $startResult = Invoke-StateAware -Request $startRequest -Experimental
-    $startEnv = Parse-Envelope -Stdout $startResult.Stdout
-    $startArm = Envelope-Arm $startEnv
-
-    if ($startArm -ne 'result') {
-        Write-Host "  Envelope arm: $startArm" -ForegroundColor Red
-        Write-Host "  Stdout: $($startResult.Stdout)" -ForegroundColor Gray
-        Write-Host "  Stderr: $($startResult.Stderr)" -ForegroundColor Gray
-        Assert-True $false "start returned a result envelope"
-    } else {
-        Assert-True ($startResult.ExitCode -eq 0) "exit code = 0 on success"
-        # Start has no metadata in v1 --`result` should be an empty object.
-        Assert-True ($null -eq $startEnv.result.metadata) "result.metadata is absent (no start metadata in v1)"
-        $startedOk = ($startResult.ExitCode -eq 0)
-    }
-}
-
-# Test 3: exec runs a command in the started session. Output streams live
-# (the backend reuses the one-shot relay path) so stdout from this
-# wxc-exec invocation is the script's output rather than a JSON envelope.
-# Skipped unless start succeeded.
-$execedOk = $false
-if ($startedOk) {
-    Write-Host "[exec] provision + start + exec sequence" -ForegroundColor Cyan
-    $execRequest = @{
-        phase     = 'exec'
-        sandboxId = $sandboxId
-        process   = @{
-            commandLine = 'echo state-aware-exec-marker'
-            timeout     = 30000
+    # Test 2: start succeeds against the provisioned sandbox. Exercises the
+    # multi-invocation pattern -- provision was a separate wxc-exec process;
+    # this is a fresh wxc-exec process consuming the same sandbox_id.
+    $startedOk = $false
+    if ($null -ne $script:sandboxId) {
+        $startedOk = Run-StateAwareTest "start (provision + start sequence)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_start.json' -SandboxId $script:sandboxId -Experimental
+            $envObj = Parse-Envelope -Stdout $r.Stdout
+            $arm = Envelope-Arm $envObj
+            if ($arm -ne 'result') {
+                Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+                Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+                Write-Host "  Stderr: $($r.Stderr)" -ForegroundColor Gray
+                Assert-True $false "start returned a result envelope"
+            } else {
+                Assert-True ($r.ExitCode -eq 0) "exit code = 0 on success"
+                # Start has no metadata in v1 -- `result` should be an empty object.
+                Assert-True ($null -eq $envObj.result.metadata) "result.metadata is absent (no start metadata in v1)"
+            }
         }
     }
-    $execResult = Invoke-StateAware -Request $execRequest -Experimental
 
-    Assert-True ($execResult.ExitCode -eq 0) "exit code = 0 on success"
-    Assert-True ($execResult.Stdout -match 'state-aware-exec-marker') `
-        "stdout contains the script's output (streamed live, not enveloped)"
-    # Exec on success does not emit a JSON envelope on stdout --the SDK
-    # discriminates between exec success (raw stdout) and dispatch failure
-    # (JSON envelope) using exit code + envelope-parseability.
-    $maybeEnv = Parse-Envelope -Stdout $execResult.Stdout
-    Assert-True ($null -eq $maybeEnv -or $null -eq $maybeEnv.error) `
-        "stdout is not a state-aware error envelope on success"
-    $execedOk = ($execResult.ExitCode -eq 0)
-}
-
-# Test 4: stop closes the started session. Asserts a clean result envelope
-# with no metadata. Skipped unless exec succeeded (so we know we have a
-# truly running session to stop, not a half-set-up one).
-$stoppedOk = $false
-if ($execedOk) {
-    Write-Host "[stop] full lifecycle through stop" -ForegroundColor Cyan
-    $stopRequest = @{
-        phase     = 'stop'
-        sandboxId = $sandboxId
+    # Test 3: exec runs a command in the started session. Output streams live
+    # (the backend reuses the one-shot relay path) so stdout from this
+    # wxc-exec invocation is the script's output rather than a JSON envelope.
+    $execedOk = $false
+    if ($startedOk) {
+        $execedOk = Run-StateAwareTest "exec (basic)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_basic.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($r.ExitCode -eq 0) "exit code = 0 on success"
+            Assert-True ($r.Stdout -match 'state-aware-exec-marker') `
+                "stdout contains the script's output (streamed live, not enveloped)"
+            # Exec on success does not emit a JSON envelope on stdout -- the
+            # SDK discriminates between exec success (raw stdout) and dispatch
+            # failure (JSON envelope) using exit code + envelope-parseability.
+            $maybeEnv = Parse-Envelope -Stdout $r.Stdout
+            Assert-True ($null -eq $maybeEnv -or $null -eq $maybeEnv.error) `
+                "stdout is not a state-aware error envelope on success"
+        }
     }
-    $stopResult = Invoke-StateAware -Request $stopRequest -Experimental
-    $stopEnv = Parse-Envelope -Stdout $stopResult.Stdout
-    $stopArm = Envelope-Arm $stopEnv
 
-    if ($stopArm -ne 'result') {
-        Write-Host "  Envelope arm: $stopArm" -ForegroundColor Red
-        Write-Host "  Stdout: $($stopResult.Stdout)" -ForegroundColor Gray
-        Write-Host "  Stderr: $($stopResult.Stderr)" -ForegroundColor Gray
-        Assert-True $false "stop returned a result envelope"
-    } else {
-        Assert-True ($stopResult.ExitCode -eq 0) "exit code = 0 on success"
-        Assert-True ($null -eq $stopEnv.result.metadata) "result.metadata is absent (no stop metadata in v1)"
-        $stoppedOk = ($stopResult.ExitCode -eq 0)
+    # Test 4: filesystem state continuity across separate wxc-exec invocations
+    # against the same sandbox_id. exec #1 writes a marker file to the agent
+    # user's TEMP, exec #2 reads it back. Each exec is a fresh wxc-exec
+    # process consuming the same sandbox_id, exercising the cross-process
+    # state-aware path.
+    if ($execedOk) {
+        Run-StateAwareTest "multi-exec (filesystem state continuity)" {
+            $w = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_write_marker.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($w.ExitCode -eq 0) "exec #1 (write) exit code = 0"
+            $rd = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_read_marker.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($rd.ExitCode -eq 0) "exec #2 (read) exit code = 0"
+            Assert-True ($rd.Stdout -match 'multi-exec-marker-content') `
+                "exec #2 stdout contains the marker exec #1 wrote (state preserved across wxc-exec processes)"
+        } | Out-Null
     }
-}
 
-# Test 5: deprovision tears down the agent user and unregisters the client.
-# After this test, $sandboxId is no longer addressable -- the finally block
-# below skips its cleanup pass when this test ran.
-$deprovisionedOk = $false
-if ($stoppedOk) {
-    Write-Host "[deprovision] full lifecycle through deprovision" -ForegroundColor Cyan
-    $deprovRequest = @{
-        phase     = 'deprovision'
-        sandboxId = $sandboxId
+    # Test 5: exit code propagation across multiple exec invocations. Three
+    # invocations exit with 1, 2, 0 in sequence. Each invocation must report
+    # its own exit code (catches stale exit code leaking between calls), and
+    # the third exec succeeding after two non-zero exits proves a non-zero
+    # exit doesn't leave the session in a broken state.
+    if ($execedOk) {
+        Run-StateAwareTest "multi-exec (exit code propagation)" {
+            foreach ($pair in @(
+                    @{ file = 'isolation_session_state_aware_exec_exit_1.json'; code = 1 },
+                    @{ file = 'isolation_session_state_aware_exec_exit_2.json'; code = 2 },
+                    @{ file = 'isolation_session_state_aware_exec_exit_0.json'; code = 0 }
+                )) {
+                $r = Invoke-StateAware -ConfigFile $pair.file -SandboxId $script:sandboxId -Experimental
+                Assert-True ($r.ExitCode -eq $pair.code) `
+                    "exec 'exit $($pair.code)' propagates exit code $($pair.code) (got $($r.ExitCode))"
+            }
+        } | Out-Null
     }
-    $deprovResult = Invoke-StateAware -Request $deprovRequest -Experimental
-    $deprovEnv = Parse-Envelope -Stdout $deprovResult.Stdout
-    $deprovArm = Envelope-Arm $deprovEnv
 
-    if ($deprovArm -ne 'result') {
-        Write-Host "  Envelope arm: $deprovArm" -ForegroundColor Red
-        Write-Host "  Stdout: $($deprovResult.Stdout)" -ForegroundColor Gray
-        Write-Host "  Stderr: $($deprovResult.Stderr)" -ForegroundColor Gray
-        Assert-True $false "deprovision returned a result envelope"
-    } else {
-        Assert-True ($deprovResult.ExitCode -eq 0) "exit code = 0 on success"
-        Assert-True ($null -eq $deprovEnv.result.metadata) "result.metadata is absent (no deprovision metadata in v1)"
-        $deprovisionedOk = $true
+    # Test 6: working_directory wire-field plumbing. Sets cwd via the wire
+    # request, runs `cd` (cmd built-in: prints current dir), asserts stdout
+    # starts with the requested path.
+    if ($execedOk) {
+        Run-StateAwareTest "multi-exec (cwd plumbing)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_cwd.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($r.ExitCode -eq 0) "exit code = 0"
+            Assert-True ($r.Stdout -match '^C:\\Windows') `
+                "stdout starts with C:\Windows (cwd wire field honored on state-aware path)"
+        } | Out-Null
     }
-}
+
+    # Test 7: wire-format env per-invocation. Three invocations: initial,
+    # modified, absent. Verifies (a) each invocation receives its own env
+    # block, (b) the second wire request actually overrides the first (no
+    # cached env block), (c) the third invocation does NOT see leakage from
+    # prior calls.
+    if ($execedOk) {
+        Run-StateAwareTest "multi-exec (wire-format env per-invocation)" {
+            $rInit = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_env_initial.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($rInit.ExitCode -eq 0) "initial exit code = 0"
+            Assert-True ($rInit.Stdout -match 'initial-value') "initial value reaches the agent"
+
+            $rMod = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_env_modified.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($rMod.ExitCode -eq 0) "modified exit code = 0"
+            Assert-True ($rMod.Stdout -match 'modified-value') "second wire request overrides the first"
+            Assert-True ($rMod.Stdout -notmatch 'initial-value') "no cached env block from prior call"
+
+            # No env block -- the agent inherits its profile env only. echo of
+            # an unset variable in cmd.exe prints `%MY_SA_ENV%` literally; the
+            # checks below catch leakage from the prior call.
+            $rAbsent = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_exec_env_absent.json' -SandboxId $script:sandboxId -Experimental
+            Assert-True ($rAbsent.ExitCode -eq 0) "absent exit code = 0"
+            Assert-True ($rAbsent.Stdout -match '%MY_SA_ENV%') `
+                "literal %MY_SA_ENV% in stdout (var unset, no leak from prior call)"
+            Assert-True ($rAbsent.Stdout -notmatch 'modified-value') `
+                "no leak of modified-value into env-absent invocation"
+        } | Out-Null
+    }
+
+    # Test 8: HKCU env var persistence and modification. Tests a different
+    # persistence layer from filesystem (Test 4): the agent user's HKCU
+    # registry. setx writes to HKCU\Environment; a fresh cmd.exe started in a
+    # subsequent invocation reads its env block from the registry at startup,
+    # so the persisted value should appear. Then we modify it and verify the
+    # modification carries forward.
+    if ($execedOk) {
+        Run-StateAwareTest "multi-exec (HKCU env persistence + modification)" {
+            foreach ($step in @(
+                    @{ file = 'isolation_session_state_aware_exec_setx_initial.json';  expect = $null;              label = 'setx initial' },
+                    @{ file = 'isolation_session_state_aware_exec_read_persist.json';  expect = 'initial-persist';  label = 'fresh cmd reads HKCU' },
+                    @{ file = 'isolation_session_state_aware_exec_setx_modified.json'; expect = $null;              label = 'setx modified' },
+                    @{ file = 'isolation_session_state_aware_exec_read_persist.json';  expect = 'modified-persist'; label = 'fresh cmd reads modified HKCU' }
+                )) {
+                $r = Invoke-StateAware -ConfigFile $step.file -SandboxId $script:sandboxId -Experimental
+                Assert-True ($r.ExitCode -eq 0) "$($step.label): exit code = 0"
+                if ($null -ne $step.expect) {
+                    Assert-True ($r.Stdout -match [regex]::Escape($step.expect)) `
+                        "$($step.label): stdout contains '$($step.expect)'"
+                }
+            }
+        } | Out-Null
+    }
+
+    # Test 9: stop closes the started session. Skipped unless exec succeeded
+    # (so we know we have a truly running session to stop, not a half-set-up
+    # one).
+    $stoppedOk = $false
+    if ($execedOk) {
+        $stoppedOk = Run-StateAwareTest "stop (full lifecycle through stop)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:sandboxId -Experimental
+            $envObj = Parse-Envelope -Stdout $r.Stdout
+            $arm = Envelope-Arm $envObj
+            if ($arm -ne 'result') {
+                Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+                Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+                Write-Host "  Stderr: $($r.Stderr)" -ForegroundColor Gray
+                Assert-True $false "stop returned a result envelope"
+            } else {
+                Assert-True ($r.ExitCode -eq 0) "exit code = 0 on success"
+                Assert-True ($null -eq $envObj.result.metadata) "result.metadata is absent (no stop metadata in v1)"
+            }
+        }
+    }
+
+    # Test 10: deprovision tears down the agent user and unregisters the
+    # client. After this test, $sandboxId is no longer addressable -- the
+    # finally block below skips its cleanup pass when this test ran.
+    if ($stoppedOk) {
+        $deprovPassed = Run-StateAwareTest "deprovision (full lifecycle through deprovision)" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:sandboxId -Experimental
+            $envObj = Parse-Envelope -Stdout $r.Stdout
+            $arm = Envelope-Arm $envObj
+            if ($arm -ne 'result') {
+                Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+                Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+                Write-Host "  Stderr: $($r.Stderr)" -ForegroundColor Gray
+                Assert-True $false "deprovision returned a result envelope"
+            } else {
+                Assert-True ($r.ExitCode -eq 0) "exit code = 0 on success"
+                Assert-True ($null -eq $envObj.result.metadata) "result.metadata is absent (no deprovision metadata in v1)"
+            }
+        }
+        if ($deprovPassed) { $deprovisionedOk = $true }
+    }
 
 } finally {
     # Best-effort cleanup. If the suite reached the deprovision test and it
     # succeeded, the agent user is already torn down -- nothing to do. If
     # the suite failed mid-flow, this still runs so a leaked Indefinite-
     # lifetime agent user does not survive across test runs.
-    if ($null -ne $sandboxId -and -not $deprovisionedOk) {
-        Write-Host "" -ForegroundColor Gray
-        Write-Host "[cleanup] best-effort deprovision of $sandboxId" -ForegroundColor DarkGray
-        $cleanupRequest = @{
-            phase     = 'deprovision'
-            sandboxId = $sandboxId
-        }
+    if ($null -ne $script:sandboxId -and -not $deprovisionedOk) {
+        Write-Host ""
+        Write-Host "[cleanup] best-effort deprovision of $script:sandboxId" -ForegroundColor DarkGray
         try {
-            $cleanupResult = Invoke-StateAware -Request $cleanupRequest -Experimental
+            $cleanupResult = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:sandboxId -Experimental
             if ($cleanupResult.ExitCode -eq 0) {
                 Write-Host "  cleanup deprovision succeeded" -ForegroundColor DarkGray
             } else {
@@ -342,11 +476,20 @@ if ($stoppedOk) {
 
 # ---------------- Summary ----------------
 
+$total  = $script:TestResults.Count
+$failed = ($script:TestResults | Where-Object { -not $_.Passed }).Count
+$passed = $total - $failed
+
 Write-Host ""
-if ($TestsFailed -eq 0) {
-    Write-Host "ALL $TestsRun TESTS PASSED" -ForegroundColor Green
+Write-Host "==========================" -ForegroundColor Cyan
+if ($failed -eq 0) {
+    Write-Host "$passed/$total passed" -ForegroundColor Green
     exit 0
 } else {
-    Write-Host "$TestsFailed of $TestsRun TESTS FAILED" -ForegroundColor Red
+    Write-Host "$passed/$total passed, $failed FAILED:" -ForegroundColor Red
+    $script:TestResults | Where-Object { -not $_.Passed } | ForEach-Object {
+        $line = if ($_.Reason) { "  FAIL: $($_.Name) - $($_.Reason)" } else { "  FAIL: $($_.Name)" }
+        Write-Host $line -ForegroundColor Red
+    }
     exit 1
 }

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -15,25 +15,25 @@
       and stdout content
     - Reports pass/fail summary
 
-    This script must run INTERACTIVELY on the test host. The IsoEnvBroker
-    cohort check rejects network-logon tokens, so PSSession-driven
-    invocations fail with Access Denied. Copy wxc-exec.exe, the test
-    configs, and this script to the host, then run it directly in
+    This script must run INTERACTIVELY on the test host. The OS-side service
+    calling-process identity check rejects network-logon tokens, so
+    PSSession-driven invocations fail with Access Denied. Copy wxc-exec.exe,
+    the test configs, and this script to the host, then run it directly in
     cmd.exe or PowerShell on that host.
 
     Automated configs (asserted by this script):
-      - isolation_session_hello.json — env vars + working dir + agent name
-      - isolation_session_exit42.json — exit code propagation
-      - isolation_session_stderr.json — separate stderr in non-ConPTY mode
-      - isolation_session_stdout_stderr_interleaved.json — interleaved streams
-      - isolation_session_timeout.json — OS-side timeout terminates with exit code 1
+      - isolation_session_hello.json --env vars + working dir + agent name
+      - isolation_session_exit42.json --exit code propagation
+      - isolation_session_stderr.json --separate stderr in non-ConPTY mode
+      - isolation_session_stdout_stderr_interleaved.json --interleaved streams
+      - isolation_session_timeout.json --OS-side timeout terminates with exit code 1
 
-    Manual smoke configs (NOT asserted — observe the output yourself):
-      - isolation_session_streaming_smoke.json — output appears with delays
+    Manual smoke configs (NOT asserted --observe the output yourself):
+      - isolation_session_streaming_smoke.json --output appears with delays
         rather than a burst at exit; verifies Commit 1 streaming.
         Run from cmd.exe directly (not redirected) so wxc-exec sees a TTY:
             wxc-exec.exe --experimental isolation_session_streaming_smoke.json
-      - isolation_session_powershell_interactive.json — launches
+      - isolation_session_powershell_interactive.json --launches
         powershell.exe in the isolation session; type commands at the prompt
         (e.g. `Get-Date`, `whoami`, `exit 7`) and verify input forwarding +
         ConPTY rendering + exit-code propagation. Requires a real cmd.exe
@@ -64,7 +64,7 @@ if (-not $ConfigDir) {
     $ConfigDir = Join-Path $RepoRoot "test_configs"
 }
 
-# Locate wxc-exec.exe — explicit path > host-arch target dir > other-arch
+# Locate wxc-exec.exe --explicit path > host-arch target dir > other-arch
 # target dir > default release dir. Detect the host arch so we look for the
 # matching build first, but also probe the other Windows target so a
 # cross-built binary is still discoverable.

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -26,7 +26,7 @@
       - isolation_session_exit42.json — exit code propagation
       - isolation_session_stderr.json — separate stderr in non-ConPTY mode
       - isolation_session_stdout_stderr_interleaved.json — interleaved streams
-      - isolation_session_timeout.json — broker terminates with exit code 1
+      - isolation_session_timeout.json — OS-side timeout terminates with exit code 1
 
     Manual smoke configs (NOT asserted — observe the output yourself):
       - isolation_session_streaming_smoke.json — output appears with delays
@@ -179,8 +179,8 @@ $null = $results.Add((Run-IsolationSessionTest "isolation_session_stderr.json" `
 # must appear in the captured output (proves streams aren't crossed or dropped mid-run).
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_stdout_stderr_interleaved.json" `
     -OutputContains @("OUT_A", "ERR_A", "OUT_B", "ERR_B", "OUT_C")))
-# Timeout: ping runs ~30s; broker timer set to 1500ms forces TerminateProcess(handle, 1)
-# (verified at IsolationSessionWorkerProcess.cpp:153-170 in the OS repo). Exit code = 1.
+# Timeout: ping runs ~30s; OS-side per-process timer set to 1500ms forces
+# the agent to exit with code 1.
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_timeout.json" `
     -ExpectedExit 1))
 


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Closes #254. Adds state-aware lifecycle support to the IsolationSession backend in `wxc-exec`. Each lifecycle phase (provision, start, exec, stop, deprovision) becomes a separate `wxc-exec` invocation, threaded by a `sandboxId` returned from provision. Output streams live on exec (re-uses the one-shot `create_process` path); non-exec phases return a JSON envelope on stdout (`{"result":...}` or `{"error":...}`). The cross-backend Rust contract — a new `StatefulSandboxBackend` trait, dispatcher, parser additions, and error model — compiles unconditionally; IsolationSession's impl stays behind the existing `isolation_session` Cargo feature.

Full design: `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md`. IsolationSession-specific Rust plan: `docs/isolation-session/state-aware-rust-initial-plan.md`.

## What's in this PR

**Cross-backend infrastructure (new modules in `wxc_common`):**
- `mxc_error` — `MxcError` + 12-variant `MxcErrorCode` + `ErrorEnvelope` + `ResponseEnvelope<T>` wire types.
- `id` — `mint_random_token` (4 bytes via `getrandom`, 8-hex format) + `parse_sandbox_id_prefix`. New `getrandom = "0.2"` workspace dep.
- `state_aware_backend` — `StatefulSandboxBackend` trait (5 phase methods + 5 validate hooks + per-phase `*Result<M>` types + `ExecHandle`); takes `&CodexRequest` + `sandbox_id` + `Option<C>` per design §9.2 (no per-phase wrapper structs, no Rust mirrors of `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` — those names exist as TS SDK interfaces only).
- `state_aware_request` — `Phase` enum, `ParsedStateAwareRequest`, public `MxcRequest::OneShot/StateAware` discriminator.
- `state_aware_dispatch` — generic `dispatch_state_aware<B>` per-backend phase router, `run_state_aware` entrypoint with cfg-gated arm for IsolationSession, `resolve_backend` (containment for provision, prefix for non-provision), envelope construction helpers.
- `validator::validate_exec_common` — cross-backend exec invariant check.
- Parser extensions: untagged `RawMxcRequest` discriminator, `ParseError::OneShot/StateAware/Decode` so the driver picks the right output convention per arm.

**Driver wiring:**
- `wxc::main.rs` — wires `load_mxc_request` and the state-aware dispatcher. State-aware errors emit JSON envelope on stdout; one-shot path unchanged.

**IsolationSession backend (`wxc_common::isolation_session_runner`):**
- `IsolationSessionRunner` impls `StatefulSandboxBackend` (`ID_PREFIX = "iso"`, `BACKEND_KEY = "isolation_session"`).
- `IsolationSessionManager::new(provision_id: &str)` refactor: takes the provisionId as parameter; one-shot caller pinned to new public `DEFAULT_PROVISION_ID = "wxc-provid"` (no behavior change). State-aware mints `wxc-<8-hex>` per provision; sandbox_id = `iso:<provisionId>`.
- All 5 phase methods + 5 validate hooks. Validate hooks reject unsupported `policy.filesystem` / `policy.network` / `policy.ui` / `policy.network.proxy` at every phase via the existing `validate_policy`. Provision returns `iso:wxc-<8-hex>` sandbox_id + `IsolationSessionProvisionMetadata { agentUserName }`. Exec reuses the one-shot relay path.
- HRESULT detection: `ERROR_NOT_FOUND` (`0x80070490`) from `AgentManager::FindActiveAgentUserByProvisionId` maps to `MxcError::StaleId`; any non-provision op against a deprovisioned sandbox surfaces `error.code = "stale_id"`.

**Documentation and tests:**
- New `docs/isolation-session/state-aware-rust-initial-plan.md` (per-phase config / metadata, policy honor matrix, idempotence, concurrency, error mapping, AbortSignal note, known issues) per design §11.6.
- `.github/copilot-instructions.md` — IsolationSession table row mentions both modes; key-docs list adds the state-aware design + overview + new Rust plan; integration tests list adds the state-aware runner.
- `test_scripts/run_isolation_session_state_aware_tests.ps1` — 12-test runner (provision / start / exec / multi-exec dimensions: filesystem state, exit codes, cwd plumbing, wire env per-invocation, HKCU env persistence + modification / stop / deprovision / policy_validation / stale_id), JSON-fixture driven, project-pattern `==========================` summary.
- `test_configs/isolation_session_state_aware_*.json` — 18 fixtures, one per request scenario, with `{{SANDBOX_ID}}` placeholder substitution.
- `wxc_e2e_tests/tests/e2e_state_aware.rs` — 2 smoke tests asserting envelope-on-stdout for unknown containment + recognised non-state-aware backend (e.g. WSLC).
- `wxc_e2e_tests/src/lib.rs` — `run_wxc_state_aware` helper; `find_binary` now picks the most-recently-modified candidate (fixes a stale-binary issue when both `target/<triple>/<profile>/` and `target/<profile>/` exist).

**Design doc updates (pre-existing branch commits, retained for context):**
- `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md` and overview reflect the design pivot: trait reuses `CodexRequest`, no per-phase wrapper structs, no Rust mirrors of cross-cutting types. Rationale captured in §9.2 "Why the trait reuses `CodexRequest`".

## Testing

**Automated** (release + debug, `x86_64-pc-windows-msvc`, with and without `--features wxc/isolation_session`):

- `cargo fmt --check`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: 0 lint warnings, both flag states.
- `cargo build --workspace`: clean, both flag states.
- `cargo test --workspace`: **346 / 346 / 0** (default features), **375 / 375 / 0** (`+isolation_session`). The +29 isolation_session-gated tests are the new state-aware infrastructure / IsolationSession backend tests.

**VM integration** (Hyper-V VM at OS build `26611.260501-1700`, `Composable` config, release build):

- 12 / 12 logical tests PASS via `run_isolation_session_state_aware_tests.ps1`: provision + start + exec (basic) + multi-exec (filesystem state continuity, exit code propagation, cwd plumbing, wire env per-invocation, HKCU env persistence + modification) + stop + deprovision + policy_validation rejection + stale_id detection.

**Manual smokes** (run interactively on the VM desktop in cmd.exe; PSSession-driven invocations fail per the OS-side calling-process identity check — same constraint as #217 / #239 / #241):

- Basic TTY routing: `echo state-aware-tty-marker` returns immediately, exit 0.
- Live streaming: `for /L %i in (1,1,5) do @(echo %i & timeout /t 1 /nobreak >/dev/null)` prints 1..5 one second apart, not in a burst at exit.
- Interactive shell: `powershell.exe -NoProfile` opens a prompt; typed `Get-Date` / `whoami` / `exit <N>` work — input forwarded, output rendered via ConPTY, exit code propagated.

## Scope notes

This PR is intentionally narrow. Deliberately deferred — see the issue's "Additional context" section:

- TypeScript SDK exposure (separate PR; mirrors #217 → SDK exposure staging).
- Explicit `AbortSignal` plumbing through `ExecHandle.terminator` (v1 uses OS-level cancellation; existing 3-tier shutdown handles timeout/cancel cases).
- Concurrent state-aware sandboxes (v1 single-sandbox-per-consumer; shared registration teardown is the constraint, documented in the plan doc).
- Streaming-during-execution e2e test infrastructure (cross-cutting; same deferred item as #240).

Closes #254.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/255)