### PR TITLE
Set all UILIMIT bits when UI is disabled, improve debug output from sandbo…

### DIFF
--- a/src/mxc_diagnostic_console/src/main.rs
+++ b/src/mxc_diagnostic_console/src/main.rs
@@ -482,7 +482,7 @@ fn display_loop(rx: mpsc::Receiver<DisplayEvent>) {
                 for line in text.lines() {
                     if line.starts_with("WARNING:") {
                         println!("{DIM}[{ts}]{RESET} {color}[{exe}:{pid}]{RESET} \x1b[1;33m{line}\x1b[0m");
-                    } else if line.starts_with("SECTION:") {
+                    } else if line.contains("SECTION:") {
                         println!("{DIM}[{ts}]{RESET} {color}[{exe}:{pid}]{RESET} \x1b[1;36m{line}\x1b[0m");
                     } else if line.starts_with("ERROR:") || line.starts_with("Error:") {
                         println!("{DIM}[{ts}]{RESET} {color}[{exe}:{pid}]{RESET} \x1b[1;31m{line}\x1b[0m");

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -22,6 +22,9 @@ use windows::Win32::System::Threading::{
 };
 use windows_core::PCWSTR;
 
+use crate::log_symbols::{
+    EMOJI_ALLOWED, EMOJI_BLOCKED, EMOJI_NEUTRAL, EMOJI_SECTION, EMOJI_WARNING,
+};
 use crate::logger::Logger;
 use crate::models::{
     CodexRequest, NetworkEnforcementMode, NetworkPolicy, ProxyAddress, ScriptResponse,
@@ -260,7 +263,7 @@ impl ScriptRunner for BaseContainerRunner {
     }
 
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        let _ = writeln!(logger, "\u{25B6} SECTION: Backend runner 'BaseContainer'");
+        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Backend runner 'BaseContainer'");
 
         let run_start = std::time::Instant::now();
 
@@ -296,7 +299,7 @@ impl ScriptRunner for BaseContainerRunner {
             );
         }
 
-        let _ = writeln!(logger, "\u{25B6} SECTION: Build sandbox spec");
+        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Build sandbox spec");
 
         // 1. Build the FlatBuffer sandbox spec from the request policy.
         let spec_bytes = Self::build_sandbox_spec(&request);
@@ -314,9 +317,9 @@ impl ScriptRunner for BaseContainerRunner {
             // Log Token
             let _ = writeln!(logger, "[token]");
             let integrity_emoji = if spec.integrity() == IntegrityLevel::system_default {
-                "\u{26AA}" // white circle (neutral)
+                EMOJI_NEUTRAL
             } else {
-                "\u{26A0}" // warning sign
+                EMOJI_WARNING
             };
             let _ = writeln!(
                 logger,
@@ -326,9 +329,9 @@ impl ScriptRunner for BaseContainerRunner {
             );
             // Log AppContainer-ness
             let app_container_emoji = if spec.app_container() {
-                "\u{26AA}" // white circle (neutral)
+                EMOJI_NEUTRAL
             } else {
-                "\u{26A0}" // warning sign
+                EMOJI_WARNING
             };
             let _ = writeln!(
                 logger,
@@ -359,12 +362,9 @@ impl ScriptRunner for BaseContainerRunner {
             let _ = writeln!(logger, "[ui subsystem]");
             let _ = writeln!(
                 logger,
-                "  win32k_system_calls: {}",
-                if spec.disallow_win32k_system_calls() {
-                    "\u{274C} blocked"
-                } else {
-                    "\u{2705} allowed"
-                }
+                "  win32k_system_calls: {} {}",
+                if spec.disallow_win32k_system_calls() { EMOJI_BLOCKED } else { EMOJI_ALLOWED },
+                if spec.disallow_win32k_system_calls() { "blocked" } else { "allowed" }
             );
             let r = spec.ui_restrictions();
             let flags: &[(&str, u64)] = &[
@@ -391,13 +391,13 @@ impl ScriptRunner for BaseContainerRunner {
                 .collect();
             let allowed_str = if allowed.is_empty() { "<none>".to_string() } else { allowed.join(", ") };
             let blocked_str = if blocked.is_empty() { "<none>".to_string() } else { blocked.join(", ") };
-            let _ = writeln!(logger, "  uilimits allowed \u{2705}: {}", allowed_str);
-            let _ = writeln!(logger, "  uilimits blocked \u{274C}: {} (0x{:04X})",
+            let _ = writeln!(logger, "  uilimits allowed {EMOJI_ALLOWED}: {}", allowed_str);
+            let _ = writeln!(logger, "  uilimits blocked {EMOJI_BLOCKED}: {} (0x{:04X})",
                 blocked_str,
                 spec.ui_restrictions());
         }
 
-        let _ = writeln!(logger, "\u{25B6} SECTION: Load API");
+        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Load API");
 
         // 2. Dynamically load the API from processmodel.dll.
         let create_process_in_sandbox = match Self::load_api() {
@@ -409,7 +409,7 @@ impl ScriptRunner for BaseContainerRunner {
             "loaded Experimental_CreateProcessInSandbox from processmodel.dll"
         );
 
-        let _ = writeln!(logger, "\u{25B6} SECTION: Launch process");
+        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Launch process");
 
         // 3. Build the command line (passed directly, same as AppContainerScriptRunner).
         let mut cmd_wide = string_util::to_wide(&request.script_code);
@@ -486,7 +486,7 @@ impl ScriptRunner for BaseContainerRunner {
 
         let _ = writeln!(logger, "process created (PID: {})", pi.dwProcessId);
 
-        let _ = writeln!(logger, "\u{25B6} SECTION: Wait for exit");
+        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Wait for exit");
 
         // 5. Wait for the child process to exit.
         let timeout_ms = get_timeout_milliseconds(request.script_timeout);
@@ -515,7 +515,7 @@ impl ScriptRunner for BaseContainerRunner {
 
         let _ = writeln!(
             logger,
-            "\u{25B6} SECTION: Done ({:.3}s)",
+            "{EMOJI_SECTION} SECTION: Done ({:.3}s)",
             run_start.elapsed().as_secs_f64()
         );
 

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -214,6 +214,13 @@ impl BaseContainerRunner {
             Err(_) => return,
         };
 
+        let _ = writeln!(
+            logger,
+            "sandbox spec built (version={}, {} bytes)",
+            spec.version(),
+            spec_bytes.len()
+        );
+
         // Token
         let _ = writeln!(logger, "[token]");
         let integrity_emoji = if spec.integrity() == IntegrityLevel::system_default {
@@ -404,13 +411,6 @@ impl ScriptRunner for BaseContainerRunner {
 
         // 1. Build the FlatBuffer sandbox spec from the request policy.
         let spec_bytes = Self::build_sandbox_spec(&request);
-
-        let _ = writeln!(
-            logger,
-            "sandbox spec built (version={}, {} bytes)",
-            SANDBOX_SPEC_VERSION,
-            spec_bytes.len()
-        );
 
         Self::log_sandbox_spec(&spec_bytes, logger);
 

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -30,8 +30,8 @@ use crate::proxy_coordinator::ProxyCoordinator;
 use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
 use crate::string_util;
 use sandbox_spec::base_container_layout::{
-    finish_sandbox_spec_buffer, proxy_info, proxy_infoArgs, NetworkPolicy as FbsNetworkPolicy,
-    NetworkPolicyArgs, SandboxSpec, SandboxSpecArgs,
+    finish_sandbox_spec_buffer, proxy_info, proxy_infoArgs, IntegrityLevel,
+    NetworkPolicy as FbsNetworkPolicy, NetworkPolicyArgs, SandboxSpec, SandboxSpecArgs,
 };
 
 /// Function pointer type matching `Experimental_CreateProcessInSandbox` from processmodel.dll.
@@ -260,7 +260,7 @@ impl ScriptRunner for BaseContainerRunner {
     }
 
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        let _ = writeln!(logger, "SECTION: Backend runner 'BaseContainer'");
+        let _ = writeln!(logger, "\u{25B6} SECTION: Backend runner 'BaseContainer'");
 
         let run_start = std::time::Instant::now();
 
@@ -296,21 +296,11 @@ impl ScriptRunner for BaseContainerRunner {
             );
         }
 
-        let _ = writeln!(logger, "SECTION: Build sandbox spec");
+        let _ = writeln!(logger, "\u{25B6} SECTION: Build sandbox spec");
 
         // 1. Build the FlatBuffer sandbox spec from the request policy.
         let spec_bytes = Self::build_sandbox_spec(&request);
 
-        // Print proxy URL in debug mode
-        if let Some(ref addr) = request.policy.network_proxy.address {
-            let _ = writeln!(logger, "proxy URL in spec: {}", addr.to_url());
-        }
-
-        let restrictions = crate::ui_policy::resolve_ui_restrictions(
-            &request.policy.ui,
-            &request.policy.base_process_ui,
-        );
-        let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(&restrictions);
         let _ = writeln!(
             logger,
             "sandbox spec built (version={}, {} bytes)",
@@ -318,41 +308,96 @@ impl ScriptRunner for BaseContainerRunner {
             spec_bytes.len()
         );
 
-        // Print flags in debug mode
-        let _ = writeln!(
-            logger,
-            "BaseContainer: disallow_win32k_system_calls={}, ui_restrictions=0x{:04X}",
-            request.policy.ui.disable, ui_restrictions
-        );
-        let _ = writeln!(
-            logger,
-            "ui.clipboard={:?}, ui.injection={}",
-            request.policy.ui.clipboard, request.policy.ui.injection
-        );
-        let _ = writeln!(
-            logger,
-            "base_process_ui: isolation={}, desktopSystemControl={}, systemSettings={}, ime={}",
-            request.policy.base_process_ui.isolation,
-            request.policy.base_process_ui.desktop_system_control,
-            request.policy.base_process_ui.system_settings,
-            request.policy.base_process_ui.ime
-        );
-        let _ = writeln!(
-            logger,
-            "UILIMIT flags: HANDLES={} READCLIP={} WRITECLIP={} SYSPARAM={} DISPLAY={} ATOMS={} DESKTOP={} EXIT={} IME={} INJECT={}",
-            restrictions.block_external_ui_objects,
-            restrictions.block_clipboard_read,
-            restrictions.block_clipboard_write,
-            restrictions.block_system_parameter_changes,
-            restrictions.block_display_settings_changes,
-            restrictions.block_global_ui_namespace,
-            restrictions.block_desktop_switching,
-            restrictions.block_logoff_or_shutdown,
-            restrictions.block_input_method_changes,
-            restrictions.block_input_injection,
-        );
+        // Read back all fields from the built FlatBuffer spec for debug verification
+        if let Ok(spec) = sandbox_spec::base_container_layout::root_as_sandbox_spec(&spec_bytes) {
 
-        let _ = writeln!(logger, "SECTION: Load API");
+            // Log Token
+            let _ = writeln!(logger, "[token]");
+            let integrity_emoji = if spec.integrity() == IntegrityLevel::system_default {
+                "\u{26AA}" // white circle (neutral)
+            } else {
+                "\u{26A0}" // warning sign
+            };
+            let _ = writeln!(
+                logger,
+                "  integrity:       {} {:?}",
+                integrity_emoji,
+                spec.integrity()
+            );
+            // Log AppContainer-ness
+            let app_container_emoji = if spec.app_container() {
+                "\u{26AA}" // white circle (neutral)
+            } else {
+                "\u{26A0}" // warning sign
+            };
+            let _ = writeln!(
+                logger,
+                "  app_container:   {} {} (least_privilege: {})",
+                app_container_emoji,
+                if spec.app_container() { "on" } else { "off" },
+                if spec.least_privilege() { "on" } else { "off" }
+            );
+            if let Some(caps) = spec.capabilities() {
+                let _ = writeln!(
+                    logger,
+                    "  capabilities:    {}", caps);
+            }
+
+            // Log network access
+            let _ = writeln!(logger, "[network]");
+            if let Some(np) = spec.network_policy() {
+                if let Some(proxy) = np.proxy() {
+                    if let Some(url) = proxy.url() {
+                        let _ = writeln!(logger, "  network_policy.proxy.url: {}", url);
+                    }
+                }
+            } else {
+                let _ = writeln!(logger, "  <unspecified>");
+            }
+
+            // Log UI restrictions (in a human-readable way)
+            let _ = writeln!(logger, "[ui subsystem]");
+            let _ = writeln!(
+                logger,
+                "  win32k_system_calls: {}",
+                if spec.disallow_win32k_system_calls() {
+                    "\u{274C} blocked"
+                } else {
+                    "\u{2705} allowed"
+                }
+            );
+            let r = spec.ui_restrictions();
+            let flags: &[(&str, u64)] = &[
+                ("handles", 0x0001),
+                ("read_clip", 0x0002),
+                ("write_clip", 0x0004),
+                ("sys_params", 0x0008),
+                ("display", 0x0010),
+                ("atoms", 0x0020),
+                ("desktop", 0x0040),
+                ("exit_windows", 0x0080),
+                ("ime", 0x0100),
+                ("injection", 0x0200),
+            ];
+            let allowed: Vec<&str> = flags
+                .iter()
+                .filter(|(_, bit)| r & bit == 0)
+                .map(|(name, _)| *name)
+                .collect();
+            let blocked: Vec<&str> = flags
+                .iter()
+                .filter(|(_, bit)| r & bit != 0)
+                .map(|(name, _)| *name)
+                .collect();
+            let allowed_str = if allowed.is_empty() { "<none>".to_string() } else { allowed.join(", ") };
+            let blocked_str = if blocked.is_empty() { "<none>".to_string() } else { blocked.join(", ") };
+            let _ = writeln!(logger, "  uilimits allowed \u{2705}: {}", allowed_str);
+            let _ = writeln!(logger, "  uilimits blocked \u{274C}: {} (0x{:04X})",
+                blocked_str,
+                spec.ui_restrictions());
+        }
+
+        let _ = writeln!(logger, "\u{25B6} SECTION: Load API");
 
         // 2. Dynamically load the API from processmodel.dll.
         let create_process_in_sandbox = match Self::load_api() {
@@ -364,7 +409,7 @@ impl ScriptRunner for BaseContainerRunner {
             "loaded Experimental_CreateProcessInSandbox from processmodel.dll"
         );
 
-        let _ = writeln!(logger, "SECTION: Launch process");
+        let _ = writeln!(logger, "\u{25B6} SECTION: Launch process");
 
         // 3. Build the command line (passed directly, same as AppContainerScriptRunner).
         let mut cmd_wide = string_util::to_wide(&request.script_code);
@@ -441,7 +486,7 @@ impl ScriptRunner for BaseContainerRunner {
 
         let _ = writeln!(logger, "process created (PID: {})", pi.dwProcessId);
 
-        let _ = writeln!(logger, "SECTION: Wait for exit");
+        let _ = writeln!(logger, "\u{25B6} SECTION: Wait for exit");
 
         // 5. Wait for the child process to exit.
         let timeout_ms = get_timeout_milliseconds(request.script_timeout);
@@ -470,7 +515,7 @@ impl ScriptRunner for BaseContainerRunner {
 
         let _ = writeln!(
             logger,
-            "SECTION: Done ({:.3}s)",
+            "\u{25B6} SECTION: Done ({:.3}s)",
             run_start.elapsed().as_secs_f64()
         );
 
@@ -521,12 +566,20 @@ mod tests {
         assert!(spec.least_privilege());
         assert_eq!(spec.capabilities(), Some("internetClient,registryRead"));
         assert!(spec.disallow_win32k_system_calls());
-        // default: disable=true → only the global UI namespace bit
+        // disable=true sets all non-IME restrictions; ime=false (default) adds IME
         assert_eq!(
             spec.ui_restrictions(),
             expected_mask(EffectiveUiRestrictions {
+                block_clipboard_read: true,
+                block_clipboard_write: true,
+                block_input_injection: true,
+                block_input_method_changes: true,
+                block_external_ui_objects: true,
                 block_global_ui_namespace: true,
-                ..Default::default()
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
             })
         );
 
@@ -585,12 +638,20 @@ mod tests {
         let spec = base_container_layout::root_as_sandbox_spec(&bytes).unwrap();
 
         assert!(spec.disallow_win32k_system_calls());
-        // disable=true → only the global UI namespace bit (Win32k disable handles the rest)
+        // disable=true sets all non-IME restrictions; ime=false (default) adds IME
         assert_eq!(
             spec.ui_restrictions(),
             expected_mask(EffectiveUiRestrictions {
+                block_clipboard_read: true,
+                block_clipboard_write: true,
+                block_input_injection: true,
+                block_input_method_changes: true,
+                block_external_ui_objects: true,
                 block_global_ui_namespace: true,
-                ..Default::default()
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
             })
         );
     }

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -204,6 +204,107 @@ impl BaseContainerRunner {
         builder.finished_data().to_vec()
     }
 
+    /// Log the contents of a built sandbox spec FlatBuffer for debug verification.
+    ///
+    /// Reads back token, network, and UI restriction fields from the serialised
+    /// spec and writes a structured summary to the logger.
+    fn log_sandbox_spec(spec_bytes: &[u8], logger: &mut Logger) {
+        let spec = match sandbox_spec::base_container_layout::root_as_sandbox_spec(spec_bytes) {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+
+        // Token
+        let _ = writeln!(logger, "[token]");
+        let integrity_emoji = if spec.integrity() == IntegrityLevel::system_default {
+            EMOJI_NEUTRAL
+        } else {
+            EMOJI_WARNING
+        };
+        let _ = writeln!(
+            logger,
+            "  integrity:       {} {:?}",
+            integrity_emoji,
+            spec.integrity()
+        );
+        let app_container_emoji = if spec.app_container() {
+            EMOJI_NEUTRAL
+        } else {
+            EMOJI_WARNING
+        };
+        let _ = writeln!(
+            logger,
+            "  app_container:   {} {} (least_privilege: {})",
+            app_container_emoji,
+            if spec.app_container() { "on" } else { "off" },
+            if spec.least_privilege() { "on" } else { "off" }
+        );
+        if let Some(caps) = spec.capabilities() {
+            let _ = writeln!(logger, "  capabilities:    {}", caps);
+        }
+
+        // Network
+        let _ = writeln!(logger, "[network]");
+        let proxy_url = spec
+            .network_policy()
+            .and_then(|np| np.proxy())
+            .and_then(|proxy| proxy.url());
+        if let Some(url) = proxy_url {
+            let _ = writeln!(logger, "  network_policy.proxy.url: {}", url);
+        } else {
+            let _ = writeln!(logger, "  <unspecified>");
+        }
+
+        // UI restrictions
+        let _ = writeln!(logger, "[ui subsystem]");
+        let _ = writeln!(
+            logger,
+            "  win32k_system_calls: {} {}",
+            if spec.disallow_win32k_system_calls() { EMOJI_BLOCKED } else { EMOJI_ALLOWED },
+            if spec.disallow_win32k_system_calls() { "blocked" } else { "allowed" }
+        );
+        let r = spec.ui_restrictions();
+        let flags: &[(&str, u64)] = &[
+            ("handles", 0x0001),
+            ("read_clip", 0x0002),
+            ("write_clip", 0x0004),
+            ("sys_params", 0x0008),
+            ("display", 0x0010),
+            ("atoms", 0x0020),
+            ("desktop", 0x0040),
+            ("exit_windows", 0x0080),
+            ("ime", 0x0100),
+            ("injection", 0x0200),
+        ];
+        let allowed: Vec<&str> = flags
+            .iter()
+            .filter(|(_, bit)| r & bit == 0)
+            .map(|(name, _)| *name)
+            .collect();
+        let blocked: Vec<&str> = flags
+            .iter()
+            .filter(|(_, bit)| r & bit != 0)
+            .map(|(name, _)| *name)
+            .collect();
+        let allowed_str = if allowed.is_empty() {
+            "<none>".to_string()
+        } else {
+            allowed.join(", ")
+        };
+        let blocked_str = if blocked.is_empty() {
+            "<none>".to_string()
+        } else {
+            blocked.join(", ")
+        };
+        let _ = writeln!(logger, "  uilimits allowed {EMOJI_ALLOWED}: {}", allowed_str);
+        let _ = writeln!(
+            logger,
+            "  uilimits blocked {EMOJI_BLOCKED}: {} (0x{:04X})",
+            blocked_str,
+            spec.ui_restrictions()
+        );
+    }
+
     /// Load `processmodel.dll` and resolve the `Experimental_CreateProcessInSandbox` export.
     fn load_api() -> Result<PfnCreateProcessInSandbox, String> {
         let dll_name = string_util::to_wide("processmodel.dll");
@@ -311,90 +412,7 @@ impl ScriptRunner for BaseContainerRunner {
             spec_bytes.len()
         );
 
-        // Read back all fields from the built FlatBuffer spec for debug verification
-        if let Ok(spec) = sandbox_spec::base_container_layout::root_as_sandbox_spec(&spec_bytes) {
-
-            // Log Token
-            let _ = writeln!(logger, "[token]");
-            let integrity_emoji = if spec.integrity() == IntegrityLevel::system_default {
-                EMOJI_NEUTRAL
-            } else {
-                EMOJI_WARNING
-            };
-            let _ = writeln!(
-                logger,
-                "  integrity:       {} {:?}",
-                integrity_emoji,
-                spec.integrity()
-            );
-            // Log AppContainer-ness
-            let app_container_emoji = if spec.app_container() {
-                EMOJI_NEUTRAL
-            } else {
-                EMOJI_WARNING
-            };
-            let _ = writeln!(
-                logger,
-                "  app_container:   {} {} (least_privilege: {})",
-                app_container_emoji,
-                if spec.app_container() { "on" } else { "off" },
-                if spec.least_privilege() { "on" } else { "off" }
-            );
-            if let Some(caps) = spec.capabilities() {
-                let _ = writeln!(
-                    logger,
-                    "  capabilities:    {}", caps);
-            }
-
-            // Log network access
-            let _ = writeln!(logger, "[network]");
-            let proxy_url = spec.network_policy()
-                .and_then(|np| np.proxy())
-                .and_then(|proxy| proxy.url());
-            if let Some(url) = proxy_url {
-                let _ = writeln!(logger, "  network_policy.proxy.url: {}", url);
-            } else {
-                let _ = writeln!(logger, "  <unspecified>");
-            }
-
-            // Log UI restrictions (in a human-readable way)
-            let _ = writeln!(logger, "[ui subsystem]");
-            let _ = writeln!(
-                logger,
-                "  win32k_system_calls: {} {}",
-                if spec.disallow_win32k_system_calls() { EMOJI_BLOCKED } else { EMOJI_ALLOWED },
-                if spec.disallow_win32k_system_calls() { "blocked" } else { "allowed" }
-            );
-            let r = spec.ui_restrictions();
-            let flags: &[(&str, u64)] = &[
-                ("handles", 0x0001),
-                ("read_clip", 0x0002),
-                ("write_clip", 0x0004),
-                ("sys_params", 0x0008),
-                ("display", 0x0010),
-                ("atoms", 0x0020),
-                ("desktop", 0x0040),
-                ("exit_windows", 0x0080),
-                ("ime", 0x0100),
-                ("injection", 0x0200),
-            ];
-            let allowed: Vec<&str> = flags
-                .iter()
-                .filter(|(_, bit)| r & bit == 0)
-                .map(|(name, _)| *name)
-                .collect();
-            let blocked: Vec<&str> = flags
-                .iter()
-                .filter(|(_, bit)| r & bit != 0)
-                .map(|(name, _)| *name)
-                .collect();
-            let allowed_str = if allowed.is_empty() { "<none>".to_string() } else { allowed.join(", ") };
-            let blocked_str = if blocked.is_empty() { "<none>".to_string() } else { blocked.join(", ") };
-            let _ = writeln!(logger, "  uilimits allowed {EMOJI_ALLOWED}: {}", allowed_str);
-            let _ = writeln!(logger, "  uilimits blocked {EMOJI_BLOCKED}: {} (0x{:04X})",
-                blocked_str,
-                spec.ui_restrictions());
-        }
+        Self::log_sandbox_spec(&spec_bytes, logger);
 
         let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Load API");
 

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -267,8 +267,16 @@ impl BaseContainerRunner {
         let _ = writeln!(
             logger,
             "  win32k_system_calls: {} {}",
-            if spec.disallow_win32k_system_calls() { EMOJI_BLOCKED } else { EMOJI_ALLOWED },
-            if spec.disallow_win32k_system_calls() { "blocked" } else { "allowed" }
+            if spec.disallow_win32k_system_calls() {
+                EMOJI_BLOCKED
+            } else {
+                EMOJI_ALLOWED
+            },
+            if spec.disallow_win32k_system_calls() {
+                "blocked"
+            } else {
+                "allowed"
+            }
         );
         let r = spec.ui_restrictions();
         let flags: &[(&str, u64)] = &[
@@ -303,7 +311,11 @@ impl BaseContainerRunner {
         } else {
             blocked.join(", ")
         };
-        let _ = writeln!(logger, "  uilimits allowed {EMOJI_ALLOWED}: {}", allowed_str);
+        let _ = writeln!(
+            logger,
+            "  uilimits allowed {EMOJI_ALLOWED}: {}",
+            allowed_str
+        );
         let _ = writeln!(
             logger,
             "  uilimits blocked {EMOJI_BLOCKED}: {} (0x{:04X})",
@@ -371,7 +383,10 @@ impl ScriptRunner for BaseContainerRunner {
     }
 
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Backend runner 'BaseContainer'");
+        let _ = writeln!(
+            logger,
+            "{EMOJI_SECTION} SECTION: Backend runner 'BaseContainer'"
+        );
 
         let run_start = std::time::Instant::now();
 

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -348,12 +348,11 @@ impl ScriptRunner for BaseContainerRunner {
 
             // Log network access
             let _ = writeln!(logger, "[network]");
-            if let Some(np) = spec.network_policy() {
-                if let Some(proxy) = np.proxy() {
-                    if let Some(url) = proxy.url() {
-                        let _ = writeln!(logger, "  network_policy.proxy.url: {}", url);
-                    }
-                }
+            let proxy_url = spec.network_policy()
+                .and_then(|np| np.proxy())
+                .and_then(|proxy| proxy.url());
+            if let Some(url) = proxy_url {
+                let _ = writeln!(logger, "  network_policy.proxy.url: {}", url);
             } else {
                 let _ = writeln!(logger, "  <unspecified>");
             }

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
 pub mod hyperlight_runner;
 pub mod id;
+pub mod log_symbols;
 pub mod logger;
 #[cfg(target_os = "windows")]
 pub mod microvm_staging;

--- a/src/wxc_common/src/log_symbols.rs
+++ b/src/wxc_common/src/log_symbols.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Shared Unicode symbols used in structured log output.
+//!
+//! Centralised here so that multiple crates (e.g. `base_container_runner`,
+//! `mxc_diagnostic_console`) can reference a single source of truth.
+
+/// ⚪ White circle — neutral / default state.
+pub const EMOJI_NEUTRAL: &str = "\u{26AA}";
+
+/// ⚠ Warning sign — non-default or noteworthy state.
+pub const EMOJI_WARNING: &str = "\u{26A0}";
+
+/// ❌ Cross mark — blocked / denied.
+pub const EMOJI_BLOCKED: &str = "\u{274C}";
+
+/// ✅ Check mark — allowed / permitted.
+pub const EMOJI_ALLOWED: &str = "\u{2705}";
+
+/// ▶ Play / section marker — delimits logical sections in log output.
+pub const EMOJI_SECTION: &str = "\u{25B6}";

--- a/src/wxc_common/src/ui_policy.rs
+++ b/src/wxc_common/src/ui_policy.rs
@@ -48,80 +48,86 @@ pub fn resolve_ui_restrictions(
     ui: &UiPolicy,
     base_proc_ui: &BaseProcessUiConfig,
 ) -> EffectiveUiRestrictions {
-    // When UI is fully disabled: on Windows, DisallowWin32kSystemCalls
-    // handles every UI surface except the global namespace (which is an
-    // NT-executive concern, not Win32k). Block only that here.
-    if ui.disable {
-        return EffectiveUiRestrictions {
-            block_global_ui_namespace: true,
-            ..Default::default()
-        };
-    }
-
     let mut r = EffectiveUiRestrictions::default();
 
-    // Clipboard (default: "none" = block both)
-    match ui.clipboard {
-        ClipboardPolicy::All => {}
-        ClipboardPolicy::Read => {
-            r.block_clipboard_write = true;
-        }
-        ClipboardPolicy::Write => {
-            r.block_clipboard_read = true;
-        }
-        // "none" or unrecognized → default-deny: block both
-        _ => {
-            r.block_clipboard_read = true;
-            r.block_clipboard_write = true;
-        }
-    }
-
-    // Input injection
-    if !ui.injection {
+    if ui.disable {
+        // When UI is fully disabled: DisallowWin32kSystemCalls blocks most
+        // Win32k functionality, but we still set all restriction flags so the
+        // sandbox spec accurately reflects the desired policy to the OS service.
+        r.block_clipboard_read = true;
+        r.block_clipboard_write = true;
         r.block_input_injection = true;
-    }
-
-    // UI-object isolation level (default: "container" = external objects + global namespace)
-    match base_proc_ui.isolation.as_str() {
-        "desktop" => {
-            // No isolation restrictions
-        }
-        "handles" => {
-            r.block_external_ui_objects = true;
-        }
-        "atoms" => {
-            r.block_global_ui_namespace = true;
-        }
-        // "container" or unrecognized → default-deny: full isolation
-        _ => {
-            r.block_external_ui_objects = true;
-            r.block_global_ui_namespace = true;
-        }
-    }
-
-    // Desktop system control: blocks switching desktops and ending the session
-    if !base_proc_ui.desktop_system_control {
+        r.block_external_ui_objects = true;
+        r.block_global_ui_namespace = true;
         r.block_desktop_switching = true;
         r.block_logoff_or_shutdown = true;
+        r.block_system_parameter_changes = true;
+        r.block_display_settings_changes = true;
+    } else {
+        // Clipboard (default: "none" = block both)
+        match ui.clipboard {
+            ClipboardPolicy::All => {}
+            ClipboardPolicy::Read => {
+                r.block_clipboard_write = true;
+            }
+            ClipboardPolicy::Write => {
+                r.block_clipboard_read = true;
+            }
+            // "none" or unrecognized → default-deny: block both
+            _ => {
+                r.block_clipboard_read = true;
+                r.block_clipboard_write = true;
+            }
+        }
+
+        // Input injection
+        if !ui.injection {
+            r.block_input_injection = true;
+        }
+
+        // UI-object isolation level (default: "container" = external objects + global namespace)
+        match base_proc_ui.isolation.as_str() {
+            "desktop" => {
+                // No isolation restrictions
+            }
+            "handles" => {
+                r.block_external_ui_objects = true;
+            }
+            "atoms" => {
+                r.block_global_ui_namespace = true;
+            }
+            // "container" or unrecognized → default-deny: full isolation
+            _ => {
+                r.block_external_ui_objects = true;
+                r.block_global_ui_namespace = true;
+            }
+        }
+
+        // Desktop system control: blocks switching desktops and ending the session
+        if !base_proc_ui.desktop_system_control {
+            r.block_desktop_switching = true;
+            r.block_logoff_or_shutdown = true;
+        }
+
+        // System settings (default: "none" = block all)
+        match base_proc_ui.system_settings.as_str() {
+            "all" => {}
+            "parameters" => {
+                r.block_display_settings_changes = true;
+            }
+            "display" => {
+                r.block_system_parameter_changes = true;
+            }
+            // "none" or unrecognized → default-deny: block all
+            _ => {
+                r.block_system_parameter_changes = true;
+                r.block_display_settings_changes = true;
+            }
+        }
     }
 
-    // System settings (default: "none" = block all)
-    match base_proc_ui.system_settings.as_str() {
-        "all" => {}
-        "parameters" => {
-            r.block_display_settings_changes = true;
-        }
-        "display" => {
-            r.block_system_parameter_changes = true;
-        }
-        // "none" or unrecognized → default-deny: block all
-        _ => {
-            r.block_system_parameter_changes = true;
-            r.block_display_settings_changes = true;
-        }
-    }
-
-    // Input method changes
+    // IME is always evaluated independently since the OS service enforces
+    // it separately from DisallowWin32kSystemCalls.
     if !base_proc_ui.ime {
         r.block_input_method_changes = true;
     }
@@ -135,31 +141,48 @@ mod tests {
     use crate::models::{BaseProcessUiConfig, ClipboardPolicy, UiPolicy};
 
     #[test]
-    fn disabled_blocks_only_global_ui_namespace() {
+    fn disabled_blocks_all_restrictions() {
         let ui = UiPolicy {
             disable: true,
             ..Default::default()
         };
         let bp = BaseProcessUiConfig::default();
         let r = resolve_ui_restrictions(&ui, &bp);
+        // disable=true sets all non-IME restrictions; ime=false (default) adds IME
         assert_eq!(
             r,
             EffectiveUiRestrictions {
+                block_clipboard_read: true,
+                block_clipboard_write: true,
+                block_input_injection: true,
+                block_input_method_changes: true,
+                block_external_ui_objects: true,
                 block_global_ui_namespace: true,
-                ..Default::default()
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
             }
         );
     }
 
     #[test]
-    fn default_policy_blocks_only_global_ui_namespace() {
-        // UiPolicy::default has disable=true → only the global namespace.
+    fn default_policy_blocks_all_restrictions() {
+        // UiPolicy::default has disable=true + ime=false → all restrictions set
         let r = resolve_ui_restrictions(&UiPolicy::default(), &BaseProcessUiConfig::default());
         assert_eq!(
             r,
             EffectiveUiRestrictions {
+                block_clipboard_read: true,
+                block_clipboard_write: true,
+                block_input_injection: true,
+                block_input_method_changes: true,
+                block_external_ui_objects: true,
                 block_global_ui_namespace: true,
-                ..Default::default()
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
             }
         );
     }


### PR DESCRIPTION
…x spec

- Change: ui_restrictions_bitmask to now set UILIMIT_IME and friends when, e.g. base_process_ui.ime=false when ui.disable=true (previously the early-return skipped IME, which was confusing)
- Debug output now reads fields from the built FlatBuffer spec instead of the CodexRequest, verifying the actual bytes sent to the OS
- UILIMIT flags shown as allowed/blocked lists with emoji indicators
- SECTION: lines prefixed with a triangle for visibility

Output appears as,
<img width="680" height="119" alt="image" src="https://github.com/user-attachments/assets/c8c68a9b-6d8d-4472-8cf1-39322f59f07a" />

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/264)