### PR TITLE
[IsolationSession] Add state-aware lifecycle support to TypeScript SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,16 +106,16 @@ The Rust workspace (`src/`) implements multiple sandboxing backends behind the `
 
 ### TypeScript layers
 
-- **SDK** (`sdk/`, `@microsoft/mxc-sdk`) — the public API. `spawnSandbox()` builds a `ContainerConfig` from a `SandboxPolicy`, serializes to base64, and spawns the correct native binary (`wxc-exec.exe` or `lxc-exec`) via `node-pty`. Platform detection is in `platform.ts`.
+- **SDK** (`sdk/`, `@microsoft/mxc-sdk`) — the public API. The one-shot surface (`spawnSandbox` / `spawnSandboxFromConfig` / `spawnSandboxAsync`) builds a `ContainerConfig` from a `SandboxPolicy`, serialises to base64, and spawns the correct native binary (`wxc-exec.exe` or `lxc-exec`) via `node-pty`. The state-aware surface (`provisionSandbox` / `startSandbox` / `execInSandbox` / `execInSandboxAsync` / `stopSandbox` / `deprovisionSandbox`, in `sdk/src/state-aware.ts`) drives a sandbox through a multi-call lifecycle against `StateAwareSandboxingMethod` backends; per-(backend, phase) typed `*Config` interfaces and a branded `SandboxId<C>` live in `sdk/src/state-aware-types.ts`. Typed wire-format errors live in `sdk/src/errors.ts` (closed `ErrorCode` union plus one `MxcError` subclass per code, mirroring the Rust `MxcErrorCode` enum). Platform detection is in `platform.ts`.
 - **CLI** (`cli/`, `mxc-cli`) — thin Commander.js wrapper around the SDK. Depends on `@microsoft/mxc-sdk` via `file:../sdk`.
 
 The SDK auto-discovers native binaries by checking `sdk/bin/<target-triple>/` (npm-packaged) and `src/target/<target-triple>/{release,debug}/` (local dev). The `build.bat`/`build.sh` scripts copy binaries into the SDK bin directory.
 
 ### Schema system
 
-- **Stable schema**: `schemas/stable/mxc-config.schema.0.4.0-alpha.json` — immutable after release
-- **Dev schema**: `schemas/dev/mxc-config.schema.0.5.0-dev.json` — includes `experimental` section
-- Current schema version: `0.4.0-alpha`
+- **Stable schemas**: `schemas/stable/mxc-config.schema.0.4.0-alpha.json` and `schemas/stable/mxc-config.schema.0.5.0-alpha.json` — immutable after release
+- **Dev schema**: `schemas/dev/mxc-config.schema.0.6.0-dev.json`
+- Current schema version: `0.5.0-alpha`
 - Config files can reference schemas via `"$schema"` for editor validation
 
 ### Key documentation (`docs/`)
@@ -179,7 +179,7 @@ When changing behavior covered by existing documentation, update the relevant do
 
 ### Policy versioning
 
-The `SandboxPolicy.version` in the SDK must match the JSON schema version (currently `0.4.0-alpha`). The SDK validates this in `sandbox.ts` — if the policy version is newer than `SUPPORTED_VERSION`, it throws. See `docs/versioning.md` for the full design.
+The `SandboxPolicy.version` in the SDK must match a JSON schema version in the supported range (`0.4.0-alpha` minimum, `0.6.0-alpha` maximum). The SDK validates this in `sandbox.ts` — if the policy version is older than `MIN_VERSION` or newer than `SUPPORTED_VERSION` it throws. State-aware lifecycle requests use `0.6.0-alpha`. See `docs/versioning.md` for the full design.
 
 ## Creating Issues
 

--- a/docs/authoring-a-new-feature.md
+++ b/docs/authoring-a-new-feature.md
@@ -103,7 +103,7 @@ Adding a feature may touch these files:
 
 | File | What to change |
 |------|----------------|
-| `schemas/dev/mxc-config.schema.0.5.0-dev.json` | Add `gpuIsolation` as a feature under `experimental` |
+| `schemas/dev/mxc-config.schema.0.6.0-dev.json` | Add `gpuIsolation` as a feature under `experimental` |
 | `src/wxc_common/src/models.rs` | Add `GpuIsolationConfig` struct, add field to `ExperimentalConfig` |
 | `src/wxc_common/src/config_parser.rs` | Add `gpuIsolation` field to `RawExperimental` |
 | Runner (`appcontainer.rs` or `lxc_runner.rs`) | Feature logic, guarded behind `experimental_enabled` |
@@ -111,7 +111,7 @@ Adding a feature may touch these files:
 
 ## Step 1: Update the schema
 
-In `schemas/dev/mxc-config.schema.0.5.0-dev.json`, the `experimental` section already
+In `schemas/dev/mxc-config.schema.0.6.0-dev.json`, the `experimental` section already
 exists with `compartments` as a feature. Add `gpuIsolation` as a new
 feature with its own typed schema:
 

--- a/docs/sandbox-policy/v1/policy.md
+++ b/docs/sandbox-policy/v1/policy.md
@@ -55,11 +55,11 @@ Omitted policy fields = most restrictive permissions. Adding a field opts *in* t
 
 ```typescript
 // Fully locked down:
-spawnSandbox("script.sh", { version: "0.5.0-dev" });
+spawnSandbox("script.sh", { version: "0.5.0-alpha" });
 
 // Allow outbound network:
 spawnSandbox("script.sh", {
-  version: "0.5.0-dev",
+  version: "0.5.0-alpha",
   network: { allowOutbound: true },
 });
 ```
@@ -242,7 +242,7 @@ Execution timeout in milliseconds. Omitted = SDK default (no timeout).
 An empty policy is fully locked down:
 
 ```typescript
-spawnSandbox("script.sh", { version: "0.5.0-dev" });
+spawnSandbox("script.sh", { version: "0.5.0-alpha" });
 // No filesystem, no network, no UI, no input injection.
 ```
 
@@ -274,7 +274,7 @@ type ContainerConfig =
 
 ```json
 {
-  "version": "0.5.0-dev",
+  "version": "0.5.0-alpha",
   "containment": "process",
   "process": {
     "commandLine": "node agent.js",
@@ -324,7 +324,7 @@ cross-platform fields mapped from Policy.
 
 ```json
 {
-  "version": "0.5.0-dev",
+  "version": "0.5.0-alpha",
   "containment": "lxc",
   "process": {
     "commandLine": "bash run.sh",
@@ -406,7 +406,7 @@ Only `"process"` is end-to-end implemented today.
 
 ```typescript
 const policy: SandboxPolicy = {
-  version: "0.5.0-dev",
+  version: "0.5.0-alpha",
   filesystem: { readwritePaths: ["C:\\workspace"] },
   network: {},
   ui: {
@@ -560,7 +560,7 @@ thing they modify.
 ### "What happens if I omit all policy fields?"
 
 ```typescript
-spawnSandbox("script.sh", { version: "0.5.0-dev" });
+spawnSandbox("script.sh", { version: "0.5.0-alpha" });
 ```
 
 Produces a fully locked-down config: no filesystem access, no network, UI disabled, no input

--- a/docs/sandbox-policy/v1/policy.md
+++ b/docs/sandbox-policy/v1/policy.md
@@ -55,11 +55,11 @@ Omitted policy fields = most restrictive permissions. Adding a field opts *in* t
 
 ```typescript
 // Fully locked down:
-spawnSandbox("script.sh", { version: "0.5.0-alpha" });
+spawnSandbox("script.sh", { version: "0.5.0-dev" });
 
 // Allow outbound network:
 spawnSandbox("script.sh", {
-  version: "0.5.0-alpha",
+  version: "0.5.0-dev",
   network: { allowOutbound: true },
 });
 ```
@@ -242,7 +242,7 @@ Execution timeout in milliseconds. Omitted = SDK default (no timeout).
 An empty policy is fully locked down:
 
 ```typescript
-spawnSandbox("script.sh", { version: "0.5.0-alpha" });
+spawnSandbox("script.sh", { version: "0.5.0-dev" });
 // No filesystem, no network, no UI, no input injection.
 ```
 
@@ -274,7 +274,7 @@ type ContainerConfig =
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.5.0-dev",
   "containment": "process",
   "process": {
     "commandLine": "node agent.js",
@@ -324,7 +324,7 @@ cross-platform fields mapped from Policy.
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.5.0-dev",
   "containment": "lxc",
   "process": {
     "commandLine": "bash run.sh",
@@ -406,7 +406,7 @@ Only `"process"` is end-to-end implemented today.
 
 ```typescript
 const policy: SandboxPolicy = {
-  version: "0.5.0-alpha",
+  version: "0.5.0-dev",
   filesystem: { readwritePaths: ["C:\\workspace"] },
   network: {},
   ui: {
@@ -560,7 +560,7 @@ thing they modify.
 ### "What happens if I omit all policy fields?"
 
 ```typescript
-spawnSandbox("script.sh", { version: "0.5.0-alpha" });
+spawnSandbox("script.sh", { version: "0.5.0-dev" });
 ```
 
 Produces a fully locked-down config: no filesystem access, no network, UI disabled, no input

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,7 +4,7 @@
 MXC uses a JSON configuration file. The current stable schema is at
 [`schemas/stable/mxc-config.schema.0.4.0-alpha.json`](../schemas/stable/mxc-config.schema.0.4.0-alpha.json).
 For development, the dev schema at
-[`schemas/dev/mxc-config.schema.0.5.0-dev.json`](../schemas/dev/mxc-config.schema.0.5.0-dev.json)
+[`schemas/dev/mxc-config.schema.0.6.0-dev.json`](../schemas/dev/mxc-config.schema.0.6.0-dev.json)
 includes experimental features and may change without notice.
 
 Editors that support JSON Schema will provide autocomplete and validation when
@@ -16,7 +16,7 @@ production configs and the dev schema when working on experimental features:
 "$schema": "./schemas/stable/mxc-config.schema.0.4.0-alpha.json"
 
 // Development (experimental features)
-"$schema": "./schemas/dev/mxc-config.schema.0.5.0-dev.json"
+"$schema": "./schemas/dev/mxc-config.schema.0.6.0-dev.json"
 ```
 
 ### Full Schema

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -4,10 +4,10 @@
 *Compiled 2026-04-28.*
 
 A state-aware sandbox API for MXC, surfaced alongside the existing one-shot
-`spawnSandbox*` family. Five lifecycle phases; opaque caller-owned `SandboxId`; typed
-per-phase backend config; cross-cutting `SandboxPolicy` shared with one-shot. Backends
-opt in by implementing a new `StatefulSandboxBackend` Rust trait. MXC retains no state
-between calls.
+`spawnSandbox*` family. Five lifecycle phases; opaque caller-owned `SandboxId`;
+per-(backend, phase) typed Config interfaces that absorb cross-cutting fields directly
+(no separate `SandboxPolicy` parameter). Backends opt in by implementing a new
+`StatefulSandboxBackend` Rust trait. MXC retains no state between calls.
 
 `spawnSandbox` is the composition of the five phases run end-to-end. State-aware exposes
 each phase individually.
@@ -20,12 +20,12 @@ function signatures throughout. One-line summaries; full definitions live in
 
 | Type | Where | Role |
 |---|---|---|
-| `SandboxPolicy` | `sdk/src/types.ts` | Cross-platform restriction policy: filesystem, network, UI, timeout. Reused as the cross-cutting policy on state-aware. |
 | `SandboxingMethod` | `sdk/src/types.ts` | String union of MXC backend names (`'appcontainer' \| 'windows_sandbox' \| 'lxc' \| 'wslc' \| 'vm' \| 'microvm' \| 'isolation_session'`). |
-| `ProcessConfig` | `sdk/src/types.ts` | Per-process settings: `commandLine`, `cwd`, `env`, `timeout`. Reused for state-aware exec. |
-| `FilesystemConfig`, `NetworkConfig`, `UiConfig` | `sdk/src/types.ts` | Wire-format restriction blocks. The `SandboxPolicy` → wire mapping is the existing `createConfigFromPolicy` logic. |
+| `ProcessConfig` | `sdk/src/types.ts` | Per-process settings: `commandLine`, `cwd`, `env`, `timeout`. Reused inside state-aware exec Configs. |
+| `FilesystemConfig`, `NetworkConfig`, `UiConfig` | `sdk/src/types.ts` | Wire-format-aligned cross-cutting interfaces. Reused inline as field types inside the per-(backend, phase) state-aware Configs. |
+| `SandboxSpawnOptions` | `sdk/src/sandbox.ts` | Existing options bag (debug, dryRun, logDir, executablePath, ptyOptions, usePty, experimental). State-aware reuses it as the third positional arg, extended with `signal?: AbortSignal` for cancellation. |
 | `pty.IPty` | `node-pty` package | Interactive PTY handle. Used as the streaming-exec return type, matching existing `spawnSandbox`. |
-| `getAvailableToolsPolicy`, `getUserProfilePolicy`, `getTemporaryFilesPolicy` | `sdk/src/policy.ts` | Filesystem-policy discovery helpers. Compose unchanged with state-aware via `SandboxPolicy`. |
+| `getAvailableToolsPolicy`, `getUserProfilePolicy`, `getTemporaryFilesPolicy` | `sdk/src/policy.ts` | Filesystem-policy discovery helpers. Produce `FilesystemPolicyResult` fragments that compose into a state-aware Config's `filesystem` field. |
 | `ContainmentBackend` (Rust) | `wxc_common::models` | Rust dispatch enum (one variant per backend). State-aware adds `IsolationSession` and future variants. |
 | ProcessContainer | MXC's existing AppContainer-based one-shot backend | Relevant context: ProcessContainer streams stdout/stderr live via PTY; state-aware exec preserves that streaming model. |
 
@@ -40,11 +40,11 @@ on the response, and neither shape carries `containerId`.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes. | `spawnSandbox` family preserved. `SandboxPolicy` reused as cross-cutting policy. `SandboxingMethod` extension reused. `*Config` naming convention reused. |
+| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed exception classes. | `spawnSandbox` family preserved. `SandboxingMethod` extension reused. The wire-format-aligned `Process` / `Filesystem` / `Network` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). `*Config` naming convention reused. |
 | JSON wire format (reference §7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (reference §9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private `Raw*` parser pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends unchanged. |
 | Error model (reference §8) | Closed enum of 12 codes. `MxcError` base + per-code subclasses. `details` open object. | Existing one-shot error paths preserved. |
-| Plug-in surface (reference §11) | Implement `StatefulSandboxBackend`. Define typed per-phase `*Config` interfaces. Register a backend-specific id prefix. Document the cross-cutting honor matrix. | Ephemeral-only backends require no changes. |
+| Plug-in surface (reference §11) | Implement `StatefulSandboxBackend`. Define typed per-(backend, phase) `*Config` interfaces. Declare the trait's `ID_PREFIX` and `BACKEND_KEY` consts. Document the cross-cutting honor matrix. | Ephemeral-only backends require no changes. |
 
 ## Lifecycle
 
@@ -61,8 +61,10 @@ Phases without native equivalents fall through to the trait's default no-op bodi
 
 ## TypeScript SDK
 
-Types used in the function signatures below. Per-phase `<Phase>SandboxOptions<C>` and
-`<Phase>Result<C>` are typed-generic over the chosen backend; full definitions are in
+Each phase takes a per-(backend, phase) Config — a single named interface that absorbs
+both the cross-cutting fields the backend honors at that phase and any backend-specific
+per-phase fields. `SandboxPolicy` does not appear in the state-aware surface. Full
+definitions and worked types are in
 [reference §6.1](./mxc-state-aware-sandbox-api.md#6-typescript-sdk).
 
 ```typescript
@@ -82,46 +84,59 @@ interface ExecResult {
 ```typescript
 function provisionSandbox<C extends StateAwareSandboxingMethod>(
   containment: C,
-  options?: ProvisionSandboxOptions<C>,
+  config?: ProvisionConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<ProvisionResult<C>>;
 
 function startSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: StartSandboxOptions<C>,
+  config?: StartConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<StartResult<C>>;
 
 function execInSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  process: ProcessConfig,
-  options?: ExecInSandboxOptions<C>,
+  config: ExecConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): pty.IPty;
 
 function execInSandboxAsync<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  process: ProcessConfig,
-  options?: ExecInSandboxOptions<C>,
+  config: ExecConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<ExecResult>;
 
 function stopSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: StopSandboxOptions<C>,
+  config?: StopConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<StopResult<C>>;
 
 function deprovisionSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: DeprovisionSandboxOptions<C>,
+  config?: DeprovisionConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<DeprovisionResult<C>>;
 ```
 
-Each phase's options carry `policy?: SandboxPolicy` (cross-cutting restrictions, shared
-with one-shot), `config?: <Phase>ConfigFor<C>` (per-phase backend config, typed), and
-`signal?: AbortSignal` (cancellation). `containment` is named once at `provisionSandbox`
-and inferred from the branded `SandboxId<C>` on every subsequent call. Each non-exec
-phase returns a typed `<Phase>Result<C>`: provision carries `sandboxId` plus optional
-metadata; start, stop, and deprovision carry optional metadata only. `execInSandbox`
-returns an `IPty` for live streaming; `execInSandboxAsync` is a buffered convenience
-that resolves on exit. Existing policy-discovery helpers (`getAvailableToolsPolicy`,
-etc.) compose into `SandboxPolicy` unchanged.
+`<Phase>ConfigFor<C>` resolves to a per-(backend, phase) named interface (e.g.,
+`IsolationSessionProvisionConfig`) that declares only the fields valid for that
+backend at that phase. Cross-cutting fields appear inline at the Config root in the
+phases where the backend honors them (e.g., `IsolationSessionProvisionConfig` carries
+`filesystem` / `network` / `ui`); phases without backend-specific or cross-cutting
+fields declare a Config carrying only `version?`. `containment` is named once at
+`provisionSandbox` and inferred from the branded `SandboxId<C>` on every subsequent
+call. Each non-exec phase returns a typed `<Phase>Result<C>`: provision carries
+`sandboxId` plus optional metadata; start, stop, and deprovision carry optional
+metadata only. `execInSandbox` returns an `IPty` for live streaming;
+`execInSandboxAsync` is a buffered convenience that resolves on exit. The third
+positional argument is the existing `SandboxSpawnOptions` (extended with
+`signal?: AbortSignal` for cancellation), the same options bag one-shot uses.
+`experimental: true` is required when the targeted backend is itself experimental
+(IsolationSession is today); state-awareness as a feature is not gated by an
+experimental flag. Existing policy-discovery helpers (`getAvailableToolsPolicy` and
+friends) produce `FilesystemPolicyResult` fragments that compose directly into a
+state-aware Config's `filesystem` field — no change to the helpers.
 
 ## Wire contract
 
@@ -164,18 +179,15 @@ interface NonProvisionStateAwareRequest {
 
 type StateAwareRequest = ProvisionStateAwareRequest | NonProvisionStateAwareRequest;
 
+// Wire-format shape of the `experimental` block on state-aware requests. The SDK
+// builds this from per-(backend, phase) Configs (see TypeScript SDK section above).
 interface ExperimentalStateAwareConfigs {
-  isolation_session?: IsolationSessionStateAwareConfigs;
+  isolation_session?: {
+    start?: { configurationId?: 'small' | 'medium' | 'large' | 'composable' };
+    // provision, exec, stop, deprovision omitted — IsolationSession has no
+    // backend-specific config for those phases.
+  };
   // future state-aware-capable backends add typed entries here
-}
-
-interface IsolationSessionStateAwareConfigs {
-  start?: IsolationSessionStartConfig;
-  // provision, exec, stop, deprovision omitted — IsolationSession has no config there
-}
-
-interface IsolationSessionStartConfig {
-  configurationId?: 'small' | 'medium' | 'large' | 'commandLine';
 }
 
 type MxcRequest = OneShotRequest | StateAwareRequest;
@@ -195,6 +207,7 @@ SDK parsing rules.
 ```rust
 pub trait StatefulSandboxBackend {
     const ID_PREFIX: &'static str;
+    const BACKEND_KEY: &'static str;
 
     type ProvisionConfig: serde::de::DeserializeOwned;
     type StartConfig: serde::de::DeserializeOwned;
@@ -247,23 +260,26 @@ pub trait StatefulSandboxBackend {
 }
 ```
 
-Backends declare a const id prefix, per-phase config and metadata as associated types
-(use `()` for phases that don't need either), and override only the methods they care
-about — `exec` is the only required method. Trait methods take `&CodexRequest` (the
-existing one-shot domain model from `wxc_common::models`) plus `sandbox_id` for
-non-provision phases and an optional backend-specific typed config; cross-cutting
-policy fields flow through `request.policy` (a `ContainerPolicy`) and per-exec process
-info flows through `request.script_code` / `request.working_directory` /
-`request.script_timeout` / `request.env`. There is no unified Rust "policy" type and
-no Rust `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` wrapper
-struct — those names exist as TypeScript SDK interfaces only. See "Why the trait
-reuses `CodexRequest`" in main doc §9.2 for the rationale.
+Backends declare two consts (`ID_PREFIX` for sandbox-id routing, `BACKEND_KEY` for the
+wire-format `containment` value and `experimental.<BACKEND_KEY>.<phase>` deserialisation
+— see reference §5), per-phase config and metadata as associated types (use `()` for
+phases that don't need either), and override only the methods they care about — `exec`
+is the only required method. Trait methods take `&CodexRequest` (the existing one-shot
+domain model from `wxc_common::models`) plus `sandbox_id` for non-provision phases and
+an optional backend-specific typed config; cross-cutting policy fields flow through
+`request.policy` (a `ContainerPolicy`) and per-exec process info flows through
+`request.script_code` / `request.working_directory` / `request.script_timeout` /
+`request.env`. There is no Rust `ProcessConfig` / `FilesystemConfig` / `NetworkConfig`
+/ `UiConfig` wrapper struct — those names exist as TypeScript SDK interfaces only. See
+"Why the trait reuses `CodexRequest`" in main doc §9.2 for the rationale.
 
 A backend's participation mode (ephemeral-only, state-aware-only, both) is declared by
-which traits it implements. State-aware backends additionally register an id prefix
-alongside their `ContainmentBackend` variant; the dispatcher reads the prefix from
-`sandboxId` to route non-provision calls. Reference §4 describes the modes; reference
-§5 covers id prefixes; reference §9 describes the Rust mirror struct and dispatch.
+which traits it implements. State-aware backends additionally register their
+`ID_PREFIX` and `BACKEND_KEY` on the trait impl alongside their `ContainmentBackend`
+variant; the dispatcher reads the prefix from `sandboxId` to route non-provision calls
+and the backend key for provision-phase routing and experimental-block deserialisation.
+Reference §4 describes the modes; reference §5 covers identifiers; reference §9
+describes the Rust mirror struct and dispatch.
 
 ## Worked example: IsolationSession
 
@@ -273,17 +289,21 @@ Provision and exec — the two most distinctive shapes. Reference §7.4 has all 
 #### Provision
 
 ```typescript
-const policy: SandboxPolicy = {
-  version: '0.5.0-alpha',
+const config: IsolationSessionProvisionConfig = {
   filesystem: { readwritePaths: ['C:\\workspace'] },
-  network: { allowOutbound: true, allowedHosts: ['api.anthropic.com'] },
+  network: { defaultPolicy: 'allow', allowedHosts: ['api.anthropic.com'] },
 };
-const { sandboxId } = await provisionSandbox('isolation_session', { policy });
+const { sandboxId } = await provisionSandbox(
+  'isolation_session',
+  config,
+  { experimental: true },
+);
 // sandboxId = "iso:reg-abc:prov-123"
 ```
 
 ```json
 {
+  "version": "0.6.0-alpha",
   "containment": "isolation_session",
   "phase": "provision",
   "filesystem": { "readwritePaths": ["C:\\workspace"] },
@@ -314,14 +334,17 @@ backend.provision(&request, /* config */ None)
 
 ```typescript
 // sandboxId from the provision example above.
-const r = await execInSandboxAsync(sandboxId, {
-  commandLine: 'echo hello',
-});
+const r = await execInSandboxAsync(
+  sandboxId,
+  { process: { commandLine: 'echo hello' } },
+  { experimental: true },
+);
 // r = { stdout: "hello\n", stderr: "", exitCode: 0 }
 ```
 
 ```json
 {
+  "version": "0.6.0-alpha",
   "phase": "exec",
   "sandboxId": "iso:reg-abc:prov-123",
   "process": { "commandLine": "echo hello" }
@@ -343,9 +366,9 @@ Wire response (raw streaming, no JSON envelope on success):
 The SDK constructs `{ stdout: "hello\n", stderr: "", exitCode: 0 }` from PTY events.
 
 The SDK auto-wraps backend-specific config under `experimental.<backend>.<phase>`.
-Cross-backend exec fields flow through top-level `process`. `SandboxPolicy` fields map to
-top-level `filesystem` / `network` / `ui` for state-aware (backend declares per-phase
-honor per reference §10.3).
+Cross-backend exec fields flow through top-level `process`. Cross-cutting fields
+(`filesystem` / `network` / `ui`) on the per-(backend, phase) Config map directly to
+top-level wire fields (backend declares per-phase honor per reference §10.3).
 
 ## Error codes
 
@@ -373,12 +396,15 @@ Reference §11 has the full guide. Operational checklist:
 1. Pick a participation mode (ephemeral-only, state-aware-only, both).
 2. Implement the trait. Define associated types for each phase's config and metadata;
    use `()` for any phase that doesn't need them.
-3. Define typed `*Config` interfaces in `@microsoft/mxc-sdk` and slot into
-   `ExperimentalStateAwareConfigs`. If newly SDK-exposed, extend `SandboxingMethod` and
-   `StateAwareSandboxingMethod`.
-4. Register a variant in the `ContainmentBackend` enum, declare the backend's id prefix
-   alongside the variant (it serves as the dispatcher's routing key for non-provision
-   calls), and add a dispatch arm.
+3. Define typed per-(backend, phase) `*Config` interfaces in `@microsoft/mxc-sdk` and
+   add an arm to `ConfigsForBackend<C>` mapping the backend to its five phase Configs.
+   If newly SDK-exposed, extend `SandboxingMethod` and `StateAwareSandboxingMethod`.
+4. Register a variant in the `ContainmentBackend` enum and declare two consts on the
+   trait impl: `ID_PREFIX` (the sandbox-id tag, dispatcher's routing key for
+   non-provision calls — pick a short distinct tag and treat it as permanent) and
+   `BACKEND_KEY` (the wire-format `containment` value, used for provision-phase
+   routing and `experimental.<BACKEND_KEY>.<phase>` deserialisation). Add a dispatch
+   arm for the new variant.
 5. Add `Raw*` intermediate structs in `config_parser.rs` for the backend's wire-format
    block.
 6. Document policy-honor matrix, idempotence, concurrency, and error mapping in
@@ -389,10 +415,11 @@ Reference §11 has the full guide. Operational checklist:
 
 ## Graduation and scope
 
-- **Graduation rule.** Per-stage config stays under `experimental.<backend>.<phase>`
-  while either the API or that backend's state-aware participation is experimental.
-  When both are stable, migrates to top-level `<backend>.<phase>`. The same `phase`
-  discrimination rule applies post-graduation. Reference §13.
+- **Graduation rule.** The state-aware API surface ships stable from `0.6.0`.
+  Per-stage config for a backend stays under `experimental.<backend>.<phase>` while
+  that backend's state-aware participation is experimental, and migrates to top-level
+  `<backend>.<phase>` when the backend's state-aware participation graduates. The
+  `phase` discrimination rule applies post-graduation. Reference §13.
 - **Out of scope for v1.** Detached / OS-level fire-and-forget execs (JS-async
   fire-and-forget IS supported via don't-await on existing functions); additional
   lifecycle stages; cross-machine `SandboxId` portability; MXC-enforced container-wide

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -40,10 +40,10 @@ on the response, and neither shape carries `containerId`.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed exception classes. | `spawnSandbox` family preserved. `SandboxingMethod` extension reused. The wire-format-aligned `Process` / `Filesystem` / `Network` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). `*Config` naming convention reused. |
+| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `SandboxingMethod` extension reused. The wire-format-aligned `Process` / `Filesystem` / `Network` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). `*Config` naming convention reused. |
 | JSON wire format (reference §7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (reference §9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private `Raw*` parser pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends unchanged. |
-| Error model (reference §8) | Closed enum of 12 codes. `MxcError` base + per-code subclasses. `details` open object. | Existing one-shot error paths preserved. |
+| Error model (reference §8) | Closed enum of 12 codes. `MxcError` class with `code: ErrorCode`. `details` open object. | Existing one-shot error paths preserved. |
 | Plug-in surface (reference §11) | Implement `StatefulSandboxBackend`. Define typed per-(backend, phase) `*Config` interfaces. Declare the trait's `ID_PREFIX` and `BACKEND_KEY` consts. Document the cross-cutting honor matrix. | Ephemeral-only backends require no changes. |
 
 ## Lifecycle
@@ -368,13 +368,15 @@ The SDK constructs `{ stdout: "hello\n", stderr: "", exitCode: 0 }` from PTY eve
 The SDK auto-wraps backend-specific config under `experimental.<backend>.<phase>`.
 Cross-backend exec fields flow through top-level `process`. Cross-cutting fields
 (`filesystem` / `network` / `ui`) on the per-(backend, phase) Config map directly to
-top-level wire fields (backend declares per-phase honor per reference §10.3).
+top-level wire fields (backend declares per-phase honor per reference §10.3). The
+SDK Config exposes only the cross-cutting fields the runtime currently honors —
+for IsolationSession at provision today that's `filesystem`; `network` and `ui` are
+added when the runtime honors them.
 
 ## Error codes
 
 Closed enum at the MXC layer; backend-specific failures use `backend_error` with
-structured `details`. Reference §8 has the full list and the typed exception class
-mapping.
+structured `details`. Reference §8 has the full list and the `MxcError` mapping.
 
 | Group | Codes |
 |---|---|
@@ -387,7 +389,7 @@ mapping.
 
 Process-runtime kill conditions (timeouts, backend-initiated termination) surface as
 sentinel exit codes from the exec process, not as typed wire-format errors. Each code
-maps to a typed TS exception class (`MxcError` base + per-code subclasses).
+maps to an `MxcError` with the corresponding `code` field.
 
 ## Plug-in steps for new backends
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -38,12 +38,15 @@
 This document proposes a state-aware sandbox API for MXC, surfaced alongside the existing
 one-shot `spawnSandbox*` family. Five lifecycle phases are exposed at the SDK level:
 provision, start, exec, stop, deprovision. Each is a discrete call. Provision returns an
-opaque `SandboxId` string the caller persists and forwards to subsequent calls. Per-stage
-configuration is typed per-backend per-phase under `experimental.<backend>.<phase>`;
-placement promotes to top-level once both the API and the backend's participation are
-stable. Backends opt in by implementing a new `StatefulSandboxBackend` Rust trait. The
-existing `ScriptRunner` trait is unchanged. A backend's participation mode (state-aware,
-ephemeral, or both) is declared by which trait or traits it implements.
+opaque `SandboxId` string the caller persists and forwards to subsequent calls. The API
+surface ships stable from `0.6.0` — state-awareness is not itself gated by an
+`--experimental` flag. Per-stage configuration is typed per-backend per-phase under
+`experimental.<backend>.<phase>` while a backend's state-aware participation is
+experimental, and migrates to top-level `<backend>.<phase>` when that backend's
+state-aware participation graduates (§13). Backends opt in by implementing a new
+`StatefulSandboxBackend` Rust trait. The existing `ScriptRunner` trait is unchanged. A
+backend's participation mode (state-aware, ephemeral, or both) is declared by which
+trait or traits it implements.
 
 The mental model: `spawnSandbox` is the composition of the five phases into one call.
 State-aware exposes them individually so callers can hold a sandbox between calls, run
@@ -60,11 +63,11 @@ elaborates.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes per error code. | `spawnSandbox` family preserved. `SandboxPolicy` reused as the cross-cutting policy across both surfaces. `SandboxingMethod` extension mechanism reused. Existing typed `*Config` naming convention reused. |
+| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed exception classes per error code. | `spawnSandbox` family preserved. `SandboxingMethod` extension mechanism reused. The existing wire-format-aligned `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside the new state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). Existing typed `*Config` naming convention reused. |
 | JSON wire format (§7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union over `phase`. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` fields at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (§9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private to parser, matching `RawConfig` pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends function without modification. |
 | Error model (§8) | Closed enum of 12 error codes. `MxcError` base + per-code subclasses. `details` open object as escape hatch for backend-specific structured information. | Existing one-shot error paths preserved. |
-| Plug-in surface (§11) | Implement `StatefulSandboxBackend` (in addition to or instead of `ScriptRunner`). Define typed per-phase `*Config` interfaces. Register a backend-specific id prefix. Document the cross-cutting policy honor matrix. | Ephemeral-only backends require no changes. The `ContainmentBackend` Rust enum is extended, not replaced. |
+| Plug-in surface (§11) | Implement `StatefulSandboxBackend` (in addition to or instead of `ScriptRunner`). Define typed per-(backend, phase) `*Config` interfaces. Declare the backend's `ID_PREFIX` and `BACKEND_KEY` consts on the trait impl. Document the cross-cutting policy honor matrix. | Ephemeral-only backends require no changes. The `ContainmentBackend` Rust enum is extended, not replaced. |
 
 ## 2. Context and motivation
 
@@ -182,6 +185,17 @@ as `const ID_PREFIX: &'static str` (§9.2) so the default `provision` body can m
 synthetic ids with the right prefix; the trait const and the dispatcher's routing table
 read from the same source, eliminating drift.
 
+A second const, `const BACKEND_KEY: &'static str`, lives alongside `ID_PREFIX` on the
+trait (§9.2). It carries the wire-format `containment` value for the backend (e.g.,
+`"isolation_session"`) and matches the SDK's `StateAwareSandboxingMethod` member name.
+The dispatcher uses it to navigate `experimental.<BACKEND_KEY>.<phase>` for typed-config
+deserialisation and to resolve `provision`-phase requests whose wire `containment`
+string maps to this backend. `ID_PREFIX` and `BACKEND_KEY` are deliberately distinct
+strings: `ID_PREFIX` is a compact tag chosen for sandbox-id brevity (e.g. `"iso"`)
+while `BACKEND_KEY` is the full backend name shared with the SDK type system (e.g.
+`"isolation_session"`). Backends that pick a long `BACKEND_KEY` for SDK readability
+are not forced to repeat that length in every persisted sandbox id.
+
 The SDK exposes the id as a branded TypeScript string parameterised by backend:
 
 ```typescript
@@ -222,7 +236,9 @@ on the response. Neither shape carries `containerId`. One-shot calls carry `cont
 ## 6. TypeScript SDK
 
 The SDK adds five new functions, exported from `@microsoft/mxc-sdk` alongside the existing
-one-shot entry points. Each function corresponds to a lifecycle phase from §4.
+one-shot entry points. Each function corresponds to a lifecycle phase from §4. The
+state-aware surface does not use `SandboxPolicy` — its cross-cutting fields live
+directly on the per-(backend, phase) Configs introduced below.
 
 ### 6.1 Type definitions
 
@@ -235,53 +251,66 @@ type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
 type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
 // extended as state-aware-capable backends are added
 
-interface ExperimentalStateAwareConfigs {
-  isolation_session?: IsolationSessionStateAwareConfigs;
-  // future state-aware-capable backends add typed entries here
-}
+// Per-(backend, phase) Configs. Each declares only the fields valid for that backend
+// at that phase. Cross-cutting fields (`filesystem`, `network`, `ui`) appear inline
+// at the Config root, only in phases where the backend honors them per its policy
+// honor matrix (§10.3). Phases with no backend-specific or cross-cutting fields
+// declare a Config carrying only `version?`.
 
-interface IsolationSessionStateAwareConfigs {
-  start?: IsolationSessionStartConfig;
-  // provision, exec, stop, deprovision omitted — IsolationSession has no per-phase
-  // config for those phases. Other backends may include any subset.
+interface IsolationSessionProvisionConfig {
+  version?: string;
+  filesystem?: FilesystemConfig;
+  network?: NetworkConfig;
+  ui?: UiConfig;
 }
 
 interface IsolationSessionStartConfig {
-  configurationId?: 'small' | 'medium' | 'large' | 'commandLine';
+  version?: string;
+  configurationId?: 'small' | 'medium' | 'large' | 'composable';
+}
+
+interface IsolationSessionExecConfig {
+  version?: string;
+  process: ProcessConfig;
+}
+
+interface IsolationSessionStopConfig {
+  version?: string;
+}
+
+interface IsolationSessionDeprovisionConfig {
+  version?: string;
 }
 
 interface IsolationSessionProvisionMetadata {
   agentUserName: string;
 }
 
-// Per-phase config lookup helpers used by the SDK function options:
+// Backend Config bundle — outer keys are state-aware-capable backends; inner per-phase
+// entries carry the typed per-(backend, phase) Config. Used by the generic per-phase
+// helpers below.
 type ConfigsForBackend<C extends StateAwareSandboxingMethod> =
-  NonNullable<ExperimentalStateAwareConfigs[C]>;
+  C extends 'isolation_session' ? {
+    provision: IsolationSessionProvisionConfig;
+    start: IsolationSessionStartConfig;
+    exec: IsolationSessionExecConfig;
+    stop: IsolationSessionStopConfig;
+    deprovision: IsolationSessionDeprovisionConfig;
+  } : never;
 
 type ProvisionConfigFor<C extends StateAwareSandboxingMethod> =
-  'provision' extends keyof ConfigsForBackend<C>
-    ? ConfigsForBackend<C>['provision']
-    : undefined;
+  ConfigsForBackend<C>['provision'];
 type StartConfigFor<C extends StateAwareSandboxingMethod> =
-  'start' extends keyof ConfigsForBackend<C>
-    ? ConfigsForBackend<C>['start']
-    : undefined;
+  ConfigsForBackend<C>['start'];
 type ExecConfigFor<C extends StateAwareSandboxingMethod> =
-  'exec' extends keyof ConfigsForBackend<C>
-    ? ConfigsForBackend<C>['exec']
-    : undefined;
+  ConfigsForBackend<C>['exec'];
 type StopConfigFor<C extends StateAwareSandboxingMethod> =
-  'stop' extends keyof ConfigsForBackend<C>
-    ? ConfigsForBackend<C>['stop']
-    : undefined;
+  ConfigsForBackend<C>['stop'];
 type DeprovisionConfigFor<C extends StateAwareSandboxingMethod> =
-  'deprovision' extends keyof ConfigsForBackend<C>
-    ? ConfigsForBackend<C>['deprovision']
-    : undefined;
+  ConfigsForBackend<C>['deprovision'];
 
-// Per-backend metadata bundle (analogous to ExperimentalStateAwareConfigs but for
-// per-phase return values). Backends omit phases that return no metadata.
-interface ExperimentalStateAwareMetadata {
+// Per-backend metadata bundle. Backends omit phases that return no metadata.
+interface StateAwareMetadata {
   isolation_session?: {
     provision?: IsolationSessionProvisionMetadata;
     // IsolationSession returns no metadata for start, stop, deprovision
@@ -290,20 +319,20 @@ interface ExperimentalStateAwareMetadata {
 }
 
 type ProvisionMetadataFor<C extends StateAwareSandboxingMethod> =
-  'provision' extends keyof NonNullable<ExperimentalStateAwareMetadata[C]>
-    ? NonNullable<ExperimentalStateAwareMetadata[C]>['provision']
+  'provision' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['provision']
     : undefined;
 type StartMetadataFor<C extends StateAwareSandboxingMethod> =
-  'start' extends keyof NonNullable<ExperimentalStateAwareMetadata[C]>
-    ? NonNullable<ExperimentalStateAwareMetadata[C]>['start']
+  'start' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['start']
     : undefined;
 type StopMetadataFor<C extends StateAwareSandboxingMethod> =
-  'stop' extends keyof NonNullable<ExperimentalStateAwareMetadata[C]>
-    ? NonNullable<ExperimentalStateAwareMetadata[C]>['stop']
+  'stop' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['stop']
     : undefined;
 type DeprovisionMetadataFor<C extends StateAwareSandboxingMethod> =
-  'deprovision' extends keyof NonNullable<ExperimentalStateAwareMetadata[C]>
-    ? NonNullable<ExperimentalStateAwareMetadata[C]>['deprovision']
+  'deprovision' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['deprovision']
     : undefined;
 
 interface ProvisionResult<C extends StateAwareSandboxingMethod> {
@@ -328,86 +357,68 @@ interface ExecResult {
   stderr: string;
   exitCode: number;
 }
-
-// Per-phase options interfaces. All carry the cross-cutting `policy: SandboxPolicy`
-// (single source of truth, shared with one-shot), the per-phase backend `config`
-// (typed per backend), and an optional `signal` for cancellation.
-interface ProvisionSandboxOptions<C extends StateAwareSandboxingMethod> {
-  policy?: SandboxPolicy;
-  config?: ProvisionConfigFor<C>;
-  signal?: AbortSignal;
-}
-
-interface StartSandboxOptions<C extends StateAwareSandboxingMethod> {
-  policy?: SandboxPolicy;
-  config?: StartConfigFor<C>;
-  signal?: AbortSignal;
-}
-
-interface ExecInSandboxOptions<C extends StateAwareSandboxingMethod> {
-  policy?: SandboxPolicy;
-  config?: ExecConfigFor<C>;
-  signal?: AbortSignal;
-}
-
-interface StopSandboxOptions<C extends StateAwareSandboxingMethod> {
-  policy?: SandboxPolicy;
-  config?: StopConfigFor<C>;
-  signal?: AbortSignal;
-}
-
-interface DeprovisionSandboxOptions<C extends StateAwareSandboxingMethod> {
-  policy?: SandboxPolicy;
-  config?: DeprovisionConfigFor<C>;
-  signal?: AbortSignal;
-}
 ```
 
-`SandboxPolicy` is the existing cross-platform policy type from `sdk/src/types.ts`,
-reused unchanged. `ProcessConfig` is the existing per-process settings type
-(`commandLine`, `cwd`, `env`, `timeout`), also reused.
+`FilesystemConfig`, `NetworkConfig`, `UiConfig`, `ProcessConfig` are the existing
+wire-format-aligned interfaces from `sdk/src/types.ts`, reused unchanged as field
+types inside the per-(backend, phase) Configs. State-aware deliberately does not use
+`SandboxPolicy`; consumers spell out wire-format-aligned values directly (e.g.,
+`network: { defaultPolicy: 'block' }` instead of `network: { allowOutbound: false }`).
 
-When a backend declares no config for a particular phase, the corresponding helper type
-resolves to `undefined`. TypeScript then refuses to accept any non-`undefined` value for
-that phase's `config` field — callers can't accidentally pass start config to a backend
-that has no start config. The same machinery applies on the return side: when a backend
-declares no metadata for a phase, `<Phase>MetadataFor<C>` resolves to `undefined` and
-the corresponding `*Result<C>` is structurally empty (its `metadata` field is statically
-undefined).
+A backend's per-(backend, phase) Config declares each cross-cutting field exactly once,
+and only in the phase where the backend's policy honor matrix (§10.3) marks it as
+`applied`. For IsolationSession, that means `IsolationSessionProvisionConfig` carries
+`filesystem` / `network` / `ui` and the other four phase Configs do not — the type
+system rejects callers passing those fields to start, exec, stop, or deprovision (§10.3
+explains how the matrix lands at compile time on the SDK and at runtime in Rust).
+Phases with no backend-specific or cross-cutting fields declare a Config carrying only
+`version?` — explicit and minimal. Adding a future state-aware backend is a localised
+change: extend `StateAwareSandboxingMethod`, define five new `*Config` interfaces, and
+add an arm to `ConfigsForBackend`.
+
+Each Config carries an optional `version?: string`. When omitted, the SDK fills in its
+own `SUPPORTED_VERSION`; an explicit value is range-validated against the SDK's
+`MIN_VERSION` and `SUPPORTED_VERSION` (same convention as today's
+`validatePolicyVersion`). The override exists so consumers can target a specific wire
+version when debugging or testing version negotiation.
 
 ### 6.2 Method signatures
 
 ```typescript
 function provisionSandbox<C extends StateAwareSandboxingMethod>(
   containment: C,
-  options?: ProvisionSandboxOptions<C>,
+  config?: ProvisionConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<ProvisionResult<C>>;
 
 function startSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: StartSandboxOptions<C>,
+  config?: StartConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<StartResult<C>>;
 
 function execInSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  process: ProcessConfig,
-  options?: ExecInSandboxOptions<C>,
+  config: ExecConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): pty.IPty;
 
 function execInSandboxAsync<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  process: ProcessConfig,
-  options?: ExecInSandboxOptions<C>,
+  config: ExecConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<ExecResult>;
 
 function stopSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: StopSandboxOptions<C>,
+  config?: StopConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<StopResult<C>>;
 
 function deprovisionSandbox<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,
-  options?: DeprovisionSandboxOptions<C>,
+  config?: DeprovisionConfigFor<C>,
+  options?: SandboxSpawnOptions,
 ): Promise<DeprovisionResult<C>>;
 ```
 
@@ -422,6 +433,17 @@ into the returned `SandboxId<C>`. Subsequent calls (`startSandbox`, `execInSandb
 branded id and do not restate it. The wire envelope mirrors this: provision carries
 `containment`; non-provision phases route via the prefix on `sandboxId` (§5, §7.1).
 
+The third positional argument is the existing `SandboxSpawnOptions` from
+`sdk/src/sandbox.ts`, extended with `signal?: AbortSignal` for cancellation.
+State-aware reuses the same options bag as one-shot — single mental model, single place
+to learn the cross-cutting flags. Phase-specific fields on `SandboxSpawnOptions`
+(`ptyOptions`, `usePty`) are honored by `execInSandbox` / `execInSandboxAsync` and
+silently ignored on the other phases. State-awareness is not itself experimental —
+`experimental: true` must be set when the targeted backend is itself experimental, just
+as it is today for one-shot calls against `microvm` and `wslc`. IsolationSession is
+experimental at the time of writing; that status is independent of the state-aware API
+surface (§13).
+
 ### 6.3 Example
 
 ```typescript
@@ -433,82 +455,77 @@ import {
   stopSandbox,
   deprovisionSandbox,
   getAvailableToolsPolicy,
-  SandboxPolicy,
+  IsolationSessionProvisionConfig,
+  SandboxSpawnOptions,
 } from '@microsoft/mxc-sdk';
 
 const tools = getAvailableToolsPolicy();
-const policy: SandboxPolicy = {
-  version: '0.5.0-alpha',
+const provisionConfig: IsolationSessionProvisionConfig = {
   filesystem: {
-    readwritePaths: ['C:\\workspace'],
+    readwritePaths: ['C:\\workspace', ...tools.readwritePaths],
     readonlyPaths: tools.readonlyPaths,
   },
-  network: { allowOutbound: true, allowedHosts: ['api.anthropic.com'] },
+  network: { defaultPolicy: 'allow', allowedHosts: ['api.anthropic.com'] },
 };
 
-// Provision — caller passes cross-cutting policy; IsolationSession honors it at this
-// phase per its documented matrix (§10.3).
-const { sandboxId } = await provisionSandbox('isolation_session', { policy });
+// IsolationSession is experimental, so every call carries `experimental: true`.
+const opts: SandboxSpawnOptions = { experimental: true };
+
+// Provision — cross-cutting fields apply at this phase per the IS honor matrix (§10.3).
+const { sandboxId } = await provisionSandbox('isolation_session', provisionConfig, opts);
 
 // Start — backend-specific config picks the session size.
-await startSandbox(sandboxId, {
-  config: { configurationId: 'small' },
-});
+await startSandbox(sandboxId, { configurationId: 'small' }, opts);
 
 // Exec — buffered convenience for short workloads.
-const result = await execInSandboxAsync(sandboxId, {
-  commandLine: 'echo hello',
-  timeout: 5000,
-});
+const result = await execInSandboxAsync(
+  sandboxId,
+  { process: { commandLine: 'echo hello', timeout: 5000 } },
+  opts,
+);
 console.log(result.stdout);  // "hello\n"
 
 // Exec — streaming for long-running workloads. Returns IPty.
-const session = execInSandbox(sandboxId, {
-  commandLine: 'C:\\workspace\\agent.exe --watch',
-});
+const session = execInSandbox(
+  sandboxId,
+  { process: { commandLine: 'C:\\workspace\\agent.exe --watch' } },
+  opts,
+);
 session.onData((chunk) => process.stdout.write(chunk));
 session.onExit(({ exitCode }) => console.log(`agent exit: ${exitCode}`));
 
-// Stop and deprovision when done.
-await stopSandbox(sandboxId);
-await deprovisionSandbox(sandboxId);
+// Stop and deprovision when done. Stop and deprovision Configs carry only `version?`,
+// so callers typically pass `{}` (or omit when no options are needed).
+await stopSandbox(sandboxId, {}, opts);
+await deprovisionSandbox(sandboxId, {}, opts);
 ```
 
 ### 6.4 Composition with the one-shot surface
 
 `spawnSandbox` is the composition of the five state-aware phases run end-to-end. The two
-surfaces share `SandboxPolicy` and `SandboxingMethod`; they differ in granularity. A
-backend that participates in both modes can be invoked through either surface; a backend
-that participates in only one returns `unsupported_phase` from the other (§8).
+surfaces share `SandboxingMethod` and the wire-format-aligned interfaces in
+`sdk/src/types.ts` (`ProcessConfig`, `FilesystemConfig`, `NetworkConfig`, `UiConfig`).
+They differ in granularity and in how those interfaces are surfaced: one-shot bundles
+them inside `ContainerConfig` (which is itself produced from a `SandboxPolicy` by
+`createConfigFromPolicy`); state-aware uses them as field types inside the
+per-(backend, phase) Configs and does not involve `SandboxPolicy` at all. A backend
+that participates in both modes can be invoked through either surface; a backend that
+participates in only one returns `unsupported_phase` from the other (§8).
 
 State-aware-capable backends extend `SandboxingMethod` and `StateAwareSandboxingMethod`
 the same way ephemeral backends extend `SandboxingMethod`. Cancellation via
-`AbortSignal` is supported on all state-aware methods. Detached / fire-and-forget exec
-(process outliving the SDK call) is deferred to v2 (§14).
+`AbortSignal` is supported on all state-aware methods (via `signal?: AbortSignal` on
+`SandboxSpawnOptions`). Detached / fire-and-forget exec (process outliving the SDK
+call) is deferred to v2 (§14).
 
 ### 6.5 Policy discovery
 
 The existing policy-discovery helpers (`getAvailableToolsPolicy`,
-`getUserProfilePolicy`, `getTemporaryFilesPolicy`) compose with state-aware functions
-unchanged. They produce `FilesystemPolicyResult` fragments that callers merge into
-`SandboxPolicy.filesystem` (as in the §6.3 example), then pass via the `policy` field.
-
-### 6.6 Why `SandboxPolicy` is retained at the SDK layer
-
-The SDK's existing `spawnSandbox(script, policy, ...)` entry point takes `SandboxPolicy`,
-and the three policy-discovery helpers (`getAvailableToolsPolicy`,
-`getUserProfilePolicy`, `getTemporaryFilesPolicy`) produce `FilesystemPolicyResult`
-fragments designed to merge into `SandboxPolicy.filesystem`. Keeping
-`policy?: SandboxPolicy` on every state-aware options interface preserves both ergonomic
-compositions and a consistent SDK surface across one-shot and state-aware lifecycle
-modes.
-
-The Rust trait remains policy-agnostic regardless: the SDK serialises both `policy` and
-`config` into the wire format (top-level `filesystem` / `network` / `ui` plus
-`experimental.<backend>.<phase>`), and the Rust trait sees only wire-shape configs
-(§9.2). No "policy" abstraction crosses the SDK-Rust boundary. Future SDK-level
-evolution of the policy concept will be contained to the SDK and will not propagate
-into backend trait implementations.
+`getUserProfilePolicy`, `getTemporaryFilesPolicy`) compose with state-aware Configs
+unchanged. They produce `FilesystemPolicyResult` fragments — `{ readonlyPaths,
+readwritePaths }` — whose shape matches `FilesystemConfig`'s readonly / readwrite path
+arrays. Consumers merge the fragments directly into a state-aware Config's `filesystem`
+field, as in the §6.3 example.
 
 ## 7. Wire contract
 
@@ -606,20 +623,32 @@ enumerated here; their definitions live in `docs/config-schema.md`.
 
 ### 7.2 The `experimental` block
 
-`ExperimentalStateAwareConfigs` is a typed bundle. Outer keys are state-aware-capable
-backend names (members of `StateAwareSandboxingMethod`); inner per-backend bundles
-enumerate the phases that backend declares config for. Each phase's value is a typed
-`<Backend><Phase>Config` interface defined alongside the backend in the SDK package.
+`ExperimentalStateAwareConfigs` describes the wire-format shape of the `experimental`
+field on a state-aware request. It is a wire-only type — consumers do not construct
+it directly. The SDK builds this shape internally from the per-(backend, phase) Configs
+defined in §6.1, lifting backend-specific fields into the nested experimental block:
 
-| Layer | Type | Constraint |
+```typescript
+interface ExperimentalStateAwareConfigs {
+  isolation_session?: {
+    start?: { configurationId?: 'small' | 'medium' | 'large' | 'composable' };
+    // provision, exec, stop, deprovision omitted — IsolationSession has no
+    // backend-specific config for those phases.
+  };
+  // future state-aware-capable backends add typed entries here
+}
+```
+
+| Layer | Wire shape | Constraint |
 |---|---|---|
 | Outer key | `StateAwareSandboxingMethod` member | Must be a state-aware-capable backend |
-| Inner key (state-aware only) | A subset of `Phase` per backend's needs | Backends omit phases with no config |
-| Innermost value | Typed `<Backend><Phase>Config` interface | Defined alongside the backend in the SDK |
+| Inner key | A subset of `Phase` per backend's needs | Backends omit phases with no backend-specific config |
+| Innermost value | Backend-specific fields only (no cross-cutting, no `version`) | The SDK extracts these from the consumer's per-(backend, phase) Config |
 
-Backends that declare no config for a phase omit the field from their bundle; TypeScript
-then refuses to accept a config for that phase from callers. Backends that declare config
-for a phase get full compile-time autocompletion on the field shape.
+Compile-time enforcement of valid combinations lives on the SDK's per-(backend, phase)
+Configs (§6.1), not on this wire-shape type. Raw-JSON callers writing
+`ExperimentalStateAwareConfigs` directly are validated by the Rust parser and
+`validate_<phase>` hooks at runtime (§10.1).
 
 For one-shot calls (phase absent), `experimental.<backend>` directly holds the backend's
 one-shot config object (e.g., `experimental.wslc?: WslcConfig`), as documented in
@@ -700,18 +729,21 @@ shape, across all five phases.
 #### Phase 1 — provision
 
 ```typescript
-const policy: SandboxPolicy = {
-  version: '0.5.0-alpha',
+const config: IsolationSessionProvisionConfig = {
   filesystem: { readwritePaths: ['C:\\workspace'] },
-  network: { allowOutbound: true, allowedHosts: ['api.anthropic.com'] },
+  network: { defaultPolicy: 'allow', allowedHosts: ['api.anthropic.com'] },
 };
-const { sandboxId } = await provisionSandbox('isolation_session', { policy });
+const { sandboxId } = await provisionSandbox(
+  'isolation_session',
+  config,
+  { experimental: true },
+);
 // sandboxId = "iso:reg-abc:prov-123"
 ```
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "containment": "isolation_session",
   "phase": "provision",
   "filesystem": { "readwritePaths": ["C:\\workspace"] },
@@ -742,14 +774,16 @@ backend.provision(&request, /* config */ None)
 #### Phase 2 — start
 
 ```typescript
-await startSandbox(sandboxId, {
-  config: { configurationId: 'small' },
-});
+await startSandbox(
+  sandboxId,
+  { configurationId: 'small' },
+  { experimental: true },
+);
 ```
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "phase": "start",
   "sandboxId": "iso:reg-abc:prov-123",
   "experimental": { "isolation_session": { "start": { "configurationId": "small" } } }
@@ -774,16 +808,17 @@ backend.start(
 #### Phase 3 — exec (buffered)
 
 ```typescript
-const r = await execInSandboxAsync(sandboxId, {
-  commandLine: 'echo hello',
-  timeout: 5000,
-});
+const r = await execInSandboxAsync(
+  sandboxId,
+  { process: { commandLine: 'echo hello', timeout: 5000 } },
+  { experimental: true },
+);
 // r = { stdout: "hello\n", stderr: "", exitCode: 0 }
 ```
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "phase": "exec",
   "sandboxId": "iso:reg-abc:prov-123",
   "process": { "commandLine": "echo hello", "timeout": 5000 }
@@ -809,12 +844,12 @@ resolves the Promise.
 #### Phase 4 — stop
 
 ```typescript
-await stopSandbox(sandboxId);
+await stopSandbox(sandboxId, {}, { experimental: true });
 ```
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "phase": "stop",
   "sandboxId": "iso:reg-abc:prov-123"
 }
@@ -832,12 +867,12 @@ backend.stop("iso:reg-abc:prov-123", &request, /* config */ None)
 #### Phase 5 — deprovision
 
 ```typescript
-await deprovisionSandbox(sandboxId);
+await deprovisionSandbox(sandboxId, {}, { experimental: true });
 ```
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "phase": "deprovision",
   "sandboxId": "iso:reg-abc:prov-123"
 }
@@ -855,14 +890,17 @@ backend.deprovision("iso:reg-abc:prov-123", &request, /* config */ None)
 #### Mapping summary
 
 The SDK auto-wraps backend-specific config under `experimental.<backend>.<phase>` when
-serialising state-aware calls. `SandboxPolicy.filesystem` / `.network` / `.ui` map to
-top-level wire fields via the same logic the existing `createConfigFromPolicy` uses for
-one-shot. Cross-backend exec fields (`commandLine`, `cwd`, `env`, `timeout`) flow through
-the top-level `process` block, not through `experimental`. For non-exec phases the
-executor emits a single JSON envelope on stdout; for exec the script's output streams
-raw and the SDK constructs the result from PTY events. Responses unwrap any `result`
-envelope at the SDK boundary so the caller sees a plain `ProvisionResult` / `StartResult` /
-`ExecResult` / `StopResult` / `DeprovisionResult`.
+serialising state-aware calls — consumers write `configurationId` directly on the
+`IsolationSessionStartConfig`, the SDK builds the nested wire form. Cross-cutting
+fields (`filesystem` / `network` / `ui`) on a per-(backend, phase) Config map directly
+to top-level wire fields — they are already wire-format-aligned in the Config, so the
+SDK passes them through unchanged. Cross-backend exec fields (`commandLine`, `cwd`,
+`env`, `timeout`) flow through the top-level `process` block, not through
+`experimental`. For non-exec phases the executor emits a single JSON envelope on
+stdout; for exec the script's output streams raw and the SDK constructs the result
+from PTY events. Responses unwrap any `result` envelope at the SDK boundary so the
+caller sees a plain `ProvisionResult` / `StartResult` / `ExecResult` / `StopResult` /
+`DeprovisionResult`.
 
 ## 8. Error model
 
@@ -1012,14 +1050,16 @@ extracted alongside the `CodexRequest` and bundled into a `ParsedStateAwareReque
 domain model — `{ request: CodexRequest, phase: Phase, containment:
 Option<ContainmentBackend>, sandbox_id: Option<String>, experimental_raw: ... }` —
 that the dispatcher consumes (§9.3). The bundling does not modify `CodexRequest`'s
-shape. There is no unified Rust "policy" type — `SandboxPolicy` is an SDK-only
-abstraction (§6.6). Domain models are exposed to the dispatch layer; the `Raw*` types
-stay private to the parser.
+shape. There is no unified Rust "policy" type — Rust reads cross-cutting fields
+directly from `request.policy` (a `ContainerPolicy`), exactly as the one-shot path does
+today. Domain models are exposed to the dispatch layer; the `Raw*` types stay private
+to the parser.
 
 ### 9.2 The trait
 
-Backends implement the trait with a const for the id prefix, associated types for each
-phase's config and metadata, and method overrides where they have substantive work.
+Backends implement the trait with two consts (id prefix and backend key, §5),
+associated types for each phase's config and metadata, and method overrides where they
+have substantive work.
 Most methods have default no-op bodies; only `exec` is strictly required. Use `()` for
 any associated type the backend does not need.
 
@@ -1029,6 +1069,14 @@ pub trait StatefulSandboxBackend {
     /// `sandbox_id` minted by the default `provision` body, and read by the
     /// dispatcher to route non-provision calls to this backend (§5).
     const ID_PREFIX: &'static str;
+
+    /// Wire-format `containment` value for this backend, matching the SDK's
+    /// `StateAwareSandboxingMethod` member name (e.g. `"isolation_session"`).
+    /// The dispatcher uses it to navigate `experimental.<BACKEND_KEY>.<phase>`
+    /// for typed-config deserialisation (§9.3), and to resolve `provision`-phase
+    /// requests whose wire `containment` string maps to this backend.
+    /// Distinct from `ID_PREFIX` — see §5 for the rationale.
+    const BACKEND_KEY: &'static str;
 
     type ProvisionConfig: serde::de::DeserializeOwned;
     type StartConfig: serde::de::DeserializeOwned;
@@ -1184,8 +1232,7 @@ through `request.script_code` / `request.working_directory` / `request.script_ti
 dispatcher from `experimental.<backend>.<phase>` and passed as the `config` parameter
 (§9.3). Per-phase result types (`ProvisionResult<M>`, `StartResult<M>`,
 `StopResult<M>`, `DeprovisionResult<M>`) carry the typed metadata return value;
-`ExecHandle` exposes the running process's pipe handles for relay. There is no
-unified Rust "policy" type — `SandboxPolicy` is an SDK-only abstraction (§6.6).
+`ExecHandle` exposes the running process's pipe handles for relay.
 `MxcError` is the typed Rust equivalent of its SDK counterpart. `PipeHandle` is a
 platform-abstracted pipe-handle wrapper — a kernel `HANDLE` on Windows, a file
 descriptor on Linux. The executor's outer driver reads from `ExecHandle.stdout` /
@@ -1301,7 +1348,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
     let request = &parsed.request;
     match parsed.phase {
         Phase::Provision => {
-            let config = parsed.deserialize_config::<B::ProvisionConfig>("provision")?;
+            let config = parsed.deserialize_config::<B::ProvisionConfig>(B::BACKEND_KEY, "provision")?;
             backend.validate_provision(request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
             let result = backend.provision(request, config)?;
@@ -1309,7 +1356,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
         }
         Phase::Start => {
             let sandbox_id = parsed.sandbox_id_required()?;
-            let config = parsed.deserialize_config::<B::StartConfig>("start")?;
+            let config = parsed.deserialize_config::<B::StartConfig>(B::BACKEND_KEY, "start")?;
             backend.validate_start(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
             let result = backend.start(sandbox_id, request, config)?;
@@ -1317,7 +1364,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
         }
         Phase::Exec => {
             let sandbox_id = parsed.sandbox_id_required()?;
-            let config = parsed.deserialize_config::<B::ExecConfig>("exec")?;
+            let config = parsed.deserialize_config::<B::ExecConfig>(B::BACKEND_KEY, "exec")?;
             validate_exec_common(request)?;
             backend.validate_exec(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
@@ -1329,7 +1376,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
         }
         Phase::Stop => {
             let sandbox_id = parsed.sandbox_id_required()?;
-            let config = parsed.deserialize_config::<B::StopConfig>("stop")?;
+            let config = parsed.deserialize_config::<B::StopConfig>(B::BACKEND_KEY, "stop")?;
             backend.validate_stop(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
             let result = backend.stop(sandbox_id, request, config)?;
@@ -1337,7 +1384,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
         }
         Phase::Deprovision => {
             let sandbox_id = parsed.sandbox_id_required()?;
-            let config = parsed.deserialize_config::<B::DeprovisionConfig>("deprovision")?;
+            let config = parsed.deserialize_config::<B::DeprovisionConfig>(B::BACKEND_KEY, "deprovision")?;
             backend.validate_deprovision(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
             let result = backend.deprovision(sandbox_id, request, config)?;
@@ -1352,10 +1399,11 @@ other phases it reads the prefix from `parsed.sandbox_id` and looks it up in the
 registered prefix table. Mismatches surface as `unsupported_containment` (unrecognised
 prefix) or `malformed_id` (no prefix structure) per §8.
 
-`ParsedStateAwareRequest::deserialize_config::<C>(phase_name)` returns
-`Result<Option<C>, MxcError>`: it deserialises the
-`experimental.<backend>.<phase>` JSON value into `C` when present, returns `Ok(None)`
-when absent, and surfaces malformed JSON as `malformed_request`.
+`ParsedStateAwareRequest::deserialize_config::<C>(backend_key, phase_name)` returns
+`Result<Option<C>, MxcError>`: it navigates the wire `experimental.<backend_key>.<phase_name>`
+JSON value and deserialises it into `C` when present, returns `Ok(None)` when absent,
+and surfaces malformed JSON as `malformed_request`. The dispatcher passes
+`B::BACKEND_KEY` so each backend reads from its own slot.
 `sandbox_id_required()` enforces that non-provision phases carry a `sandboxId`,
 returning `&str` on success or `malformed_request` on absence. `validate_exec_common`
 is a free function in `validator.rs` that checks cross-backend per-phase invariants
@@ -1379,9 +1427,12 @@ type system enforces the declaration: dispatch arms can only invoke trait method
 the backend actually implements. Dispatch-wiring mismatches are compile-time errors,
 not runtime registry checks.
 
-State-aware backends additionally register an id prefix (§5) alongside their
-`ContainmentBackend` variant, used by the dispatcher to resolve non-provision calls to
-the right backend.
+State-aware backends additionally register two consts on their trait impl alongside
+their `ContainmentBackend` variant: `ID_PREFIX` (the sandbox-id tag, used by the
+dispatcher to resolve non-provision calls to the right backend) and `BACKEND_KEY` (the
+wire-format `containment` value, used for provision-phase routing and
+`experimental.<BACKEND_KEY>.<phase>` typed-config deserialisation). Both are described
+in §5.
 
 Per-stage config contents are also typed at compile time — the backend's associated
 types declare exactly what JSON shape each phase accepts, and the dispatch layer
@@ -1413,8 +1464,13 @@ agent user").
 
 A typical state-aware backend defines its `*Config` types alongside the trait
 implementation, in both Rust and TypeScript. The Rust types use `#[derive(Deserialize)]`
-with serde renames to camelCase. The TypeScript types are exported from the SDK package
-and slot into `ExperimentalStateAwareConfigs`.
+with serde renames to camelCase and represent the wire-shape sub-portion that lives
+under `experimental.<BACKEND_KEY>.<phase>` — backend-specific fields only. The
+TypeScript type exported from the SDK package is the consumer-facing per-(backend,
+phase) Config from §6.1; it is a strict superset of the wire shape, adding
+`version?` (for explicit version overrides) and the cross-cutting `filesystem` /
+`network` / `ui` fields in phases where the backend's policy honor matrix marks them
+as `applied` (§10.3).
 
 ```rust
 #[derive(Debug, Deserialize)]
@@ -1426,53 +1482,53 @@ pub struct IsolationSessionStartConfig {
 
 ```typescript
 interface IsolationSessionStartConfig {
-  configurationId?: 'small' | 'medium' | 'large' | 'commandLine';
+  version?: string;
+  configurationId?: 'small' | 'medium' | 'large' | 'composable';
 }
 ```
 
-The wire JSON is `{ "configurationId": "small" }` either way. The SDK and dispatch layer
-agree on shape; the backend gets a typed Rust struct ready for use.
+The TypeScript Config carries `version` (which the SDK serialises to the top-level
+wire `version` field) plus any cross-cutting fields the matrix marks `applied` for
+that phase (none for IsolationSession's `start`). The Rust struct receives only what
+the wire's `experimental.isolation_session.start` block carries —
+`{ "configurationId": "small" }` — because that is what the dispatcher deserialises
+into `Self::StartConfig` (§9.3). The SDK is responsible for splitting the consumer
+Config into top-level wire fields (cross-cutting, `version`) and the experimental
+sub-block; Rust sees only the post-split shape.
 
 ### 10.3 Cross-cutting policy honor matrix
 
-Each backend declares which phases honor which `SandboxPolicy` fields. Caller-supplied
-fields at unsupported phases produce `policy_validation`.
-
-The shape of the matrix is the proposal-level contract: a row per cross-cutting
-`SandboxPolicy` field, a column per phase, with values from the closed set
+Each backend declares which phases honor which cross-cutting field (`filesystem`,
+`network`, `ui`). The matrix shape is the proposal-level contract: a row per
+cross-cutting field, a column per phase, with values from the closed set
 `applied` / `rejected` / `ignored`. Specific values per backend are documented in each
 backend's plan doc (§11.6). For IsolationSession, illustrative values (final values
 documented in the backend's plan doc):
 
 | Field | provision | start | exec | stop | deprovision |
 |---|---|---|---|---|---|
-| `policy.filesystem` | applied | rejected | rejected | rejected | rejected |
-| `policy.network` | applied | rejected | rejected | rejected | rejected |
-| `policy.ui` | applied | rejected | rejected | rejected | rejected |
+| `filesystem` | applied | rejected | rejected | rejected | rejected |
+| `network` | applied | rejected | rejected | rejected | rejected |
+| `ui` | applied | rejected | rejected | rejected | rejected |
 
-`SandboxPolicy` is shared across all phase calls (single source of truth — when its
-fields evolve, all backends inherit them automatically). Per-phase honor is the
-backend's choice and must be documented.
+The matrix lands at two layers, each enforcing it independently:
 
-**Why runtime rejection rather than compile-time type narrowing.** A plausible
-alternative is to narrow each backend's per-phase options at the TypeScript type level,
-removing unsupported cross-cutting fields from the type entirely. Runtime rejection via
-this matrix was chosen instead:
+- **Compile-time enforcement at the SDK.** Each per-(backend, phase) Config (§6.1)
+  declares only the cross-cutting fields the matrix marks as `applied` for that phase.
+  TypeScript rejects callers passing fields the backend does not honor at that phase.
+  For IsolationSession's matrix above, only `IsolationSessionProvisionConfig` carries
+  `filesystem` / `network` / `ui`; the start, exec, stop, and deprovision Configs do
+  not. Callers cannot accidentally pass them.
+- **Runtime enforcement at Rust.** The backend's `validate_<phase>` hooks reject
+  cross-cutting fields received from raw-JSON callers (or from a future SDK release
+  whose typing has fallen out of step) that the matrix marks as `rejected`. Failures
+  surface as `policy_validation` (§8). The Rust check is the authoritative contract
+  for any wire-format consumer that bypasses the SDK; the SDK check is a strictly
+  stricter (compile-time) restatement of the same matrix for TypeScript callers.
 
-- Existing one-shot dispatch already validates unsupported combinations at runtime
-  (e.g., `network.proxy` is AppContainer-only and rejected by the parser for other
-  backends). State-aware matches that pattern.
-- Cross-cutting fields are intentionally shared across backends; splitting them into
-  per-backend typed bundles fragments the abstraction and breaks generic code that
-  targets "any state-aware backend".
-- Compile-time narrowing requires conditional types parameterised by `(backend, phase)`,
-  which are slow to type-check and brittle to extend.
-
-If a specific backend's policy-honor mismatch becomes a real usability problem, narrowing
-that backend's options for that phase is a localised future fix that does not require
-changing the framework. The closed `ErrorCode` enum and typed `MxcPolicyValidationError`
-exception class give callers the same caught-at-the-call-site experience as compile-time
-errors, just at runtime.
+Per-phase honor is the backend's choice and must be documented in its plan doc. When
+the matrix evolves (e.g., a new cross-cutting field lands at the SDK layer), each
+backend's per-phase Configs and Rust runtime checks must be updated in lockstep.
 
 ## 11. Plug-in guide for new backends
 
@@ -1490,6 +1546,11 @@ The `StatefulSandboxBackend` trait signatures are in §9.2. Declare:
 
 - `const ID_PREFIX: &'static str` — the leading `<tag>:` segment for this backend's
   `sandbox_id` values; also used by the dispatcher for non-provision routing (§5).
+- `const BACKEND_KEY: &'static str` — the wire-format `containment` value for this
+  backend, matching the SDK's `StateAwareSandboxingMethod` member name (e.g.,
+  `"isolation_session"`). Used by the dispatcher to navigate
+  `experimental.<BACKEND_KEY>.<phase>` for typed-config deserialisation and to resolve
+  `provision`-phase requests (§5).
 - Per-phase config associated types (`ProvisionConfig`, ..., `DeprovisionConfig`).
 - Per-phase metadata associated types (`ProvisionMetadata`, ..., `DeprovisionMetadata`).
   Use `()` for any associated type the backend does not need.
@@ -1509,27 +1570,40 @@ Validation runs before the phase method; failures short-circuit and surface as t
 
 ### 11.3 Define typed `*Config` interfaces in the SDK
 
-For each phase the backend declares config for, add a typed TypeScript interface to
-`@microsoft/mxc-sdk`. Example shape:
+For each of the five lifecycle phases, add a typed TypeScript interface to
+`@microsoft/mxc-sdk`. Each Config carries only the fields valid for that backend at
+that phase: `version?` always, the cross-cutting `filesystem` / `network` / `ui`
+fields in the phases where the backend honors them (§10.3), and any backend-specific
+fields. Phases with no backend-specific or cross-cutting fields declare a Config
+carrying only `version?`. Example shape (mirroring §6.1):
 
 ```typescript
-interface MyBackendStartConfig {
-  // backend-specific fields with typed values
+interface MyBackendProvisionConfig {
+  version?: string;
+  // cross-cutting fields for phases where MyBackend's matrix marks `applied`
 }
+
+interface MyBackendStartConfig {
+  version?: string;
+  // backend-specific start fields
+}
+
+// ... and similarly for exec, stop, deprovision
 ```
 
-Slot the interfaces into `ExperimentalStateAwareConfigs`:
+Add an arm to `ConfigsForBackend<C>` mapping the new backend's `SandboxingMethod`
+member to its five phase Configs:
 
 ```typescript
-interface ExperimentalStateAwareConfigs {
-  isolation_session?: IsolationSessionStateAwareConfigs;
-  my_backend?: MyBackendStateAwareConfigs;  // new
-}
-
-interface MyBackendStateAwareConfigs {
-  start?: MyBackendStartConfig;
-  // omit phases without config
-}
+type ConfigsForBackend<C extends StateAwareSandboxingMethod> =
+  C extends 'isolation_session' ? { /* IS phase Configs */ } :
+  C extends 'my_backend' ? {
+    provision: MyBackendProvisionConfig;
+    start: MyBackendStartConfig;
+    exec: MyBackendExecConfig;
+    stop: MyBackendStopConfig;
+    deprovision: MyBackendDeprovisionConfig;
+  } : never;
 ```
 
 If the backend was not previously SDK-exposed, also extend `SandboxingMethod` and add
@@ -1539,9 +1613,11 @@ an entry to `StateAwareSandboxingMethod`.
 
 The dispatch layer in the executor matches on `ContainmentBackend` to route calls. Add a
 variant for the new backend along with a dispatch arm that invokes the trait method via
-`dispatch_state_aware`. Declare the backend's id prefix (§5) alongside the variant; the
-prefix is the routing key for non-provision calls, so pick a short distinct tag and
-treat it as permanent (persisted ids carry it). Compile-time errors will catch
+`dispatch_state_aware`. The trait impl declares both `ID_PREFIX` and `BACKEND_KEY` (§5);
+`ID_PREFIX` is the routing key for non-provision calls (so pick a short distinct tag
+and treat it as permanent — persisted ids carry it), and `BACKEND_KEY` is the
+wire-format containment value used for `provision`-phase routing and
+`experimental.<BACKEND_KEY>.<phase>` deserialisation. Compile-time errors will catch
 capability mismatches automatically (§9.4).
 
 ### 11.5 Add a config-parser case
@@ -1563,9 +1639,9 @@ A per-backend document at `docs/<backend-or-feature>/<plan-name>.md` is required
 - **Per-phase metadata shapes.** The fields of each `*Metadata` interface returned by
   the backend (any subset of provision, start, stop, deprovision). Phases that return
   no metadata are omitted from the bundle.
-- **Cross-cutting policy honor matrix.** For each `SandboxPolicy` field
-  (`filesystem`, `network`, `ui`), which phases the backend applies, rejects, or
-  ignores it at. Per §10.3.
+- **Cross-cutting policy honor matrix.** For each cross-cutting field (`filesystem`,
+  `network`, `ui`), which phases the backend applies, rejects, or ignores it at.
+  Per §10.3.
 - **Mode-specific fields.** For backends participating in both ephemeral and state-aware
   modes: which fields are valid in each mode. Fields whose only sensible state-aware
   value is fixed should be hardcoded inside the state-aware implementation rather than
@@ -1643,21 +1719,20 @@ in MXC. Each backend's plan doc (§11.6) carries its specific recovery semantics
 
 ## 13. Graduation path
 
-State-aware functionality matures along two independent axes:
-
-1. **State-aware API stability.** Whether the surface defined in this proposal (the
-   five lifecycle phases, the wire format, the error envelope, the trait) is stable
-   enough to be relied on without the experimental opt-in.
-2. **Per-backend state-aware participation.** Whether a given backend's state-aware
-   implementation, per-stage config shapes, and error mappings are stable enough to
-   rely on.
+The state-aware API surface (the five lifecycle phases, the wire-format envelope, the
+error envelope, the trait) is stable from `0.6.0` onwards — it is not gated by an
+`--experimental` flag. The only graduation axis is per-backend: whether a given
+backend's state-aware participation, per-stage config shapes, and error mappings are
+stable enough to rely on. A backend whose state-aware participation is still
+experimental requires `experimental: true` on every state-aware call, just as one-shot
+calls against experimental backends do today.
 
 ### 13.1 Wire-format placement rule
 
 Per-stage config for backend X stays under `experimental.<backend>.<phase>` while
-**either** the state-aware API itself is experimental **or** backend X's state-aware
-participation is experimental. When both are stable, per-stage config migrates to
-top-level `<backend>.<phase>`.
+backend X's state-aware participation is experimental. When backend X's state-aware
+participation graduates to stable, per-stage config migrates to top-level
+`<backend>.<phase>`.
 
 The `phase`-as-discriminator rule from §7.1 continues to apply post-graduation, just at
 the top level: top-level `<backend>: { ... }` carries one-shot config when the call has
@@ -1667,27 +1742,24 @@ call.
 
 ### 13.2 Worked scenarios
 
-**State-aware API graduates while IsolationSession stays experimental.** Per-stage
-configs remain at `experimental.isolation_session.<phase>`. Callers using
-IsolationSession's state-aware path still pass the experimental flag. New
-state-aware-capable backends stabilise on their own timelines.
+A backend's ephemeral and state-aware paths graduate independently. The same backend
+can have a stable ephemeral path and an experimental state-aware path simultaneously,
+or vice versa — they are separate graduation events.
 
-**Backend's ephemeral path graduates while state-aware is still experimental.** The
-backend's ephemeral one-shot config can move from `experimental.<backend>` to top-level
-`<backend>` independently, following the existing one-shot graduation pattern.
-State-aware participation stays under `experimental.<backend>.<phase>` until the
-state-aware API itself graduates. The
-same backend can have a stable ephemeral path and an experimental state-aware path
-simultaneously.
+**Backend's ephemeral path graduates; state-aware path stays experimental.** The
+backend's ephemeral one-shot config moves from `experimental.<backend>` to top-level
+`<backend>`, following the existing one-shot graduation pattern. Its state-aware
+per-stage configs stay under `experimental.<backend>.<phase>`.
 
-**Both graduate together.** Per-stage configs migrate from
-`experimental.<backend>.<phase>` to top-level `<backend>.<phase>`. The `--experimental`
-flag is no longer required for that backend's state-aware calls. For example, a `start`
-call against IsolationSession migrates from this shape:
+**Backend's state-aware path graduates.** Per-stage configs migrate from
+`experimental.<backend>.<phase>` to top-level `<backend>.<phase>`. The
+`experimental: true` SDK option is no longer required for that backend's state-aware
+calls (and the executor stops gating them behind `--experimental`). For example, a
+`start` call against IsolationSession migrates from this shape:
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "phase": "start",
   "sandboxId": "iso:reg-abc:prov-123",
   "experimental": {
@@ -1698,11 +1770,11 @@ call against IsolationSession migrates from this shape:
 }
 ```
 
-to this shape after both axes have graduated:
+to this shape after the backend's state-aware path graduates:
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.7.0-alpha",
   "phase": "start",
   "sandboxId": "iso:reg-abc:prov-123",
   "isolation_session": {
@@ -1711,17 +1783,13 @@ to this shape after both axes have graduated:
 }
 ```
 
-**Sub-graduating a backend's state-aware participation alone (while the API is still
-experimental) is not supported.** A backend's state-aware story cannot stabilise faster
-than the API surface it depends on. Both must graduate together for state-aware config
-placement to migrate.
-
 ### 13.3 Versioning
 
-Each graduation event triggers a schema version bump in `docs/versioning.md`,
-following the existing MXC convention for graduating features. The version bump and
-the associated SDK type changes (such as dropping `experimental: true` requirements for
-graduated containment values) ship as a single release.
+Each backend's graduation event (ephemeral, state-aware, or both at once) triggers a
+schema version bump in `docs/versioning.md`, following the existing MXC convention for
+graduating features. The version bump and the associated SDK type changes (such as
+dropping `experimental: true` requirements for graduated containment values) ship as a
+single release.
 
 ## 14. Out of scope for v1
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -63,10 +63,10 @@ elaborates.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed exception classes per error code. | `spawnSandbox` family preserved. `SandboxingMethod` extension mechanism reused. The existing wire-format-aligned `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside the new state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). Existing typed `*Config` naming convention reused. |
+| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `SandboxingMethod` extension mechanism reused. The existing wire-format-aligned `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside the new state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). Existing typed `*Config` naming convention reused. |
 | JSON wire format (§7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union over `phase`. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` fields at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (§9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private to parser, matching `RawConfig` pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends function without modification. |
-| Error model (§8) | Closed enum of 12 error codes. `MxcError` base + per-code subclasses. `details` open object as escape hatch for backend-specific structured information. | Existing one-shot error paths preserved. |
+| Error model (§8) | Closed enum of 12 error codes. `MxcError` class with `code: ErrorCode`. `details` open object as escape hatch for backend-specific structured information. | Existing one-shot error paths preserved. |
 | Plug-in surface (§11) | Implement `StatefulSandboxBackend` (in addition to or instead of `ScriptRunner`). Define typed per-(backend, phase) `*Config` interfaces. Declare the backend's `ID_PREFIX` and `BACKEND_KEY` consts on the trait impl. Document the cross-cutting policy honor matrix. | Ephemeral-only backends require no changes. The `ContainmentBackend` Rust enum is extended, not replaced. |
 
 ## 2. Context and motivation
@@ -905,10 +905,10 @@ caller sees a plain `ProvisionResult` / `StartResult` / `ExecResult` / `StopResu
 ## 8. Error model
 
 Errors crossing the wire-format boundary are typed by a closed enum of error codes
-defined at the MXC layer. Backends map their native errors to these codes; the SDK maps
-each code to a typed TypeScript exception class. An `MxcStaleIdError` thrown from
-IsolationSession behaves the same as one thrown from any other state-aware backend, so
-caller error-handling code is portable across backends.
+defined at the MXC layer. Backends map their native errors to these codes; the SDK
+throws an `MxcError` carrying the corresponding `code` field. An `MxcError` with
+`code: 'stale_id'` thrown from IsolationSession behaves the same as one thrown from any
+other state-aware backend, so caller error-handling code is portable across backends.
 
 ### 8.1 Error code enum
 
@@ -957,29 +957,21 @@ convey structured information that callers may inspect: a backend's native error
 partial output captured before a timeout fired, or any other context. The shape of
 `details` for each error code is documented in the relevant backend's own docs (§11).
 
-### 8.3 TypeScript exception classes
+### 8.3 TypeScript error class
 
-The SDK throws (rejects) typed exception classes, one per error code, all extending a
-common base:
+The SDK throws (rejects) a single `MxcError` class. The wire-format error code lives on
+the `code` field and is the discriminator callers pattern-match on:
 
 ```typescript
 class MxcError extends Error {
   readonly code: ErrorCode;
   readonly details?: Record<string, unknown>;
 }
-
-// Per-code subclasses, named by converting the snake_case code to PascalCase with
-// 'Mxc' prefix; the class name ends with 'Error'. If the code already ends with
-// '_error' (i.e., `backend_error`), the existing suffix is preserved (so the class
-// is `MxcBackendError`, not `MxcBackendErrorError`):
-class MxcStaleIdError extends MxcError { /* code = 'stale_id' */ }
-class MxcPolicyValidationError extends MxcError { /* code = 'policy_validation' */ }
-class MxcBackendError extends MxcError { /* code = 'backend_error' */ }
 ```
 
-Callers can pattern-match either via `instanceof` on the typed class or by inspecting
-`error.code` directly. Both forms are supported; the typed-class form is generally
-preferred in TypeScript code.
+Callers discriminate by comparing `.code` to a wire-format error code string
+(`err instanceof MxcError && err.code === 'stale_id'`). The TypeScript string-literal
+union on `ErrorCode` gives the same IDE completion as a per-code class hierarchy.
 
 ## 9. Rust layer architecture
 
@@ -1514,11 +1506,15 @@ documented in the backend's plan doc):
 The matrix lands at two layers, each enforcing it independently:
 
 - **Compile-time enforcement at the SDK.** Each per-(backend, phase) Config (§6.1)
-  declares only the cross-cutting fields the matrix marks as `applied` for that phase.
-  TypeScript rejects callers passing fields the backend does not honor at that phase.
-  For IsolationSession's matrix above, only `IsolationSessionProvisionConfig` carries
-  `filesystem` / `network` / `ui`; the start, exec, stop, and deprovision Configs do
-  not. Callers cannot accidentally pass them.
+  declares only the cross-cutting fields the matrix marks as `applied` for that phase
+  *and* that the runtime currently honors. TypeScript rejects callers passing fields
+  the backend does not honor at that phase, and also fields the matrix would mark as
+  `applied` but the runtime does not yet implement. For IsolationSession's matrix
+  above, `IsolationSessionProvisionConfig` is the only Config that carries any
+  cross-cutting fields. The SDK currently exposes `filesystem` only; `network` and
+  `ui` will be added at provision when the IsolationSession runtime honors them.
+  The start, exec, stop, and deprovision Configs carry none of these fields. Callers
+  cannot accidentally pass them.
 - **Runtime enforcement at Rust.** The backend's `validate_<phase>` hooks reject
   cross-cutting fields received from raw-JSON callers (or from a future SDK release
   whose typing has fallen out of step) that the matrix marks as `rejected`. Failures

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -48,24 +48,24 @@ Per [semver.org](https://semver.org/):
 ```
 mxc/schemas/
 ├── stable/
-│   └── mxc-config.schema.0.4.0-alpha.json  (shipped — current stable)
+│   ├── mxc-config.schema.0.4.0-alpha.json
+│   └── mxc-config.schema.0.5.0-alpha.json  (shipped — current stable)
 └── dev/
-    └── mxc-config.schema.0.5.0-dev.json   (current — includes experimental section definition)
+    └── mxc-config.schema.0.6.0-dev.json    (current — work in progress)
 ```
 
 The dev schema file (`mxc-config.schema.X.Y.Z-dev.json`) must define the `experimental`
-section structure so that editors can validate experimental configs. Stable
-schemas in `stable/` do not include the experimental section.
+section structure so that editors can validate experimental configs.
 
 ### Shipped vs Experimental
 
-The current stable schema version is `0.4.0-alpha`. The parser also accepts
-`0.5.0-alpha`, which should be used for configs that include promoted and experimental
-features:
+The current stable schema versions are `0.4.0-alpha` and `0.5.0-alpha`. The parser
+also accepts `0.6.0-alpha`, which should be used for configs that include
+experimental features:
 
 ```json
 {
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "process": { ... },
   "filesystem": { ... },
   "network": { ... },

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -1,17 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/microsoft/mxc/schemas/dev/mxc-config.schema.0.5.0-dev.json",
+  "$id": "https://github.com/microsoft/mxc/schemas/dev/mxc-config.schema.0.6.0-dev.json",
   "title": "MXC Configuration",
-  "description": "Configuration schema for MXC container execution engine. Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
+  "description": "Configuration schema for MXC container execution engine. Defines the recommended config format for both one-shot and state-aware sandbox lifecycle requests. The parser also accepts legacy fields not listed here during the migration period.",
   "type": "object",
-
-  "required": ["process"],
 
   "properties": {
     "version": {
       "type": "string",
-      "description": "MXC config schema version (semver). Current stable: '0.4.0-alpha'. Configs using promoted or experimental features should use '0.5.0-alpha'.",
-      "examples": ["0.4.0-alpha"]
+      "description": "MXC config schema version (semver). Current stable: '0.4.0-alpha'. Configs using promoted or experimental features should use '0.6.0-alpha'. State-aware lifecycle requests use '0.6.0-alpha'.",
+      "examples": ["0.4.0-alpha", "0.6.0-alpha"]
     },
     "containerId": {
       "type": "string",
@@ -19,9 +17,19 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["appcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "macos_sandbox"],
+      "enum": ["appcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "macos_sandbox", "isolation_session"],
       "default": "appcontainer",
-      "description": "Containment backend to use for execution. Note: 'windows_sandbox', 'wslc', and 'macos_sandbox' are experimental and require the --experimental CLI flag."
+      "description": "Containment backend to use for execution. Note: 'windows_sandbox', 'wslc', 'macos_sandbox', and 'isolation_session' are experimental and require the --experimental CLI flag."
+    },
+
+    "phase": {
+      "type": "string",
+      "enum": ["provision", "start", "exec", "stop", "deprovision"],
+      "description": "State-aware lifecycle phase. When present, the request is a state-aware request: 'sandboxId' is required for non-provision phases, and 'process' is required only for the 'exec' phase. When absent, the request is a one-shot request and 'process' is required."
+    },
+    "sandboxId": {
+      "type": "string",
+      "description": "Sandbox identifier returned by a prior provision request. Required for non-provision state-aware phases ('start', 'exec', 'stop', 'deprovision')."
     },
 
     "lifecycle": {
@@ -43,7 +51,7 @@
 
     "process": {
       "type": "object",
-      "description": "Process execution settings.",
+      "description": "Process execution settings. Required for one-shot requests and for the state-aware 'exec' phase; omitted for non-exec state-aware phases.",
       "required": ["commandLine"],
       "properties": {
         "commandLine": {
@@ -322,6 +330,42 @@
             "profileOverride": {
               "type": "string",
               "description": "Optional override of the generated TinyScheme sandbox profile."
+            }
+          }
+        },
+        "isolation_session": {
+          "type": "object",
+          "description": "IsolationSession backend (experimental, Windows-only). Used when containment is 'isolation_session'. For one-shot requests, set 'configurationId' directly on this object. For state-aware requests, place per-phase configuration under 'provision', 'start', 'stop', or 'deprovision'.",
+          "properties": {
+            "configurationId": {
+              "type": "string",
+              "enum": ["small", "medium", "large", "composable"],
+              "default": "composable",
+              "description": "IsoSession configuration ID for one-shot requests. For state-aware requests, place this under 'start.configurationId' instead. Unknown values are accepted but warned and downgraded to 'composable'."
+            },
+            "provision": {
+              "type": "object",
+              "description": "State-aware: provision-phase configuration. No fields defined yet."
+            },
+            "start": {
+              "type": "object",
+              "description": "State-aware: start-phase configuration.",
+              "properties": {
+                "configurationId": {
+                  "type": "string",
+                  "enum": ["small", "medium", "large", "composable"],
+                  "default": "composable",
+                  "description": "IsoSession configuration ID. Unknown values are accepted but warned and downgraded to 'composable'."
+                }
+              }
+            },
+            "stop": {
+              "type": "object",
+              "description": "State-aware: stop-phase configuration. No fields defined yet."
+            },
+            "deprovision": {
+              "type": "object",
+              "description": "State-aware: deprovision-phase configuration. No fields defined yet."
             }
           }
         }

--- a/schemas/stable/mxc-config.schema.0.5.0-alpha.json
+++ b/schemas/stable/mxc-config.schema.0.5.0-alpha.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/microsoft/mxc/schemas/stable/mxc-config.schema.0.5.0-alpha.json",
+  "title": "MXC Configuration",
+  "description": "Configuration schema for MXC container execution engine. Defines the recommended config format. The parser also accepts legacy fields not listed here during the migration period.",
+  "type": "object",
+
+  "required": ["process"],
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "MXC config schema version (semver). Current: '0.5.0-alpha'.",
+      "examples": ["0.5.0-alpha"]
+    },
+    "containerId": {
+      "type": "string",
+      "description": "Externally assigned container identifier."
+    },
+    "containment": {
+      "type": "string",
+      "enum": ["appcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "macos_sandbox"],
+      "default": "appcontainer",
+      "description": "Containment backend to use for execution. Note: 'windows_sandbox', 'wslc', and 'macos_sandbox' are experimental and require the --experimental CLI flag."
+    },
+
+    "lifecycle": {
+      "type": "object",
+      "description": "Container lifecycle settings shared across all backends.",
+      "properties": {
+        "destroyOnExit": {
+          "type": "boolean",
+          "default": true,
+          "description": "Destroy the container after execution completes."
+        },
+        "preservePolicy": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, retain filesystem and network policies after execution. If false (default), policies are cleaned up on exit."
+        }
+      }
+    },
+
+    "process": {
+      "type": "object",
+      "description": "Process execution settings.",
+      "required": ["commandLine"],
+      "properties": {
+        "commandLine": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Complete command line to execute (e.g., \"python3 app.py\")."
+        },
+        "cwd": {
+          "type": "string",
+          "description": "Working directory for the process."
+        },
+        "env": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Environment variables as KEY=VALUE strings.",
+          "examples": [["MY_VAR=value", "PATH=/usr/bin"]]
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Execution timeout in milliseconds. 0 = no timeout (infinite)."
+        }
+      }
+    },
+
+    "filesystem": {
+      "type": "object",
+      "description": "Filesystem access policy. Shared across all backends.",
+      "properties": {
+        "readwritePaths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Paths the process can read and write."
+        },
+        "readonlyPaths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Paths the process can read but not write."
+        },
+        "deniedPaths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Paths the process cannot access at all."
+        }
+      }
+    },
+
+    "network": {
+      "type": "object",
+      "description": "Network access policy. Shared across all backends.",
+      "properties": {
+        "defaultPolicy": {
+          "type": "string",
+          "enum": ["allow", "block"],
+          "default": "allow",
+          "description": "Default network posture."
+        },
+        "enforcementMode": {
+          "type": "string",
+          "enum": ["capabilities", "firewall", "both"],
+          "default": "capabilities",
+          "description": "How network policy is enforced."
+        },
+        "allowedHosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc' and 'appcontainer' containment backends."
+        },
+        "blockedHosts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc' and 'appcontainer' containment backends."
+        },
+        "proxy": {
+          "type": "object",
+          "description": "Proxy configuration. Only supported with appcontainer backend.",
+          "oneOf": [
+            {
+              "properties": {
+                "localhost": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "Port of an external already running proxy on localhost."
+                }
+              },
+              "required": ["localhost"],
+              "additionalProperties": false
+            },
+            {
+              "properties": {
+                "builtinTestServer": {
+                  "type": "boolean",
+                  "const": true,
+                  "description": "Use WXC's built-in test proxy server. Mutually exclusive with localhost."
+                }
+              },
+              "required": ["builtinTestServer"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+
+    "ui": {
+      "type": "object",
+      "description": "Cross-platform UI policy. Mapped from SandboxPolicy.ui by createConfigFromPolicy.",
+      "properties": {
+        "disable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether UI is disabled (no visible windows)."
+        },
+        "clipboard": {
+          "type": "string",
+          "enum": ["none", "read", "write", "all"],
+          "default": "none",
+          "description": "Clipboard access level."
+        },
+        "injection": {
+          "type": "boolean",
+          "default": false,
+          "description": "Whether input injection (keyboard/mouse) is allowed."
+        }
+      }
+    },
+
+    "appContainer": {
+      "type": "object",
+      "description": "AppContainer-specific settings. Used when containment is 'appcontainer'.",
+      "properties": {
+        "leastPrivilege": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enforce least privilege mode."
+        },
+        "capabilities": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "AppContainer capabilities (e.g., 'internetClient', 'registryRead')."
+        },
+        "ui": {
+          "type": "object",
+          "description": "BaseProcessContainer-specific UI settings (Windows only).",
+          "properties": {
+            "isolation": {
+              "type": "string",
+              "enum": ["desktop", "handles", "atoms", "container"],
+              "default": "container",
+              "description": "UI isolation level for the desktop."
+            },
+            "desktopSystemControl": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether desktop system control is allowed."
+            },
+            "systemSettings": {
+              "type": "string",
+              "default": "none",
+              "description": "System settings access level."
+            },
+            "ime": {
+              "type": "boolean",
+              "default": false,
+              "description": "Whether IME (Input Method Editor) is allowed."
+            }
+          }
+        }
+      }
+    },
+
+    "lxc": {
+      "type": "object",
+      "description": "LXC-specific settings. Used when containment is 'lxc'.",
+      "required": ["distribution", "release"],
+      "properties": {
+        "distribution": {
+          "type": "string",
+          "description": "Linux distribution for the container rootfs (e.g., 'alpine', 'ubuntu'). Required."
+        },
+        "release": {
+          "type": "string",
+          "description": "Distribution release version (e.g., '3.20', '24.04'). Required."
+        }
+      }
+    },
+
+    "experimental": {
+      "type": "object",
+      "description": "Experimental features. Only active when --experimental is passed.",
+      "properties": {
+        "test": {
+          "type": "object",
+          "description": "Placeholder feature for testing experimental infrastructure.",
+          "properties": {
+            "message": {
+              "type": "string",
+              "description": "Message to log when the feature is applied."
+            }
+          }
+        },
+        "windows_sandbox": {
+          "type": "object",
+          "description": "Windows Sandbox backend (experimental). Full VM isolation via a long-lived sandbox daemon.",
+          "properties": {
+            "idleTimeoutMs": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 300000,
+              "description": "Idle timeout in milliseconds before the daemon tears down the sandbox VM. 0 = no timeout."
+            },
+            "daemonPipeName": {
+              "type": "string",
+              "default": "wxc-windows-sandbox",
+              "description": "Named pipe name the daemon listens on (without \\\\.\\pipe\\ prefix)."
+            }
+          }
+        },
+        "wslc": {
+          "type": "object",
+          "description": "WSL Container (WSLC SDK) settings. Used when containment is 'wslc'.",
+          "properties": {
+            "targetOs": {
+              "type": "string",
+              "default": "linux",
+              "description": "Target OS for the container. Currently only 'linux' is supported."
+            },
+            "image": {
+              "type": "string",
+              "default": "alpine:latest",
+              "description": "Container image name (e.g., 'alpine:latest', 'python:3.12').",
+              "examples": ["alpine:latest", "python:3.12", "ubuntu:24.04"]
+            },
+            "imageTarPath": {
+              "type": "string",
+              "description": "Path to a local tar file to import as the container image. Supports both rootfs tars (from `docker export`) and Docker image archives (from `docker save`). When set, the image is imported from this file instead of pulling from a registry. The format is auto-detected: archives containing `manifest.json` are treated as Docker image format, archives with Linux root directories (bin/, etc/, usr/) are treated as rootfs tars, and unrecognized formats are rejected.",
+              "examples": ["C:\\images\\alpine.tar", "/home/user/images/alpine.tar"]
+            },
+            "cpuCount": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of CPUs allocated to the WSLC session. Omit for host-determined default."
+            },
+            "memoryMb": {
+              "type": "integer",
+              "minimum": 256,
+              "description": "Memory in MB allocated to the WSLC session. Omit for host-determined default."
+            },
+            "gpu": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable GPU passthrough to the container."
+            },
+            "storagePath": {
+              "type": "string",
+              "description": "Storage path for the WSLC session image store. Omit to use a temporary directory."
+            }
+          }
+        },
+        "macos_sandbox": {
+          "type": "object",
+          "description": "macOS sandbox backend (experimental). Used when containment is 'macos_sandbox'.",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "enum": ["exec", "inproc"],
+              "default": "exec",
+              "description": "How the sandbox profile is applied: 'exec' spawns /usr/bin/sandbox-exec; 'inproc' calls sandbox_init_with_parameters after fork (uses a private macOS API)."
+            },
+            "profileOverride": {
+              "type": "string",
+              "description": "Optional override of the generated TinyScheme sandbox profile."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc --watch",
     "clean": "rimraf dist",
     "test": "npm run test:unit",
-    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js",
+    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js",
     "test:integration": "cd tests/integration && npm install && npm run build && npm test",
     "prepublishOnly": "npm run build"
   },

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -23,9 +23,10 @@ export type ErrorCode =
   | 'backend_error';
 
 /**
- * Base class for typed errors thrown by the MXC SDK in response to a
- * wire-format error envelope. Use `instanceof <subclass>` or compare
- * `.code` to discriminate.
+ * Typed error thrown by the MXC SDK in response to a wire-format error
+ * envelope. Discriminate by comparing `.code` to a wire-format error code
+ * string; the TypeScript string-literal union gives the same IDE
+ * completion as a class hierarchy without the multiplicative class count.
  */
 export class MxcError extends Error {
   readonly code: ErrorCode;
@@ -35,110 +36,23 @@ export class MxcError extends Error {
     super(message);
     this.code = code;
     this.details = details;
-    // Restore the prototype chain so `instanceof <subclass>` keeps working
+    // Restore the prototype chain so `instanceof MxcError` keeps working
     // after the TypeScript ES2020 → ES5-compatible class downlevelling.
     Object.setPrototypeOf(this, new.target.prototype);
-    this.name = new.target.name;
-  }
-}
-
-export class MxcMalformedRequestError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('malformed_request', message, details);
-  }
-}
-
-export class MxcUnsupportedContainmentError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('unsupported_containment', message, details);
-  }
-}
-
-export class MxcUnsupportedPhaseError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('unsupported_phase', message, details);
-  }
-}
-
-export class MxcBackendUnavailableError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('backend_unavailable', message, details);
-  }
-}
-
-export class MxcMalformedIdError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('malformed_id', message, details);
-  }
-}
-
-export class MxcStaleIdError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('stale_id', message, details);
-  }
-}
-
-export class MxcNotProvisionedError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('not_provisioned', message, details);
-  }
-}
-
-export class MxcNotStartedError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('not_started', message, details);
-  }
-}
-
-export class MxcAlreadyStartedError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('already_started', message, details);
-  }
-}
-
-export class MxcAlreadyStoppedError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('already_stopped', message, details);
-  }
-}
-
-export class MxcPolicyValidationError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('policy_validation', message, details);
-  }
-}
-
-// Code `backend_error` already ends in `_error`, so the naming convention
-// drops the redundant suffix that would otherwise produce `MxcBackendErrorError`.
-export class MxcBackendError extends MxcError {
-  constructor(message: string, details?: Record<string, unknown>) {
-    super('backend_error', message, details);
+    this.name = 'MxcError';
   }
 }
 
 /**
- * Constructs the typed `MxcError` subclass corresponding to a wire-format
- * error code. Falls back to the base `MxcError` for unknown codes; in
- * practice the wire format's closed enum should not produce these.
+ * Constructs an `MxcError` from a wire-format error code. Accepts a plain
+ * `string` so callers parsing a wire envelope don't need to narrow first;
+ * unknown codes still produce an `MxcError` with `.code` set to whatever
+ * was on the wire.
  */
 export function mxcErrorFromCode(
   code: string,
   message: string,
   details?: Record<string, unknown>,
 ): MxcError {
-  switch (code) {
-    case 'malformed_request': return new MxcMalformedRequestError(message, details);
-    case 'unsupported_containment': return new MxcUnsupportedContainmentError(message, details);
-    case 'unsupported_phase': return new MxcUnsupportedPhaseError(message, details);
-    case 'backend_unavailable': return new MxcBackendUnavailableError(message, details);
-    case 'malformed_id': return new MxcMalformedIdError(message, details);
-    case 'stale_id': return new MxcStaleIdError(message, details);
-    case 'not_provisioned': return new MxcNotProvisionedError(message, details);
-    case 'not_started': return new MxcNotStartedError(message, details);
-    case 'already_started': return new MxcAlreadyStartedError(message, details);
-    case 'already_stopped': return new MxcAlreadyStoppedError(message, details);
-    case 'policy_validation': return new MxcPolicyValidationError(message, details);
-    case 'backend_error': return new MxcBackendError(message, details);
-    default: return new MxcError(code as ErrorCode, message, details);
-  }
+  return new MxcError(code as ErrorCode, message, details);
 }

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Closed set of MXC wire-format error codes. Mirrors `MxcErrorCode` on the
+ * Rust side one-for-one and serialises as the same snake_case strings on
+ * the wire. Backend-specific failures that don't fit one of these codes
+ * surface as `backend_error`, with structured information carried in
+ * `details`.
+ */
+export type ErrorCode =
+  | 'malformed_request'
+  | 'unsupported_containment'
+  | 'unsupported_phase'
+  | 'backend_unavailable'
+  | 'malformed_id'
+  | 'stale_id'
+  | 'not_provisioned'
+  | 'not_started'
+  | 'already_started'
+  | 'already_stopped'
+  | 'policy_validation'
+  | 'backend_error';
+
+/**
+ * Base class for typed errors thrown by the MXC SDK in response to a
+ * wire-format error envelope. Use `instanceof <subclass>` or compare
+ * `.code` to discriminate.
+ */
+export class MxcError extends Error {
+  readonly code: ErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: ErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.code = code;
+    this.details = details;
+    // Restore the prototype chain so `instanceof <subclass>` keeps working
+    // after the TypeScript ES2020 → ES5-compatible class downlevelling.
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.name = new.target.name;
+  }
+}
+
+export class MxcMalformedRequestError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('malformed_request', message, details);
+  }
+}
+
+export class MxcUnsupportedContainmentError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('unsupported_containment', message, details);
+  }
+}
+
+export class MxcUnsupportedPhaseError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('unsupported_phase', message, details);
+  }
+}
+
+export class MxcBackendUnavailableError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('backend_unavailable', message, details);
+  }
+}
+
+export class MxcMalformedIdError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('malformed_id', message, details);
+  }
+}
+
+export class MxcStaleIdError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('stale_id', message, details);
+  }
+}
+
+export class MxcNotProvisionedError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('not_provisioned', message, details);
+  }
+}
+
+export class MxcNotStartedError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('not_started', message, details);
+  }
+}
+
+export class MxcAlreadyStartedError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('already_started', message, details);
+  }
+}
+
+export class MxcAlreadyStoppedError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('already_stopped', message, details);
+  }
+}
+
+export class MxcPolicyValidationError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('policy_validation', message, details);
+  }
+}
+
+// Code `backend_error` already ends in `_error`, so the naming convention
+// drops the redundant suffix that would otherwise produce `MxcBackendErrorError`.
+export class MxcBackendError extends MxcError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('backend_error', message, details);
+  }
+}
+
+/**
+ * Constructs the typed `MxcError` subclass corresponding to a wire-format
+ * error code. Falls back to the base `MxcError` for unknown codes; in
+ * practice the wire format's closed enum should not produce these.
+ */
+export function mxcErrorFromCode(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+): MxcError {
+  switch (code) {
+    case 'malformed_request': return new MxcMalformedRequestError(message, details);
+    case 'unsupported_containment': return new MxcUnsupportedContainmentError(message, details);
+    case 'unsupported_phase': return new MxcUnsupportedPhaseError(message, details);
+    case 'backend_unavailable': return new MxcBackendUnavailableError(message, details);
+    case 'malformed_id': return new MxcMalformedIdError(message, details);
+    case 'stale_id': return new MxcStaleIdError(message, details);
+    case 'not_provisioned': return new MxcNotProvisionedError(message, details);
+    case 'not_started': return new MxcNotStartedError(message, details);
+    case 'already_started': return new MxcAlreadyStartedError(message, details);
+    case 'already_stopped': return new MxcAlreadyStoppedError(message, details);
+    case 'policy_validation': return new MxcPolicyValidationError(message, details);
+    case 'backend_error': return new MxcBackendError(message, details);
+    default: return new MxcError(code as ErrorCode, message, details);
+  }
+}

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -62,8 +62,62 @@ export function makeLogFilePath(dir: string): string {
 }
 
 /**
- * Resolves the executable path and builds CLI arguments for a sandbox invocation.
- * Shared setup used by both PTY and non-PTY spawn paths.
+ * Resolves the executor binary and builds the common CLI arguments for any
+ * MXC request envelope (one-shot or state-aware). Performs platform support
+ * and binary-presence checks; does not validate envelope contents — callers
+ * apply request-specific validation before delegating to this helper.
+ */
+export function resolveBinaryAndCommonArgs(
+  envelopeJson: string,
+  options: SandboxSpawnOptions,
+): { executablePath: string; args: string[] } {
+  const platformSupport = getPlatformSupport();
+  if (!platformSupport.isSupported) {
+    throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
+  }
+
+  const platform = os.platform();
+  let executablePath: string;
+
+  if (options.executablePath) {
+    if (!fs.existsSync(options.executablePath)) {
+      throw new Error(`File not found: ${options.executablePath}`);
+    }
+    executablePath = options.executablePath;
+  } else if (platform === 'linux') {
+    const p = findLxcExecutable();
+    if (!p) {
+      throw new Error(
+        'lxc-exec not found. Ensure it is built and available in a standard location.'
+      );
+    }
+    executablePath = p;
+  } else {
+    const p = findWxcExecutable();
+    if (!p) {
+      throw new Error(
+        'wxc-exec.exe not found. Set options.executablePath or ensure it exists in a standard location.'
+      );
+    }
+    executablePath = p;
+  }
+
+  const args: string[] = [];
+  const envelopeBase64 = Buffer.from(envelopeJson, 'utf-8').toString('base64');
+  args.push('--config-base64', envelopeBase64);
+
+  if (options.dryRun) args.push('--dry-run');
+  if (options.debug) args.push('--debug');
+  if (options.experimental) args.push('--experimental');
+
+  return { executablePath, args };
+}
+
+/**
+ * Resolves the executable path and builds CLI arguments for a one-shot
+ * sandbox invocation. Validates one-shot-specific invariants (commandLine
+ * required, experimental gating, containment-vs-platform compatibility)
+ * before delegating to the shared `resolveBinaryAndCommonArgs`.
  */
 export function resolveExecutableAndArgs(
   config: ContainerConfig,
@@ -102,48 +156,7 @@ export function resolveExecutableAndArgs(
     }
   }
 
-  const platform = os.platform();
-  let executablePath: string | null;
-
-  if (options.executablePath) {
-    if (!fs.existsSync(options.executablePath)) {
-      throw new Error(`File not found: ${options.executablePath}`);
-    }
-    executablePath = options.executablePath;
-  } else if (platform === 'linux') {
-    executablePath = findLxcExecutable();
-    if (!executablePath) {
-      throw new Error(
-        'lxc-exec not found. Ensure it is built and available in a standard location.'
-      );
-    }
-  } else {
-    executablePath = findWxcExecutable();
-    if (!executablePath) {
-      throw new Error(
-        'wxc-exec.exe not found. Set options.executablePath or ensure it exists in a standard location.'
-      );
-    }
-  }
-
-  const args: string[] = [];
-  const configJson = JSON.stringify(config);
-  const configBase64 = Buffer.from(configJson, 'utf-8').toString('base64');
-  args.push('--config-base64', configBase64);
-
-  if (options.dryRun) {
-    args.push('--dry-run');
-  }
-
-  if (options.debug) {
-    args.push('--debug');
-  }
-
-  if (options.experimental) {
-    args.push('--experimental');
-  }
-
-  return { executablePath, args };
+  return resolveBinaryAndCommonArgs(JSON.stringify(config), options);
 }
 
 /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -58,3 +58,61 @@ export {
   FilesystemPolicyResult,
   ToolsPolicyOptions,
 } from './policy.js';
+
+// Export typed wire-format errors
+export {
+  ErrorCode,
+  MxcError,
+  MxcMalformedRequestError,
+  MxcUnsupportedContainmentError,
+  MxcUnsupportedPhaseError,
+  MxcBackendUnavailableError,
+  MxcMalformedIdError,
+  MxcStaleIdError,
+  MxcNotProvisionedError,
+  MxcNotStartedError,
+  MxcAlreadyStartedError,
+  MxcAlreadyStoppedError,
+  MxcPolicyValidationError,
+  MxcBackendError,
+  mxcErrorFromCode,
+} from './errors.js';
+
+// Export state-aware lifecycle types
+export {
+  Phase,
+  StateAwareSandboxingMethod,
+  SandboxId,
+  IsolationSessionProvisionConfig,
+  IsolationSessionStartConfig,
+  IsolationSessionExecConfig,
+  IsolationSessionStopConfig,
+  IsolationSessionDeprovisionConfig,
+  IsolationSessionProvisionMetadata,
+  ConfigsForBackend,
+  ProvisionConfigFor,
+  StartConfigFor,
+  ExecConfigFor,
+  StopConfigFor,
+  DeprovisionConfigFor,
+  StateAwareMetadata,
+  ProvisionMetadataFor,
+  StartMetadataFor,
+  StopMetadataFor,
+  DeprovisionMetadataFor,
+  ProvisionResult,
+  StartResult,
+  StopResult,
+  DeprovisionResult,
+  ExecResult,
+} from './state-aware-types.js';
+
+// Export state-aware lifecycle functions
+export {
+  provisionSandbox,
+  startSandbox,
+  execInSandbox,
+  execInSandboxAsync,
+  stopSandbox,
+  deprovisionSandbox,
+} from './state-aware.js';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -63,18 +63,6 @@ export {
 export {
   ErrorCode,
   MxcError,
-  MxcMalformedRequestError,
-  MxcUnsupportedContainmentError,
-  MxcUnsupportedPhaseError,
-  MxcBackendUnavailableError,
-  MxcMalformedIdError,
-  MxcStaleIdError,
-  MxcNotProvisionedError,
-  MxcNotStartedError,
-  MxcAlreadyStartedError,
-  MxcAlreadyStoppedError,
-  MxcPolicyValidationError,
-  MxcBackendError,
   mxcErrorFromCode,
 } from './errors.js';
 

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -10,7 +10,7 @@ import { SandboxPolicy, ContainerConfig, ContainmentType } from './types.js';
 import { prepareSpawn, diagLogVersion } from './helper.js';
 import { diagLog } from './diagnostic.js';
 
-const SUPPORTED_VERSION = '0.5.0-alpha';
+const SUPPORTED_VERSION = '0.6.0-alpha';
 const MIN_VERSION = '0.4.0-alpha';
 
 /**
@@ -358,6 +358,20 @@ export interface SandboxSpawnOptions {
    * Defaults to true (uses PTY).
    */
   usePty?: boolean;
+
+  /**
+   * Optional cancellation signal. When it aborts, the SDK kills the
+   * spawned executor process and rejects any pending result promise with
+   * the signal's reason. Honored by the state-aware lifecycle functions;
+   * one-shot spawn currently ignores it (kill the returned IPty /
+   * ChildProcess directly instead).
+   *
+   * Cancellation is best-effort: killing the executor mid-call leaves
+   * any backend-side state (e.g. a partially-provisioned IsolationSession)
+   * wherever it landed. Callers may need a follow-up `deprovisionSandbox`
+   * (or its equivalent) to clean up an orphaned sandbox after an abort.
+   */
+  signal?: AbortSignal;
 }
 
 /**

--- a/sdk/src/state-aware-helper.ts
+++ b/sdk/src/state-aware-helper.ts
@@ -1,0 +1,246 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { spawn } from 'child_process';
+import { resolveBinaryAndCommonArgs } from './helper.js';
+import { SandboxSpawnOptions } from './sandbox.js';
+import { mxcErrorFromCode } from './errors.js';
+import { diagLog } from './diagnostic.js';
+import { Phase, StateAwareSandboxingMethod } from './state-aware-types.js';
+
+export const STATE_AWARE_VERSION = '0.6.0-alpha';
+
+// Wire-format cross-cutting fields that live at the envelope's top level.
+// Anything else on a per-(backend, phase) Config is backend-specific and is
+// nested under `experimental.<backend>.<phase>`.
+export const CROSS_CUTTING_FIELDS = ['filesystem', 'network', 'ui', 'process'] as const;
+
+// Per-backend wire-format prefix. Each value mirrors the corresponding
+// Rust `<Backend>Runner::ID_PREFIX` const and is the leading segment of a
+// `sandboxId` produced by that backend. Each future state-aware backend
+// declares its own `<BACKEND>_ID_PREFIX` const here.
+export const ISOLATION_SESSION_ID_PREFIX = 'iso';
+
+// Mapping from a sandboxId's leading prefix segment to the wire-format
+// backend key. Extended as more state-aware backends opt in.
+export const PREFIX_TO_BACKEND: Record<string, StateAwareSandboxingMethod> = {
+  [ISOLATION_SESSION_ID_PREFIX]: 'isolation_session',
+};
+
+/**
+ * Resolves the wire-format backend key for a sandbox id by reading its
+ * leading prefix segment. Throws an `MxcError` with `code: 'malformed_id'`
+ * when the id has no recognised prefix.
+ */
+export function backendForSandboxId(sandboxId: string): StateAwareSandboxingMethod {
+  const colon = sandboxId.indexOf(':');
+  if (colon < 0) {
+    throw mxcErrorFromCode('malformed_id', `sandboxId must carry a backend prefix: ${sandboxId}`);
+  }
+  const prefix = sandboxId.slice(0, colon);
+  const backend = PREFIX_TO_BACKEND[prefix];
+  if (!backend) {
+    throw mxcErrorFromCode('malformed_id', `sandboxId prefix '${prefix}' does not match a known state-aware backend`);
+  }
+  return backend;
+}
+
+export interface BuildEnvelopeArgs {
+  phase: Phase;
+  backendKey: StateAwareSandboxingMethod;
+  containment?: StateAwareSandboxingMethod; // provision only
+  sandboxId?: string;                        // non-provision only
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Constructs the wire-format JSON-shaped envelope for a state-aware request
+ * from a per-(backend, phase) Config. Lifts cross-cutting fields
+ * (filesystem, network, ui, process) to envelope top-level; nests any
+ * remaining backend-specific fields under `experimental.<backend>.<phase>`.
+ */
+export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string, unknown> {
+  const { phase, backendKey, containment, sandboxId, config } = args;
+  // Copy of config; fields are removed as they are lifted into the envelope.
+  // Anything left becomes experimental.<backend>.<phase>.
+  const backendSpecific: Record<string, unknown> = { ...(config ?? {}) };
+  const version = (typeof backendSpecific.version === 'string' && backendSpecific.version) || STATE_AWARE_VERSION;
+  delete backendSpecific.version;
+
+  const envelope: Record<string, unknown> = { version, phase };
+  if (containment) {
+    envelope.containment = containment;
+  }
+  if (sandboxId) {
+    envelope.sandboxId = sandboxId;
+  }
+
+  for (const field of CROSS_CUTTING_FIELDS) {
+    if (backendSpecific[field] !== undefined) {
+      envelope[field] = backendSpecific[field];
+      delete backendSpecific[field];
+    }
+  }
+
+  if (Object.keys(backendSpecific).length > 0) {
+    envelope.experimental = { [backendKey]: { [phase]: backendSpecific } };
+  }
+
+  return envelope;
+}
+
+export interface WireErrorEnvelope {
+  error: { code: string; message: string; details?: Record<string, unknown> };
+}
+
+export interface WireResultEnvelope<T> {
+  result: T;
+}
+
+/**
+ * Parses the single-envelope JSON stdout produced by non-exec state-aware
+ * phases. Throws the corresponding `MxcError` on `{error}`, returns the
+ * unwrapped `result` on `{result}`.
+ */
+export function parseNonExecResponse<T>(stdout: string): T {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch (e) {
+    throw new Error(`Failed to parse state-aware response envelope: ${(e as Error).message}`);
+  }
+  if (parsed && typeof parsed === 'object') {
+    if ('error' in parsed) {
+      const env = (parsed as WireErrorEnvelope).error;
+      throw mxcErrorFromCode(env.code, env.message, env.details);
+    }
+    if ('result' in parsed) {
+      return (parsed as WireResultEnvelope<T>).result;
+    }
+  }
+  throw new Error(`Unexpected state-aware response envelope shape: ${stdout}`);
+}
+
+/**
+ * Attempts to parse stdout as an `{error}` envelope. Returns the parsed
+ * envelope when stdout is exactly that, or `null` otherwise (script output
+ * mistaken for an envelope is suppressed). Used by exec to discriminate
+ * dispatch failure from script failure.
+ */
+export function tryParseErrorEnvelope(stdout: string): WireErrorEnvelope | null {
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    if (
+      parsed && typeof parsed === 'object' && 'error' in parsed &&
+      (parsed as WireErrorEnvelope).error?.code
+    ) {
+      return parsed as WireErrorEnvelope;
+    }
+  } catch {
+    // Not JSON. Definitely script output.
+  }
+  return null;
+}
+
+// --- Spawn injection (test-only) ---
+
+export type SpawnImpl = (cmd: string, args: string[], opts: unknown) => unknown;
+let spawnImpl: SpawnImpl = spawn as unknown as SpawnImpl;
+
+/**
+ * Test-only hook: replace the `child_process.spawn` implementation used by
+ * non-exec state-aware calls and the buffered `execInSandboxAsync`. Not
+ * exported from `index.ts` — production code uses the real `spawn`.
+ */
+export function _setSpawnImpl(fn: SpawnImpl): void {
+  spawnImpl = fn;
+}
+
+/** Test-only hook: restore the default `child_process.spawn`. */
+export function _resetSpawnImpl(): void {
+  spawnImpl = spawn as unknown as SpawnImpl;
+}
+
+export interface CollectedOutput {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Spawns the executor with the given envelope, captures stdout/stderr,
+ * and resolves on close. Honors `options.signal` for cancellation.
+ */
+export function spawnAndCollect(
+  envelope: Record<string, unknown>,
+  options: SandboxSpawnOptions,
+): Promise<CollectedOutput> {
+  return new Promise((resolve, reject) => {
+    const signal = options.signal;
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Aborted'));
+      return;
+    }
+
+    let executablePath: string;
+    let args: string[];
+    try {
+      ({ executablePath, args } = resolveBinaryAndCommonArgs(JSON.stringify(envelope), options));
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    diagLog(`state-aware: spawning phase=${envelope.phase}`);
+
+    const child = spawnImpl(executablePath, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as {
+      stdout: NodeJS.ReadableStream | null;
+      stderr: NodeJS.ReadableStream | null;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+      on: (event: string, cb: (...a: unknown[]) => void) => unknown;
+    };
+
+    let stdoutData = '';
+    let stderrData = '';
+
+    child.stdout?.on('data', (d: Buffer | string) => {
+      stdoutData += typeof d === 'string' ? d : d.toString('utf-8');
+    });
+    child.stderr?.on('data', (d: Buffer | string) => {
+      stderrData += typeof d === 'string' ? d : d.toString('utf-8');
+    });
+
+    const onAbort = () => {
+      child.kill();
+    };
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    child.on('close', (...a: unknown[]) => {
+      const code = a[0] as number | null;
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      if (signal?.aborted) {
+        reject(signal.reason ?? new Error('Aborted'));
+        return;
+      }
+      resolve({ stdout: stdoutData, stderr: stderrData, exitCode: code ?? -1 });
+    });
+
+    child.on('error', (...a: unknown[]) => {
+      reject(a[0] as Error);
+    });
+  });
+}
+
+export async function nonExecCall<T>(
+  envelope: Record<string, unknown>,
+  options: SandboxSpawnOptions,
+): Promise<T> {
+  const { stdout } = await spawnAndCollect(envelope, options);
+  return parseNonExecResponse<T>(stdout);
+}

--- a/sdk/src/state-aware-types.ts
+++ b/sdk/src/state-aware-types.ts
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  FilesystemConfig,
+  NetworkConfig,
+  ProcessConfig,
+  SandboxingMethod,
+  UiConfig,
+} from './types.js';
+
+/**
+ * Lifecycle phase in a state-aware sandbox request.
+ */
+export type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
+
+/**
+ * Subset of `SandboxingMethod` whose backends participate in the state-aware
+ * lifecycle. Extended as more backends opt in.
+ */
+export type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
+
+/**
+ * Branded sandbox identifier returned by `provisionSandbox` and routed back
+ * to the same backend by subsequent phases. The runtime value is a plain
+ * string; the brand exists at compile time only — TypeScript prevents
+ * callers from passing a bare string, or a `SandboxId` from one backend
+ * where one for a different backend is expected.
+ */
+export type SandboxId<C extends StateAwareSandboxingMethod> =
+  string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
+
+// IsolationSession per-(backend, phase) Configs. Each declares only the
+// fields valid for the IsolationSession backend at that phase. Cross-cutting
+// fields appear inline at the Config root, only in phases where the backend
+// honors them per its policy honor matrix; phases with no backend-specific
+// or cross-cutting fields declare a Config carrying only `version?` —
+// explicit and minimal.
+
+export interface IsolationSessionProvisionConfig {
+  /** Schema version (semver). When omitted, the SDK fills in its own SUPPORTED_VERSION. */
+  version?: string;
+  filesystem?: FilesystemConfig;
+  network?: NetworkConfig;
+  ui?: UiConfig;
+}
+
+export interface IsolationSessionStartConfig {
+  /** Schema version (semver). */
+  version?: string;
+  /**
+   * Selected IsoSession size profile. Unknown values are warned and
+   * downgraded to `'composable'` on the Rust side.
+   */
+  configurationId?: 'small' | 'medium' | 'large' | 'composable';
+}
+
+export interface IsolationSessionExecConfig {
+  /** Schema version (semver). */
+  version?: string;
+  process: ProcessConfig;
+}
+
+export interface IsolationSessionStopConfig {
+  /** Schema version (semver). */
+  version?: string;
+}
+
+export interface IsolationSessionDeprovisionConfig {
+  /** Schema version (semver). */
+  version?: string;
+}
+
+/**
+ * IsolationSession's provision-phase metadata: the per-instance agent user
+ * account name minted for this sandbox.
+ */
+export interface IsolationSessionProvisionMetadata {
+  agentUserName: string;
+}
+
+/**
+ * Per-backend per-phase typed Config bundle. Selects the correct Config
+ * bundle for the backend type parameter.
+ */
+export type ConfigsForBackend<C extends StateAwareSandboxingMethod> =
+  C extends 'isolation_session'
+    ? {
+        provision: IsolationSessionProvisionConfig;
+        start: IsolationSessionStartConfig;
+        exec: IsolationSessionExecConfig;
+        stop: IsolationSessionStopConfig;
+        deprovision: IsolationSessionDeprovisionConfig;
+      }
+    : never;
+
+export type ProvisionConfigFor<C extends StateAwareSandboxingMethod> =
+  ConfigsForBackend<C>['provision'];
+export type StartConfigFor<C extends StateAwareSandboxingMethod> =
+  ConfigsForBackend<C>['start'];
+export type ExecConfigFor<C extends StateAwareSandboxingMethod> =
+  ConfigsForBackend<C>['exec'];
+export type StopConfigFor<C extends StateAwareSandboxingMethod> =
+  ConfigsForBackend<C>['stop'];
+export type DeprovisionConfigFor<C extends StateAwareSandboxingMethod> =
+  ConfigsForBackend<C>['deprovision'];
+
+/**
+ * Per-backend per-phase metadata bundle. Backends that don't return
+ * metadata for a given phase omit that key.
+ */
+export interface StateAwareMetadata {
+  isolation_session?: {
+    provision?: IsolationSessionProvisionMetadata;
+    // IsolationSession returns no metadata for start, stop, or deprovision.
+  };
+  // Future state-aware-capable backends add typed entries here.
+}
+
+export type ProvisionMetadataFor<C extends StateAwareSandboxingMethod> =
+  'provision' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['provision']
+    : undefined;
+export type StartMetadataFor<C extends StateAwareSandboxingMethod> =
+  'start' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['start']
+    : undefined;
+export type StopMetadataFor<C extends StateAwareSandboxingMethod> =
+  'stop' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['stop']
+    : undefined;
+export type DeprovisionMetadataFor<C extends StateAwareSandboxingMethod> =
+  'deprovision' extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>['deprovision']
+    : undefined;
+
+export interface ProvisionResult<C extends StateAwareSandboxingMethod> {
+  sandboxId: SandboxId<C>;
+  metadata?: ProvisionMetadataFor<C>;
+}
+
+export interface StartResult<C extends StateAwareSandboxingMethod> {
+  metadata?: StartMetadataFor<C>;
+}
+
+export interface StopResult<C extends StateAwareSandboxingMethod> {
+  metadata?: StopMetadataFor<C>;
+}
+
+export interface DeprovisionResult<C extends StateAwareSandboxingMethod> {
+  metadata?: DeprovisionMetadataFor<C>;
+}
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}

--- a/sdk/src/state-aware-types.ts
+++ b/sdk/src/state-aware-types.ts
@@ -3,10 +3,8 @@
 
 import {
   FilesystemConfig,
-  NetworkConfig,
   ProcessConfig,
   SandboxingMethod,
-  UiConfig,
 } from './types.js';
 
 /**
@@ -30,19 +28,15 @@ export type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_se
 export type SandboxId<C extends StateAwareSandboxingMethod> =
   string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
 
-// IsolationSession per-(backend, phase) Configs. Each declares only the
-// fields valid for the IsolationSession backend at that phase. Cross-cutting
-// fields appear inline at the Config root, only in phases where the backend
-// honors them per its policy honor matrix; phases with no backend-specific
-// or cross-cutting fields declare a Config carrying only `version?` —
-// explicit and minimal.
+// IsolationSession per-(backend, phase) Configs. Each declares only
+// the fields the SDK currently exposes at that phase — scoped to
+// what the backend honors per the policy honor matrix and currently
+// implements. TypeScript rejects passing fields outside this set.
 
 export interface IsolationSessionProvisionConfig {
   /** Schema version (semver). When omitted, the SDK fills in its own SUPPORTED_VERSION. */
   version?: string;
   filesystem?: FilesystemConfig;
-  network?: NetworkConfig;
-  ui?: UiConfig;
 }
 
 export interface IsolationSessionStartConfig {
@@ -117,22 +111,15 @@ export interface StateAwareMetadata {
   // Future state-aware-capable backends add typed entries here.
 }
 
-export type ProvisionMetadataFor<C extends StateAwareSandboxingMethod> =
-  'provision' extends keyof NonNullable<StateAwareMetadata[C]>
-    ? NonNullable<StateAwareMetadata[C]>['provision']
+type MetadataForPhase<C extends StateAwareSandboxingMethod, Phase extends string> =
+  Phase extends keyof NonNullable<StateAwareMetadata[C]>
+    ? NonNullable<StateAwareMetadata[C]>[Phase]
     : undefined;
-export type StartMetadataFor<C extends StateAwareSandboxingMethod> =
-  'start' extends keyof NonNullable<StateAwareMetadata[C]>
-    ? NonNullable<StateAwareMetadata[C]>['start']
-    : undefined;
-export type StopMetadataFor<C extends StateAwareSandboxingMethod> =
-  'stop' extends keyof NonNullable<StateAwareMetadata[C]>
-    ? NonNullable<StateAwareMetadata[C]>['stop']
-    : undefined;
-export type DeprovisionMetadataFor<C extends StateAwareSandboxingMethod> =
-  'deprovision' extends keyof NonNullable<StateAwareMetadata[C]>
-    ? NonNullable<StateAwareMetadata[C]>['deprovision']
-    : undefined;
+
+export type ProvisionMetadataFor<C extends StateAwareSandboxingMethod> = MetadataForPhase<C, 'provision'>;
+export type StartMetadataFor<C extends StateAwareSandboxingMethod> = MetadataForPhase<C, 'start'>;
+export type StopMetadataFor<C extends StateAwareSandboxingMethod> = MetadataForPhase<C, 'stop'>;
+export type DeprovisionMetadataFor<C extends StateAwareSandboxingMethod> = MetadataForPhase<C, 'deprovision'>;
 
 export interface ProvisionResult<C extends StateAwareSandboxingMethod> {
   sandboxId: SandboxId<C>;

--- a/sdk/src/state-aware.ts
+++ b/sdk/src/state-aware.ts
@@ -2,254 +2,32 @@
 // Licensed under the MIT License.
 
 import pty from 'node-pty';
-import { spawn } from 'child_process';
 import { resolveBinaryAndCommonArgs } from './helper.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { mxcErrorFromCode } from './errors.js';
 import { diagLog } from './diagnostic.js';
 import {
   DeprovisionConfigFor,
-  DeprovisionMetadataFor,
   DeprovisionResult,
   ExecConfigFor,
   ExecResult,
-  Phase,
   ProvisionConfigFor,
   ProvisionMetadataFor,
   ProvisionResult,
   SandboxId,
   StartConfigFor,
-  StartMetadataFor,
   StartResult,
   StateAwareSandboxingMethod,
   StopConfigFor,
-  StopMetadataFor,
   StopResult,
 } from './state-aware-types.js';
-
-const STATE_AWARE_VERSION = '0.6.0-alpha';
-
-// Wire-format cross-cutting fields that live at the envelope's top level.
-// Anything else on a per-(backend, phase) Config is backend-specific and is
-// nested under `experimental.<backend>.<phase>`.
-const CROSS_CUTTING_FIELDS = ['filesystem', 'network', 'ui', 'process'] as const;
-
-// Mapping from a sandboxId's leading prefix segment to the wire-format
-// backend key. Extended as more state-aware backends opt in.
-const PREFIX_TO_BACKEND: Record<string, StateAwareSandboxingMethod> = {
-  iso: 'isolation_session',
-};
-
-/**
- * Resolves the wire-format backend key for a sandbox id by reading its
- * leading prefix segment. Throws `MxcMalformedIdError` when the id has no
- * recognised prefix.
- */
-function backendForSandboxId(sandboxId: string): StateAwareSandboxingMethod {
-  const colon = sandboxId.indexOf(':');
-  if (colon < 0) {
-    throw mxcErrorFromCode('malformed_id', `sandboxId must carry a backend prefix: ${sandboxId}`);
-  }
-  const prefix = sandboxId.slice(0, colon);
-  const backend = PREFIX_TO_BACKEND[prefix];
-  if (!backend) {
-    throw mxcErrorFromCode('malformed_id', `sandboxId prefix '${prefix}' does not match a known state-aware backend`);
-  }
-  return backend;
-}
-
-interface BuildEnvelopeArgs {
-  phase: Phase;
-  backendKey: StateAwareSandboxingMethod;
-  containment?: StateAwareSandboxingMethod; // provision only
-  sandboxId?: string;                        // non-provision only
-  config?: Record<string, unknown>;
-}
-
-/**
- * Constructs the wire-format JSON-shaped envelope for a state-aware request
- * from a per-(backend, phase) Config. Lifts cross-cutting fields
- * (filesystem, network, ui, process) to envelope top-level; nests any
- * remaining backend-specific fields under `experimental.<backend>.<phase>`.
- * Exported for unit testing; consumers do not call this directly.
- */
-export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string, unknown> {
-  const { phase, backendKey, containment, sandboxId, config } = args;
-  const remaining: Record<string, unknown> = { ...(config ?? {}) };
-  const version = (typeof remaining.version === 'string' && remaining.version) || STATE_AWARE_VERSION;
-  delete remaining.version;
-
-  const envelope: Record<string, unknown> = { version, phase };
-  if (containment) envelope.containment = containment;
-  if (sandboxId) envelope.sandboxId = sandboxId;
-
-  for (const field of CROSS_CUTTING_FIELDS) {
-    if (remaining[field] !== undefined) {
-      envelope[field] = remaining[field];
-      delete remaining[field];
-    }
-  }
-
-  if (Object.keys(remaining).length > 0) {
-    envelope.experimental = { [backendKey]: { [phase]: remaining } };
-  }
-
-  return envelope;
-}
-
-interface WireErrorEnvelope {
-  error: { code: string; message: string; details?: Record<string, unknown> };
-}
-
-interface WireResultEnvelope<T> {
-  result: T;
-}
-
-/**
- * Parses the single-envelope JSON stdout produced by non-exec state-aware
- * phases. Throws the corresponding `MxcError` subclass on `{error}`,
- * returns the unwrapped `result` on `{result}`. Exported for unit testing.
- */
-export function parseNonExecResponse<T>(stdout: string): T {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(stdout.trim());
-  } catch (e) {
-    throw new Error(`Failed to parse state-aware response envelope: ${(e as Error).message}`);
-  }
-  if (parsed && typeof parsed === 'object') {
-    if ('error' in parsed) {
-      const env = (parsed as WireErrorEnvelope).error;
-      throw mxcErrorFromCode(env.code, env.message, env.details);
-    }
-    if ('result' in parsed) {
-      return (parsed as WireResultEnvelope<T>).result;
-    }
-  }
-  throw new Error(`Unexpected state-aware response envelope shape: ${stdout}`);
-}
-
-/**
- * Attempts to parse stdout as an `{error}` envelope. Returns the parsed
- * envelope when stdout is exactly that, or `null` otherwise (script output
- * mistaken for an envelope is suppressed). Used by exec to discriminate
- * dispatch failure from script failure.
- */
-function tryParseErrorEnvelope(stdout: string): WireErrorEnvelope | null {
-  try {
-    const parsed = JSON.parse(stdout.trim());
-    if (
-      parsed && typeof parsed === 'object' && 'error' in parsed &&
-      (parsed as WireErrorEnvelope).error?.code
-    ) {
-      return parsed as WireErrorEnvelope;
-    }
-  } catch {
-    // Not JSON. Definitely script output.
-  }
-  return null;
-}
-
-// --- Spawn injection (test-only) ---
-
-type SpawnImpl = (cmd: string, args: string[], opts: unknown) => unknown;
-let spawnImpl: SpawnImpl = spawn as unknown as SpawnImpl;
-
-/**
- * Test-only hook: replace the `child_process.spawn` implementation used by
- * non-exec state-aware calls and the buffered `execInSandboxAsync`. Not
- * exported from `index.ts` — production code uses the real `spawn`.
- */
-export function _setSpawnImpl(fn: SpawnImpl): void {
-  spawnImpl = fn;
-}
-
-/** Test-only hook: restore the default `child_process.spawn`. */
-export function _resetSpawnImpl(): void {
-  spawnImpl = spawn as unknown as SpawnImpl;
-}
-
-interface CollectedOutput {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-/**
- * Spawns the executor with the given envelope, captures stdout/stderr,
- * and resolves on close. Honors `options.signal` for cancellation.
- */
-function spawnAndCollect(
-  envelope: Record<string, unknown>,
-  options: SandboxSpawnOptions,
-): Promise<CollectedOutput> {
-  return new Promise((resolve, reject) => {
-    const signal = options.signal;
-    if (signal?.aborted) {
-      reject(signal.reason ?? new Error('Aborted'));
-      return;
-    }
-
-    let executablePath: string;
-    let args: string[];
-    try {
-      ({ executablePath, args } = resolveBinaryAndCommonArgs(JSON.stringify(envelope), options));
-    } catch (err) {
-      reject(err);
-      return;
-    }
-
-    diagLog(`state-aware: spawning phase=${envelope.phase}`);
-
-    const child = spawnImpl(executablePath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }) as {
-      stdout: NodeJS.ReadableStream | null;
-      stderr: NodeJS.ReadableStream | null;
-      kill: (signal?: NodeJS.Signals | number) => boolean;
-      on: (event: string, cb: (...a: unknown[]) => void) => unknown;
-    };
-
-    let stdoutData = '';
-    let stderrData = '';
-
-    child.stdout?.on('data', (d: Buffer | string) => {
-      stdoutData += typeof d === 'string' ? d : d.toString('utf-8');
-    });
-    child.stderr?.on('data', (d: Buffer | string) => {
-      stderrData += typeof d === 'string' ? d : d.toString('utf-8');
-    });
-
-    const onAbort = () => {
-      child.kill();
-    };
-    if (signal) signal.addEventListener('abort', onAbort, { once: true });
-
-    child.on('close', (...a: unknown[]) => {
-      const code = a[0] as number | null;
-      if (signal) signal.removeEventListener('abort', onAbort);
-      if (signal?.aborted) {
-        reject(signal.reason ?? new Error('Aborted'));
-        return;
-      }
-      resolve({ stdout: stdoutData, stderr: stderrData, exitCode: code ?? -1 });
-    });
-
-    child.on('error', (...a: unknown[]) => {
-      reject(a[0] as Error);
-    });
-  });
-}
-
-async function nonExecCall<T>(
-  envelope: Record<string, unknown>,
-  options: SandboxSpawnOptions,
-): Promise<T> {
-  const { stdout } = await spawnAndCollect(envelope, options);
-  return parseNonExecResponse<T>(stdout);
-}
-
-// --- Public API: the 5 functions ---
+import {
+  backendForSandboxId,
+  buildStateAwareEnvelope,
+  nonExecCall,
+  spawnAndCollect,
+  tryParseErrorEnvelope,
+} from './state-aware-helper.js';
 
 /**
  * Provisions a state-aware sandbox of the requested backend. Returns a
@@ -338,9 +116,9 @@ export function execInSandbox<C extends StateAwareSandboxingMethod>(
 
 /**
  * Buffered exec convenience. Resolves with `{stdout, stderr, exitCode}`
- * on script completion. Throws the typed `MxcError` subclass when the
- * executor reports a dispatch failure (recognised by exit != 0 and stdout
- * being a complete `{error}` envelope).
+ * on script completion. Throws an `MxcError` (with the wire-format `code`
+ * field set) when the executor reports a dispatch failure (recognised by
+ * exit != 0 and stdout being a complete `{error}` envelope).
  */
 export async function execInSandboxAsync<C extends StateAwareSandboxingMethod>(
   sandboxId: SandboxId<C>,

--- a/sdk/src/state-aware.ts
+++ b/sdk/src/state-aware.ts
@@ -1,0 +1,406 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import pty from 'node-pty';
+import { spawn } from 'child_process';
+import { resolveBinaryAndCommonArgs } from './helper.js';
+import { SandboxSpawnOptions } from './sandbox.js';
+import { mxcErrorFromCode } from './errors.js';
+import { diagLog } from './diagnostic.js';
+import {
+  DeprovisionConfigFor,
+  DeprovisionMetadataFor,
+  DeprovisionResult,
+  ExecConfigFor,
+  ExecResult,
+  Phase,
+  ProvisionConfigFor,
+  ProvisionMetadataFor,
+  ProvisionResult,
+  SandboxId,
+  StartConfigFor,
+  StartMetadataFor,
+  StartResult,
+  StateAwareSandboxingMethod,
+  StopConfigFor,
+  StopMetadataFor,
+  StopResult,
+} from './state-aware-types.js';
+
+const STATE_AWARE_VERSION = '0.6.0-alpha';
+
+// Wire-format cross-cutting fields that live at the envelope's top level.
+// Anything else on a per-(backend, phase) Config is backend-specific and is
+// nested under `experimental.<backend>.<phase>`.
+const CROSS_CUTTING_FIELDS = ['filesystem', 'network', 'ui', 'process'] as const;
+
+// Mapping from a sandboxId's leading prefix segment to the wire-format
+// backend key. Extended as more state-aware backends opt in.
+const PREFIX_TO_BACKEND: Record<string, StateAwareSandboxingMethod> = {
+  iso: 'isolation_session',
+};
+
+/**
+ * Resolves the wire-format backend key for a sandbox id by reading its
+ * leading prefix segment. Throws `MxcMalformedIdError` when the id has no
+ * recognised prefix.
+ */
+function backendForSandboxId(sandboxId: string): StateAwareSandboxingMethod {
+  const colon = sandboxId.indexOf(':');
+  if (colon < 0) {
+    throw mxcErrorFromCode('malformed_id', `sandboxId must carry a backend prefix: ${sandboxId}`);
+  }
+  const prefix = sandboxId.slice(0, colon);
+  const backend = PREFIX_TO_BACKEND[prefix];
+  if (!backend) {
+    throw mxcErrorFromCode('malformed_id', `sandboxId prefix '${prefix}' does not match a known state-aware backend`);
+  }
+  return backend;
+}
+
+interface BuildEnvelopeArgs {
+  phase: Phase;
+  backendKey: StateAwareSandboxingMethod;
+  containment?: StateAwareSandboxingMethod; // provision only
+  sandboxId?: string;                        // non-provision only
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Constructs the wire-format JSON-shaped envelope for a state-aware request
+ * from a per-(backend, phase) Config. Lifts cross-cutting fields
+ * (filesystem, network, ui, process) to envelope top-level; nests any
+ * remaining backend-specific fields under `experimental.<backend>.<phase>`.
+ * Exported for unit testing; consumers do not call this directly.
+ */
+export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string, unknown> {
+  const { phase, backendKey, containment, sandboxId, config } = args;
+  const remaining: Record<string, unknown> = { ...(config ?? {}) };
+  const version = (typeof remaining.version === 'string' && remaining.version) || STATE_AWARE_VERSION;
+  delete remaining.version;
+
+  const envelope: Record<string, unknown> = { version, phase };
+  if (containment) envelope.containment = containment;
+  if (sandboxId) envelope.sandboxId = sandboxId;
+
+  for (const field of CROSS_CUTTING_FIELDS) {
+    if (remaining[field] !== undefined) {
+      envelope[field] = remaining[field];
+      delete remaining[field];
+    }
+  }
+
+  if (Object.keys(remaining).length > 0) {
+    envelope.experimental = { [backendKey]: { [phase]: remaining } };
+  }
+
+  return envelope;
+}
+
+interface WireErrorEnvelope {
+  error: { code: string; message: string; details?: Record<string, unknown> };
+}
+
+interface WireResultEnvelope<T> {
+  result: T;
+}
+
+/**
+ * Parses the single-envelope JSON stdout produced by non-exec state-aware
+ * phases. Throws the corresponding `MxcError` subclass on `{error}`,
+ * returns the unwrapped `result` on `{result}`. Exported for unit testing.
+ */
+export function parseNonExecResponse<T>(stdout: string): T {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch (e) {
+    throw new Error(`Failed to parse state-aware response envelope: ${(e as Error).message}`);
+  }
+  if (parsed && typeof parsed === 'object') {
+    if ('error' in parsed) {
+      const env = (parsed as WireErrorEnvelope).error;
+      throw mxcErrorFromCode(env.code, env.message, env.details);
+    }
+    if ('result' in parsed) {
+      return (parsed as WireResultEnvelope<T>).result;
+    }
+  }
+  throw new Error(`Unexpected state-aware response envelope shape: ${stdout}`);
+}
+
+/**
+ * Attempts to parse stdout as an `{error}` envelope. Returns the parsed
+ * envelope when stdout is exactly that, or `null` otherwise (script output
+ * mistaken for an envelope is suppressed). Used by exec to discriminate
+ * dispatch failure from script failure.
+ */
+function tryParseErrorEnvelope(stdout: string): WireErrorEnvelope | null {
+  try {
+    const parsed = JSON.parse(stdout.trim());
+    if (
+      parsed && typeof parsed === 'object' && 'error' in parsed &&
+      (parsed as WireErrorEnvelope).error?.code
+    ) {
+      return parsed as WireErrorEnvelope;
+    }
+  } catch {
+    // Not JSON. Definitely script output.
+  }
+  return null;
+}
+
+// --- Spawn injection (test-only) ---
+
+type SpawnImpl = (cmd: string, args: string[], opts: unknown) => unknown;
+let spawnImpl: SpawnImpl = spawn as unknown as SpawnImpl;
+
+/**
+ * Test-only hook: replace the `child_process.spawn` implementation used by
+ * non-exec state-aware calls and the buffered `execInSandboxAsync`. Not
+ * exported from `index.ts` — production code uses the real `spawn`.
+ */
+export function _setSpawnImpl(fn: SpawnImpl): void {
+  spawnImpl = fn;
+}
+
+/** Test-only hook: restore the default `child_process.spawn`. */
+export function _resetSpawnImpl(): void {
+  spawnImpl = spawn as unknown as SpawnImpl;
+}
+
+interface CollectedOutput {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/**
+ * Spawns the executor with the given envelope, captures stdout/stderr,
+ * and resolves on close. Honors `options.signal` for cancellation.
+ */
+function spawnAndCollect(
+  envelope: Record<string, unknown>,
+  options: SandboxSpawnOptions,
+): Promise<CollectedOutput> {
+  return new Promise((resolve, reject) => {
+    const signal = options.signal;
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('Aborted'));
+      return;
+    }
+
+    let executablePath: string;
+    let args: string[];
+    try {
+      ({ executablePath, args } = resolveBinaryAndCommonArgs(JSON.stringify(envelope), options));
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    diagLog(`state-aware: spawning phase=${envelope.phase}`);
+
+    const child = spawnImpl(executablePath, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as {
+      stdout: NodeJS.ReadableStream | null;
+      stderr: NodeJS.ReadableStream | null;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+      on: (event: string, cb: (...a: unknown[]) => void) => unknown;
+    };
+
+    let stdoutData = '';
+    let stderrData = '';
+
+    child.stdout?.on('data', (d: Buffer | string) => {
+      stdoutData += typeof d === 'string' ? d : d.toString('utf-8');
+    });
+    child.stderr?.on('data', (d: Buffer | string) => {
+      stderrData += typeof d === 'string' ? d : d.toString('utf-8');
+    });
+
+    const onAbort = () => {
+      child.kill();
+    };
+    if (signal) signal.addEventListener('abort', onAbort, { once: true });
+
+    child.on('close', (...a: unknown[]) => {
+      const code = a[0] as number | null;
+      if (signal) signal.removeEventListener('abort', onAbort);
+      if (signal?.aborted) {
+        reject(signal.reason ?? new Error('Aborted'));
+        return;
+      }
+      resolve({ stdout: stdoutData, stderr: stderrData, exitCode: code ?? -1 });
+    });
+
+    child.on('error', (...a: unknown[]) => {
+      reject(a[0] as Error);
+    });
+  });
+}
+
+async function nonExecCall<T>(
+  envelope: Record<string, unknown>,
+  options: SandboxSpawnOptions,
+): Promise<T> {
+  const { stdout } = await spawnAndCollect(envelope, options);
+  return parseNonExecResponse<T>(stdout);
+}
+
+// --- Public API: the 5 functions ---
+
+/**
+ * Provisions a state-aware sandbox of the requested backend. Returns a
+ * branded sandbox id and any provision-time metadata the backend produces.
+ */
+export async function provisionSandbox<C extends StateAwareSandboxingMethod>(
+  containment: C,
+  config?: ProvisionConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): Promise<ProvisionResult<C>> {
+  const envelope = buildStateAwareEnvelope({
+    phase: 'provision',
+    backendKey: containment,
+    containment,
+    config: config as Record<string, unknown> | undefined,
+  });
+  const result = await nonExecCall<{ sandboxId: string; metadata?: ProvisionMetadataFor<C> }>(
+    envelope,
+    options,
+  );
+  return {
+    sandboxId: result.sandboxId as SandboxId<C>,
+    metadata: result.metadata,
+  };
+}
+
+/**
+ * Starts a previously provisioned sandbox. The backend is inferred from
+ * the `sandboxId` prefix.
+ */
+export async function startSandbox<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+  config?: StartConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): Promise<StartResult<C>> {
+  const backendKey = backendForSandboxId(sandboxId) as C;
+  const envelope = buildStateAwareEnvelope({
+    phase: 'start',
+    backendKey,
+    sandboxId,
+    config: config as Record<string, unknown> | undefined,
+  });
+  return nonExecCall<StartResult<C>>(envelope, options);
+}
+
+/**
+ * Streams a script execution inside a started sandbox. Returns an
+ * `IPty` for live stdout/stderr/exit handling, mirroring `spawnSandbox`.
+ * On dispatch failure the executor emits a single error envelope on stdout;
+ * the SDK does not parse it here — callers consuming `IPty.onData` see the
+ * raw bytes. Use `execInSandboxAsync` when typed-error throwing is needed.
+ */
+export function execInSandbox<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+  config: ExecConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): pty.IPty {
+  const backendKey = backendForSandboxId(sandboxId) as C;
+  const envelope = buildStateAwareEnvelope({
+    phase: 'exec',
+    backendKey,
+    sandboxId,
+    config: config as unknown as Record<string, unknown>,
+  });
+  const { executablePath, args } = resolveBinaryAndCommonArgs(JSON.stringify(envelope), options);
+  diagLog(`state-aware: spawning exec via PTY`);
+  const ptyProcess = pty.spawn(executablePath, args, {
+    name: 'xterm-color',
+    cols: 120,
+    rows: 80,
+    cwd: process.cwd(),
+    ...options.ptyOptions,
+  });
+  const signal = options.signal;
+  if (signal) {
+    if (signal.aborted) {
+      ptyProcess.kill();
+    } else {
+      const onAbort = () => ptyProcess.kill();
+      signal.addEventListener('abort', onAbort, { once: true });
+      ptyProcess.onExit(() => signal.removeEventListener('abort', onAbort));
+    }
+  }
+  return ptyProcess;
+}
+
+/**
+ * Buffered exec convenience. Resolves with `{stdout, stderr, exitCode}`
+ * on script completion. Throws the typed `MxcError` subclass when the
+ * executor reports a dispatch failure (recognised by exit != 0 and stdout
+ * being a complete `{error}` envelope).
+ */
+export async function execInSandboxAsync<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+  config: ExecConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): Promise<ExecResult> {
+  const backendKey = backendForSandboxId(sandboxId) as C;
+  const envelope = buildStateAwareEnvelope({
+    phase: 'exec',
+    backendKey,
+    sandboxId,
+    config: config as unknown as Record<string, unknown>,
+  });
+  const { stdout, stderr, exitCode } = await spawnAndCollect(envelope, options);
+
+  if (exitCode !== 0) {
+    const errorEnvelope = tryParseErrorEnvelope(stdout);
+    if (errorEnvelope) {
+      const e = errorEnvelope.error;
+      throw mxcErrorFromCode(e.code, e.message, e.details);
+    }
+  }
+
+  return { stdout, stderr, exitCode };
+}
+
+/**
+ * Stops a started sandbox without releasing its provision-side resources.
+ * The same sandbox can be started again via `startSandbox`.
+ */
+export async function stopSandbox<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+  config?: StopConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): Promise<StopResult<C>> {
+  const backendKey = backendForSandboxId(sandboxId) as C;
+  const envelope = buildStateAwareEnvelope({
+    phase: 'stop',
+    backendKey,
+    sandboxId,
+    config: config as Record<string, unknown> | undefined,
+  });
+  return nonExecCall<StopResult<C>>(envelope, options);
+}
+
+/**
+ * Releases all backend resources associated with a provisioned sandbox.
+ * The id becomes invalid after this call returns successfully.
+ */
+export async function deprovisionSandbox<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+  config?: DeprovisionConfigFor<C>,
+  options: SandboxSpawnOptions = {},
+): Promise<DeprovisionResult<C>> {
+  const backendKey = backendForSandboxId(sandboxId) as C;
+  const envelope = buildStateAwareEnvelope({
+    phase: 'deprovision',
+    backendKey,
+    sandboxId,
+    config: config as Record<string, unknown> | undefined,
+  });
+  return nonExecCall<DeprovisionResult<C>>(envelope, options);
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -172,7 +172,7 @@ export interface ContainerConfig {
   /** Externally assigned container identifier */
   containerId?: string;
   /** Containment backend */
-  containment?: 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox';
+  containment?: 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox' | 'isolation_session';
   /** Container lifecycle settings */
   lifecycle?: LifecycleConfig;
   /** Process execution settings (required) */
@@ -281,7 +281,7 @@ export interface MacosSandboxConfig {
 /**
  * Sandboxing methods available on the platform
  */
-export type SandboxingMethod = 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox';
+export type SandboxingMethod = 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox' | 'isolation_session';
 
 /**
  * Platform support information

--- a/sdk/tests/integration/isolation-session-state-aware.test.ts
+++ b/sdk/tests/integration/isolation-session-state-aware.test.ts
@@ -4,72 +4,35 @@
 // SDK end-to-end tests for the IsolationSession state-aware lifecycle.
 //
 // These tests invoke real wxc-exec.exe and exercise the full lifecycle:
-// provision -> start -> exec -> stop -> deprovision. Each test calls into
-// the SDK and skips itself when wxc-exec returns `backend_unavailable`,
+// provision -> start -> exec -> stop -> deprovision. The whole suite skips
+// at module evaluation time when this host lacks IsolationSession runtime
+// support (or when wxc-exec was built without `--features isolation_session`),
 // so the suite runs cleanly on any Windows host but only meaningfully on
 // a host with IsolationSession runtime support.
 //
 // Build prerequisites:
 //   - wxc-exec.exe built with `--features isolation_session`
 
-import { describe, it, type TestContext } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert';
+import fs from 'fs';
 import os from 'os';
+import path from 'path';
 import {
-  MxcBackendUnavailableError,
-  MxcUnsupportedPhaseError,
-  deprovisionSandbox,
   execInSandboxAsync,
   provisionSandbox,
   startSandbox,
   stopSandbox,
-  type SandboxId,
 } from '@microsoft/mxc-sdk';
+import { createTempDir, probeStateAwareRuntime, safeDeprovision } from './test-helpers.js';
 
-const isWindows = os.platform() === 'win32';
+const skipReason = os.platform() !== 'win32'
+  ? 'IsolationSession is Windows-only'
+  : await probeStateAwareRuntime('isolation_session');
 
-async function runOrSkipIfBackendUnavailable<T>(
-  t: TestContext,
-  label: string,
-  fn: () => Promise<T>,
-): Promise<T | undefined> {
-  try {
-    return await fn();
-  } catch (err) {
-    if (err instanceof MxcBackendUnavailableError) {
-      t.skip(`${label}: IsolationSession runtime unavailable on this host`);
-      return undefined;
-    }
-    if (err instanceof MxcUnsupportedPhaseError) {
-      // wxc-exec was built without `--features isolation_session`, so the
-      // state-aware dispatch path is compiled out. Same outcome from the
-      // test's perspective as a host without the IS runtime: we cannot
-      // exercise the lifecycle, so skip rather than fail.
-      t.skip(`${label}: wxc-exec lacks the isolation_session feature; rebuild with --features isolation_session to run this test`);
-      return undefined;
-    }
-    throw err;
-  }
-}
-
-async function safeDeprovision(sandboxId: SandboxId<'isolation_session'>): Promise<void> {
-  try {
-    await deprovisionSandbox(sandboxId, undefined, { experimental: true });
-  } catch (err) {
-    // Don't override the original test failure. Surface for debugging only.
-    console.error(`Cleanup deprovision failed for ${sandboxId}: ${err}`);
-  }
-}
-
-describe('IsolationSession state-aware lifecycle E2E', {
-  skip: !isWindows ? 'IsolationSession is Windows-only' : undefined,
-}, () => {
-  it('full lifecycle: provision -> start -> exec -> stop -> deprovision', async (t) => {
-    const provisionResult = await runOrSkipIfBackendUnavailable(t, 'provision', () =>
-      provisionSandbox('isolation_session', {}, { experimental: true }),
-    );
-    if (!provisionResult) return;
-
+describe('IsolationSession state-aware lifecycle E2E', { skip: skipReason }, () => {
+  it('runs full lifecycle: provision -> start -> exec -> stop -> deprovision', async () => {
+    const provisionResult = await provisionSandbox('isolation_session', {}, { experimental: true });
     const sandboxId = provisionResult.sandboxId;
     assert.ok(
       sandboxId.startsWith('iso:'),
@@ -97,12 +60,8 @@ describe('IsolationSession state-aware lifecycle E2E', {
     }
   });
 
-  it('exec surfaces a non-zero script exit as ExecResult.exitCode', async (t) => {
-    const provisionResult = await runOrSkipIfBackendUnavailable(t, 'provision', () =>
-      provisionSandbox('isolation_session', {}, { experimental: true }),
-    );
-    if (!provisionResult) return;
-
+  it('exec surfaces a non-zero script exit as ExecResult.exitCode', async () => {
+    const provisionResult = await provisionSandbox('isolation_session', {}, { experimental: true });
     const sandboxId = provisionResult.sandboxId;
 
     try {
@@ -119,6 +78,107 @@ describe('IsolationSession state-aware lifecycle E2E', {
       await stopSandbox(sandboxId, undefined, { experimental: true });
     } finally {
       await safeDeprovision(sandboxId);
+    }
+  });
+
+  it('honors readwritePaths at provision: agent writes are visible on the host', async () => {
+    const rwDir = createTempDir('mxc-iso-rw');
+    const markerName = 'agent-write.txt';
+    const markerHostPath = path.join(rwDir, markerName);
+    const markerExpected = 'agent-wrote-this';
+
+    const provisionResult = await provisionSandbox(
+      'isolation_session',
+      { filesystem: { readwritePaths: [rwDir] } },
+      { experimental: true },
+    );
+    const sandboxId = provisionResult.sandboxId;
+
+    try {
+      await startSandbox(sandboxId, {}, { experimental: true });
+
+      const result = await execInSandboxAsync(
+        sandboxId,
+        { process: { commandLine: `cmd /c echo ${markerExpected}> "${rwDir}\\${markerName}"` } },
+        { experimental: true },
+      );
+
+      assert.strictEqual(result.exitCode, 0, `exec exit code: stdout=${result.stdout}, stderr=${result.stderr}`);
+      assert.ok(fs.existsSync(markerHostPath), `expected ${markerHostPath} to exist after agent write`);
+      assert.strictEqual(fs.readFileSync(markerHostPath, 'utf-8').trim(), markerExpected);
+
+      await stopSandbox(sandboxId, undefined, { experimental: true });
+    } finally {
+      await safeDeprovision(sandboxId);
+      fs.rmSync(rwDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors readonlyPaths at provision: agent reads pre-seeded content', async () => {
+    const roDir = createTempDir('mxc-iso-ro');
+    const markerName = 'host-seeded.txt';
+    const markerHostPath = path.join(roDir, markerName);
+    const markerExpected = 'host-seeded-content';
+    fs.writeFileSync(markerHostPath, markerExpected, 'utf-8');
+
+    const provisionResult = await provisionSandbox(
+      'isolation_session',
+      { filesystem: { readonlyPaths: [roDir] } },
+      { experimental: true },
+    );
+    const sandboxId = provisionResult.sandboxId;
+
+    try {
+      await startSandbox(sandboxId, {}, { experimental: true });
+
+      const result = await execInSandboxAsync(
+        sandboxId,
+        { process: { commandLine: `cmd /c type "${roDir}\\${markerName}"` } },
+        { experimental: true },
+      );
+
+      assert.strictEqual(result.exitCode, 0, `exec exit code: stdout=${result.stdout}, stderr=${result.stderr}`);
+      assert.ok(
+        result.stdout.includes(markerExpected),
+        `stdout did not contain seeded content '${markerExpected}': ${result.stdout}`,
+      );
+
+      await stopSandbox(sandboxId, undefined, { experimental: true });
+    } finally {
+      await safeDeprovision(sandboxId);
+      fs.rmSync(roDir, { recursive: true, force: true });
+    }
+  });
+
+  it('honors readonlyPaths at provision: agent writes to a readonly path fail', async () => {
+    const roDir = createTempDir('mxc-iso-ro-write');
+    const markerName = 'agent-should-not-write.txt';
+
+    const provisionResult = await provisionSandbox(
+      'isolation_session',
+      { filesystem: { readonlyPaths: [roDir] } },
+      { experimental: true },
+    );
+    const sandboxId = provisionResult.sandboxId;
+
+    try {
+      await startSandbox(sandboxId, {}, { experimental: true });
+
+      const result = await execInSandboxAsync(
+        sandboxId,
+        { process: { commandLine: `cmd /c echo nope> "${roDir}\\${markerName}"` } },
+        { experimental: true },
+      );
+
+      assert.notStrictEqual(
+        result.exitCode, 0,
+        `expected non-zero exit when writing to a readonly path, got ${result.exitCode}; stdout=${result.stdout}, stderr=${result.stderr}`,
+      );
+
+      await stopSandbox(sandboxId, undefined, { experimental: true });
+    } finally {
+      await safeDeprovision(sandboxId);
+      fs.rmSync(roDir, { recursive: true, force: true });
     }
   });
 });

--- a/sdk/tests/integration/isolation-session-state-aware.test.ts
+++ b/sdk/tests/integration/isolation-session-state-aware.test.ts
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// SDK end-to-end tests for the IsolationSession state-aware lifecycle.
+//
+// These tests invoke real wxc-exec.exe and exercise the full lifecycle:
+// provision -> start -> exec -> stop -> deprovision. Each test calls into
+// the SDK and skips itself when wxc-exec returns `backend_unavailable`,
+// so the suite runs cleanly on any Windows host but only meaningfully on
+// a host with IsolationSession runtime support.
+//
+// Build prerequisites:
+//   - wxc-exec.exe built with `--features isolation_session`
+
+import { describe, it, type TestContext } from 'node:test';
+import assert from 'node:assert';
+import os from 'os';
+import {
+  MxcBackendUnavailableError,
+  MxcUnsupportedPhaseError,
+  deprovisionSandbox,
+  execInSandboxAsync,
+  provisionSandbox,
+  startSandbox,
+  stopSandbox,
+  type SandboxId,
+} from '@microsoft/mxc-sdk';
+
+const isWindows = os.platform() === 'win32';
+
+async function runOrSkipIfBackendUnavailable<T>(
+  t: TestContext,
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof MxcBackendUnavailableError) {
+      t.skip(`${label}: IsolationSession runtime unavailable on this host`);
+      return undefined;
+    }
+    if (err instanceof MxcUnsupportedPhaseError) {
+      // wxc-exec was built without `--features isolation_session`, so the
+      // state-aware dispatch path is compiled out. Same outcome from the
+      // test's perspective as a host without the IS runtime: we cannot
+      // exercise the lifecycle, so skip rather than fail.
+      t.skip(`${label}: wxc-exec lacks the isolation_session feature; rebuild with --features isolation_session to run this test`);
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+async function safeDeprovision(sandboxId: SandboxId<'isolation_session'>): Promise<void> {
+  try {
+    await deprovisionSandbox(sandboxId, undefined, { experimental: true });
+  } catch (err) {
+    // Don't override the original test failure. Surface for debugging only.
+    console.error(`Cleanup deprovision failed for ${sandboxId}: ${err}`);
+  }
+}
+
+describe('IsolationSession state-aware lifecycle E2E', {
+  skip: !isWindows ? 'IsolationSession is Windows-only' : undefined,
+}, () => {
+  it('full lifecycle: provision -> start -> exec -> stop -> deprovision', async (t) => {
+    const provisionResult = await runOrSkipIfBackendUnavailable(t, 'provision', () =>
+      provisionSandbox('isolation_session', {}, { experimental: true }),
+    );
+    if (!provisionResult) return;
+
+    const sandboxId = provisionResult.sandboxId;
+    assert.ok(
+      sandboxId.startsWith('iso:'),
+      `Expected sandboxId to start with 'iso:', got '${sandboxId}'`,
+    );
+
+    try {
+      await startSandbox(sandboxId, {}, { experimental: true });
+
+      const result = await execInSandboxAsync(
+        sandboxId,
+        { process: { commandLine: 'cmd /c echo hello' } },
+        { experimental: true },
+      );
+
+      assert.strictEqual(result.exitCode, 0, `exec exit code: stdout=${result.stdout}, stderr=${result.stderr}`);
+      assert.ok(
+        result.stdout.includes('hello'),
+        `stdout did not contain 'hello': ${result.stdout}`,
+      );
+
+      await stopSandbox(sandboxId, undefined, { experimental: true });
+    } finally {
+      await safeDeprovision(sandboxId);
+    }
+  });
+
+  it('exec surfaces a non-zero script exit as ExecResult.exitCode', async (t) => {
+    const provisionResult = await runOrSkipIfBackendUnavailable(t, 'provision', () =>
+      provisionSandbox('isolation_session', {}, { experimental: true }),
+    );
+    if (!provisionResult) return;
+
+    const sandboxId = provisionResult.sandboxId;
+
+    try {
+      await startSandbox(sandboxId, {}, { experimental: true });
+
+      const result = await execInSandboxAsync(
+        sandboxId,
+        { process: { commandLine: 'cmd /c exit 7' } },
+        { experimental: true },
+      );
+
+      assert.strictEqual(result.exitCode, 7, `expected exit 7, got ${result.exitCode}`);
+
+      await stopSandbox(sandboxId, undefined, { experimental: true });
+    } finally {
+      await safeDeprovision(sandboxId);
+    }
+  });
+});

--- a/sdk/tests/integration/test-helpers.ts
+++ b/sdk/tests/integration/test-helpers.ts
@@ -3,12 +3,20 @@
 
 import { spawn, ChildProcess, execSync } from 'child_process';
 import assert from 'node:assert';
+import type { TestContext } from 'node:test';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import semver from 'semver';
 import { createRequire } from 'node:module';
 import * as sdkNamespace from '@microsoft/mxc-sdk';
+import {
+  MxcError,
+  deprovisionSandbox,
+  provisionSandbox,
+  type SandboxId,
+  type StateAwareSandboxingMethod,
+} from '@microsoft/mxc-sdk';
 
 const require = createRequire(import.meta.url);
 export const sdk = sdkNamespace;
@@ -151,6 +159,79 @@ const skipLxcNetworkTests = process.env.MXC_SKIP_LXC_NETWORK_TESTS === '1';
 export const lxcNetworkSkipReason = skipLxcNetworkTests
   ? 'Skipped: LXC network not available in this environment (MXC_SKIP_LXC_NETWORK_TESTS)'
   : undefined;
+
+// State-aware lifecycle helpers
+
+/**
+ * Wraps a state-aware SDK call, skipping the test (rather than failing) when
+ * the executor reports `backend_unavailable` or `unsupported_phase` — either
+ * indicates this environment cannot exercise the lifecycle. Other errors
+ * propagate.
+ */
+export async function runOrSkipIfBackendUnavailable<T>(
+  t: TestContext,
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (err instanceof MxcError && err.code === 'backend_unavailable') {
+      t.skip(`${label}: state-aware backend runtime unavailable on this host`);
+      return undefined;
+    }
+    if (err instanceof MxcError && err.code === 'unsupported_phase') {
+      // wxc-exec was built without the backend's feature flag, so the
+      // state-aware dispatch path is compiled out. Same outcome from the
+      // test's perspective as a host without the runtime: cannot exercise
+      // the lifecycle, skip rather than fail.
+      t.skip(`${label}: wxc-exec lacks the backend feature; rebuild with the feature flag to run this test`);
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+/** Deprovision a sandbox best-effort, swallowing errors so cleanup never masks the original failure. */
+export async function safeDeprovision<C extends StateAwareSandboxingMethod>(
+  sandboxId: SandboxId<C>,
+): Promise<void> {
+  try {
+    await deprovisionSandbox(sandboxId, undefined, { experimental: true });
+  } catch (err) {
+    console.error(`Cleanup deprovision failed for ${sandboxId}: ${err}`);
+  }
+}
+
+/**
+ * Probes a state-aware backend's runtime by attempting a provision /
+ * deprovision cycle. Returns a skip-reason string when the runtime is
+ * unavailable (`backend_unavailable` or `unsupported_phase`), `undefined`
+ * when the backend can be exercised. Other errors propagate so genuine
+ * failures aren't masked as "skipped." Intended for one-shot probing at
+ * module load — pair the result with `describe`'s `{ skip }` option.
+ */
+export async function probeStateAwareRuntime<C extends StateAwareSandboxingMethod>(
+  containment: C,
+): Promise<string | undefined> {
+  try {
+    const provisionResult = await provisionSandbox(
+      containment,
+      undefined,
+      { experimental: true },
+    );
+    await safeDeprovision(provisionResult.sandboxId);
+    return undefined;
+  } catch (err) {
+    if (err instanceof MxcError && err.code === 'backend_unavailable') {
+      return `${containment} runtime unavailable on this host`;
+    }
+    if (err instanceof MxcError && err.code === 'unsupported_phase') {
+      return `wxc-exec lacks the ${containment} feature; rebuild with --features ${containment} to run this test`;
+    }
+    throw err;
+  }
+}
 
 // Temp directory helpers
 

--- a/sdk/tests/integration/test-helpers.ts
+++ b/sdk/tests/integration/test-helpers.ts
@@ -17,7 +17,7 @@ export const sdk = sdkNamespace;
 
 export const supportedVersions = [
   new semver.SemVer('0.4.0-alpha'),
-  new semver.SemVer('0.5.0-dev'),
+  new semver.SemVer('0.5.0-alpha'),
 ];
 
 // SDK package location

--- a/sdk/tests/unit/errors.test.ts
+++ b/sdk/tests/unit/errors.test.ts
@@ -3,80 +3,51 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-import {
-  ErrorCode,
-  MxcError,
-  MxcMalformedRequestError,
-  MxcUnsupportedContainmentError,
-  MxcUnsupportedPhaseError,
-  MxcBackendUnavailableError,
-  MxcMalformedIdError,
-  MxcStaleIdError,
-  MxcNotProvisionedError,
-  MxcNotStartedError,
-  MxcAlreadyStartedError,
-  MxcAlreadyStoppedError,
-  MxcPolicyValidationError,
-  MxcBackendError,
-  mxcErrorFromCode,
-} from '../../src/errors.js';
+import { ErrorCode, MxcError, mxcErrorFromCode } from '../../src/errors.js';
 
-interface ErrorCase {
-  cls: new (message: string, details?: Record<string, unknown>) => MxcError;
-  code: ErrorCode;
-  className: string;
-}
-
-const cases: ErrorCase[] = [
-  { cls: MxcMalformedRequestError, code: 'malformed_request', className: 'MxcMalformedRequestError' },
-  { cls: MxcUnsupportedContainmentError, code: 'unsupported_containment', className: 'MxcUnsupportedContainmentError' },
-  { cls: MxcUnsupportedPhaseError, code: 'unsupported_phase', className: 'MxcUnsupportedPhaseError' },
-  { cls: MxcBackendUnavailableError, code: 'backend_unavailable', className: 'MxcBackendUnavailableError' },
-  { cls: MxcMalformedIdError, code: 'malformed_id', className: 'MxcMalformedIdError' },
-  { cls: MxcStaleIdError, code: 'stale_id', className: 'MxcStaleIdError' },
-  { cls: MxcNotProvisionedError, code: 'not_provisioned', className: 'MxcNotProvisionedError' },
-  { cls: MxcNotStartedError, code: 'not_started', className: 'MxcNotStartedError' },
-  { cls: MxcAlreadyStartedError, code: 'already_started', className: 'MxcAlreadyStartedError' },
-  { cls: MxcAlreadyStoppedError, code: 'already_stopped', className: 'MxcAlreadyStoppedError' },
-  { cls: MxcPolicyValidationError, code: 'policy_validation', className: 'MxcPolicyValidationError' },
-  { cls: MxcBackendError, code: 'backend_error', className: 'MxcBackendError' },
+const codes: ErrorCode[] = [
+  'malformed_request',
+  'unsupported_containment',
+  'unsupported_phase',
+  'backend_unavailable',
+  'malformed_id',
+  'stale_id',
+  'not_provisioned',
+  'not_started',
+  'already_started',
+  'already_stopped',
+  'policy_validation',
+  'backend_error',
 ];
 
-describe('MxcError class hierarchy', () => {
-  for (const { cls, code, className } of cases) {
-    it(`${className} sets code='${code}', extends MxcError and Error`, () => {
-      const err = new cls('boom');
+describe('MxcError', () => {
+  for (const code of codes) {
+    it(`constructs with code='${code}', extends Error, exposes message and code`, () => {
+      const err = new MxcError(code, 'boom');
       assert.strictEqual(err.code, code);
       assert.strictEqual(err.message, 'boom');
-      assert.strictEqual(err.name, className);
+      assert.strictEqual(err.name, 'MxcError');
       assert.ok(err instanceof MxcError);
       assert.ok(err instanceof Error);
-      assert.ok(err instanceof cls);
-    });
-
-    it(`${className} round-trips details`, () => {
-      const err = new cls('boom', { hresult: '0x80004005' });
-      assert.deepStrictEqual(err.details, { hresult: '0x80004005' });
-    });
-
-    it(`${className} omits details when not supplied`, () => {
-      const err = new cls('boom');
-      assert.strictEqual(err.details, undefined);
     });
   }
 
-  it('discriminates between subclasses by instanceof', () => {
-    const stale: MxcError = new MxcStaleIdError('expired');
-    assert.ok(stale instanceof MxcStaleIdError);
-    assert.ok(!(stale instanceof MxcBackendError));
+  it('round-trips details', () => {
+    const err = new MxcError('backend_error', 'boom', { hresult: '0x80004005' });
+    assert.deepStrictEqual(err.details, { hresult: '0x80004005' });
+  });
+
+  it('omits details when not supplied', () => {
+    const err = new MxcError('stale_id', 'boom');
+    assert.strictEqual(err.details, undefined);
   });
 });
 
 describe('mxcErrorFromCode', () => {
-  for (const { cls, code, className } of cases) {
-    it(`maps '${code}' to ${className}`, () => {
+  for (const code of codes) {
+    it(`maps '${code}' to MxcError with that code`, () => {
       const err = mxcErrorFromCode(code, 'boom');
-      assert.ok(err instanceof cls);
+      assert.ok(err instanceof MxcError);
       assert.strictEqual(err.code, code);
       assert.strictEqual(err.message, 'boom');
     });
@@ -84,15 +55,13 @@ describe('mxcErrorFromCode', () => {
 
   it('passes details through to the constructed instance', () => {
     const err = mxcErrorFromCode('backend_error', 'boom', { hresult: '0x80004005' });
-    assert.ok(err instanceof MxcBackendError);
+    assert.ok(err instanceof MxcError);
     assert.deepStrictEqual(err.details, { hresult: '0x80004005' });
   });
 
-  it('returns the base MxcError for unknown codes', () => {
+  it('returns an MxcError carrying the unknown code verbatim', () => {
     const err = mxcErrorFromCode('not_a_real_code', 'boom');
     assert.ok(err instanceof MxcError);
-    for (const { cls } of cases) {
-      assert.ok(!(err instanceof cls), `unexpected match for ${cls.name}`);
-    }
+    assert.strictEqual(err.code, 'not_a_real_code');
   });
 });

--- a/sdk/tests/unit/errors.test.ts
+++ b/sdk/tests/unit/errors.test.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  ErrorCode,
+  MxcError,
+  MxcMalformedRequestError,
+  MxcUnsupportedContainmentError,
+  MxcUnsupportedPhaseError,
+  MxcBackendUnavailableError,
+  MxcMalformedIdError,
+  MxcStaleIdError,
+  MxcNotProvisionedError,
+  MxcNotStartedError,
+  MxcAlreadyStartedError,
+  MxcAlreadyStoppedError,
+  MxcPolicyValidationError,
+  MxcBackendError,
+  mxcErrorFromCode,
+} from '../../src/errors.js';
+
+interface ErrorCase {
+  cls: new (message: string, details?: Record<string, unknown>) => MxcError;
+  code: ErrorCode;
+  className: string;
+}
+
+const cases: ErrorCase[] = [
+  { cls: MxcMalformedRequestError, code: 'malformed_request', className: 'MxcMalformedRequestError' },
+  { cls: MxcUnsupportedContainmentError, code: 'unsupported_containment', className: 'MxcUnsupportedContainmentError' },
+  { cls: MxcUnsupportedPhaseError, code: 'unsupported_phase', className: 'MxcUnsupportedPhaseError' },
+  { cls: MxcBackendUnavailableError, code: 'backend_unavailable', className: 'MxcBackendUnavailableError' },
+  { cls: MxcMalformedIdError, code: 'malformed_id', className: 'MxcMalformedIdError' },
+  { cls: MxcStaleIdError, code: 'stale_id', className: 'MxcStaleIdError' },
+  { cls: MxcNotProvisionedError, code: 'not_provisioned', className: 'MxcNotProvisionedError' },
+  { cls: MxcNotStartedError, code: 'not_started', className: 'MxcNotStartedError' },
+  { cls: MxcAlreadyStartedError, code: 'already_started', className: 'MxcAlreadyStartedError' },
+  { cls: MxcAlreadyStoppedError, code: 'already_stopped', className: 'MxcAlreadyStoppedError' },
+  { cls: MxcPolicyValidationError, code: 'policy_validation', className: 'MxcPolicyValidationError' },
+  { cls: MxcBackendError, code: 'backend_error', className: 'MxcBackendError' },
+];
+
+describe('MxcError class hierarchy', () => {
+  for (const { cls, code, className } of cases) {
+    it(`${className} sets code='${code}', extends MxcError and Error`, () => {
+      const err = new cls('boom');
+      assert.strictEqual(err.code, code);
+      assert.strictEqual(err.message, 'boom');
+      assert.strictEqual(err.name, className);
+      assert.ok(err instanceof MxcError);
+      assert.ok(err instanceof Error);
+      assert.ok(err instanceof cls);
+    });
+
+    it(`${className} round-trips details`, () => {
+      const err = new cls('boom', { hresult: '0x80004005' });
+      assert.deepStrictEqual(err.details, { hresult: '0x80004005' });
+    });
+
+    it(`${className} omits details when not supplied`, () => {
+      const err = new cls('boom');
+      assert.strictEqual(err.details, undefined);
+    });
+  }
+
+  it('discriminates between subclasses by instanceof', () => {
+    const stale: MxcError = new MxcStaleIdError('expired');
+    assert.ok(stale instanceof MxcStaleIdError);
+    assert.ok(!(stale instanceof MxcBackendError));
+  });
+});
+
+describe('mxcErrorFromCode', () => {
+  for (const { cls, code, className } of cases) {
+    it(`maps '${code}' to ${className}`, () => {
+      const err = mxcErrorFromCode(code, 'boom');
+      assert.ok(err instanceof cls);
+      assert.strictEqual(err.code, code);
+      assert.strictEqual(err.message, 'boom');
+    });
+  }
+
+  it('passes details through to the constructed instance', () => {
+    const err = mxcErrorFromCode('backend_error', 'boom', { hresult: '0x80004005' });
+    assert.ok(err instanceof MxcBackendError);
+    assert.deepStrictEqual(err.details, { hresult: '0x80004005' });
+  });
+
+  it('returns the base MxcError for unknown codes', () => {
+    const err = mxcErrorFromCode('not_a_real_code', 'boom');
+    assert.ok(err instanceof MxcError);
+    for (const { cls } of cases) {
+      assert.ok(!(err instanceof cls), `unexpected match for ${cls.name}`);
+    }
+  });
+});

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -4,7 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { buildSandboxPayload, createConfigFromPolicy, spawnSandbox, spawnSandboxFromConfig } from '../../src/sandbox.js';
-import { SandboxPolicy } from '../../src/types.js';
+import { ContainerConfig, SandboxPolicy, SandboxingMethod } from '../../src/types.js';
 
 describe('buildSandboxPayload', () => {
   const defaultPolicy: SandboxPolicy = { version: '0.4.0-alpha' };
@@ -84,6 +84,15 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.4.0-alpha' }));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should accept version 0.6.0-alpha', () => {
+      mockWindows();
+      try {
+        assert.doesNotThrow(() => buildSandboxPayload('echo hi', { version: '0.6.0-alpha' }));
       } finally {
         restore();
       }
@@ -659,5 +668,20 @@ describe('createConfigFromPolicy', () => {
         { message: /experimental mode/ },
       );
     });
+  });
+});
+
+describe('Schema 0.6.0 vocabulary', () => {
+  it('should accept isolation_session as a SandboxingMethod', () => {
+    const m: SandboxingMethod = 'isolation_session';
+    assert.strictEqual(m, 'isolation_session');
+  });
+
+  it('should accept isolation_session as a ContainerConfig.containment value', () => {
+    const c: ContainerConfig = {
+      version: '0.6.0-alpha',
+      containment: 'isolation_session',
+    };
+    assert.strictEqual(c.containment, 'isolation_session');
   });
 });

--- a/sdk/tests/unit/state-aware-types.test.ts
+++ b/sdk/tests/unit/state-aware-types.test.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  ConfigsForBackend,
+  DeprovisionConfigFor,
+  ExecConfigFor,
+  IsolationSessionProvisionConfig,
+  IsolationSessionStartConfig,
+  ProvisionResult,
+  SandboxId,
+  StopConfigFor,
+} from '../../src/state-aware-types.js';
+
+// These tests are primarily compile-time checks. Lines marked with
+// `// @ts-expect-error` MUST trigger a TypeScript error on the line below;
+// otherwise the marker itself becomes a violation and the test build fails.
+// The runtime assertions are minimal placeholders so node:test sees a
+// passing test for each scenario.
+
+describe('SandboxId<C> brand', () => {
+  it('rejects bare strings where SandboxId is expected', () => {
+    function takesIsolationSessionId(_id: SandboxId<'isolation_session'>): void {
+      // body unused
+    }
+    // @ts-expect-error — bare string is not a branded SandboxId.
+    takesIsolationSessionId('iso:abcd');
+    assert.ok(true);
+  });
+
+  it('runtime value is a string', () => {
+    const id = 'iso:abcd' as SandboxId<'isolation_session'>;
+    assert.strictEqual(typeof id, 'string');
+  });
+});
+
+describe('Per-(backend, phase) Configs', () => {
+  it('IsolationSessionProvisionConfig accepts cross-cutting fields per the policy honor matrix', () => {
+    const cfg: IsolationSessionProvisionConfig = {
+      version: '0.6.0-alpha',
+      filesystem: { readwritePaths: ['C:\\workspace'] },
+      network: { defaultPolicy: 'block' },
+      ui: { disable: true, clipboard: 'none', injection: false },
+    };
+    assert.strictEqual(cfg.network?.defaultPolicy, 'block');
+  });
+
+  it('IsolationSessionStartConfig rejects cross-cutting fields the matrix marks as rejected', () => {
+    const cfg: IsolationSessionStartConfig = {
+      // @ts-expect-error — start phase does not honor filesystem.
+      filesystem: { readwritePaths: ['C:\\workspace'] },
+    };
+    assert.ok(cfg);
+  });
+
+  it('IsolationSessionStartConfig accepts configurationId only from the closed enum', () => {
+    const ok: IsolationSessionStartConfig = { configurationId: 'composable' };
+    assert.strictEqual(ok.configurationId, 'composable');
+
+    const bogus: IsolationSessionStartConfig = {
+      // @ts-expect-error — configurationId must be in the closed enum.
+      configurationId: 'xlarge',
+    };
+    assert.ok(bogus);
+  });
+
+  it('IsolationSessionExecConfig requires process', () => {
+    const cfg: ExecConfigFor<'isolation_session'> = {
+      process: { commandLine: 'echo hi' },
+    };
+    assert.strictEqual(cfg.process.commandLine, 'echo hi');
+
+    // @ts-expect-error — exec config requires process.
+    const missing: ExecConfigFor<'isolation_session'> = {};
+    assert.ok(missing);
+  });
+
+  it('IsolationSessionStopConfig and DeprovisionConfig only carry version', () => {
+    const stopCfg: StopConfigFor<'isolation_session'> = { version: '0.6.0-alpha' };
+    const deprovCfg: DeprovisionConfigFor<'isolation_session'> = {};
+
+    const wrongStop: StopConfigFor<'isolation_session'> = {
+      // @ts-expect-error — stop phase does not honor network.
+      network: { defaultPolicy: 'block' },
+    };
+    assert.ok(stopCfg);
+    assert.ok(deprovCfg);
+    assert.ok(wrongStop);
+  });
+});
+
+describe('ConfigsForBackend conditional', () => {
+  it('selects the IsolationSession bundle for the isolation_session backend', () => {
+    const bundle: ConfigsForBackend<'isolation_session'> = {
+      provision: { version: '0.6.0-alpha' },
+      start: {},
+      exec: { process: { commandLine: 'echo' } },
+      stop: {},
+      deprovision: {},
+    };
+    assert.strictEqual(bundle.exec.process.commandLine, 'echo');
+  });
+});
+
+describe('ProvisionResult<C> carries backend-typed metadata', () => {
+  it('ProvisionResult<isolation_session>.metadata is IsolationSessionProvisionMetadata', () => {
+    const result: ProvisionResult<'isolation_session'> = {
+      sandboxId: 'iso:abcd' as SandboxId<'isolation_session'>,
+      metadata: { agentUserName: 'iso\\agent' },
+    };
+    assert.strictEqual(result.metadata?.agentUserName, 'iso\\agent');
+  });
+});

--- a/sdk/tests/unit/state-aware-types.test.ts
+++ b/sdk/tests/unit/state-aware-types.test.ts
@@ -36,18 +36,31 @@ describe('SandboxId<C> brand', () => {
   });
 });
 
-describe('Per-(backend, phase) Configs', () => {
-  it('IsolationSessionProvisionConfig accepts cross-cutting fields per the policy honor matrix', () => {
+describe('IsolationSessionProvisionConfig', () => {
+  it('accepts version and filesystem', () => {
     const cfg: IsolationSessionProvisionConfig = {
       version: '0.6.0-alpha',
       filesystem: { readwritePaths: ['C:\\workspace'] },
-      network: { defaultPolicy: 'block' },
-      ui: { disable: true, clipboard: 'none', injection: false },
     };
-    assert.strictEqual(cfg.network?.defaultPolicy, 'block');
+    assert.deepStrictEqual(cfg.filesystem?.readwritePaths, ['C:\\workspace']);
   });
 
-  it('IsolationSessionStartConfig rejects cross-cutting fields the matrix marks as rejected', () => {
+  it('rejects network and ui until those features land Rust-side', () => {
+    const withNetwork: IsolationSessionProvisionConfig = {
+      // @ts-expect-error — network is not exposed at provision until the Rust runtime honors it.
+      network: { defaultPolicy: 'block' },
+    };
+    const withUi: IsolationSessionProvisionConfig = {
+      // @ts-expect-error — ui is not exposed at provision until the Rust runtime honors it.
+      ui: { disable: true, clipboard: 'none', injection: false },
+    };
+    assert.ok(withNetwork);
+    assert.ok(withUi);
+  });
+});
+
+describe('IsolationSessionStartConfig', () => {
+  it('rejects cross-cutting fields the matrix marks as rejected', () => {
     const cfg: IsolationSessionStartConfig = {
       // @ts-expect-error — start phase does not honor filesystem.
       filesystem: { readwritePaths: ['C:\\workspace'] },
@@ -55,7 +68,7 @@ describe('Per-(backend, phase) Configs', () => {
     assert.ok(cfg);
   });
 
-  it('IsolationSessionStartConfig accepts configurationId only from the closed enum', () => {
+  it('accepts configurationId only from the closed enum', () => {
     const ok: IsolationSessionStartConfig = { configurationId: 'composable' };
     assert.strictEqual(ok.configurationId, 'composable');
 
@@ -65,8 +78,10 @@ describe('Per-(backend, phase) Configs', () => {
     };
     assert.ok(bogus);
   });
+});
 
-  it('IsolationSessionExecConfig requires process', () => {
+describe('IsolationSessionExecConfig', () => {
+  it('requires process', () => {
     const cfg: ExecConfigFor<'isolation_session'> = {
       process: { commandLine: 'echo hi' },
     };
@@ -76,8 +91,10 @@ describe('Per-(backend, phase) Configs', () => {
     const missing: ExecConfigFor<'isolation_session'> = {};
     assert.ok(missing);
   });
+});
 
-  it('IsolationSessionStopConfig and DeprovisionConfig only carry version', () => {
+describe('IsolationSessionStopConfig and IsolationSessionDeprovisionConfig', () => {
+  it('only carry version', () => {
     const stopCfg: StopConfigFor<'isolation_session'> = { version: '0.6.0-alpha' };
     const deprovCfg: DeprovisionConfigFor<'isolation_session'> = {};
 
@@ -91,7 +108,7 @@ describe('Per-(backend, phase) Configs', () => {
   });
 });
 
-describe('ConfigsForBackend conditional', () => {
+describe('ConfigsForBackend', () => {
   it('selects the IsolationSession bundle for the isolation_session backend', () => {
     const bundle: ConfigsForBackend<'isolation_session'> = {
       provision: { version: '0.6.0-alpha' },
@@ -104,8 +121,8 @@ describe('ConfigsForBackend conditional', () => {
   });
 });
 
-describe('ProvisionResult<C> carries backend-typed metadata', () => {
-  it('ProvisionResult<isolation_session>.metadata is IsolationSessionProvisionMetadata', () => {
+describe('ProvisionResult<C>', () => {
+  it('carries backend-typed metadata for isolation_session', () => {
     const result: ProvisionResult<'isolation_session'> = {
       sandboxId: 'iso:abcd' as SandboxId<'isolation_session'>,
       metadata: { agentUserName: 'iso\\agent' },

--- a/sdk/tests/unit/state-aware.test.ts
+++ b/sdk/tests/unit/state-aware.test.ts
@@ -1,0 +1,354 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+import {
+  _resetSpawnImpl,
+  _setSpawnImpl,
+  buildStateAwareEnvelope,
+  deprovisionSandbox,
+  execInSandboxAsync,
+  parseNonExecResponse,
+  provisionSandbox,
+  startSandbox,
+  stopSandbox,
+} from '../../src/state-aware.js';
+import {
+  MxcAlreadyStartedError,
+  MxcBackendError,
+  MxcBackendUnavailableError,
+  MxcMalformedIdError,
+  MxcMalformedRequestError,
+  MxcNotProvisionedError,
+  MxcNotStartedError,
+  MxcPolicyValidationError,
+  MxcStaleIdError,
+  MxcUnsupportedContainmentError,
+  MxcUnsupportedPhaseError,
+} from '../../src/errors.js';
+import { SandboxId } from '../../src/state-aware-types.js';
+import { SandboxSpawnOptions } from '../../src/sandbox.js';
+
+// Tests stub child_process.spawn but the binary-resolution path runs first
+// and demands an existing executable on disk. Pointing it at the Node
+// binary is the simplest always-on-disk choice; the fake spawn ignores the
+// path anyway.
+function testOptions(extra?: Partial<SandboxSpawnOptions>): SandboxSpawnOptions {
+  return { experimental: true, executablePath: process.execPath, ...extra };
+}
+
+interface FakeChildOpts {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  error?: Error;
+}
+
+function fakeSpawn(opts: FakeChildOpts): {
+  spawn: (cmd: string, args: string[], spawnOpts: unknown) => unknown;
+  captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> };
+  killCount: () => number;
+} {
+  const captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> } = {};
+  let kills = 0;
+  const spawn = (cmd: string, args: string[], _spawnOpts: unknown) => {
+    captured.cmd = cmd;
+    captured.args = args;
+    const idx = args.indexOf('--config-base64');
+    if (idx >= 0 && idx + 1 < args.length) {
+      const decoded = Buffer.from(args[idx + 1], 'base64').toString('utf-8');
+      captured.envelope = JSON.parse(decoded);
+    }
+    const ee = new EventEmitter();
+    const stdout = new Readable({ read() { /* no-op */ } });
+    const stderr = new Readable({ read() { /* no-op */ } });
+    setImmediate(() => {
+      if (opts.error) {
+        ee.emit('error', opts.error);
+        return;
+      }
+      stdout.push(opts.stdout ?? '');
+      stdout.push(null);
+      stderr.push(opts.stderr ?? '');
+      stderr.push(null);
+      ee.emit('close', opts.exitCode ?? 0);
+    });
+    return Object.assign(ee, {
+      stdout,
+      stderr,
+      kill: (_sig?: NodeJS.Signals | number) => {
+        kills += 1;
+        setImmediate(() => ee.emit('close', null));
+        return true;
+      },
+    });
+  };
+  return { spawn, captured, killCount: () => kills };
+}
+
+describe('buildStateAwareEnvelope', () => {
+  it('produces a provision envelope with cross-cutting fields lifted to top-level', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'provision',
+      backendKey: 'isolation_session',
+      containment: 'isolation_session',
+      config: {
+        version: '0.6.0-alpha',
+        filesystem: { readwritePaths: ['C:\\workspace'] },
+        network: { defaultPolicy: 'block' },
+        ui: { disable: true, clipboard: 'none', injection: false },
+      },
+    });
+    assert.strictEqual(env.phase, 'provision');
+    assert.strictEqual(env.containment, 'isolation_session');
+    assert.deepStrictEqual(env.filesystem, { readwritePaths: ['C:\\workspace'] });
+    assert.deepStrictEqual(env.network, { defaultPolicy: 'block' });
+    assert.deepStrictEqual(env.ui, { disable: true, clipboard: 'none', injection: false });
+    assert.strictEqual(env.experimental, undefined);
+    assert.strictEqual(env.sandboxId, undefined);
+  });
+
+  it('produces a start envelope with backend-specific configurationId nested under experimental', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'start',
+      backendKey: 'isolation_session',
+      sandboxId: 'iso:reg-abc:prov-123',
+      config: { configurationId: 'small' },
+    });
+    assert.strictEqual(env.phase, 'start');
+    assert.strictEqual(env.sandboxId, 'iso:reg-abc:prov-123');
+    assert.deepStrictEqual(env.experimental, {
+      isolation_session: { start: { configurationId: 'small' } },
+    });
+  });
+
+  it('produces an exec envelope with process at top-level and no experimental block', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'exec',
+      backendKey: 'isolation_session',
+      sandboxId: 'iso:abc',
+      config: { process: { commandLine: 'echo hi' } },
+    });
+    assert.strictEqual(env.phase, 'exec');
+    assert.deepStrictEqual(env.process, { commandLine: 'echo hi' });
+    assert.strictEqual(env.experimental, undefined);
+  });
+
+  it('produces stop and deprovision envelopes carrying only version + phase + sandboxId', () => {
+    for (const phase of ['stop', 'deprovision'] as const) {
+      const env = buildStateAwareEnvelope({
+        phase,
+        backendKey: 'isolation_session',
+        sandboxId: 'iso:abc',
+      });
+      assert.strictEqual(env.phase, phase);
+      assert.strictEqual(env.sandboxId, 'iso:abc');
+      assert.strictEqual(env.experimental, undefined);
+      assert.ok(typeof env.version === 'string' && env.version.length > 0);
+    }
+  });
+
+  it('uses caller-supplied version when provided', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'provision',
+      backendKey: 'isolation_session',
+      containment: 'isolation_session',
+      config: { version: '0.6.5-alpha' },
+    });
+    assert.strictEqual(env.version, '0.6.5-alpha');
+  });
+});
+
+describe('parseNonExecResponse', () => {
+  it('unwraps result payload', () => {
+    const result = parseNonExecResponse<{ sandboxId: string }>('{"result":{"sandboxId":"iso:abc"}}');
+    assert.deepStrictEqual(result, { sandboxId: 'iso:abc' });
+  });
+
+  it('throws the matching MxcError subclass on each wire error code', () => {
+    type MxcCtor = new (message: string, details?: Record<string, unknown>) => Error;
+    const cases: Array<[string, MxcCtor]> = [
+      ['malformed_request', MxcMalformedRequestError],
+      ['unsupported_containment', MxcUnsupportedContainmentError],
+      ['unsupported_phase', MxcUnsupportedPhaseError],
+      ['backend_unavailable', MxcBackendUnavailableError],
+      ['malformed_id', MxcMalformedIdError],
+      ['stale_id', MxcStaleIdError],
+      ['not_provisioned', MxcNotProvisionedError],
+      ['not_started', MxcNotStartedError],
+      ['already_started', MxcAlreadyStartedError],
+      ['policy_validation', MxcPolicyValidationError],
+      ['backend_error', MxcBackendError],
+    ];
+    for (const [code, cls] of cases) {
+      const stdout = JSON.stringify({ error: { code, message: 'boom' } });
+      assert.throws(() => parseNonExecResponse(stdout), (err: unknown) => err instanceof cls);
+    }
+  });
+
+  it('passes details through when wire envelope carries them', () => {
+    const stdout = JSON.stringify({
+      error: { code: 'backend_error', message: 'boom', details: { hresult: '0x80004005' } },
+    });
+    assert.throws(() => parseNonExecResponse(stdout), (err: unknown) => {
+      return err instanceof MxcBackendError &&
+        (err as MxcBackendError).details?.hresult === '0x80004005';
+    });
+  });
+
+  it('throws a plain Error on unparseable stdout', () => {
+    assert.throws(() => parseNonExecResponse('not json'), (err: unknown) => {
+      return err instanceof Error && !(err instanceof MxcBackendError);
+    });
+  });
+
+  it('throws a plain Error on stdout that parses but lacks {result}/{error}', () => {
+    assert.throws(() => parseNonExecResponse('{"unexpected":"shape"}'));
+  });
+});
+
+describe('provisionSandbox', () => {
+  let activeFake: ReturnType<typeof fakeSpawn> | null = null;
+
+  beforeEach(() => { activeFake = null; });
+  afterEach(() => { _resetSpawnImpl(); activeFake = null; });
+
+  it('builds a provision envelope and unwraps the SandboxId from the response', async () => {
+    const fake = fakeSpawn({
+      stdout: '{"result":{"sandboxId":"iso:reg-abc:prov-1","metadata":{"agentUserName":"agent\\\\u1"}}}',
+      exitCode: 0,
+    });
+    activeFake = fake;
+    _setSpawnImpl(fake.spawn);
+    const result = await provisionSandbox(
+      'isolation_session',
+      { filesystem: { readwritePaths: ['C:\\workspace'] } },
+      testOptions(),
+    );
+    assert.strictEqual(result.sandboxId, 'iso:reg-abc:prov-1');
+    assert.strictEqual(result.metadata?.agentUserName, 'agent\\u1');
+    assert.strictEqual(fake.captured.envelope?.phase, 'provision');
+    assert.strictEqual(fake.captured.envelope?.containment, 'isolation_session');
+    assert.deepStrictEqual(fake.captured.envelope?.filesystem, { readwritePaths: ['C:\\workspace'] });
+    assert.ok(fake.captured.args?.includes('--experimental'));
+  });
+
+  it('throws MxcBackendUnavailableError when the executor reports backend_unavailable', async () => {
+    const fake = fakeSpawn({
+      stdout: '{"error":{"code":"backend_unavailable","message":"IsoSessionApp.dll not registered"}}',
+      exitCode: 1,
+    });
+    activeFake = fake;
+    _setSpawnImpl(fake.spawn);
+    await assert.rejects(
+      () => provisionSandbox('isolation_session', undefined, testOptions()),
+      (err: unknown) => err instanceof MxcBackendUnavailableError,
+    );
+  });
+
+  it('rejects when AbortSignal fires before close', async () => {
+    const ac = new AbortController();
+    const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
+    activeFake = fake;
+    _setSpawnImpl(fake.spawn);
+    const promise = provisionSandbox(
+      'isolation_session',
+      undefined,
+      testOptions({ signal: ac.signal }),
+    );
+    ac.abort();
+    await assert.rejects(promise);
+    assert.ok(activeFake.killCount() >= 1, 'expected child.kill() to fire on abort');
+  });
+});
+
+describe('startSandbox / stopSandbox / deprovisionSandbox', () => {
+  afterEach(() => { _resetSpawnImpl(); });
+
+  it('startSandbox infers backend from sandboxId prefix and nests configurationId under experimental', async () => {
+    const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:reg-abc:prov-1' as SandboxId<'isolation_session'>;
+    await startSandbox(id, { configurationId: 'small' }, testOptions());
+    assert.strictEqual(fake.captured.envelope?.phase, 'start');
+    assert.strictEqual(fake.captured.envelope?.sandboxId, 'iso:reg-abc:prov-1');
+    assert.deepStrictEqual(fake.captured.envelope?.experimental, {
+      isolation_session: { start: { configurationId: 'small' } },
+    });
+  });
+
+  it('stopSandbox builds a minimal stop envelope', async () => {
+    const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:abc' as SandboxId<'isolation_session'>;
+    await stopSandbox(id, undefined, testOptions());
+    assert.strictEqual(fake.captured.envelope?.phase, 'stop');
+    assert.strictEqual(fake.captured.envelope?.sandboxId, 'iso:abc');
+    assert.strictEqual(fake.captured.envelope?.experimental, undefined);
+  });
+
+  it('deprovisionSandbox builds a minimal deprovision envelope', async () => {
+    const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:abc' as SandboxId<'isolation_session'>;
+    await deprovisionSandbox(id, undefined, testOptions());
+    assert.strictEqual(fake.captured.envelope?.phase, 'deprovision');
+    assert.strictEqual(fake.captured.envelope?.sandboxId, 'iso:abc');
+  });
+
+  it('rejects with MxcMalformedIdError when sandboxId has no recognised prefix', async () => {
+    await assert.rejects(
+      () => stopSandbox('not-a-real-id' as SandboxId<'isolation_session'>),
+      (err: unknown) => err instanceof MxcMalformedIdError,
+    );
+    await assert.rejects(
+      () => stopSandbox('unknownprefix:abc' as SandboxId<'isolation_session'>),
+      (err: unknown) => err instanceof MxcMalformedIdError,
+    );
+  });
+});
+
+describe('execInSandboxAsync', () => {
+  afterEach(() => { _resetSpawnImpl(); });
+
+  it('returns ExecResult on successful script run', async () => {
+    const fake = fakeSpawn({ stdout: 'hello\n', stderr: '', exitCode: 0 });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:abc' as SandboxId<'isolation_session'>;
+    const result = await execInSandboxAsync(
+      id,
+      { process: { commandLine: 'echo hello' } },
+      testOptions(),
+    );
+    assert.deepStrictEqual(result, { stdout: 'hello\n', stderr: '', exitCode: 0 });
+  });
+
+  it('returns ExecResult on script exit != 0 when stdout is plain script output (not an error envelope)', async () => {
+    const fake = fakeSpawn({ stdout: 'oops\n', stderr: 'err\n', exitCode: 7 });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:abc' as SandboxId<'isolation_session'>;
+    const result = await execInSandboxAsync(
+      id,
+      { process: { commandLine: 'fail' } },
+      testOptions(),
+    );
+    assert.deepStrictEqual(result, { stdout: 'oops\n', stderr: 'err\n', exitCode: 7 });
+  });
+
+  it('throws the typed MxcError on dispatch failure (exit != 0 and stdout is a complete error envelope)', async () => {
+    const fake = fakeSpawn({
+      stdout: '{"error":{"code":"stale_id","message":"id expired"}}',
+      stderr: '',
+      exitCode: 1,
+    });
+    _setSpawnImpl(fake.spawn);
+    const id = 'iso:abc' as SandboxId<'isolation_session'>;
+    await assert.rejects(
+      () => execInSandboxAsync(id, { process: { commandLine: 'echo' } }, testOptions()),
+      (err: unknown) => err instanceof MxcStaleIdError,
+    );
+  });
+});

--- a/sdk/tests/unit/state-aware.test.ts
+++ b/sdk/tests/unit/state-aware.test.ts
@@ -3,91 +3,22 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { EventEmitter } from 'events';
-import { Readable } from 'stream';
 import {
-  _resetSpawnImpl,
-  _setSpawnImpl,
-  buildStateAwareEnvelope,
   deprovisionSandbox,
   execInSandboxAsync,
-  parseNonExecResponse,
   provisionSandbox,
   startSandbox,
   stopSandbox,
 } from '../../src/state-aware.js';
 import {
-  MxcAlreadyStartedError,
-  MxcBackendError,
-  MxcBackendUnavailableError,
-  MxcMalformedIdError,
-  MxcMalformedRequestError,
-  MxcNotProvisionedError,
-  MxcNotStartedError,
-  MxcPolicyValidationError,
-  MxcStaleIdError,
-  MxcUnsupportedContainmentError,
-  MxcUnsupportedPhaseError,
-} from '../../src/errors.js';
+  _resetSpawnImpl,
+  _setSpawnImpl,
+  buildStateAwareEnvelope,
+  parseNonExecResponse,
+} from '../../src/state-aware-helper.js';
+import { MxcError } from '../../src/errors.js';
 import { SandboxId } from '../../src/state-aware-types.js';
-import { SandboxSpawnOptions } from '../../src/sandbox.js';
-
-// Tests stub child_process.spawn but the binary-resolution path runs first
-// and demands an existing executable on disk. Pointing it at the Node
-// binary is the simplest always-on-disk choice; the fake spawn ignores the
-// path anyway.
-function testOptions(extra?: Partial<SandboxSpawnOptions>): SandboxSpawnOptions {
-  return { experimental: true, executablePath: process.execPath, ...extra };
-}
-
-interface FakeChildOpts {
-  stdout?: string;
-  stderr?: string;
-  exitCode?: number;
-  error?: Error;
-}
-
-function fakeSpawn(opts: FakeChildOpts): {
-  spawn: (cmd: string, args: string[], spawnOpts: unknown) => unknown;
-  captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> };
-  killCount: () => number;
-} {
-  const captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> } = {};
-  let kills = 0;
-  const spawn = (cmd: string, args: string[], _spawnOpts: unknown) => {
-    captured.cmd = cmd;
-    captured.args = args;
-    const idx = args.indexOf('--config-base64');
-    if (idx >= 0 && idx + 1 < args.length) {
-      const decoded = Buffer.from(args[idx + 1], 'base64').toString('utf-8');
-      captured.envelope = JSON.parse(decoded);
-    }
-    const ee = new EventEmitter();
-    const stdout = new Readable({ read() { /* no-op */ } });
-    const stderr = new Readable({ read() { /* no-op */ } });
-    setImmediate(() => {
-      if (opts.error) {
-        ee.emit('error', opts.error);
-        return;
-      }
-      stdout.push(opts.stdout ?? '');
-      stdout.push(null);
-      stderr.push(opts.stderr ?? '');
-      stderr.push(null);
-      ee.emit('close', opts.exitCode ?? 0);
-    });
-    return Object.assign(ee, {
-      stdout,
-      stderr,
-      kill: (_sig?: NodeJS.Signals | number) => {
-        kills += 1;
-        setImmediate(() => ee.emit('close', null));
-        return true;
-      },
-    });
-  };
-  return { spawn, captured, killCount: () => kills };
-}
+import { fakeSpawn, testOptions } from './test-helpers.js';
 
 describe('buildStateAwareEnvelope', () => {
   it('produces a provision envelope with cross-cutting fields lifted to top-level', () => {
@@ -168,24 +99,26 @@ describe('parseNonExecResponse', () => {
     assert.deepStrictEqual(result, { sandboxId: 'iso:abc' });
   });
 
-  it('throws the matching MxcError subclass on each wire error code', () => {
-    type MxcCtor = new (message: string, details?: Record<string, unknown>) => Error;
-    const cases: Array<[string, MxcCtor]> = [
-      ['malformed_request', MxcMalformedRequestError],
-      ['unsupported_containment', MxcUnsupportedContainmentError],
-      ['unsupported_phase', MxcUnsupportedPhaseError],
-      ['backend_unavailable', MxcBackendUnavailableError],
-      ['malformed_id', MxcMalformedIdError],
-      ['stale_id', MxcStaleIdError],
-      ['not_provisioned', MxcNotProvisionedError],
-      ['not_started', MxcNotStartedError],
-      ['already_started', MxcAlreadyStartedError],
-      ['policy_validation', MxcPolicyValidationError],
-      ['backend_error', MxcBackendError],
+  it('throws an MxcError carrying each wire error code', () => {
+    const codes = [
+      'malformed_request',
+      'unsupported_containment',
+      'unsupported_phase',
+      'backend_unavailable',
+      'malformed_id',
+      'stale_id',
+      'not_provisioned',
+      'not_started',
+      'already_started',
+      'policy_validation',
+      'backend_error',
     ];
-    for (const [code, cls] of cases) {
+    for (const code of codes) {
       const stdout = JSON.stringify({ error: { code, message: 'boom' } });
-      assert.throws(() => parseNonExecResponse(stdout), (err: unknown) => err instanceof cls);
+      assert.throws(
+        () => parseNonExecResponse(stdout),
+        (err: unknown) => err instanceof MxcError && err.code === code,
+      );
     }
   });
 
@@ -194,14 +127,15 @@ describe('parseNonExecResponse', () => {
       error: { code: 'backend_error', message: 'boom', details: { hresult: '0x80004005' } },
     });
     assert.throws(() => parseNonExecResponse(stdout), (err: unknown) => {
-      return err instanceof MxcBackendError &&
-        (err as MxcBackendError).details?.hresult === '0x80004005';
+      return err instanceof MxcError &&
+        err.code === 'backend_error' &&
+        err.details?.hresult === '0x80004005';
     });
   });
 
   it('throws a plain Error on unparseable stdout', () => {
     assert.throws(() => parseNonExecResponse('not json'), (err: unknown) => {
-      return err instanceof Error && !(err instanceof MxcBackendError);
+      return err instanceof Error && !(err instanceof MxcError);
     });
   });
 
@@ -236,7 +170,7 @@ describe('provisionSandbox', () => {
     assert.ok(fake.captured.args?.includes('--experimental'));
   });
 
-  it('throws MxcBackendUnavailableError when the executor reports backend_unavailable', async () => {
+  it('throws an MxcError carrying backend_unavailable when the executor reports it', async () => {
     const fake = fakeSpawn({
       stdout: '{"error":{"code":"backend_unavailable","message":"IsoSessionApp.dll not registered"}}',
       exitCode: 1,
@@ -245,7 +179,7 @@ describe('provisionSandbox', () => {
     _setSpawnImpl(fake.spawn);
     await assert.rejects(
       () => provisionSandbox('isolation_session', undefined, testOptions()),
-      (err: unknown) => err instanceof MxcBackendUnavailableError,
+      (err: unknown) => err instanceof MxcError && err.code === 'backend_unavailable',
     );
   });
 
@@ -265,10 +199,10 @@ describe('provisionSandbox', () => {
   });
 });
 
-describe('startSandbox / stopSandbox / deprovisionSandbox', () => {
+describe('startSandbox', () => {
   afterEach(() => { _resetSpawnImpl(); });
 
-  it('startSandbox infers backend from sandboxId prefix and nests configurationId under experimental', async () => {
+  it('infers backend from sandboxId prefix and nests configurationId under experimental', async () => {
     const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
     _setSpawnImpl(fake.spawn);
     const id = 'iso:reg-abc:prov-1' as SandboxId<'isolation_session'>;
@@ -279,8 +213,12 @@ describe('startSandbox / stopSandbox / deprovisionSandbox', () => {
       isolation_session: { start: { configurationId: 'small' } },
     });
   });
+});
 
-  it('stopSandbox builds a minimal stop envelope', async () => {
+describe('stopSandbox', () => {
+  afterEach(() => { _resetSpawnImpl(); });
+
+  it('builds a minimal stop envelope', async () => {
     const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
     _setSpawnImpl(fake.spawn);
     const id = 'iso:abc' as SandboxId<'isolation_session'>;
@@ -290,24 +228,28 @@ describe('startSandbox / stopSandbox / deprovisionSandbox', () => {
     assert.strictEqual(fake.captured.envelope?.experimental, undefined);
   });
 
-  it('deprovisionSandbox builds a minimal deprovision envelope', async () => {
+  it('rejects with malformed_id when sandboxId has no recognised prefix', async () => {
+    await assert.rejects(
+      () => stopSandbox('not-a-real-id' as SandboxId<'isolation_session'>),
+      (err: unknown) => err instanceof MxcError && err.code === 'malformed_id',
+    );
+    await assert.rejects(
+      () => stopSandbox('unknownprefix:abc' as SandboxId<'isolation_session'>),
+      (err: unknown) => err instanceof MxcError && err.code === 'malformed_id',
+    );
+  });
+});
+
+describe('deprovisionSandbox', () => {
+  afterEach(() => { _resetSpawnImpl(); });
+
+  it('builds a minimal deprovision envelope', async () => {
     const fake = fakeSpawn({ stdout: '{"result":{}}', exitCode: 0 });
     _setSpawnImpl(fake.spawn);
     const id = 'iso:abc' as SandboxId<'isolation_session'>;
     await deprovisionSandbox(id, undefined, testOptions());
     assert.strictEqual(fake.captured.envelope?.phase, 'deprovision');
     assert.strictEqual(fake.captured.envelope?.sandboxId, 'iso:abc');
-  });
-
-  it('rejects with MxcMalformedIdError when sandboxId has no recognised prefix', async () => {
-    await assert.rejects(
-      () => stopSandbox('not-a-real-id' as SandboxId<'isolation_session'>),
-      (err: unknown) => err instanceof MxcMalformedIdError,
-    );
-    await assert.rejects(
-      () => stopSandbox('unknownprefix:abc' as SandboxId<'isolation_session'>),
-      (err: unknown) => err instanceof MxcMalformedIdError,
-    );
   });
 });
 
@@ -348,7 +290,7 @@ describe('execInSandboxAsync', () => {
     const id = 'iso:abc' as SandboxId<'isolation_session'>;
     await assert.rejects(
       () => execInSandboxAsync(id, { process: { commandLine: 'echo' } }, testOptions()),
-      (err: unknown) => err instanceof MxcStaleIdError,
+      (err: unknown) => err instanceof MxcError && err.code === 'stale_id',
     );
   });
 });

--- a/sdk/tests/unit/test-helpers.ts
+++ b/sdk/tests/unit/test-helpers.ts
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { EventEmitter } from 'events';
+import { Readable } from 'stream';
+import { SandboxSpawnOptions } from '../../src/sandbox.js';
+
+/**
+ * Spawn-options preset for unit tests that drive the real binary-resolver
+ * code path but stub the actual `child_process.spawn`. `experimental: true`
+ * exposes the state-aware functions; `executablePath: process.execPath`
+ * gives the resolver an always-on-disk path so it can succeed without the
+ * fake spawn ever using it.
+ */
+export function testOptions(extra?: Partial<SandboxSpawnOptions>): SandboxSpawnOptions {
+  return { experimental: true, executablePath: process.execPath, ...extra };
+}
+
+export interface FakeChildOpts {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  error?: Error;
+}
+
+/**
+ * Stub for `child_process.spawn` that emits a single round of stdout / stderr
+ * data and a synthetic `close` event. Captures the command, args, and
+ * decoded envelope (if `--config-base64` is present in args). Tracks
+ * `child.kill()` invocations for AbortSignal tests.
+ */
+export function fakeSpawn(opts: FakeChildOpts): {
+  spawn: (cmd: string, args: string[], spawnOpts: unknown) => unknown;
+  captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> };
+  killCount: () => number;
+} {
+  const captured: { cmd?: string; args?: string[]; envelope?: Record<string, unknown> } = {};
+  let kills = 0;
+  const spawn = (cmd: string, args: string[], _spawnOpts: unknown) => {
+    captured.cmd = cmd;
+    captured.args = args;
+    const idx = args.indexOf('--config-base64');
+    if (idx >= 0 && idx + 1 < args.length) {
+      const decoded = Buffer.from(args[idx + 1], 'base64').toString('utf-8');
+      captured.envelope = JSON.parse(decoded);
+    }
+    const ee = new EventEmitter();
+    const stdout = new Readable({ read() { /* no-op */ } });
+    const stderr = new Readable({ read() { /* no-op */ } });
+    setImmediate(() => {
+      if (opts.error) {
+        ee.emit('error', opts.error);
+        return;
+      }
+      stdout.push(opts.stdout ?? '');
+      stdout.push(null);
+      stderr.push(opts.stderr ?? '');
+      stderr.push(null);
+      ee.emit('close', opts.exitCode ?? 0);
+    });
+    return Object.assign(ee, {
+      stdout,
+      stderr,
+      kill: (_sig?: NodeJS.Signals | number) => {
+        kills += 1;
+        setImmediate(() => ee.emit('close', null));
+        return true;
+      },
+    });
+  };
+  return { spawn, captured, killCount: () => kills };
+}

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -417,7 +417,7 @@ pub fn decode_request_input(
 // ---------- Cross-field validation ----------
 
 /// Maximum supported schema version (major.minor). Configs with a higher major.minor are rejected.
-const SUPPORTED_VERSION: &str = ">=0.4, <=0.5";
+const SUPPORTED_VERSION: &str = ">=0.4, <=0.6";
 
 /// The minimum schema version that implies BaseContainer backend usage.
 const BASE_CONTAINER_MIN_VERSION: &str = "0.5.0";
@@ -1792,7 +1792,7 @@ mod tests {
 
     #[test]
     fn schema_version_too_new_rejected() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.6.0"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.7.0"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1808,6 +1808,19 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.schema_version, "0.5.0-alpha");
+    }
+
+    #[test]
+    fn schema_version_state_aware_06_accepted() {
+        // 0.6 is the state-aware schema version (SDK side bumps to it for
+        // provision/start/exec/stop/deprovision envelopes); the parser must
+        // accept it on the same path used for one-shot 0.5 requests.
+        let json = r#"{"process": {"commandLine": "echo hi"}, "version": "0.6.0-alpha"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.schema_version, "0.6.0-alpha");
     }
 
     #[test]

--- a/src/wxc_common/src/mxc_error.rs
+++ b/src/wxc_common/src/mxc_error.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for MxcErrorCode {
     }
 }
 
-/// Typed Rust equivalent of the SDK `MxcError` class hierarchy.
+/// Typed Rust equivalent of the SDK `MxcError`.
 ///
 /// Constructed via `MxcError::new(code, message)` or one of the per-code
 /// convenience constructors (e.g. `MxcError::stale_id("...")`); attach

--- a/test_scripts/README.md
+++ b/test_scripts/README.md
@@ -36,6 +36,17 @@ These scripts are local helpers. Not every script is run by CI because several
 depend on local OS features such as Windows Sandbox, WHP, proxy setup, or stress
 test duration.
 
+### Deployment helpers (TShell `putd`)
+
+These scripts copy build artifacts onto a remote test VM via TShell. Source them
+from inside an active TShell session (`Open-Device -vm <vm>`).
+
+| Script | Copies |
+|--------|--------|
+| `push_exes_to_vm.ps1` | Native Rust binaries (Debug + Release) |
+| `push_batch_and_config_files_to_vm.ps1` | `test_configs\`, `examples\`, runner batch files, helper scripts |
+| `push_sdk_integration_tests_to_vm.ps1` | SDK integration test artifacts (`sdk\bin\x64`, compiled tests, `node_modules`, `package.json`, `run-tests.js`) |
+
 CI currently runs the MicroVM Rust E2E suite when WHP is available. Other
 executor E2E tests are local/prerequisite-gated and should be run on machines
 with the required Windows features and binaries.

--- a/test_scripts/README.md
+++ b/test_scripts/README.md
@@ -36,16 +36,18 @@ These scripts are local helpers. Not every script is run by CI because several
 depend on local OS features such as Windows Sandbox, WHP, proxy setup, or stress
 test duration.
 
-### Deployment helpers (TShell `putd`)
+### Deployment helpers
 
-These scripts copy build artifacts onto a remote test VM via TShell. Source them
-from inside an active TShell session (`Open-Device -vm <vm>`).
+These scripts copy build artifacts onto a remote test VM. The TShell-based
+scripts must be sourced from inside an active TShell session
+(`Open-Device -vm <vm>`); the PowerShell Remoting script handles the session
+itself and takes a `-ComputerName` / `-VMName` plus `-Credential`.
 
-| Script | Copies |
-|--------|--------|
-| `push_exes_to_vm.ps1` | Native Rust binaries (Debug + Release) |
-| `push_batch_and_config_files_to_vm.ps1` | `test_configs\`, `examples\`, runner batch files, helper scripts |
-| `push_sdk_integration_tests_to_vm.ps1` | SDK integration test artifacts (`sdk\bin\x64`, compiled tests, `node_modules`, `package.json`, `run-tests.js`) |
+| Script | Copies | Transport |
+|--------|--------|-----------|
+| `push_exes_to_vm.ps1` | Native Rust binaries (Debug + Release) | TShell (active `Open-Device` session) |
+| `push_batch_and_config_files_to_vm.ps1` | `test_configs\`, `examples\`, runner batch files, helper scripts | TShell (active `Open-Device` session) |
+| `push_sdk_integration_tests_to_vm.ps1` | SDK integration test artifacts (`sdk\bin\x64`, compiled tests, `node_modules`, `package.json`, `run-tests.js`) | PowerShell Remoting (`-ComputerName`/`-VMName` + `-Credential`) |
 
 CI currently runs the MicroVM Rust E2E suite when WHP is available. Other
 executor E2E tests are local/prerequisite-gated and should be run on machines

--- a/test_scripts/push_sdk_integration_tests_to_vm.ps1
+++ b/test_scripts/push_sdk_integration_tests_to_vm.ps1
@@ -1,0 +1,24 @@
+# Copies the SDK integration-test artifacts onto the connected TShell device.
+#
+# Prerequisites:
+#   - Active TShell session connected via Open-Device.
+#   - SDK binaries built locally:
+#       build.bat --x64 --with-isolation-session
+#   - SDK integration tests built locally:
+#       cd sdk\tests\integration; npm install; npm run build
+#
+# Usage:
+#   . .\push_sdk_integration_tests_to_vm.ps1
+#
+# Paths are anchored to this script's directory ($PSScriptRoot) so the
+# script works regardless of the active TShell session's current location.
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+$integrationDir = Join-Path $repoRoot 'sdk\tests\integration'
+$binDir = Join-Path $repoRoot 'sdk\bin\x64'
+
+putd $binDir WXC\sdk-integration-tests\bin\x64\
+putd (Join-Path $integrationDir 'dist') WXC\sdk-integration-tests\dist\
+putd (Join-Path $integrationDir 'node_modules') WXC\sdk-integration-tests\node_modules\
+putd (Join-Path $integrationDir 'package.json') WXC\sdk-integration-tests\
+putd (Join-Path $integrationDir 'run-tests.js') WXC\sdk-integration-tests\

--- a/test_scripts/push_sdk_integration_tests_to_vm.ps1
+++ b/test_scripts/push_sdk_integration_tests_to_vm.ps1
@@ -1,24 +1,134 @@
-# Copies the SDK integration-test artifacts onto the connected TShell device.
-#
-# Prerequisites:
-#   - Active TShell session connected via Open-Device.
-#   - SDK binaries built locally:
-#       build.bat --x64 --with-isolation-session
-#   - SDK integration tests built locally:
-#       cd sdk\tests\integration; npm install; npm run build
-#
-# Usage:
-#   . .\push_sdk_integration_tests_to_vm.ps1
-#
-# Paths are anchored to this script's directory ($PSScriptRoot) so the
-# script works regardless of the active TShell session's current location.
+<#
+.SYNOPSIS
+Copies the SDK integration-test artifacts onto a remote test VM via PowerShell Remoting.
+
+.DESCRIPTION
+Stages a flat payload of the integration-test artifacts (built tests, runner,
+package.json, node_modules) plus the SDK's published shape (bin, dist,
+package.json, LICENSE.md, node_modules) into a temp directory on the host,
+zips it, copies the single zip onto the VM via PSSession, and expands it
+in place.
+
+The integration-test `node_modules\@microsoft\mxc-sdk` is a symlink to the
+SDK root, which itself contains `tests\integration\node_modules` — directly
+copying the tree would recurse indefinitely. The staging step skips the
+symlink and copies the SDK's published shape directly instead.
+
+.PARAMETER ComputerName
+DNS name or IP of the remote VM. Mutually exclusive with -VMName.
+
+.PARAMETER VMName
+Hyper-V VM name. Mutually exclusive with -ComputerName.
+
+.PARAMETER Credential
+PSCredential for the remote session.
+
+.PARAMETER DestinationPath
+Path on the VM where artifacts are deployed. Defaults to C:\sdk-integration-tests.
+
+.EXAMPLE
+.\push_sdk_integration_tests_to_vm.ps1 -ComputerName myvm -Credential (Get-Credential)
+
+.EXAMPLE
+.\push_sdk_integration_tests_to_vm.ps1 -VMName HYPERV-VM -Credential (Get-Credential)
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'ComputerName')]
+param(
+    [Parameter(ParameterSetName = 'ComputerName', Mandatory)]
+    [string]$ComputerName,
+
+    [Parameter(ParameterSetName = 'VMName', Mandatory)]
+    [string]$VMName,
+
+    [Parameter(Mandatory)]
+    [System.Management.Automation.PSCredential]$Credential,
+
+    [string]$DestinationPath = 'C:\sdk-integration-tests'
+)
+
+$ErrorActionPreference = 'Stop'
 
 $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
-$integrationDir = Join-Path $repoRoot 'sdk\tests\integration'
-$binDir = Join-Path $repoRoot 'sdk\bin\x64'
+$sdkRoot = Join-Path $repoRoot 'sdk'
+$integrationDir = Join-Path $sdkRoot 'tests\integration'
 
-putd $binDir WXC\sdk-integration-tests\bin\x64\
-putd (Join-Path $integrationDir 'dist') WXC\sdk-integration-tests\dist\
-putd (Join-Path $integrationDir 'node_modules') WXC\sdk-integration-tests\node_modules\
-putd (Join-Path $integrationDir 'package.json') WXC\sdk-integration-tests\
-putd (Join-Path $integrationDir 'run-tests.js') WXC\sdk-integration-tests\
+if (-not (Test-Path (Join-Path $integrationDir 'dist'))) {
+    throw "Integration tests not built. Run: cd sdk\tests\integration; npm install; npm run build"
+}
+if (-not (Test-Path (Join-Path $sdkRoot 'bin'))) {
+    throw "SDK binaries not built. Run: build.bat --x64 --with-isolation-session"
+}
+
+$stagingRoot = Join-Path $env:TEMP "mxc-sdk-integration-deploy-$([Guid]::NewGuid())"
+$zipPath = "$stagingRoot.zip"
+
+try {
+    Write-Host "Staging payload at $stagingRoot..."
+    New-Item -ItemType Directory -Path $stagingRoot -Force | Out-Null
+
+    Copy-Item -Recurse (Join-Path $integrationDir 'dist') (Join-Path $stagingRoot 'dist')
+    Copy-Item (Join-Path $integrationDir 'package.json') (Join-Path $stagingRoot 'package.json')
+    Copy-Item (Join-Path $integrationDir 'run-tests.js') (Join-Path $stagingRoot 'run-tests.js')
+
+    # Walk the integration node_modules, skipping the @microsoft symlink (we'll
+    # copy the SDK's published shape directly below).
+    $integrationNodeModules = Join-Path $integrationDir 'node_modules'
+    $stagingNodeModules = Join-Path $stagingRoot 'node_modules'
+    New-Item -ItemType Directory -Path $stagingNodeModules -Force | Out-Null
+    foreach ($entry in Get-ChildItem -Path $integrationNodeModules -Force) {
+        if ($entry.Name -eq '@microsoft') { continue }
+        Copy-Item -Recurse -Force $entry.FullName (Join-Path $stagingNodeModules $entry.Name)
+    }
+
+    # Copy the SDK's published shape directly — no recursion into the symlink.
+    $sdkStaged = Join-Path $stagingNodeModules '@microsoft\mxc-sdk'
+    New-Item -ItemType Directory -Path $sdkStaged -Force | Out-Null
+    Copy-Item -Recurse (Join-Path $sdkRoot 'bin') (Join-Path $sdkStaged 'bin')
+    Copy-Item -Recurse (Join-Path $sdkRoot 'dist') (Join-Path $sdkStaged 'dist')
+    Copy-Item (Join-Path $sdkRoot 'package.json') (Join-Path $sdkStaged 'package.json')
+    $licensePath = Join-Path $sdkRoot 'LICENSE.md'
+    if (Test-Path $licensePath) {
+        Copy-Item $licensePath (Join-Path $sdkStaged 'LICENSE.md')
+    }
+    Copy-Item -Recurse (Join-Path $sdkRoot 'node_modules') (Join-Path $sdkStaged 'node_modules')
+
+    Write-Host "Compressing payload to $zipPath..."
+    Compress-Archive -Path "$stagingRoot\*" -DestinationPath $zipPath -CompressionLevel Fastest -Force
+
+    $sessionParams = if ($PSCmdlet.ParameterSetName -eq 'VMName') {
+        @{ VMName = $VMName; Credential = $Credential }
+    } else {
+        @{ ComputerName = $ComputerName; Credential = $Credential }
+    }
+
+    Write-Host "Opening PSSession..."
+    $session = New-PSSession @sessionParams
+    try {
+        Write-Host "Preparing destination $DestinationPath on the VM..."
+        Invoke-Command -Session $session -ScriptBlock {
+            param($Dest)
+            if (Test-Path $Dest) { Remove-Item -Recurse -Force $Dest }
+            New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+        } -ArgumentList $DestinationPath
+
+        $remoteZip = Join-Path $DestinationPath 'integration-deploy.zip'
+        Write-Host "Copying zip to $remoteZip..."
+        Copy-Item -ToSession $session -Path $zipPath -Destination $remoteZip -Force
+
+        Write-Host "Expanding zip on the VM..."
+        Invoke-Command -Session $session -ScriptBlock {
+            param($Dest, $Zip)
+            Expand-Archive -Path $Zip -DestinationPath $Dest -Force
+            Remove-Item -Force $Zip
+        } -ArgumentList $DestinationPath, $remoteZip
+
+        Write-Host "Deployed to $DestinationPath."
+    } finally {
+        Remove-PSSession $session
+    }
+}
+finally {
+    if (Test-Path $stagingRoot) { Remove-Item -Recurse -Force $stagingRoot }
+    if (Test-Path $zipPath) { Remove-Item -Force $zipPath }
+}


### PR DESCRIPTION
## 📖 Description

The SDK-side complement to #255. Adds five new functions plus the supporting types that callers use to drive a sandbox through `provision -> start -> exec -> stop -> deprovision` against IsolationSession (the only state-aware backend today; future backends opt in by extending `StateAwareSandboxingMethod` and adding an arm to `ConfigsForBackend`).

New public functions:

- `provisionSandbox(containment, config?, options?) -> Promise<ProvisionResult<C>>`
- `startSandbox(sandboxId, config?, options?) -> Promise<StartResult<C>>`
- `execInSandbox(sandboxId, config, options?) -> IPty` (streaming)
- `execInSandboxAsync(sandboxId, config, options?) -> Promise<ExecResult>` (buffered)
- `stopSandbox(sandboxId, config?, options?) -> Promise<StopResult<C>>`
- `deprovisionSandbox(sandboxId, config?, options?) -> Promise<DeprovisionResult<C>>`

Types layer:

- `SandboxId<C>` — branded TypeScript string parameterised by backend.
- Per-(backend, phase) `*Config` interfaces declaring only the fields valid at that phase, with cross-cutting fields (`filesystem` / `network` / `ui`) appearing only in phases the backend's policy honor matrix marks as `applied` — giving compile-time enforcement of the matrix on TypeScript callers.
- `*Result<C>` per phase with backend-typed `metadata` via `StateAwareMetadata` and `<Phase>MetadataFor<C>`.
- Closed `ErrorCode` union plus one typed `MxcError` subclass per code (12 total), mirroring the Rust `MxcErrorCode` enum, plus an `mxcErrorFromCode` helper for the SDK's wire-envelope parser.

Schema version bumps to `0.6.0-alpha`. The Rust parser was capped at `<=0.5` and was rejecting 0.6 envelopes from the SDK at parse time; the wxc-exec change in this PR raises the ceiling to `<=0.6` and adds parser coverage for the new accepted version.

`SandboxSpawnOptions` gains an optional `signal: AbortSignal` honored by the state-aware functions. Cancellation is best-effort: aborting kills the executor process and rejects the pending promise, but OS-side state may need a follow-up `deprovisionSandbox` to clean up.

Note: the design baked into this PR drops `SandboxPolicy` from the state-aware surface in favor of per-(backend, phase) Configs that absorb cross-cutting fields directly. The design docs in `docs/state-aware-lifecycle/` are revised in the first commit on this PR. The umbrella issue's older summary still references `SandboxPolicy` — that summary is design-stale relative to the design as it now ships.

## 🔗 References

Resolves #232 (umbrella issue tracking state-aware sandbox lifecycle APIs).

Rust-side state-aware support: #255.

Design: `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md` and `docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md` (revised in the first commit on this PR).

## 🔍 Validation

Each commit was validated locally with the four MXC pre-push checks (build + Rust unit tests + clippy + fmt) plus `npm test` in `sdk/`. Final state at the tip of the branch:

- 141 SDK unit tests pass (61 pre-existing + 80 new). The new tests cover the `MxcError` class hierarchy and `mxcErrorFromCode`, the per-(backend, phase) Config matrix and `SandboxId<C>` brand at compile time via `// @ts-expect-error` patterns, and the state-aware function logic (envelope construction, response parsing, error mapping, AbortSignal cancellation, exec dispatch-vs-script-failure discrimination) using an injected fake spawn so unit tests do not depend on a real `wxc-exec` binary.
- Default-features and `--features isolation_session` Rust unit tests pass. The wxc-exec commit adds `schema_version_state_aware_06_accepted` and repoints the existing `schema_version_too_new_rejected` test at `0.7.0` as the new "too new" sentinel.
- Integration tests verified two ways. (1) On a Windows host without an IsolationSession runtime, the WinRT activation in `wxc-exec` returns `IsolationSessionError::ServiceUnavailable` which the dispatcher maps to wire `error.code: "backend_unavailable"`; the SDK throws `MxcBackendUnavailableError` and the new integration tests skip with a clear diagnostic. (2) Interactively on a Windows host with the IsolationSession runtime registered, the full provision -> start -> exec -> stop -> deprovision lifecycle passes end-to-end.

## Out of scope — deferred follow-ups

These items are intentionally not addressed in this PR. Each is a discrete concern that benefits from its own PR.

- IsolationSession detection in `sdk/src/platform.ts`. OS build-number alone is insufficient (IS depends on component dependencies beyond OS version); proper detection belongs in a follow-up, likely via a `wxc-exec --query-capabilities` subcommand the SDK consumes. The integration tests' try-and-skip pattern handles probing implicitly today, so this does not block the test suite.
- `'isolation_session'` in the consumer-facing `ContainmentType` plus a one-shot translation arm in `createConfigFromPolicy`. Today, callers wanting one-shot IS hand-build a `ContainerConfig` and call `spawnSandboxFromConfig`.
- Removing `SandboxPolicy` from the existing one-shot SDK paths. The state-aware surface added here does not use it; the one-shot surface still does and is left untouched in this PR.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Feature

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/265)