### PR TITLE
Split SDK containment into intent vs. backend

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -76,6 +76,19 @@ production configs and the dev schema when working on experimental features:
 
 ### Containment Backends
 
+The `containment` field accepts both **abstract intent values** (which the
+native binary resolves per host) and **concrete backend values** (which select
+a specific runner). Prefer abstract intents unless you specifically need to
+force a particular backend.
+
+#### Abstract intents
+
+| Value | Resolution |
+|-------|------------|
+| `"process"` | AppContainer on Windows, LXC on Linux |
+
+#### Concrete backends
+
 | Value | Description |
 |-------|-------------|
 | `"appcontainer"` | (Default) Windows AppContainer process-level isolation |

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -21,7 +21,7 @@ function signatures throughout. One-line summaries; full definitions live in
 | Type | Where | Role |
 |---|---|---|
 | `SandboxPolicy` | `sdk/src/types.ts` | Cross-platform restriction policy: filesystem, network, UI, timeout. Reused as the cross-cutting policy on state-aware. |
-| `SandboxingMethod` | `sdk/src/types.ts` | String union of MXC backend names (`'appcontainer' \| 'windows_sandbox' \| 'lxc' \| 'wslc' \| 'vm' \| 'microvm' \| 'isolation_session'`). |
+| `ContainmentType` / `ContainmentBackend` | `sdk/src/types.ts` | Two-tier containment names: `ContainmentType` for abstract intents (`'process' \| 'microvm'` today); `ContainmentBackend` for concrete runners (`'appcontainer' \| 'windows_sandbox' \| 'lxc' \| 'wslc' \| 'microvm' \| 'isolation_session'`). Wire `containment` accepts either. The deprecated alias `SandboxingMethod = ContainmentType \| ContainmentBackend` is retained for back-compat. |
 | `ProcessConfig` | `sdk/src/types.ts` | Per-process settings: `commandLine`, `cwd`, `env`, `timeout`. Reused for state-aware exec. |
 | `FilesystemConfig`, `NetworkConfig`, `UiConfig` | `sdk/src/types.ts` | Wire-format restriction blocks. The `SandboxPolicy` → wire mapping is the existing `createConfigFromPolicy` logic. |
 | `pty.IPty` | `node-pty` package | Interactive PTY handle. Used as the streaming-exec return type, matching existing `spawnSandbox`. |
@@ -40,7 +40,7 @@ on the response, and neither shape carries `containerId`.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes. | `spawnSandbox` family preserved. `SandboxPolicy` reused as cross-cutting policy. `SandboxingMethod` extension reused. `*Config` naming convention reused. |
+| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes. | `spawnSandbox` family preserved. `SandboxPolicy` reused as cross-cutting policy. `ContainmentBackend` extension reused. `*Config` naming convention reused. |
 | JSON wire format (reference §7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (reference §9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private `Raw*` parser pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends unchanged. |
 | Error model (reference §8) | Closed enum of 12 codes. `MxcError` base + per-code subclasses. `details` open object. | Existing one-shot error paths preserved. |
@@ -69,7 +69,7 @@ Types used in the function signatures below. Per-phase `<Phase>SandboxOptions<C>
 type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
 type SandboxId<C extends StateAwareSandboxingMethod> =
   string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
-type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
+type StateAwareSandboxingMethod = Extract<ContainmentBackend, 'isolation_session'>;
 // extended as state-aware-capable backends are added
 
 interface ExecResult {
@@ -134,7 +134,7 @@ information.
 ```typescript
 interface OneShotRequest {
   phase?: never;
-  containment: SandboxingMethod;
+  containment: ContainmentType | ContainmentBackend;
   process: ProcessConfig;
   filesystem?: FilesystemConfig;
   network?: NetworkConfig;
@@ -374,7 +374,7 @@ Reference §11 has the full guide. Operational checklist:
 2. Implement the trait. Define associated types for each phase's config and metadata;
    use `()` for any phase that doesn't need them.
 3. Define typed `*Config` interfaces in `@microsoft/mxc-sdk` and slot into
-   `ExperimentalStateAwareConfigs`. If newly SDK-exposed, extend `SandboxingMethod` and
+   `ExperimentalStateAwareConfigs`. If newly SDK-exposed, extend `ContainmentBackend` and
    `StateAwareSandboxingMethod`.
 4. Register a variant in the `ContainmentBackend` enum, declare the backend's id prefix
    alongside the variant (it serves as the dispatcher's routing key for non-provision

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -60,7 +60,7 @@ elaborates.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes per error code. | `spawnSandbox` family preserved. `SandboxPolicy` reused as the cross-cutting policy across both surfaces. `SandboxingMethod` extension mechanism reused. Existing typed `*Config` naming convention reused. |
+| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-phase typed `*Config` types per backend. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation. Typed exception classes per error code. | `spawnSandbox` family preserved. `SandboxPolicy` reused as the cross-cutting policy across both surfaces. `ContainmentBackend` extension mechanism reused. Existing typed `*Config` naming convention reused. |
 | JSON wire format (§7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union over `phase`. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` fields at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (§9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private to parser, matching `RawConfig` pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends function without modification. |
 | Error model (§8) | Closed enum of 12 error codes. `MxcError` base + per-code subclasses. `details` open object as escape hatch for backend-specific structured information. | Existing one-shot error paths preserved. |
@@ -232,7 +232,7 @@ type SandboxId<C extends StateAwareSandboxingMethod> =
 
 type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
 
-type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
+type StateAwareSandboxingMethod = Extract<ContainmentBackend, 'isolation_session'>;
 // extended as state-aware-capable backends are added
 
 interface ExperimentalStateAwareConfigs {
@@ -477,12 +477,12 @@ await deprovisionSandbox(sandboxId);
 ### 6.4 Composition with the one-shot surface
 
 `spawnSandbox` is the composition of the five state-aware phases run end-to-end. The two
-surfaces share `SandboxPolicy` and `SandboxingMethod`; they differ in granularity. A
+surfaces share `SandboxPolicy` and `ContainmentBackend`; they differ in granularity. A
 backend that participates in both modes can be invoked through either surface; a backend
 that participates in only one returns `unsupported_phase` from the other (§8).
 
-State-aware-capable backends extend `SandboxingMethod` and `StateAwareSandboxingMethod`
-the same way ephemeral backends extend `SandboxingMethod`. Cancellation via
+State-aware-capable backends extend `ContainmentBackend` and `StateAwareSandboxingMethod`
+the same way ephemeral backends extend `ContainmentBackend`. Cancellation via
 `AbortSignal` is supported on all state-aware methods. Detached / fire-and-forget exec
 (process outliving the SDK call) is deferred to v2 (§14).
 
@@ -529,7 +529,7 @@ single call — `phase` fully discriminates which interpretation applies.
 interface OneShotRequest {
   phase?: never;                                  // discriminator: absent
   version?: string;
-  containment: SandboxingMethod;
+  containment: ContainmentType | ContainmentBackend;
   containerId?: string;
   process: ProcessConfig;
   filesystem?: FilesystemConfig;
@@ -582,7 +582,7 @@ Backend-routing fields:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `containment` | `SandboxingMethod` member | One-shot: yes. State-aware: yes for `provision`, absent for `start` / `exec` / `stop` / `deprovision`. | Backend selection on calls that do not yet have a `sandboxId`. |
+| `containment` | `ContainmentType` or `ContainmentBackend` member | One-shot: yes. State-aware: yes for `provision`, absent for `start` / `exec` / `stop` / `deprovision`. | Backend selection on calls that do not yet have a `sandboxId`. |
 | `sandboxId` | branded string | State-aware non-provision: yes. Otherwise absent. | Opaque sandbox id returned by `provision`. Carries the backend prefix used to route non-provision calls (§5). |
 
 State-aware-only fields:
@@ -1532,7 +1532,7 @@ interface MyBackendStateAwareConfigs {
 }
 ```
 
-If the backend was not previously SDK-exposed, also extend `SandboxingMethod` and add
+If the backend was not previously SDK-exposed, also extend `ContainmentBackend` and add
 an entry to `StateAwareSandboxingMethod`.
 
 ### 11.4 Register in the `ContainmentBackend` enum

--- a/schemas/dev/mxc-config.schema.0.5.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.5.0-dev.json
@@ -19,9 +19,9 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["appcontainer", "windows_sandbox", "lxc", "microvm", "wslc"],
+      "enum": ["process", "appcontainer", "windows_sandbox", "lxc", "microvm", "wslc"],
       "default": "appcontainer",
-      "description": "Containment backend to use for execution. Note: 'windows_sandbox' and 'wslc' are experimental and require the --experimental CLI flag."
+      "description": "Containment value to use for execution. Accepts both abstract intents ('process') and concrete backends ('appcontainer', 'windows_sandbox', 'lxc', 'microvm', 'wslc'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities. Note: 'windows_sandbox' and 'wslc' are experimental and require the --experimental CLI flag."
     },
 
     "lifecycle": {

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -104,6 +104,22 @@ ptyProcess.onExit((event: { exitCode: number }) => {
 
 ### Platform Detection
 
+#### Containment values: intent vs. backend
+
+The SDK distinguishes two layers of containment values:
+
+- **`ContainmentType`** — abstract intent (what *kind* of isolation you want).
+  Currently `"process"` and `"microvm"`. The native binary resolves these
+  to a concrete backend per host. Prefer these in policy code so the
+  same policy works across hosts with different capabilities.
+- **`ContainmentBackend`** — concrete backend (a specific runner). Currently
+  `"appcontainer"`, `"windows_sandbox"`, `"wslc"`, `"lxc"`, `"microvm"`. Use
+  these to force a particular backend.
+
+`ContainerConfig.containment` accepts either layer. The deprecated
+`SandboxingMethod` alias is the union of both and is retained for backward
+compatibility.
+
 #### `getPlatformSupport(): PlatformSupport`
 
 Returns platform support information including whether MXC is supported.
@@ -126,7 +142,7 @@ if (support.reason) {
 interface PlatformSupport {
   isSupported: boolean;
   reason?: string;
-  availableMethods: SandboxingMethod[];
+  availableMethods: ContainmentBackend[];
 }
 ```
 
@@ -439,7 +455,9 @@ The package includes full TypeScript definitions. All public types are exported 
 import {
   // Types
   SandboxPolicy,
-  SandboxingMethod,
+  ContainmentType,
+  ContainmentBackend,
+  SandboxingMethod, // deprecated alias for ContainmentType | ContainmentBackend
   PlatformSupport,
 
   // Platform detection

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger';
-import { ContainerConfig, ContainmentType, ExperimentalBackends, SandboxingMethod } from './types';
+import { ContainerConfig, ContainmentBackend, ExperimentalBackends } from './types';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform';
 import { SandboxSpawnOptions } from './sandbox';
 
@@ -50,7 +50,7 @@ export function resolveExecutableAndArgs(
 
   // Check experimental mode before anything else so the caller gets a clear
   // message about the missing flag rather than a platform/binary error.
-  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
+  if (config.containment && ExperimentalBackends.includes(config.containment) && !options.experimental) {
     throw new Error(
       `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
     );
@@ -67,7 +67,7 @@ export function resolveExecutableAndArgs(
       throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
     }
     if (!(ExperimentalBackends as readonly string[]).includes(config.containment) &&
-        !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
+        !platformSupport.availableMethods.includes(config.containment as ContainmentBackend)) {
       throw new Error(
         `Containment backend '${config.containment}' is not available on this platform. ` +
         `Available methods: ${platformSupport.availableMethods.join(', ')}`

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -30,6 +30,7 @@ export {
   SandboxPolicy,
   SandboxingMethod,
   ContainmentType,
+  ContainmentBackend,
   ExperimentalBackends,
   ContainerConfig,
   PlatformSupport,

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, ContainerConfig, ContainmentType } from './types';
+import { SandboxPolicy, ContainerConfig, ContainmentType, ContainmentBackend } from './types';
 import { prepareSpawn } from './helper';
 
 const SUPPORTED_VERSION = '0.5.0-alpha';
@@ -91,7 +91,6 @@ function buildLinuxProcessConfig(
     config: ContainerConfig,
     containerId: string,
 ): ContainerConfig {
-    config.containment = 'lxc';
     config.lxc = {
         containerName: containerId,
         distribution: 'alpine',
@@ -203,7 +202,7 @@ function buildMicroVmConfig(
  */
 export function createConfigFromPolicy(
     policy: SandboxPolicy,
-    containment: ContainmentType = "process",
+    containment: ContainmentType | ContainmentBackend = "process",
     containerName?: string,
 ): ContainerConfig {
     validatePolicyVersion(policy.version);
@@ -276,6 +275,7 @@ export function createConfigFromPolicy(
     }
 
     if (containment === 'process') {
+        config.containment = 'process';
         if (platform === 'linux') {
             return buildLinuxProcessConfig(config, containerId);
         }
@@ -299,7 +299,7 @@ export function buildSandboxPayload(
     policy: SandboxPolicy,
     workingDirectory?: string,
     containerName?: string,
-    containment: ContainmentType = "process",
+    containment: ContainmentType | ContainmentBackend = "process",
 ): ContainerConfig {
     const config = createConfigFromPolicy(policy, containment, containerName);
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -32,17 +32,41 @@ export interface LifecycleConfig {
 }
 
 /**
- * Containment type abstraction for createConfigFromPolicy.
- * Maps to platform-specific backends:
- * - "process": BaseProcessContainer (Windows) / LXC (Linux)
- * - "microvm": MicroVM/Nanvix backend (Windows only, experimental)
+ * Abstract containment intent. Names the *kind* of isolation the caller
+ * wants. The native binary (or the SDK as a fallback) resolves this to a
+ * concrete {@link ContainmentBackend} at run time based on what the host
+ * supports.
+ *
+ * Today's intents:
+ * - "process": OS-native process-level isolation. Resolves to AppContainer
+ *   (Windows) or LXC (Linux).
+ * - "microvm": lightweight-VM isolation. Resolves to the current MicroVM
+ *   runner (Windows only, experimental); intended to expand as additional
+ *   microvm backends (e.g. NanVix) are added.
+ *
+ * Concrete-only backends (such as `"wslc"`) live on
+ * {@link ContainmentBackend} until there is a meaningful abstraction over
+ * multiple implementations of the same kind.
  */
-export type ContainmentType = "process" | "wslc" | "microvm";
+export type ContainmentType = "process" | "microvm";
 
 /**
- * Containment backends that require the --experimental flag.
+ * Concrete containment backend. Each value names a specific runner
+ * implementation in the native binary. Prefer a {@link ContainmentType}
+ * value unless you specifically need to force a particular backend.
  */
-export const ExperimentalBackends: readonly ContainmentType[] = ['microvm', 'wslc'];
+export type ContainmentBackend =
+  | 'appcontainer'
+  | 'windows_sandbox'
+  | 'wslc'
+  | 'lxc'
+  | 'microvm';
+
+/**
+ * Containment values (abstract intent or concrete backend) that require
+ * the `--experimental` flag.
+ */
+export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'wslc'];
 
 /**
  * Clipboard access policy levels
@@ -171,8 +195,8 @@ export interface ContainerConfig {
   version: string;
   /** Externally assigned container identifier */
   containerId?: string;
-  /** Containment backend */
-  containment?: 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
+  /** Containment intent (preferred) or concrete backend (override). */
+  containment?: ContainmentType | ContainmentBackend;
   /** Container lifecycle settings */
   lifecycle?: LifecycleConfig;
   /** Process execution settings (required) */
@@ -259,9 +283,13 @@ export interface LxcConfig {
 }
 
 /**
- * Sandboxing methods available on the platform
+ * Sandboxing methods available on the platform.
+ *
+ * @deprecated Prefer {@link ContainmentBackend} (concrete) or
+ * {@link ContainmentType} (abstract). This alias is retained for
+ * backward compatibility and may be removed in a future minor release.
  */
-export type SandboxingMethod = 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm';
+export type SandboxingMethod = ContainmentType | ContainmentBackend;
 
 /**
  * Platform support information
@@ -272,5 +300,5 @@ export interface PlatformSupport {
   /** Reason why the platform is not supported (if applicable) */
   reason?: string;
   /** Available sandboxing methods on this platform */
-  availableMethods: SandboxingMethod[];
+  availableMethods: ContainmentBackend[];
 }

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -206,11 +206,11 @@ describe('buildSandboxPayload', () => {
       }
     };
 
-    it('should default to lxc on Linux', () => {
+    it('should default to process containment on Linux (resolved by binary to lxc)', () => {
       mockLinux();
       try {
         const payload = buildSandboxPayload('echo hi', defaultPolicy);
-        assert.strictEqual(payload.containment, 'lxc');
+        assert.strictEqual(payload.containment, 'process');
         assert.strictEqual(payload.lxc!.destroyOnExit, true);
       } finally {
         restore();
@@ -517,11 +517,11 @@ describe('createConfigFromPolicy', () => {
       }
     };
 
-    it('should default to lxc containment', () => {
+    it('should default to process containment (resolved by binary to lxc on Linux)', () => {
       mockLinux();
       try {
         const config = createConfigFromPolicy(defaultPolicy);
-        assert.strictEqual(config.containment, 'lxc');
+        assert.strictEqual(config.containment, 'process');
         assert.strictEqual(config.lxc!.distribution, 'alpine');
         assert.strictEqual(config.lxc!.destroyOnExit, true);
       } finally {

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -559,6 +559,21 @@ fn convert_raw_config_inner(
     // Containment backend selection
     let containment = match raw.containment.as_deref() {
         None | Some("appcontainer") => ContainmentBackend::AppContainer,
+        Some("process") => {
+            // Abstract intent: the caller wants process-level containment but
+            // does not care which concrete backend implements it. Today this
+            // resolves trivially per OS (AppContainer on Windows, LXC on
+            // Linux). The lxc-exec binary additionally overrides this to LXC
+            // unconditionally on Linux.
+            #[cfg(target_os = "linux")]
+            {
+                ContainmentBackend::Lxc
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                ContainmentBackend::AppContainer
+            }
+        }
         Some("windows_sandbox") => ContainmentBackend::WindowsSandbox,
         Some("wslc") => ContainmentBackend::Wslc,
         Some("lxc") => ContainmentBackend::Lxc,
@@ -567,7 +582,7 @@ fn convert_raw_config_inner(
         Some("isolation_session") => ContainmentBackend::IsolationSession,
         Some(other) => {
             let msg = format!(
-                "Invalid containment value '{}' (must be 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', or 'microvm')",
+                "Invalid containment value '{}' (must be 'process', 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', or 'microvm')",
                 other
             );
             logger.log_line(&msg);
@@ -871,6 +886,16 @@ fn convert_raw_state_aware(
 fn parse_containment_str(s: &str, logger: &mut Logger) -> Result<ContainmentBackend, WxcError> {
     match s {
         "appcontainer" => Ok(ContainmentBackend::AppContainer),
+        "process" => {
+            #[cfg(target_os = "linux")]
+            {
+                Ok(ContainmentBackend::Lxc)
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                Ok(ContainmentBackend::AppContainer)
+            }
+        }
         "windows_sandbox" => Ok(ContainmentBackend::WindowsSandbox),
         "wslc" => Ok(ContainmentBackend::Wslc),
         "lxc" => Ok(ContainmentBackend::Lxc),
@@ -879,7 +904,7 @@ fn parse_containment_str(s: &str, logger: &mut Logger) -> Result<ContainmentBack
         "isolation_session" => Ok(ContainmentBackend::IsolationSession),
         other => {
             let msg = format!(
-                "Invalid containment value '{}' (must be 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', or 'microvm')",
+                "Invalid containment value '{}' (must be 'process', 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', or 'microvm')",
                 other
             );
             logger.log_line(&msg);
@@ -1411,6 +1436,22 @@ mod tests {
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.containment, ContainmentBackend::AppContainer);
+    }
+
+    #[test]
+    fn process_containment_resolves_per_target() {
+        // Abstract intent "process" resolves to the per-OS default backend:
+        // AppContainer on Windows, LXC on Linux.
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "process"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+
+        #[cfg(target_os = "linux")]
+        assert_eq!(req.containment, ContainmentBackend::Lxc);
+        #[cfg(not(target_os = "linux"))]
         assert_eq!(req.containment, ContainmentBackend::AppContainer);
     }
 

--- a/test_configs/containment_process_intent.json
+++ b/test_configs/containment_process_intent.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.5.0-dev",
+  "containerId": "CLI-ProcessIntent-Test",
+  "containment": "process",
+  "process": {
+    "commandLine": "python -c \"import sys; print(f'Hello from Python {sys.version}'); print('Process intent test successful')\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\Users\\AdminUser\\AppData\\Local\\Programs"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}


### PR DESCRIPTION
Introduce two type aliases in the SDK: ContainmentType for abstract intents (process, microvm) and ContainmentBackend for concrete runners (appcontainer, windows_sandbox, lxc, wslc, microvm, isolation_session). The wire field accepts either, and the binary owns intent resolution. The deprecated SandboxingMethod alias is kept as their union for back-compat.

Also drop "vm" from ContainmentBackend (never in any schema), narrow ContainmentType to just process and microvm, expand the dev schema's containment enum to include "process", and update the state-aware design docs to use ContainmentBackend as the extension point.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/267)