### PR TITLE
Split SDK containment into intent vs. backend, and rename to match

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,7 +131,7 @@ Execute your script with AppContainer in permissive learning mode:
 ```json
 {
   "script": "your_code_here",
-  "appContainer": {
+  "processContainer": {
     "capabilities": ["permissiveLearningMode"]
   }
 }

--- a/docs/UIPolicy_Schema.md
+++ b/docs/UIPolicy_Schema.md
@@ -39,12 +39,12 @@ This makes version a compatibility contract: a config that says `"version": 1` w
 
 ## Config Structure
 
-The `"ui"` section is a sibling of `"appContainer"`, `"filesystem"`, `"network"`, and `"windows_sandbox"` in the WXC config. All fields shown explicitly for illustration — in practice, omitted fields default to their most restrictive value:
+The `"ui"` section is a sibling of `"processContainer"`, `"filesystem"`, `"network"`, and `"windows_sandbox"` in the WXC config. All fields shown explicitly for illustration — in practice, omitted fields default to their most restrictive value:
 
 ```json
 {
   "script": "myapp.exe",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "ui": {
     "disable": false,
     "clipboard": "none",
@@ -57,7 +57,7 @@ The `"ui"` section is a sibling of `"appContainer"`, `"filesystem"`, `"network"`
 }
 ```
 
-> **Note:** The `"ui"` section is only meaningful when `"containment"` is `"appcontainer"`. When `"containment"` is `"windows_sandbox"`, the sandbox VM provides its own isolation — the `"ui"` section is ignored and a warning is emitted.
+> **Note:** The `"ui"` section is only meaningful when `"containment"` is `"processcontainer"`. When `"containment"` is `"windows_sandbox"`, the sandbox VM provides its own isolation — the `"ui"` section is ignored and a warning is emitted.
 
 ---
 

--- a/docs/authoring-a-new-feature.md
+++ b/docs/authoring-a-new-feature.md
@@ -315,7 +315,7 @@ Create a test config that exercises your feature:
 ```json
 {
   "version": "0.5.0-alpha",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo gpu isolation test"
   },

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,7 +6,7 @@ For a more comprehensive list of examples, look in the examples\ directory.
 ```json
 {
   "script": "python -c \"import sys; print('Hello from WXC!'); print(f'Python version: {sys.version}');\"",
-  "appContainer": {
+  "processContainer": {
     "name": "CLI-HelloWorld"
   }
 }
@@ -16,7 +16,7 @@ For a more comprehensive list of examples, look in the examples\ directory.
 ```json
 {
   "script": "python -c \"open('C:\\\\temp\\\\output.txt', 'w').write('test')\"",
-  "appContainer": {
+  "processContainer": {
     "name": "CLI-Filesystem-Test"
   },
   "filesystem": {
@@ -45,8 +45,8 @@ For a more comprehensive list of examples, look in the examples\ directory.
 
 ### Network Proxy
 
-Route AppContainer traffic through a localhost proxy. Supported with the
-`appcontainer` containment backend only. Two mutually exclusive modes are available:
+Route process-container traffic through a localhost proxy. Supported with the
+`processcontainer` containment backend only. Two mutually exclusive modes are available:
 
 **External proxy** — connect to an already-running localhost proxy:
 
@@ -54,7 +54,7 @@ Route AppContainer traffic through a localhost proxy. Supported with the
 {
   "script": "python -c \"import urllib.request; print(urllib.request.urlopen('https://api.github.com').status)\"",
   "timeout": 30000,
-  "appContainer": {
+  "processContainer": {
     "name": "CLI-Proxy",
     "capabilities": ["internetClient"]
   },
@@ -71,7 +71,7 @@ an OS-assigned port (for integration testing only, not production):
 {
   "script": "python -c \"import urllib.request; print(urllib.request.urlopen('https://api.github.com').status)\"",
   "timeout": 30000,
-  "appContainer": {
+  "processContainer": {
     "name": "CLI-BuiltinProxy",
     "capabilities": ["internetClient"]
   },

--- a/docs/nanvix-integration-plan.md
+++ b/docs/nanvix-integration-plan.md
@@ -80,7 +80,7 @@ Inside the NanVix VM:
 3. **Pre-built artifacts, not built from source** — NanVix binaries (`nanvixd.exe`, `kernel.elf`, `python.elf`, `cpython-ramfs.img`) are downloaded from GitHub pre-releases. MXC does not compile or build NanVix components.
 
 
-4. **Unsupported policies are rejected** — If a config specifies `filesystem`, `network`, or `appContainer` policies with `containment: "nanvix"`, the runner returns a clear error.
+4. **Unsupported policies are rejected** — If a config specifies `filesystem`, `network`, or `processContainer` policies with `containment: "nanvix"`, the runner returns a clear error.
 
 5. **Host-side I/O risk mitigated by IKC framing** — `nanvixd.exe` parses guest I/O via IKC (Inter-Kernel Communication) messages using fixed-size frames with bounds checking. A crafted guest could attempt malformed messages. Mitigation: formal fuzzing (future work).
 
@@ -185,12 +185,12 @@ All variants are surfaced via stderr output. Preflight and Platform errors preve
 | `timeout` | `script_timeout: u32` | ✅ **Used** — script execution timeout in ms |
 | `containment` | `containment: ContainmentBackend` | ✅ **Used** — must be `"nanvix"` |
 | `workingDirectory` | `working_directory: String` | ❌ **Rejected** — guest has its own filesystem namespace |
-| `appContainer.*` | `policy: ContainerPolicy` | ❌ **Rejected** — not applicable to NanVix |
+| `processContainer.*` | `policy: ContainerPolicy` | ❌ **Rejected** — not applicable to NanVix |
 | `filesystem.*` | (part of `policy`) | ❌ **Rejected** — guest FS is a read-only ramfs |
 | `network.*` | (part of `policy`) | ❌ **Rejected** — no network stack in guest |
 | `sandbox.*` | `sandbox_config: WindowsSandboxConfig` | ❌ **Rejected** — NanVix is not Windows Sandbox |
 
-**Policy validation**: If a config specifies `containment: "nanvix"` alongside `filesystem`, `network`, `appContainer`, or `workingDirectory` fields, the runner returns a error.
+**Policy validation**: If a config specifies `containment: "nanvix"` alongside `filesystem`, `network`, `processContainer`, or `workingDirectory` fields, the runner returns a error.
 
 ## Binary Distribution & Versioning
 

--- a/docs/sandbox-policy/v1/policy.md
+++ b/docs/sandbox-policy/v1/policy.md
@@ -110,7 +110,7 @@ spawnSandbox(script, policy);
 
 // Advanced: choose containment, get config, modify, then spawn.
 const config = createConfigFromPolicy(policy, "process");
-config.appContainer!.ui!.isolation = "atoms";  // backend-specific tweak
+config.processContainer!.ui!.isolation = "atoms";  // backend-specific tweak
 spawnSandboxFromConfig(config);
 ```
 
@@ -255,8 +255,8 @@ specific backend. Users receive it, may modify backend-specific fields, then pas
 `spawnSandboxFromConfig()`.
 Key rules:
 
-- **One backend per Config.** A Windows process config has an `appcontainer` section; no `lxc`
-  section. A Linux process config has an `lxc` section; no `appcontainer`.
+- **One backend per Config.** A Windows process config has an `processcontainer` section; no `lxc`
+  section. A Linux process config has an `lxc` section; no `processcontainer`.
 - **User-modifiable.** Advanced users can set any Config field before spawning.
 - **Schema-defined.** Schemas live in `schemas/`. The SDK TypeScript types mirror them.
 
@@ -298,7 +298,7 @@ type ContainerConfig =
     "blockedHosts": [],
     "proxy": null
   },
-  "appcontainer": {
+  "processcontainer": {
     "leastPrivilege": true,
     "capabilities": [],
     "ui": {
@@ -317,7 +317,7 @@ type ContainerConfig =
 ```
 
 Backend-specific UI fields (`isolation`, `desktopSystemControl`, `systemSettings`, `ime`)
-live inside `appcontainer.ui`, not at the top level. Top-level `ui` contains only the
+live inside `processcontainer.ui`, not at the top level. Top-level `ui` contains only the
 cross-platform fields mapped from Policy.
 
 ### Example: LxcContainerConfig
@@ -352,7 +352,7 @@ cross-platform fields mapped from Policy.
 }
 ```
 
-No `appcontainer` section. No `ui` section. Backend-specific fields are scoped to the backend
+No `processcontainer` section. No `ui` section. Backend-specific fields are scoped to the backend
 that uses them.
 
 ---
@@ -424,7 +424,7 @@ spawnSandbox("myapp.exe --flag1 arg", policy);
 
 ```typescript
 const config = createConfigFromPolicy(policy, "process");
-config.appContainer!.ui!.isolation = "atoms";
+config.processContainer!.ui!.isolation = "atoms";
 spawnSandboxFromConfig(config);
 ```
 
@@ -463,7 +463,7 @@ Top-level `ui` (maps from policy, all backends):
 Process container-specific UI fields (in this case Windows):
 
 ```json
-"appcontainer": {
+"processcontainer": {
   "ui": {
     "isolation": "full",
     "desktopSystemControl": false,
@@ -486,10 +486,10 @@ ui: {
 };
 ```
 
-Process container-specific UI (inside `appcontainer`):
+Process container-specific UI (inside `processcontainer`):
 
 ```typescript
-// Add to ProcessContainerConfig.appcontainer:
+// Add to ProcessContainerConfig.processcontainer:
 ui: {
   isolation: "desktop" | "handles" | "atoms" | "full";
   desktopSystemControl: boolean;
@@ -513,7 +513,7 @@ config.ui = {
 
 // Process container-specific ui (Windows only):
 if (platform === 'win32' && config.containment === 'process') {
-  config.appcontainer.ui = {
+  config.processcontainer.ui = {
     isolation: 'full',
     desktopSystemControl: false,
     systemSettings: 'none',
@@ -548,7 +548,7 @@ Backend-specific mechanisms belong in ContainerConfig.
 
 ### "What if my feature is Windows-only?"
 
-Put it in ContainerConfig under the appropriate backend section (e.g., `appcontainer` or `ui`
+Put it in ContainerConfig under the appropriate backend section (e.g., `processcontainer` or `ui`
 inside ProcessContainerConfig). Policy stays cross-platform.
 
 ### "Can a developer bypass the SDK defaults?"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -25,7 +25,7 @@ production configs and the dev schema when working on experimental features:
 {
     "version": "0.4.0-alpha",              // Schema version (semver). Current stable: "0.4.0-alpha". Also accepts "0.5.0-alpha".
     "containerId": "my-container",         // Externally assigned container ID
-    "containment": "appcontainer",         // Backend (see table below)
+    "containment": "processcontainer",     // Backend (see table below)
 
     "lifecycle": {
         "destroyOnExit": true,             // Destroy container after execution
@@ -48,10 +48,10 @@ production configs and the dev schema when working on experimental features:
     "network": {
         "defaultPolicy": "block",          // "allow" or "block"
         "enforcementMode": "firewall",     // "capabilities", "firewall", or "both"
-        "proxy": { "localhost": 8080 }     // Localhost proxy port (appcontainer only)
+        "proxy": { "localhost": 8080 }     // Localhost proxy port (processcontainer only)
     },
 
-    "appContainer": {                      // Process-based container-specific
+    "processContainer": {                  // Process-based container-specific
         "leastPrivilege": false,
         "capabilities": ["internetClient"]
     },
@@ -76,14 +76,29 @@ production configs and the dev schema when working on experimental features:
 
 ### Containment Backends
 
+The `containment` field accepts both **abstract intent values** (which the
+native binary resolves per host) and **concrete backend values** (which select
+a specific runner). Prefer abstract intents unless you specifically need to
+force a particular backend.
+
+#### Abstract intents
+
+| Value | Resolution |
+|-------|------------|
+| `"process"` | `processcontainer` on Windows, `lxc` on Linux, `seatbelt` on macOS |
+| `"vm"` | Full hardware-virtualised VM isolation. Resolves to `windows_sandbox` on Windows. |
+| `"microvm"` | MicroVM on Windows (NanVix via the Windows Hypervisor Platform). Experimental. |
+
+#### Concrete backends
+
 | Value | Description |
 |-------|-------------|
-| `"appcontainer"` | (Default) Windows AppContainer process-level isolation |
+| `"processcontainer"` | (Default) Windows process-level isolation. Resolves to AppContainer (legacy) or BaseContainer (newer OS sandbox API) at run time depending on host capabilities and the `--experimental` flag. |
 | `"windows_sandbox"` | Windows Sandbox VM isolation via a long-lived daemon |
 | `"wslc"` | Linux containers via the WSL Container SDK |
 | `"lxc"` | Native LXC container isolation |
-| `"vm"` | VM-based isolation (not yet implemented) |
 | `"microvm"` | MicroVM isolation via Windows HyperV Platform (NanVix microkernel) |
+| `"seatbelt"` | macOS sandbox isolation (Seatbelt; experimental) |
 
 Only the backend section matching the selected `containment` value is used;
 other backend sections are ignored.
@@ -137,6 +152,6 @@ changes require a major bump.
 | Version | Changes |
 |---|---|
 | 0.3.0-alpha | Initial versioned schema. Added `process`, `lifecycle`, `containerId`, `wslc` alias. Dual-read fallbacks for legacy fields. |
-| 0.4.0-alpha | Removed legacy fields (`script`, `workingDirectory`, `appContainer.name`, etc.). `process` section now required. |
+| 0.4.0-alpha | Removed legacy fields (`script`, `workingDirectory`, `processContainer.name`, etc.). `process` section now required. |
 
 See the `examples/` directory for complete configuration examples.

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -20,7 +20,7 @@ function signatures throughout. One-line summaries; full definitions live in
 
 | Type | Where | Role |
 |---|---|---|
-| `SandboxingMethod` | `sdk/src/types.ts` | String union of MXC backend names (`'appcontainer' \| 'windows_sandbox' \| 'lxc' \| 'wslc' \| 'vm' \| 'microvm' \| 'isolation_session'`). |
+| `ContainmentType` / `ContainmentBackend` | `sdk/src/types.ts` | Two-tier containment names: `ContainmentType` for abstract intents (`'process' \| 'vm' \| 'microvm'` today); `ContainmentBackend` for concrete runners (`'processcontainer' \| 'windows_sandbox' \| 'lxc' \| 'wslc' \| 'microvm' \| 'seatbelt' \| 'isolation_session'`). Wire `containment` accepts either. The deprecated alias `SandboxingMethod = ContainmentType \| ContainmentBackend` is retained for back-compat. |
 | `ProcessConfig` | `sdk/src/types.ts` | Per-process settings: `commandLine`, `cwd`, `env`, `timeout`. Reused inside state-aware exec Configs. |
 | `FilesystemConfig`, `NetworkConfig`, `UiConfig` | `sdk/src/types.ts` | Wire-format-aligned cross-cutting interfaces. Reused inline as field types inside the per-(backend, phase) state-aware Configs. |
 | `SandboxSpawnOptions` | `sdk/src/sandbox.ts` | Existing options bag (debug, dryRun, logDir, executablePath, ptyOptions, usePty, experimental). State-aware reuses it as the third positional arg, extended with `signal?: AbortSignal` for cancellation. |
@@ -40,7 +40,7 @@ on the response, and neither shape carries `containerId`.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `SandboxingMethod` extension reused. The wire-format-aligned `Process` / `Filesystem` / `Network` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). `*Config` naming convention reused. |
+| TypeScript SDK (reference §6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `ContainmentBackend` extension reused. The wire-format-aligned `Process` / `Filesystem` / `Network` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). `*Config` naming convention reused. |
 | JSON wire format (reference §7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (reference §9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private `Raw*` parser pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends unchanged. |
 | Error model (reference §8) | Closed enum of 12 codes. `MxcError` class with `code: ErrorCode`. `details` open object. | Existing one-shot error paths preserved. |
@@ -71,7 +71,7 @@ definitions and worked types are in
 type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
 type SandboxId<C extends StateAwareSandboxingMethod> =
   string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
-type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
+type StateAwareSandboxingMethod = Extract<ContainmentBackend, 'isolation_session'>;
 // extended as state-aware-capable backends are added
 
 interface ExecResult {
@@ -149,7 +149,7 @@ information.
 ```typescript
 interface OneShotRequest {
   phase?: never;
-  containment: SandboxingMethod;
+  containment: ContainmentType | ContainmentBackend;
   process: ProcessConfig;
   filesystem?: FilesystemConfig;
   network?: NetworkConfig;
@@ -400,7 +400,7 @@ Reference §11 has the full guide. Operational checklist:
    use `()` for any phase that doesn't need them.
 3. Define typed per-(backend, phase) `*Config` interfaces in `@microsoft/mxc-sdk` and
    add an arm to `ConfigsForBackend<C>` mapping the backend to its five phase Configs.
-   If newly SDK-exposed, extend `SandboxingMethod` and `StateAwareSandboxingMethod`.
+   If newly SDK-exposed, extend `ContainmentBackend` and `StateAwareSandboxingMethod`.
 4. Register a variant in the `ContainmentBackend` enum and declare two consts on the
    trait impl: `ID_PREFIX` (the sandbox-id tag, dispatcher's routing key for
    non-provision calls — pick a short distinct tag and treat it as permanent) and

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -63,7 +63,7 @@ elaborates.
 
 | MXC layer | What's new | What's unchanged |
 |---|---|---|
-| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `SandboxingMethod` extension mechanism reused. The existing wire-format-aligned `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside the new state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). Existing typed `*Config` naming convention reused. |
+| TypeScript SDK (§6) | Five new functions: `provisionSandbox`, `startSandbox`, `execInSandbox` / `execInSandboxAsync`, `stopSandbox`, `deprovisionSandbox`. Branded `SandboxId<C>` type tagging ids by backend (`containment` named once at provision, inferred from the id thereafter). Per-(backend, phase) typed `*Config` interfaces (e.g. `IsolationSessionProvisionConfig`) that absorb cross-cutting fields directly — no separate policy parameter. Per-phase typed `*Result` types per backend. `AbortSignal` cancellation via the existing `SandboxSpawnOptions`. Typed `MxcError` class carrying a closed-enum `code`. | `spawnSandbox` family preserved. `ContainmentBackend` extension mechanism reused. The existing wire-format-aligned `ProcessConfig` / `FilesystemConfig` / `NetworkConfig` / `UiConfig` interfaces from `sdk/src/types.ts` are reused as field types inside the new state-aware Configs. `SandboxSpawnOptions` reused as the third-arg options bag (gains `signal?: AbortSignal`). Existing typed `*Config` naming convention reused. |
 | JSON wire format (§7) | Top-level `phase` discriminator. Top-level `sandboxId`. `containment` carried on provision only; non-provision phases route via the `sandboxId` prefix. Per-phase nesting under `experimental.<backend>.<phase>`. Named envelope types as a TypeScript discriminated union over `phase`. | One-shot configs (no `phase`) work unchanged. Cross-cutting `filesystem` / `network` / `ui` fields at top level for state-aware too — backends declare per-phase honor. |
 | Rust executor (§9) | Dispatch arm for state-aware. New `StatefulSandboxBackend` trait. Rust mirror of the wire envelope (private to parser, matching `RawConfig` pattern). | `ScriptRunner` trait. Existing one-shot dispatch path. Existing backends function without modification. |
 | Error model (§8) | Closed enum of 12 error codes. `MxcError` class with `code: ErrorCode`. `details` open object as escape hatch for backend-specific structured information. | Existing one-shot error paths preserved. |
@@ -248,7 +248,7 @@ type SandboxId<C extends StateAwareSandboxingMethod> =
 
 type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
 
-type StateAwareSandboxingMethod = Extract<SandboxingMethod, 'isolation_session'>;
+type StateAwareSandboxingMethod = Extract<ContainmentBackend, 'isolation_session'>;
 // extended as state-aware-capable backends are added
 
 // Per-(backend, phase) Configs. Each declares only the fields valid for that backend
@@ -503,7 +503,7 @@ await deprovisionSandbox(sandboxId, {}, opts);
 ### 6.4 Composition with the one-shot surface
 
 `spawnSandbox` is the composition of the five state-aware phases run end-to-end. The two
-surfaces share `SandboxingMethod` and the wire-format-aligned interfaces in
+surfaces share `ContainmentBackend` and the wire-format-aligned interfaces in
 `sdk/src/types.ts` (`ProcessConfig`, `FilesystemConfig`, `NetworkConfig`, `UiConfig`).
 They differ in granularity and in how those interfaces are surfaced: one-shot bundles
 them inside `ContainerConfig` (which is itself produced from a `SandboxPolicy` by
@@ -512,8 +512,8 @@ per-(backend, phase) Configs and does not involve `SandboxPolicy` at all. A back
 that participates in both modes can be invoked through either surface; a backend that
 participates in only one returns `unsupported_phase` from the other (§8).
 
-State-aware-capable backends extend `SandboxingMethod` and `StateAwareSandboxingMethod`
-the same way ephemeral backends extend `SandboxingMethod`. Cancellation via
+State-aware-capable backends extend `ContainmentBackend` and `StateAwareSandboxingMethod`
+the same way ephemeral backends extend `ContainmentBackend`. Cancellation via
 `AbortSignal` is supported on all state-aware methods (via `signal?: AbortSignal` on
 `SandboxSpawnOptions`). Detached / fire-and-forget exec (process outliving the SDK
 call) is deferred to v2 (§14).
@@ -546,14 +546,14 @@ single call — `phase` fully discriminates which interpretation applies.
 interface OneShotRequest {
   phase?: never;                                  // discriminator: absent
   version?: string;
-  containment: SandboxingMethod;
+  containment: ContainmentType | ContainmentBackend;
   containerId?: string;
   process: ProcessConfig;
   filesystem?: FilesystemConfig;
   network?: NetworkConfig;
   ui?: UiConfig;
   lifecycle?: LifecycleConfig;
-  appContainer?: AppContainerConfig;
+  processContainer?: ProcessContainerConfig;
   lxc?: LxcConfig;
   experimental?: ExperimentalOneShotConfigs;     // existing one-shot shape per docs/config-schema.md
 }
@@ -599,7 +599,7 @@ Backend-routing fields:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `containment` | `SandboxingMethod` member | One-shot: yes. State-aware: yes for `provision`, absent for `start` / `exec` / `stop` / `deprovision`. | Backend selection on calls that do not yet have a `sandboxId`. |
+| `containment` | `ContainmentType` or `ContainmentBackend` member | One-shot: yes. State-aware: yes for `provision`, absent for `start` / `exec` / `stop` / `deprovision`. | Backend selection on calls that do not yet have a `sandboxId`. |
 | `sandboxId` | branded string | State-aware non-provision: yes. Otherwise absent. | Opaque sandbox id returned by `provision`. Carries the backend prefix used to route non-provision calls (§5). |
 
 State-aware-only fields:
@@ -618,7 +618,7 @@ declare which phases honor them, see §10.3):
 | `network` | `NetworkConfig` | Network access policy. |
 | `ui` | `UiConfig` | UI access policy. |
 
-One-shot-only fields (`containerId`, `lifecycle`, `appContainer`, `lxc`) are not
+One-shot-only fields (`containerId`, `lifecycle`, `processContainer`, `lxc`) are not
 enumerated here; their definitions live in `docs/config-schema.md`.
 
 ### 7.2 The `experimental` block
@@ -1587,7 +1587,7 @@ interface MyBackendStartConfig {
 // ... and similarly for exec, stop, deprovision
 ```
 
-Add an arm to `ConfigsForBackend<C>` mapping the new backend's `SandboxingMethod`
+Add an arm to `ConfigsForBackend<C>` mapping the new backend's `ContainmentBackend`
 member to its five phase Configs:
 
 ```typescript
@@ -1602,7 +1602,7 @@ type ConfigsForBackend<C extends StateAwareSandboxingMethod> =
   } : never;
 ```
 
-If the backend was not previously SDK-exposed, also extend `SandboxingMethod` and add
+If the backend was not previously SDK-exposed, also extend `ContainmentBackend` and add
 an entry to `StateAwareSandboxingMethod`.
 
 ### 11.4 Register in the `ContainmentBackend` enum

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -69,7 +69,7 @@ experimental features:
   "process": { ... },
   "filesystem": { ... },
   "network": { ... },
-  "appContainer": { ... },
+  "processContainer": { ... },
   "lxc": { ... },
 
   "experimental": {

--- a/docs/windows-sandbox.md
+++ b/docs/windows-sandbox.md
@@ -90,13 +90,13 @@ This avoids the 30-60s boot cost for subsequent executions.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `containment` | `"appcontainer"` | Must be `"windows_sandbox"` to use this backend |
+| `containment` | `"processcontainer"` | Must be `"windows_sandbox"` to use this backend |
 | `process.commandLine` | *(required)* | Command line to execute inside the sandbox |
 | `process.timeout` | `0` (none) | Script execution timeout in milliseconds |
 | `experimental.windows_sandbox.idleTimeoutMs` | `300000` (5 min) | Daemon idle timeout before VM teardown |
 | `experimental.windows_sandbox.daemonPipeName` | `"wxc-windows-sandbox"` | IPC identifier (determines TCP port) |
 
-When `containment` is `"windows_sandbox"`, the `appContainer`, `filesystem`, and `network` sections are ignored — isolation is managed by the sandbox VM and guest agent firewall.
+When `containment` is `"windows_sandbox"`, the `processContainer`, `filesystem`, and `network` sections are ignored — isolation is managed by the sandbox VM and guest agent firewall.
 
 ## Security Model
 

--- a/examples/01_hello_world.json
+++ b/examples/01_hello_world.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-HelloWorld",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys; print('Hello from WXC!'); print(f'Python version: {sys.version}'); print('Script executed successfully in AppContainer')\""
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": ["permissiveLearningMode"]
   }
 }

--- a/examples/02_filesystem_access.json
+++ b/examples/02_filesystem_access.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Filesystem-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import os\nimport sys\n\nprint('Testing filesystem access control...')\nprint()\n\n# Test 1: Write to allowed path\nallowed_file = 'C:\\\\temp\\\\wxc_sandbox\\\\output.txt'\nprint(f'Test 1: Writing to allowed path: {allowed_file}')\ntry:\n    os.makedirs(os.path.dirname(allowed_file), exist_ok=True)\n    with open(allowed_file, 'w') as f:\n        f.write('This write succeeded!')\n    print('  SUCCESS: File written successfully')\n    \n    # Read it back\n    with open(allowed_file, 'r') as f:\n        content = f.read()\n    print(f'  Content: {content}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\n\n# Test 2: Try to write to denied path (Windows System32)\ndenied_file = 'C:\\\\Windows\\\\System32\\\\test_forbidden.txt'\nprint(f'Test 2: Writing to denied path: {denied_file}')\ntry:\n    with open(denied_file, 'w') as f:\n        f.write('This should fail')\n    print('  ERROR: Should not have succeeded!')\nexcept PermissionError:\n    print('  SUCCESS: Access denied as expected')\nexcept Exception as e:\n    print(f'  SUCCESS: Access blocked with {type(e).__name__}: {e}')\n\nprint()\nprint('Filesystem access control test complete!')\"",
     "timeout": 15000

--- a/examples/03_network_restricted.json
+++ b/examples/03_network_restricted.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport socket\n\nprint('Testing network firewall enforcement...')\nprint('NOTE: This example requires administrator privileges')\nprint()\n\n# Test 1: Connect to allowed host\nallowed_host = 'https://api.github.com'\nprint(f'Test 1: Connecting to allowed host ({allowed_host})...')\ntry:\n    response = urllib.request.urlopen(allowed_host, timeout=10)\n    print(f'  SUCCESS: Connected (status: {response.status})')\n    print(f'  Response headers: {response.getheader(\"Server\")}')\nexcept Exception as e:\n    print(f'  ERROR: Failed to connect: {type(e).__name__}: {e}')\n\nprint()\n\n# Test 2: Try to connect to blocked host (default block policy)\nblocked_host = 'https://www.google.com'\nprint(f'Test 2: Connecting to blocked host ({blocked_host})...')\ntry:\n    response = urllib.request.urlopen(blocked_host, timeout=5)\n    print(f'  ERROR: Should not have connected! Status: {response.status}')\nexcept socket.timeout:\n    print('  SUCCESS: Connection blocked (timeout)')\nexcept urllib.error.URLError as e:\n    print(f'  SUCCESS: Connection blocked ({type(e.reason).__name__})')\nexcept Exception as e:\n    print(f'  SUCCESS: Connection blocked with {type(e).__name__}')\n\nprint()\nprint('Network firewall test complete!')\"",
     "timeout": 30000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": ["internetClient"]
   },
   "network": {

--- a/examples/04_combined_restrictions.json
+++ b/examples/04_combined_restrictions.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Combined-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import os\nimport urllib.request\nimport json\n\nprint('Combined Filesystem and Network Restrictions Test')\nprint('=' * 60)\nprint('NOTE: Network restrictions require administrator privileges')\nprint()\n\n# Test filesystem access\nprint('FILESYSTEM TESTS:')\nprint('-' * 60)\n\nworkdir = 'C:\\\\temp\\\\wxc_combined_test'\nos.makedirs(workdir, exist_ok=True)\n\n# Test 1: Download data to allowed path\ndata_file = os.path.join(workdir, 'github_data.json')\nprint(f'Test 1: Downloading data from allowed host to allowed path...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    data = response.read()\n    with open(data_file, 'wb') as f:\n        f.write(data)\n    print(f'  SUCCESS: Downloaded and saved to {data_file}')\n    print(f'  File size: {len(data)} bytes')\nexcept Exception as e:\n    print(f'  ERROR: {type(e).__name__}: {e}')\n\nprint()\n\n# Test 2: Try to write to restricted path\ndenied_file = 'C:\\\\Windows\\\\System32\\\\forbidden.txt'\nprint(f'Test 2: Attempting to write to denied path...')\ntry:\n    with open(denied_file, 'w') as f:\n        f.write('This should fail')\n    print('  ERROR: Should not have succeeded!')\nexcept Exception as e:\n    print(f'  SUCCESS: Access denied - {type(e).__name__}')\n\nprint()\nprint('NETWORK TESTS:')\nprint('-' * 60)\n\n# Test 3: Allowed network access\nprint('Test 3: Connecting to allowed host (api.github.com)...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  SUCCESS: Connected (status: {response.status})')\nexcept Exception as e:\n    print(f'  ERROR: {type(e).__name__}: {e}')\n\nprint()\n\n# Test 4: Blocked network access\nprint('Test 4: Attempting to connect to blocked host (example.com)...')\ntry:\n    response = urllib.request.urlopen('https://example.com', timeout=5)\n    print(f'  ERROR: Should not have connected!')\nexcept Exception as e:\n    print(f'  SUCCESS: Connection blocked - {type(e).__name__}')\n\nprint()\nprint('=' * 60)\nprint('Combined restrictions test complete!')\"",
     "timeout": 45000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [ "internetClient" ]
   },
   "filesystem": {

--- a/examples/05_custom_python.json
+++ b/examples/05_custom_python.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-CustomPython",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys\nimport os\nimport platform\n\nprint('Python Environment Information')\nprint('=' * 60)\nprint(f'Python Version: {sys.version}')\nprint(f'Python Executable: {sys.executable}')\nprint(f'Platform: {platform.platform()}')\nprint(f'Architecture: {platform.architecture()}')\nprint()\nprint('Working Directory:')\nprint(f'  Current: {os.getcwd()}')\nprint()\nprint('Python Path:')\nfor i, path in enumerate(sys.path, 1):\n    print(f'  {i}. {path}')\nprint()\nprint('Environment Variables (sample):')\nfor key in ['PATH', 'PYTHONPATH', 'USERPROFILE']:\n    value = os.environ.get(key, '(not set)')\n    if len(value) > 100:\n        value = value[:100] + '...'\n    print(f'  {key}: {value}')\nprint('=' * 60)\"",
     "timeout": 10000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [ "registryRead" ]
   },
   "fileSystem": {

--- a/examples/06_network_capabilities_only.json
+++ b/examples/06_network_capabilities_only.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Capabilities",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport sys\n\nprint('Testing network access using AppContainer capabilities only')\nprint('=' * 60)\nprint('Enforcement mode: capabilities (no firewall rules, no admin required)')\nprint()\n\n# Test 1: Make HTTP request to GitHub API\nprint('Test 1: Connecting to api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    data = response.read()\n    print(f'  SUCCESS: Connected (status: {response.status})')\n    print(f'  Response size: {len(data)} bytes')\n    print(f'  Server: {response.getheader(\"Server\")}')\nexcept Exception as e:\n    print(f'  ERROR: {type(e).__name__}: {e}')\n\nprint()\n\n# Test 2: Make HTTP request to Google\nprint('Test 2: Connecting to www.google.com...')\ntry:\n    response = urllib.request.urlopen('https://www.google.com', timeout=10)\n    print(f'  SUCCESS: Connected (status: {response.status})')\nexcept Exception as e:\n    print(f'  ERROR: {type(e).__name__}: {e}')\n\nprint()\nprint('=' * 60)\nprint('Network access test complete!')\nprint()\nprint('Note: With capabilities-only mode, the internetClient capability')\nprint('      grants access to ALL network hosts. For granular control,')\nprint('      use enforcementMode: \"firewall\" or \"both\".')\"",
     "timeout": 30000

--- a/examples/07_test_delete.json
+++ b/examples/07_test_delete.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Filesystem-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd /c echo Test AppContainer for deletion"
   },

--- a/examples/08_pwsh.json
+++ b/examples/08_pwsh.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Pwsh",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "pwsh.exe -nop -nol -c \"Set-PSReadLineOption -HistorySaveStyle SaveNothing; Set-Location c:\\temp\"; Get-Location"
   },

--- a/examples/11_localhost_proxy_processcontainer.json
+++ b/examples/11_localhost_proxy_processcontainer.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Proxy-Example",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\n\nprint('Test 1: Requesting api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Test 2: Requesting httpbin.org...')\ntry:\n    response = urllib.request.urlopen('https://httpbin.org/get', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Done.')\"",
     "timeout": 45000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": ["internetClient"]
   },
   "network": {

--- a/examples/12_builtin_test_proxy_processcontainer.json
+++ b/examples/12_builtin_test_proxy_processcontainer.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-BuiltinProxy-Example",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\n\nprint('Test 1: Requesting api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Test 2: Requesting httpbin.org...')\ntry:\n    response = urllib.request.urlopen('https://httpbin.org/get', timeout=15)\n    print(f'  SUCCESS: status {response.status}')\nexcept Exception as e:\n    print(f'  ERROR: {e}')\n\nprint()\nprint('Done.')\"",
     "timeout": 45000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": ["internetClient"]
   },
   "network": {

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -17,9 +17,9 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["appcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "macos_sandbox", "isolation_session"],
-      "default": "appcontainer",
-      "description": "Containment backend to use for execution. Note: 'windows_sandbox', 'wslc', 'macos_sandbox', and 'isolation_session' are experimental and require the --experimental CLI flag."
+      "enum": ["process", "processcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "seatbelt", "isolation_session"],
+      "default": "processcontainer",
+      "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'microvm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'wslc', 'seatbelt', 'isolation_session'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities. Note: 'windows_sandbox', 'wslc', 'seatbelt', and 'isolation_session' are experimental and require the --experimental CLI flag."
     },
 
     "phase": {
@@ -122,16 +122,16 @@
         "allowedHosts": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc' and 'appcontainer' containment backends."
+          "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc' and 'processcontainer' containment backends."
         },
         "blockedHosts": {
           "type": "array",
           "items": { "type": "string" },
-          "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc' and 'appcontainer' containment backends."
+          "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc' and 'processcontainer' containment backends."
         },
         "proxy": {
           "type": "object",
-          "description": "Proxy configuration. Only supported with appcontainer backend.",
+          "description": "Proxy configuration. Only supported with processcontainer backend.",
           "oneOf": [
             {
               "properties": {
@@ -184,9 +184,9 @@
       }
     },
 
-    "appContainer": {
+    "processContainer": {
       "type": "object",
-      "description": "AppContainer-specific settings. Used when containment is 'appcontainer'.",
+      "description": "ProcessContainer-specific settings. Used when containment is 'processcontainer'. The runner picks the legacy AppContainer implementation (which honors `capabilities` and `leastPrivilege`) or the newer BaseContainer implementation (which honors `ui`) at run time based on the host OS and the --experimental flag.",
       "properties": {
         "leastPrivilege": {
           "type": "boolean",
@@ -317,9 +317,9 @@
             }
           }
         },
-        "macos_sandbox": {
+        "seatbelt": {
           "type": "object",
-          "description": "macOS sandbox backend (experimental). Used when containment is 'macos_sandbox'.",
+          "description": "macOS sandbox backend (experimental). Used when containment is 'seatbelt'.",
           "properties": {
             "mode": {
               "type": "string",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -104,6 +104,22 @@ ptyProcess.onExit((event: { exitCode: number }) => {
 
 ### Platform Detection
 
+#### Containment values: intent vs. backend
+
+The SDK distinguishes two layers of containment values:
+
+- **`ContainmentType`** — abstract intent (what *kind* of isolation you want).
+  Currently `"process"`, `"vm"`, and `"microvm"`. The native binary resolves
+  these to a concrete backend per host. Prefer these in policy code so the
+  same policy works across hosts with different capabilities.
+- **`ContainmentBackend`** — concrete backend (a specific runner). Currently
+  `"processcontainer"`, `"windows_sandbox"`, `"wslc"`, `"lxc"`, `"microvm"`,
+  `"seatbelt"`. Use these to force a particular backend.
+
+`ContainerConfig.containment` accepts either layer. The deprecated
+`SandboxingMethod` alias is the union of both and is retained for backward
+compatibility.
+
 #### `getPlatformSupport(): PlatformSupport`
 
 Returns platform support information including whether MXC is supported.
@@ -126,7 +142,7 @@ if (support.reason) {
 interface PlatformSupport {
   isSupported: boolean;
   reason?: string;
-  availableMethods: SandboxingMethod[];
+  availableMethods: ContainmentBackend[];
 }
 ```
 
@@ -135,7 +151,7 @@ interface PlatformSupport {
 Supported system:
 ```
 Supported: true
-Available methods: ['appcontainer']
+Available methods: ['processcontainer']
 ```
 
 Unsupported system:
@@ -439,7 +455,9 @@ The package includes full TypeScript definitions. All public types are exported 
 import {
   // Types
   SandboxPolicy,
-  SandboxingMethod,
+  ContainmentType,
+  ContainmentBackend,
+  SandboxingMethod, // deprecated alias for ContainmentType | ContainmentBackend
   PlatformSupport,
 
   // Platform detection

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -31,7 +31,7 @@
     "wxc",
     "sandbox",
     "security",
-    "appcontainer",
+    "processcontainer",
     "windows",
     "node-pty"
   ],

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger.js';
-import { ContainerConfig, ContainmentType, ExperimentalBackends, SandboxingMethod } from './types.js';
+import { ContainerConfig, ContainmentBackend, ContainmentTypes, ExperimentalBackends } from './types.js';
 import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { diagLog } from './diagnostic.js';
@@ -129,7 +129,7 @@ export function resolveExecutableAndArgs(
 
   // Check experimental mode before anything else so the caller gets a clear
   // message about the missing flag rather than a platform/binary error.
-  if (ExperimentalBackends.includes(config.containment as ContainmentType) && !options.experimental) {
+  if (config.containment && ExperimentalBackends.includes(config.containment) && !options.experimental) {
     throw new Error(
       `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
     );
@@ -147,8 +147,13 @@ export function resolveExecutableAndArgs(
     if (config.containment === 'microvm' && os.platform() !== 'win32') {
       throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
     }
-    if (!(ExperimentalBackends as readonly string[]).includes(config.containment) &&
-        !platformSupport.availableMethods.includes(config.containment as SandboxingMethod)) {
+    // Abstract intents (process, microvm) are resolved by the native binary
+    // at run time, so the SDK accepts them without checking against the
+    // host's concrete backend list.
+    const isIntent = (ContainmentTypes as readonly string[]).includes(config.containment);
+    const isExperimental = (ExperimentalBackends as readonly string[]).includes(config.containment);
+    const isAvailable = platformSupport.availableMethods.includes(config.containment as ContainmentBackend);
+    if (!isIntent && !isExperimental && !isAvailable) {
       throw new Error(
         `Containment backend '${config.containment}' is not available on this platform. ` +
         `Available methods: ${platformSupport.availableMethods.join(', ')}`

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -30,6 +30,8 @@ export {
   SandboxPolicy,
   SandboxingMethod,
   ContainmentType,
+  ContainmentTypes,
+  ContainmentBackend,
   ExperimentalBackends,
   ContainerConfig,
   PlatformSupport,

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -127,7 +127,7 @@ export function getPlatformSupport(): PlatformSupport {
   const buildSupported = checkWindowsBuildVersion();
   if (buildSupported) {
     support.isSupported = true;
-    support.availableMethods = ['appcontainer'];
+    support.availableMethods = ['processcontainer'];
     return support;
   }
 

--- a/sdk/src/policy.ts
+++ b/sdk/src/policy.ts
@@ -32,11 +32,11 @@ export interface FilesystemPolicyResult {
  */
 export interface ToolsPolicyOptions {
     /**
-     * When set to `'appcontainer'`, directories whose ACLs already grant
+     * When set to `'processcontainer'`, directories whose ACLs already grant
      * access to ALL_APPLICATION_PACKAGES are excluded from the result
      * because AppContainer processes can already see them implicitly.
      */
-    containerType?: 'appcontainer';
+    containerType?: 'processcontainer';
 }
 
 // ---------------------------------------------------------------------------
@@ -253,7 +253,7 @@ function getPowerShellPolicy(
  *
  * 1. Directories that do not exist on disk are removed.
  * 2. System-critical directories (under `%WINDIR%`) are removed.
- * 3. When `options.containerType` is `'appcontainer'`, directories whose ACLs
+ * 3. When `options.containerType` is `'processcontainer'`, directories whose ACLs
  *    already grant access to `ALL_APPLICATION_PACKAGES` are removed because
  *    AppContainer processes can see them without explicit brokering.
  *
@@ -297,7 +297,7 @@ export function getAvailableToolsPolicy(
         if (isSystemCriticalPath(dirPath)) {
             return false;
         }
-        if (options?.containerType === 'appcontainer' && hasAllApplicationPackagesAccess(dirPath)) {
+        if (options?.containerType === 'processcontainer' && hasAllApplicationPackagesAccess(dirPath)) {
             return false;
         }
         return true;

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -6,7 +6,7 @@ import * as os from 'os';
 import { spawn, ChildProcess } from 'child_process';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
-import { SandboxPolicy, ContainerConfig, ContainmentType } from './types.js';
+import { SandboxPolicy, ContainerConfig, ContainmentType, ContainmentBackend } from './types.js';
 import { prepareSpawn, diagLogVersion } from './helper.js';
 import { diagLog } from './diagnostic.js';
 
@@ -92,7 +92,6 @@ function buildLinuxProcessConfig(
     config: ContainerConfig,
     containerId: string,
 ): ContainerConfig {
-    config.containment = 'lxc';
     config.lxc = {
         containerName: containerId,
         distribution: 'alpine',
@@ -119,7 +118,7 @@ function buildProcessBaseContainerConfig(
         capabilities.push("privateNetworkClientServer");
     }
 
-    config.appContainer = {
+    config.processContainer = {
         name: containerId,
         leastPrivilege: false,
         capabilities,
@@ -199,12 +198,12 @@ function buildMicroVmConfig(
  *
  * // Advanced: tweak backend-specific settings
  * const config = createConfigFromPolicy(policy, "process");
- * config.appContainer!.ui!.isolation = "atoms";
+ * config.processContainer!.ui!.isolation = "atoms";
  * ```
  */
 export function createConfigFromPolicy(
     policy: SandboxPolicy,
-    containment: ContainmentType = "process",
+    containment: ContainmentType | ContainmentBackend = "process",
     containerName?: string,
 ): ContainerConfig {
     diagLogVersion();
@@ -279,6 +278,7 @@ export function createConfigFromPolicy(
     }
 
     if (containment === 'process') {
+        config.containment = 'process';
         if (platform === 'linux') {
             diagLog(`createConfigFromPolicy: containment=lxc, id=${containerId}`);
             return buildLinuxProcessConfig(config, containerId);
@@ -304,7 +304,7 @@ export function buildSandboxPayload(
     policy: SandboxPolicy,
     workingDirectory?: string,
     containerName?: string,
-    containment: ContainmentType = "process",
+    containment: ContainmentType | ContainmentBackend = "process",
 ): ContainerConfig {
     const config = createConfigFromPolicy(policy, containment, containerName);
 
@@ -465,7 +465,7 @@ export function spawnSandbox(
  * ```typescript
  * const config = createConfigFromPolicy(policy, "process");
  * config.process!.commandLine = 'echo hello';
- * config.appContainer!.ui!.isolation = "atoms";
+ * config.processContainer!.ui!.isolation = "atoms";
  *
  * // PTY mode (default) — returns IPty:
  * const ptyProcess = spawnSandboxFromConfig(config);

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -227,6 +227,16 @@ export interface ContainerConfig {
   process?: ProcessConfig;
   /** ProcessContainer configuration */
   processContainer?: ProcessContainerConfig;
+  /**
+   * Legacy alias of {@link processContainer}. Retained so callers
+   * migrating from pre-0.6 SDK versions can keep their existing code
+   * compiling; the native binary parses both names into the same slot
+   * via a serde alias.
+   *
+   * @deprecated Use {@link processContainer} instead. This alias may be
+   * removed in a future minor release.
+   */
+  appContainer?: ProcessContainerConfig;
   /** LXC container configuration (Linux only) */
   lxc?: LxcConfig;
   /** Filesystem access configuration */

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -32,17 +32,59 @@ export interface LifecycleConfig {
 }
 
 /**
- * Containment type abstraction for createConfigFromPolicy.
- * Maps to platform-specific backends:
- * - "process": BaseProcessContainer (Windows) / LXC (Linux) / macOS sandbox (macOS)
- * - "microvm": MicroVM/Nanvix backend (Windows only, experimental)
+ * Abstract containment intent. Names the *kind* of isolation the caller
+ * wants. The native binary (or the SDK as a fallback) resolves this to a
+ * concrete {@link ContainmentBackend} at run time based on what the host
+ * supports.
+ *
+/**
+ * Abstract containment intent. Names the *kind* of isolation the caller
+ * wants; the native binary resolves it to a concrete
+ * {@link ContainmentBackend} per host capability.
+ *
+ * Today's intents:
+ * - "process": OS-native process-level isolation. Resolves to
+ *   `processcontainer` (Windows), `lxc` (Linux), or `seatbelt` (macOS).
+ * - "vm": full hardware-virtualised VM isolation. Resolves to
+ *   `windows_sandbox` on Windows; no concrete VM backend exists on other
+ *   platforms today.
+ * - "microvm": lightweight-VM isolation. Resolves to the current MicroVM
+ *   runner (Windows only, experimental); intended to expand as additional
+ *   microvm backends (e.g. NanVix) are added.
+ *
+ * Concrete-only backends (such as `"wslc"`) live on
+ * {@link ContainmentBackend} until there is a meaningful abstraction over
+ * multiple implementations of the same kind.
  */
-export type ContainmentType = "process" | "wslc" | "microvm";
+export type ContainmentType = "process" | "vm" | "microvm";
 
 /**
- * Containment backends that require the --experimental flag.
+ * Runtime list of {@link ContainmentType} values. Kept in sync with the
+ * `ContainmentType` union via the type annotation. Use this to recognise
+ * abstract intents at run time (the union itself only exists at compile
+ * time).
  */
-export const ExperimentalBackends: readonly ContainmentType[] = ['microvm', 'wslc'];
+export const ContainmentTypes: readonly ContainmentType[] = ['process', 'vm', 'microvm'];
+
+/**
+ * Concrete containment backend. Each value names a specific runner
+ * implementation in the native binary. Prefer a {@link ContainmentType}
+ * value unless you specifically need to force a particular backend.
+ */
+export type ContainmentBackend =
+  | 'processcontainer'
+  | 'windows_sandbox'
+  | 'wslc'
+  | 'lxc'
+  | 'microvm'
+  | 'seatbelt'
+  | 'isolation_session';
+
+/**
+ * Containment values (abstract intent or concrete backend) that require
+ * the `--experimental` flag.
+ */
+export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'wslc', 'seatbelt'];
 
 /**
  * Clipboard access policy levels
@@ -64,7 +106,7 @@ export interface UiConfig {
 
 /**
  * BaseProcess-specific UI configuration (Windows only).
- * Lives under appContainer.ui in ContainerConfig.
+ * Lives under processContainer.ui in ContainerConfig.
  */
 export interface BaseProcessUiConfig {
   /** UI isolation level for the desktop */
@@ -78,9 +120,15 @@ export interface BaseProcessUiConfig {
 }
 
 /**
- * AppContainer configuration for Windows sandbox
+ * ProcessContainer configuration for the Windows process-level backend.
+ *
+ * `processcontainer` is the abstraction layer; the runner picks between
+ * the legacy AppContainer implementation (which honors `capabilities`,
+ * `leastPrivilege`) and the newer BaseContainer implementation (which
+ * honors `ui`) at run time based on the host OS and the `--experimental`
+ * flag.
  */
-export interface AppContainerConfig {
+export interface ProcessContainerConfig {
   /** AppContainer profile name (default: "CLI"). Deprecated: use containerId instead. */
   name?: string;
   /** Use least privilege mode with PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT (default: false) */
@@ -171,14 +219,14 @@ export interface ContainerConfig {
   version: string;
   /** Externally assigned container identifier */
   containerId?: string;
-  /** Containment backend */
-  containment?: 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox' | 'isolation_session';
+  /** Containment intent (preferred) or concrete backend (override). */
+  containment?: ContainmentType | ContainmentBackend;
   /** Container lifecycle settings */
   lifecycle?: LifecycleConfig;
   /** Process execution settings (required) */
   process?: ProcessConfig;
-  /** AppContainer configuration */
-  appContainer?: AppContainerConfig;
+  /** ProcessContainer configuration */
+  processContainer?: ProcessContainerConfig;
   /** LXC container configuration (Linux only) */
   lxc?: LxcConfig;
   /** Filesystem access configuration */
@@ -190,7 +238,7 @@ export interface ContainerConfig {
     /** WSLC SDK configuration for Linux containers from Windows */
     wslc?: WslcConfig;
     /** macOS sandbox configuration (macOS only) */
-    macos_sandbox?: MacosSandboxConfig;
+    seatbelt?: SeatbeltConfig;
   };
   /** Cross-platform UI configuration */
   ui?: UiConfig;
@@ -261,10 +309,10 @@ export interface LxcConfig {
 }
 
 /**
- * macOS sandbox configuration (experimental). Used under
- * `experimental.macos_sandbox` when containment is 'macos_sandbox'.
+ * macOS Seatbelt sandbox configuration (experimental). Used under
+ * `experimental.seatbelt` when containment is `'seatbelt'`.
  */
-export interface MacosSandboxConfig {
+export interface SeatbeltConfig {
   /**
    * Which sandbox entry point to use:
    * - "exec" (default): spawn /usr/bin/sandbox-exec.
@@ -280,8 +328,12 @@ export interface MacosSandboxConfig {
 
 /**
  * Sandboxing methods available on the platform
+ *
+ * @deprecated Prefer {@link ContainmentBackend} (concrete) or
+ * {@link ContainmentType} (abstract). This alias is retained for
+ * backward compatibility and may be removed in a future minor release.
  */
-export type SandboxingMethod = 'appcontainer' | 'windows_sandbox' | 'wslc' | 'lxc' | 'vm' | 'microvm' | 'macos_sandbox' | 'isolation_session';
+export type SandboxingMethod = ContainmentType | ContainmentBackend;
 
 /**
  * Platform support information
@@ -292,5 +344,5 @@ export interface PlatformSupport {
   /** Reason why the platform is not supported (if applicable) */
   reason?: string;
   /** Available sandboxing methods on this platform */
-  availableMethods: SandboxingMethod[];
+  availableMethods: ContainmentBackend[];
 }

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -4,6 +4,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import { buildSandboxPayload, createConfigFromPolicy, spawnSandbox, spawnSandboxFromConfig } from '../../src/sandbox.js';
+import { resolveExecutableAndArgs } from '../../src/helper.js';
 import { ContainerConfig, SandboxPolicy, SandboxingMethod } from '../../src/types.js';
 
 describe('buildSandboxPayload', () => {
@@ -33,7 +34,7 @@ describe('buildSandboxPayload', () => {
       }
     });
 
-    it('should map network policy to appcontainer capabilities', () => {
+    it('should map network policy to processcontainer capabilities', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
@@ -41,8 +42,8 @@ describe('buildSandboxPayload', () => {
           network: { allowOutbound: true, allowLocalNetwork: true },
         };
         const payload = buildSandboxPayload('echo hi', policy);
-        assert.ok(payload.appContainer!.capabilities!.includes('internetClient'));
-        assert.ok(payload.appContainer!.capabilities!.includes('privateNetworkClientServer'));
+        assert.ok(payload.processContainer!.capabilities!.includes('internetClient'));
+        assert.ok(payload.processContainer!.capabilities!.includes('privateNetworkClientServer'));
       } finally {
         restore();
       }
@@ -215,11 +216,11 @@ describe('buildSandboxPayload', () => {
       }
     };
 
-    it('should default to lxc on Linux', () => {
+    it('should default to process containment on Linux (resolved by binary to lxc)', () => {
       mockLinux();
       try {
         const payload = buildSandboxPayload('echo hi', defaultPolicy);
-        assert.strictEqual(payload.containment, 'lxc');
+        assert.strictEqual(payload.containment, 'process');
         assert.strictEqual(payload.lxc!.destroyOnExit, true);
       } finally {
         restore();
@@ -263,7 +264,7 @@ describe('buildSandboxPayload', () => {
         const payload = buildSandboxPayload('print(42)', defaultPolicy, undefined, undefined, 'microvm');
         assert.strictEqual(payload.containment, 'microvm');
         assert.strictEqual(payload.filesystem, undefined);
-        assert.strictEqual(payload.appContainer, undefined);
+        assert.strictEqual(payload.processContainer, undefined);
       } finally {
         restore();
       }
@@ -299,7 +300,7 @@ describe('buildSandboxPayload', () => {
       }
     });
 
-    it('should build appcontainer config on Windows with default process containment', () => {
+    it('should build processcontainer config on Windows with default process containment', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
@@ -307,8 +308,8 @@ describe('buildSandboxPayload', () => {
           network: { allowOutbound: true },
         };
         const payload = buildSandboxPayload('echo hi', policy);
-        assert.ok(payload.appContainer, 'appContainer section should be present');
-        assert.ok(payload.appContainer!.capabilities!.includes('internetClient'));
+        assert.ok(payload.processContainer, 'processContainer section should be present');
+        assert.ok(payload.processContainer!.capabilities!.includes('internetClient'));
       } finally {
         restore();
       }
@@ -384,9 +385,9 @@ describe('buildSandboxPayload', () => {
       assert.strictEqual(payload.experimental!.wslc!.image, 'alpine:latest');
     });
 
-    it('should not set appContainer or lxc config', () => {
+    it('should not set processContainer or lxc config', () => {
       const payload = buildSandboxPayload('echo hello', { version: '0.5.0-alpha' }, undefined, undefined, 'wslc');
-      assert.strictEqual(payload.appContainer, undefined);
+      assert.strictEqual(payload.processContainer, undefined);
       assert.strictEqual(payload.lxc, undefined);
     });
 
@@ -458,14 +459,14 @@ describe('createConfigFromPolicy', () => {
       }
     };
 
-    it('should set appContainer with UI defaults for process containment', () => {
+    it('should set processContainer with UI defaults for process containment', () => {
       mockWindows();
       try {
         const config = createConfigFromPolicy(defaultPolicy, 'process');
-        assert.ok(config.appContainer);
-        assert.deepStrictEqual(config.appContainer!.capabilities, []);
-        assert.strictEqual(config.appContainer!.ui!.isolation, 'container');
-        assert.strictEqual(config.appContainer!.ui!.desktopSystemControl, false);
+        assert.ok(config.processContainer);
+        assert.deepStrictEqual(config.processContainer!.capabilities, []);
+        assert.strictEqual(config.processContainer!.ui!.isolation, 'container');
+        assert.strictEqual(config.processContainer!.ui!.desktopSystemControl, false);
       } finally {
         restore();
       }
@@ -483,8 +484,8 @@ describe('createConfigFromPolicy', () => {
             blockedHosts: ['evil.com'],
           },
         });
-        assert.ok(config.appContainer!.capabilities!.includes('internetClient'));
-        assert.ok(config.appContainer!.capabilities!.includes('privateNetworkClientServer'));
+        assert.ok(config.processContainer!.capabilities!.includes('internetClient'));
+        assert.ok(config.processContainer!.capabilities!.includes('privateNetworkClientServer'));
         assert.deepStrictEqual(config.network!.allowedHosts, ['example.com']);
         assert.deepStrictEqual(config.network!.blockedHosts, ['evil.com']);
       } finally {
@@ -526,11 +527,11 @@ describe('createConfigFromPolicy', () => {
       }
     };
 
-    it('should default to lxc containment', () => {
+    it('should default to process containment (resolved by binary to lxc on Linux)', () => {
       mockLinux();
       try {
         const config = createConfigFromPolicy(defaultPolicy);
-        assert.strictEqual(config.containment, 'lxc');
+        assert.strictEqual(config.containment, 'process');
         assert.strictEqual(config.lxc!.distribution, 'alpine');
         assert.strictEqual(config.lxc!.destroyOnExit, true);
       } finally {
@@ -614,9 +615,9 @@ describe('createConfigFromPolicy', () => {
       assert.deepStrictEqual(config.network!.allowedHosts, ['example.com']);
     });
 
-    it('should not set appContainer config for wslc', () => {
+    it('should not set processContainer config for wslc', () => {
       const config = createConfigFromPolicy({ version: '0.5.0-alpha' }, 'wslc');
-      assert.strictEqual(config.appContainer, undefined);
+      assert.strictEqual(config.processContainer, undefined);
     });
 
     it('should not set lxc config for wslc', () => {
@@ -683,5 +684,74 @@ describe('Schema 0.6.0 vocabulary', () => {
       containment: 'isolation_session',
     };
     assert.strictEqual(c.containment, 'isolation_session');
+  });
+});
+
+describe('resolveExecutableAndArgs (containment validation)', () => {
+  // Use the running node binary as a stand-in executable so the helper does
+  // not try to discover wxc-exec on disk. The helper does not actually exec
+  // anything; it just builds the path + args.
+  const fakeExe = process.execPath;
+
+  function makeConfig(containment: string): ContainerConfig {
+    return {
+      version: '0.5.0-alpha',
+      containment: containment as ContainerConfig['containment'],
+      process: { commandLine: 'echo hi' },
+    };
+  }
+
+  it('should accept the abstract intent "process" without throwing', () => {
+    // Regression guard: createConfigFromPolicy() defaults to "process" and
+    // the SDK no longer pre-resolves it to a concrete backend. The validator
+    // must accept abstract intents and let the native binary resolve them.
+    assert.doesNotThrow(() =>
+      resolveExecutableAndArgs(makeConfig('process'), { executablePath: fakeExe }),
+    );
+  });
+
+  it('should accept the abstract intent "microvm" with experimental flag (Windows only)', function (this: { skip: (reason?: string) => void }) {
+    if (process.platform !== 'win32') {
+      this.skip('microvm is Windows-only');
+      return;
+    }
+    assert.doesNotThrow(() =>
+      resolveExecutableAndArgs(makeConfig('microvm'), {
+        executablePath: fakeExe,
+        experimental: true,
+      }),
+    );
+  });
+
+  it('should not require experimental mode for the non-experimental "process" intent', () => {
+    // process is an abstract intent; only its concrete resolution may be
+    // experimental (e.g. seatbelt today). The intent itself does not
+    // require --experimental at the SDK boundary.
+    assert.doesNotThrow(() =>
+      resolveExecutableAndArgs(makeConfig('process'), { executablePath: fakeExe }),
+    );
+  });
+
+  it('should accept the abstract intent "vm" without throwing', () => {
+    // "vm" is a forward-looking ContainmentType intent. Even though no
+    // concrete VM backend resolves it yet, the SDK validator must let it
+    // pass — the binary owns the resolve/error step.
+    assert.doesNotThrow(() =>
+      resolveExecutableAndArgs(makeConfig('vm'), { executablePath: fakeExe }),
+    );
+  });
+
+  it('should still reject genuinely unknown containment values', () => {
+    assert.throws(
+      () => resolveExecutableAndArgs(makeConfig('bogus_backend'), { executablePath: fakeExe }),
+      { message: /not available on this platform/ },
+    );
+  });
+
+  it('should still require experimental mode for experimental backends like wslc', () => {
+    assert.throws(
+      () => resolveExecutableAndArgs(makeConfig('wslc'), { executablePath: fakeExe }),
+      { message: /experimental mode/ },
+    );
   });
 });

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -312,7 +312,7 @@ fn main() {
     // BaseContainer is used when --experimental is passed or schema version >= 0.5.
     // Sandbox and MicroVM require --experimental flag.
     let mut runner: Box<dyn ScriptRunner> = match request.containment {
-        ContainmentBackend::AppContainer => {
+        ContainmentBackend::ProcessContainer => {
             let version_implies_base_container = is_base_container_version(&request.schema_version);
             let use_base_container = request.experimental_enabled || version_implies_base_container;
 
@@ -356,10 +356,8 @@ fn main() {
             eprintln!("Error: LXC backend not available on Windows");
             process::exit(1);
         }
-        ContainmentBackend::MacosSandbox => {
-            eprintln!(
-                "Error: macOS sandbox backend is only available on macOS (use mxc-exec-darwin)"
-            );
+        ContainmentBackend::Seatbelt => {
+            eprintln!("Error: Seatbelt backend is only available on macOS (use mxc-exec-darwin)");
             process::exit(1);
         }
         ContainmentBackend::Vm => {

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -11,9 +11,9 @@ use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
     ClipboardPolicy, CodexRequest, ContainerPolicy, ContainmentBackend, ExperimentalConfig,
-    IsolationSessionConfig, IsolationSessionUser, LifecycleConfig, LxcConfig, MacosSandboxConfig,
-    MacosSandboxMode, NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress,
-    ProxyConfig, TestFeatureConfig, UiPolicy, WindowsSandboxConfig, WslcConfig,
+    IsolationSessionConfig, IsolationSessionUser, LifecycleConfig, LxcConfig,
+    NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig,
+    SeatbeltMode, TestFeatureConfig, UiPolicy, WindowsSandboxConfig, WslcConfig,
 };
 use crate::mxc_error::MxcError;
 use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
@@ -38,7 +38,7 @@ pub enum ParseError {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
-struct RawAppContainer {
+struct RawProcessContainer {
     #[serde(rename = "leastPrivilege")]
     least_privilege: Option<bool>,
     #[serde(rename = "learningMode")]
@@ -165,7 +165,7 @@ struct RawIsolationSession {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
-struct RawMacosSandbox {
+struct RawSeatbelt {
     mode: Option<String>,
     #[serde(rename = "profileOverride")]
     profile_override: Option<String>,
@@ -180,8 +180,8 @@ struct RawExperimental {
     wslc: Option<RawContainerConfig>,
     #[serde(rename = "isolation_session")]
     isolation_session: Option<RawIsolationSession>,
-    #[serde(rename = "macos_sandbox")]
-    macos_sandbox: Option<RawMacosSandbox>,
+    #[serde(alias = "macos_sandbox")]
+    seatbelt: Option<RawSeatbelt>,
 }
 
 #[derive(Deserialize, Default)]
@@ -202,8 +202,8 @@ struct RawConfig {
     process: Option<RawProcess>,
     lifecycle: Option<RawLifecycle>,
     containment: Option<String>,
-    #[serde(rename = "appContainer")]
-    app_container: Option<RawAppContainer>,
+    #[serde(rename = "processContainer", alias = "appContainer")]
+    process_container: Option<RawProcessContainer>,
     lxc: Option<RawLxc>,
     filesystem: Option<RawFilesystem>,
     network: Option<RawNetwork>,
@@ -567,19 +567,80 @@ fn convert_raw_config_inner(
         None => (String::new(), String::new(), 0, Vec::new()),
     };
 
-    // Containment backend selection
+    // Containment backend selection.
+    //
+    // The `containment` wire field is dual-purpose: callers may pass either
+    //   (a) an abstract intent (e.g. "process") that names a *kind* of
+    //       isolation and lets the binary pick the host-appropriate runner,
+    //   or
+    //   (b) a concrete backend id (e.g. "processcontainer", "lxc", "seatbelt")
+    //       that pins the runner explicitly.
+    //
+    // Both forms target the same internal `ContainmentBackend` enum. The
+    // match below recognises every concrete id verbatim and resolves the
+    // abstract intents into the appropriate concrete variant per
+    // target_os. Any future concrete-only backend just needs an arm; any
+    // future abstract intent should resolve here (and likewise in
+    // `parse_containment_str` below for the state-aware path).
     let containment = match raw.containment.as_deref() {
-        None | Some("appcontainer") => ContainmentBackend::AppContainer,
+        None | Some("processcontainer") => ContainmentBackend::ProcessContainer,
+        Some("appcontainer") => {
+            logger.log_line(
+                "[deprecated] containment value 'appcontainer' is a legacy alias for 'processcontainer'; \
+                 update your config to use 'processcontainer' (the 'appcontainer' alias may be removed in a future schema version).",
+            );
+            ContainmentBackend::ProcessContainer
+        }
+        Some("process") => {
+            // Abstract intent: the caller wants process-level containment but
+            // does not care which concrete backend implements it. Today this
+            // resolves trivially per OS (ProcessContainer on Windows, LXC on
+            // Linux, Seatbelt on macOS). The lxc-exec binary additionally
+            // overrides this to LXC unconditionally on Linux.
+            #[cfg(target_os = "linux")]
+            {
+                ContainmentBackend::Lxc
+            }
+            #[cfg(target_os = "macos")]
+            {
+                ContainmentBackend::Seatbelt
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+            {
+                ContainmentBackend::ProcessContainer
+            }
+        }
         Some("windows_sandbox") => ContainmentBackend::WindowsSandbox,
         Some("wslc") => ContainmentBackend::Wslc,
         Some("lxc") => ContainmentBackend::Lxc,
-        Some("vm") => ContainmentBackend::Vm,
+        Some("vm") => {
+            // Abstract intent: full hardware-virtualised VM isolation.
+            // Today the only concrete VM backend is Windows Sandbox; on
+            // non-Windows targets we fall through to the historical
+            // `Vm` variant which the host binaries surface as an
+            // explicit "not implemented" error.
+            #[cfg(target_os = "windows")]
+            {
+                ContainmentBackend::WindowsSandbox
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                ContainmentBackend::Vm
+            }
+        }
         Some("microvm") => ContainmentBackend::MicroVm,
         Some("isolation_session") => ContainmentBackend::IsolationSession,
-        Some("macos_sandbox") => ContainmentBackend::MacosSandbox,
+        Some("seatbelt") => ContainmentBackend::Seatbelt,
+        Some("macos_sandbox") => {
+            logger.log_line(
+                "[deprecated] containment value 'macos_sandbox' is a legacy alias for 'seatbelt'; \
+                 update your config to use 'seatbelt' (the 'macos_sandbox' alias may be removed in a future schema version).",
+            );
+            ContainmentBackend::Seatbelt
+        }
         Some(other) => {
             let msg = format!(
-                "Invalid containment value '{}' (must be 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', 'microvm', or 'macos_sandbox')",
+                "Invalid containment value '{}' (must be 'process', 'processcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', 'microvm' or 'seatbelt')",
                 other
             );
             logger.log_line(&msg);
@@ -598,8 +659,12 @@ fn convert_raw_config_inner(
 
     let mut policy = ContainerPolicy::default();
 
-    // AppContainer section
-    if let Some(ac) = raw.app_container {
+    // ProcessContainer section. Holds settings that apply to the Windows
+    // process-level backend regardless of whether the runner picks the
+    // legacy AppContainer implementation (which honors `capabilities`,
+    // `learningMode`, `leastPrivilege`) or the newer BaseContainer
+    // implementation (which honors `ui`).
+    if let Some(ac) = raw.process_container {
         if let Some(lp) = ac.least_privilege {
             policy.least_privilege_mode = lp;
         }
@@ -667,9 +732,9 @@ fn convert_raw_config_inner(
     if let Some(net) = raw.network {
         if let Some(proxy_value) = net.proxy {
             let proxy_config = parse_proxy_config(&proxy_value)?;
-            if proxy_config.is_enabled() && containment != ContainmentBackend::AppContainer {
+            if proxy_config.is_enabled() && containment != ContainmentBackend::ProcessContainer {
                 let msg =
-                    "Network proxy is only supported with the 'appcontainer' containment backend";
+                    "Network proxy is only supported with the 'processcontainer' containment backend";
                 logger.log_line(msg);
                 return Err(WxcError::ConfigParse(msg.to_string()));
             }
@@ -791,19 +856,19 @@ fn convert_raw_config_inner(
             config.user = as_cfg.user;
             config
         });
-        let macos_sandbox = raw_exp.macos_sandbox.map(|raw_sb| {
+        let seatbelt = raw_exp.seatbelt.map(|raw_sb| {
             let mode = match raw_sb.mode.as_deref() {
-                None | Some("exec") => MacosSandboxMode::Exec,
-                Some("inproc") => MacosSandboxMode::Inproc,
+                None | Some("exec") => SeatbeltMode::Exec,
+                Some("inproc") => SeatbeltMode::Inproc,
                 Some(other) => {
                     logger.log_line(&format!(
-                        "Unknown macos_sandbox mode '{}', defaulting to 'exec'",
+                        "Unknown seatbelt mode '{}', defaulting to 'exec'",
                         other
                     ));
-                    MacosSandboxMode::Exec
+                    SeatbeltMode::Exec
                 }
             };
-            MacosSandboxConfig {
+            SeatbeltConfig {
                 mode,
                 profile_override: raw_sb.profile_override,
             }
@@ -813,7 +878,7 @@ fn convert_raw_config_inner(
             windows_sandbox,
             wslc,
             isolation_session,
-            macos_sandbox,
+            seatbelt,
         }
     } else {
         ExperimentalConfig::default()
@@ -876,7 +941,7 @@ fn convert_raw_state_aware(
         process: raw.process,
         lifecycle: None,
         containment: raw.containment,
-        app_container: None,
+        process_container: None,
         lxc: None,
         filesystem: raw.filesystem,
         network: raw.network,
@@ -899,19 +964,63 @@ fn convert_raw_state_aware(
     })
 }
 
+/// State-aware path: parse the `containment` wire field on a per-phase
+/// request envelope.
+///
+/// Mirrors the dual-acceptance contract of the one-shot match in
+/// `convert_raw_config_inner`: the input may be either an abstract intent
+/// (resolved per `target_os`) or a concrete backend id. Keep the two
+/// match expressions in lockstep when adding new values.
 fn parse_containment_str(s: &str, logger: &mut Logger) -> Result<ContainmentBackend, WxcError> {
     match s {
-        "appcontainer" => Ok(ContainmentBackend::AppContainer),
+        "processcontainer" => Ok(ContainmentBackend::ProcessContainer),
+        "appcontainer" => {
+            logger.log_line(
+                "[deprecated] containment value 'appcontainer' is a legacy alias for 'processcontainer'; \
+                 update your config to use 'processcontainer' (the 'appcontainer' alias may be removed in a future schema version).",
+            );
+            Ok(ContainmentBackend::ProcessContainer)
+        }
+        "process" => {
+            #[cfg(target_os = "linux")]
+            {
+                Ok(ContainmentBackend::Lxc)
+            }
+            #[cfg(target_os = "macos")]
+            {
+                Ok(ContainmentBackend::Seatbelt)
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+            {
+                Ok(ContainmentBackend::ProcessContainer)
+            }
+        }
         "windows_sandbox" => Ok(ContainmentBackend::WindowsSandbox),
         "wslc" => Ok(ContainmentBackend::Wslc),
         "lxc" => Ok(ContainmentBackend::Lxc),
-        "vm" => Ok(ContainmentBackend::Vm),
+        "vm" => {
+            #[cfg(target_os = "windows")]
+            {
+                Ok(ContainmentBackend::WindowsSandbox)
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                Ok(ContainmentBackend::Vm)
+            }
+        }
         "microvm" => Ok(ContainmentBackend::MicroVm),
         "isolation_session" => Ok(ContainmentBackend::IsolationSession),
-        "macos_sandbox" => Ok(ContainmentBackend::MacosSandbox),
+        "seatbelt" => Ok(ContainmentBackend::Seatbelt),
+        "macos_sandbox" => {
+            logger.log_line(
+                "[deprecated] containment value 'macos_sandbox' is a legacy alias for 'seatbelt'; \
+                 update your config to use 'seatbelt' (the 'macos_sandbox' alias may be removed in a future schema version).",
+            );
+            Ok(ContainmentBackend::Seatbelt)
+        }
         other => {
             let msg = format!(
-                "Invalid containment value '{}' (must be 'appcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', 'microvm', or 'macos_sandbox')",
+                "Invalid containment value '{}' (must be 'process', 'processcontainer', 'windows_sandbox', 'isolation_session', 'wslc', 'lxc', 'vm', 'microvm', or 'seatbelt')",
                 other
             );
             logger.log_line(&msg);
@@ -1051,7 +1160,7 @@ mod tests {
 
     #[test]
     fn missing_process_section() {
-        let json = r#"{"containment": "appcontainer"}"#;
+        let json = r#"{"containment": "processcontainer"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1098,7 +1207,7 @@ mod tests {
                 "cwd": "C:\\temp",
                 "timeout": 3000
             },
-            "appContainer": {
+            "processContainer": {
                 "leastPrivilege": true,
                 "capabilities": ["internetClient"]
             },
@@ -1198,7 +1307,7 @@ mod tests {
     #[test]
     fn learning_mode_adds_capability_in_debug() {
         let json =
-            r#"{"process": {"commandLine": "echo x"}, "appContainer": {"learningMode": true}}"#;
+            r#"{"process": {"commandLine": "echo x"}, "processContainer": {"learningMode": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1213,7 +1322,7 @@ mod tests {
     #[cfg(not(debug_assertions))]
     #[test]
     fn learning_mode_stripped_in_release() {
-        let json = r#"{"process": {"commandLine": "echo x"}, "appContainer": {"capabilities": ["permissiveLearningMode"]}}"#;
+        let json = r#"{"process": {"commandLine": "echo x"}, "processContainer": {"capabilities": ["permissiveLearningMode"]}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1239,10 +1348,10 @@ mod tests {
     }
 
     #[test]
-    fn app_container_capabilities() {
+    fn process_container_capabilities() {
         let json = r#"{
             "process": {"commandLine": "print('test')"},
-            "appContainer": {
+            "processContainer": {
                 "capabilities": ["internetClient", "privateNetworkClientServer", "documentsLibrary"]
             }
         }"#;
@@ -1258,7 +1367,7 @@ mod tests {
 
     #[test]
     fn least_privilege_mode() {
-        let json = r#"{"process": {"commandLine": "print('test')"}, "appContainer": {"leastPrivilege": true}}"#;
+        let json = r#"{"process": {"commandLine": "print('test')"}, "processContainer": {"leastPrivilege": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -1390,7 +1499,7 @@ mod tests {
                 "commandLine": "import sys\nprint(sys.version)",
                 "timeout": 10000
             },
-            "appContainer": {
+            "processContainer": {
                 "capabilities": ["internetClient", "privateNetworkClientServer"]
             }
         }"#;
@@ -1427,23 +1536,60 @@ mod tests {
     // ====== Containment backend selection tests ======
 
     #[test]
-    fn default_containment_is_appcontainer() {
+    fn default_containment_is_processcontainer() {
         let json = r#"{"process": {"commandLine": "echo hello"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.containment, ContainmentBackend::AppContainer);
+        assert_eq!(req.containment, ContainmentBackend::ProcessContainer);
     }
 
     #[test]
-    fn explicit_appcontainer_containment() {
-        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "appcontainer"}"#;
+    fn explicit_processcontainer_containment() {
+        let json =
+            r#"{"process": {"commandLine": "echo hello"}, "containment": "processcontainer"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.containment, ContainmentBackend::AppContainer);
+        assert_eq!(req.containment, ContainmentBackend::ProcessContainer);
+    }
+
+    #[test]
+    fn process_containment_resolves_per_target() {
+        // Abstract intent "process" resolves to the per-OS default backend:
+        // ProcessContainer on Windows, LXC on Linux, Seatbelt on macOS.
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "process"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+
+        #[cfg(target_os = "linux")]
+        assert_eq!(req.containment, ContainmentBackend::Lxc);
+        #[cfg(target_os = "macos")]
+        assert_eq!(req.containment, ContainmentBackend::Seatbelt);
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert_eq!(req.containment, ContainmentBackend::ProcessContainer);
+    }
+
+    #[test]
+    fn vm_containment_resolves_per_target() {
+        // Abstract intent "vm" resolves to Windows Sandbox on Windows. On
+        // other targets there is no concrete VM backend yet, so the parser
+        // returns the historical `Vm` placeholder variant which the host
+        // binaries surface as a "not implemented" error.
+        let json = r#"{"process": {"commandLine": "echo hello"}, "containment": "vm"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+
+        #[cfg(target_os = "windows")]
+        assert_eq!(req.containment, ContainmentBackend::WindowsSandbox);
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(req.containment, ContainmentBackend::Vm);
     }
 
     #[test]
@@ -1616,7 +1762,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_rejected_with_non_appcontainer() {
+    fn proxy_rejected_with_non_processcontainer() {
         let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"localhost":8080}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
@@ -1694,7 +1840,7 @@ mod tests {
     }
 
     #[test]
-    fn proxy_builtin_test_server_rejected_with_non_appcontainer() {
+    fn proxy_builtin_test_server_rejected_with_non_processcontainer() {
         let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"builtinTestServer":true}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
@@ -1773,16 +1919,6 @@ mod tests {
     }
 
     #[test]
-    fn containment_vm_accepted() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "vm"}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.containment, ContainmentBackend::Vm);
-    }
-
-    #[test]
     fn containment_microvm_accepted() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "microvm"}"#;
         let encoded = base64_encode(json.as_bytes());
@@ -1850,7 +1986,7 @@ mod tests {
         let json = r#"{
             "version": "0.5.0-alpha",
             "containerId": "test-050",
-            "containment": "appcontainer",
+            "containment": "processcontainer",
             "process": { "commandLine": "echo hello", "timeout": 5000 },
             "filesystem": { "readwritePaths": ["C:\\workspace"] },
             "network": { "defaultPolicy": "block" }
@@ -2252,69 +2388,136 @@ mod tests {
     }
 
     #[test]
-    fn containment_macos_sandbox_accepted() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox"}"#;
+    fn containment_seatbelt_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.containment, ContainmentBackend::MacosSandbox);
+        assert_eq!(req.containment, ContainmentBackend::Seatbelt);
     }
 
     #[test]
-    fn macos_sandbox_config_defaults() {
-        // When no experimental.macos_sandbox block is provided the parser
+    fn seatbelt_config_defaults() {
+        // When no experimental.seatbelt block is provided the parser
         // leaves it unset (None) — runners should fall back to defaults.
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox"}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.experimental.macos_sandbox.is_none());
+        assert!(req.experimental.seatbelt.is_none());
     }
 
     #[test]
-    fn macos_sandbox_config_inproc_mode() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox", "experimental": {"macos_sandbox": {"mode": "inproc"}}}"#;
+    fn seatbelt_config_inproc_mode() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"mode": "inproc"}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         let cfg = req
             .experimental
-            .macos_sandbox
-            .expect("experimental.macos_sandbox should be populated");
-        assert_eq!(cfg.mode, crate::models::MacosSandboxMode::Inproc);
+            .seatbelt
+            .expect("experimental.seatbelt should be populated");
+        assert_eq!(cfg.mode, crate::models::SeatbeltMode::Inproc);
     }
 
     #[test]
-    fn macos_sandbox_config_unknown_mode_defaults_to_exec() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox", "experimental": {"macos_sandbox": {"mode": "bogus"}}}"#;
+    fn seatbelt_config_unknown_mode_defaults_to_exec() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"mode": "bogus"}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         let cfg = req
             .experimental
-            .macos_sandbox
-            .expect("experimental.macos_sandbox should be populated");
-        assert_eq!(cfg.mode, crate::models::MacosSandboxMode::Exec);
+            .seatbelt
+            .expect("experimental.seatbelt should be populated");
+        assert_eq!(cfg.mode, crate::models::SeatbeltMode::Exec);
     }
 
     #[test]
-    fn macos_sandbox_profile_override_passed_through() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox", "experimental": {"macos_sandbox": {"profileOverride": "(version 1)(deny default)"}}}"#;
+    fn seatbelt_profile_override_passed_through() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"profileOverride": "(version 1)(deny default)"}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         let cfg = req
             .experimental
-            .macos_sandbox
-            .expect("experimental.macos_sandbox should be populated");
+            .seatbelt
+            .expect("experimental.seatbelt should be populated");
         assert_eq!(
             cfg.profile_override.as_deref(),
             Some("(version 1)(deny default)")
         );
+    }
+
+    // Legacy wire-name aliases. The parser accepts the pre-0.6 wire vocabulary
+    // (`appcontainer`, `macos_sandbox`, and the `appContainer` /
+    // `experimental.macos_sandbox` sub-block keys) so that configs declaring
+    // earlier stable schemas (0.4.0-alpha, 0.5.0-alpha) continue to parse.
+    // Each alias maps to the canonical backend / sub-block and emits a
+    // deprecation log so callers know to migrate.
+
+    #[test]
+    fn legacy_appcontainer_wire_value_aliases_processcontainer() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "appcontainer"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.containment, ContainmentBackend::ProcessContainer);
+    }
+
+    #[test]
+    fn legacy_macos_sandbox_wire_value_aliases_seatbelt() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "macos_sandbox"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.containment, ContainmentBackend::Seatbelt);
+    }
+
+    #[test]
+    fn legacy_app_container_subblock_alias_accepted() {
+        // Configs written against 0.4.0-alpha / 0.5.0-alpha still use the
+        // `appContainer` JSON key; serde's alias routes it to the same
+        // `processContainer` parsing path.
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "appContainer": {
+                "leastPrivilege": true,
+                "capabilities": ["internetClient"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.least_privilege_mode);
+        assert_eq!(req.policy.capabilities, vec!["internetClient".to_string()]);
+    }
+
+    #[test]
+    fn legacy_experimental_macos_sandbox_subblock_alias_accepted() {
+        // `experimental.macos_sandbox` is the pre-rename key; serde's alias
+        // routes it to the same `seatbelt` parsing path.
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "containment": "macos_sandbox",
+            "experimental": {"macos_sandbox": {"mode": "inproc"}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cfg = req
+            .experimental
+            .seatbelt
+            .expect("experimental.seatbelt should be populated (via macos_sandbox alias)");
+        assert_eq!(cfg.mode, crate::models::SeatbeltMode::Inproc);
     }
 }

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -8,8 +8,12 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum ContainmentBackend {
     #[default]
-    /// Windows AppContainer — process-level isolation on the host.
-    AppContainer,
+    /// Windows process-level containment. Resolves at runtime to either
+    /// AppContainer (legacy OS API) or BaseContainer (newer Windows
+    /// sandbox API exposed via `Experimental_CreateProcessInSandbox`),
+    /// based on `--experimental` and the schema version of the request.
+    /// Selected on the wire as `"processcontainer"`.
+    ProcessContainer,
     /// Linux container via WSL Container SDK (WSLC SDK).
     Wslc,
     /// LXC — Linux container isolation.
@@ -24,14 +28,14 @@ pub enum ContainmentBackend {
     /// Isolation Session — process isolation via IsoEnvBroker Session API (experimental).
     #[serde(rename = "isolation_session")]
     IsolationSession,
-    /// macOS sandbox — experimental backend (requires --experimental).
-    /// Implemented on top of the OS-bundled sandbox facility (historical
-    /// Apple internal codename: "Seatbelt").
-    #[serde(rename = "macos_sandbox")]
-    MacosSandbox,
+    /// macOS Seatbelt — experimental sandbox backend (requires --experimental).
+    /// Implemented on top of the OS-bundled sandbox facility (Apple's
+    /// internal codename for the App Sandbox / `sandbox-exec` machinery
+    /// is "Seatbelt"); selected on the wire as `"seatbelt"`.
+    Seatbelt,
 }
 
-/// Mode used by the macOS sandbox backend to apply the sandbox profile.
+/// Mode used by the Seatbelt backend to apply the sandbox profile.
 ///
 /// `Exec` (default) spawns `/usr/bin/sandbox-exec` and is always available.
 /// `Inproc` calls the private `sandbox_init_with_parameters` API in the
@@ -39,19 +43,19 @@ pub enum ContainmentBackend {
 /// non-public macOS interface.
 #[derive(Debug, Default, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum MacosSandboxMode {
+pub enum SeatbeltMode {
     #[default]
     Exec,
     Inproc,
 }
 
-/// Configuration specific to the macOS sandbox backend (experimental).
-/// Used under `experimental.macos_sandbox` when `containment == MacosSandbox`.
+/// Configuration specific to the Seatbelt backend (experimental).
+/// Used under `experimental.seatbelt` when `containment == Seatbelt`.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct MacosSandboxConfig {
+pub struct SeatbeltConfig {
     /// Which sandbox entry point to use. Default: `Exec` (sandbox-exec).
-    pub mode: MacosSandboxMode,
+    pub mode: SeatbeltMode,
     /// Optional override of the generated TinyScheme profile.
     #[serde(rename = "profileOverride", skip_serializing_if = "Option::is_none")]
     pub profile_override: Option<String>,
@@ -257,7 +261,7 @@ impl Default for UiPolicy {
 }
 
 /// BaseProcessContainer-specific UI configuration (Windows only).
-/// Parsed from `appContainer.ui` in the JSON config.
+/// Parsed from `processContainer.ui` in the JSON config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct BaseProcessUiConfig {
@@ -300,7 +304,7 @@ pub struct ContainerPolicy {
     pub network_proxy: ProxyConfig,
     /// Cross-platform UI policy.
     pub ui: UiPolicy,
-    /// BaseProcessContainer-specific UI config (Windows only, from appContainer.ui).
+    /// BaseProcessContainer-specific UI config (Windows only, from processContainer.ui).
     pub base_process_ui: BaseProcessUiConfig,
 }
 
@@ -403,9 +407,8 @@ pub struct ExperimentalConfig {
     /// Isolation Session backend (experimental).
     #[serde(rename = "isolation_session")]
     pub isolation_session: Option<IsolationSessionConfig>,
-    /// macOS sandbox backend (experimental).
-    #[serde(rename = "macos_sandbox")]
-    pub macos_sandbox: Option<MacosSandboxConfig>,
+    /// Seatbelt (macOS) backend (experimental).
+    pub seatbelt: Option<SeatbeltConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -422,11 +425,11 @@ pub struct CodexRequest {
     pub script_code: String,
     pub working_directory: String,
     pub script_timeout: u32,
-    /// Which containment backend to use. Default: AppContainer.
+    /// Which containment backend to use. Default: ProcessContainer.
     pub containment: ContainmentBackend,
     /// Shared lifecycle settings.
     pub lifecycle: LifecycleConfig,
-    /// AppContainer-specific policy (used when containment == AppContainer).
+    /// ProcessContainer-specific policy (used when containment == ProcessContainer).
     pub policy: ContainerPolicy,
     /// LXC-specific configuration (used when containment == Lxc).
     pub lxc_config: LxcConfig,

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -64,11 +64,11 @@ fn assert_wxc_success(config_file: &str, extra_args: &[&str]) {
     assert_success_or_skip_missing_prerequisite(&result);
 }
 
-fn appcontainer_basic() {
-    assert_wxc_success("basic_appcontainer.json", &["--debug"]);
+fn processcontainer_basic() {
+    assert_wxc_success("basic_processcontainer.json", &["--debug"]);
 }
 
-fn appcontainer_lpac() {
+fn processcontainer_lpac() {
     assert_wxc_success("basic_lpac.json", &["--debug"]);
 }
 
@@ -120,7 +120,7 @@ fn microvm_basic() {
     assert_wxc_success("microvm_hello.json", &["--debug", "--experimental"]);
 }
 
-fn appcontainer_proxy() {
+fn processcontainer_proxy() {
     let config = test_configs_dir().join("proxy_builtin_test.json");
     if !config.exists() {
         println!("SKIPPED: proxy config not found: {}", config.display());
@@ -137,20 +137,20 @@ fn appcontainer_proxy() {
 
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
-fn test_appcontainer_basic() {
+fn test_processcontainer_basic() {
     if !cached_has_wxc_exe() {
         return;
     }
-    with_test_lock(appcontainer_basic);
+    with_test_lock(processcontainer_basic);
 }
 
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
-fn test_appcontainer_lpac() {
+fn test_processcontainer_lpac() {
     if !cached_has_wxc_exe() {
         return;
     }
-    with_test_lock(appcontainer_lpac);
+    with_test_lock(processcontainer_lpac);
 }
 
 #[test]
@@ -245,11 +245,11 @@ fn test_microvm_suite() {
 
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled and elevation
-fn test_appcontainer_proxy() {
+fn test_processcontainer_proxy() {
     if !cached_has_test_driver() {
         return;
     }
-    with_test_lock(appcontainer_proxy);
+    with_test_lock(processcontainer_proxy);
 }
 
 #[test]
@@ -262,10 +262,10 @@ fn test_on_repeat() {
     with_test_lock(|| {
         for pass in 1..=10 {
             println!("=== Pass {pass} of 10 ===");
-            appcontainer_basic();
+            processcontainer_basic();
             filesystem_bfs();
             filesystem_bfs_readonly();
-            appcontainer_lpac();
+            processcontainer_lpac();
         }
     });
 }

--- a/test_configs/base_container_ui_configs/01_disable_true.json
+++ b/test_configs/base_container_ui_configs/01_disable_true.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-01",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo PASS: process ran with Win32k disabled",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "container", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "container", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": true, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/02_clip_none_write_blocked.json
+++ b/test_configs/base_container_ui_configs/02_clip_none_write_blocked.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-02",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"echo test | clip.exe && echo FAIL: wrote clipboard || echo PASS: clipboard write blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/03_clip_read_allowed.json
+++ b/test_configs/base_container_ui_configs/03_clip_read_allowed.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-03",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "powershell.exe -NoProfile -Command \"$r = Get-Clipboard; Write-Output 'PASS: clipboard read allowed'\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "read", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/04_clip_read_write_blocked.json
+++ b/test_configs/base_container_ui_configs/04_clip_read_write_blocked.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-04",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"echo test | clip.exe && echo FAIL: wrote clipboard || echo PASS: clipboard write blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "read", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/05_clip_write_allowed.json
+++ b/test_configs/base_container_ui_configs/05_clip_write_allowed.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-05",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"echo test | clip.exe && echo PASS: clipboard write allowed || echo FAIL: clipboard write blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
   "ui": { "disable": false, "clipboard": "write", "injection": true }
 }

--- a/test_configs/base_container_ui_configs/06_clip_all_both.json
+++ b/test_configs/base_container_ui_configs/06_clip_all_both.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-06",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"echo cliptest | clip.exe && echo PASS: clipboard write OK || echo FAIL: clipboard write blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
   "ui": { "disable": false, "clipboard": "all", "injection": true }
 }

--- a/test_configs/base_container_ui_configs/07_isolation_container.json
+++ b/test_configs/base_container_ui_configs/07_isolation_container.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-07",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"tasklist /FI \"IMAGENAME eq explorer.exe\" | findstr explorer.exe && echo FAIL: can see explorer || echo PASS: handles isolated\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "container", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "container", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/08_isolation_desktop.json
+++ b/test_configs/base_container_ui_configs/08_isolation_desktop.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-08",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo PASS: isolation desktop mode active",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/09_desktop_control_blocked.json
+++ b/test_configs/base_container_ui_configs/09_desktop_control_blocked.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-09",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"shutdown /l /t 0 2>nul && echo FAIL: shutdown allowed || echo PASS: shutdown blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/10_no_ui_default_deny.json
+++ b/test_configs/base_container_ui_configs/10_no_ui_default_deny.json
@@ -1,10 +1,10 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-10",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo PASS: default-deny process ran",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [] }
+  "processContainer": { "capabilities": [] }
 }

--- a/test_configs/base_container_ui_configs/11_system_settings_blocked.json
+++ b/test_configs/base_container_ui_configs/11_system_settings_blocked.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-11",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c \"mode con cols=40 2>nul && echo FAIL: display settings changed || echo PASS: display settings blocked\"",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": false, "systemSettings": "none", "ime": false } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/base_container_ui_configs/12_system_settings_allowed.json
+++ b/test_configs/base_container_ui_configs/12_system_settings_allowed.json
@@ -1,11 +1,11 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "UI-Test-12",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo PASS: system settings all mode active",
     "timeout": 15000
   },
-  "appContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
+  "processContainer": { "capabilities": [], "ui": { "isolation": "desktop", "desktopSystemControl": true, "systemSettings": "all", "ime": true } },
   "ui": { "disable": false, "clipboard": "none", "injection": false }
 }

--- a/test_configs/basic_lpac.json
+++ b/test_configs/basic_lpac.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-LPAC-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"print('import sys; Testing LPAC (Least Privilege AppContainer) mode'); print(f'Python: {sys.version}')\"",
     "timeout": 30000
   },
-  "appContainer": {
+  "processContainer": {
     "leastPrivilege": true
   },
   "filesystem": {

--- a/test_configs/basic_permissive.json
+++ b/test_configs/basic_permissive.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Permissive-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys; print(f'Hello from Python {sys.version}'); print('Container test successful')\"",
     "timeout": 30000

--- a/test_configs/basic_processcontainer.json
+++ b/test_configs/basic_processcontainer.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-BasicAppContainer-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys; print(f'Hello from Python {sys.version}'); print('Container test successful')\"",
     "timeout": 30000

--- a/test_configs/containment_process_intent.json
+++ b/test_configs/containment_process_intent.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "CLI-ProcessIntent-Test",
+  "containment": "process",
+  "process": {
+    "commandLine": "python -c \"import sys; print(f'Hello from Python {sys.version}'); print('Process intent test successful')\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\Users\\AdminUser\\AppData\\Local\\Programs"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/test_configs/experimental_hello_processcontainer.json
+++ b/test_configs/experimental_hello_processcontainer.json
@@ -1,7 +1,7 @@
 {
   "version": "0.5.0-alpha",
   "containerId": "CLI-Experimental-Hello",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo experimental hello test"
   },

--- a/test_configs/filesystem_bfs_readonly_test.json
+++ b/test_configs/filesystem_bfs_readonly_test.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-BFSReadOnly-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import os\nallowedreadonly_path = 'C:\\\\temp\\\\wxc_test_allowedreadonly\\\\test_input.txt'\nprint('Testing filesystem BFS Read-Only enforcement...')\nf = open(allowedreadonly_path, 'r')\ntemp = f.read()\nf.close()\nprint(f'Successfully read from : {allowedreadonly_path}')\nprint('Now attempting to write to readonly path...')\ntry:\n    f2 = open(allowedreadonly_path, 'w')\n    f2.write('This should fail')\n    f2.close()\n    print('ERROR: Should not have been able to write to read-only path!')\nexcept PermissionError:\n    print('SUCCESS: Write access to read-only path was blocked as expected')\"",
     "timeout": 30000

--- a/test_configs/filesystem_bfs_spaces_test.json
+++ b/test_configs/filesystem_bfs_spaces_test.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-BFS-Spaces-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "cmd.exe /c echo SUCCESS > \"C:\\Users\\Public\\wxc bfs test\\test_output.txt\" && type \"C:\\Users\\Public\\wxc bfs test\\test_output.txt\"",
     "timeout": 30000

--- a/test_configs/filesystem_bfs_test.json
+++ b/test_configs/filesystem_bfs_test.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-BFS-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import os\nallowed_path = 'C:\\\\temp\\\\wxc_test_allowed\\\\test_output.txt'\ndenied_path = 'C:\\\\temp\\\\wxc_test_denied\\\\forbidden.txt'\nprint('Testing filesystem BFS enforcement...')\nf = open(allowed_path, 'w')\nf.write('SUCCESS: Write to allowed path worked!')\nf.close()\nprint(f'Successfully wrote to: {allowed_path}')\nprint('Now attempting to write to denied path...')\ntry:\n    f2 = open(denied_path, 'w')\n    f2.write('This should fail')\n    f2.close()\n    print('ERROR: Should not have been able to write to denied path!')\nexcept PermissionError:\n    print('SUCCESS: Access to denied path was blocked as expected')\"",
     "timeout": 30000

--- a/test_configs/hello_world_v050.json
+++ b/test_configs/hello_world_v050.json
@@ -1,11 +1,11 @@
 {
   "version": "0.5.0-alpha",
   "containerId": "CLI-HelloWorld-v050",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys; print('Hello from MXC 0.5.0-alpha!'); print(f'Python version: {sys.version}')\""
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "permissiveLearningMode"
     ]

--- a/test_configs/network_both_test.json
+++ b/test_configs/network_both_test.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Both-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport socket\n\nprint('Testing network firewall enforcement...')\nprint('')\n\n# Test 1: Try to connect to allowed host (should succeed)\nprint('Test 1: Connecting to allowed host (api.github.com)...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  SUCCESS: Connected to api.github.com (status: {response.status})')\nexcept Exception as e:\n    print(f'  ERROR: Failed to connect to api.github.com: {e}')\n\nprint('')\n\n# Test 2: Try to connect to blocked host (should fail/timeout)\nprint('Test 2: Connecting to blocked host (google.com)...')\ntry:\n    response = urllib.request.urlopen('https://google.com', timeout=5)\n    print(f'  ERROR: Should not have been able to connect to google.com!')\nexcept Exception as e:\n    print(f'  SUCCESS: Connection to google.com was blocked as expected: {type(e).__name__}')\n\nprint('')\nprint('Network firewall test complete')\"",
     "timeout": 15000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "internetClient"
     ]

--- a/test_configs/network_capabilities_test.json
+++ b/test_configs/network_capabilities_test.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Capabilities-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport socket\n\nprint('Testing network firewall enforcement...')\nprint('')\n\n# Test 1: Try to connect to allowed host (should succeed)\nprint('Test 1: Connecting to allowed host (api.github.com)...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  SUCCESS: Connected to api.github.com (status: {response.status})')\nexcept Exception as e:\n    print(f'  ERROR: Failed to connect to api.github.com: {e}')\n\nprint('')\n\n# Test 2: Try to connect to blocked host (should fail/timeout)\nprint('Test 2: Connecting to blocked host (google.com)...')\ntry:\n    response = urllib.request.urlopen('https://google.com', timeout=5)\n    print(f'  ERROR: Should not have been able to connect to google.com!')\nexcept Exception as e:\n    print(f'  SUCCESS: Connection to google.com was blocked as expected: {type(e).__name__}')\n\nprint('')\nprint('Network firewall test complete')\"",
     "timeout": 15000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "internetClient"
     ]

--- a/test_configs/network_default_test.json
+++ b/test_configs/network_default_test.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Default-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport socket\n\nprint('Testing network firewall enforcement...')\nprint('')\n\n# Test 1: Try to connect to allowed host (should succeed)\nprint('Test 1: Connecting to allowed host (api.github.com)...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  SUCCESS: Connected to api.github.com (status: {response.status})')\nexcept Exception as e:\n    print(f'  ERROR: Failed to connect to api.github.com: {e}')\n\nprint('')\n\n# Test 2: Try to connect to blocked host (should fail/timeout)\nprint('Test 2: Connecting to blocked host (google.com)...')\ntry:\n    response = urllib.request.urlopen('https://google.com', timeout=5)\n    print(f'  ERROR: Should not have been able to connect to google.com!')\nexcept Exception as e:\n    print(f'  SUCCESS: Connection to google.com was blocked as expected: {type(e).__name__}')\n\nprint('')\nprint('Network firewall test complete')\"",
     "timeout": 15000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "internetClient"
     ]

--- a/test_configs/network_firewall_test.json
+++ b/test_configs/network_firewall_test.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Network-Firewall-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\nimport socket\n\nfrom colorama import Fore, Style\n\nprint('Testing network firewall enforcement...')\nprint('')\n\n# Test 1: Try to connect to allowed host (should succeed)\nprint('Test 1: Connecting to allowed host (api.github.com)...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(Fore.GREEN + f'  SUCCESS: Connected to api.github.com (status: {response.status})')\n    print(Style.RESET_ALL)\nexcept Exception as e:\n    print(Fore.RED + f'  ERROR: Failed to connect to api.github.com: {e}')\n    print(Style.RESET_ALL)\n\nprint('')\n\n# Test 2: Try to connect to blocked host (should fail/timeout)\nprint('Test 2: Connecting to blocked host (google.com)...')\ntry:\n    response = urllib.request.urlopen('https://google.com', timeout=5)\n    print(Fore.RED + f'  ERROR: Should not have been able to connect to google.com!')\n    print(Style.RESET_ALL)\nexcept Exception as e:\n    print(Fore.GREEN + f'  SUCCESS: Connection to google.com was blocked as expected: {type(e).__name__}')\n    print(Style.RESET_ALL)\n\nprint('')\nprint('Network firewall test complete')\"",
     "timeout": 15000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "internetClient"
     ]

--- a/test_configs/proxy_builtin_test.json
+++ b/test_configs/proxy_builtin_test.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Proxy-Builtin-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import urllib.request\n\nprint('Test 1: Requesting api.github.com...')\ntry:\n    response = urllib.request.urlopen('https://api.github.com', timeout=10)\n    print(f'  Status: {response.status}')\nexcept Exception as err:\n    print(f'  Error: {err}')\n\nprint()\nprint('Done.')\"",
     "timeout": 15000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "internetClient"
     ]

--- a/test_configs/pwsh_setlocation.json
+++ b/test_configs/pwsh_setlocation.json
@@ -1,7 +1,7 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Pwsh-SetLocation-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "pwsh.exe -nop -nol -c \"Set-PSReadLineOption -HistorySaveStyle SaveNothing; Set-Location c:\\temp\"; Get-ChildItem",
     "timeout": 30000

--- a/test_configs/rejected_version_too_old.json
+++ b/test_configs/rejected_version_too_old.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.0-alpha",
   "containerId": "rejected-too-old",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "echo 'This should not run — version 0.3.0-alpha is rejected'"
   },

--- a/test_configs/with_capabilities.json
+++ b/test_configs/with_capabilities.json
@@ -1,12 +1,12 @@
 {
   "version": "0.4.0-alpha",
   "containerId": "CLI-Cap-Test",
-  "containment": "appcontainer",
+  "containment": "processcontainer",
   "process": {
     "commandLine": "python -c \"import sys; import os; print(f'Python version: {sys.version}'); print(f'Current directory: {os.getcwd()}'); print('Script executed successfully')\"",
     "timeout": 30000
   },
-  "appContainer": {
+  "processContainer": {
     "capabilities": [
       "registryRead"
     ]

--- a/test_scripts/run_basicac_test.ps1
+++ b/test_scripts/run_basicac_test.ps1
@@ -24,7 +24,7 @@ if (-not $BinDir) {
 }
 
 $WxcExec = Join-Path $BinDir "wxc-exec.exe"
-$TestConfig = Join-Path $RepoRoot "test_configs\basic_appcontainer.json"
+$TestConfig = Join-Path $RepoRoot "test_configs\basic_processcontainer.json"
 
 if (-not (Test-Path $WxcExec)) {
     Write-Host "ERROR: wxc-exec.exe not found at $WxcExec" -ForegroundColor Red


### PR DESCRIPTION
Split SDK containment into intent vs. backend, and rename to match

Introduce a two-tier containment naming scheme in the MXC SDK and align
the wire format, schema, runner dispatch, and docs with it. The wire
field accepts either layer; the binary owns intent resolution.

* `ContainmentType`: abstract intent. `'process' | 'vm' | 'microvm'`
  today. Names the *kind* of isolation the caller wants.
* `ContainmentBackend`: concrete runner. `'processcontainer' |
  'windows_sandbox' | 'wslc' | 'lxc' | 'microvm' | 'seatbelt' |
  'isolation_session'`. Names a specific implementation.

The deprecated `SandboxingMethod = ContainmentType | ContainmentBackend`
alias is retained for back-compat. A runtime `ContainmentTypes` list is
exported so callers can recognise abstract intents at run time without
re-deriving the union.

Intent resolution
-----------------

The Rust parser resolves abstract intents at run time, in both
`convert_raw_config_inner` and `parse_containment_str`:

* `process` resolves to `processcontainer` on Windows, `lxc` on Linux,
  and `seatbelt` on macOS.
* `vm` resolves to `windows_sandbox` on Windows; on other platforms it
  falls through to the placeholder `Vm` variant which the host binaries
  surface as a "VM backend not yet implemented" error.
* `microvm` keeps its existing single-backend mapping.

The SDK validator (`resolveExecutableAndArgs`) accepts abstract intents
without checking them against the host's concrete-backend list — the
binary is the source of truth at run time.

Wire-string and type-name renames
---------------------------------

Two PR-feedback renames target the abstraction layer only. The
underlying OS APIs and their Rust modules keep their original names.

* `appcontainer` → `processcontainer` (wire) /
  `appContainer` → `processContainer` (JSON sub-block).
  Reflects that the value names the Windows process-level abstraction;
  wxc-exec dispatches between the legacy AppContainer implementation
  (honors `capabilities`, `learningMode`, `leastPrivilege`) and the
  newer BaseContainer implementation (honors `ui`) at run time based on
  host OS and `--experimental`.
  Rust: `ContainmentBackend::AppContainer` → `ProcessContainer`,
  `RawAppContainer` → `RawProcessContainer`.
  TypeScript: `AppContainerConfig` → `ProcessContainerConfig`.

* `macos_sandbox` → `seatbelt` (wire). Internal types follow:
  `ContainmentBackend::MacosSandbox` → `Seatbelt`,
  `MacosSandboxMode` → `SeatbeltMode`,
  `MacosSandboxConfig` → `SeatbeltConfig`,
  `RawMacosSandbox` → `RawSeatbelt`,
  `experimental.macos_sandbox` field → `seatbelt`. Redundant
  `#[serde(rename)]` attributes are dropped where the field name now
  matches the wire form. Test names follow.

Backward compatibility
----------------------

The parser keeps the pre-0.6 wire vocabulary as dual-read aliases so
configs written against the stable schemas (`0.4.0-alpha`,
`0.5.0-alpha`) continue to parse unchanged:

* `containment: "appcontainer"` is accepted and routed to
  `ContainmentBackend::ProcessContainer`.
* `containment: "macos_sandbox"` is accepted and routed to
  `ContainmentBackend::Seatbelt`.
* JSON sub-block `appContainer` is accepted via `#[serde(alias)]` and
  parsed into the same `process_container` slot as `processContainer`.
* JSON sub-block `experimental.macos_sandbox` is accepted via
  `#[serde(alias)]` and parsed into the same `seatbelt` slot as
  `experimental.seatbelt`.

Type-level back-compat in the TypeScript SDK mirrors the wire-
level aliases:

* `ContainerConfig` exposes a `@deprecated appContainer?:
  ProcessContainerConfig` field next to `processContainer`, so
  callers who construct configs in code with the pre-0.6 name
  keep compiling. The SDK forwards configs to wxc-exec via
  `JSON.stringify` without transforming them, so the Rust-side
  serde alias handles the runtime mapping; the TS alias just
  restores the matching compile-time surface.

Each legacy wire-value encounter emits a one-line deprecation log via
the existing `Logger`, pointing callers at the canonical name. The
aliases are intended for the deprecation window; the 0.6.0-dev schema
documents only the canonical names, and a future schema bump may remove
the aliases.

Kept unchanged
--------------

* `wxc_common::appcontainer_runner` module and its
  `AppContainerScriptRunner` struct (implements the legacy AppContainer
  OS API specifically).
* `BaseContainerSpecification.fbs` `app_container` flatbuffer field
  (controlled by the OS-side schema).
* WinHTTP per-AppContainer proxy policy references (the Win32 API
  itself is named after AppContainer).
* JSDoc, comments, and prose describing AppContainer-the-OS-API
  behaviour.

Schema, docs, and configs
-------------------------

* Dev schema `0.6.0-dev` enum updated; default is `processcontainer`;
  sub-block renamed to `processContainer`. Stable schemas
  `0.4.0-alpha` and `0.5.0-alpha` are untouched (immutable release
  artifacts); the parser's dual-read aliases keep configs targeting
  them working without edits.
* `docs/schema.md` adds an "Abstract intents" table alongside the
  concrete-backends table and uses the new wire strings.
* `docs/examples.md`, `docs/UIPolicy_Schema.md`,
  `docs/windows-sandbox.md`, `docs/nanvix-integration-plan.md`,
  `docs/versioning.md`, `docs/sandbox-policy/v1/policy.md`, and the
  `docs/state-aware-lifecycle/` design docs all migrate to the new
  wire / type names. Prose that describes the underlying OS APIs is
  preserved.
* `examples/*.json` and `test_configs/*.json` updated to the new wire
  values and sub-block keys; appcontainer-named files renamed to their
  processcontainer equivalents (with the e2e and PowerShell harnesses
  updated to match).

Tests and validation
--------------------

* SDK validator gets unit-level coverage for the spawn-path so the
  abstract-intent regression cannot recur.
* New parser tests `process_containment_resolves_per_target` and
  `vm_containment_resolves_per_target` pin the per-target resolution.
* New parser tests
  `legacy_appcontainer_wire_value_aliases_processcontainer`,
  `legacy_macos_sandbox_wire_value_aliases_seatbelt`,
  `legacy_app_container_subblock_alias_accepted`, and
  `legacy_experimental_macos_sandbox_subblock_alias_accepted` pin the
  dual-read behaviour.
* The redundant `containment_vm_accepted` test is removed (now covered
  by the per-target test).

Validation (post-rebase onto main):

* `cargo build --workspace` clean
* `cargo test --workspace --lib` 383/383 passing
* `cargo fmt --all -- --check` clean
* `cargo clippy --workspace --lib --tests -- -D warnings` clean
* `npm run build` (sdk) clean
* `npm test` (sdk) 125/125 passing

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

