### PR TITLE
fix(lxc): resolve unprivileged lxcpath instead of hard-coding /var/lib/lxc

### DIFF
--- a/src/lxc_common/src/filesystem_mounts.rs
+++ b/src/lxc_common/src/filesystem_mounts.rs
@@ -78,8 +78,7 @@ pub fn configure_filesystem_mounts(
 
         // Determine if the path is a file or directory inside the container rootfs
         // so we use the correct LXC `create=` type for the mount entry.
-        let lxc_base = container.config_path().unwrap_or("/var/lib/lxc");
-        let rootfs_base = format!("{}/{}/rootfs", lxc_base, container.name());
+        let rootfs_base = format!("{}/{}/rootfs", container.lxc_path(), container.name());
         let full_path = format!("{}/{}", rootfs_base, container_path);
 
         // Use /dev/null bind mount for files, tmpfs for directories

--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -51,11 +51,20 @@ where
 /// See [`resolve_lxcpath_with_env`] for the exact algorithm. This wrapper
 /// reads the real environment and effective UID.
 pub fn resolve_default_lxcpath() -> String {
+    // `geteuid` only exists on Unix; on other targets the function is never
+    // invoked in production (lxc-exec is Linux-only) but the crate still
+    // needs to compile workspace-wide, so fall back to a non-root EUID.
+    #[cfg(unix)]
     // SAFETY: `geteuid` is a thread-safe, side-effect-free libc call.
-    resolve_lxcpath_with_env(
-        |k| std::env::var(k).ok(),
-        || unsafe { libc::geteuid() } as u32,
-    )
+    fn current_euid() -> u32 {
+        unsafe { libc::geteuid() as u32 }
+    }
+    #[cfg(not(unix))]
+    fn current_euid() -> u32 {
+        1
+    }
+
+    resolve_lxcpath_with_env(|k| std::env::var(k).ok(), current_euid)
 }
 
 /// Safe wrapper around an LXC container.

--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -7,18 +7,79 @@
 //! function pointer fields. This module provides an RAII `LxcContainer` wrapper
 //! that calls the appropriate function pointers and handles cleanup.
 
+/// Resolve the default LXC storage path the way liblxc does.
+///
+/// Replicates the algorithm liblxc applies when no explicit `-P <lxcpath>` is
+/// provided to its CLI tools, using the supplied environment lookup and
+/// effective-uid hooks. Extracted into a free function so unit tests can
+/// exercise every branch deterministically.
+///
+/// Resolution order:
+///  1. `LXC_PATH` env var (if non-empty).
+///  2. `/var/lib/lxc` when running as root (EUID 0).
+///  3. `$XDG_DATA_HOME/lxc` if `XDG_DATA_HOME` is set and non-empty.
+///  4. `$HOME/.local/share/lxc` if `HOME` is set and non-empty.
+///  5. `/var/lib/lxc` as a last-resort fallback.
+fn resolve_lxcpath_with_env<F, G>(get_env: F, geteuid: G) -> String
+where
+    F: Fn(&str) -> Option<String>,
+    G: Fn() -> u32,
+{
+    if let Some(p) = get_env("LXC_PATH") {
+        if !p.is_empty() {
+            return p;
+        }
+    }
+    if geteuid() == 0 {
+        return "/var/lib/lxc".to_string();
+    }
+    if let Some(xdg) = get_env("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return format!("{}/lxc", xdg.trim_end_matches('/'));
+        }
+    }
+    if let Some(home) = get_env("HOME") {
+        if !home.is_empty() {
+            return format!("{}/.local/share/lxc", home.trim_end_matches('/'));
+        }
+    }
+    "/var/lib/lxc".to_string()
+}
+
+/// Resolve the default LXC storage path for the current process.
+///
+/// See [`resolve_lxcpath_with_env`] for the exact algorithm. This wrapper
+/// reads the real environment and effective UID.
+pub fn resolve_default_lxcpath() -> String {
+    // SAFETY: `geteuid` is a thread-safe, side-effect-free libc call.
+    resolve_lxcpath_with_env(
+        |k| std::env::var(k).ok(),
+        || unsafe { libc::geteuid() } as u32,
+    )
+}
+
 /// Safe wrapper around an LXC container.
 pub struct LxcContainer {
     name: String,
-    config_path: Option<String>,
+    /// Resolved LXC storage path (the "lxcpath"). Always populated — either
+    /// from an explicit caller override or from [`resolve_default_lxcpath`].
+    /// Passed via `-P <path>` to every `lxc-*` shell-out so behavior is
+    /// identical regardless of how the binary is launched (e.g. cron, systemd
+    /// units with non-default `HOME`).
+    lxc_path: String,
 }
 
 impl LxcContainer {
     /// Create a new LXC container handle.
-    pub fn new(name: &str, config_path: Option<&str>) -> Self {
+    ///
+    /// `lxc_path`, when `Some`, overrides liblxc's default path resolution.
+    /// When `None`, the default is resolved via [`resolve_default_lxcpath`].
+    pub fn new(name: &str, lxc_path: Option<&str>) -> Self {
         Self {
             name: name.to_string(),
-            config_path: config_path.map(|s| s.to_string()),
+            lxc_path: lxc_path
+                .map(|s| s.to_string())
+                .unwrap_or_else(resolve_default_lxcpath),
         }
     }
 
@@ -27,14 +88,16 @@ impl LxcContainer {
         &self.name
     }
 
-    /// Get the config path (LXC storage path), if set.
-    pub fn config_path(&self) -> Option<&str> {
-        self.config_path.as_deref()
+    /// Get the resolved LXC storage path (the "lxcpath") used by this handle.
+    pub fn lxc_path(&self) -> &str {
+        &self.lxc_path
     }
 
     /// Check if the container exists.
     pub fn is_defined(&self) -> bool {
         let output = std::process::Command::new("lxc-info")
+            .arg("-P")
+            .arg(&self.lxc_path)
             .arg("-n")
             .arg(&self.name)
             .output();
@@ -44,6 +107,8 @@ impl LxcContainer {
     /// Check if the container is running.
     pub fn is_running(&self) -> bool {
         let output = std::process::Command::new("lxc-info")
+            .arg("-P")
+            .arg(&self.lxc_path)
             .arg("-n")
             .arg(&self.name)
             .arg("-s")
@@ -60,7 +125,9 @@ impl LxcContainer {
     /// Create the container from a template/distribution.
     pub fn create(&self, distribution: &str, release: &str) -> Result<(), String> {
         let mut cmd = std::process::Command::new("lxc-create");
-        cmd.arg("-n")
+        cmd.arg("-P")
+            .arg(&self.lxc_path)
+            .arg("-n")
             .arg(&self.name)
             .arg("-t")
             .arg("download")
@@ -71,10 +138,6 @@ impl LxcContainer {
             .arg(release)
             .arg("-a")
             .arg(Self::current_arch());
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
 
         let output = cmd
             .output()
@@ -89,6 +152,11 @@ impl LxcContainer {
     }
 
     /// Set a configuration item on the container.
+    ///
+    /// Appends `key = value` to the container's config file. The error
+    /// message includes the key, value, and target path so users can tell at
+    /// a glance whether the failure is about the entry contents (e.g. a
+    /// nonexistent mount source) or about the config file itself.
     pub fn set_config_item(&self, key: &str, value: &str) -> Result<(), String> {
         let config_path = self.config_file_path();
         let entry = format!("{} = {}\n", key, value);
@@ -100,17 +168,18 @@ impl LxcContainer {
                 use std::io::Write;
                 f.write_all(entry.as_bytes())
             })
-            .map_err(|e| format!("Failed to set config item {}: {}", key, e))
+            .map_err(|e| {
+                format!(
+                    "Failed to set config item {} = {}: {} (config file: {})",
+                    key, value, e, config_path
+                )
+            })
     }
 
     /// Start the container.
     pub fn start(&self) -> Result<(), String> {
         let mut cmd = std::process::Command::new("lxc-start");
-        cmd.arg("-n").arg(&self.name);
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
+        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
 
         let output = cmd
             .output()
@@ -135,11 +204,7 @@ impl LxcContainer {
         // TODO: Implement timeout and working directory support.
 
         let mut cmd = std::process::Command::new("lxc-execute");
-        cmd.arg("-n").arg(&self.name);
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
+        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
 
         cmd.arg("--").arg("/bin/sh").arg("-c").arg(command);
 
@@ -161,11 +226,7 @@ impl LxcContainer {
         _working_directory: &str,
     ) -> Result<(i32, String, String), String> {
         let mut cmd = std::process::Command::new("lxc-attach");
-        cmd.arg("-n").arg(&self.name);
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
+        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
 
         cmd.arg("--").arg("/bin/sh").arg("-c").arg(command);
 
@@ -183,11 +244,7 @@ impl LxcContainer {
     /// Stop the container.
     pub fn stop(&self) -> Result<(), String> {
         let mut cmd = std::process::Command::new("lxc-stop");
-        cmd.arg("-n").arg(&self.name);
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
+        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
 
         let output = cmd
             .output()
@@ -208,11 +265,11 @@ impl LxcContainer {
         }
 
         let mut cmd = std::process::Command::new("lxc-destroy");
-        cmd.arg("-n").arg(&self.name).arg("-f");
-
-        if let Some(ref path) = self.config_path {
-            cmd.arg("-P").arg(path);
-        }
+        cmd.arg("-P")
+            .arg(&self.lxc_path)
+            .arg("-n")
+            .arg(&self.name)
+            .arg("-f");
 
         let output = cmd
             .output()
@@ -228,8 +285,7 @@ impl LxcContainer {
 
     /// Get the path to the container's config file.
     fn config_file_path(&self) -> String {
-        let base = self.config_path.as_deref().unwrap_or("/var/lib/lxc");
-        format!("{}/{}/config", base, self.name)
+        format!("{}/{}/config", self.lxc_path, self.name)
     }
 
     /// Get the current system architecture string for LXC templates.
@@ -246,5 +302,190 @@ impl LxcContainer {
         {
             "amd64"
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn no_env(_: &str) -> Option<String> {
+        None
+    }
+
+    #[test]
+    fn lxcpath_honors_lxc_path_env() {
+        let p = resolve_lxcpath_with_env(
+            |k| {
+                if k == "LXC_PATH" {
+                    Some("/custom/lxc".into())
+                } else {
+                    None
+                }
+            },
+            || 1000,
+        );
+        assert_eq!(p, "/custom/lxc");
+    }
+
+    #[test]
+    fn lxcpath_lxc_path_takes_precedence_over_root_default() {
+        // Even as root, LXC_PATH wins, matching liblxc's behavior.
+        let p = resolve_lxcpath_with_env(
+            |k| {
+                if k == "LXC_PATH" {
+                    Some("/srv/lxc".into())
+                } else {
+                    None
+                }
+            },
+            || 0,
+        );
+        assert_eq!(p, "/srv/lxc");
+    }
+
+    #[test]
+    fn lxcpath_root_default() {
+        let p = resolve_lxcpath_with_env(no_env, || 0);
+        assert_eq!(p, "/var/lib/lxc");
+    }
+
+    #[test]
+    fn lxcpath_user_uses_xdg_data_home() {
+        let p = resolve_lxcpath_with_env(
+            |k| match k {
+                "XDG_DATA_HOME" => Some("/home/u/.data".into()),
+                "HOME" => Some("/home/u".into()),
+                _ => None,
+            },
+            || 1000,
+        );
+        // XDG_DATA_HOME wins over HOME for unprivileged users.
+        assert_eq!(p, "/home/u/.data/lxc");
+    }
+
+    #[test]
+    fn lxcpath_user_strips_trailing_slash_on_xdg() {
+        let p = resolve_lxcpath_with_env(
+            |k| {
+                if k == "XDG_DATA_HOME" {
+                    Some("/home/u/.data/".into())
+                } else {
+                    None
+                }
+            },
+            || 1000,
+        );
+        assert_eq!(p, "/home/u/.data/lxc");
+    }
+
+    #[test]
+    fn lxcpath_user_falls_back_to_home() {
+        let p = resolve_lxcpath_with_env(
+            |k| {
+                if k == "HOME" {
+                    Some("/home/u".into())
+                } else {
+                    None
+                }
+            },
+            || 1000,
+        );
+        assert_eq!(p, "/home/u/.local/share/lxc");
+    }
+
+    #[test]
+    fn lxcpath_user_strips_trailing_slash_on_home() {
+        let p = resolve_lxcpath_with_env(
+            |k| {
+                if k == "HOME" {
+                    Some("/home/u/".into())
+                } else {
+                    None
+                }
+            },
+            || 1000,
+        );
+        assert_eq!(p, "/home/u/.local/share/lxc");
+    }
+
+    #[test]
+    fn lxcpath_empty_env_values_are_ignored() {
+        // Empty LXC_PATH/XDG_DATA_HOME must not be used as the path; resolution
+        // should fall through to the next candidate.
+        let p = resolve_lxcpath_with_env(
+            |k| match k {
+                "LXC_PATH" | "XDG_DATA_HOME" => Some(String::new()),
+                "HOME" => Some("/h".into()),
+                _ => None,
+            },
+            || 1000,
+        );
+        assert_eq!(p, "/h/.local/share/lxc");
+    }
+
+    #[test]
+    fn lxcpath_user_with_no_env_has_safe_fallback() {
+        // Highly unusual: unprivileged process with neither HOME nor
+        // XDG_DATA_HOME. We still return a deterministic path rather than
+        // panicking; callers will surface the resulting filesystem error.
+        let p = resolve_lxcpath_with_env(no_env, || 1000);
+        assert_eq!(p, "/var/lib/lxc");
+    }
+
+    #[test]
+    fn lxc_container_uses_resolved_lxcpath_when_none_provided() {
+        // We can't easily mock libc::geteuid() in the real ctor, but we can
+        // assert the contract: lxc_path() always returns a non-empty path,
+        // even when the caller passes None.
+        let c = LxcContainer::new("any", None);
+        assert!(!c.lxc_path().is_empty());
+    }
+
+    #[test]
+    fn lxc_container_honors_explicit_lxc_path() {
+        let c = LxcContainer::new("my-box", Some("/opt/lxc"));
+        assert_eq!(c.lxc_path(), "/opt/lxc");
+        assert_eq!(c.config_file_path(), "/opt/lxc/my-box/config");
+    }
+
+    #[test]
+    fn config_file_path_uses_resolved_path() {
+        let c = LxcContainer::new("box", Some("/var/lib/lxc"));
+        assert_eq!(c.config_file_path(), "/var/lib/lxc/box/config");
+    }
+
+    #[test]
+    fn set_config_item_error_includes_key_value_and_path() {
+        // Point the container at a path that does not exist so the open()
+        // call reliably fails. The error message must include all three
+        // diagnostic details so users can pinpoint the failure.
+        let bogus_base = std::env::temp_dir().join(format!(
+            "mxc-nonexistent-lxc-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let container = LxcContainer::new("ghost", Some(bogus_base.to_str().unwrap()));
+        let key = "lxc.mount.entry";
+        let value = "/host /target none bind,create=dir 0 0";
+
+        let err = container
+            .set_config_item(key, value)
+            .expect_err("set_config_item should fail when config file is missing");
+
+        assert!(err.contains(key), "error must mention key, got: {}", err);
+        assert!(
+            err.contains(value),
+            "error must mention value, got: {}",
+            err
+        );
+        assert!(
+            err.contains("ghost/config"),
+            "error must mention container config path, got: {}",
+            err
+        );
     }
 }

--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -102,62 +102,56 @@ impl LxcContainer {
         &self.lxc_path
     }
 
+    /// Build a `Command` for an `lxc-*` tool with `-P <lxc_path> -n <name>`
+    /// already populated. Centralizes the argv prefix so we can't accidentally
+    /// drop `-P` again (see #274).
+    fn lxc_command(&self, tool: &str) -> std::process::Command {
+        let mut cmd = std::process::Command::new(tool);
+        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
+        cmd
+    }
+
+    /// Run a prepared `lxc-*` command, mapping spawn / non-zero-exit failures
+    /// to a `String` error tagged with the tool name.
+    fn run_status(mut cmd: std::process::Command, tool: &str) -> Result<(), String> {
+        let output = cmd
+            .output()
+            .map_err(|e| format!("Failed to run {}: {}", tool, e))?;
+        if !output.status.success() {
+            return Err(format!(
+                "{} failed: {}",
+                tool,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+        Ok(())
+    }
+
     /// Check if the container exists.
     pub fn is_defined(&self) -> bool {
-        let output = std::process::Command::new("lxc-info")
-            .arg("-P")
-            .arg(&self.lxc_path)
-            .arg("-n")
-            .arg(&self.name)
-            .output();
+        let output = self.lxc_command("lxc-info").output();
         matches!(output, Ok(o) if o.status.success())
     }
 
     /// Check if the container is running.
     pub fn is_running(&self) -> bool {
-        let output = std::process::Command::new("lxc-info")
-            .arg("-P")
-            .arg(&self.lxc_path)
-            .arg("-n")
-            .arg(&self.name)
-            .arg("-s")
-            .output();
+        let output = self.lxc_command("lxc-info").arg("-s").output();
         match output {
-            Ok(o) => {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                stdout.contains("RUNNING")
-            }
+            Ok(o) => String::from_utf8_lossy(&o.stdout).contains("RUNNING"),
             Err(_) => false,
         }
     }
 
     /// Create the container from a template/distribution.
     pub fn create(&self, distribution: &str, release: &str) -> Result<(), String> {
-        let mut cmd = std::process::Command::new("lxc-create");
-        cmd.arg("-P")
-            .arg(&self.lxc_path)
-            .arg("-n")
-            .arg(&self.name)
-            .arg("-t")
-            .arg("download")
-            .arg("--")
-            .arg("-d")
+        let mut cmd = self.lxc_command("lxc-create");
+        cmd.args(["-t", "download", "--", "-d"])
             .arg(distribution)
             .arg("-r")
             .arg(release)
             .arg("-a")
             .arg(Self::current_arch());
-
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Failed to run lxc-create: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("lxc-create failed: {}", stderr));
-        }
-
-        Ok(())
+        Self::run_status(cmd, "lxc-create")
     }
 
     /// Set a configuration item on the container.
@@ -187,19 +181,7 @@ impl LxcContainer {
 
     /// Start the container.
     pub fn start(&self) -> Result<(), String> {
-        let mut cmd = std::process::Command::new("lxc-start");
-        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
-
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Failed to run lxc-start: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("lxc-start failed: {}", stderr));
-        }
-
-        Ok(())
+        Self::run_status(self.lxc_command("lxc-start"), "lxc-start")
     }
 
     /// Execute a command inside the container, capturing stdout/stderr.
@@ -211,21 +193,18 @@ impl LxcContainer {
         _timeout_ms: u32,
     ) -> Result<(i32, String, String), String> {
         // TODO: Implement timeout and working directory support.
-
-        let mut cmd = std::process::Command::new("lxc-execute");
-        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
-
-        cmd.arg("--").arg("/bin/sh").arg("-c").arg(command);
+        let mut cmd = self.lxc_command("lxc-execute");
+        cmd.args(["--", "/bin/sh", "-c", command]);
 
         let output = cmd
             .output()
             .map_err(|e| format!("Failed to run lxc-execute: {}", e))?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        Ok((exit_code, stdout, stderr))
+        Ok((
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ))
     }
 
     /// Execute a command inside a running container using lxc-attach.
@@ -234,37 +213,23 @@ impl LxcContainer {
         command: &str,
         _working_directory: &str,
     ) -> Result<(i32, String, String), String> {
-        let mut cmd = std::process::Command::new("lxc-attach");
-        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
-
-        cmd.arg("--").arg("/bin/sh").arg("-c").arg(command);
+        let mut cmd = self.lxc_command("lxc-attach");
+        cmd.args(["--", "/bin/sh", "-c", command]);
 
         let output = cmd
             .output()
             .map_err(|e| format!("Failed to run lxc-attach: {}", e))?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        Ok((exit_code, stdout, stderr))
+        Ok((
+            output.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&output.stdout).to_string(),
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ))
     }
 
     /// Stop the container.
     pub fn stop(&self) -> Result<(), String> {
-        let mut cmd = std::process::Command::new("lxc-stop");
-        cmd.arg("-P").arg(&self.lxc_path).arg("-n").arg(&self.name);
-
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Failed to run lxc-stop: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("lxc-stop failed: {}", stderr));
-        }
-
-        Ok(())
+        Self::run_status(self.lxc_command("lxc-stop"), "lxc-stop")
     }
 
     /// Destroy the container (removes rootfs and config).
@@ -272,24 +237,9 @@ impl LxcContainer {
         if self.is_running() {
             let _ = self.stop();
         }
-
-        let mut cmd = std::process::Command::new("lxc-destroy");
-        cmd.arg("-P")
-            .arg(&self.lxc_path)
-            .arg("-n")
-            .arg(&self.name)
-            .arg("-f");
-
-        let output = cmd
-            .output()
-            .map_err(|e| format!("Failed to run lxc-destroy: {}", e))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("lxc-destroy failed: {}", stderr));
-        }
-
-        Ok(())
+        let mut cmd = self.lxc_command("lxc-destroy");
+        cmd.arg("-f");
+        Self::run_status(cmd, "lxc-destroy")
     }
 
     /// Get the path to the container's config file.


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Fixes the LXC unprivileged-mode failure reported in #274:

```
Error: Failed to configure filesystem: Failed to set config item lxc.mount.entry: No such file or directory (os error 2)
```

### Root cause

`LxcContainer::config_file_path()` hard-coded `/var/lib/lxc`, but every `lxc-*` shell-out (`lxc-create`, `lxc-info`, `lxc-start`, ...) was invoked **without `-P`**. As a non-root user, liblxc auto-routes the container to `~/.local/share/lxc/<name>/config` (per `XDG_DATA_HOME` / `HOME`); our wrapper then tried to append `lxc.mount.entry` to `/var/lib/lxc/<name>/config`, which doesn't exist → `ENOENT`.

The same hard-coded path bug also affected the denied-paths rootfs probe in `filesystem_mounts.rs`, where `is_file()` would always return false for unprivileged users and silently mask files with `tmpfs` instead of `/dev/null`.

### Fix

- New `resolve_default_lxcpath()` helper that mimics liblxc's resolution: `LXC_PATH` → `/var/lib/lxc` for root → `$XDG_DATA_HOME/lxc` → `$HOME/.local/share/lxc` → `/var/lib/lxc` last-resort fallback. Extracted into a parameterized `resolve_lxcpath_with_env(get_env, geteuid)` so every branch is covered by deterministic unit tests.
- `LxcContainer` now stores the resolved `lxc_path` (always populated, no `Option`) and passes `-P <resolved>` to **every** `lxc-*` invocation, so behavior is identical regardless of how the binary is launched (cron, systemd unit with non-default `HOME`, etc.).
- `filesystem_mounts.rs` denied-path rootfs probe now uses the resolved `container.lxc_path()` instead of the hard-coded fallback.
- `set_config_item`'s error now includes the key, value, and target config-file path, addressing the diagnostic gap also called out in #274.

### Tests

Added 12 unit tests in `lxc_common::lxc_bindings::tests` covering:

- All `resolve_lxcpath_with_env` branches (`LXC_PATH` precedence even as root, root default, XDG_DATA_HOME wins over HOME, HOME fallback, trailing-slash normalization, empty-env handling, last-resort fallback when neither env var is set).
- `LxcContainer::new(..., None)` always yields a non-empty resolved path.
- `LxcContainer::new(..., Some(...))` honors explicit overrides and `config_file_path()` derives from the resolved path.
- `set_config_item` error message contains key, value, and the container config path.

`cargo test -p lxc_common`: **25 passed** (12 new). `cargo build -p lxc` and `cargo clippy -p lxc_common --no-deps -- -D warnings` clean.

Closes #274
Refs https://github.com/github/copilot-agent-runtime/issues/164

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/275)