### PR TITLE
phase0: add filesystem.allowDaclFallback config option

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -42,7 +42,8 @@ production configs and the dev schema when working on experimental features:
     "filesystem": {
         "readwritePaths": ["C:\\temp"],     // Read-write access
         "readonlyPaths": ["C:\\data"],      // Read-only access
-        "deniedPaths": ["C:\\Windows"]      // Blocked paths
+        "deniedPaths": ["C:\\Windows"],     // Blocked paths
+        "allowDaclFallback": true           // Allow Tier 3 DACL fallback (default true)
     },
 
     "network": {
@@ -76,6 +77,17 @@ production configs and the dev schema when working on experimental features:
     }
 }
 ```
+
+### Filesystem Policy
+
+The `filesystem` section defines path access policy shared across backends:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `readwritePaths` | string[] | `[]` | Paths the process can read and write. |
+| `readonlyPaths` | string[] | `[]` | Paths the process can read but not write. |
+| `deniedPaths` | string[] | `[]` | Paths the process cannot access at all. |
+| `allowDaclFallback` | boolean | `true` | When the BaseContainer API is absent and `bfscfg.exe` is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). **⚠️ This modifies host filesystem security descriptors**; original DACLs are restored on exit. Set to `false` to refuse this fallback — the run will then fail on machines that require Tier 3 (e.g., pre-GE Windows 11 builds without the BaseContainer API). |
 
 ### Containment Backends
 

--- a/schemas/stable/mxc-config.schema.0.5.0-alpha.json
+++ b/schemas/stable/mxc-config.schema.0.5.0-alpha.json
@@ -91,6 +91,11 @@
           "items": { "type": "string" },
           "default": [],
           "description": "Paths the process cannot access at all."
+        },
+        "allowDaclFallback": {
+          "type": "boolean",
+          "default": true,
+          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS — original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3)."
         }
       }
     },

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -67,6 +67,8 @@ struct RawFilesystem {
     readonly_paths: Option<Vec<String>>,
     #[serde(rename = "deniedPaths")]
     denied_paths: Option<Vec<String>>,
+    #[serde(rename = "allowDaclFallback")]
+    allow_dacl_fallback: Option<bool>,
 }
 
 #[derive(Deserialize, Default)]
@@ -723,6 +725,9 @@ fn convert_raw_config_inner(
         }
         if let Some(v) = fscfg.readonly_paths {
             policy.readonly_paths = v;
+        }
+        if let Some(v) = fscfg.allow_dacl_fallback {
+            policy.allow_dacl_fallback = v;
         }
     }
     validate_filesystem_paths(&policy, logger)?;
@@ -1516,6 +1521,39 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.script_timeout, 0);
+    }
+
+    #[test]
+    fn allow_dacl_fallback_default_true() {
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.allow_dacl_fallback);
+    }
+
+    #[test]
+    fn allow_dacl_fallback_explicit_false() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "filesystem": {"allowDaclFallback": false}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.policy.allow_dacl_fallback);
+    }
+
+    #[test]
+    fn allow_dacl_fallback_explicit_true() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "filesystem": {"allowDaclFallback": true}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.allow_dacl_fallback);
     }
 
     // ====== Containment backend selection tests ======

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -272,7 +272,7 @@ impl Default for BaseProcessUiConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ContainerPolicy {
     pub least_privilege_mode: bool,
@@ -280,6 +280,12 @@ pub struct ContainerPolicy {
     pub readwrite_paths: Vec<String>,
     pub readonly_paths: Vec<String>,
     pub denied_paths: Vec<String>,
+    /// When the BaseContainer API is absent and `bfscfg.exe` is unavailable,
+    /// allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). This
+    /// modifies host filesystem security descriptors; original DACLs are
+    /// restored on exit. Defaults to `true`. Set to `false` to refuse the
+    /// fallback (the run will fail on machines that require Tier 3).
+    pub allow_dacl_fallback: bool,
     pub default_network_policy: NetworkPolicy,
     pub network_enforcement_mode: NetworkEnforcementMode,
     pub allowed_hosts: Vec<String>,
@@ -290,6 +296,26 @@ pub struct ContainerPolicy {
     pub ui: UiPolicy,
     /// BaseProcessContainer-specific UI config (Windows only, from processContainer.ui).
     pub base_process_ui: BaseProcessUiConfig,
+}
+
+impl Default for ContainerPolicy {
+    fn default() -> Self {
+        Self {
+            least_privilege_mode: false,
+            capabilities: Vec::new(),
+            readwrite_paths: Vec::new(),
+            readonly_paths: Vec::new(),
+            denied_paths: Vec::new(),
+            allow_dacl_fallback: true,
+            default_network_policy: NetworkPolicy::default(),
+            network_enforcement_mode: NetworkEnforcementMode::default(),
+            allowed_hosts: Vec::new(),
+            blocked_hosts: Vec::new(),
+            network_proxy: ProxyConfig::default(),
+            ui: UiPolicy::default(),
+            base_process_ui: BaseProcessUiConfig::default(),
+        }
+    }
 }
 
 /// Port mapping for host↔container port forwarding.


### PR DESCRIPTION
## 📖 Description

Introduces a new boolean field `filesystem.allowDaclFallback` (default: `true`) on the MXC dev schema. When the BaseContainer OS API is absent and `bfscfg.exe` is unavailable, MXC may fall back to applying DACL ACEs directly on policy paths (Tier 3 fallback). Because this modifies host filesystem security descriptors, operators need a way to refuse the fallback even though the original DACLs are restored on exit.

The default is `true` so that pre-GE Windows 11 builds — which currently have no other downlevel containment path — continue to work out of the box. Setting the field to `false` causes runs that would require Tier 3 to fail fast with a clear error (wired up in a later phase).

Plumbed through:

- `schemas/stable/mxc-config.schema.0.5.0-alpha.json` (new property)
- `RawFilesystem` in `config_parser.rs` (serde field, optional)
- `ContainerPolicy` in `models.rs` (new bool field; manual `Default` impl so the field defaults to `true` rather than `false`)
- Mapping in `load_request` copies the value through, preserving the `true` default when the field is omitted
- Three new unit tests covering default, explicit-true, explicit-false
- `docs/schema.md` updated with a new Filesystem Policy table that documents all four fields

No runner code is touched in this phase; consumers of `allow_dacl_fallback` are added in subsequent phases (phase1+).

This is **phase 0 of the downlevel containment stack** (phase0 → phase5). Subsequent PRs build on this one.

## 🔗 References

Part of the downlevel containment series.

## 🔍 Validation

- New unit tests in `config_parser.rs` cover the three field states (default, explicit true, explicit false).
- No runner behavior changes in this PR — purely schema/config plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)