### PR TITLE
phase0: add fallback.allowDaclMutation config option

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -45,6 +45,10 @@ production configs and the dev schema when working on experimental features:
         "deniedPaths": ["C:\\Windows"]      // Blocked paths
     },
 
+    "fallback": {
+        "allowDaclMutation": true          // Allow Tier 3 DACL fallback (default true)
+    },
+
     "network": {
         "defaultPolicy": "block",          // "allow" or "block"
         "enforcementMode": "firewall",     // "capabilities", "firewall", or "both"
@@ -76,6 +80,24 @@ production configs and the dev schema when working on experimental features:
     }
 }
 ```
+
+### Filesystem Policy
+
+The `filesystem` section defines path access policy shared across backends:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `readwritePaths` | string[] | `[]` | Paths the process can read and write. |
+| `readonlyPaths` | string[] | `[]` | Paths the process can read but not write. |
+| `deniedPaths` | string[] | `[]` | Paths the process cannot access at all. |
+
+### Fallback Policy
+
+The `fallback` section gates the runner's host-impacting fallbacks. Each flag is an explicit operator consent for a specific mechanism the runner may otherwise pick when the preferred primitive is unavailable. Defaults preserve the pre-fallback-section behavior (all permitted).
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `allowDaclMutation` | boolean | `true` | When the BaseContainer API is absent and `bfscfg.exe` is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). **⚠️ This modifies host filesystem security descriptors**; original DACLs are restored on exit. Set to `false` to refuse this fallback — the run will then fail on machines that require Tier 3 (e.g., pre-GE Windows 11 builds without the BaseContainer API). |
 
 ### Containment Backends
 

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -103,6 +103,18 @@
       }
     },
 
+    "fallback": {
+      "type": "object",
+      "description": "Operator consent for host-impacting containment fallbacks. Each flag gates a specific fallback mechanism the runner may otherwise pick when the preferred primitive is unavailable. Defaults preserve the pre-fallback-section behavior (all permitted).",
+      "properties": {
+        "allowDaclMutation": {
+          "type": "boolean",
+          "default": true,
+          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS — original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3)."
+        }
+      }
+    },
+
     "network": {
       "type": "object",
       "description": "Network access policy. Shared across all backends.",

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -71,6 +71,13 @@ struct RawFilesystem {
 
 #[derive(Deserialize, Default)]
 #[serde(default)]
+struct RawFallback {
+    #[serde(rename = "allowDaclMutation")]
+    allow_dacl_mutation: Option<bool>,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
 struct RawNetwork {
     #[serde(rename = "defaultPolicy")]
     default_policy: Option<String>,
@@ -205,6 +212,7 @@ struct RawConfig {
     process_container: Option<RawProcessContainer>,
     lxc: Option<RawLxc>,
     filesystem: Option<RawFilesystem>,
+    fallback: Option<RawFallback>,
     network: Option<RawNetwork>,
     ui: Option<RawUi>,
     experimental: Option<RawExperimental>,
@@ -229,6 +237,8 @@ struct RawStateAwareRequest {
     process: Option<RawProcess>,
     #[serde(default)]
     filesystem: Option<RawFilesystem>,
+    #[serde(default)]
+    fallback: Option<RawFallback>,
     #[serde(default)]
     network: Option<RawNetwork>,
     #[serde(default)]
@@ -728,6 +738,13 @@ fn convert_raw_config_inner(
     }
     validate_filesystem_paths(&policy, logger)?;
 
+    // Fallback section
+    if let Some(fbcfg) = raw.fallback {
+        if let Some(v) = fbcfg.allow_dacl_mutation {
+            policy.fallback.allow_dacl_mutation = v;
+        }
+    }
+
     // Network section
     if let Some(net) = raw.network {
         if let Some(proxy_value) = net.proxy {
@@ -930,6 +947,7 @@ fn convert_raw_state_aware(
         process_container: None,
         lxc: None,
         filesystem: raw.filesystem,
+        fallback: raw.fallback,
         network: raw.network,
         ui: raw.ui,
         // The state-aware experimental block has a different shape from the
@@ -1517,6 +1535,39 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.script_timeout, 0);
+    }
+
+    #[test]
+    fn allow_dacl_mutation_default_true() {
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.fallback.allow_dacl_mutation);
+    }
+
+    #[test]
+    fn allow_dacl_mutation_explicit_false() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "fallback": {"allowDaclMutation": false}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.policy.fallback.allow_dacl_mutation);
+    }
+
+    #[test]
+    fn allow_dacl_mutation_explicit_true() {
+        let json = r#"{
+            "process": {"commandLine": "echo hi"},
+            "fallback": {"allowDaclMutation": true}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.fallback.allow_dacl_mutation);
     }
 
     // ====== Containment backend selection tests ======

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -277,7 +277,30 @@ impl Default for BaseProcessUiConfig {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+/// Operator consent for host-impacting containment fallbacks. Each flag gates
+/// a specific fallback the runner may otherwise pick when the preferred
+/// primitive is unavailable. Defaults preserve the pre-fallback-section
+/// behavior (all permitted).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct FallbackPolicy {
+    /// When the BaseContainer API is absent and `bfscfg.exe` is unavailable,
+    /// allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). This
+    /// modifies host filesystem security descriptors; original DACLs are
+    /// restored on exit. Defaults to `true`. Set to `false` to refuse the
+    /// fallback (the run will fail on machines that require Tier 3).
+    pub allow_dacl_mutation: bool,
+}
+
+impl Default for FallbackPolicy {
+    fn default() -> Self {
+        Self {
+            allow_dacl_mutation: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ContainerPolicy {
     pub least_privilege_mode: bool,
@@ -285,6 +308,7 @@ pub struct ContainerPolicy {
     pub readwrite_paths: Vec<String>,
     pub readonly_paths: Vec<String>,
     pub denied_paths: Vec<String>,
+    pub fallback: FallbackPolicy,
     pub default_network_policy: NetworkPolicy,
     pub network_enforcement_mode: NetworkEnforcementMode,
     pub allowed_hosts: Vec<String>,


### PR DESCRIPTION
## 📖 Description

Introduces a new top-level `fallback` section on the MXC dev schema (`0.6.0-dev`), with a single occupant: `allowDaclMutation` (default: `true`). When the BaseContainer OS API is absent and `bfscfg.exe` is unavailable, MXC may fall back to applying DACL ACEs directly on policy paths (Tier 3 fallback). Because this modifies host filesystem security descriptors, operators need a way to refuse the fallback even though the original DACLs are restored on exit.

The `fallback` section names **operator consent for host-impacting containment fallbacks**. It is intentionally a section rather than a filesystem-scoped flag so future host-mutating fallbacks can land alongside as siblings without re-shuffling the schema. (Addresses review feedback on the prior shape.)

The default is `true` so that pre-GE Windows 11 builds — which currently have no other downlevel containment path — continue to work out of the box. Setting the field to `false` causes runs that would require Tier 3 to fail fast with a clear error (wired up in a later phase).

Plumbed through:

- `schemas/dev/mxc-config.schema.0.6.0-dev.json` (new top-level `fallback` object with `allowDaclMutation` property)
- `RawFallback` in `config_parser.rs` (new serde struct, optional on both `RawConfig` and the state-aware request envelope)
- `FallbackPolicy` in `models.rs` (new struct with manual `Default` impl so `allow_dacl_mutation` defaults to `true`); `ContainerPolicy` gains a `fallback: FallbackPolicy` field
- Mapping in `load_request` copies the value through, preserving the `true` default when the field is omitted
- Three new unit tests covering default, explicit-true, explicit-false
- `docs/schema.md` updated with a new Fallback Policy section

No runner code is touched in this phase; consumers of `fallback.allow_dacl_mutation` are added in subsequent phases (phase1+).

This is **phase 0 of the downlevel containment stack** (phase0 → phase5). Subsequent PRs build on this one.

## 🔗 References

Part of the downlevel containment series. Schema-doc coverage tracked separately in #285.

## 🔍 Validation

- New unit tests in `config_parser.rs` cover the three field states (default, explicit true, explicit false).
- No runner behavior changes in this PR — purely schema/config plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)