### PR TITLE
[IsolationSession] Defer regid unregister to enable concurrent sandboxes

### DIFF
--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -51,21 +51,17 @@ use windows_core::{HSTRING, PCWSTR};
 
 // -- Identifiers -------------------------------------------------------------
 
-/// Registration ID used with the `IsoSessionOps` wrapper.
+/// Registration ID used with the in-proc `IsoSessionOps` API.
 ///
-/// The `IsoSessionOps` wrapper hardcodes `L"regid"` internally for every
-/// agent-name-keyed op, so callers must register with this exact literal
-/// or subsequent calls hit the wrong registration.
+/// The OS API hardcodes `L"regid"` internally for every agent-name-keyed
+/// op, so callers must register with this exact literal or subsequent
+/// calls hit the wrong registration. Because the id is hardcoded, the
+/// registration is effectively shared across all concurrent MXC
+/// isolation-session sandboxes for the calling user; see
+/// `IsolationSessionManager::register_client` (idempotence) and
+/// `unregister_client` (intentional non-call) for the lifecycle
+/// implications.
 const REGISTRATION_ID: &str = "regid";
-
-/// Default provisionId used by the one-shot backend path. State-aware
-/// callers mint their own dynamic ids (e.g. `wxc-<8-hex>`) instead.
-///
-/// `provisionId` scopes the agent user across the lifecycle and is reused as
-/// the `agentName` parameter on every subsequent op — the `IsoSessionOps`
-/// wrapper aliases `agentName` to this `provisionId` at the COM layer, so
-/// callers pass `provisionId` where the IDL says `agentName`.
-pub const DEFAULT_PROVISION_ID: &str = "wxc-provid";
 
 impl From<IsolationSessionConfigurationId> for IsoSessionConfigId {
     fn from(value: IsolationSessionConfigurationId) -> Self {
@@ -91,7 +87,7 @@ pub enum IsolationSessionError {
     /// `Feature_IsoBrokerSessionApis` disabled).
     ServiceUnavailable(String),
     /// An OS-side lifecycle step (register / provision / start / exec /
-    /// stop / deprovision / unregister) returned a failure.
+    /// stop / deprovision) returned a failure.
     Lifecycle(String),
     /// The OS-side service could not find the provisionId — the sandbox
     /// has been deprovisioned (or never provisioned in this user's
@@ -492,11 +488,11 @@ pub(crate) fn aggregate_share_folder_outcomes(
 pub struct IsolationSessionManager {
     /// Registration identifier used in `RegisterApp` / `AddUserAsync`
     /// / `UnregisterAppAsync`. Pegged to the literal `"regid"` per the
-    /// wrapper's internal hardcode.
+    /// OS API's internal hardcode.
     registration_id: HSTRING,
     /// Provision identifier. Used as the `provisionId` argument to
     /// `AddUserAsync` and as the `agentName` argument to every subsequent
-    /// op (the wrapper aliases them at the COM layer).
+    /// op (the OS API aliases them at the COM layer).
     provision_id: HSTRING,
     /// The activated `IsoSessionOps` instance. Held for the lifetime of the
     /// manager so the WinRT factory is reused across calls.
@@ -506,8 +502,8 @@ pub struct IsolationSessionManager {
 impl IsolationSessionManager {
     /// Activates the `IsoSessionOps` factory, verifies the service is
     /// available, and pegs the manager to the supplied `provisionId`.
-    /// One-shot callers pass `DEFAULT_PROVISION_ID`; state-aware callers
-    /// mint a dynamic id per provision (e.g. `wxc-<8-hex>`).
+    /// Both one-shot and state-aware callers mint a dynamic id per
+    /// invocation (e.g. `wxc-<8-hex>`).
     pub fn new(provision_id: &str) -> Result<Self, IsolationSessionError> {
         let ops = check_service_available_and_activate()?;
         Ok(Self {
@@ -517,8 +513,11 @@ impl IsolationSessionManager {
         })
     }
 
-    /// Step 0: Register the app with the OS-side service.
+    /// Registers the app with the OS-side service.
     pub fn register_client(&self) -> Result<(), IsolationSessionError> {
+        // RegisterApp is safe to call repeatedly with the same regid — the
+        // OS API returns a non-error result on duplicates, so we register
+        // on every provision and let the service dedupe.
         let result = self
             .ops
             .RegisterApp(&self.registration_id)
@@ -927,16 +926,26 @@ impl IsolationSessionManager {
         check_result(&result, "RemoveUserAsync")
     }
 
-    /// Step 6: Unregister the client.
+    /// Tears down the client registration set up by `register_client` —
+    /// currently a no-op (see body comment).
     pub fn unregister_client(&self) -> Result<(), IsolationSessionError> {
-        let async_op = self
-            .ops
-            .UnregisterAppAsync(&self.registration_id)
-            .map_err(|e| lifecycle_err(format!("UnregisterAppAsync call failed: {}", e)))?;
-        let result = async_op
-            .join()
-            .map_err(|e| lifecycle_err(format!("UnregisterAppAsync wait failed: {}", e)))?;
-        check_result(&result, "UnregisterAppAsync")
+        // The following call is commented out by design. The regid is
+        // currently hardcoded as `L"regid"` and shared across all
+        // concurrent MXC isolation-session sandboxes for the calling
+        // user; calling UnregisterAppAsync would tear down the
+        // registration for every other still-running one. Reversible
+        // when the OS APIs eliminate registration IDs entirely; do not
+        // uncomment without verifying OS API behavior has changed.
+        //
+        // let async_op = self
+        //     .ops
+        //     .UnregisterAppAsync(&self.registration_id)
+        //     .map_err(|e| lifecycle_err(format!("UnregisterAppAsync call failed: {}", e)))?;
+        // let result = async_op
+        //     .join()
+        //     .map_err(|e| lifecycle_err(format!("UnregisterAppAsync wait failed: {}", e)))?;
+        // check_result(&result, "UnregisterAppAsync")
+        Ok(())
     }
 }
 
@@ -998,7 +1007,9 @@ pub struct ProcessResult {
 
 /// Thin `ScriptRunner` wrapper that performs the full isolation session
 /// lifecycle per invocation. For v0.1, each `run()` call does:
-/// register → provision → start → execute → stop → deprovision → unregister.
+/// register → provision → start → execute → stop → deprovision.
+/// `unregister_client` is still called as part of teardown but is a
+/// deliberate no-op — see its body comment.
 pub struct IsolationSessionRunner;
 
 impl IsolationSessionRunner {
@@ -1057,14 +1068,16 @@ impl ScriptRunner for IsolationSessionRunner {
             .map(|cfg| cfg.configuration_id)
             .unwrap_or_default();
 
-        // Activate the in-proc IsoSessionOps factory. One-shot uses the
-        // hardcoded default provisionId; state-aware mints a dynamic one.
-        let manager = match IsolationSessionManager::new(DEFAULT_PROVISION_ID) {
+        // Activate the in-proc IsoSessionOps factory. Both one-shot and
+        // state-aware mint a per-invocation provisionId so concurrent MXC
+        // isolation-session processes do not collide on agent identity.
+        let provision_id = format!("wxc-{}", mint_random_token());
+        let manager = match IsolationSessionManager::new(&provision_id) {
             Ok(m) => m,
             Err(e) => return e.into(),
         };
 
-        // Full lifecycle: register → provision → start → execute → stop → deprovision → unregister.
+        // Full lifecycle: register → provision → start → execute → stop → deprovision.
         if let Err(e) = manager.register_client() {
             return e.into();
         }
@@ -1113,7 +1126,7 @@ impl ScriptRunner for IsolationSessionRunner {
             }
         };
 
-        // Cleanup: stop → deprovision → unregister.
+        // Cleanup: stop → deprovision.
         if let Err(e) = manager.stop_session() {
             let _ = writeln!(logger, "Warning: stop_session failed: {}", e);
         }
@@ -1262,15 +1275,11 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         Ok(StopResult { metadata: None })
     }
 
-    /// Removes the agent user, then unregisters the client. Mirrors the
-    /// one-shot teardown sequence so a state-aware lifecycle leaves the
-    /// OS-side service in the same end state as a one-shot run.
-    ///
-    /// `unregister_client` tears down the client registration that
-    /// `provision` set up via `register_client`. v1 does not target
-    /// concurrent state-aware sessions, which would share that
-    /// registration -- if that becomes a real requirement, this will
-    /// need either a refcount or a "leave-registration-alone" mode.
+    /// Removes the agent user. The `unregister_client` step is currently
+    /// a no-op (see `IsolationSessionManager::unregister_client`) so
+    /// concurrent MXC isolation-session sandboxes can coexist on the
+    /// shared hardcoded regid; deprovisioning one does not tear down
+    /// another still-running sandbox.
     fn deprovision(
         &mut self,
         sandbox_id: &str,

--- a/test_configs/isolation_session_concurrent_A.json
+++ b/test_configs/isolation_session_concurrent_A.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-concurrent-A",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\A.ps1",
+    "timeout": 60000
+  },
+  "policy": {
+    "readwritePaths": ["C:\\mxc_concurrent_log"]
+  }
+}

--- a/test_configs/isolation_session_concurrent_B.json
+++ b/test_configs/isolation_session_concurrent_B.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-concurrent-B",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\B.ps1",
+    "timeout": 30000
+  },
+  "policy": {
+    "readwritePaths": ["C:\\mxc_concurrent_log"]
+  }
+}

--- a/test_configs/isolation_session_concurrent_C.json
+++ b/test_configs/isolation_session_concurrent_C.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-concurrent-C",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\C.ps1",
+    "timeout": 75000
+  },
+  "policy": {
+    "readwritePaths": ["C:\\mxc_concurrent_log"]
+  }
+}

--- a/test_configs/isolation_session_concurrent_D.json
+++ b/test_configs/isolation_session_concurrent_D.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-concurrent-D",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "echo D-start & ping -n 11 127.0.0.1 > nul & echo D-done",
+    "timeout": 30000
+  }
+}

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -224,12 +224,24 @@ function Setup-LockedDownTestDir {
 
 # Sends a state-aware provision request and surfaces a `backend_unavailable`
 # envelope as a SKIP. This catches feature-flag-off builds without raising
-# false test failures.
+# false test failures. On a healthy build the probe successfully creates an
+# agent user, so we immediately deprovision the throwaway sandbox -- without
+# this, every test run would leak one local agent user.
 $probe = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision.json' -Experimental
 $probeEnv = Parse-Envelope -Stdout $probe.Stdout
 if ($null -ne $probeEnv -and $probeEnv.error.code -eq 'backend_unavailable') {
     Write-Host "SKIPPED: wxc-exec reports backend_unavailable (likely built without --features isolation_session)" -ForegroundColor Yellow
     exit 0
+}
+if ($null -ne $probeEnv -and $null -ne $probeEnv.result -and $null -ne $probeEnv.result.sandboxId) {
+    $probeSandboxId = [string]$probeEnv.result.sandboxId
+    $probeAgent = if ($probeEnv.result.metadata) { [string]$probeEnv.result.metadata.agentUserName } else { '<absent>' }
+    Write-Host "Backend probe: provisioned $probeSandboxId (agentUserName=$probeAgent), deprovisioning ..." -ForegroundColor DarkGray
+    $probeDeprov = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $probeSandboxId -Experimental
+    if ($probeDeprov.ExitCode -ne 0) {
+        Write-Host "WARN: probe deprovision returned exit $($probeDeprov.ExitCode); local user $probeAgent may persist" -ForegroundColor Yellow
+        Write-Host "  Stdout: $($probeDeprov.Stdout)" -ForegroundColor Gray
+    }
 }
 
 # ---------------- Tests ----------------
@@ -688,6 +700,8 @@ try {
             $script:fsSandboxId = $envObj.result.sandboxId
             Assert-True ($script:fsSandboxId -match '^iso:wxc-[0-9a-f]{8}$') `
                 "sandbox_id matches iso:wxc-<8-hex> ($script:fsSandboxId)"
+            $agentUserName = if ($envObj.result.metadata) { [string]$envObj.result.metadata.agentUserName } else { '<absent>' }
+            Write-Host "  filesystem provisioned: agentUserName=$agentUserName" -ForegroundColor DarkGray
         }
     }
 
@@ -818,6 +832,8 @@ try {
             $script:mediumSandboxId = $envObj.result.sandboxId
             Assert-True ($script:mediumSandboxId -match '^iso:wxc-[0-9a-f]{8}$') `
                 "sandbox_id matches iso:wxc-<8-hex> ($script:mediumSandboxId)"
+            $agentUserName = if ($envObj.result.metadata) { [string]$envObj.result.metadata.agentUserName } else { '<absent>' }
+            Write-Host "  Medium provisioned: agentUserName=$agentUserName" -ForegroundColor DarkGray
         }
     } | Out-Null
 
@@ -956,6 +972,255 @@ Run-StateAwareTest "start (user.upn mismatches sandboxId)" {
     Assert-True ($msg.Contains('does not match sandboxId')) "error.message mentions sandboxId mismatch (got '$msg')"
 } | Out-Null
 
+# ---------------- Lifecycle E: Simultaneous isolation-session sandboxes ----------------
+#
+# Three concurrently-provisioned sandboxes (A, B, C) verify that
+# deprovisioning one does not tear down the others. The runner does not
+# call UnregisterAppAsync (see IsolationSessionManager::unregister_client)
+# so the per-user hardcoded `regid` registration survives a deprovision of
+# any individual sandbox. Without that property the first deprovision
+# would break every still-running concurrent sandbox.
+#
+# Per-agent state isolation is verified by having each sandbox write a
+# unique marker file into its agent's %TEMP% and asserting that each
+# sandbox sees only its own marker.
+
+$script:saSandboxA = $null
+$script:saSandboxB = $null
+$script:saSandboxC = $null
+$script:saSandboxD = $null
+$saADeprov = $false
+$saBDeprov = $false
+$saCDeprov = $false
+$saDDeprov = $false
+
+# Helper: provision a fresh sandbox; returns the sandboxId on success, $null on
+# failure. Also logs the OS-assigned agentUserName so post-run inspection of
+# leftover local users can be correlated back to a specific test.
+function Provision-LifecycleESandbox {
+    param([string]$Label)
+    $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision.json' -Experimental
+    $envObj = Parse-Envelope -Stdout $r.Stdout
+    if ((Envelope-Arm $envObj) -ne 'result') {
+        Write-Host "  $Label provision returned arm: $(Envelope-Arm $envObj)" -ForegroundColor Red
+        Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+        return $null
+    }
+    $sandboxId = $envObj.result.sandboxId
+    $agentUserName = if ($envObj.result.metadata) { [string]$envObj.result.metadata.agentUserName } else { '<absent>' }
+    Write-Host "  $Label provisioned: sandboxId=$sandboxId agentUserName=$agentUserName" -ForegroundColor DarkGray
+    return $sandboxId
+}
+
+# Helper: exec a marker-write command inside the given sandbox.
+function Exec-LifecycleEWriteMarker {
+    param([string]$SandboxId, [string]$Marker)
+    $req = @{
+        phase     = 'exec'
+        sandboxId = $SandboxId
+        process   = @{
+            commandLine = "cmd /c `"echo $Marker-content > %TEMP%\$Marker.txt`""
+            timeout     = 30000
+        }
+    }
+    Invoke-StateAware -Request $req -Experimental
+}
+
+# Helper: exec a "list all markers" command inside the given sandbox.
+function Exec-LifecycleEListMarkers {
+    param([string]$SandboxId)
+    $req = @{
+        phase     = 'exec'
+        sandboxId = $SandboxId
+        process   = @{
+            commandLine = 'cmd /c "dir /b %TEMP%\marker_*.txt 2>nul"'
+            timeout     = 30000
+        }
+    }
+    Invoke-StateAware -Request $req -Experimental
+}
+
+try {
+    # E1: Provision A, B, C (three distinct sandbox_ids).
+    Run-StateAwareTest "Lifecycle E: provision A" {
+        $script:saSandboxA = Provision-LifecycleESandbox -Label "A"
+        Assert-True ($null -ne $script:saSandboxA) "saSandboxA is non-null"
+        if ($null -ne $script:saSandboxA) {
+            Assert-True ($script:saSandboxA -match '^iso:wxc-[0-9a-f]{8}$') "saSandboxA matches expected format ($script:saSandboxA)"
+        }
+    } | Out-Null
+    Run-StateAwareTest "Lifecycle E: provision B" {
+        $script:saSandboxB = Provision-LifecycleESandbox -Label "B"
+        Assert-True ($null -ne $script:saSandboxB) "saSandboxB is non-null"
+        if ($null -ne $script:saSandboxB) {
+            Assert-True ($script:saSandboxB -ne $script:saSandboxA) "saSandboxB differs from saSandboxA"
+        }
+    } | Out-Null
+    Run-StateAwareTest "Lifecycle E: provision C" {
+        $script:saSandboxC = Provision-LifecycleESandbox -Label "C"
+        Assert-True ($null -ne $script:saSandboxC) "saSandboxC is non-null"
+        if ($null -ne $script:saSandboxC) {
+            Assert-True ($script:saSandboxC -ne $script:saSandboxA) "saSandboxC differs from saSandboxA"
+            Assert-True ($script:saSandboxC -ne $script:saSandboxB) "saSandboxC differs from saSandboxB"
+        }
+    } | Out-Null
+
+    $allProvisioned = $null -ne $script:saSandboxA -and $null -ne $script:saSandboxB -and $null -ne $script:saSandboxC
+
+    if ($allProvisioned) {
+        # E2: Start A, B, C.
+        Run-StateAwareTest "Lifecycle E: start A" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_start.json' -SandboxId $script:saSandboxA -Experimental
+            Assert-True ($r.ExitCode -eq 0) "start A exit 0"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: start B" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_start.json' -SandboxId $script:saSandboxB -Experimental
+            Assert-True ($r.ExitCode -eq 0) "start B exit 0"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: start C" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_start.json' -SandboxId $script:saSandboxC -Experimental
+            Assert-True ($r.ExitCode -eq 0) "start C exit 0"
+        } | Out-Null
+
+        # E3: Each agent writes its own marker into its %TEMP%.
+        Run-StateAwareTest "Lifecycle E: A writes marker_A" {
+            $r = Exec-LifecycleEWriteMarker -SandboxId $script:saSandboxA -Marker "marker_A"
+            Assert-True ($r.ExitCode -eq 0) "exec write marker_A exit 0"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: B writes marker_B" {
+            $r = Exec-LifecycleEWriteMarker -SandboxId $script:saSandboxB -Marker "marker_B"
+            Assert-True ($r.ExitCode -eq 0) "exec write marker_B exit 0"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: C writes marker_C" {
+            $r = Exec-LifecycleEWriteMarker -SandboxId $script:saSandboxC -Marker "marker_C"
+            Assert-True ($r.ExitCode -eq 0) "exec write marker_C exit 0"
+        } | Out-Null
+
+        # E4: Each agent's %TEMP% lists only its own marker.
+        Run-StateAwareTest "Lifecycle E: A sees only its own marker" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxA
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0"
+            Assert-True ($out.Contains("marker_A.txt")) "A sees marker_A.txt"
+            Assert-True (-not $out.Contains("marker_B.txt")) "A does not see marker_B.txt"
+            Assert-True (-not $out.Contains("marker_C.txt")) "A does not see marker_C.txt"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: B sees only its own marker" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxB
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0"
+            Assert-True ($out.Contains("marker_B.txt")) "B sees marker_B.txt"
+            Assert-True (-not $out.Contains("marker_A.txt")) "B does not see marker_A.txt"
+            Assert-True (-not $out.Contains("marker_C.txt")) "B does not see marker_C.txt"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: C sees only its own marker" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxC
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0"
+            Assert-True ($out.Contains("marker_C.txt")) "C sees marker_C.txt"
+            Assert-True (-not $out.Contains("marker_A.txt")) "C does not see marker_A.txt"
+            Assert-True (-not $out.Contains("marker_B.txt")) "C does not see marker_B.txt"
+        } | Out-Null
+
+        # E5: Stop + deprovision B. The regid leak means the registration
+        # survives B's deprovision and A / C remain functional.
+        Run-StateAwareTest "Lifecycle E: stop B" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:saSandboxB -Experimental
+            Assert-True ($r.ExitCode -eq 0) "stop B exit 0"
+        } | Out-Null
+        $bDeprovPassed = Run-StateAwareTest "Lifecycle E: deprovision B" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:saSandboxB -Experimental
+            Assert-True ($r.ExitCode -eq 0) "deprovision B exit 0"
+        }
+        if ($bDeprovPassed) { $saBDeprov = $true }
+
+        # E6: Regression check -- A and C remain functional after B
+        # deprovisioned. Would fail without the regid leak.
+        Run-StateAwareTest "Lifecycle E: A still functional after B deprov" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxA
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0 (regid not torn down by B's deprovision)"
+            Assert-True ($out.Contains("marker_A.txt")) "A still sees marker_A.txt"
+        } | Out-Null
+        Run-StateAwareTest "Lifecycle E: C still functional after B deprov" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxC
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0 (regid not torn down by B's deprovision)"
+            Assert-True ($out.Contains("marker_C.txt")) "C still sees marker_C.txt"
+        } | Out-Null
+
+        # E7: Stop + deprovision A.
+        Run-StateAwareTest "Lifecycle E: stop A" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:saSandboxA -Experimental
+            Assert-True ($r.ExitCode -eq 0) "stop A exit 0"
+        } | Out-Null
+        $aDeprovPassed = Run-StateAwareTest "Lifecycle E: deprovision A" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:saSandboxA -Experimental
+            Assert-True ($r.ExitCode -eq 0) "deprovision A exit 0"
+        }
+        if ($aDeprovPassed) { $saADeprov = $true }
+
+        # E8: Regression check -- C remains functional after A deprovisioned.
+        Run-StateAwareTest "Lifecycle E: C still functional after A deprov" {
+            $r = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxC
+            $out = [string]$r.Stdout
+            Assert-True ($r.ExitCode -eq 0) "list exit 0"
+            Assert-True ($out.Contains("marker_C.txt")) "C still sees marker_C.txt"
+        } | Out-Null
+
+        # E9: Stop + deprovision C.
+        Run-StateAwareTest "Lifecycle E: stop C" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:saSandboxC -Experimental
+            Assert-True ($r.ExitCode -eq 0) "stop C exit 0"
+        } | Out-Null
+        $cDeprovPassed = Run-StateAwareTest "Lifecycle E: deprovision C" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:saSandboxC -Experimental
+            Assert-True ($r.ExitCode -eq 0) "deprovision C exit 0"
+        }
+        if ($cDeprovPassed) { $saCDeprov = $true }
+    }
+
+    # E10: Fresh provision D after all three torn down -- the leaked regid
+    # must not poison new sandboxes either.
+    Run-StateAwareTest "Lifecycle E: provision D after all torn down" {
+        $script:saSandboxD = Provision-LifecycleESandbox -Label "D"
+        Assert-True ($null -ne $script:saSandboxD) "saSandboxD is non-null"
+    } | Out-Null
+    if ($null -ne $script:saSandboxD) {
+        $dBundlePassed = Run-StateAwareTest "Lifecycle E: D start + exec + stop + deprovision" {
+            $rs = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_start.json' -SandboxId $script:saSandboxD -Experimental
+            Assert-True ($rs.ExitCode -eq 0) "start D exit 0"
+            $rw = Exec-LifecycleEWriteMarker -SandboxId $script:saSandboxD -Marker "marker_D"
+            Assert-True ($rw.ExitCode -eq 0) "exec write marker_D exit 0"
+            $rl = Exec-LifecycleEListMarkers -SandboxId $script:saSandboxD
+            $out = [string]$rl.Stdout
+            Assert-True ($out.Contains("marker_D.txt")) "D sees marker_D.txt"
+            $rst = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_stop.json' -SandboxId $script:saSandboxD -Experimental
+            Assert-True ($rst.ExitCode -eq 0) "stop D exit 0"
+            $rd = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:saSandboxD -Experimental
+            Assert-True ($rd.ExitCode -eq 0) "deprovision D exit 0"
+        }
+        if ($dBundlePassed) { $saDDeprov = $true }
+    }
+} finally {
+    # Best-effort deprovision of any sandbox left provisioned (e.g., due
+    # to a mid-flow test failure).
+    foreach ($entry in @(
+            @{ id = $script:saSandboxA; done = $saADeprov; label = 'A' },
+            @{ id = $script:saSandboxB; done = $saBDeprov; label = 'B' },
+            @{ id = $script:saSandboxC; done = $saCDeprov; label = 'C' },
+            @{ id = $script:saSandboxD; done = $saDDeprov; label = 'D' }
+        )) {
+        if ($null -ne $entry.id -and -not $entry.done) {
+            Write-Host ""
+            Write-Host "[cleanup] best-effort deprovision of Lifecycle E sandbox $($entry.label) ($($entry.id))" -ForegroundColor DarkGray
+            try {
+                $null = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $entry.id -Experimental
+            } catch { }
+        }
+    }
+}
+
 } finally {
     # Outer-try finally: remove the locked-down test tree. Runs even if a
     # test panics so we don't leak the directory between runs.
@@ -965,7 +1230,11 @@ Run-StateAwareTest "start (user.upn mismatches sandboxId)" {
 # ---------------- Summary ----------------
 
 $total  = $script:TestResults.Count
-$failed = ($script:TestResults | Where-Object { -not $_.Passed }).Count
+# @(...) forces array context so a single failure doesn't get unwrapped to
+# the bare result object, where .Count would return the property/key count
+# instead of 1. PSCustomObject happens to do the right thing today, but
+# the wrap makes the count robust regardless of the result-object type.
+$failed = @($script:TestResults | Where-Object { -not $_.Passed }).Count
 $passed = $total - $failed
 
 Write-Host ""

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -108,6 +108,55 @@ Write-Host "==========================" -ForegroundColor Cyan
 Write-Host "Binary: $WxcExec" -ForegroundColor Gray
 Write-Host "Configs: $ConfigDir`n" -ForegroundColor Gray
 
+# ---------------- Backend-availability probe ----------------
+#
+# Three-tier probe mirroring run_isolation_session_state_aware_tests.ps1:
+#   1. IsoSessionApp.dll present in System32
+#   2. WinRT activatable class IsoSessionOps registered
+#   3. wxc-exec responds to a state-aware request without backend_unavailable
+#      (catches feature-flag-off builds)
+# Any failure surfaces as SKIP rather than a forest of FAILed tests.
+
+if (-not (Test-Path 'C:\Windows\System32\IsoSessionApp.dll')) {
+    Write-Host "SKIPPED: IsoSessionApp.dll not present in System32" -ForegroundColor Yellow
+    exit 0
+}
+$IsoSessionOpsKey = "HKLM:\SOFTWARE\Microsoft\WindowsRuntime\ActivatableClassId\Windows.AI.IsolationSession.IsoSessionOps"
+if (-not (Test-Path $IsoSessionOpsKey)) {
+    Write-Host "SKIPPED: Windows.AI.IsolationSession.IsoSessionOps WinRT class not registered" -ForegroundColor Yellow
+    exit 0
+}
+
+# Helper: send an inline state-aware request via --config-base64 and return
+# { Stdout, ExitCode }.
+function Invoke-StateAwareProbe {
+    param([hashtable]$Request)
+    $json = $Request | ConvertTo-Json -Compress -Depth 8
+    $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($json))
+    $out = & $WxcExec --experimental --config-base64 $b64 2>&1 | Out-String
+    @{ Stdout = $out; ExitCode = $LASTEXITCODE }
+}
+
+$probe = Invoke-StateAwareProbe -Request @{ phase = 'provision'; containment = 'isolation_session' }
+$probeEnv = $null
+try { $probeEnv = $probe.Stdout | ConvertFrom-Json } catch { }
+if ($null -ne $probeEnv -and $probeEnv.error.code -eq 'backend_unavailable') {
+    Write-Host "SKIPPED: wxc-exec reports backend_unavailable (likely built without --features isolation_session)" -ForegroundColor Yellow
+    exit 0
+}
+# On a healthy build the probe successfully provisions an agent user --
+# deprovision it immediately so the probe doesn't leak.
+if ($null -ne $probeEnv -and $null -ne $probeEnv.result -and $null -ne $probeEnv.result.sandboxId) {
+    $probeSandboxId = [string]$probeEnv.result.sandboxId
+    $probeAgent = if ($probeEnv.result.metadata) { [string]$probeEnv.result.metadata.agentUserName } else { '<absent>' }
+    Write-Host "Backend probe: provisioned $probeSandboxId (agentUserName=$probeAgent), deprovisioning ..." -ForegroundColor DarkGray
+    $deprov = Invoke-StateAwareProbe -Request @{ phase = 'deprovision'; sandboxId = $probeSandboxId }
+    if ($deprov.ExitCode -ne 0) {
+        Write-Host "WARN: probe deprovision returned exit $($deprov.ExitCode); local user $probeAgent may persist" -ForegroundColor Yellow
+        Write-Host "  Stdout: $($deprov.Stdout)" -ForegroundColor Gray
+    }
+}
+
 # Helper: run one IsolationSession test config.
 #
 # The wxc-exec invocation is wrapped in try-catch so an unexpected
@@ -137,7 +186,12 @@ function Run-IsolationSessionTest {
     try {
         $prevPref = $ErrorActionPreference
         $ErrorActionPreference = "Continue"
-        $output = & $WxcExec --experimental $configPath 2>&1 | Out-String
+        # --debug flips wxc-exec's Logger into Mode::Console so its output
+        # (including "Isolation Session: agent user = <name>") goes to
+        # stdout. Without --debug, one-shot keeps Logger in Mode::Buffer
+        # and never flushes the buffer, so the agent name is lost and
+        # leaks cannot be correlated to a specific test.
+        $output = & $WxcExec --debug --experimental $configPath 2>&1 | Out-String
         $exitCode = $LASTEXITCODE
         $ErrorActionPreference = $prevPref
     } catch {
@@ -188,6 +242,15 @@ function Run-IsolationSessionTest {
         foreach ($line in $meaningful) {
             Write-Host "    > $($line.TrimEnd())" -ForegroundColor Gray
         }
+    }
+
+    # Log the OS-assigned agent user name from wxc-exec's stderr (relayed
+    # via 2>&1 into $output). The runner prints "Isolation Session: agent
+    # user = <name>" once per provision. Correlates leftover local users
+    # back to specific tests during post-run inspection.
+    $agentMatch = [regex]::Match($output, 'Isolation Session: agent user = (\S+)')
+    if ($agentMatch.Success) {
+        Write-Host "    agent: $($agentMatch.Groups[1].Value)" -ForegroundColor DarkGray
     }
 
     return @{ Name = $ConfigFile; Pass = $pass; Skipped = $false; Reason = $reason }
@@ -268,14 +331,232 @@ $null = $results.Add((Run-IsolationSessionTest "isolation_session_one_shot_user_
     -ExpectedExit -1 `
     -OutputContains @("user is not supported in one-shot mode")))
 
+# ---------------- Concurrent one-shot test ----------------
+#
+# Three wxc-exec processes (A, B, C) run a per-agent PowerShell script
+# from a shared rw-policy directory. Each script writes timestamped lines
+# to its own X.log file: "X-started", "X-still-alive-1" .. "X-still-alive-N",
+# "X-done", with one second between iterations. After all three wxc-execs
+# exit, the test reads each agent's log file and asserts (a) the wxc-exec
+# exited 0, (b) the log contains start / final-still-alive / done markers,
+# (c) timestamps are monotonic. This decouples the regid-leak check from
+# OS-side teardown timing -- if any of the three isolation sessions were
+# torn down mid-run its log would be truncated, and if cleanup failed its
+# wxc-exec exit code would be non-zero. A fresh fourth process (D) then
+# proves the leak does not poison subsequent sandboxes either.
+#
+# Each launch is gated on the previously-launched agent's "X-started"
+# line appearing in its log file. Polling the log file (not wxc-exec's
+# stdout) avoids matching the --debug Logger's command-line echo. The
+# barrier prevents the OS-side per-StartSessionAsync setup race where
+# two StartSessionAsync calls landing within ~1-2s of each other leave
+# the second isolation session unusable.
+
+Write-Host ""
+Write-Host "--- Concurrent one-shot ---" -ForegroundColor Cyan
+
+# Shared rw directory the three agent PS1 scripts and X.log files live in.
+# Each X.json grants the agent rw access to this path via
+# policy.readwritePaths.
+$concurrentLogDir = 'C:\mxc_concurrent_log'
+Remove-Item -Recurse -Force $concurrentLogDir -ErrorAction SilentlyContinue
+New-Item -Path $concurrentLogDir -ItemType Directory -Force | Out-Null
+
+# wxc-exec stdout/stderr capture dir (preserved across runs for inspection;
+# cleaned at the start of each run).
+$concurrentTempRoot = Join-Path $env:TEMP 'mxc_concurrent_oneshot'
+Remove-Item -Recurse -Force $concurrentTempRoot -ErrorAction SilentlyContinue
+New-Item -Path $concurrentTempRoot -ItemType Directory -Force | Out-Null
+$stdoutA = Join-Path $concurrentTempRoot 'A.stdout.txt'
+$stderrA = Join-Path $concurrentTempRoot 'A.stderr.txt'
+$stdoutB = Join-Path $concurrentTempRoot 'B.stdout.txt'
+$stderrB = Join-Path $concurrentTempRoot 'B.stderr.txt'
+$stdoutC = Join-Path $concurrentTempRoot 'C.stdout.txt'
+$stderrC = Join-Path $concurrentTempRoot 'C.stderr.txt'
+
+# Generate one PS1 script per agent. Each writes timestamped lines to
+# its own X.log file. Backtick-escaped expressions (`$(Get-Date), `$_)
+# survive this here-string verbatim so they're evaluated by the inner
+# PowerShell when the agent runs the script.
+function Write-AgentScript {
+    param([string]$Label, [int]$IterCount)
+    $logPath = Join-Path $concurrentLogDir "$Label.log"
+    $body = @"
+Add-Content -Path '$logPath' -Value "`$(Get-Date -Format 'HH:mm:ss.fff') $Label-started"
+1..$IterCount | ForEach-Object {
+    Add-Content -Path '$logPath' -Value "`$(Get-Date -Format 'HH:mm:ss.fff') $Label-still-alive-`$_"
+    Start-Sleep -Seconds 1
+}
+Add-Content -Path '$logPath' -Value "`$(Get-Date -Format 'HH:mm:ss.fff') $Label-done"
+"@
+    Set-Content -Path (Join-Path $concurrentLogDir "$Label.ps1") -Value $body -Encoding UTF8
+}
+
+Write-AgentScript -Label 'A' -IterCount 15
+Write-AgentScript -Label 'B' -IterCount 5
+Write-AgentScript -Label 'C' -IterCount 30
+
+# Launch helper: route wxc-exec through `cmd /c` with cmd-managed shell
+# redirects (`1>` / `2>`). PowerShell's Start-Process -RedirectStandardOutput
+# combined with -NoNewWindow has known issues under concurrent launches.
+# -WindowStyle Hidden gives each cmd.exe its own (invisible) console
+# session. --debug routes wxc-exec's Logger to stdout so the per-process
+# "agent user = <name>" line lands in the capture file (otherwise the
+# Logger buffer is silently dropped on one-shot exit).
+function Start-ConcurrentWxc {
+    param([string]$Exec, [string]$ConfigPath, [string]$StdoutFile, [string]$StderrFile)
+    $cmdLine = "/c $Exec --debug --experimental $ConfigPath 1>$StdoutFile 2>$StderrFile"
+    Start-Process -FilePath cmd.exe -ArgumentList $cmdLine -WindowStyle Hidden -PassThru
+}
+
+# Block until "X-started" appears in $LogPath (the agent's own log file,
+# not the wxc-exec stdout capture). Reading with FileShare.ReadWrite lets
+# us peek while the agent's PowerShell holds the file open for Add-Content.
+function Wait-AgentLogStart {
+    param([string]$Label, [string]$LogPath, [int]$TimeoutSeconds = 30)
+    $pattern = [regex]::new("\b$Label-started\b")
+    $start = Get-Date
+    while (((Get-Date) - $start).TotalSeconds -lt $TimeoutSeconds) {
+        if (Test-Path $LogPath) {
+            try {
+                $fs = [System.IO.File]::Open($LogPath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+                $sr = New-Object System.IO.StreamReader($fs)
+                $text = $sr.ReadToEnd()
+                $sr.Close(); $fs.Close()
+                if ($pattern.IsMatch($text)) {
+                    $elapsed = ((Get-Date) - $start).TotalMilliseconds
+                    Write-Host "  $Label-started in log after $([int]$elapsed) ms" -ForegroundColor DarkGray
+                    return $true
+                }
+            } catch { }
+        }
+        Start-Sleep -Milliseconds 100
+    }
+    Write-Host "  WARN: $Label-started did not appear in log within ${TimeoutSeconds}s -- launching next anyway" -ForegroundColor Yellow
+    return $false
+}
+
+$pA = $null; $pB = $null; $pC = $null
+
+try {
+    Write-Host "  starting A (15 still-alive iters), B (5), C (30) with log-file barriers..." -ForegroundColor Gray
+    $pA = Start-ConcurrentWxc -Exec $WxcExec `
+        -ConfigPath (Join-Path $ConfigDir 'isolation_session_concurrent_A.json') `
+        -StdoutFile $stdoutA -StderrFile $stderrA
+    [void](Wait-AgentLogStart -Label 'A' -LogPath (Join-Path $concurrentLogDir 'A.log'))
+    $pB = Start-ConcurrentWxc -Exec $WxcExec `
+        -ConfigPath (Join-Path $ConfigDir 'isolation_session_concurrent_B.json') `
+        -StdoutFile $stdoutB -StderrFile $stderrB
+    [void](Wait-AgentLogStart -Label 'B' -LogPath (Join-Path $concurrentLogDir 'B.log'))
+    $pC = Start-ConcurrentWxc -Exec $WxcExec `
+        -ConfigPath (Join-Path $ConfigDir 'isolation_session_concurrent_C.json') `
+        -StdoutFile $stdoutC -StderrFile $stderrC
+    [void](Wait-AgentLogStart -Label 'C' -LogPath (Join-Path $concurrentLogDir 'C.log'))
+
+    # Wait for all three to exit. Generous per-process timeout because
+    # OS-side teardown can take tens of seconds.
+    Write-Host "  waiting for all three wxc-execs to exit..." -ForegroundColor Gray
+    $aFinished = $pA.WaitForExit(120000)
+    $bFinished = $pB.WaitForExit(120000)
+    $cFinished = $pC.WaitForExit(120000)
+    Write-Host "  A finished=$aFinished exit=$($pA.ExitCode)" -ForegroundColor Gray
+    Write-Host "  B finished=$bFinished exit=$($pB.ExitCode)" -ForegroundColor Gray
+    Write-Host "  C finished=$cFinished exit=$($pC.ExitCode)" -ForegroundColor Gray
+
+    # Agent-user-name extraction (from wxc-exec --debug stdout) for leak
+    # attribution if any deprovision silently fails downstream.
+    foreach ($pair in @(
+            @{ Label = 'A'; Stdout = $stdoutA; Stderr = $stderrA },
+            @{ Label = 'B'; Stdout = $stdoutB; Stderr = $stderrB },
+            @{ Label = 'C'; Stdout = $stdoutC; Stderr = $stderrC }
+        )) {
+        $combined = ''
+        if (Test-Path $pair.Stdout) { $combined += [string](Get-Content $pair.Stdout -Raw) }
+        if (Test-Path $pair.Stderr) { $combined += [string](Get-Content $pair.Stderr -Raw) }
+        $m = [regex]::Match($combined, 'Isolation Session: agent user = (\S+)')
+        $agentName = if ($m.Success) { $m.Groups[1].Value } else { '<not found>' }
+        Write-Host "  $($pair.Label) agent: $agentName" -ForegroundColor DarkGray
+    }
+
+    # Per-agent assertions from log file. Each X.log line is prefixed
+    # with HH:mm:ss.fff so we can also check monotonicity.
+    $tsPattern = [regex]::new('^(\d\d):(\d\d):(\d\d)\.(\d\d\d)\s')
+    foreach ($spec in @(
+            @{ Label = 'A'; Process = $pA; Iters = 15 },
+            @{ Label = 'B'; Process = $pB; Iters = 5 },
+            @{ Label = 'C'; Process = $pC; Iters = 30 }
+        )) {
+        $label = $spec.Label
+        $proc = $spec.Process
+        $iters = $spec.Iters
+        $logPath = Join-Path $concurrentLogDir "$label.log"
+        $log = if (Test-Path $logPath) { [string](Get-Content $logPath -Raw) } else { '' }
+        if ($null -eq $log) { $log = '' }
+
+        $reasons = New-Object System.Collections.ArrayList
+        if ($proc.ExitCode -ne 0) { [void]$reasons.Add("wxc-exec exit=$($proc.ExitCode)") }
+        if (-not ($log -match "\b$label-started\b")) { [void]$reasons.Add("$label-started missing") }
+        if (-not ($log -match "\b$label-still-alive-$iters\b")) { [void]$reasons.Add("$label-still-alive-$iters missing (truncated?)") }
+        if (-not ($log -match "\b$label-done\b")) { [void]$reasons.Add("$label-done missing") }
+
+        # Monotonicity check: every line is "HH:mm:ss.fff <message>";
+        # successive timestamps must not regress. Cheap defense against
+        # pathological scheduling weirdness inside the isolation session.
+        $prevTicks = [int64]-1
+        $lineNum = 0
+        foreach ($line in ($log -split "`r?`n")) {
+            $lineNum++
+            if ([string]::IsNullOrWhiteSpace($line)) { continue }
+            $m = $tsPattern.Match($line)
+            if (-not $m.Success) { continue }
+            $ticks = ([int]$m.Groups[1].Value * 3600000) +
+                     ([int]$m.Groups[2].Value * 60000) +
+                     ([int]$m.Groups[3].Value * 1000) +
+                     ([int]$m.Groups[4].Value)
+            if ($prevTicks -ge 0 -and $ticks -lt $prevTicks) {
+                [void]$reasons.Add("timestamp regression at line $lineNum")
+                break
+            }
+            $prevTicks = $ticks
+        }
+
+        $pass = ($reasons.Count -eq 0)
+        $reasonStr = ($reasons -join '; ')
+        Write-Host "  concurrent: $label ran full sequence ... $(if ($pass) { 'PASS' } else { 'FAIL: ' + $reasonStr })" `
+            -ForegroundColor $(if ($pass) { 'Green' } else { 'Red' })
+        $null = $results.Add(@{ Name = "concurrent: $label ran full sequence"; Pass = $pass; Skipped = $false; Reason = $reasonStr })
+    }
+
+    # Fresh D after A/B/C: verifies the leak does not poison subsequent
+    # sandboxes. D uses the original ping-based simple form (no shared log
+    # dir), exercising the unmodified one-shot path.
+    $null = $results.Add((Run-IsolationSessionTest "isolation_session_concurrent_D.json" `
+        -OutputContains @("D-start", "D-done")))
+} finally {
+    foreach ($p in @($pA, $pB, $pC)) {
+        if ($null -ne $p -and -not $p.HasExited) {
+            try { $p.Kill() } catch { }
+        }
+    }
+    # Clean up the shared agent log dir; the wxc-exec stdout/stderr
+    # capture dir is preserved for post-run inspection (next run's
+    # start-of-test cleanup will replace it).
+    Remove-Item -Recurse -Force $concurrentLogDir -ErrorAction SilentlyContinue
+    Write-Host "  (concurrent stdout/stderr preserved at: $concurrentTempRoot)" -ForegroundColor DarkGray
+}
+
 } finally {
     Remove-Item -Recurse -Force $FsTestRoot -ErrorAction SilentlyContinue
 }
 
-# Summary
-$passed = ($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count
-$failed = ($results | Where-Object { -not $_.Pass -and -not $_.Skipped }).Count
-$skipped = ($results | Where-Object { $_.Skipped }).Count
+# Summary -- wrap each filtered pipeline in @(...) to force array context.
+# Without @(), a Where-Object that returns a single hashtable is unwrapped
+# to the bare hashtable; calling .Count on a single hashtable returns its
+# KEY count (4 for the {Name,Pass,Skipped,Reason} shape), not 1, making
+# the failure tally wildly wrong when exactly one test fails.
+$passed = @($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count
+$failed = @($results | Where-Object { -not $_.Pass -and -not $_.Skipped }).Count
+$skipped = @($results | Where-Object { $_.Skipped }).Count
 $total = $results.Count
 $executed = $passed + $failed
 


### PR DESCRIPTION
## 📖 Description
Skip `UnregisterAppAsync` on the IsolationSession deprovision path so the hardcoded `regid` survives across MXC isolation-session sandbox lifecycles, allowing concurrent use until registration IDs are removed from the in-proc `Windows.AI.IsolationSession` APIs. `RegisterApp` stays in place (the API is idempotent on duplicates). One-shot also switches from a hardcoded `provisionId` to a per-invocation `wxc-<8-hex>`, matching state-aware.

## 🔗 References
Resolves #286

## 🔍 Validation
- Pre-push: build / test / clippy / fmt -- both with and without `--features isolation_session`.
- VM state-aware: `run_isolation_session_state_aware_tests.ps1` 59/59 incl. new Lifecycle E (provision A/B/C, exec on each, deprovision in B→A→C→D order with regression checks between).
- VM one-shot: `run_isolation_session_tests.ps1` 12/12 -- 8 sequential tests, 3 concurrent (file-based timestamped audit trail per agent), and a fresh D after the concurrent block.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue

## 📋 Issue Type
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/287)