### PR TITLE
phase1a: extract ui_restrictions_bitmask into ui_policy module

### DIFF
--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -24,8 +24,7 @@ use windows_core::PCWSTR;
 
 use crate::logger::Logger;
 use crate::models::{
-    BaseProcessUiConfig, ClipboardPolicy, CodexRequest, NetworkEnforcementMode, NetworkPolicy,
-    ProxyAddress, ScriptResponse, UiPolicy,
+    CodexRequest, NetworkEnforcementMode, NetworkPolicy, ProxyAddress, ScriptResponse,
 };
 use crate::proxy_coordinator::ProxyCoordinator;
 use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
@@ -82,95 +81,6 @@ impl BaseContainerRunner {
     /// the feature is disabled (e.g., via internal feature-enablement mechanisms).
     pub fn is_base_container_api_present() -> Result<(), String> {
         Self::load_api().map(|_| ())
-    }
-
-    /// JOB_OBJECT_UILIMIT_* flag constants (from UIPolicy_Schema.md).
-    const UILIMIT_HANDLES: u64 = 0x0001;
-    const UILIMIT_READCLIPBOARD: u64 = 0x0002;
-    const UILIMIT_WRITECLIPBOARD: u64 = 0x0004;
-    const UILIMIT_SYSTEMPARAMETERS: u64 = 0x0008;
-    const UILIMIT_DISPLAYSETTINGS: u64 = 0x0010;
-    const UILIMIT_GLOBALATOMS: u64 = 0x0020;
-    const UILIMIT_DESKTOP: u64 = 0x0040;
-    const UILIMIT_EXITWINDOWS: u64 = 0x0080;
-    const UILIMIT_IME: u64 = 0x0100;
-    const UILIMIT_INJECTION: u64 = 0x0200;
-
-    /// Build the JOB_OBJECT_UILIMIT_* bitmask from the cross-platform UI policy
-    /// and the BaseProcessContainer-specific UI config.
-    /// Mapping follows docs/UIPolicy_Schema.md.
-    fn ui_restrictions_bitmask(ui: &UiPolicy, base_proc_ui: &BaseProcessUiConfig) -> u64 {
-        // When UI is fully disabled: DisallowWin32kSystemCalls handles everything
-        // except atoms (NT executive syscalls, not Win32k). Only set GLOBALATOMS.
-        if ui.disable {
-            return Self::UILIMIT_GLOBALATOMS;
-        }
-
-        let mut mask: u64 = 0;
-
-        // Cross-platform: clipboard (default: "none" = block both)
-        match ui.clipboard {
-            ClipboardPolicy::All => {}
-            ClipboardPolicy::Read => {
-                mask |= Self::UILIMIT_WRITECLIPBOARD;
-            }
-            ClipboardPolicy::Write => {
-                mask |= Self::UILIMIT_READCLIPBOARD;
-            }
-            // "none" or unrecognized → default-deny: block both
-            _ => {
-                mask |= Self::UILIMIT_READCLIPBOARD | Self::UILIMIT_WRITECLIPBOARD;
-            }
-        }
-
-        // Cross-platform: input injection
-        if !ui.injection {
-            mask |= Self::UILIMIT_INJECTION;
-        }
-
-        // Backend-specific: isolation level (default: "container" = HANDLES + GLOBALATOMS)
-        match base_proc_ui.isolation.as_str() {
-            "desktop" => {
-                // No isolation flags
-            }
-            "handles" => {
-                mask |= Self::UILIMIT_HANDLES;
-            }
-            "atoms" => {
-                mask |= Self::UILIMIT_GLOBALATOMS;
-            }
-            // "container" or unrecognized → default-deny: full isolation
-            _ => {
-                mask |= Self::UILIMIT_HANDLES | Self::UILIMIT_GLOBALATOMS;
-            }
-        }
-
-        // Backend-specific: desktop system control
-        if !base_proc_ui.desktop_system_control {
-            mask |= Self::UILIMIT_DESKTOP | Self::UILIMIT_EXITWINDOWS;
-        }
-
-        // Backend-specific: system settings (default: "none" = block all)
-        match base_proc_ui.system_settings.as_str() {
-            "all" => {}
-            "parameters" => {
-                mask |= Self::UILIMIT_DISPLAYSETTINGS;
-            }
-            "display" => {
-                mask |= Self::UILIMIT_SYSTEMPARAMETERS;
-            }
-            // "none" or unrecognized → default-deny: block all
-            _ => {
-                mask |= Self::UILIMIT_SYSTEMPARAMETERS | Self::UILIMIT_DISPLAYSETTINGS;
-            }
-        }
-
-        // Backend-specific: IME
-        if !base_proc_ui.ime {
-            mask |= Self::UILIMIT_IME;
-        }
-
-        mask
     }
 
     /// Build a FlatBuffer `SandboxSpec` from the container policy in the request.
@@ -264,8 +174,10 @@ impl BaseContainerRunner {
         };
 
         // UI restrictions
-        let ui_restrictions =
-            Self::ui_restrictions_bitmask(&request.policy.ui, &request.policy.base_process_ui);
+        let ui_restrictions = crate::ui_policy::ui_restrictions_bitmask(
+            &request.policy.ui,
+            &request.policy.base_process_ui,
+        );
 
         let spec = SandboxSpec::create(
             &mut builder,
@@ -392,8 +304,10 @@ impl ScriptRunner for BaseContainerRunner {
             let _ = writeln!(logger, "proxy URL in spec: {}", addr.to_url());
         }
 
-        let ui_restrictions =
-            Self::ui_restrictions_bitmask(&request.policy.ui, &request.policy.base_process_ui);
+        let ui_restrictions = crate::ui_policy::ui_restrictions_bitmask(
+            &request.policy.ui,
+            &request.policy.base_process_ui,
+        );
         let _ = writeln!(
             logger,
             "sandbox spec built (version={}, {} bytes)",
@@ -423,16 +337,16 @@ impl ScriptRunner for BaseContainerRunner {
         let _ = writeln!(
             logger,
             "UILIMIT flags: HANDLES={} READCLIP={} WRITECLIP={} SYSPARAM={} DISPLAY={} ATOMS={} DESKTOP={} EXIT={} IME={} INJECT={}",
-            ui_restrictions & Self::UILIMIT_HANDLES != 0,
-            ui_restrictions & Self::UILIMIT_READCLIPBOARD != 0,
-            ui_restrictions & Self::UILIMIT_WRITECLIPBOARD != 0,
-            ui_restrictions & Self::UILIMIT_SYSTEMPARAMETERS != 0,
-            ui_restrictions & Self::UILIMIT_DISPLAYSETTINGS != 0,
-            ui_restrictions & Self::UILIMIT_GLOBALATOMS != 0,
-            ui_restrictions & Self::UILIMIT_DESKTOP != 0,
-            ui_restrictions & Self::UILIMIT_EXITWINDOWS != 0,
-            ui_restrictions & Self::UILIMIT_IME != 0,
-            ui_restrictions & Self::UILIMIT_INJECTION != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_HANDLES != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_READCLIPBOARD != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_WRITECLIPBOARD != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_SYSTEMPARAMETERS != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_DISPLAYSETTINGS != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_GLOBALATOMS != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_DESKTOP != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_EXITWINDOWS != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_IME != 0,
+            ui_restrictions & crate::ui_policy::UILIMIT_INJECTION != 0,
         );
 
         let _ = writeln!(logger, "SECTION: Load API");
@@ -572,7 +486,12 @@ impl ScriptRunner for BaseContainerRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::ProxyConfig;
+    use crate::models::{ClipboardPolicy, ProxyConfig, UiPolicy};
+    use crate::ui_policy::{
+        UILIMIT_DESKTOP, UILIMIT_DISPLAYSETTINGS, UILIMIT_EXITWINDOWS, UILIMIT_GLOBALATOMS,
+        UILIMIT_HANDLES, UILIMIT_IME, UILIMIT_INJECTION, UILIMIT_SYSTEMPARAMETERS,
+        UILIMIT_WRITECLIPBOARD,
+    };
     use sandbox_spec::base_container_layout;
 
     #[test]
@@ -598,10 +517,7 @@ mod tests {
         assert!(spec.least_privilege());
         assert_eq!(spec.capabilities(), Some("internetClient,registryRead"));
         assert!(spec.disallow_win32k_system_calls());
-        assert_eq!(
-            spec.ui_restrictions(),
-            BaseContainerRunner::UILIMIT_GLOBALATOMS
-        ); // default: disable=true → only GLOBALATOMS
+        assert_eq!(spec.ui_restrictions(), UILIMIT_GLOBALATOMS); // default: disable=true → only GLOBALATOMS
 
         let rw = spec.fs_read_write().unwrap();
         assert_eq!(rw.len(), 1);
@@ -648,8 +564,6 @@ mod tests {
 
     #[test]
     fn build_sandbox_spec_ui_disabled() {
-        use crate::models::UiPolicy;
-
         let mut request = CodexRequest::default();
         request.policy.ui = UiPolicy {
             disable: true,
@@ -661,10 +575,7 @@ mod tests {
 
         assert!(spec.disallow_win32k_system_calls());
         // disable=true → only GLOBALATOMS (Win32k disable handles the rest)
-        assert_eq!(
-            spec.ui_restrictions(),
-            BaseContainerRunner::UILIMIT_GLOBALATOMS
-        );
+        assert_eq!(spec.ui_restrictions(), UILIMIT_GLOBALATOMS);
     }
 
     #[test]
@@ -682,14 +593,14 @@ mod tests {
         assert!(!spec.disallow_win32k_system_calls());
         // WRITECLIPBOARD + backend defaults (isolation=container: HANDLES+GLOBALATOMS,
         // desktopSystemControl=false: DESKTOP+EXITWINDOWS, systemSettings=none: SYSTEMPARAMETERS+DISPLAYSETTINGS, ime=false: IME)
-        let expected = BaseContainerRunner::UILIMIT_WRITECLIPBOARD
-            | BaseContainerRunner::UILIMIT_HANDLES
-            | BaseContainerRunner::UILIMIT_GLOBALATOMS
-            | BaseContainerRunner::UILIMIT_DESKTOP
-            | BaseContainerRunner::UILIMIT_EXITWINDOWS
-            | BaseContainerRunner::UILIMIT_SYSTEMPARAMETERS
-            | BaseContainerRunner::UILIMIT_DISPLAYSETTINGS
-            | BaseContainerRunner::UILIMIT_IME;
+        let expected = UILIMIT_WRITECLIPBOARD
+            | UILIMIT_HANDLES
+            | UILIMIT_GLOBALATOMS
+            | UILIMIT_DESKTOP
+            | UILIMIT_EXITWINDOWS
+            | UILIMIT_SYSTEMPARAMETERS
+            | UILIMIT_DISPLAYSETTINGS
+            | UILIMIT_IME;
         assert_eq!(spec.ui_restrictions(), expected);
     }
 
@@ -707,14 +618,14 @@ mod tests {
 
         assert!(!spec.disallow_win32k_system_calls());
         // INJECTION + backend defaults
-        let expected = BaseContainerRunner::UILIMIT_INJECTION
-            | BaseContainerRunner::UILIMIT_HANDLES
-            | BaseContainerRunner::UILIMIT_GLOBALATOMS
-            | BaseContainerRunner::UILIMIT_DESKTOP
-            | BaseContainerRunner::UILIMIT_EXITWINDOWS
-            | BaseContainerRunner::UILIMIT_SYSTEMPARAMETERS
-            | BaseContainerRunner::UILIMIT_DISPLAYSETTINGS
-            | BaseContainerRunner::UILIMIT_IME;
+        let expected = UILIMIT_INJECTION
+            | UILIMIT_HANDLES
+            | UILIMIT_GLOBALATOMS
+            | UILIMIT_DESKTOP
+            | UILIMIT_EXITWINDOWS
+            | UILIMIT_SYSTEMPARAMETERS
+            | UILIMIT_DISPLAYSETTINGS
+            | UILIMIT_IME;
         assert_eq!(spec.ui_restrictions(), expected);
     }
 
@@ -743,74 +654,5 @@ mod tests {
         let bytes = BaseContainerRunner::build_sandbox_spec(&request);
         let spec = base_container_layout::root_as_sandbox_spec(&bytes).unwrap();
         assert!(spec.network_policy().is_none());
-    }
-
-    #[test]
-    fn ui_bitmask_disabled() {
-        use crate::models::BaseProcessUiConfig;
-        let ui = UiPolicy {
-            disable: true,
-            ..Default::default()
-        };
-        let bp = BaseProcessUiConfig::default();
-        // disable=true → only GLOBALATOMS
-        assert_eq!(
-            BaseContainerRunner::ui_restrictions_bitmask(&ui, &bp),
-            BaseContainerRunner::UILIMIT_GLOBALATOMS
-        );
-    }
-
-    #[test]
-    fn ui_bitmask_default_deny() {
-        use crate::models::BaseProcessUiConfig;
-        // UiPolicy default: disable=true → only GLOBALATOMS
-        assert_eq!(
-            BaseContainerRunner::ui_restrictions_bitmask(
-                &UiPolicy::default(),
-                &BaseProcessUiConfig::default()
-            ),
-            BaseContainerRunner::UILIMIT_GLOBALATOMS
-        );
-    }
-
-    #[test]
-    fn ui_bitmask_clipboard_read_with_default_backend() {
-        use crate::models::BaseProcessUiConfig;
-        let ui = UiPolicy {
-            disable: false,
-            clipboard: ClipboardPolicy::Read,
-            injection: true,
-        };
-        let bp = BaseProcessUiConfig::default(); // isolation=container, desktopSystemControl=false, systemSettings=none, ime=false
-        let expected = BaseContainerRunner::UILIMIT_WRITECLIPBOARD
-            | BaseContainerRunner::UILIMIT_HANDLES
-            | BaseContainerRunner::UILIMIT_GLOBALATOMS
-            | BaseContainerRunner::UILIMIT_DESKTOP
-            | BaseContainerRunner::UILIMIT_EXITWINDOWS
-            | BaseContainerRunner::UILIMIT_SYSTEMPARAMETERS
-            | BaseContainerRunner::UILIMIT_DISPLAYSETTINGS
-            | BaseContainerRunner::UILIMIT_IME;
-        assert_eq!(
-            BaseContainerRunner::ui_restrictions_bitmask(&ui, &bp),
-            expected
-        );
-    }
-
-    #[test]
-    fn ui_bitmask_no_backend_restrictions() {
-        use crate::models::BaseProcessUiConfig;
-        let ui = UiPolicy {
-            disable: false,
-            clipboard: ClipboardPolicy::All,
-            injection: true,
-        };
-        let bp = BaseProcessUiConfig {
-            isolation: "desktop".to_string(),
-            desktop_system_control: true,
-            system_settings: "all".to_string(),
-            ime: true,
-        };
-        // No cross-platform restrictions + no backend restrictions = 0
-        assert_eq!(BaseContainerRunner::ui_restrictions_bitmask(&ui, &bp), 0);
     }
 }

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod script_runner;
 pub mod state_aware_backend;
 pub mod state_aware_dispatch;
 pub mod state_aware_request;
+pub mod ui_policy;
 pub mod validator;
 
 // Windows-specific modules

--- a/src/wxc_common/src/ui_policy.rs
+++ b/src/wxc_common/src/ui_policy.rs
@@ -1,0 +1,166 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! UI policy bitmask helpers.
+//!
+//! Maps cross-platform [`UiPolicy`] and BaseProcessContainer-specific
+//! [`BaseProcessUiConfig`] values onto the Windows `JOB_OBJECT_UILIMIT_*`
+//! flag set. The mapping follows `docs/UIPolicy_Schema.md`.
+//!
+//! This module is platform-agnostic: the values are pure `u64` bitmasks
+//! computed from the policy structs in [`crate::models`]. The actual
+//! application of the bitmask to a Job Object is performed by Windows-only
+//! runners (BaseContainer in Phase 1a; AppContainer in Phase 1c).
+
+use crate::models::{BaseProcessUiConfig, ClipboardPolicy, UiPolicy};
+
+/// JOB_OBJECT_UILIMIT_* flag constants (from UIPolicy_Schema.md).
+pub const UILIMIT_HANDLES: u64 = 0x0001;
+pub const UILIMIT_READCLIPBOARD: u64 = 0x0002;
+pub const UILIMIT_WRITECLIPBOARD: u64 = 0x0004;
+pub const UILIMIT_SYSTEMPARAMETERS: u64 = 0x0008;
+pub const UILIMIT_DISPLAYSETTINGS: u64 = 0x0010;
+pub const UILIMIT_GLOBALATOMS: u64 = 0x0020;
+pub const UILIMIT_DESKTOP: u64 = 0x0040;
+pub const UILIMIT_EXITWINDOWS: u64 = 0x0080;
+pub const UILIMIT_IME: u64 = 0x0100;
+pub const UILIMIT_INJECTION: u64 = 0x0200;
+
+/// Build the JOB_OBJECT_UILIMIT_* bitmask from the cross-platform UI policy
+/// and the BaseProcessContainer-specific UI config.
+/// Mapping follows docs/UIPolicy_Schema.md.
+pub fn ui_restrictions_bitmask(ui: &UiPolicy, base_proc_ui: &BaseProcessUiConfig) -> u64 {
+    // When UI is fully disabled: DisallowWin32kSystemCalls handles everything
+    // except atoms (NT executive syscalls, not Win32k). Only set GLOBALATOMS.
+    if ui.disable {
+        return UILIMIT_GLOBALATOMS;
+    }
+
+    let mut mask: u64 = 0;
+
+    // Cross-platform: clipboard (default: "none" = block both)
+    match ui.clipboard {
+        ClipboardPolicy::All => {}
+        ClipboardPolicy::Read => {
+            mask |= UILIMIT_WRITECLIPBOARD;
+        }
+        ClipboardPolicy::Write => {
+            mask |= UILIMIT_READCLIPBOARD;
+        }
+        // "none" or unrecognized → default-deny: block both
+        _ => {
+            mask |= UILIMIT_READCLIPBOARD | UILIMIT_WRITECLIPBOARD;
+        }
+    }
+
+    // Cross-platform: input injection
+    if !ui.injection {
+        mask |= UILIMIT_INJECTION;
+    }
+
+    // Backend-specific: isolation level (default: "container" = HANDLES + GLOBALATOMS)
+    match base_proc_ui.isolation.as_str() {
+        "desktop" => {
+            // No isolation flags
+        }
+        "handles" => {
+            mask |= UILIMIT_HANDLES;
+        }
+        "atoms" => {
+            mask |= UILIMIT_GLOBALATOMS;
+        }
+        // "container" or unrecognized → default-deny: full isolation
+        _ => {
+            mask |= UILIMIT_HANDLES | UILIMIT_GLOBALATOMS;
+        }
+    }
+
+    // Backend-specific: desktop system control
+    if !base_proc_ui.desktop_system_control {
+        mask |= UILIMIT_DESKTOP | UILIMIT_EXITWINDOWS;
+    }
+
+    // Backend-specific: system settings (default: "none" = block all)
+    match base_proc_ui.system_settings.as_str() {
+        "all" => {}
+        "parameters" => {
+            mask |= UILIMIT_DISPLAYSETTINGS;
+        }
+        "display" => {
+            mask |= UILIMIT_SYSTEMPARAMETERS;
+        }
+        // "none" or unrecognized → default-deny: block all
+        _ => {
+            mask |= UILIMIT_SYSTEMPARAMETERS | UILIMIT_DISPLAYSETTINGS;
+        }
+    }
+
+    // Backend-specific: IME
+    if !base_proc_ui.ime {
+        mask |= UILIMIT_IME;
+    }
+
+    mask
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{BaseProcessUiConfig, ClipboardPolicy, UiPolicy};
+
+    #[test]
+    fn ui_bitmask_disabled() {
+        let ui = UiPolicy {
+            disable: true,
+            ..Default::default()
+        };
+        let bp = BaseProcessUiConfig::default();
+        // disable=true → only GLOBALATOMS
+        assert_eq!(ui_restrictions_bitmask(&ui, &bp), UILIMIT_GLOBALATOMS);
+    }
+
+    #[test]
+    fn ui_bitmask_default_deny() {
+        // UiPolicy default: disable=true → only GLOBALATOMS
+        assert_eq!(
+            ui_restrictions_bitmask(&UiPolicy::default(), &BaseProcessUiConfig::default()),
+            UILIMIT_GLOBALATOMS
+        );
+    }
+
+    #[test]
+    fn ui_bitmask_clipboard_read_with_default_backend() {
+        let ui = UiPolicy {
+            disable: false,
+            clipboard: ClipboardPolicy::Read,
+            injection: true,
+        };
+        let bp = BaseProcessUiConfig::default(); // isolation=container, desktopSystemControl=false, systemSettings=none, ime=false
+        let expected = UILIMIT_WRITECLIPBOARD
+            | UILIMIT_HANDLES
+            | UILIMIT_GLOBALATOMS
+            | UILIMIT_DESKTOP
+            | UILIMIT_EXITWINDOWS
+            | UILIMIT_SYSTEMPARAMETERS
+            | UILIMIT_DISPLAYSETTINGS
+            | UILIMIT_IME;
+        assert_eq!(ui_restrictions_bitmask(&ui, &bp), expected);
+    }
+
+    #[test]
+    fn ui_bitmask_no_backend_restrictions() {
+        let ui = UiPolicy {
+            disable: false,
+            clipboard: ClipboardPolicy::All,
+            injection: true,
+        };
+        let bp = BaseProcessUiConfig {
+            isolation: "desktop".to_string(),
+            desktop_system_control: true,
+            system_settings: "all".to_string(),
+            ime: true,
+        };
+        // No cross-platform restrictions + no backend restrictions = 0
+        assert_eq!(ui_restrictions_bitmask(&ui, &bp), 0);
+    }
+}


### PR DESCRIPTION
## 📖 Description

Pure refactor with no behavior change. The `JOB_OBJECT_UILIMIT_*` flag constants and the `ui_restrictions_bitmask` function are moved out of `BaseContainerRunner` into a new platform-agnostic `crate::ui_policy` module. The four pure-bitmask unit tests move alongside the function; the `build_sandbox_spec_*` tests in `base_container_runner.rs` continue to exercise the same logic via `crate::ui_policy::UILIMIT_*` and confirm the bitmask flows correctly into the FlatBuffer `SandboxSpec`.

**Motivation:** the bitmask logic will be reused by the AppContainer Job Object code in Phase 1c of the BaseContainer fallback plan, so it needs to live in a shared, platform-agnostic location rather than as a private associated item on `BaseContainerRunner`.

## 🔗 References

First PR in the BaseContainer downlevel-fallback stack:
- **phase1a → main** (this PR)
- phase1b → phase1a (next)
- phase1c, phase1d, phase1_integrate, phase2, phase3, phase4 follow

phase0 already merged as #282.

## 🔍 Validation

- All 217 `wxc_common` tests pass
- `cargo fmt` and `cargo clippy -D warnings` clean
- End-to-end coverage lives in `Win25H2Safe-Tests.ps1` in phase5 (held)
