### PR TITLE
phase1c: add UiJobObject + split UI policy resolution from encoding

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -49,6 +49,7 @@ windows = { version = "0.62", features = [
     "Win32_System_ProcessStatus",
     "Win32_System_Time",
     "Win32_System_SystemServices",
+    "Win32_System_JobObjects",
 ] }
 windows-core = "0.62"
 serde = { version = "1", features = ["derive"] }

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -174,10 +174,12 @@ impl BaseContainerRunner {
         };
 
         // UI restrictions
-        let ui_restrictions = crate::ui_policy::ui_restrictions_bitmask(
-            &request.policy.ui,
-            &request.policy.base_process_ui,
-        );
+        let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
+            &crate::ui_policy::resolve_ui_restrictions(
+                &request.policy.ui,
+                &request.policy.base_process_ui,
+            ),
+        ) as u64;
 
         let spec = SandboxSpec::create(
             &mut builder,
@@ -304,10 +306,11 @@ impl ScriptRunner for BaseContainerRunner {
             let _ = writeln!(logger, "proxy URL in spec: {}", addr.to_url());
         }
 
-        let ui_restrictions = crate::ui_policy::ui_restrictions_bitmask(
+        let restrictions = crate::ui_policy::resolve_ui_restrictions(
             &request.policy.ui,
             &request.policy.base_process_ui,
         );
+        let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(&restrictions);
         let _ = writeln!(
             logger,
             "sandbox spec built (version={}, {} bytes)",
@@ -337,16 +340,16 @@ impl ScriptRunner for BaseContainerRunner {
         let _ = writeln!(
             logger,
             "UILIMIT flags: HANDLES={} READCLIP={} WRITECLIP={} SYSPARAM={} DISPLAY={} ATOMS={} DESKTOP={} EXIT={} IME={} INJECT={}",
-            ui_restrictions & crate::ui_policy::UILIMIT_HANDLES != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_READCLIPBOARD != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_WRITECLIPBOARD != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_SYSTEMPARAMETERS != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_DISPLAYSETTINGS != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_GLOBALATOMS != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_DESKTOP != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_EXITWINDOWS != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_IME != 0,
-            ui_restrictions & crate::ui_policy::UILIMIT_INJECTION != 0,
+            restrictions.block_external_ui_objects,
+            restrictions.block_clipboard_read,
+            restrictions.block_clipboard_write,
+            restrictions.block_system_parameter_changes,
+            restrictions.block_display_settings_changes,
+            restrictions.block_global_ui_namespace,
+            restrictions.block_desktop_switching,
+            restrictions.block_logoff_or_shutdown,
+            restrictions.block_input_method_changes,
+            restrictions.block_input_injection,
         );
 
         let _ = writeln!(logger, "SECTION: Load API");
@@ -486,13 +489,14 @@ impl ScriptRunner for BaseContainerRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::job_object::to_job_object_uilimit_mask;
     use crate::models::{ClipboardPolicy, ProxyConfig, UiPolicy};
-    use crate::ui_policy::{
-        UILIMIT_DESKTOP, UILIMIT_DISPLAYSETTINGS, UILIMIT_EXITWINDOWS, UILIMIT_GLOBALATOMS,
-        UILIMIT_HANDLES, UILIMIT_IME, UILIMIT_INJECTION, UILIMIT_SYSTEMPARAMETERS,
-        UILIMIT_WRITECLIPBOARD,
-    };
+    use crate::ui_policy::EffectiveUiRestrictions;
     use sandbox_spec::base_container_layout;
+
+    fn expected_mask(r: EffectiveUiRestrictions) -> u64 {
+        to_job_object_uilimit_mask(&r) as u64
+    }
 
     #[test]
     fn build_sandbox_spec_produces_valid_flatbuffer() {
@@ -517,7 +521,14 @@ mod tests {
         assert!(spec.least_privilege());
         assert_eq!(spec.capabilities(), Some("internetClient,registryRead"));
         assert!(spec.disallow_win32k_system_calls());
-        assert_eq!(spec.ui_restrictions(), UILIMIT_GLOBALATOMS); // default: disable=true → only GLOBALATOMS
+        // default: disable=true → only the global UI namespace bit
+        assert_eq!(
+            spec.ui_restrictions(),
+            expected_mask(EffectiveUiRestrictions {
+                block_global_ui_namespace: true,
+                ..Default::default()
+            })
+        );
 
         let rw = spec.fs_read_write().unwrap();
         assert_eq!(rw.len(), 1);
@@ -574,8 +585,14 @@ mod tests {
         let spec = base_container_layout::root_as_sandbox_spec(&bytes).unwrap();
 
         assert!(spec.disallow_win32k_system_calls());
-        // disable=true → only GLOBALATOMS (Win32k disable handles the rest)
-        assert_eq!(spec.ui_restrictions(), UILIMIT_GLOBALATOMS);
+        // disable=true → only the global UI namespace bit (Win32k disable handles the rest)
+        assert_eq!(
+            spec.ui_restrictions(),
+            expected_mask(EffectiveUiRestrictions {
+                block_global_ui_namespace: true,
+                ..Default::default()
+            })
+        );
     }
 
     #[test]
@@ -593,15 +610,20 @@ mod tests {
         assert!(!spec.disallow_win32k_system_calls());
         // WRITECLIPBOARD + backend defaults (isolation=container: HANDLES+GLOBALATOMS,
         // desktopSystemControl=false: DESKTOP+EXITWINDOWS, systemSettings=none: SYSTEMPARAMETERS+DISPLAYSETTINGS, ime=false: IME)
-        let expected = UILIMIT_WRITECLIPBOARD
-            | UILIMIT_HANDLES
-            | UILIMIT_GLOBALATOMS
-            | UILIMIT_DESKTOP
-            | UILIMIT_EXITWINDOWS
-            | UILIMIT_SYSTEMPARAMETERS
-            | UILIMIT_DISPLAYSETTINGS
-            | UILIMIT_IME;
-        assert_eq!(spec.ui_restrictions(), expected);
+        assert_eq!(
+            spec.ui_restrictions(),
+            expected_mask(EffectiveUiRestrictions {
+                block_clipboard_write: true,
+                block_external_ui_objects: true,
+                block_global_ui_namespace: true,
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
+                block_input_method_changes: true,
+                ..Default::default()
+            })
+        );
     }
 
     #[test]
@@ -618,15 +640,20 @@ mod tests {
 
         assert!(!spec.disallow_win32k_system_calls());
         // INJECTION + backend defaults
-        let expected = UILIMIT_INJECTION
-            | UILIMIT_HANDLES
-            | UILIMIT_GLOBALATOMS
-            | UILIMIT_DESKTOP
-            | UILIMIT_EXITWINDOWS
-            | UILIMIT_SYSTEMPARAMETERS
-            | UILIMIT_DISPLAYSETTINGS
-            | UILIMIT_IME;
-        assert_eq!(spec.ui_restrictions(), expected);
+        assert_eq!(
+            spec.ui_restrictions(),
+            expected_mask(EffectiveUiRestrictions {
+                block_input_injection: true,
+                block_external_ui_objects: true,
+                block_global_ui_namespace: true,
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
+                block_input_method_changes: true,
+                ..Default::default()
+            })
+        );
     }
 
     #[test]

--- a/src/wxc_common/src/job_object.rs
+++ b/src/wxc_common/src/job_object.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! RAII wrapper around a Windows Job Object used to apply UI restrictions
+//! (`JOB_OBJECT_UILIMIT_*`) to a child process and any descendants it creates,
+//! plus the Windows-specific encoder that maps a platform-agnostic
+//! [`crate::ui_policy::EffectiveUiRestrictions`] to the corresponding bitmask.
+//!
+//! The wrapper owns the underlying job HANDLE and closes it on drop. Once a
+//! process has been assigned to a job, the kernel keeps the restrictions
+//! attached for the process lifetime regardless of whether the job HANDLE is
+//! still open in the creator, so dropping a `UiJobObject` after assignment is
+//! safe and does not relax the restrictions on the running process.
+
+use core::ffi::c_void;
+use std::mem::size_of;
+
+use windows::Win32::Foundation::{CloseHandle, HANDLE};
+use windows::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectBasicUIRestrictions,
+    SetInformationJobObject, JOBOBJECT_BASIC_UI_RESTRICTIONS, JOB_OBJECT_UILIMIT,
+    JOB_OBJECT_UILIMIT_DESKTOP, JOB_OBJECT_UILIMIT_DISPLAYSETTINGS, JOB_OBJECT_UILIMIT_EXITWINDOWS,
+    JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES, JOB_OBJECT_UILIMIT_READCLIPBOARD,
+    JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS, JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+};
+use windows::Win32::System::SystemServices::JOB_OBJECT_UILIMIT_IME;
+use windows_core::PCWSTR;
+
+use crate::error::WxcError;
+use crate::ui_policy::EffectiveUiRestrictions;
+
+/// `JOB_OBJECT_UILIMIT_INJECTION` from `winnt.h`. The `windows` crate
+/// does not emit this constant; if a future release adds it, the local
+/// definition can be removed and the import above extended.
+const JOB_OBJECT_UILIMIT_INJECTION: u32 = 0x0000_0200;
+
+/// Encode platform-agnostic UI restrictions as the `JOB_OBJECT_UILIMIT_*`
+/// bitmask consumed by `SetInformationJobObject(JobObjectBasicUIRestrictions)`
+/// and by the BaseContainer SandboxSpec `ui_restrictions` field.
+pub fn to_job_object_uilimit_mask(r: &EffectiveUiRestrictions) -> u32 {
+    let mut mask: u32 = 0;
+    if r.block_external_ui_objects {
+        mask |= JOB_OBJECT_UILIMIT_HANDLES.0;
+    }
+    if r.block_clipboard_read {
+        mask |= JOB_OBJECT_UILIMIT_READCLIPBOARD.0;
+    }
+    if r.block_clipboard_write {
+        mask |= JOB_OBJECT_UILIMIT_WRITECLIPBOARD.0;
+    }
+    if r.block_system_parameter_changes {
+        mask |= JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS.0;
+    }
+    if r.block_display_settings_changes {
+        mask |= JOB_OBJECT_UILIMIT_DISPLAYSETTINGS.0;
+    }
+    if r.block_global_ui_namespace {
+        mask |= JOB_OBJECT_UILIMIT_GLOBALATOMS.0;
+    }
+    if r.block_desktop_switching {
+        mask |= JOB_OBJECT_UILIMIT_DESKTOP.0;
+    }
+    if r.block_logoff_or_shutdown {
+        mask |= JOB_OBJECT_UILIMIT_EXITWINDOWS.0;
+    }
+    if r.block_input_method_changes {
+        mask |= JOB_OBJECT_UILIMIT_IME;
+    }
+    if r.block_input_injection {
+        mask |= JOB_OBJECT_UILIMIT_INJECTION;
+    }
+    mask
+}
+
+/// RAII wrapper for an unnamed Windows Job Object configured for UI
+/// restrictions. The job HANDLE is closed when this value is dropped.
+pub struct UiJobObject {
+    handle: HANDLE,
+}
+
+impl UiJobObject {
+    /// Creates an unnamed Job Object owned by the current process.
+    pub fn new() -> Result<Self, WxcError> {
+        // SAFETY: CreateJobObjectW with NULL security attributes and NULL name
+        // is documented to either return a valid HANDLE or an error.
+        let handle = unsafe { CreateJobObjectW(None, PCWSTR::null()) }
+            .map_err(|e| WxcError::Process(format!("CreateJobObjectW: {e}")))?;
+        Ok(Self { handle })
+    }
+
+    /// Applies the given UI restrictions via `JobObjectBasicUIRestrictions`.
+    /// Passing `EffectiveUiRestrictions::default()` clears all UI restrictions
+    /// and is a valid no-op call.
+    pub fn set_ui_limits(&self, restrictions: &EffectiveUiRestrictions) -> Result<(), WxcError> {
+        let info = JOBOBJECT_BASIC_UI_RESTRICTIONS {
+            UIRestrictionsClass: JOB_OBJECT_UILIMIT(to_job_object_uilimit_mask(restrictions)),
+        };
+        // SAFETY: `info` is a valid, fully-initialized struct living on the
+        // stack for the duration of the call. The size matches the struct
+        // type that JobObjectBasicUIRestrictions expects.
+        unsafe {
+            SetInformationJobObject(
+                self.handle,
+                JobObjectBasicUIRestrictions,
+                &info as *const _ as *const c_void,
+                size_of::<JOBOBJECT_BASIC_UI_RESTRICTIONS>() as u32,
+            )
+        }
+        .map_err(|e| WxcError::Process(format!("SetInformationJobObject(UI): {e}")))
+    }
+
+    /// Assigns the given process handle to this job. The process and any
+    /// future descendants will inherit the job's UI restrictions.
+    pub fn assign_process(&self, process_handle: HANDLE) -> Result<(), WxcError> {
+        // SAFETY: Both handles must be valid for the duration of the call;
+        // this is the caller's responsibility for `process_handle`.
+        unsafe { AssignProcessToJobObject(self.handle, process_handle) }
+            .map_err(|e| WxcError::Process(format!("AssignProcessToJobObject: {e}")))
+    }
+}
+
+impl Drop for UiJobObject {
+    fn drop(&mut self) {
+        if !self.handle.is_invalid() {
+            // SAFETY: `self.handle` was produced by CreateJobObjectW and has
+            // not been closed elsewhere — `UiJobObject` owns it.
+            unsafe {
+                let _ = CloseHandle(self.handle);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_set_limits_drop() {
+        let job = UiJobObject::new().expect("create");
+        // Empty restrictions: should still succeed.
+        job.set_ui_limits(&EffectiveUiRestrictions::default())
+            .expect("set zero limits");
+        // Apply a real restriction.
+        job.set_ui_limits(&EffectiveUiRestrictions {
+            block_global_ui_namespace: true,
+            ..Default::default()
+        })
+        .expect("set global-namespace block");
+        drop(job);
+    }
+
+    #[test]
+    fn encoder_known_bit_positions() {
+        // Sanity-check that the encoder produces the documented winnt.h
+        // bit positions. If the `windows` crate ever changes its
+        // representation, this catches it.
+        let r = EffectiveUiRestrictions {
+            block_external_ui_objects: true,
+            block_clipboard_read: true,
+            block_clipboard_write: true,
+            block_system_parameter_changes: true,
+            block_display_settings_changes: true,
+            block_global_ui_namespace: true,
+            block_desktop_switching: true,
+            block_logoff_or_shutdown: true,
+            block_input_method_changes: true,
+            block_input_injection: true,
+        };
+        assert_eq!(to_job_object_uilimit_mask(&r), 0x03FF);
+    }
+
+    #[test]
+    fn encoder_empty() {
+        assert_eq!(
+            to_job_object_uilimit_mask(&EffectiveUiRestrictions::default()),
+            0
+        );
+    }
+
+    #[test]
+    fn encoder_individual_flags() {
+        assert_eq!(
+            to_job_object_uilimit_mask(&EffectiveUiRestrictions {
+                block_external_ui_objects: true,
+                ..Default::default()
+            }),
+            0x0001
+        );
+        assert_eq!(
+            to_job_object_uilimit_mask(&EffectiveUiRestrictions {
+                block_input_injection: true,
+                ..Default::default()
+            }),
+            0x0200
+        );
+        assert_eq!(
+            to_job_object_uilimit_mask(&EffectiveUiRestrictions {
+                block_input_method_changes: true,
+                ..Default::default()
+            }),
+            0x0100
+        );
+    }
+}

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -28,6 +28,8 @@ pub mod appcontainer_runner;
 #[cfg(target_os = "windows")]
 pub mod filesystem_bfs;
 #[cfg(target_os = "windows")]
+pub mod job_object;
+#[cfg(target_os = "windows")]
 pub mod network_manager;
 #[cfg(target_os = "windows")]
 pub mod process_mitigation;

--- a/src/wxc_common/src/ui_policy.rs
+++ b/src/wxc_common/src/ui_policy.rs
@@ -1,106 +1,132 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! UI policy bitmask helpers.
+//! UI policy resolution.
 //!
-//! Maps cross-platform [`UiPolicy`] and BaseProcessContainer-specific
-//! [`BaseProcessUiConfig`] values onto the Windows `JOB_OBJECT_UILIMIT_*`
-//! flag set. The mapping follows `docs/UIPolicy_Schema.md`.
+//! Reads the user-facing [`UiPolicy`] and [`BaseProcessUiConfig`] structs
+//! from [`crate::models`] and produces an [`EffectiveUiRestrictions`] —
+//! a normalized, platform-agnostic record of which UI capabilities are
+//! to be blocked. The mapping follows `docs/UIPolicy_Schema.md`.
 //!
-//! This module is platform-agnostic: the values are pure `u64` bitmasks
-//! computed from the policy structs in [`crate::models`]. The actual
-//! application of the bitmask to a Job Object is performed by Windows-only
-//! runners (BaseContainer in Phase 1a; AppContainer in Phase 1c).
+//! Encoding the result into a platform-specific shape (Windows
+//! `JOB_OBJECT_UILIMIT_*` bitmask, or future macOS/Linux equivalents) is
+//! done in platform-specific modules — for Windows, see
+//! `crate::job_object::to_job_object_uilimit_mask`.
 
 use crate::models::{BaseProcessUiConfig, ClipboardPolicy, UiPolicy};
 
-/// JOB_OBJECT_UILIMIT_* flag constants (from UIPolicy_Schema.md).
-pub const UILIMIT_HANDLES: u64 = 0x0001;
-pub const UILIMIT_READCLIPBOARD: u64 = 0x0002;
-pub const UILIMIT_WRITECLIPBOARD: u64 = 0x0004;
-pub const UILIMIT_SYSTEMPARAMETERS: u64 = 0x0008;
-pub const UILIMIT_DISPLAYSETTINGS: u64 = 0x0010;
-pub const UILIMIT_GLOBALATOMS: u64 = 0x0020;
-pub const UILIMIT_DESKTOP: u64 = 0x0040;
-pub const UILIMIT_EXITWINDOWS: u64 = 0x0080;
-pub const UILIMIT_IME: u64 = 0x0100;
-pub const UILIMIT_INJECTION: u64 = 0x0200;
+/// Resolved UI restrictions ready for platform-specific encoding.
+///
+/// Each field names a single capability the child must be denied; `true`
+/// means "block this." This layer carries intent only — there is no
+/// Windows (or other OS) coupling here.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct EffectiveUiRestrictions {
+    // Clipboard
+    pub block_clipboard_read: bool,
+    pub block_clipboard_write: bool,
 
-/// Build the JOB_OBJECT_UILIMIT_* bitmask from the cross-platform UI policy
-/// and the BaseProcessContainer-specific UI config.
-/// Mapping follows docs/UIPolicy_Schema.md.
-pub fn ui_restrictions_bitmask(ui: &UiPolicy, base_proc_ui: &BaseProcessUiConfig) -> u64 {
-    // When UI is fully disabled: DisallowWin32kSystemCalls handles everything
-    // except atoms (NT executive syscalls, not Win32k). Only set GLOBALATOMS.
+    // Input
+    pub block_input_injection: bool,
+    pub block_input_method_changes: bool,
+
+    // UI-object isolation
+    pub block_external_ui_objects: bool,
+    pub block_global_ui_namespace: bool,
+    pub block_desktop_switching: bool,
+    pub block_logoff_or_shutdown: bool,
+
+    // System-wide settings
+    pub block_system_parameter_changes: bool,
+    pub block_display_settings_changes: bool,
+}
+
+/// Resolve user policy into the set of UI capabilities to block.
+///
+/// Mapping follows `docs/UIPolicy_Schema.md`.
+pub fn resolve_ui_restrictions(
+    ui: &UiPolicy,
+    base_proc_ui: &BaseProcessUiConfig,
+) -> EffectiveUiRestrictions {
+    // When UI is fully disabled: on Windows, DisallowWin32kSystemCalls
+    // handles every UI surface except the global namespace (which is an
+    // NT-executive concern, not Win32k). Block only that here.
     if ui.disable {
-        return UILIMIT_GLOBALATOMS;
+        return EffectiveUiRestrictions {
+            block_global_ui_namespace: true,
+            ..Default::default()
+        };
     }
 
-    let mut mask: u64 = 0;
+    let mut r = EffectiveUiRestrictions::default();
 
-    // Cross-platform: clipboard (default: "none" = block both)
+    // Clipboard (default: "none" = block both)
     match ui.clipboard {
         ClipboardPolicy::All => {}
         ClipboardPolicy::Read => {
-            mask |= UILIMIT_WRITECLIPBOARD;
+            r.block_clipboard_write = true;
         }
         ClipboardPolicy::Write => {
-            mask |= UILIMIT_READCLIPBOARD;
+            r.block_clipboard_read = true;
         }
         // "none" or unrecognized → default-deny: block both
         _ => {
-            mask |= UILIMIT_READCLIPBOARD | UILIMIT_WRITECLIPBOARD;
+            r.block_clipboard_read = true;
+            r.block_clipboard_write = true;
         }
     }
 
-    // Cross-platform: input injection
+    // Input injection
     if !ui.injection {
-        mask |= UILIMIT_INJECTION;
+        r.block_input_injection = true;
     }
 
-    // Backend-specific: isolation level (default: "container" = HANDLES + GLOBALATOMS)
+    // UI-object isolation level (default: "container" = external objects + global namespace)
     match base_proc_ui.isolation.as_str() {
         "desktop" => {
-            // No isolation flags
+            // No isolation restrictions
         }
         "handles" => {
-            mask |= UILIMIT_HANDLES;
+            r.block_external_ui_objects = true;
         }
         "atoms" => {
-            mask |= UILIMIT_GLOBALATOMS;
+            r.block_global_ui_namespace = true;
         }
         // "container" or unrecognized → default-deny: full isolation
         _ => {
-            mask |= UILIMIT_HANDLES | UILIMIT_GLOBALATOMS;
+            r.block_external_ui_objects = true;
+            r.block_global_ui_namespace = true;
         }
     }
 
-    // Backend-specific: desktop system control
+    // Desktop system control: blocks switching desktops and ending the session
     if !base_proc_ui.desktop_system_control {
-        mask |= UILIMIT_DESKTOP | UILIMIT_EXITWINDOWS;
+        r.block_desktop_switching = true;
+        r.block_logoff_or_shutdown = true;
     }
 
-    // Backend-specific: system settings (default: "none" = block all)
+    // System settings (default: "none" = block all)
     match base_proc_ui.system_settings.as_str() {
         "all" => {}
         "parameters" => {
-            mask |= UILIMIT_DISPLAYSETTINGS;
+            r.block_display_settings_changes = true;
         }
         "display" => {
-            mask |= UILIMIT_SYSTEMPARAMETERS;
+            r.block_system_parameter_changes = true;
         }
         // "none" or unrecognized → default-deny: block all
         _ => {
-            mask |= UILIMIT_SYSTEMPARAMETERS | UILIMIT_DISPLAYSETTINGS;
+            r.block_system_parameter_changes = true;
+            r.block_display_settings_changes = true;
         }
     }
 
-    // Backend-specific: IME
+    // Input method changes
     if !base_proc_ui.ime {
-        mask |= UILIMIT_IME;
+        r.block_input_method_changes = true;
     }
 
-    mask
+    r
 }
 
 #[cfg(test)]
@@ -109,46 +135,62 @@ mod tests {
     use crate::models::{BaseProcessUiConfig, ClipboardPolicy, UiPolicy};
 
     #[test]
-    fn ui_bitmask_disabled() {
+    fn disabled_blocks_only_global_ui_namespace() {
         let ui = UiPolicy {
             disable: true,
             ..Default::default()
         };
         let bp = BaseProcessUiConfig::default();
-        // disable=true → only GLOBALATOMS
-        assert_eq!(ui_restrictions_bitmask(&ui, &bp), UILIMIT_GLOBALATOMS);
-    }
-
-    #[test]
-    fn ui_bitmask_default_deny() {
-        // UiPolicy default: disable=true → only GLOBALATOMS
+        let r = resolve_ui_restrictions(&ui, &bp);
         assert_eq!(
-            ui_restrictions_bitmask(&UiPolicy::default(), &BaseProcessUiConfig::default()),
-            UILIMIT_GLOBALATOMS
+            r,
+            EffectiveUiRestrictions {
+                block_global_ui_namespace: true,
+                ..Default::default()
+            }
         );
     }
 
     #[test]
-    fn ui_bitmask_clipboard_read_with_default_backend() {
+    fn default_policy_blocks_only_global_ui_namespace() {
+        // UiPolicy::default has disable=true → only the global namespace.
+        let r = resolve_ui_restrictions(&UiPolicy::default(), &BaseProcessUiConfig::default());
+        assert_eq!(
+            r,
+            EffectiveUiRestrictions {
+                block_global_ui_namespace: true,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn clipboard_read_with_default_backend() {
         let ui = UiPolicy {
             disable: false,
             clipboard: ClipboardPolicy::Read,
             injection: true,
         };
-        let bp = BaseProcessUiConfig::default(); // isolation=container, desktopSystemControl=false, systemSettings=none, ime=false
-        let expected = UILIMIT_WRITECLIPBOARD
-            | UILIMIT_HANDLES
-            | UILIMIT_GLOBALATOMS
-            | UILIMIT_DESKTOP
-            | UILIMIT_EXITWINDOWS
-            | UILIMIT_SYSTEMPARAMETERS
-            | UILIMIT_DISPLAYSETTINGS
-            | UILIMIT_IME;
-        assert_eq!(ui_restrictions_bitmask(&ui, &bp), expected);
+        let bp = BaseProcessUiConfig::default();
+        let r = resolve_ui_restrictions(&ui, &bp);
+        assert_eq!(
+            r,
+            EffectiveUiRestrictions {
+                block_clipboard_write: true,
+                block_external_ui_objects: true,
+                block_global_ui_namespace: true,
+                block_desktop_switching: true,
+                block_logoff_or_shutdown: true,
+                block_system_parameter_changes: true,
+                block_display_settings_changes: true,
+                block_input_method_changes: true,
+                ..Default::default()
+            }
+        );
     }
 
     #[test]
-    fn ui_bitmask_no_backend_restrictions() {
+    fn no_restrictions_when_everything_allowed() {
         let ui = UiPolicy {
             disable: false,
             clipboard: ClipboardPolicy::All,
@@ -160,7 +202,9 @@ mod tests {
             system_settings: "all".to_string(),
             ime: true,
         };
-        // No cross-platform restrictions + no backend restrictions = 0
-        assert_eq!(ui_restrictions_bitmask(&ui, &bp), 0);
+        assert_eq!(
+            resolve_ui_restrictions(&ui, &bp),
+            EffectiveUiRestrictions::default()
+        );
     }
 }


### PR DESCRIPTION
## 📖 Description

Splits the phase1a `ui_policy` module into two concerns and introduces the Windows Job Object wrapper that consumes the second one.

**The policy layer (`crate::ui_policy`)** stays platform-agnostic. It exposes:

- `EffectiveUiRestrictions`, a record of ten booleans naming which UI capabilities the child must be denied.
- `resolve_ui_restrictions(&UiPolicy, &BaseProcessUiConfig) -> EffectiveUiRestrictions`, replacing `ui_restrictions_bitmask`. No `windows`-crate references; ready for future macOS/Linux consumers.

The `UILIMIT_*` bare-`u64` constants are gone.

**The Windows encoding layer (`crate::job_object`, new)** is Windows-only. It exposes:

- `UiJobObject`, an RAII wrapper around a Windows Job Object that applies UI restrictions to a child and its descendants. `set_ui_limits` takes an `&EffectiveUiRestrictions` directly so callers never deal in raw bits.
- `to_job_object_uilimit_mask(&EffectiveUiRestrictions) -> u32`, the encoder. Sources nine of the ten flag bits from the `windows` crate (`Win32::System::JobObjects::JOB_OBJECT_UILIMIT_*` for eight, `Win32::System::SystemServices::JOB_OBJECT_UILIMIT_IME` for IME). The tenth, `JOB_OBJECT_UILIMIT_INJECTION`, is hand-typed because the `windows` crate metadata does not include it; if a future release adds it, the local constant can be removed.

**Side effects:**

- `wxc_common::ui_policy` returns to the platform-agnostic section of `lib.rs`. The Windows-specific encoding moved out, so the module no longer has any OS-specific code.
- `base_container_runner.rs` is updated to use the new APIs (encoder's `u32` is cast to `u64` for the BaseContainer FlatBuffer `ui_restrictions` field).
- Enables the `Win32_System_JobObjects` feature on the workspace `windows` crate dependency.
- Drops `UiJobObject::handle()`; no caller used it and exposing the raw HANDLE was a footgun.

## 🔗 References

Stacked on top of #290 (phase1b → main).

## 🔍 Validation

- `cargo test -p wxc_common --lib` — 336/336 pass
- `cargo build -p wxc_common` clean
- End-to-end coverage lives in `Win25H2Safe-Tests.ps1` in phase5 (held)