### PR TITLE
Phase 4: dispatcher integration for BaseContainer fallback

### DIFF
--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -8,7 +8,6 @@ use std::time::Instant;
 
 use clap::Parser;
 use wxc_common::appcontainer_runner::{delete_app_container_profile, AppContainerScriptRunner};
-use wxc_common::base_container_runner::BaseContainerRunner;
 use wxc_common::config_parser::{is_base_container_version, load_mxc_request, ParseError};
 use wxc_common::diagnostic::DiagnosticConfig;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
@@ -501,13 +500,55 @@ fn main() {
         wxc_common::diagnostic::redacted_request_json(&request)
     );
 
+    // Drop-order contract — DO NOT REORDER, AND DO NOT ADD `process::exit`
+    // BETWEEN THIS DECLARATION AND THE EXPLICIT `drop(_dacl_guard)` LATER
+    // IN main() WITHOUT FIRST GOING THROUGH THAT DROP:
+    //
+    //   `_dacl_guard` is declared BEFORE `runner` so that, by Rust's
+    //   reverse-declaration destructor order, `runner` drops first (its
+    //   internal handles release the child) and the `DaclManager` Drop
+    //   runs afterwards, removing the host filesystem ACEs we applied.
+    //   Inverting the order would yank the ACEs while the child is still
+    //   running. The explicit `drop(runner); drop(_dacl_guard);` later
+    //   in main() is the `process::exit`-safe equivalent — `process::exit`
+    //   skips destructors, so any new exit added between dispatch and
+    //   that explicit drop must run `drop(_dacl_guard)` first or it will
+    //   leak ACEs permanently on the host filesystem.
+    //
+    //   Audit of exit sites at this commit: every `process::exit` after
+    //   `_dacl_guard = dispatched.dacl_manager;` is either (a) on the
+    //   dispatcher's `Err` arm where `_dacl_guard` is still `None`, or
+    //   (b) reached only after the explicit drops. Panic strategy is
+    //   `unwind` (default; no `panic = "abort"` in any `[profile.*]`),
+    //   so panics during `runner.run()` unwind through Drop and restore
+    //   ACEs naturally. If you change either invariant, this comment is
+    //   the place to update.
+    let mut _dacl_guard: Option<wxc_common::filesystem_dacl::DaclManager> = None;
+
     // Run script in selected containment backend.
     // BaseContainer is used when --experimental is passed or schema version >= 0.5.
     // Sandbox and MicroVM require --experimental flag.
     let mut runner: Box<dyn ScriptRunner> = match request.containment {
         ContainmentBackend::ProcessContainer => {
+            // Compute fallback eligibility on the ProcessContainer arm
+            // only — every other `ContainmentBackend` variant is
+            // unaffected by `use_base_container` and does not need to
+            // pay the (trivial) semver parse cost.
             let version_implies_base_container = is_base_container_version(&request.schema_version);
             let use_base_container = request.experimental_enabled || version_implies_base_container;
+
+            // Validation warning: deniedPaths is only honored on the
+            // BaseContainer-fallback path. Surface once at parse time
+            // through the buffered logger so it lands in `--dry-run`
+            // output and any tooling scraping the diagnostic pipe.
+            if !use_base_container && !request.policy.denied_paths.is_empty() {
+                let _ = writeln!(
+                    logger,
+                    "warning: filesystem.deniedPaths is set but containment is ProcessContainer \
+                     (no BaseContainer fallback in effect). deniedPaths will not be honored. \
+                     Use --experimental or schema 0.5+ to enable fallback with deny enforcement."
+                );
+            }
 
             if use_base_container {
                 let reason = if version_implies_base_container {
@@ -516,7 +557,27 @@ fn main() {
                     "--experimental".to_string()
                 };
                 let _ = writeln!(logger, "Using BaseContainer runner ({reason})");
-                Box::new(BaseContainerRunner::new())
+
+                match wxc_common::dispatcher::dispatch_with_fallback(&request) {
+                    Ok(dispatched) => {
+                        for w in &dispatched.warnings {
+                            let _ = writeln!(logger, "warning: {w}");
+                        }
+                        let _ = writeln!(
+                            logger,
+                            "selected isolation tier: {}",
+                            dispatched.tier.as_str()
+                        );
+
+                        _dacl_guard = dispatched.dacl_manager;
+                        dispatched.runner
+                    }
+                    Err(e) => {
+                        eprintln!("error: {e}");
+                        eprint!("{}", logger.get_buffer());
+                        process::exit(1);
+                    }
+                }
             } else {
                 Box::new(AppContainerScriptRunner::new())
             }
@@ -636,6 +697,14 @@ fn main() {
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
+
+    // Explicitly drop the runner before the DACL guard so any
+    // runner-internal resources holding child handles release first, then
+    // the DaclManager's Drop restores the host filesystem ACEs we applied.
+    // (process::exit below skips destructors, so we must do this manually
+    // for prompt cleanup on the normal path.)
+    drop(runner);
+    drop(_dacl_guard);
 
     if cli.dry_run {
         handle_dry_run_exit(&response, &mut logger);

--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -6,10 +6,11 @@ use std::ptr;
 use windows::Win32::Foundation::{
     GetLastError, LocalFree, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
+use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
-use windows::Win32::Security::PSID;
+use windows::Win32::Security::{FreeSid, PSID};
 use windows::Win32::System::Threading::{
     CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
     InitializeProcThreadAttributeList, ResumeThread, TerminateProcess, UpdateProcThreadAttribute,
@@ -141,11 +142,121 @@ fn compute_attr_count(least_privilege_mode: bool, ui_disable: bool) -> u32 {
     n
 }
 
+/// Derive the AppContainer SID for `profile_name` and return it as a string
+/// in `S-1-15-...` form.
+///
+/// Used by the Phase 4 dispatcher to target deny / grant ACEs at the same
+/// AppContainer principal the runner will execute under. Co-located with
+/// [`AppContainerScriptRunner::create_app_container_sid`] so any future
+/// name normalization is added to a single place — keeping the dispatcher's
+/// ACE target and the runner's process principal from drifting.
+///
+/// `profile_name` corresponds to the AppContainer profile name the runner
+/// would create (matching the `request.container_id` mapping in the
+/// AppContainer / BaseContainer runners — empty becomes `"CLI"` at the
+/// caller; this function rejects empty input outright).
+///
+/// # Errors
+///
+/// Returns [`WxcError::Initialization`] if `profile_name` is empty, the
+/// derivation Win32 call fails, or the returned SID cannot be converted to
+/// a string.
+pub(crate) fn derive_sid_string(profile_name: &str) -> Result<String, WxcError> {
+    if profile_name.is_empty() {
+        return Err(WxcError::Initialization(
+            "AppContainer profile name is empty; cannot derive SID".to_string(),
+        ));
+    }
+
+    let wide_name = string_util::to_wide(profile_name);
+    let pcwstr_name = PCWSTR(wide_name.as_ptr());
+
+    // SAFETY: `wide_name` is a valid null-terminated UTF-16 string and lives
+    // for the duration of the call.
+    let sid: PSID =
+        unsafe { DeriveAppContainerSidFromAppContainerName(pcwstr_name) }.map_err(|e| {
+            WxcError::Initialization(format!(
+                "DeriveAppContainerSidFromAppContainerName failed for '{profile_name}': {e}"
+            ))
+        })?;
+
+    let mut string_sid = PWSTR::null();
+    // SAFETY: `sid` is a valid SID returned by the call above.
+    let convert_result = unsafe { ConvertSidToStringSidW(sid, &mut string_sid) };
+
+    let result = match convert_result {
+        Ok(()) => {
+            // Defensive null-check: `ConvertSidToStringSidW` documents
+            // that it always allocates a valid pointer on success, but
+            // matching the rest of the codebase's posture on raw Win32
+            // pointers is cheap. If we ever see a null here it's a
+            // real Win32 bug — surface it as an error rather than UB.
+            if string_sid.is_null() {
+                Err(WxcError::Initialization(
+                    "ConvertSidToStringSidW returned success but produced a null string SID"
+                        .to_string(),
+                ))
+            } else {
+                // SAFETY: ConvertSidToStringSidW writes a null-terminated
+                // wide string to `string_sid` on success and we just
+                // verified non-null.
+                let s = unsafe { string_sid.to_string() }
+                    .map_err(|e| WxcError::Initialization(format!("SID-to-string failed: {e}")));
+                // SAFETY: `string_sid` was allocated by ConvertSidToStringSidW;
+                // free it with LocalFree per the Win32 contract.
+                unsafe {
+                    let _ = LocalFree(Some(HLOCAL(string_sid.0 as *mut std::ffi::c_void)));
+                }
+                s
+            }
+        }
+        Err(e) => Err(WxcError::Initialization(format!(
+            "ConvertSidToStringSidW failed: {e}"
+        ))),
+    };
+
+    // SAFETY: SIDs returned by DeriveAppContainerSidFromAppContainerName
+    // must be released with FreeSid.
+    unsafe {
+        let _ = FreeSid(sid);
+    }
+
+    result
+}
+
+/// Selects how filesystem policy is enforced for an AppContainer run.
+///
+/// Used by the Phase 4 dispatcher to skip the in-runner BFS configure when
+/// the caller (Tier 3) is enforcing filesystem policy via host DACLs
+/// instead.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum FilesystemMode {
+    /// Configure the AppContainer's BFS policy via `bfscfg.exe` (default
+    /// historical behavior).
+    #[default]
+    Bfs,
+    /// Skip BFS setup; the caller has handled filesystem policy via host
+    /// DACL augmentation (Tier 3 path).
+    Dacl,
+}
+
 /// Script runner that executes commands inside a Windows AppContainer.
 pub struct AppContainerScriptRunner {
     app_container_name: String,
     app_container_sid: PSID,
     proxy_address: Option<crate::models::ProxyAddress>,
+    filesystem_mode: FilesystemMode,
+    /// Optional pre-derived SID string supplied by the dispatcher.
+    ///
+    /// When `Some`, the runner uses this value for the firewall
+    /// principal-id and any other capability-string lookups instead of
+    /// re-running `ConvertSidToStringSidW` on its owned `PSID`. The
+    /// `PSID` itself is still derived by [`create_app_container_sid`]
+    /// at run time because `windows-rs` does not expose a safe
+    /// "string → PSID" conversion with the same ownership semantics as
+    /// [`DeriveAppContainerSidFromAppContainerName`] / `FreeSid`; that
+    /// duplicate Win32 call is documented and left as a follow-up.
+    preset_sid_string: Option<String>,
 }
 
 impl AppContainerScriptRunner {
@@ -154,10 +265,50 @@ impl AppContainerScriptRunner {
             app_container_name: String::new(),
             app_container_sid: PSID(ptr::null_mut()),
             proxy_address: None,
+            filesystem_mode: FilesystemMode::Bfs,
+            preset_sid_string: None,
+        }
+    }
+
+    /// Construct a runner with an explicit [`FilesystemMode`].
+    ///
+    /// Used by the Phase 4 dispatcher to disable in-runner BFS setup for
+    /// the Tier 3 (DACL-augmented) path.
+    pub fn with_filesystem_mode(mode: FilesystemMode) -> Self {
+        Self {
+            app_container_name: String::new(),
+            app_container_sid: PSID(ptr::null_mut()),
+            proxy_address: None,
+            filesystem_mode: mode,
+            preset_sid_string: None,
+        }
+    }
+
+    /// Construct a runner with an explicit [`FilesystemMode`] and a
+    /// pre-derived SID string.
+    ///
+    /// Used by the Phase 4 dispatcher to avoid a second
+    /// `ConvertSidToStringSidW` round-trip when the dispatcher has
+    /// already derived the SID string for ACE targeting. The `PSID`
+    /// itself is still derived inside [`create_app_container_sid`] at
+    /// run time — see [`Self::preset_sid_string`].
+    pub fn with_filesystem_mode_and_sid_string(mode: FilesystemMode, sid_string: String) -> Self {
+        Self {
+            app_container_name: String::new(),
+            app_container_sid: PSID(ptr::null_mut()),
+            proxy_address: None,
+            filesystem_mode: mode,
+            preset_sid_string: Some(sid_string),
         }
     }
 
     /// Create or derive an AppContainer SID for the given container name.
+    ///
+    /// Returns a [`PSID`] owned by the runner (released via [`FreeSid`] in
+    /// cleanup). If you only need the string form of the SID (e.g. to
+    /// target ACEs at the same principal), call
+    /// [`derive_sid_string`] — it shares the underlying derivation so the
+    /// two paths can't drift in name normalization.
     fn create_app_container_sid(name: &str) -> Result<PSID, WxcError> {
         let wide_name = string_util::to_wide(name);
         let pcwstr_name = PCWSTR(wide_name.as_ptr());
@@ -595,6 +746,12 @@ impl AppContainerScriptRunner {
 
     /// Return the SID string for firewall rule association.
     fn get_principal_id(&self) -> String {
+        // Prefer the dispatcher-supplied string when present — saves a
+        // `ConvertSidToStringSidW` round-trip (the dispatcher has
+        // already converted the underlying SID once for ACE targeting).
+        if let Some(s) = &self.preset_sid_string {
+            return s.clone();
+        }
         if self.app_container_sid.0.is_null() {
             return "unknown-sid".to_string();
         }
@@ -642,20 +799,24 @@ impl ScriptRunner for AppContainerScriptRunner {
 
         // Resolve `bfscfg.exe` by absolute path so probe and execution
         // agree on the binary — defeats executable-search-order
-        // hijacking (see `fallback_detector::find_bfscfg_exe`). On
-        // hosts where SystemRoot itself cannot be resolved (a
-        // pathological state on any healthy Windows install) we surface
-        // the resolution error rather than silently demoting to a
-        // weaker isolation tier.
-        let bfscfg_path = match crate::fallback_detector::find_bfscfg_exe() {
-            Ok(p) => p,
-            Err(e) => return ScriptResponse::error(&e.to_string()),
+        // hijacking (see `fallback_detector::find_bfscfg_exe`). Only
+        // resolve when we actually plan to use BFS; Tier 3 (DACL) hosts
+        // legitimately may not have `bfscfg.exe` installed.
+        let bfscfg_path = if self.filesystem_mode == FilesystemMode::Bfs {
+            match crate::fallback_detector::find_bfscfg_exe() {
+                Ok(p) => p,
+                Err(e) => return ScriptResponse::error(&e.to_string()),
+            }
+        } else {
+            None
         };
 
         let mut bfs_manager =
             FileSystemBfsManager::new(self.app_container_name.clone(), bfscfg_path);
-        if let Err(e) = bfs_manager.configure(&request.policy, logger) {
-            return ScriptResponse::error(&e.to_string());
+        if self.filesystem_mode == FilesystemMode::Bfs {
+            if let Err(e) = bfs_manager.configure(&request.policy, logger) {
+                return ScriptResponse::error(&e.to_string());
+            }
         }
 
         let mut network_manager = NetworkManager::new();
@@ -704,7 +865,10 @@ impl ScriptRunner for AppContainerScriptRunner {
         }
 
         network_manager.stop_all(!request.lifecycle.preserve_policy, logger);
-        if bfs_manager.configured() && !request.lifecycle.preserve_policy {
+        if self.filesystem_mode == FilesystemMode::Bfs
+            && bfs_manager.configured()
+            && !request.lifecycle.preserve_policy
+        {
             bfs_manager.remove_configuration(logger);
         }
 
@@ -776,5 +940,31 @@ mod tests {
     #[test]
     fn attr_count_both() {
         assert_eq!(super::compute_attr_count(true, true), 3);
+    }
+
+    #[test]
+    fn derive_sid_string_empty_profile_name_errors() {
+        let res = super::derive_sid_string("");
+        assert!(matches!(
+            res,
+            Err(crate::error::WxcError::Initialization(_))
+        ));
+    }
+
+    #[test]
+    fn derive_sid_string_returns_appcontainer_prefix() {
+        let sid =
+            super::derive_sid_string("MxcDeriveSidTestSimple").expect("derivation should succeed");
+        assert!(
+            sid.starts_with("S-1-15-"),
+            "expected AppContainer SID prefix S-1-15-, got: {sid}"
+        );
+    }
+
+    #[test]
+    fn derive_sid_string_is_stable_for_same_name() {
+        let a = super::derive_sid_string("MxcDeriveSidTestStable").expect("first derivation");
+        let b = super::derive_sid_string("MxcDeriveSidTestStable").expect("second derivation");
+        assert_eq!(a, b);
     }
 }

--- a/src/wxc_common/src/dispatcher.rs
+++ b/src/wxc_common/src/dispatcher.rs
@@ -1,0 +1,377 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! BaseContainer-fallback tier dispatcher.
+//!
+//! Wires Phases 0–3 (telemetry, fallback detector, AppContainer modes,
+//! DACL manager) into a single entrypoint. Given a [`CodexRequest`], the
+//! dispatcher consults [`crate::fallback_detector::detect`] to choose
+//! between Tier 1 (BaseContainer), Tier 2 (AppContainer + BFS), or Tier 3
+//! (AppContainer + DACL), constructs the appropriate runner, and applies
+//! [`DaclManager`] augmentation when the chosen tier requires it.
+//!
+//! Filesystem-policy enforcement under T1 is delegated entirely to
+//! BaseContainer's own `Experimental_CreateProcessInSandbox` API
+//! (including `deniedPaths` once native deny support lands); the
+//! dispatcher does **not** apply host DACLs in T1. The opaque
+//! `identity` BaseContainer runs the child under is not guaranteed to
+//! match an `AppContainer` SID derived from the same container name, so
+//! adding host-DACL belt-and-suspenders here would risk silently
+//! targeting the wrong principal.
+//!
+//! See `docs/proposals/downlevel_support/basecontainer-fallback-plan-v2.md`.
+//!
+//! # Drop ordering
+//!
+//! Callers must keep the returned [`Dispatched::dacl_manager`] alive for the
+//! entire duration of the run — its [`Drop`] removes the ACEs we added to
+//! the host filesystem. Dropping it before the runner finishes would yank
+//! filesystem access mid-execution.
+//!
+//! # Performance
+//!
+//! Tier 1 has the lowest per-invocation cost: a single
+//! `BaseContainerRunner::new()`. Tier 2 with empty `denied_paths` is also
+//! near-free. The heavy paths are Tier 2 with deny-only and Tier 3, both
+//! of which stamp host-DACL ACEs via [`DaclManager`].
+//!
+//! The DACL cost is roughly O(N) Win32 syscalls plus one state-file
+//! write per path in (Tier 3: `readwrite_paths` ∪ `readonly_paths` ∪
+//! `denied_paths`; Tier 2: `denied_paths`). The same number of syscalls
+//! is replayed in reverse on `Drop`. At the typical N (6–12 paths) this
+//! adds tens of milliseconds to both dispatch and shutdown; at larger N
+//! it scales linearly and can add hundreds of milliseconds on each side.
+//! SDK callers that spawn `wxc-exec` per task pay this cost on every
+//! invocation. Parent-directory ACE rollup and session-scoped
+//! [`DaclManager`] caching are tracked as follow-ups.
+//!
+//! Windows-only by virtue of `lib.rs` gating the module behind
+//! `#[cfg(target_os = "windows")]`; no inner attribute is needed.
+
+use std::path::PathBuf;
+
+use crate::appcontainer_runner::{derive_sid_string, AppContainerScriptRunner, FilesystemMode};
+use crate::base_container_runner::BaseContainerRunner;
+use crate::error::WxcError;
+use crate::fallback_detector::{self, FallbackError, IsolationTier};
+use crate::filesystem_dacl::{DaclError, DaclManager};
+use crate::models::CodexRequest;
+use crate::script_runner::ScriptRunner;
+
+/// Result of a successful dispatch decision.
+///
+/// The caller should bind `dacl_manager` to a local that outlives the
+/// runner so its `Drop` removes any ACEs we applied after the child
+/// process completes.
+pub struct Dispatched {
+    /// Runner ready to execute.
+    pub runner: Box<dyn ScriptRunner>,
+    /// `DaclManager` whose `Drop` restores ACEs. `None` when the chosen
+    /// tier did not require host DACL augmentation.
+    pub dacl_manager: Option<DaclManager>,
+    /// The selected tier, for telemetry.
+    pub tier: IsolationTier,
+    /// Operator-visible warnings collected during tier selection.
+    pub warnings: Vec<String>,
+}
+
+/// Errors that can abort dispatch before the runner executes.
+#[derive(Debug)]
+pub enum DispatchError {
+    /// Fallback detection refused the request.
+    Fallback(FallbackError),
+    /// `DaclManager` failed to apply ACEs.
+    Dacl(DaclError),
+    /// AppContainer SID derivation failed.
+    Sid(WxcError),
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DispatchError::Fallback(FallbackError::DaclFallbackDisabled) => write!(
+                f,
+                "BaseContainer is unavailable on this system and DACL fallback is disabled \
+                 (fallback.allowDaclMutation=false). Run on a system with the BaseContainer \
+                 API or bfscfg.exe, or set fallback.allowDaclMutation=true in your config."
+            ),
+            DispatchError::Fallback(FallbackError::WriteDacUnavailable { path, reason }) => {
+                write!(
+                    f,
+                    "BaseContainer is unavailable; DACL fallback requires write-DAC permission \
+                     on '{}', which the current user lacks ({reason}).",
+                    path.display()
+                )
+            }
+            DispatchError::Fallback(FallbackError::SystemRootUnresolved { reason }) => write!(
+                f,
+                "Could not resolve the Windows system directory while probing for bfscfg.exe \
+                 ({reason}). This indicates a corrupted or unsupported OS configuration."
+            ),
+            DispatchError::Dacl(e) => write!(f, "Failed to apply DACL ACEs: {e}"),
+            DispatchError::Sid(e) => write!(f, "Failed to derive AppContainer SID: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DispatchError {}
+
+impl From<FallbackError> for DispatchError {
+    fn from(e: FallbackError) -> Self {
+        DispatchError::Fallback(e)
+    }
+}
+
+impl From<DaclError> for DispatchError {
+    fn from(e: DaclError) -> Self {
+        DispatchError::Dacl(e)
+    }
+}
+
+/// The container-id → AppContainer-name mapping used by the runners. Empty
+/// container_id maps to `"CLI"` (matches both AppContainerScriptRunner and
+/// BaseContainerRunner internals).
+fn container_name(request: &CodexRequest) -> String {
+    if request.container_id.is_empty() {
+        "CLI".to_string()
+    } else {
+        request.container_id.clone()
+    }
+}
+
+fn paths_to_pathbufs(paths: &[String]) -> Vec<PathBuf> {
+    paths.iter().map(PathBuf::from).collect()
+}
+
+/// Build a runner with appropriate DACL augmentation for the
+/// BaseContainer-preferred path. The caller is responsible for the explicit
+/// (no-fallback) AppContainer path.
+///
+/// On success the returned [`Dispatched`] contains a runner ready to
+/// execute and (when applicable) a [`DaclManager`] that has already
+/// applied its ACEs. The caller MUST keep `dacl_manager` alive through the
+/// run.
+pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, DispatchError> {
+    let decision = fallback_detector::detect(&request.policy, /*prefer_bc=*/ true)?;
+
+    let (runner, dacl_manager): (Box<dyn ScriptRunner>, Option<DaclManager>) = match decision.tier {
+        IsolationTier::BaseContainer => {
+            // Tier 1 delegates filesystem-policy enforcement to
+            // BaseContainer's native API. We do NOT stamp host-DACL
+            // deny ACEs here because the AppContainer SID derived from
+            // `container_name(request)` is not guaranteed to match the
+            // opaque principal `Experimental_CreateProcessInSandbox`
+            // actually runs the child under; a mismatch would render
+            // the ACEs inert and silently un-enforce `deniedPaths`.
+            let runner: Box<dyn ScriptRunner> = Box::new(BaseContainerRunner::new());
+            (runner, None)
+        }
+        IsolationTier::AppContainerBfs => {
+            // T2 only needs deny ACEs (BFS handles the rest in-runner)
+            // and only when `deniedPaths` is non-empty. Allocate the
+            // path Vec and derive the SID inside that branch so the
+            // common no-deny case skips both costs.
+            if request.policy.denied_paths.is_empty() {
+                let runner: Box<dyn ScriptRunner> = Box::new(
+                    AppContainerScriptRunner::with_filesystem_mode(FilesystemMode::Bfs),
+                );
+                (runner, None)
+            } else {
+                let denied = paths_to_pathbufs(&request.policy.denied_paths);
+                let sid =
+                    derive_sid_string(&container_name(request)).map_err(DispatchError::Sid)?;
+                let mut mgr = DaclManager::new()?;
+                mgr.add_deny_aces(&sid, &denied)?;
+                // Hand the derived SID string to the runner so it does
+                // not re-run `ConvertSidToStringSidW` for the firewall
+                // principal-id lookup.
+                let runner: Box<dyn ScriptRunner> = Box::new(
+                    AppContainerScriptRunner::with_filesystem_mode_and_sid_string(
+                        FilesystemMode::Bfs,
+                        sid,
+                    ),
+                );
+                (runner, Some(mgr))
+            }
+        }
+        IsolationTier::AppContainerDacl => {
+            // T3 always stamps grant ACEs (for readwrite/readonly paths)
+            // and optionally deny ACEs. Allocate per-arm so T1/T2 don't
+            // pay the cost.
+            let readwrite = paths_to_pathbufs(&request.policy.readwrite_paths);
+            let readonly = paths_to_pathbufs(&request.policy.readonly_paths);
+            let denied = paths_to_pathbufs(&request.policy.denied_paths);
+            let sid = derive_sid_string(&container_name(request)).map_err(DispatchError::Sid)?;
+            let mut mgr = DaclManager::new()?;
+            mgr.grant_appcontainer_access(&sid, &readwrite, &readonly)?;
+            if !denied.is_empty() {
+                mgr.add_deny_aces(&sid, &denied)?;
+            }
+            let runner: Box<dyn ScriptRunner> = Box::new(
+                AppContainerScriptRunner::with_filesystem_mode_and_sid_string(
+                    FilesystemMode::Dacl,
+                    sid,
+                ),
+            );
+            (runner, Some(mgr))
+        }
+    };
+
+    Ok(Dispatched {
+        runner,
+        dacl_manager,
+        tier: decision.tier,
+        warnings: decision.warnings,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{CodexRequest, ContainerPolicy};
+    // `ForceTierGuard` lives in `crate::test_env` so the lock is
+    // shared with the `fallback_detector::tests` module — otherwise
+    // a dispatcher test and a fallback-detector test running on
+    // different threads could each mutate `MXC_FORCE_TIER` under
+    // independent locks and race.
+    use crate::test_env::ForceTierGuard;
+
+    fn test_request(policy: ContainerPolicy) -> CodexRequest {
+        CodexRequest {
+            container_id: "MxcDispatcherTest".to_string(),
+            policy,
+            ..CodexRequest::default()
+        }
+    }
+
+    fn empty_policy() -> ContainerPolicy {
+        ContainerPolicy::default()
+    }
+    fn policy_with_denied_temp() -> (ContainerPolicy, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut p = ContainerPolicy::default();
+        p.denied_paths
+            .push(dir.path().to_string_lossy().into_owned());
+        (p, dir)
+    }
+    fn policy_with_rw_temp() -> (ContainerPolicy, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut p = ContainerPolicy::default();
+        p.readwrite_paths
+            .push(dir.path().to_string_lossy().into_owned());
+        (p, dir)
+    }
+    #[test]
+    fn dispatch_t1_no_denied_paths_no_dacl() {
+        let _g = ForceTierGuard::set("base-container");
+        let req = test_request(empty_policy());
+        let d = dispatch_with_fallback(&req).expect("T1 dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::BaseContainer));
+        assert!(
+            d.dacl_manager.is_none(),
+            "T1 with no denied_paths should not allocate DaclManager"
+        );
+    }
+    #[test]
+    fn dispatch_t1_with_denied_paths_has_no_dacl() {
+        // T1 delegates filesystem-policy enforcement (including
+        // `deniedPaths`) to BaseContainer's native API; the dispatcher
+        // does not stamp host-DACL deny ACEs on the T1 path, so no
+        // `DaclManager` is attached regardless of the `deniedPaths`
+        // contents. See the module-level doc for the principal-match
+        // reasoning.
+        let _g = ForceTierGuard::set("base-container");
+        let (policy, _tmp) = policy_with_denied_temp();
+        let req = test_request(policy);
+        let d = dispatch_with_fallback(&req).expect("T1+deny dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::BaseContainer));
+        assert!(
+            d.dacl_manager.is_none(),
+            "T1 must not attach a DaclManager — BC handles deny natively"
+        );
+    }
+    #[test]
+    fn dispatch_t2_with_denied_paths_has_dacl() {
+        let _g = ForceTierGuard::set("appcontainer-bfs");
+        let (policy, _tmp) = policy_with_denied_temp();
+        let req = test_request(policy);
+        let d = dispatch_with_fallback(&req).expect("T2+deny dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
+        assert!(d.dacl_manager.is_some());
+    }
+    #[test]
+    fn dispatch_t3_always_has_dacl() {
+        let _g = ForceTierGuard::set("appcontainer-dacl");
+        let (policy, _tmp) = policy_with_rw_temp();
+        let req = test_request(policy);
+        let d = dispatch_with_fallback(&req).expect("T3 dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::AppContainerDacl));
+        assert!(
+            d.dacl_manager.is_some(),
+            "T3 always requires DaclManager (grants applied)"
+        );
+    }
+    #[test]
+    fn dispatch_fallback_disabled_errors() {
+        let _g = ForceTierGuard::set("appcontainer-dacl");
+        let (mut policy, _tmp) = policy_with_rw_temp();
+        policy.fallback.allow_dacl_mutation = false;
+        let req = test_request(policy);
+        let res = dispatch_with_fallback(&req);
+        assert!(matches!(
+            res,
+            Err(DispatchError::Fallback(FallbackError::DaclFallbackDisabled))
+        ));
+    }
+    #[test]
+    fn dispatch_warnings_propagated() {
+        // Forced decisions don't synthesize warnings, so trigger the real
+        // chain with an unrecognized force value: the detector ignores it
+        // and walks the probe chain, accumulating "BaseContainer API not
+        // present" or "bfscfg.exe not present" warnings as appropriate on
+        // the test machine.
+        let _g = ForceTierGuard::set("not-a-real-tier");
+        let req = test_request(empty_policy());
+        // We can't predict the tier on arbitrary CI hardware, so just
+        // assert dispatch returns a Dispatched whose warnings field is
+        // honored from the decision.
+        let d = dispatch_with_fallback(&req).expect("real chain on empty policy");
+        // Warnings vector is present (possibly empty if we got T1 on a
+        // BC-capable machine). Just assert it was forwarded from the
+        // decision — the type guarantees this.
+        let _ = d.warnings.len();
+    }
+
+    #[test]
+    fn dispatch_error_display_messages_non_empty() {
+        let f = DispatchError::Fallback(FallbackError::DaclFallbackDisabled);
+        assert!(!format!("{f}").is_empty());
+
+        let w = DispatchError::Fallback(FallbackError::WriteDacUnavailable {
+            path: PathBuf::from("C:\\foo"),
+            reason: "ACCESS_DENIED".to_string(),
+        });
+        let s = format!("{w}");
+        assert!(s.contains("C:\\foo"));
+        assert!(s.contains("ACCESS_DENIED"));
+
+        let s = DispatchError::Sid(WxcError::Initialization("bad sid".to_string()));
+        assert!(format!("{s}").contains("AppContainer SID"));
+    }
+
+    #[test]
+    fn dispatch_t1_runs_trivial_command_when_bc_present() {
+        // Natural T1 selection (no force). Skip on systems where the
+        // BaseContainer API isn't present.
+        if !crate::fallback_detector::is_base_container_api_present() {
+            eprintln!("skipping: BaseContainer API not present on this machine");
+            return;
+        }
+        // Just exercise dispatcher construction; we don't actually exec
+        // here because spinning up BC requires kernel support and fights
+        // the test runner's stdio capture.
+        let req = test_request(empty_policy());
+        let d = dispatch_with_fallback(&req).expect("dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::BaseContainer));
+    }
+}

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -102,7 +102,7 @@ pub enum FallbackError {
 ///
 /// The algorithm matches the design doc:
 ///
-/// 1. If `MXC_FORCE_TIER` is set in a debug build, honor it (test seam).
+/// 1. If `MXC_FORCE_TIER` is set in a test build, honor it (test seam).
 /// 2. Try Tier 1 (BaseContainer) when `prefer_base_container` is true and the
 ///    API surface is detected.
 /// 3. Otherwise try Tier 2 (AppContainer + BFS) when there's no filesystem
@@ -131,7 +131,18 @@ pub fn detect(
     // Test-only injection seam. An invalid value is silently ignored and we
     // proceed with the real probe chain — that lets tests assert
     // pass-through behavior without any error plumbing.
-    #[cfg(debug_assertions)]
+    //
+    // Gate is `cfg(test)`, not `cfg(debug_assertions)`: production
+    // `wxc-exec.exe` builds (release *and* dev binaries) must not honor
+    // `MXC_FORCE_TIER` from the environment. `cfg(test)` ensures the
+    // seam is compiled in only when the crate is built as a test binary
+    // — which is exactly the case for unit tests under any profile,
+    // including CI's `cargo test --profile release` invocation. The
+    // dispatcher/fallback unit tests in this crate's `mod tests` thus
+    // actually exercise tier selection under release-profile CI runs
+    // (previously the seam was elided by `cfg(debug_assertions)` and
+    // the tests silently no-op'd).
+    #[cfg(test)]
     if let Ok(forced) = std::env::var("MXC_FORCE_TIER") {
         if let Some(tier) = parse_force_tier(&forced) {
             return forced_decision(tier, policy, denied);
@@ -231,7 +242,7 @@ fn check_write_dac_path(path: &Path) -> Result<(), FallbackError> {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(test)]
 fn parse_force_tier(s: &str) -> Option<IsolationTier> {
     match s {
         "base-container" => Some(IsolationTier::BaseContainer),
@@ -241,7 +252,7 @@ fn parse_force_tier(s: &str) -> Option<IsolationTier> {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(test)]
 fn forced_decision(
     tier: IsolationTier,
     policy: &ContainerPolicy,
@@ -288,10 +299,14 @@ pub(crate) fn is_base_container_api_present() -> bool {
 ///   `SystemRoot` environment variable is deliberately ignored to deny
 ///   an attacker who can scrub or rewrite the process environment a
 ///   Tier 2 → Tier 3 downgrade primitive.
-/// - **Debug builds** additionally honor `MXC_BFSCFG_PATH` as a narrow
+/// - **Test builds** additionally honor `MXC_BFSCFG_PATH` as a narrow
 ///   test seam. Its value is used verbatim as the resolved path; an
-///   empty value simulates "not present" by returning `Ok(None)`. The
-///   release build cannot read this variable at all.
+///   empty value simulates "not present" by returning `Ok(None)`.
+///   Production `wxc-exec.exe` (both release and dev binaries) cannot
+///   read this variable at all — the seam is gated by `cfg(test)` so
+///   it compiles in only when building this crate's test binary,
+///   regardless of profile (so CI's `--profile release` test run
+///   exercises these paths).
 /// - We deliberately do not look in `SysWOW64`: `bfscfg.exe` is shipped
 ///   only in the native System32 directory.
 ///
@@ -299,7 +314,7 @@ pub(crate) fn is_base_container_api_present() -> bool {
 /// Win32 API itself fails — on a healthy Windows host this should never
 /// happen.
 pub fn find_bfscfg_exe() -> Result<Option<PathBuf>, FallbackError> {
-    #[cfg(debug_assertions)]
+    #[cfg(test)]
     if let Ok(override_path) = std::env::var("MXC_BFSCFG_PATH") {
         if override_path.is_empty() {
             return Ok(None);
@@ -437,61 +452,21 @@ pub(crate) fn has_write_dac(path: &Path) -> Result<bool, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(debug_assertions)]
     use crate::models::ContainerPolicy;
-    #[cfg(debug_assertions)]
-    use std::sync::Mutex;
+    // Shared ENV_LOCK + guards live in `crate::test_env` so they're
+    // honored uniformly across the dispatcher and fallback_detector
+    // test modules. A per-module lock would let cross-module test
+    // threads race on `MXC_FORCE_TIER` / `MXC_BFSCFG_PATH`.
+    use crate::test_env::{BfscfgPathGuard, ForceTierGuard, ENV_LOCK};
 
-    /// Serializes tests that mutate `MXC_FORCE_TIER` because env vars are
-    /// process-global. We don't have `serial_test` as a dev-dep so we roll
-    /// our own. Gated with the force-tier mechanism itself.
-    #[cfg(debug_assertions)]
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    #[cfg(debug_assertions)]
-    struct ForceTierGuard {
-        // Holding the lock inside the guard ensures the env-var clear in
-        // `Drop` happens *before* the lock is released. The previous
-        // `(Self, MutexGuard)` tuple shape released the lock first (rev.
-        // declaration order), allowing concurrent tests to observe stale
-        // `MXC_FORCE_TIER`.
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-    #[cfg(debug_assertions)]
-    impl ForceTierGuard {
-        fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-            // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
-            unsafe {
-                std::env::set_var("MXC_FORCE_TIER", value);
-            }
-            ForceTierGuard { _lock: lock }
-        }
-    }
-    #[cfg(debug_assertions)]
-    impl Drop for ForceTierGuard {
-        fn drop(&mut self) {
-            // SAFETY: serialized by ENV_LOCK still held in `_lock`; the lock
-            // is released only after this `Drop` returns.
-            unsafe {
-                std::env::remove_var("MXC_FORCE_TIER");
-            }
-        }
-    }
-
-    #[cfg(debug_assertions)]
     fn empty_policy() -> ContainerPolicy {
         ContainerPolicy::default()
     }
-
-    #[cfg(debug_assertions)]
     fn policy_with_denied() -> ContainerPolicy {
         let mut p = ContainerPolicy::default();
         p.denied_paths.push("C:\\Windows".to_string());
         p
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn empty_policy_t1_when_bc_present_and_preferred() {
         let _g = ForceTierGuard::set("base-container");
@@ -501,8 +476,6 @@ mod tests {
         assert!(!d.needs_dacl_augmentation);
         assert!(d.warnings.is_empty());
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn empty_policy_no_filesystem_t2_path() {
         let _g = ForceTierGuard::set("appcontainer-bfs");
@@ -511,8 +484,6 @@ mod tests {
         assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
         assert!(!d.needs_dacl_augmentation);
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn denied_paths_disabled_blocks_t1() {
         let _g = ForceTierGuard::set("base-container");
@@ -523,8 +494,6 @@ mod tests {
             Err(FallbackError::DaclFallbackDisabled)
         ));
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn denied_paths_disabled_blocks_t2() {
         let _g = ForceTierGuard::set("appcontainer-bfs");
@@ -535,8 +504,6 @@ mod tests {
             Err(FallbackError::DaclFallbackDisabled)
         ));
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn denied_paths_disabled_blocks_t3() {
         let _g = ForceTierGuard::set("appcontainer-dacl");
@@ -547,8 +514,6 @@ mod tests {
             Err(FallbackError::DaclFallbackDisabled)
         ));
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn force_tier_env_var_parses_all_three_values() {
         assert!(matches!(
@@ -564,8 +529,6 @@ mod tests {
             Some(IsolationTier::AppContainerDacl)
         ));
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn force_tier_env_var_invalid_value_falls_through_to_real_probes() {
         // An unrecognized value must NOT raise an error. The detector should
@@ -583,9 +546,7 @@ mod tests {
     fn find_bfscfg_exe_smoke() {
         // Tests run in parallel by default and other tests below mutate
         // `MXC_BFSCFG_PATH`. We must therefore observe the unset state
-        // under `ENV_LOCK` so we don't race them. In release builds the
-        // override is ignored entirely, so the lock is debug-only.
-        #[cfg(debug_assertions)]
+        // under `ENV_LOCK` so we don't race them.
         let _lock = {
             let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
             // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
@@ -620,35 +581,6 @@ mod tests {
         );
     }
 
-    /// Guard for `MXC_BFSCFG_PATH` mirroring `ForceTierGuard`. Holds
-    /// `ENV_LOCK` for the duration of the test so concurrent threads
-    /// don't observe stale values.
-    #[cfg(debug_assertions)]
-    struct BfscfgPathGuard {
-        _lock: std::sync::MutexGuard<'static, ()>,
-    }
-    #[cfg(debug_assertions)]
-    impl BfscfgPathGuard {
-        fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-            // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
-            unsafe {
-                std::env::set_var("MXC_BFSCFG_PATH", value);
-            }
-            BfscfgPathGuard { _lock: lock }
-        }
-    }
-    #[cfg(debug_assertions)]
-    impl Drop for BfscfgPathGuard {
-        fn drop(&mut self) {
-            // SAFETY: serialized by ENV_LOCK still held in `_lock`.
-            unsafe {
-                std::env::remove_var("MXC_BFSCFG_PATH");
-            }
-        }
-    }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn mxc_bfscfg_path_empty_value_simulates_missing() {
         let _g = BfscfgPathGuard::set("");
@@ -658,8 +590,6 @@ mod tests {
             "empty MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn mxc_bfscfg_path_nonexistent_path_is_none() {
         let _g = BfscfgPathGuard::set("C:\\__mxc_does_not_exist__\\bfscfg.exe");
@@ -669,8 +599,6 @@ mod tests {
             "non-existent MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn mxc_bfscfg_path_existing_path_is_returned_verbatim() {
         // Use a file we know exists (this source file itself, via the
@@ -711,8 +639,6 @@ mod tests {
             "expected error for non-existent path, got {res:?}"
         );
     }
-
-    #[cfg(debug_assertions)]
     #[test]
     fn compute_decision_with_force_tier_carries_warnings_empty() {
         let _g = ForceTierGuard::set("appcontainer-dacl");

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -1747,57 +1747,12 @@ mod tests {
     // `cargo test --workspace` suite — and to avoid interference with
     // a concurrent real `wxc-exec` on the same host — each test scopes
     // `MXC_DACL_STATE_DIR` to a fresh tempdir for its lifetime via
-    // [`ScopedStateDir`], serialized within a process by a static
-    // mutex around the env-var mutation.
-
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    /// Process-global mutex serializing all tests that depend on the
-    /// `MXC_DACL_STATE_DIR` override. `std::env::set_var` is not
-    /// thread-safe in the presence of concurrent C `getenv` callers,
-    /// so we hold this for the entire duration of any test that
-    /// touches the override.
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-    }
-
-    /// RAII helper that points `MXC_DACL_STATE_DIR` at a freshly
-    /// created tempdir for the duration of a test, then restores the
-    /// previous value on drop. Holds [`env_lock`] for its lifetime,
-    /// which serializes integration tests within the process while
-    /// still allowing parallel `cargo test` invocations in distinct
-    /// processes to each use their own tempdir.
-    struct ScopedStateDir {
-        _lock: MutexGuard<'static, ()>,
-        _td: tempfile::TempDir,
-        prev: Option<std::ffi::OsString>,
-    }
-
-    impl ScopedStateDir {
-        fn new() -> Self {
-            let lock = env_lock();
-            let td = tempfile::tempdir().expect("create tempdir");
-            let prev = std::env::var_os("MXC_DACL_STATE_DIR");
-            std::env::set_var("MXC_DACL_STATE_DIR", td.path());
-            Self {
-                _lock: lock,
-                _td: td,
-                prev,
-            }
-        }
-    }
-
-    impl Drop for ScopedStateDir {
-        fn drop(&mut self) {
-            match &self.prev {
-                Some(v) => std::env::set_var("MXC_DACL_STATE_DIR", v),
-                None => std::env::remove_var("MXC_DACL_STATE_DIR"),
-            }
-        }
-    }
+    // [`crate::test_env::ScopedStateDir`]. That helper acquires the
+    // shared crate-wide `ENV_LOCK`, which also serializes against
+    // `dispatcher::tests` and `fallback_detector::tests` so concurrent
+    // tests don't race on `MXC_DACL_STATE_DIR` / `MXC_FORCE_TIER` /
+    // `MXC_BFSCFG_PATH`.
+    use crate::test_env::ScopedStateDir;
 
     #[test]
     fn state_dir_honors_env_override() {

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -27,6 +27,8 @@ pub mod validator;
 #[cfg(target_os = "windows")]
 pub mod appcontainer_runner;
 #[cfg(target_os = "windows")]
+pub mod dispatcher;
+#[cfg(target_os = "windows")]
 pub mod fallback_detector;
 #[cfg(target_os = "windows")]
 pub mod filesystem_bfs;
@@ -66,3 +68,11 @@ pub mod sandbox_tracking;
 // Isolation Session (IsoEnvBroker Session API) support
 #[cfg(all(target_os = "windows", feature = "isolation_session"))]
 pub mod isolation_session;
+
+/// Test-only helpers shared across unit-test modules.
+///
+/// Gated by `#[cfg(test)]` so this module compiles in only when
+/// building the crate's own test binary (under any profile, including
+/// CI's `--profile release`). Production binaries never link this.
+#[cfg(test)]
+pub(crate) mod test_env;

--- a/src/wxc_common/src/test_env.rs
+++ b/src/wxc_common/src/test_env.rs
@@ -1,0 +1,138 @@
+//! Shared test-only helpers for env-var serialization across modules.
+//!
+//! The dispatcher tier-selection tests and the fallback-detector probe
+//! tests both mutate `MXC_FORCE_TIER` and `MXC_BFSCFG_PATH` (which are
+//! process-global). Each module previously owned its own private
+//! `ENV_LOCK`, but that meant a `fallback_detector::tests` thread and a
+//! `dispatcher::tests` thread could mutate the same env var
+//! concurrently — observable as a race once both test families started
+//! running under the same profile (cfg(test), any profile).
+//!
+//! This module exposes a single shared `ENV_LOCK` that all test
+//! modules in this crate take before touching the relevant env vars.
+//! Hold the guard for the entire duration of the env-var-dependent
+//! work so the value remains stable across the call. The provided
+//! `ForceTierGuard` and `BfscfgPathGuard` types encapsulate the
+//! set / clear discipline.
+//!
+//! Compiled in only under `#[cfg(test)]`.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Process-wide serialization for tests that mutate test-seam env
+/// vars. Tests in any module in this crate should acquire this lock
+/// (typically via [`ForceTierGuard`] / [`BfscfgPathGuard`]) before
+/// reading or writing `MXC_FORCE_TIER` or `MXC_BFSCFG_PATH`.
+pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock() -> MutexGuard<'static, ()> {
+    // Poison is irrelevant here: the env var is restored on Drop
+    // regardless of whether a previous holder panicked, and the lock's
+    // only purpose is to serialize accesses.
+    ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// RAII guard that sets `MXC_FORCE_TIER` to `value` for the lifetime
+/// of the guard and restores it on `Drop`. Acquires [`ENV_LOCK`]
+/// internally so concurrent guards serialize.
+///
+/// Holding the lock *inside* the struct ensures the env-var clear in
+/// `Drop` happens before the lock is released — preventing a follow-up
+/// thread from observing the stale value.
+pub(crate) struct ForceTierGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl ForceTierGuard {
+    pub(crate) fn set(value: &str) -> Self {
+        let guard = lock();
+        // SAFETY: env-var mutation is gated by ENV_LOCK; no other
+        // ForceTierGuard / BfscfgPathGuard can be active concurrently.
+        unsafe {
+            std::env::set_var("MXC_FORCE_TIER", value);
+        }
+        ForceTierGuard { _lock: guard }
+    }
+}
+
+impl Drop for ForceTierGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialized by ENV_LOCK still held in `_lock`; the
+        // lock is released only after this `Drop` returns.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_TIER");
+        }
+    }
+}
+
+/// RAII guard for `MXC_BFSCFG_PATH`, mirroring [`ForceTierGuard`].
+pub(crate) struct BfscfgPathGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl BfscfgPathGuard {
+    pub(crate) fn set(value: &str) -> Self {
+        let guard = lock();
+        // SAFETY: see ForceTierGuard::set.
+        unsafe {
+            std::env::set_var("MXC_BFSCFG_PATH", value);
+        }
+        BfscfgPathGuard { _lock: guard }
+    }
+}
+
+impl Drop for BfscfgPathGuard {
+    fn drop(&mut self) {
+        // SAFETY: see ForceTierGuard::drop.
+        unsafe {
+            std::env::remove_var("MXC_BFSCFG_PATH");
+        }
+    }
+}
+
+/// RAII helper that points `MXC_DACL_STATE_DIR` at a freshly created
+/// tempdir for the duration of a test, then restores the previous
+/// value on drop. Holds [`ENV_LOCK`] for its lifetime via [`lock`],
+/// which serializes all env-var-touching tests within the process.
+///
+/// Lives here (rather than in `filesystem_dacl::tests`) so it shares
+/// `ENV_LOCK` with [`ForceTierGuard`] / [`BfscfgPathGuard`]. Without
+/// the shared lock, a `filesystem_dacl` test could delete its tempdir
+/// while a concurrent `dispatcher` test was mid-write to the same
+/// path (the dispatcher test reads `MXC_DACL_STATE_DIR` through
+/// `state_dir()` inside `DaclManager::new()` and would race the
+/// `Drop` on the other test's `ScopedStateDir`).
+pub(crate) struct ScopedStateDir {
+    _lock: MutexGuard<'static, ()>,
+    _td: tempfile::TempDir,
+    prev: Option<std::ffi::OsString>,
+}
+
+impl ScopedStateDir {
+    pub(crate) fn new() -> Self {
+        let guard = lock();
+        let td = tempfile::tempdir().expect("create tempdir");
+        let prev = std::env::var_os("MXC_DACL_STATE_DIR");
+        // SAFETY: serialized by ENV_LOCK; see ForceTierGuard::set.
+        unsafe {
+            std::env::set_var("MXC_DACL_STATE_DIR", td.path());
+        }
+        Self {
+            _lock: guard,
+            _td: td,
+            prev,
+        }
+    }
+}
+
+impl Drop for ScopedStateDir {
+    fn drop(&mut self) {
+        // SAFETY: serialized by ENV_LOCK still held in `_lock`.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var("MXC_DACL_STATE_DIR", v),
+                None => std::env::remove_var("MXC_DACL_STATE_DIR"),
+            }
+        }
+    }
+}


### PR DESCRIPTION
Phase 4: ProcessContainer dispatcher with downlevel fallback

This PR adds a tier dispatcher for `containment: "ProcessContainer"` so
configs on hosts without the BaseContainer OS API no longer fail hard
— the dispatcher detects host capability and policy, then selects
BaseContainer (T1), AppContainer + bypass-traverse (T2), or
AppContainer + DACL augmentation (T3). The dispatcher is only engaged
when `--experimental` is passed or the schema version is ≥ 0.5;
schema 0.4 and all other `ContainmentBackend` variants are unchanged.

Details

* New `wxc_common::dispatcher` module wires Phases 0–3 together:
  consults `fallback_detector::detect()`, constructs the appropriate
  runner, and for T3 applies host-filesystem ACEs via `DaclManager`.
* `AppContainerScriptRunner` gains `FilesystemMode { Bfs, Dacl }`;
  `::new()` defaults to `Bfs`, so existing callers are unchanged.
* `wxc/src/main.rs` routes `ProcessContainer` through
  `dispatch_with_fallback` when fallback is in effect; declares the
  `DaclManager` guard before the runner binding so Drop tears down
  ACEs after the child completes, not mid-run.
* Validation warning when `filesystem.deniedPaths` is set but
  `ProcessContainer` is requested without fallback in effect, so the
  user knows the field will be ignored.

Tests

* `cargo fmt --check`, `cargo clippy --workspace --all-targets
  --all-features --profile release --locked -- -D warnings`, and
  `cargo test -p wxc_common --lib --all-features --profile release
  --locked` all clean on the pinned 1.93 toolchain. 534/534 lib tests
  pass, including dispatcher unit tests covering tier selection
  across BaseContainer present/absent, `deniedPaths` empty/set, and
  the `fallback.allowDaclMutation` policy gate.
* End-to-end coverage (the 8-cell T3 access matrix over rw / ro /
  denied / control paths) lives in `Win25H2Safe-Tests.ps1` on the
  held Phase 5 branch and will land with that PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
