### PR TITLE
build.sh: run cargo fmt --check and cargo clippy after build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,12 @@ else
     cargo build -p lxc $CARGO_FEATURES
 fi
 
+echo "  Check formatting"
+cargo fmt --all -- --check
+
+echo "  Check linting"
+cargo clippy --workspace --all-targets -- -D warnings
+
 echo "Rust build complete."
 
 # Copy binaries to SDK bin directory


### PR DESCRIPTION
## 📖 Description

Brings `build.sh` (Linux) to parity with `build.bat` (Windows), which already runs `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` after the Rust build (build.bat:62-64).

CI runs the same two commands as a gate on every PR. Running them locally before pushing avoids a 3-minute round-trip when something trivial (formatting, an easy lint) trips the gate.

**Cost in the developer loop:** negligible after the first build. On a typical Windows-on-ARM workstation:

| Scenario | Time |
|---|---|
| Cold (after `cargo clean`) | ~38s |
| Warm (no changes) | ~1s |
| Incremental (1 file touched) | ~2s |

The cold cost is paid once; subsequent runs share clippy's incremental compilation cache with `cargo build`.

## 🔗 References

Motivated by hitting `clippy::field_reassign_with_default` in CI on #291 after only running `cargo build` / `cargo test` locally — `build.bat` would have caught it before pushing, `build.sh` would not have.

## 🔍 Validation

- Eyeballed: pattern mirrors `build.bat` lines 62-64.
- `build.sh` keeps `set -euo pipefail`, so non-zero exit from either command halts the script before the SDK build step.
- No flag changes; existing `--debug`, `--rust-only`, `--with-hyperlight` behavior is preserved (both lint commands always run regardless).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/299)