### PR TITLE
Propagate Hyperlight guest exit code and add e2e test

### DIFF
--- a/.github/workflows/hyperlight-e2e.yml
+++ b/.github/workflows/hyperlight-e2e.yml
@@ -67,10 +67,10 @@ jobs:
           $pyhlHome = Join-Path $env:LOCALAPPDATA "pyhl"
           New-Item -ItemType Directory -Force -Path $pyhlHome | Out-Null
 
-          .\crane.exe export ghcr.io/danbugs/hyperlight-unikraft/python-agent-driver-kernel:latest kernel.tar
+          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-kernel:latest kernel.tar
           tar -xf kernel.tar -C $pyhlHome kernel
 
-          .\crane.exe export ghcr.io/danbugs/hyperlight-unikraft/python-agent-driver-initrd:latest initrd.tar
+          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-initrd:latest initrd.tar
           tar -xf initrd.tar -C $pyhlHome initrd.cpio
 
           Write-Host "Downloaded to ${pyhlHome}:"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -844,7 +844,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-unikraft-host"
 version = "0.1.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#d23fdeeb847df4996d716d6d4bcaff22c09e1dbe"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#8affbccb1f7a2f9aa0c8e0aea08c82f76b45bbe5"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -844,15 +844,17 @@ dependencies = [
 [[package]]
 name = "hyperlight-unikraft-host"
 version = "0.1.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#a72768132b699176ac348f5d2d1765f3ed62a061"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#d23fdeeb847df4996d716d6d4bcaff22c09e1dbe"
 dependencies = [
  "anyhow",
  "base64",
  "clap",
  "hyperlight-host",
+ "libc",
  "memmap2",
  "nix",
  "serde_json",
+ "windows-sys",
 ]
 
 [[package]]

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -63,8 +63,10 @@
 //!
 //! ## Exit codes
 //!
-//! 0 on clean `run_code` completion, -1 on any error (preflight, install,
-//! runtime, guest crash). The specific failure mode is in `error_message`.
+//! Guest exit code on clean `run_code` completion (0 for normal exit,
+//! non-zero for `sys.exit(N)` or unhandled exceptions), -1 on any
+//! runner error (preflight, install, runtime, guest crash). The specific
+//! failure mode is in `error_message`.
 
 use std::path::{Path, PathBuf};
 
@@ -474,11 +476,11 @@ impl ScriptRunner for HyperlightScriptRunner {
         match rt.run_code(&request.script_code) {
             Ok(timing) => {
                 logger.log_line(&format!(
-                    "hyperlight: run ok (restore={:.1}ms call={:.1}ms)",
-                    timing.restore_ms, timing.call_ms
+                    "hyperlight: run ok (restore={:.1}ms call={:.1}ms exit={})",
+                    timing.restore_ms, timing.call_ms, timing.exit_code
                 ));
                 ScriptResponse {
-                    exit_code: 0,
+                    exit_code: timing.exit_code,
                     ..Default::default()
                 }
             }

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -596,6 +596,12 @@ fn hyperlight_suite() {
             expected_exit: 0,
             output_contains: Some("'x':"),
         },
+        HyperlightCase {
+            config: "hyperlight_exit_code.json",
+            description: "sys.exit(42) propagates exit code",
+            expected_exit: 42,
+            output_contains: None,
+        },
     ];
 
     let mut failures = Vec::new();

--- a/test_configs/hyperlight_exit_code.json
+++ b/test_configs/hyperlight_exit_code.json
@@ -1,0 +1,7 @@
+{
+    "process": {
+        "commandLine": "import sys; sys.exit(42)",
+        "timeout": 30000
+    },
+    "containment": "hyperlight"
+}


### PR DESCRIPTION
## Summary

- Update `hyperlight-unikraft` dep to pick up exit code propagation (PR hyperlight-dev/hyperlight-unikraft#20) and library-level surrogates fix (PR hyperlight-dev/hyperlight-unikraft#22)
- Use `timing.exit_code` from `RunTiming` instead of hardcoding 0 on successful runs — `sys.exit(N)` and unhandled exceptions now surface the correct exit code to callers
- Add `hyperlight_exit_code.json` test config and e2e test case validating `sys.exit(42)` returns 42
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/306)