### PR TITLE
Update pipeline to produce zip with binaries + pdbs for addition to GitHub Releases page

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -92,17 +92,9 @@ extends:
       jobs:
       - template: .azure-pipelines/templates/Package.NpmSdk.Job.yml@self
         parameters:
-          targets:
-            - artifact: wxc-binaries-x86_64-pc-windows-msvc
-              sdkArch: x64
-            - artifact: wxc-binaries-aarch64-pc-windows-msvc
-              sdkArch: arm64
-            - artifact: lxc-binaries-x86_64-unknown-linux-gnu
-              sdkArch: x64
-            - artifact: lxc-binaries-aarch64-unknown-linux-gnu
-              sdkArch: arm64
-
           ESRPInfo: ${{ parameters.ESRPInfo }}
+
+      - template: .azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml@self
 
     - stage: SDK_Unit_Tests
       displayName: 'SDK Unit Tests'

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -86,8 +86,8 @@ extends:
 
             ESRPInfo: ${{ parameters.ESRPInfo }}
 
-    - stage: Package_MXC_NPM_SDK
-      displayName: 'Package Npm Sdk'
+    - stage: Package_MXC
+      displayName: 'Package MXC'
       dependsOn: Build_Binaries
       jobs:
       - template: .azure-pipelines/templates/Package.NpmSdk.Job.yml@self
@@ -106,7 +106,7 @@ extends:
 
     - stage: SDK_Integration_Tests
       displayName: 'SDK Integration Tests'
-      dependsOn: Package_MXC_NPM_SDK
+      dependsOn: Package_MXC
       jobs:
       - template: .azure-pipelines/templates/SDK.Integration.Test.Job.yml@self
         parameters:

--- a/.azure-pipelines/templates/Mac.Build.Job.yml
+++ b/.azure-pipelines/templates/Mac.Build.Job.yml
@@ -89,6 +89,15 @@ jobs:
         contents: mxc-exec-mac
         targetFolder: $(outputDirectory)/$(targetTriple)
 
+    # Copy the .dSYM bundle into a sibling `symbols/` subdir, mirroring the
+    # Windows/Linux pattern (see Rust.Build.Job.yml for the BinSkim rationale).
+    - task: CopyFiles@2
+      displayName: Copy dSYM bundle
+      inputs:
+        sourceFolder: $(targetTripleDir)
+        contents: 'mxc-exec-mac.dSYM/**'
+        targetFolder: $(outputDirectory)/$(targetTriple)/symbols
+
     - task: 1ES.PublishPipelineArtifact@1
       displayName: Publish
       inputs:

--- a/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
+++ b/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Bundles the per-arch build artifacts into a single mxc-release-binaries.zip
+# (x64/ + arm64/ folders containing executables and symbol files) for upload
+# to the GitHub Release page, until we publish to a symbol server. Runs in
+# parallel with the npm SDK packaging job.
+
+parameters:
+- name: targets
+  type: object
+  default:
+    - artifact: wxc-binaries-x86_64-pc-windows-msvc
+      sdkArch: x64
+    - artifact: wxc-binaries-aarch64-pc-windows-msvc
+      sdkArch: arm64
+    - artifact: lxc-binaries-x86_64-unknown-linux-gnu
+      sdkArch: x64
+    - artifact: lxc-binaries-aarch64-unknown-linux-gnu
+      sdkArch: arm64
+
+jobs:
+- job: package_mxc_release_binaries
+  displayName: Package Mxc Release Binaries
+  pool:
+    name: Azure-Pipelines-1ESPT-ExDShared
+    image: ubuntu-latest
+    os: linux
+  variables:
+    stagingDirectory: $(Build.SourcesDirectory)/release-binaries-staging
+    outputDirectory: $(Build.SourcesDirectory)/out
+    artifactName: mxc-release-binaries
+
+  steps:
+    - checkout: none
+
+    # Download all per-arch artifacts into a flat <arch>/ layout matching the
+    # one that ships in the npm package.
+    - ${{ each target in parameters.targets }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: Download ${{ target.artifact }}
+        inputs:
+          artifact: ${{ target.artifact }}
+          path: $(stagingDirectory)/${{ target.sdkArch }}
+
+    - task: ArchiveFiles@2
+      displayName: Archive mxc-release-binaries.zip
+      inputs:
+        rootFolderOrFile: '$(stagingDirectory)'
+        includeRootFolder: false
+        archiveType: zip
+        archiveFile: '$(outputDirectory)/release-binaries/mxc-release-binaries.zip'
+        replaceExistingArchive: true
+
+    - task: 1ES.PublishPipelineArtifact@1
+      displayName: Publish mxc-release-binaries artifact
+      inputs:
+        path: '$(outputDirectory)/release-binaries'
+        artifactName: $(artifactName)

--- a/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
+++ b/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
@@ -45,17 +45,6 @@ jobs:
           artifact: ${{ target.artifact }}
           path: $(stagingDirectory)/${{ target.sdkArch }}
 
-    # Flatten symbols/ subdirs back into each arch root.
-    - pwsh: |
-        Get-ChildItem -Path "$(stagingDirectory)" -Directory | ForEach-Object {
-          $symbols = Join-Path $_.FullName 'symbols'
-          if (Test-Path $symbols) {
-            Get-ChildItem -Path $symbols -File | Move-Item -Destination $_.FullName -Force -Verbose
-            Remove-Item -Path $symbols -Force
-          }
-        }
-      displayName: Flatten symbols/ into arch dirs
-
     - task: ArchiveFiles@2
       displayName: Archive mxc-release-binaries.zip
       inputs:

--- a/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
+++ b/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
@@ -43,6 +43,17 @@ jobs:
           artifact: ${{ target.artifact }}
           path: $(stagingDirectory)/${{ target.sdkArch }}
 
+    # Flatten symbols/ subdirs back into each arch root.
+    - pwsh: |
+        Get-ChildItem -Path "$(stagingDirectory)" -Directory | ForEach-Object {
+          $symbols = Join-Path $_.FullName 'symbols'
+          if (Test-Path $symbols) {
+            Get-ChildItem -Path $symbols -File | Move-Item -Destination $_.FullName -Force -Verbose
+            Remove-Item -Path $symbols -Force
+          }
+        }
+      displayName: Flatten symbols/ into arch dirs
+
     - task: ArchiveFiles@2
       displayName: Archive mxc-release-binaries.zip
       inputs:

--- a/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
+++ b/.azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml
@@ -18,6 +18,8 @@ parameters:
       sdkArch: x64
     - artifact: lxc-binaries-aarch64-unknown-linux-gnu
       sdkArch: arm64
+    - artifact: mxc-binaries-aarch64-apple-darwin
+      sdkArch: arm64
 
 jobs:
 - job: package_mxc_release_binaries

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -42,8 +42,8 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
-    # Archive sdk/bin (x64/ + arm64/, executables + pdbs) for upload to the
-    # GitHub Release page, until we publish to a symbol server.
+    # Archive sdk/bin (x64/ + arm64/, executables + symbol files) for upload
+    # to the GitHub Release page, until we publish to a symbol server.
     - task: ArchiveFiles@2
       displayName: Archive mxc-release-binaries.zip
       inputs:
@@ -59,9 +59,9 @@ jobs:
         path: '$(outputDirectory)/release-binaries'
         artifactName: mxc-release-binaries
 
-    # Strip pdbs before npm pack — symbols ship via mxc-release-binaries.zip.
-    - script: rm -f $(sdkDirectory)/bin/*/*.pdb
-      displayName: Strip pdbs from npm package
+    # Strip symbol files before npm pack — symbols ship via mxc-release-binaries.zip.
+    - script: rm -f $(sdkDirectory)/bin/*/*.pdb $(sdkDirectory)/bin/*/*.dwp
+      displayName: Strip symbol files from npm package
 
     # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
     - task: CopyFiles@2

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -4,7 +4,15 @@
 parameters:
 - name: Targets
   type: object
-  default: []   # list of { artifact, path, sdkArch }
+  default:
+    - artifact: wxc-binaries-x86_64-pc-windows-msvc
+      sdkArch: x64
+    - artifact: wxc-binaries-aarch64-pc-windows-msvc
+      sdkArch: arm64
+    - artifact: lxc-binaries-x86_64-unknown-linux-gnu
+      sdkArch: x64
+    - artifact: lxc-binaries-aarch64-unknown-linux-gnu
+      sdkArch: arm64
 - name: ESRPInfo
   type: object
   default: {}
@@ -42,24 +50,8 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
-    # Archive sdk/bin (x64/ + arm64/, executables + symbol files) for upload
-    # to the GitHub Release page, until we publish to a symbol server.
-    - task: ArchiveFiles@2
-      displayName: Archive mxc-release-binaries.zip
-      inputs:
-        rootFolderOrFile: '$(sdkDirectory)/bin'
-        includeRootFolder: false
-        archiveType: zip
-        archiveFile: '$(outputDirectory)/release-binaries/mxc-release-binaries.zip'
-        replaceExistingArchive: true
-
-    - task: 1ES.PublishPipelineArtifact@1
-      displayName: Publish mxc-release-binaries artifact
-      inputs:
-        path: '$(outputDirectory)/release-binaries'
-        artifactName: mxc-release-binaries
-
-    # Strip symbol files before npm pack — symbols ship via mxc-release-binaries.zip.
+    # Strip symbol files before npm pack — they ship via the separate
+    # mxc-release-binaries artifact (see Mxc.Binary.Packaging.Job.yml).
     - script: rm -f $(sdkDirectory)/bin/*/*.pdb $(sdkDirectory)/bin/*/*.dwp
       displayName: Strip symbol files from npm package
 

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -50,10 +50,9 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
-    # Strip symbol files before npm pack — they ship via the separate
-    # mxc-release-binaries artifact (see Mxc.Binary.Packaging.Job.yml).
-    - script: rm -f $(sdkDirectory)/bin/*/*.pdb $(sdkDirectory)/bin/*/*.dwp
-      displayName: Strip symbol files from npm package
+    # Drop symbol files from the npm package — symbols ship separately.
+    - script: rm -rf $(sdkDirectory)/bin/*/symbols
+      displayName: Strip symbols/ from npm package
 
     - script: |
         set -euo pipefail

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -42,6 +42,27 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
+    # Archive sdk/bin (x64/ + arm64/, executables + wxc_exec.pdb) for upload
+    # to the GitHub Release page, until we publish to a symbol server.
+    - task: ArchiveFiles@2
+      displayName: Archive mxc-release-binaries.zip
+      inputs:
+        rootFolderOrFile: '$(sdkDirectory)/bin'
+        includeRootFolder: false
+        archiveType: zip
+        archiveFile: '$(outputDirectory)/release-binaries/mxc-release-binaries.zip'
+        replaceExistingArchive: true
+
+    - task: 1ES.PublishPipelineArtifact@1
+      displayName: Publish mxc-release-binaries artifact
+      inputs:
+        path: '$(outputDirectory)/release-binaries'
+        artifactName: mxc-release-binaries
+
+    # Strip pdbs before npm pack — symbols ship via mxc-release-binaries.zip.
+    - script: rm -f $(sdkDirectory)/bin/*/*.pdb
+      displayName: Strip pdbs from npm package
+
     # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
     - task: CopyFiles@2
       displayName: Copy .npmrc to SDK

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -18,8 +18,8 @@ parameters:
   default: {}
 
 jobs:
-- job: package_mxc_npm_sdk
-  displayName: Package Mxc Npm Sdk
+- job: package_npm_sdk
+  displayName: Package Npm Sdk
   pool:
     name: Azure-Pipelines-1ESPT-ExDShared
     image: ubuntu-latest

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -42,8 +42,8 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
-    # Archive sdk/bin (x64/ + arm64/, executables + wxc_exec.pdb) for upload
-    # to the GitHub Release page, until we publish to a symbol server.
+    # Archive sdk/bin (x64/ + arm64/, executables + pdbs) for upload to the
+    # GitHub Release page, until we publish to a symbol server.
     - task: ArchiveFiles@2
       displayName: Archive mxc-release-binaries.zip
       inputs:

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 parameters:
-- name: Targets
+- name: targets
   type: object
   default:
     - artifact: wxc-binaries-x86_64-pc-windows-msvc

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -50,17 +50,15 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
-<<<<<<< HEAD
     # Strip symbol files before npm pack — they ship via the separate
     # mxc-release-binaries artifact (see Mxc.Binary.Packaging.Job.yml).
     - script: rm -f $(sdkDirectory)/bin/*/*.pdb $(sdkDirectory)/bin/*/*.dwp
       displayName: Strip symbol files from npm package
-=======
+
     - script: |
         set -euo pipefail
         find $(sdkDirectory)/bin -name mxc-exec-mac -exec chmod +x {} +
       displayName: Restore execute permission on mxc-exec-mac
->>>>>>> main
 
     # Copy .npmrc to the SDK directory so Azure artifacts feed is used for npm install.
     - task: CopyFiles@2

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -175,8 +175,12 @@ jobs:
           contents: wslcsdk.dll
           targetFolder: $(outputDirectory)/$(targetTriple)
 
-      # Copy all symbol files alongside the binaries: .pdb on Windows (MSVC),
-      # .dwp on Linux (DWARF package from split-debuginfo = "packed").
+      # Copy symbol files into a sibling `symbols/` subdir, NOT alongside the
+      # binaries. Workaround for BinSkim BA2007: when the pdb is co-located,
+      # BinSkim reads its S_COMPILE3 records and flags `-wd4146` in the
+      # statically-linked MS CRT obj files (libucrt.lib internals). We still
+      # want +crt-static so consumers don't need a vcruntime DLL — separating
+      # the pdb hides those records from BinSkim without changing the binary.
       - task: CopyFiles@2
         displayName: Copy symbol files
         inputs:
@@ -184,7 +188,7 @@ jobs:
           contents: |
             *.pdb
             *.dwp
-          targetFolder: $(outputDirectory)/$(targetTriple)
+          targetFolder: $(outputDirectory)/$(targetTriple)/symbols
 
       - task: 1ES.PublishPipelineArtifact@1
         displayName: Publish

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -175,6 +175,15 @@ jobs:
           contents: wslcsdk.dll
           targetFolder: $(outputDirectory)/$(targetTriple)
 
+      # Copy wxc-exec.pdb so consumers can symbolicate crashes (Windows only).
+      - task: CopyFiles@2
+        displayName: Copy wxc-exec.pdb
+        condition: and(succeeded(), eq('${{ item.os }}', 'windows'))
+        inputs:
+          sourceFolder: $(targetTripleDir)
+          contents: wxc-exec.pdb
+          targetFolder: $(outputDirectory)/$(targetTriple)
+
       - task: 1ES.PublishPipelineArtifact@1
         displayName: Publish
         inputs:

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -175,12 +175,16 @@ jobs:
           contents: wslcsdk.dll
           targetFolder: $(outputDirectory)/$(targetTriple)
 
-      # Copy wxc_exec.pdb (rustc names pdbs after the crate, underscored) and
-      # rename it to wxc-exec.pdb to match the exe.
-      - powershell: |
-          Copy-Item -Force "$(targetTripleDir)/wxc_exec.pdb" "$(outputDirectory)/$(targetTriple)/wxc-exec.pdb"
-        displayName: Copy wxc-exec.pdb
-        condition: and(succeeded(), eq('${{ item.os }}', 'windows'))
+      # Copy all symbol files alongside the binaries: .pdb on Windows (MSVC),
+      # .dwp on Linux (DWARF package from split-debuginfo = "packed").
+      - task: CopyFiles@2
+        displayName: Copy symbol files
+        inputs:
+          sourceFolder: $(targetTripleDir)
+          contents: |
+            *.pdb
+            *.dwp
+          targetFolder: $(outputDirectory)/$(targetTriple)
 
       - task: 1ES.PublishPipelineArtifact@1
         displayName: Publish

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -175,14 +175,12 @@ jobs:
           contents: wslcsdk.dll
           targetFolder: $(outputDirectory)/$(targetTriple)
 
-      # Copy wxc-exec.pdb so consumers can symbolicate crashes (Windows only).
-      - task: CopyFiles@2
+      # Copy wxc_exec.pdb (rustc names pdbs after the crate, underscored) and
+      # rename it to wxc-exec.pdb to match the exe.
+      - powershell: |
+          Copy-Item -Force "$(targetTripleDir)/wxc_exec.pdb" "$(outputDirectory)/$(targetTriple)/wxc-exec.pdb"
         displayName: Copy wxc-exec.pdb
         condition: and(succeeded(), eq('${{ item.os }}', 'windows'))
-        inputs:
-          sourceFolder: $(targetTripleDir)
-          contents: wxc-exec.pdb
-          targetFolder: $(outputDirectory)/$(targetTriple)
 
       - task: 1ES.PublishPipelineArtifact@1
         displayName: Publish

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,19 @@
 
-# Use static CRT for Windows targets so vcruntime DLLs don't need to be
-# pre-installed on the machine.
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
+# Hardening flags for Windows targets:
+# - target-feature=+crt-static — static CRT so vcruntime DLLs aren't needed at runtime
+# - control-flow-guard (rustc) + /guard:cf (linker) — Control Flow Guard
+# - /DYNAMICBASE — ASLR
+# - /CETCOMPAT — Intel CET shadow stack opt-in
+# - /LTCG — link-time codegen (pairs best with profile-level lto = "thin"|"fat")
+# - -D warnings — make warnings fatal at compile time
+[target.'cfg(target_os = "windows")']
+rustflags = [
+  "-C",
+  "control-flow-guard",
+  "-C",
+  "target-feature=+crt-static",
+  "-C",
+  "link-args=/guard:cf /DYNAMICBASE /CETCOMPAT /LTCG",
+  "-D",
+  "warnings",
+]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,16 @@
 
-# Hardening flags for Windows targets:
-# - target-feature=+crt-static — static CRT so vcruntime DLLs aren't needed at runtime
+# Hardening flags for Windows targets. Most flags apply to both arches;
+# /CETCOMPAT is x86/x64 only (Intel Control-flow Enforcement Technology;
+# ARM64 uses Pointer Authentication / BTI instead).
+#
+# Shared flags:
 # - control-flow-guard (rustc) + /guard:cf (linker) — Control Flow Guard
+# - target-feature=+crt-static — static CRT so vcruntime DLLs aren't needed at runtime
 # - /DYNAMICBASE — ASLR
-# - /CETCOMPAT — Intel CET shadow stack opt-in
 # - /LTCG — link-time codegen (pairs best with profile-level lto = "thin"|"fat")
 # - -D warnings — make warnings fatal at compile time
-[target.'cfg(target_os = "windows")']
+
+[target.x86_64-pc-windows-msvc]
 rustflags = [
   "-C",
   "control-flow-guard",
@@ -14,6 +18,18 @@ rustflags = [
   "target-feature=+crt-static",
   "-C",
   "link-args=/guard:cf /DYNAMICBASE /CETCOMPAT /LTCG",
+  "-D",
+  "warnings",
+]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = [
+  "-C",
+  "control-flow-guard",
+  "-C",
+  "target-feature=+crt-static",
+  "-C",
+  "link-args=/guard:cf /DYNAMICBASE /LTCG",
   "-D",
   "warnings",
 ]

--- a/build.bat
+++ b/build.bat
@@ -74,6 +74,8 @@ for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
         if not exist "sdk\bin\!SDK_ARCH!" mkdir "sdk\bin\!SDK_ARCH!"
         copy /Y "!BIN_DIR!\wxc-exec.exe" "sdk\bin\!SDK_ARCH!\" >nul
         echo   Copied !SDK_ARCH!\wxc-exec.exe
+        copy /Y "!BIN_DIR!\wxc-exec.pdb" "sdk\bin\!SDK_ARCH!\" >nul
+        echo   Copied !SDK_ARCH!\wxc-exec.pdb
         if exist "!BIN_DIR!\wxc-windows-sandbox-guest.exe" (
             copy /Y "!BIN_DIR!\wxc-windows-sandbox-guest.exe" "sdk\bin\!SDK_ARCH!\" >nul
             echo   Copied !SDK_ARCH!\wxc-windows-sandbox-guest.exe

--- a/build.bat
+++ b/build.bat
@@ -74,8 +74,6 @@ for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
         if not exist "sdk\bin\!SDK_ARCH!" mkdir "sdk\bin\!SDK_ARCH!"
         copy /Y "!BIN_DIR!\wxc-exec.exe" "sdk\bin\!SDK_ARCH!\" >nul
         echo   Copied !SDK_ARCH!\wxc-exec.exe
-        copy /Y "!BIN_DIR!\wxc-exec.pdb" "sdk\bin\!SDK_ARCH!\" >nul
-        echo   Copied !SDK_ARCH!\wxc-exec.pdb
         if exist "!BIN_DIR!\wxc-windows-sandbox-guest.exe" (
             copy /Y "!BIN_DIR!\wxc-windows-sandbox-guest.exe" "sdk\bin\!SDK_ARCH!\" >nul
             echo   Copied !SDK_ARCH!\wxc-windows-sandbox-guest.exe

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -19,6 +19,12 @@ members = [
 ]
 resolver = "3"
 
+# Full debug info so we can analyse customer crash dumps in WinDbg until we
+# publish to a symbol server.
+[profile.release]
+debug = "full"
+split-debuginfo = "packed"
+
 [workspace.package]
 edition = "2021"
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -21,10 +21,14 @@ members = [
 resolver = "3"
 
 # Full debug info so we can analyse customer crash dumps in WinDbg until we
-# publish to a symbol server.
+# publish to a symbol server. `strip = "debuginfo"` removes embedded debug
+# sections from the binary itself (mainly relevant on Linux — Windows pdbs
+# are already split by `split-debuginfo = "packed"`). Full debug info still
+# ships via the side-by-side .pdb / .dwp files.
 [profile.release]
 debug = "full"
 split-debuginfo = "packed"
+strip = "debuginfo"
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
## 📖 Description
PR makes our build pipeline produce a `mxc-release-binaries.zip` file that can be added to the github releases page on every release. The pipeline will now also produce pdbs and add it to the zip. This is a stop gap until we have symbol publishing, Although I think we'll keep doing this for folks who want easy access to the symbols.
## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->
Resolves #309
## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
Will confirm artifacts are produced from PR pipeline on success.
## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [X] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [X] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [X] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/310)