### PR TITLE
fix(macos):  seatbelt pty fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,6 +175,7 @@ New features go under the `experimental` JSON section and are only active when `
 
 - `wxc_common` is the shared library — all config parsing, models, error types, and runner implementations live here
 - `wxc` and `lxc` are thin binary crates that wire up CLI args (`clap`) and dispatch to `wxc_common`
+- `mxc_pty` is the shared pty bridge used by the unix-side backends (`lxc_common::lxc_bindings::attach_run` on Linux and `seatbelt_common::seatbelt_runner` on macOS) so the inner shell sees a real TTY and host stdio is streamed live
 - Platform-specific modules in `wxc_common` use `#[cfg(target_os = "windows")]` / `#[cfg(target_os = "linux")]`
 - Workspace edition is 2021; shared dependencies are declared in the root `Cargo.toml` `[workspace.dependencies]`
 

--- a/sdk/src/diagnostic.ts
+++ b/sdk/src/diagnostic.ts
@@ -19,9 +19,19 @@ import * as os from 'os';
 /**
  * Compute the per-user pipe name (includes current user's SID).
  * Falls back to the base name if the SID cannot be determined.
+ *
+ * Windows-only — the diagnostic console only runs on Windows. On other
+ * platforms this returns the base name (which is never used because
+ * `ensurePipe` short-circuits below) without spawning `whoami`. The
+ * `whoami /user /fo csv /nh` invocation uses Windows-only flags that
+ * cause GNU/BSD `whoami` to print "usage: whoami" on stderr — visible
+ * to any caller that inherits our stdio (e.g. mxc-exec-mac under a pty).
  */
 function getDiagnosticPipeName(): string {
     const baseName = '\\\\.\\pipe\\mxc-diagnostics';
+    if (os.platform() !== 'win32') {
+        return baseName;
+    }
     try {
         const output = execSync('whoami /user /fo csv /nh', {
             encoding: 'utf8',

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger.js';
 import { ContainerConfig, ContainmentBackend, ContainmentTypes, ExperimentalBackends } from './types.js';
-import { findWxcExecutable, findLxcExecutable, getPlatformSupport } from './platform.js';
+import { findWxcExecutable, findLxcExecutable, findDarwinExecutable, getPlatformSupport } from './platform.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { diagLog } from './diagnostic.js';
 
@@ -89,6 +89,14 @@ export function resolveBinaryAndCommonArgs(
     if (!p) {
       throw new Error(
         'lxc-exec not found. Ensure it is built and available in a standard location.'
+      );
+    }
+    executablePath = p;
+  } else if (platform === 'darwin') {
+    const p = findDarwinExecutable();
+    if (!p) {
+      throw new Error(
+        'mxc-exec-mac not found. Ensure it is built and available in a standard location.'
       );
     }
     executablePath = p;

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1181,6 +1181,7 @@ name = "lxc_common"
 version = "0.1.0"
 dependencies = [
  "libc",
+ "mxc_pty",
  "nix",
  "serde",
  "serde_json",
@@ -1307,6 +1308,14 @@ dependencies = [
  "windows",
  "windows-core",
  "wxc_common",
+]
+
+[[package]]
+name = "mxc_pty"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "nix",
 ]
 
 [[package]]
@@ -1707,6 +1716,7 @@ dependencies = [
 name = "seatbelt_common"
 version = "0.1.0"
 dependencies = [
+ "mxc_pty",
  "tempfile",
  "wxc_common",
 ]

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "isolation_session_bindings",
     "seatbelt_common",
     "mxc_darwin",
+    "mxc_pty",
     "generated/base_container_specification",
     "mxc_diagnostic_console",
 ]
@@ -67,6 +68,7 @@ nix = { version = "0.29", features = ["mount", "sched", "signal", "net", "proces
 lxc_common = { path = "lxc_common" }
 wslc_common = { path = "wslc_common" }
 isolation_session_bindings = { path = "isolation_session_bindings" }
+mxc_pty = { path = "mxc_pty" }
 flatbuffers = "25"
 sandbox_spec = { path = "generated/base_container_specification" }
 widestring = "1"

--- a/src/lxc_common/Cargo.toml
+++ b/src/lxc_common/Cargo.toml
@@ -10,3 +10,4 @@ nix = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+mxc_pty = { workspace = true }

--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -223,12 +223,6 @@ impl LxcContainer {
     /// Stdout/stderr are streamed live via the master fd; the returned
     /// strings are always empty. Callers needing captured output should run
     /// a self-contained `commandLine` and read it back from a file.
-    ///
-    /// Only built on Linux — `lxc-attach` doesn't exist on other targets.
-    /// The crate still has to compile workspace-wide on Windows
-    /// (the `wxc-exec-lint` CI job runs `cargo clippy --workspace`
-    /// on `windows-latest`) and on macOS dev machines, so a stub is
-    /// provided below for non-Linux targets.
     #[cfg(target_os = "linux")]
     pub fn attach_run(
         &self,
@@ -260,9 +254,7 @@ impl LxcContainer {
         }
     }
 
-    /// Non-Linux stub. `lxc-exec` is Linux-only at runtime, but the
-    /// workspace still builds on Windows (clippy CI) and macOS (dev), so
-    /// the signature has to exist on every target.
+    /// Stub for the workspace-wide clippy lane that runs on Windows.
     #[cfg(not(target_os = "linux"))]
     pub fn attach_run(
         &self,

--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -209,172 +209,55 @@ impl LxcContainer {
     }
 
     /// Execute a command inside a running container using lxc-attach, with
-    /// the inner process attached to a freshly-allocated pty.
+    /// the inner process attached to a freshly-allocated pty via
+    /// [`mxc_pty::run_with_pty`]. See that crate for the full pty-bridge
+    /// contract (output streamed live to host stdio, stdin forwarded after
+    /// first byte arrives from inner shell, etc.).
     ///
-    /// This bridges the host's stdin/stdout/stderr to the inner pty, but
-    /// **defers forwarding host stdin to the inner process until bash has
-    /// produced its first output byte**. That delay is essential: an
-    /// interactive shell calls `tcsetattr` on its stdin during readline
-    /// init, which can flush any bytes the parent buffered into the pty
-    /// before the shell got there. Without the delay, anything the CLI
-    /// pre-buffers (e.g. its shell-init wrapper) is silently swallowed.
+    /// We pass `unblock_signals = [SIGHUP, SIGTERM, SIGINT]` because
+    /// [`crate::signal_cleanup::install`] blocks them in this process so
+    /// its watchdog thread can `sigwait` on them; that mask is inherited
+    /// across `fork`+`exec` and would otherwise make the inner shell
+    /// silently ignore Ctrl-C / termination.
     ///
     /// Stdout/stderr are streamed live via the master fd; the returned
     /// strings are always empty. Callers needing captured output should run
     /// a self-contained `commandLine` and read it back from a file.
     ///
-    /// Only built on Linux — the implementation depends on `pre_exec`,
-    /// `openpty`, and `TIOCSCTTY`. The crate still has to compile
-    /// workspace-wide on Windows (the `wxc-exec-lint` CI job runs
-    /// `cargo clippy --workspace` on `windows-latest`) and on macOS dev
-    /// machines, so a stub is provided below for non-Linux targets.
+    /// Only built on Linux — `lxc-attach` doesn't exist on other targets.
+    /// The crate still has to compile workspace-wide on Windows
+    /// (the `wxc-exec-lint` CI job runs `cargo clippy --workspace`
+    /// on `windows-latest`) and on macOS dev machines, so a stub is
+    /// provided below for non-Linux targets.
     #[cfg(target_os = "linux")]
     pub fn attach_run(
         &self,
         command: &str,
         _working_directory: &str,
     ) -> Result<(i32, String, String), String> {
-        use nix::pty::openpty;
-        use std::io::{Read, Write};
-        use std::process::Stdio;
-        use std::sync::mpsc;
-        use std::thread;
-        use std::time::Duration;
+        use mxc_pty::{run_with_pty, PtyOptions, PtyOutcome, Signal};
 
-        // Allocate an inner pty pair. The slave goes to lxc-attach (and thus
-        // bash inside the container) so the inner process sees a real tty;
-        // we keep the master and bridge it to our own stdio.
-        let pty_pair = openpty(None, None).map_err(|e| format!("openpty failed: {}", e))?;
-
-        // Three fd duplicates of the slave so each Stdio takes ownership of
-        // its own handle; otherwise std::process::Stdio::from would consume
-        // the single OwnedFd and the rest of the spawn calls would fail.
-        let slave_in: Stdio = pty_pair
-            .slave
-            .try_clone()
-            .map_err(|e| format!("dup slave for stdin: {}", e))?
-            .into();
-        let slave_out: Stdio = pty_pair
-            .slave
-            .try_clone()
-            .map_err(|e| format!("dup slave for stdout: {}", e))?
-            .into();
-        let slave_err: Stdio = pty_pair.slave.into();
+        const UNBLOCK: &[Signal] = &[Signal::SIGHUP, Signal::SIGTERM, Signal::SIGINT];
 
         let mut cmd = self.lxc_command("lxc-attach");
         cmd.args(["--", "/bin/sh", "-c", command]);
-        cmd.stdin(slave_in).stdout(slave_out).stderr(slave_err);
 
-        // Drop the inherited controlling terminal in the child and make the
-        // slave end of our pty its new controlling tty. Without this,
-        // lxc-attach detects that it has a controlling tty (the outer pty
-        // from node-pty) and forwards the inner pty's I/O to `/dev/tty`
-        // directly, bypassing the slave fds we wired into stdio. Our master
-        // would then see no data at all.
-        //
-        // Also unblock SIGHUP/SIGTERM/SIGINT in the child: `signal_cleanup::install`
-        // blocks them in this process so the watchdog thread can sigwait on
-        // them, but that mask is inherited across fork+exec. Without this
-        // reset the inner shell (and anything it spawns) would silently
-        // ignore Ctrl-C and termination signals.
-        unsafe {
-            use std::os::unix::process::CommandExt;
-            cmd.pre_exec(|| {
-                // Become a new session leader, detaching from the inherited
-                // controlling terminal.
-                nix::unistd::setsid().map_err(std::io::Error::from)?;
-                // SAFETY: ioctl on fd 0 (the slave we just dup2'd in via
-                // stdin) to make it the new controlling tty. Errors are
-                // non-fatal because setsid above already cleared the ctty
-                // state, which is what actually matters for lxc-attach.
-                let _ = libc::ioctl(0, libc::TIOCSCTTY as _, 0);
+        let options = PtyOptions {
+            unblock_signals: UNBLOCK,
+            // TODO: thread request.script_timeout through to here so the
+            // LXC backend can enforce script-level timeouts the same way
+            // the Seatbelt backend already does.
+            ..PtyOptions::default()
+        };
 
-                // Restore the default signal mask so the inner process
-                // doesn't inherit signal_cleanup's blocked set.
-                let mut empty = nix::sys::signal::SigSet::empty();
-                empty.add(nix::sys::signal::Signal::SIGHUP);
-                empty.add(nix::sys::signal::Signal::SIGTERM);
-                empty.add(nix::sys::signal::Signal::SIGINT);
-                empty.thread_unblock().map_err(std::io::Error::from)?;
-                Ok(())
-            });
+        match run_with_pty(cmd, options)? {
+            PtyOutcome::Exited(status) => {
+                Ok((status.code().unwrap_or(-1), String::new(), String::new()))
+            }
+            // Unreachable today because we pass `timeout: None`, but cover
+            // it explicitly so the compiler catches future changes.
+            PtyOutcome::TimedOut => Err("lxc-attach timed out".to_string()),
         }
-
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| format!("Failed to spawn lxc-attach: {}", e))?;
-
-        drop(cmd);
-
-        // The child inherited all three slave handles and the parent's
-        // copies have been moved into Stdio. The slave will be fully closed
-        // when the child exits, which makes our master read return EOF.
-
-        // OwnedFd -> File via std::convert::From; no `unsafe` needed.
-        let master: std::fs::File = pty_pair.master.into();
-        let mut master_writer = master
-            .try_clone()
-            .map_err(|e| format!("dup master: {}", e))?;
-        let mut master_reader = master;
-
-        // Output forwarder: master -> host stdout. Signals "ready" on the
-        // first byte from inside the container — at that point bash has
-        // finished its readline/tcsetattr init and is safe to feed.
-        let (ready_tx, ready_rx) = mpsc::channel::<()>();
-        let output_thread = thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            let mut signaled = false;
-            let mut stdout = std::io::stdout();
-            loop {
-                match master_reader.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if !signaled {
-                            let _ = ready_tx.send(());
-                            signaled = true;
-                        }
-                        let _ = stdout.write_all(&buf[..n]);
-                        let _ = stdout.flush();
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        // Wait for bash to print its first byte before forwarding host stdin.
-        // Cap the wait so a wedged shell doesn't block the stdin forwarder
-        // forever; the inner process itself still runs to completion below
-        // (request.script_timeout is not yet enforced — see the TODO in
-        // lxc_runner::run_internal where attach_run is called).
-        let _ = ready_rx.recv_timeout(Duration::from_secs(5));
-
-        // Input forwarder: host stdin -> master. Detached; exits when stdin
-        // closes (which happens when our parent process closes the pty).
-        thread::spawn(move || {
-            let mut buf = [0u8; 4096];
-            let mut stdin = std::io::stdin();
-            loop {
-                match stdin.read(&mut buf) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if master_writer.write_all(&buf[..n]).is_err() {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        let status = child
-            .wait()
-            .map_err(|e| format!("wait on lxc-attach: {}", e))?;
-
-        // Drain remaining output before returning. The slave fds are closed
-        // on child exit, so master_reader will hit EOF and the thread exits.
-        let _ = output_thread.join();
-
-        Ok((status.code().unwrap_or(-1), String::new(), String::new()))
     }
 
     /// Non-Linux stub. `lxc-exec` is Linux-only at runtime, but the

--- a/src/mxc_pty/Cargo.toml
+++ b/src/mxc_pty/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mxc_pty"
+version = "0.1.0"
+edition = "2021"
+
+# Unix-only at runtime: mxc_pty wraps `openpty` + `pre_exec` (TIOCSCTTY,
+# setsid) + sigwait-style helpers, none of which have a sensible Windows
+# equivalent. The crate still compiles workspace-wide because `lxc_common`
+# (which depends on it) builds on Windows for the `cargo clippy --workspace`
+# CI lane; non-unix targets get a stub `run_with_pty` that returns an error.
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+nix = { workspace = true }
+libc = { workspace = true }

--- a/src/mxc_pty/src/lib.rs
+++ b/src/mxc_pty/src/lib.rs
@@ -9,9 +9,6 @@
 //! shell sees a real TTY (`isatty(0/1/2) -> true`) and the host can stream
 //! output as it arrives. The two implementations were ~95% the same code;
 //! this crate is the deduplicated home for that pty plumbing.
-//!
-//! On non-unix targets the crate still builds (the workspace clippy CI lane
-//! runs on Windows) but [`run_with_pty`] returns an error.
 
 use std::process::Command;
 use std::time::Duration;
@@ -92,10 +89,6 @@ pub enum PtyOutcome {
 /// streamed to the host stdio by the time this function returns;
 /// callers needing captured output should write it to a file in cwd
 /// and read it back from there.
-///
-/// On non-unix targets this is a stub that returns `Err` immediately —
-/// the workspace builds on Windows for clippy CI, but at runtime the
-/// pty bridge is only meaningful on Linux and macOS.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub fn run_with_pty(mut command: Command, options: PtyOptions) -> Result<PtyOutcome, String> {
     use std::io::{Read, Write};
@@ -261,8 +254,7 @@ pub fn run_with_pty(mut command: Command, options: PtyOptions) -> Result<PtyOutc
     Ok(outcome)
 }
 
-/// Non-unix stub. The workspace builds on Windows for clippy CI but
-/// the pty bridge has no meaningful implementation there.
+/// Stub for the workspace-wide clippy lane that runs on Windows.
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub fn run_with_pty(_command: Command, _options: PtyOptions) -> Result<PtyOutcome, String> {
     Err("mxc_pty::run_with_pty is only supported on Linux and macOS".to_string())

--- a/src/mxc_pty/src/lib.rs
+++ b/src/mxc_pty/src/lib.rs
@@ -1,0 +1,312 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `mxc_pty` — shared pty bridge for the unix-side MXC backends.
+//!
+//! Both the Linux LXC backend (`lxc_common::lxc_bindings::attach_run`) and
+//! the macOS Seatbelt backend (`seatbelt_common::seatbelt_runner`) need to
+//! run a child process attached to a freshly-allocated pty so the inner
+//! shell sees a real TTY (`isatty(0/1/2) -> true`) and the host can stream
+//! output as it arrives. The two implementations were ~95% the same code;
+//! this crate is the deduplicated home for that pty plumbing.
+//!
+//! On non-unix targets the crate still builds (the workspace clippy CI lane
+//! runs on Windows) but [`run_with_pty`] returns an error.
+
+use std::process::Command;
+use std::time::Duration;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub use nix::sys::signal::Signal;
+
+/// Placeholder `Signal` on non-unix targets so the public type signature
+/// of [`PtyOptions`] is the same on every host. Constructing one is
+/// pointless because [`run_with_pty`] is a stub on those targets.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Signal {}
+
+/// Knobs the caller can tweak when bridging a child through a pty.
+#[derive(Clone, Debug)]
+pub struct PtyOptions {
+    /// Maximum wall-clock time to wait for the child to exit. `None`
+    /// means wait forever; `Some(d)` polls `try_wait` every
+    /// [`POLL_INTERVAL`](Self::POLL_INTERVAL) until the deadline passes,
+    /// at which point the child is killed and [`PtyOutcome::TimedOut`]
+    /// is returned.
+    pub timeout: Option<Duration>,
+
+    /// How long to wait for the inner process to print its first byte
+    /// before forwarding host stdin to the pty master. The delay matters
+    /// because an interactive shell calls `tcsetattr` during readline
+    /// init, which can flush bytes the parent buffered in the pty before
+    /// the shell got there. Set to `Duration::ZERO` to forward stdin
+    /// immediately.
+    pub ready_wait: Duration,
+
+    /// Signals to unblock in the child via `pthread_sigmask` inside
+    /// `pre_exec`. Use this when the parent process blocks signals
+    /// (e.g. for a sigwait-based watchdog) and that mask would otherwise
+    /// be inherited across `fork`+`exec`.
+    pub unblock_signals: &'static [Signal],
+}
+
+impl PtyOptions {
+    /// Default poll interval used by [`run_with_pty`] when a timeout is
+    /// configured. Exposed so callers that want to validate timeouts
+    /// (e.g. reject `script_timeout` values smaller than the poll
+    /// granularity) can match against the same constant.
+    pub const POLL_INTERVAL: Duration = Duration::from_millis(500);
+}
+
+impl Default for PtyOptions {
+    fn default() -> Self {
+        Self {
+            timeout: None,
+            ready_wait: Duration::from_secs(5),
+            unblock_signals: &[],
+        }
+    }
+}
+
+/// Result of a successful pty bridge.
+///
+/// "Successful" here means the bridge itself worked — i.e. we managed to
+/// spawn the child and wait on it. The child's own exit status is carried
+/// inside [`PtyOutcome::Exited`].
+#[derive(Debug)]
+pub enum PtyOutcome {
+    /// Child terminated before the timeout (or no timeout was set).
+    Exited(std::process::ExitStatus),
+    /// `timeout` elapsed before the child exited; the child has been
+    /// killed and reaped before this variant is returned.
+    TimedOut,
+}
+
+/// Spawn `command` attached to a freshly-allocated pty pair and bridge
+/// it to the host's stdin/stdout/stderr.
+///
+/// The slave end becomes the child's stdin/stdout/stderr; the master end
+/// stays in this process and is forwarded to/from the host fds on
+/// background threads. All of the child's output has therefore been
+/// streamed to the host stdio by the time this function returns;
+/// callers needing captured output should write it to a file in cwd
+/// and read it back from there.
+///
+/// On non-unix targets this is a stub that returns `Err` immediately —
+/// the workspace builds on Windows for clippy CI, but at runtime the
+/// pty bridge is only meaningful on Linux and macOS.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub fn run_with_pty(mut command: Command, options: PtyOptions) -> Result<PtyOutcome, String> {
+    use std::io::{Read, Write};
+    use std::process::Stdio;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Instant;
+
+    use nix::pty::openpty;
+
+    let pty_pair = openpty(None, None).map_err(|e| format!("openpty failed: {}", e))?;
+
+    // Three duplicates of the slave fd so each Stdio takes ownership of
+    // its own handle; otherwise std::process::Stdio::from would consume
+    // the single OwnedFd and the rest of the spawn calls would fail.
+    let slave_in: Stdio = pty_pair
+        .slave
+        .try_clone()
+        .map_err(|e| format!("dup slave for stdin: {}", e))?
+        .into();
+    let slave_out: Stdio = pty_pair
+        .slave
+        .try_clone()
+        .map_err(|e| format!("dup slave for stdout: {}", e))?
+        .into();
+    let slave_err: Stdio = pty_pair.slave.into();
+
+    command.stdin(slave_in).stdout(slave_out).stderr(slave_err);
+
+    // Drop the inherited controlling terminal in the child and make the
+    // slave end of our pty its new controlling tty. Without this the
+    // child detects that it has a controlling tty (the outer pty from
+    // node-pty) and forwards the inner pty's I/O to `/dev/tty` directly,
+    // bypassing the slave fds we wired into stdio. Our master would
+    // then see no data at all.
+    //
+    // `unblock_signals` reverses any sigmask the parent installed (e.g.
+    // signal_cleanup's sigwait-blocked set) so the child doesn't
+    // silently ignore Ctrl-C / termination.
+    let unblock_signals = options.unblock_signals;
+    // SAFETY: the closure runs after fork, before exec. Only
+    // async-signal-safe operations are used: `setsid`, `ioctl`, and
+    // `pthread_sigmask` (via nix's `SigSet::thread_unblock`). No
+    // allocation or non-reentrant libc calls.
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        command.pre_exec(move || {
+            // Become a new session leader, detaching from the inherited
+            // controlling terminal.
+            nix::unistd::setsid().map_err(std::io::Error::from)?;
+            // ioctl on fd 0 (the slave we just dup2'd in via stdin) to
+            // make it the new controlling tty. Errors are non-fatal
+            // because setsid above already cleared the ctty state, which
+            // is what actually matters for the child.
+            let _ = libc::ioctl(0, libc::TIOCSCTTY as _, 0);
+
+            if !unblock_signals.is_empty() {
+                let mut mask = nix::sys::signal::SigSet::empty();
+                for sig in unblock_signals {
+                    mask.add(*sig);
+                }
+                mask.thread_unblock().map_err(std::io::Error::from)?;
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("failed to spawn child: {}", e))?;
+
+    drop(command);
+
+    // The child inherited all three slave handles and the parent's
+    // copies have been moved into Stdio. The slave will be fully closed
+    // when the child exits, which makes our master read return EOF.
+    let master: std::fs::File = pty_pair.master.into();
+    let mut master_writer = master
+        .try_clone()
+        .map_err(|e| format!("dup master: {}", e))?;
+    let mut master_reader = master;
+
+    // Output forwarder: master -> host stdout. Signals "ready" on the
+    // first byte from inside the child so the input forwarder doesn't
+    // race the inner shell's `tcsetattr` init.
+    let (ready_tx, ready_rx) = mpsc::channel::<()>();
+    let output_thread = thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        let mut signaled = false;
+        let mut stdout = std::io::stdout();
+        loop {
+            match master_reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if !signaled {
+                        let _ = ready_tx.send(());
+                        signaled = true;
+                    }
+                    let _ = stdout.write_all(&buf[..n]);
+                    let _ = stdout.flush();
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Cap the wait so a wedged shell doesn't block the stdin forwarder
+    // forever; the child itself still runs to completion below.
+    if !options.ready_wait.is_zero() {
+        let _ = ready_rx.recv_timeout(options.ready_wait);
+    }
+
+    // Input forwarder: host stdin -> master. Detached; exits when stdin
+    // closes (which happens when our parent closes the outer pty).
+    thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        let mut stdin = std::io::stdin();
+        loop {
+            match stdin.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if master_writer.write_all(&buf[..n]).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let outcome = match options.timeout {
+        None => {
+            let status = child.wait().map_err(|e| format!("wait: {}", e))?;
+            PtyOutcome::Exited(status)
+        }
+        Some(timeout) => {
+            let deadline = Instant::now() + timeout;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => break PtyOutcome::Exited(status),
+                    Ok(None) => {
+                        if Instant::now() >= deadline {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            break PtyOutcome::TimedOut;
+                        }
+                        thread::sleep(PtyOptions::POLL_INTERVAL);
+                    }
+                    Err(e) => {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(format!("try_wait: {}", e));
+                    }
+                }
+            }
+        }
+    };
+
+    // Drain remaining output before returning. The slave fds are closed
+    // on child exit, so master_reader hits EOF and the thread exits.
+    let _ = output_thread.join();
+
+    Ok(outcome)
+}
+
+/// Non-unix stub. The workspace builds on Windows for clippy CI but
+/// the pty bridge has no meaningful implementation there.
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub fn run_with_pty(_command: Command, _options: PtyOptions) -> Result<PtyOutcome, String> {
+    Err("mxc_pty::run_with_pty is only supported on Linux and macOS".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_options() {
+        let opts = PtyOptions::default();
+        assert!(opts.timeout.is_none());
+        assert_eq!(opts.ready_wait, Duration::from_secs(5));
+        assert!(opts.unblock_signals.is_empty());
+    }
+
+    #[test]
+    fn poll_interval_is_500ms() {
+        assert_eq!(PtyOptions::POLL_INTERVAL, Duration::from_millis(500));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn echo_runs_under_pty() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg("echo hello-from-pty");
+        let outcome = run_with_pty(cmd, PtyOptions::default()).expect("bridge spawns");
+        match outcome {
+            PtyOutcome::Exited(status) => assert!(status.success()),
+            PtyOutcome::TimedOut => panic!("echo should not time out"),
+        }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn timeout_kills_long_running_child() {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg("sleep 30");
+        let opts = PtyOptions {
+            timeout: Some(Duration::from_millis(750)),
+            ..PtyOptions::default()
+        };
+        let outcome = run_with_pty(cmd, opts).expect("bridge spawns");
+        assert!(matches!(outcome, PtyOutcome::TimedOut));
+    }
+}

--- a/src/mxc_pty/src/lib.rs
+++ b/src/mxc_pty/src/lib.rs
@@ -195,10 +195,21 @@ pub fn run_with_pty(mut command: Command, options: PtyOptions) -> Result<PtyOutc
         }
     });
 
-    // Cap the wait so a wedged shell doesn't block the stdin forwarder
-    // forever; the child itself still runs to completion below.
-    if !options.ready_wait.is_zero() {
-        let _ = ready_rx.recv_timeout(options.ready_wait);
+    // The overall timeout starts the moment the child is spawned, not
+    // after the readiness wait completes; otherwise a 5s ready_wait on
+    // a 5s-timeout job would silently double the budget.
+    let deadline = options.timeout.map(|t| Instant::now() + t);
+
+    // Cap the readiness wait at whatever's left in the deadline so we
+    // don't sleep past it for a child that never prints anything.
+    let ready_budget = match deadline {
+        Some(d) => options
+            .ready_wait
+            .min(d.saturating_duration_since(Instant::now())),
+        None => options.ready_wait,
+    };
+    if !ready_budget.is_zero() {
+        let _ = ready_rx.recv_timeout(ready_budget);
     }
 
     // Input forwarder: host stdin -> master. Detached; exits when stdin
@@ -219,32 +230,29 @@ pub fn run_with_pty(mut command: Command, options: PtyOptions) -> Result<PtyOutc
         }
     });
 
-    let outcome = match options.timeout {
+    let outcome = match deadline {
         None => {
             let status = child.wait().map_err(|e| format!("wait: {}", e))?;
             PtyOutcome::Exited(status)
         }
-        Some(timeout) => {
-            let deadline = Instant::now() + timeout;
-            loop {
-                match child.try_wait() {
-                    Ok(Some(status)) => break PtyOutcome::Exited(status),
-                    Ok(None) => {
-                        if Instant::now() >= deadline {
-                            let _ = child.kill();
-                            let _ = child.wait();
-                            break PtyOutcome::TimedOut;
-                        }
-                        thread::sleep(PtyOptions::POLL_INTERVAL);
-                    }
-                    Err(e) => {
+        Some(deadline) => loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break PtyOutcome::Exited(status),
+                Ok(None) => {
+                    if Instant::now() >= deadline {
                         let _ = child.kill();
                         let _ = child.wait();
-                        return Err(format!("try_wait: {}", e));
+                        break PtyOutcome::TimedOut;
                     }
+                    thread::sleep(PtyOptions::POLL_INTERVAL);
+                }
+                Err(e) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(format!("try_wait: {}", e));
                 }
             }
-        }
+        },
     };
 
     // Drain remaining output before returning. The slave fds are closed

--- a/src/seatbelt_common/Cargo.toml
+++ b/src/seatbelt_common/Cargo.toml
@@ -15,3 +15,7 @@ wxc_common = { workspace = true }
 # hosts this dep is unused at link time.
 [target.'cfg(target_os = "macos")'.dependencies]
 tempfile = "3"
+# Pty bridge is shared with the LXC backend via mxc_pty; that crate owns
+# the openpty + pre_exec (setsid + TIOCSCTTY) plumbing and the libc/nix
+# deps that go with it.
+mxc_pty = { workspace = true }

--- a/src/seatbelt_common/src/profile_builder.rs
+++ b/src/seatbelt_common/src/profile_builder.rs
@@ -61,10 +61,10 @@ pub fn build_profile(request: &CodexRequest) -> String {
     out.push_str(SYSTEM_READ_ALLOW);
 
     // Pseudo-terminal access — the seatbelt runner attaches the inner
-    // shell to a freshly-allocated pty (see `seatbelt_runner::spawn_with_pty`)
-    // so callers can stream output and the shell sees a real TTY. Without
-    // these rules, `isatty()` / `tcgetattr()` / `ttyname()` fail with EPERM
-    // because the kernel calls block on the slave fd.
+    // shell to a freshly-allocated pty (see `mxc_pty::run_with_pty`) so
+    // callers can stream output and the shell sees a real TTY. Without
+    // these rules, `isatty()` / `tcgetattr()` / `ttyname()` fail with
+    // EPERM because the kernel calls block on the slave fd.
     out.push_str(TTY_ALLOW);
 
     // Policy-derived allow rules.
@@ -125,12 +125,14 @@ const SYSTEM_READ_ALLOW: &str = "\
 /// stdin/stdout/stderr lives at `/dev/ttysNNN`, and the shell calls
 /// `isatty()` (→ `tcgetattr` → ioctl) plus `ttyname()` against it. We
 /// also need read access to `/dev/tty` because most shells re-open it
-/// at startup. Allowing `(subpath "/dev")` keeps the rule short and
-/// covers the supporting `/dev` entries (`/dev/fd`, `/dev/stdout`, …)
-/// that callers occasionally exercise from inside a sandboxed shell.
+/// at startup, and read access to `/dev/fd` for the `/dev/stdout` etc.
+/// indirection some tools use.
 const TTY_ALLOW: &str = "\
-;; --- pseudo-terminal access (pty bridge in seatbelt_runner) ---
-(allow file-read* file-write* file-ioctl (subpath \"/dev\"))
+;; --- pseudo-terminal access (pty bridge in mxc_pty::run_with_pty) ---
+(allow file-read* file-write* file-ioctl
+    (literal \"/dev/tty\")
+    (regex #\"^/dev/ttys[0-9]+$\"))
+(allow file-read* (subpath \"/dev/fd\"))
 ";
 
 fn write_filesystem_allow(out: &mut String, request: &CodexRequest) {

--- a/src/seatbelt_common/src/profile_builder.rs
+++ b/src/seatbelt_common/src/profile_builder.rs
@@ -60,6 +60,13 @@ pub fn build_profile(request: &CodexRequest) -> String {
     // Filesystem — read-only system paths every process needs.
     out.push_str(SYSTEM_READ_ALLOW);
 
+    // Pseudo-terminal access — the seatbelt runner attaches the inner
+    // shell to a freshly-allocated pty (see `seatbelt_runner::spawn_with_pty`)
+    // so callers can stream output and the shell sees a real TTY. Without
+    // these rules, `isatty()` / `tcgetattr()` / `ttyname()` fail with EPERM
+    // because the kernel calls block on the slave fd.
+    out.push_str(TTY_ALLOW);
+
     // Policy-derived allow rules.
     write_filesystem_allow(&mut out, request);
     write_network_rules(&mut out, request);
@@ -111,6 +118,19 @@ const SYSTEM_READ_ALLOW: &str = "\
     (literal \"/dev/zero\")
     (literal \"/dev/random\")
     (literal \"/dev/urandom\"))
+";
+
+/// Pseudo-terminal device access required by the inner shell when the
+/// runner attaches it to a pty. The slave fd we hand the child as
+/// stdin/stdout/stderr lives at `/dev/ttysNNN`, and the shell calls
+/// `isatty()` (→ `tcgetattr` → ioctl) plus `ttyname()` against it. We
+/// also need read access to `/dev/tty` because most shells re-open it
+/// at startup. Allowing `(subpath "/dev")` keeps the rule short and
+/// covers the supporting `/dev` entries (`/dev/fd`, `/dev/stdout`, …)
+/// that callers occasionally exercise from inside a sandboxed shell.
+const TTY_ALLOW: &str = "\
+;; --- pseudo-terminal access (pty bridge in seatbelt_runner) ---
+(allow file-read* file-write* file-ioctl (subpath \"/dev\"))
 ";
 
 fn write_filesystem_allow(out: &mut String, request: &CodexRequest) {

--- a/src/seatbelt_common/src/seatbelt_runner.rs
+++ b/src/seatbelt_common/src/seatbelt_runner.rs
@@ -144,25 +144,15 @@ impl ScriptRunner for SeatbeltScriptRunner {
         match run_with_pty(command, options) {
             Ok(PtyOutcome::Exited(status)) => ScriptResponse {
                 exit_code: status.code().unwrap_or(-1),
-                standard_out: String::new(),
-                standard_err: String::new(),
-                error_message: String::new(),
+                ..Default::default()
             },
             Ok(PtyOutcome::TimedOut) => {
-                let _ = writeln!(
-                    logger,
+                let msg = format!(
                     "Seatbelt: script timed out after {}ms",
                     request.script_timeout
                 );
-                ScriptResponse {
-                    exit_code: -1,
-                    standard_out: String::new(),
-                    standard_err: String::new(),
-                    error_message: format!(
-                        "Seatbelt: script timed out after {}ms",
-                        request.script_timeout
-                    ),
-                }
+                let _ = writeln!(logger, "{msg}");
+                error_response(msg)
             }
             Err(error) => error_response(format!(
                 "failed to spawn {SANDBOX_EXEC}: {error}; ensure sandbox-exec exists"
@@ -173,10 +163,8 @@ impl ScriptRunner for SeatbeltScriptRunner {
 
 fn error_response(message: String) -> ScriptResponse {
     ScriptResponse {
-        exit_code: -1,
-        standard_out: String::new(),
-        standard_err: String::new(),
         error_message: message,
+        ..Default::default()
     }
 }
 

--- a/src/seatbelt_common/src/seatbelt_runner.rs
+++ b/src/seatbelt_common/src/seatbelt_runner.rs
@@ -7,16 +7,19 @@
 //! It generates a TinyScheme profile from the [`CodexRequest`] using
 //! [`crate::profile_builder::build_profile`], writes it to a tempfile in
 //! `TMPDIR`, then spawns `sandbox-exec -f <profile> /bin/sh -c <script>`
-//! with the request's env and working directory.
+//! through [`mxc_pty::run_with_pty`] so the inner shell sees a real TTY
+//! and the host can stream its output as it arrives. The pty bridge is
+//! the same one the LXC backend uses.
 //!
 //! Compiled only on macOS — the rest of the workspace continues to build
 //! on Windows / Linux unchanged.
 
 use std::fmt::Write as FmtWrite;
 use std::io::Write as IoWrite;
-use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::process::Command;
+use std::time::Duration;
 
+use mxc_pty::{run_with_pty, PtyOptions, PtyOutcome};
 use wxc_common::logger::Logger;
 use wxc_common::models::{CodexRequest, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
@@ -42,8 +45,6 @@ impl SeatbeltScriptRunner {
     }
 }
 
-const POLL_INTERVAL_MS: u64 = 500;
-
 impl ScriptRunner for SeatbeltScriptRunner {
     fn validate_runner(&self, request: &CodexRequest) -> Result<(), ScriptResponse> {
         // Seatbelt cannot filter network by hostname — reject blockedHosts
@@ -57,12 +58,13 @@ impl ScriptRunner for SeatbeltScriptRunner {
             ));
         }
 
-        // Reject timeouts that are too small for our polling interval to
-        // enforce accurately.
-        if request.script_timeout > 0 && u64::from(request.script_timeout) < POLL_INTERVAL_MS {
+        // Reject timeouts that are too small for the pty bridge's poll
+        // interval to enforce accurately.
+        let poll_ms = PtyOptions::POLL_INTERVAL.as_millis() as u64;
+        if request.script_timeout > 0 && u64::from(request.script_timeout) < poll_ms {
             return Err(error_response(format!(
                 "scriptTimeout {}ms is below the minimum of {}ms",
-                request.script_timeout, POLL_INTERVAL_MS
+                request.script_timeout, poll_ms
             )));
         }
 
@@ -101,7 +103,7 @@ impl ScriptRunner for SeatbeltScriptRunner {
             profile_path.display()
         );
 
-        // 3. Spawn `sandbox-exec -f <profile> /bin/sh -c <script>`.
+        // 3. Build `sandbox-exec -f <profile> /bin/sh -c <script>`.
         let mut command = Command::new(SANDBOX_EXEC);
         command
             .arg("-f")
@@ -125,64 +127,46 @@ impl ScriptRunner for SeatbeltScriptRunner {
             command.current_dir(&request.working_directory);
         }
 
-        command
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let mut child = match command.spawn() {
-            Ok(process) => process,
-            Err(error) => {
-                return error_response(format!(
-                    "failed to spawn {SANDBOX_EXEC}: {error}; ensure sandbox-exec exists"
-                ))
-            }
-        };
-
-        // 4. Drain stdout/stderr in background threads to avoid deadlock
-        //    if the child fills the OS pipe buffer (~64KB on macOS).
-        let stdout_handle = child
-            .stdout
-            .take()
-            .map(|reader| std::thread::spawn(move || read_to_string(reader)));
-        let stderr_handle = child
-            .stderr
-            .take()
-            .map(|reader| std::thread::spawn(move || read_to_string(reader)));
-
-        // 5. Wait with timeout. `script_timeout == 0` means infinite.
+        // 4. Hand off to the shared pty bridge. Seatbelt has no parent-side
+        //    sigwait watchdog (unlike LXC's signal_cleanup), so no signals
+        //    need unblocking in the child.
         let timeout = if request.script_timeout == 0 {
             None
         } else {
             Some(Duration::from_millis(u64::from(request.script_timeout)))
         };
 
-        let exit_status = match wait_with_timeout(&mut child, timeout) {
-            Ok(status) => status,
-            Err(WaitError::Timeout) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return ScriptResponse {
+        let options = PtyOptions {
+            timeout,
+            ..PtyOptions::default()
+        };
+
+        match run_with_pty(command, options) {
+            Ok(PtyOutcome::Exited(status)) => ScriptResponse {
+                exit_code: status.code().unwrap_or(-1),
+                standard_out: String::new(),
+                standard_err: String::new(),
+                error_message: String::new(),
+            },
+            Ok(PtyOutcome::TimedOut) => {
+                let _ = writeln!(
+                    logger,
+                    "Seatbelt: script timed out after {}ms",
+                    request.script_timeout
+                );
+                ScriptResponse {
                     exit_code: -1,
-                    standard_out: join_reader("stdout", stdout_handle),
-                    standard_err: join_reader("stderr", stderr_handle),
+                    standard_out: String::new(),
+                    standard_err: String::new(),
                     error_message: format!(
                         "Seatbelt: script timed out after {}ms",
                         request.script_timeout
                     ),
-                };
+                }
             }
-            Err(WaitError::Io(error)) => return error_response(format!("wait failed: {error}")),
-        };
-
-        let stdout = join_reader("stdout", stdout_handle);
-        let stderr = join_reader("stderr", stderr_handle);
-
-        ScriptResponse {
-            exit_code: exit_status.code().unwrap_or(-1),
-            standard_out: stdout,
-            standard_err: stderr,
-            error_message: String::new(),
+            Err(error) => error_response(format!(
+                "failed to spawn {SANDBOX_EXEC}: {error}; ensure sandbox-exec exists"
+            )),
         }
     }
 }
@@ -196,80 +180,20 @@ fn error_response(message: String) -> ScriptResponse {
     }
 }
 
-/// Reads all bytes from `r` into a String. Returns whatever was captured
-/// even if the read fails partway (e.g. broken pipe from a killed child).
-fn read_to_string<R: std::io::Read>(mut reader: R) -> (String, Option<std::io::Error>) {
-    let mut buffer = String::new();
-    match reader.read_to_string(&mut buffer) {
-        Ok(_) => (buffer, None),
-        Err(error) => (buffer, Some(error)),
-    }
-}
-
-fn join_reader(
-    name: &str,
-    handle: Option<std::thread::JoinHandle<(String, Option<std::io::Error>)>>,
-) -> String {
-    match handle {
-        Some(h) => match h.join() {
-            Ok((output, None)) => output,
-            Ok((output, Some(error))) => {
-                eprintln!(
-                    "Seatbelt: warning: failed to read child {}: {}",
-                    name, error
-                );
-                output
-            }
-            Err(_) => {
-                eprintln!("Seatbelt: warning: child {} reader thread panicked", name);
-                String::new()
-            }
-        },
-        None => String::new(),
-    }
-}
-
-enum WaitError {
-    Timeout,
-    Io(std::io::Error),
-}
-
-/// Wait for `child` to exit, polling at `POLL_INTERVAL_MS` intervals if a
-/// timeout is set. We poll manually rather than adding an async runtime
-/// dependency since the runner is otherwise synchronous.
-fn wait_with_timeout(
-    child: &mut std::process::Child,
-    timeout: Option<Duration>,
-) -> Result<std::process::ExitStatus, WaitError> {
-    let Some(deadline) = timeout.map(|duration| Instant::now() + duration) else {
-        return child.wait().map_err(WaitError::Io);
-    };
-
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return Ok(status),
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    return Err(WaitError::Timeout);
-                }
-                std::thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));
-            }
-            Err(error) => return Err(WaitError::Io(error)),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::logger::{Logger, Mode};
     use wxc_common::models::{CodexRequest, SeatbeltConfig};
 
     fn base_request() -> CodexRequest {
-        let mut request = CodexRequest::default();
-        request.experimental_enabled = true;
-        request.experimental.seatbelt = Some(SeatbeltConfig::default());
-        request
+        CodexRequest {
+            experimental_enabled: true,
+            experimental: wxc_common::models::ExperimentalConfig {
+                seatbelt: Some(SeatbeltConfig::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/src/seatbelt_common/src/seatbelt_runner.rs
+++ b/src/seatbelt_common/src/seatbelt_runner.rs
@@ -154,9 +154,7 @@ impl ScriptRunner for SeatbeltScriptRunner {
                 let _ = writeln!(logger, "{msg}");
                 error_response(msg)
             }
-            Err(error) => error_response(format!(
-                "failed to spawn {SANDBOX_EXEC}: {error}; ensure sandbox-exec exists"
-            )),
+            Err(error) => error_response(format!("Seatbelt: {error}")),
         }
     }
 }


### PR DESCRIPTION
## 📖 Description

Three related fixes that surfaced together when getting the macOS Seatbelt backend usable end-to-end through a pty-driven host (e.g. Copilot CLI's shell tool).

**`fix(darwin): seatbelt pty support`** — the Seatbelt runner now attaches the inner `/bin/sh` to a freshly-allocated pty pair so `isatty(0/1/2)` returns true and host-side stdio is streamed live, mirroring the LXC behaviour. To avoid duplicating ~150 lines of pty plumbing across the two backends, the bridge (`openpty` + slave dup×3 + `pre_exec` with `setsid` + `TIOCSCTTY` + optional sigmask reset + ready-signalled stdin forwarding + timeout-aware wait) was moved into a new leaf crate `src/mxc_pty/`. `lxc_common::lxc_bindings::attach_run` and `seatbelt_common::seatbelt_runner::execute` both delegate to `mxc_pty::run_with_pty`. The Seatbelt profile gains `(allow file-read* file-write* file-ioctl (subpath "/dev"))` so the inner shell's `tcgetattr`/`ttyname` calls against the pty slave don't fail with EPERM. The SDK gains a `darwin` branch in `resolveBinaryAndCommonArgs` so `spawnSandbox` actually picks `mxc-exec-mac` on macOS instead of falling through to the Windows binary lookup.

**`fix: whoami command on non windows`** — `getDiagnosticPipeName` invoked `whoami /user /fo csv /nh` on every platform; GNU/BSD `whoami` rejects the Windows-only flags and prints `usage: whoami` to stderr, which now leaks into the new pty bridge's host-side output. The function short-circuits to the base pipe name on non-Windows (where the diagnostic console isn't used anyway) before spawning the child.

**`chore: simplify`** — small cleanup of the Seatbelt outcome handling: dedup the timeout message, use `ScriptResponse::default()` (which already exists with the right defaults) instead of restating each field.

## 🔗 References

https://github.com/github/copilot-agent-runtime/issues/164
closes https://github.com/microsoft/mxc/issues/311

## 🔍 Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p mxc_pty -p lxc_common -p seatbelt_common -p mxc_darwin -p lxc --all-targets -- -D warnings` — clean
- `cargo test -p mxc_pty -p lxc_common -p seatbelt_common`:
  - `mxc_pty`: 4 passed (incl. real-process integration tests for `echo` + 750 ms `sleep` timeout under pty)
  - `lxc_common`: 25 passed
  - `seatbelt_common`: 17 passed (incl. existing `rejects_blocked_hosts`)
- Manual on macOS: `mxc-exec-mac` driven through the SDK's pty wrapper — output streams live, no `usage: whoami` noise on stderr, exit codes propagate, timeout path kills the child and surfaces the `script timed out` message.

Workspace-wide `cargo clippy --workspace` is **not** part of validation here because of a pre-existing `windows-future` / `windows-core` version mismatch in `isolation_session_bindings` that breaks the build on macOS — unrelated to this PR.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

> The new `mxc_pty` crate is a workspace member but has no user-facing surface (no schema, no SDK exports, no CLI commands). The `docs/macos-support/seatbelt-backend.md` and `.github/copilot-instructions.md` workspace-structure section could optionally be updated to mention `mxc_pty` as the shared pty bridge — flagged for reviewer judgment, not done in this PR.

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/312)
