### PR TITLE
Initial Learning Mode Checkin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -152,6 +152,34 @@ xperf -stop
 xperf -merge user.etl kernel.etl merged.etl
 ```
 
+### `--audit` Flag
+
+The `wxc` CLI supports an `--audit` flag that automates the start/stop tracing flow above using the `Application Capability Profiler (ACP)` module, via the PowerShell helpers in [`src/learning_mode/`](src/learning_mode/readme.md).
+
+When `--audit` is passed:
+
+1. `permissiveLearningMode` is appended to the container's capability list, so the AppContainer runs in audit (non-blocking) mode and the profiler can observe all file accesses.
+2. **Before** the runner starts, `wxc` invokes `start_plm_logging.ps1` to begin an ACP profiling session.
+3. The script/container runs as usual.
+4. **After** the runner completes, `wxc` invokes `stop_plm_logging.ps1 -FilePath <config-path>`, where `<config-path>` is the JSON config that was passed to `wxc`. The stop script:
+   - Writes the ETL trace, `results.csv`, `summary.txt`, and `manifest.xml` to a timestamped folder under `logs\`.
+   - Parses `summary.txt` for observed file accesses.
+   - Emits an `Adjusted_<config-name>.json` next to the original config, with the observed paths merged into `filesystem.readwritePaths`.
+
+Example:
+
+```powershell
+wxc --audit --config-path C:\path\to\my-config.json
+```
+
+After the run, `Adjusted_my-config.json` will sit next to `my-config.json`, ready to be used as a tightened (or expanded) policy that reflects what the workload actually touched.
+
+> NOTE: `wxc` currently shells out to a hard-coded helper path (`C:\Users\AdminUser\Desktop\MXC\start_plm_logging.ps1` / `stop_plm_logging.ps1`). The helpers themselves live in [`src/learning_mode/`](src/learning_mode/readme.md) — see that readme for the full parameter list (`-LogDir`, `-FilePath`, and the stubbed `-OutputConfigPath` / `-InPlaceEdit` / `-AcpPath` parameters).
+
+ACP needs to be swapped out for XPERF
+Code in main.rs should be moved to another files (LearningMode.rs?)
+Finalize paths for output, and output structure
+
 ## Linux Support (LXC)
 
 MXC also supports Linux via [LXC (Linux Containers)](https://linuxcontainers.org/lxc/). On Linux, the `lxc-exec` binary provides container-based isolation using Linux namespaces, bind mounts for filesystem policy, and iptables/nftables for network policy.

--- a/src/learning_mode/readme.md
+++ b/src/learning_mode/readme.md
@@ -1,0 +1,85 @@
+# Learning Mode — PLM Logging Scripts
+
+PowerShell helpers around the `ApplicationCapabilityProfiler` module that capture an ETW trace of a sandboxed run and roll the observed file accesses back into an MXC container config. This is currently capable of detecting and resoving filesystem access failures. This will be expanded to capability, UI, and network failure mitigation. 
+The intended workflow is:
+
+1. Run `start_plm_logging.ps1` to begin profiling.
+2. Exercise the workload you want to learn (e.g., run your app or test config).
+3. Run `stop_plm_logging.ps1 -FilePath <path-to-mxc-config.json>` to stop profiling and emit an "Adjusted_" config with the discovered read/write paths merged in.
+
+Both scripts depend on `Microsoft.Windows.Win32Isolation.ApplicationCapabilityProfiler.dll` being available at:
+
+```
+c:\users\adminuser\desktop\acp\
+```
+
+(see the `$AcpPath` variable in each script).
+
+> NOTE: There is a `#TODO replace with xperf` marker in both scripts — long term the intent is to migrate away from the ACP module to xperf.
+
+## `start_plm_logging.ps1`
+
+Imports the profiler module and starts a profiling session.
+
+```powershell
+.\start_plm_logging.ps1
+```
+
+No parameters. Internally:
+
+- Imports `$AcpPath\Microsoft.Windows.Win32Isolation.ApplicationCapabilityProfiler.dll`.
+- Calls `Start-Profiling -Force` to begin a new trace (the `-Force` flag overrides any existing session).
+
+## `stop_plm_logging.ps1`
+
+Stops the in-progress profiling session, writes trace artifacts to a timestamped log directory, parses the resulting summary to extract observed file paths, and optionally merges those paths into a provided MXC container config.
+
+```powershell
+.\stop_plm_logging.ps1 [-LogDir <path>] [-FilePath <path-to-config.json>] [-OutputConfigPath <path>] [-InPlaceEdit <bool>] [-AcpPath <path>]
+```
+
+### Parameters
+
+| Name                 | Type     | Default                                                         | Description |
+|----------------------|----------|-----------------------------------------------------------------|-------------|
+| `-LogDir`            | `string` | `<cwd>\logs\yyyy-MM-dd_HHmmss`                                  | Directory where the ETL trace and profiling outputs are written. Created if missing. |
+| `-FilePath`          | `string` | *(none)*                                                        | Optional path to an MXC container config (JSON). When provided, an adjusted copy is produced and the discovered file paths are merged into `filesystem.readwritePaths`. |
+| `-OutputConfigPath`  | `string` | *(none)*                                                        | *(stubbed — not yet wired up)* Reserved for specifying an explicit output location for the adjusted config. |
+| `-InPlaceEdit`       | `bool`   | `$false`                                                        | *(stubbed — not yet wired up)* Reserved for editing `-FilePath` in place instead of producing an `Adjusted_*.json` copy. |
+| `-AcpPath`           | `string` | *(none — script falls back to `c:\users\adminuser\desktop\acp`)*| *(stubbed — not yet wired up)* Reserved for overriding the location of `Microsoft.Windows.Win32Isolation.ApplicationCapabilityProfiler.dll`. |
+
+### Outputs (written to `$LogDir`)
+
+- `trace.etl`     — raw profiling trace.
+- `results.csv`   — per-record results from `Get-ProfilingResults`.
+- `summary.txt`   — human-readable summary (used by the script to extract file paths).
+- `manifest.xml`  — manifest emitted by `Get-ProfilingResults`.
+- If `-FilePath` is supplied:
+  - `<original-name>.json`           — verbatim copy of the source config.
+  - `Adjusted_<original-name>.json`  — config with the merged `filesystem.readwritePaths`. A copy of this adjusted file is also written back next to the original `-FilePath`.
+
+### Behavior
+
+1. Imports the profiler module and creates `$LogDir`.
+2. Calls `Stop-Profiling -TracePath $LogDir\trace.etl`.
+3. Calls `Get-ProfilingResults` to produce `results.csv`, `summary.txt`, and `manifest.xml` in `$LogDir`.
+4. Parses `summary.txt`:
+   - Finds the section that begins with `Type: File`.
+   - For each non-blank line in that section, strips the `\??\` NT-path prefix and collects the remaining path.
+5. If `-FilePath` is provided:
+   - Copies the config into `$LogDir`, parses it as JSON, and ensures `filesystem.readwritePaths` exists (creating it — and a `filesystem` object — if missing).
+   - Appends any newly observed file paths that aren't already present in `readwritePaths`.
+   - For each entry in the merged list that exists on disk as a file (`Test-Path -PathType Leaf`), also adds its parent directory to `readwritePaths` if not already covered. (The current implementation widens `readwritePaths` rather than emitting a separate `readonlyPaths` — see the inline comment in the script.)
+   - Writes the result to `Adjusted_<name>.json` in `$LogDir` and copies it back to the directory containing `-FilePath`.
+
+### Example
+
+```powershell
+.\start_plm_logging.ps1
+
+# ... run the workload to be profiled ...
+
+.\stop_plm_logging.ps1 -FilePath C:\Tessera\mxc\test_configs\basic_appcontainer.json
+```
+
+After completion, `Adjusted_basic_appcontainer.json` will sit next to the original config with the learned paths folded into `filesystem.readwritePaths`.

--- a/src/learning_mode/start_plm_logging.ps1
+++ b/src/learning_mode/start_plm_logging.ps1
@@ -1,0 +1,5 @@
+#TODO replace with xperf
+
+$AcpPath = "c:\users\adminuser\desktop\acp"
+import-module "$AcpPath\Microsoft.Windows.Win32Isolation.ApplicationCapabilityProfiler.dll"
+start-profiling -force

--- a/src/learning_mode/stop_plm_logging.ps1
+++ b/src/learning_mode/stop_plm_logging.ps1
@@ -1,0 +1,83 @@
+#Param for file locations
+param(
+    [string]$LogDir = (Join-Path (Get-Location) "logs" (Get-Date -Format "yyyy-MM-dd_HHmmss")),
+    [string]$FilePath,
+    [string]$OutputConfigPath,
+    [bool]$InPlaceEdit,
+    [string]$AcpPath
+)
+
+
+#TODO replace with xperf
+$AcpPath = "c:\users\adminuser\desktop\acp"
+import-module "$AcpPath\Microsoft.Windows.Win32Isolation.ApplicationCapabilityProfiler.dll"
+
+$traceFileName = "trace.etl"
+New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+# Set-Location $logDir
+
+stop-profiling -TracePath $logDir\$traceFileName
+Get-ProfilingResults -EtlFilePaths $logDir\$traceFileName -RecordsOutputPath $logDir\results.csv -SummaryOutputPath $logDir\summary.txt -ManifestPath $logDir\manifest.xml
+
+$summaryPath = Join-Path $logDir "summary.txt"
+$filePaths = @()
+if (Test-Path $summaryPath) {
+    $inFileSection = $false
+    foreach ($line in Get-Content $summaryPath) {
+        if ($line -match '^\s*Type:\s*File\s*$') {
+            $inFileSection = $true
+            continue
+        }
+        if ($inFileSection -and -not ($line.Trim() -eq '')) {
+            $trimmed = $line.Trim()
+
+            #Stripping away leading \\??\\
+            $trimmed = $trimmed.substring(4)
+
+            $filePaths += $trimmed
+            # Write-Host $trimmed
+        }
+    }
+    Write-Host #newline
+}
+
+if ($FilePath) {
+    $destConfig = Join-Path $logDir (Split-Path $FilePath -Leaf)
+    Copy-Item -Path $FilePath -Destination $destConfig -Force
+    $config = Get-Content $destConfig -Raw | ConvertFrom-Json
+    write-host $config
+
+    if (-not $config.PSObject.Properties['filesystem']) {
+        $config | Add-Member -NotePropertyName filesystem -NotePropertyValue ([pscustomobject]@{})
+    }
+    if (-not $config.filesystem.PSObject.Properties['readwritePaths']) {
+        $config.filesystem | Add-Member -NotePropertyName readwritePaths -NotePropertyValue @()
+    }
+
+    $ReadWrite = @($config.filesystem.readwritePaths)
+    $merged = $ReadWrite + ($filePaths | Where-Object { $ReadWrite -notcontains $_ })
+    $config.filesystem.readwritePaths = [string[]]$merged
+
+    # if (-not $config.filesystem.PSObject.Properties['readonlyPaths']) {
+    #     $config.filesystem | Add-Member -NotePropertyName readonlyPaths -NotePropertyValue @()
+    # }
+    
+    # Only files have their parent directories added as readonly. 
+    # I couldn't get this to work with just read @Salah does shouldn't it only require read desktop if it has explicit write permission for a file?
+
+    $readonly = @($config.filesystem.readwritePaths)
+    foreach ($p in  $readonly) {
+        if (-not (Test-Path -Path $p -PathType Leaf)) { continue }
+        $parent = Split-Path $p -Parent
+        if ($parent -and ($readonly -notcontains $parent) -and ($readonly -notcontains $parent)) {
+            $readonly += $parent
+        }
+    }
+    $config.filesystem.readwritePaths = [string[]]$readonly
+
+    $adjustedPath = Join-Path (Split-Path $destConfig -Parent) ("Adjusted_" + (Split-Path $destConfig -Leaf))
+    $config | ConvertTo-Json -Depth 32 | Set-Content -Path $adjustedPath -Encoding UTF8
+
+    Copy-Item -Path $adjustedPath  -Destination (Split-Path $FilePath -Parent)
+}
+

--- a/src/wxc/build.rs
+++ b/src/wxc/build.rs
@@ -1,14 +1,68 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Build script for wxc — copies NanVix binaries next to the output executable.
+//! Build script for wxc — copies NanVix binaries and learning-mode PowerShell
+//! helpers next to the output executable.
 
 fn main() {
     #[cfg(all(windows, feature = "microvm"))]
     copy_nanvix_binaries();
 
+    #[cfg(all(windows, debug_assertions))]
+    copy_learning_mode_scripts();
+
     // Always emit rerun-if-changed so Cargo doesn't re-run unnecessarily.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+#[cfg(all(windows, debug_assertions))]
+fn copy_learning_mode_scripts() {
+    use std::fs;
+    use std::path::Path;
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let src_dir = Path::new(&manifest_dir).join("..").join("learning_mode");
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let target_dir = Path::new(&out_dir)
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent());
+
+    let target_dir = match target_dir {
+        Some(d) => d,
+        None => {
+            eprintln!("wxc build.rs: could not determine target dir from OUT_DIR");
+            return;
+        }
+    };
+
+    for name in &["start_plm_logging.ps1", "stop_plm_logging.ps1"] {
+        let src = src_dir.join(name);
+        let dst = target_dir.join(name);
+
+        println!("cargo:rerun-if-changed={}", src.display());
+
+        if !src.exists() {
+            eprintln!(
+                "wxc build.rs: WARNING: {} not found, skipping",
+                src.display()
+            );
+            continue;
+        }
+
+        if !dst.exists() || is_newer(&src, &dst) {
+            eprintln!(
+                "wxc build.rs: copying {} -> {}",
+                src.display(),
+                dst.display()
+            );
+            if let Err(e) = fs::copy(&src, &dst) {
+                let _ = fs::remove_file(&dst);
+                eprintln!("wxc build.rs: WARNING: failed to copy {}: {}", name, e);
+            }
+        }
+    }
 }
 
 #[cfg(all(windows, feature = "microvm"))]
@@ -63,7 +117,7 @@ fn copy_nanvix_binaries() {
     println!("cargo:rerun-if-env-changed=DEP_NANVIX_BINARIES_BIN_DIR");
 }
 
-#[cfg(all(windows, feature = "microvm"))]
+#[cfg(windows)]
 fn is_newer(src: &std::path::Path, dst: &std::path::Path) -> bool {
     let src_time = src.metadata().and_then(|m| m.modified()).ok();
     let dst_time = dst.metadata().and_then(|m| m.modified()).ok();

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -282,7 +282,7 @@ fn main() {
         }
     };
 
-    let mut request: CodexRequest = request;
+    let mut request= request;
     request.experimental_enabled = cli.experimental;
     request.dry_run = cli.dry_run;
 
@@ -364,22 +364,6 @@ fn main() {
         "{}",
         wxc_common::diagnostic::redacted_request_json(&request)
     );
-
-    // // If permissiveLearningMode is enabled, require explicit user confirmation before proceeding.
-    // if request
-    //     .policy
-    //     .capabilities
-    //     .iter()
-    //     .any(|c| c == "permissiveLearningMode")
-    // {
-    //     #[cfg(debug_assertions)]
-    //     eprintln!(
-    //         "WARNING: permissiveLearningMode is enabled. \
-    //          Container restrictions will NOT be enforced."
-    //     );
-    //     eprintln!("Press Enter to continue...");
-    //     let _ = std::io::stdin().read_line(&mut String::new());
-    // }
 
     // Run script in selected containment backend.
     // BaseContainer is used when --experimental is passed or schema version >= 0.5.

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -282,7 +282,7 @@ fn main() {
         }
     };
 
-    let mut request= request;
+    let mut request = request;
     request.experimental_enabled = cli.experimental;
     request.dry_run = cli.dry_run;
 

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -79,6 +79,10 @@ struct Cli {
     /// the new bits. Requires --setup-hyperlight.
     #[arg(long, requires = "setup_hyperlight")]
     force: bool,
+
+    /// Enable Audit mode for AppContainers
+    #[arg(long = "audit")]
+    audit: bool,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -278,9 +282,16 @@ fn main() {
         }
     };
 
-    let mut request = request;
+    let mut request: CodexRequest = request;
     request.experimental_enabled = cli.experimental;
     request.dry_run = cli.dry_run;
+
+    if cli.audit {
+        request
+            .policy
+            .capabilities
+            .push("permissiveLearningMode".to_string());
+    }
 
     // Inject learningModeLogging capability when diagnostic console is enabled.
     let learning_mode_injected = if DiagnosticConfig::force_learning_mode()
@@ -353,6 +364,22 @@ fn main() {
         "{}",
         wxc_common::diagnostic::redacted_request_json(&request)
     );
+
+    // // If permissiveLearningMode is enabled, require explicit user confirmation before proceeding.
+    // if request
+    //     .policy
+    //     .capabilities
+    //     .iter()
+    //     .any(|c| c == "permissiveLearningMode")
+    // {
+    //     #[cfg(debug_assertions)]
+    //     eprintln!(
+    //         "WARNING: permissiveLearningMode is enabled. \
+    //          Container restrictions will NOT be enforced."
+    //     );
+    //     eprintln!("Press Enter to continue...");
+    //     let _ = std::io::stdin().read_line(&mut String::new());
+    // }
 
     // Run script in selected containment backend.
     // BaseContainer is used when --experimental is passed or schema version >= 0.5.
@@ -473,6 +500,23 @@ fn main() {
         }
     };
 
+    if cli.audit {
+        match std::process::Command::new("pwsh.exe")
+            .args([
+                "-command",
+                "C:\\Users\\AdminUser\\Desktop\\MXC\\start_plm_logging.ps1",
+            ])
+            .status()
+        {
+            Ok(status) => {
+                let _ = writeln!(logger, "start_plm_logging.ps1 start exited with {}", status);
+            }
+            Err(e) => {
+                let _ = writeln!(logger, "Failed to start start_plm_logging.ps1: {}", e);
+            }
+        }
+    }
+
     let run_start = Instant::now();
     let response = runner.run(&request, &mut logger);
     let run_elapsed = run_start.elapsed();
@@ -495,5 +539,25 @@ fn main() {
     if !response.standard_err.is_empty() {
         eprint!("{}", response.standard_err);
     }
+
+    if cli.audit {
+        match std::process::Command::new("pwsh.exe")
+            .args([
+                "-command",
+                "C:\\Users\\AdminUser\\Desktop\\MXC\\stop_plm_logging.ps1",
+                "-FilePath",
+                &cli.config_path.unwrap_or_default(),
+            ])
+            .status()
+        {
+            Ok(status) => {
+                let _ = writeln!(logger, "stop_plm_logging.ps1 stop exited with {}", status);
+            }
+            Err(e) => {
+                let _ = writeln!(logger, "Failed to stop stop_plm_logging.ps1: {}", e);
+            }
+        }
+    }
+
     process::exit(response.exit_code);
 }


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Adding support for automatic permissive learning mode logging through --audit
It's currently cumbersome to edit and diagnose failures for sandboxed apps.
This currently does not support capability failure mitigation, though it can detect failure, UI or networks. Those will be added in future PRs

## 🔗 References

#62261659
#62261667
#62261659

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
Manually tested using a VM and test executable

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [x] Feature
- [ ] Task

## TODO Before check-in
Add automated testing before check-in
Remove hardcoded paths
Move Learning mode rust code out of main.rs
