### PR TITLE
hyperlight: pin v0.4.0 release, deny inbound bind

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -843,8 +843,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.1.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#0eb9887fbccf338208efe37101b04e7ffa204424"
+version = "0.4.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#0bcbd386ce5a00c8a3f6a594bfc5eca267db6da0"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -200,9 +200,12 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     logger.log_line("hyperlight setup: pulling image from GHCR (docker/podman)");
     let opts = pyhl::InstallOptions {
         home: &home,
-        source: pyhl::InstallSource::Ghcr,
+        source: pyhl::InstallSource::Ghcr {
+            tag: Some("v0.4.0"),
+        },
         mounts: &[],
         network: None,
+        listen_ports: None,
         force,
     };
     let report = pyhl::install(&opts).map_err(|e| format!("hyperlight install: {e:#}"))?;
@@ -462,6 +465,7 @@ impl HyperlightScriptRunner {
                 },
                 mounts: &preopens,
                 network: network.as_ref(),
+                listen_ports: None,
                 force: false,
             };
             let report = pyhl::install(&opts)
@@ -473,7 +477,7 @@ impl HyperlightScriptRunner {
         }
 
         logger.log_line(&format!("hyperlight: using image home {home:?}"));
-        let rt = pyhl::Runtime::new(home, &preopens, network.as_ref())
+        let rt = pyhl::Runtime::new(home, &preopens, network.as_ref(), None)
             .map_err(|e| PyhlError::Runtime(format!("open hyperlight runtime: {e:#}")))?;
         self.runtime = Some(rt);
         self.active_home = Some(home.to_path_buf());


### PR DESCRIPTION
Bump hyperlight-unikraft to v0.4.0 and pin the GHCR image pull to the
tagged release instead of :latest for deterministic installs.

- Pin InstallSource::Ghcr to tag v0.4.0
- Pass listen_ports: None on all call sites (denies all inbound bind
  by default)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/320)