### PR TITLE
MXC Playground + Windows Sandbox daemon fixes

### DIFF
--- a/docs/playground-limitations.md
+++ b/docs/playground-limitations.md
@@ -1,0 +1,143 @@
+# MXC Playground — Known Limitations & Compatibility
+
+## Platform Support
+
+| Feature | Windows 24H2 (build 26100) | Windows 25H2+ (build 26600+) | Linux |
+|---------|---------------------------|------------------------------|-------|
+| AppContainer (v0.4.0) | ✅ Works | ✅ Works | N/A |
+| BaseContainer (v0.5.0) | ❌ No processmodel.dll | ✅ Works | N/A |
+| BFS filesystem brokering | ❌ No bfscfg.exe | ✅ Works | N/A |
+| Proxy (AppContainer) | ✅ Works (needs admin for shim) | ✅ Works | N/A |
+| Proxy (BaseContainer) | N/A | ⚠️ WinHTTP only, see below | N/A |
+| LXC containers | N/A | N/A | ✅ Works |
+
+## Shell Compatibility in Containers
+
+| Shell | AppContainer (v0.4.0) | BaseContainer (v0.5.0) default UI | BaseContainer with relaxed UI |
+|-------|----------------------|-----------------------------------|-------------------------------|
+| cmd.exe | ✅ Works | ✅ Works (even with Win32k disabled) | ✅ Works |
+| powershell.exe (5.1) | ✅ Works | ❌ DLL_INIT_FAILED (ui_restrictions=0x03FF) | ✅ Works (set isolation=desktop) |
+| pwsh.exe (7+) | ✅ Works (if installed system-wide) | ❌ Same as PS 5.1 | ✅ Works (set isolation=desktop) |
+| python.exe | ⚠️ Needs ALL APPLICATION PACKAGES ACL | ❌ Same as PS 5.1 | Untested |
+| curl.exe | ✅ Works | ✅ Works (no Win32k needed) | ✅ Works |
+
+### PowerShell in BaseContainer
+
+PowerShell (both 5.1 and 7+) fails with `STATUS_DLL_INIT_FAILED` (0xC0000142) when
+BaseContainer uses default UI restrictions (`ui_restrictions=0x03FF`). This is because the
+default-deny policy sets all UILIMIT flags, and PowerShell's DLL initialization requires
+access to desktop handles.
+
+**Workaround:** Set `appContainer.ui.isolation` to `"desktop"` in the ContainerConfig to
+relax handle/atoms restrictions. This allows PowerShell to initialize while still enforcing
+other restrictions (clipboard, injection, etc.).
+
+### Python in AppContainers
+
+Per-user Python installs (`AppData\Local\Python\`) cannot be executed inside AppContainers
+because they lack `ALL APPLICATION PACKAGES` ACL. System-wide Python installs (`C:\Python*`)
+work if the ACL is set:
+
+```
+icacls C:\Python314 /grant "ALL APPLICATION PACKAGES:(OI)(CI)(RX)" /T
+```
+
+This is a Windows security model limitation, not an MXC bug.
+
+## Network Limitations
+
+### DNS Resolution
+
+| Method | AppContainer | BaseContainer |
+|--------|-------------|---------------|
+| PowerShell `Invoke-WebRequest` | ❌ DNS fails (uses .NET, not WinHTTP) | ❌ Same |
+| WinHTTP COM (`WinHttp.WinHttpRequest.5.1`) | ⚠️ See below | ⚠️ See below |
+| curl.exe | ✅ Works with proxy shim (0.4.0) | ❌ Doesn't use WinHTTP auto-proxy |
+
+### PowerShell `Invoke-WebRequest` DNS Issue
+
+`Invoke-WebRequest` uses .NET's `HttpClient` which performs DNS resolution in-process.
+Inside an AppContainer without DNS access, this fails even when `internetClient` capability
+is granted. `internetClient` enables TCP connections but does not grant DNS resolution
+for .NET's resolver.
+
+**Workaround:** Use WinHTTP-based tools (curl.exe with proxy shim, or WinHTTP COM object)
+instead of `Invoke-WebRequest` for network tests.
+
+### Proxy Routing
+
+**AppContainer (v0.4.0):** The SDK uses `winhttp-proxy-shim.exe` (requires admin/elevation)
+to set per-AppContainer WinHTTP proxy policy via the DNS cache service. Tools that use
+WinHTTP with `WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY` (like curl.exe) respect this policy.
+Tools that use their own DNS resolution (.NET HttpClient, PowerShell) do not.
+
+**BaseContainer (v0.5.0):** The proxy URL is passed in the FlatBuffer spec to
+`CreateProcessInSandbox`. The OS-level `appinfosvc` configures WinHTTP proxy for the
+container. System-level WinHTTP sessions (Windows telemetry) use the proxy. App-created
+WinHTTP sessions may or may not pick it up depending on how they're initialized.
+
+### Admin Requirements
+
+| Feature | Needs Admin? |
+|---------|-------------|
+| Basic AppContainer execution | No |
+| BFS filesystem brokering | No |
+| Network (capabilities only) | No |
+| Network (firewall rules) | Yes — `netsh advfirewall` |
+| Proxy shim (v0.4.0) | Yes — elevated winhttp-proxy-shim |
+| Proxy (v0.5.0 BaseContainer) | No — handled by OS |
+
+## UI Restrictions (BaseContainer)
+
+### Default UI Restrictions Bitmask
+
+When `ui.disable=false` (UI enabled) with default settings, all sub-restrictions are applied:
+
+| Flag | Value | Default | Effect |
+|------|-------|---------|--------|
+| HANDLES | 0x0001 | ON | Blocks access to window handles |
+| READCLIPBOARD | 0x0002 | ON | Blocks clipboard read |
+| WRITECLIPBOARD | 0x0004 | ON | Blocks clipboard write |
+| SYSTEMPARAMETERS | 0x0008 | ON | Blocks system parameter changes |
+| DISPLAYSETTINGS | 0x0010 | ON | Blocks display setting changes |
+| GLOBALATOMS | 0x0020 | ON | Blocks global atom access |
+| DESKTOP | 0x0040 | ON | Blocks desktop switching |
+| EXITWINDOWS | 0x0080 | ON | Blocks shutdown/logoff |
+| IME | 0x0100 | ON | Blocks IME |
+| INJECTION | 0x0200 | ON | Blocks input injection |
+
+**Total default: 0x03FF** (all flags on)
+
+This is by design (least-privilege). Applications that need desktop access must explicitly
+configure relaxed UI settings via the advanced API (`createConfigFromPolicy` +
+`spawnSandboxFromConfig`) with appropriate `appContainer.ui` settings.
+
+### Win32k Disabled (`ui.disable=true`)
+
+When `disallowWin32kSystemCalls=true`:
+- Only `GLOBALATOMS` (0x0020) is set as a UI restriction
+- The Win32k filter driver blocks all Win32k system calls
+- `cmd.exe` may still work (doesn't use Win32k)
+- PowerShell, GUI apps, and most Windows executables will fail
+
+## Filesystem (BFS)
+
+### Trailing Backslash
+
+Paths ending in `\` (e.g., `C:\`) are handled correctly. The SDK's bfscfg argument
+builder only quotes paths containing spaces, avoiding the `"C:\"` escaping issue.
+
+### Short Paths (8.3)
+
+BFS brokers paths using long path names. If `os.tmpdir()` returns a short path like
+`C:\Users\ADMINU~1\...`, use `fs.realpathSync.native()` to resolve it before passing
+to the SDK.
+
+## Version Compatibility
+
+| Policy Version | Schema | Backend | Status |
+|---------------|--------|---------|--------|
+| 0.4.0-alpha | Stable | AppContainer via CreateProcessW | Production |
+| 0.5.0-dev | Dev | BaseContainer via CreateProcessInSandbox | Experimental (25H2+) |
+
+The SDK accepts versions 0.4.x through 0.5.x. The Rust parser accepts `>=0.4, <=0.5`.

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+out/
+*.tgz

--- a/playground/build-renderer.js
+++ b/playground/build-renderer.js
@@ -1,0 +1,15 @@
+// Build script: copies static files to dist/renderer
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, 'src', 'renderer');
+const distDir = path.join(__dirname, 'dist', 'renderer');
+
+fs.mkdirSync(distDir, { recursive: true });
+
+// Copy HTML and CSS
+for (const file of ['index.html', 'styles.css']) {
+  fs.copyFileSync(path.join(srcDir, file), path.join(distDir, file));
+}
+
+console.log('Renderer static files copied.');

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -1,0 +1,5871 @@
+{
+  "name": "mxc-playground",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mxc-playground",
+      "version": "0.1.0",
+      "dependencies": {
+        "@microsoft/mxc-sdk": "file:../sdk",
+        "node-pty": "^1.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "electron": "^33.0.0",
+        "electron-builder": "^25.0.0",
+        "node-gyp": "^12.2.0",
+        "typescript": "^5.4.0"
+      }
+    },
+    "../sdk": {
+      "name": "@microsoft/mxc-sdk",
+      "version": "0.1.5",
+      "license": "MIT",
+      "os": [
+        "win32",
+        "linux"
+      ],
+      "dependencies": {
+        "node-pty": "^1.2.0-beta.12",
+        "semver": "^7.7.4"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@types/semver": "^7.7.1",
+        "rimraf": "^6.1.3",
+        "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
+      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@electron/rebuild/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/rebuild/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@microsoft/mxc-sdk": {
+      "resolved": "../sdk",
+      "link": true
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
+      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.1",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chromium-pickle-js": "^0.2.0",
+        "config-file-ts": "0.2.8-rc1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.1.7",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.1.8",
+        "electron-builder-squirrel-windows": "25.1.8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
+      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.10",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/builder-util/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/cacache/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
+      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
+      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
+      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "archiver": "^5.3.1",
+        "builder-util": "25.1.7",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
+      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-publish/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/temp-file/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/temp-file/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "mxc-playground",
+  "version": "0.1.0-alpha.1",
+  "description": "Visual sandbox testing tool for MXC process containers",
+  "main": "dist/main/main.js",
+  "scripts": {
+    "build:main": "tsc -p tsconfig.main.json",
+    "build:renderer": "tsc -p tsconfig.renderer.json && node build-renderer.js",
+    "build": "npm run build:main && npm run build:renderer",
+    "start": "npm run build && electron .",
+    "dev": "npm run build:main && electron .",
+    "pack": "electron-builder --dir",
+    "dist": "electron-builder"
+  },
+  "build": {
+    "appId": "com.microsoft.mxc-playground",
+    "productName": "MXC Playground",
+    "directories": {
+      "output": "out"
+    },
+    "files": [
+      "dist/**/*",
+      "node_modules/**/*"
+    ],
+    "extraResources": [
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-exec.exe",
+        "to": "bin/x64/wxc-exec.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-test-proxy.exe",
+        "to": "bin/x64/wxc-test-proxy.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/winhttp-proxy-shim.exe",
+        "to": "bin/x64/winhttp-proxy-shim.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-windows-sandbox-daemon.exe",
+        "to": "bin/x64/wxc-windows-sandbox-daemon.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-windows-sandbox-guest.exe",
+        "to": "bin/x64/wxc-windows-sandbox-guest.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-sandbox-daemon.exe",
+        "to": "bin/x64/wxc-sandbox-daemon.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/wxc-sandbox-agent.exe",
+        "to": "bin/x64/wxc-sandbox-agent.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/nanvixd.exe",
+        "to": "bin/x64/nanvixd.exe"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/kernel.elf",
+        "to": "bin/x64/kernel.elf"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/python.elf",
+        "to": "bin/x64/python.elf"
+      },
+      {
+        "from": "../src/target/x86_64-pc-windows-msvc/release/cpython-ramfs.img",
+        "to": "bin/x64/cpython-ramfs.img"
+      },
+      {
+        "from": "../sdk/bin/x64/vcruntime140.dll",
+        "to": "bin/x64/vcruntime140.dll"
+      },
+      {
+        "from": "test-scripts",
+        "to": "test-scripts"
+      }
+    ],
+    "win": {
+      "target": "dir"
+    },
+    "npmRebuild": false
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "electron": "^33.0.0",
+    "electron-builder": "^25.0.0",
+    "node-gyp": "^12.2.0",
+    "typescript": "^5.4.0"
+  },
+  "dependencies": {
+    "@microsoft/mxc-sdk": "file:../sdk",
+    "node-pty": "^1.0.0"
+  }
+}

--- a/playground/src/main/main.ts
+++ b/playground/src/main/main.ts
@@ -1,0 +1,540 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { app, BrowserWindow, dialog, ipcMain } from 'electron';
+import * as path from 'path';
+import * as pty from 'node-pty';
+
+let mainWindow: BrowserWindow | null = null;
+let activePty: pty.IPty | null = null;
+
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    minWidth: 1000,
+    minHeight: 700,
+    title: 'MXC Playground',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  mainWindow.loadFile(path.join(__dirname, '..', 'renderer', 'index.html'));
+
+  // Open external links in the default browser
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    require('electron').shell.openExternal(url);
+    return { action: 'deny' };
+  });
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!url.startsWith('file://')) {
+      event.preventDefault();
+      require('electron').shell.openExternal(url);
+    }
+  });
+
+  mainWindow.webContents.on('context-menu', (_event, params) => {
+    const { Menu } = require('electron');
+    const menu = Menu.buildFromTemplate([
+      { role: 'undo' },
+      { role: 'redo' },
+      { type: 'separator' },
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { role: 'selectAll' },
+    ]);
+    menu.popup();
+  });
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+    killActivePty();
+  });
+}
+
+function killActivePty(): void {
+  if (activePty) {
+    try {
+      activePty.kill();
+    } catch { /* already dead */ }
+    activePty = null;
+  }
+}
+
+function loadSdk(): typeof import('@microsoft/mxc-sdk') {
+  return require('@microsoft/mxc-sdk');
+}
+
+/** Resolve wxc-exec path — checks extraResources for packaged app, then falls back to SDK discovery. */
+function resolveExecutablePath(): string | undefined {
+  const fs = require('fs');
+  const sdk = loadSdk();
+
+  // Packaged Electron app: binary is in resources/bin/x64/
+  if ((process as any).resourcesPath) {
+    const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+    const packaged = path.join((process as any).resourcesPath, 'bin', arch, 'wxc-exec.exe');
+    if (fs.existsSync(packaged)) {
+      return packaged;
+    }
+  }
+
+  // Dev mode: let SDK discover it normally
+  return undefined;
+}
+
+function attachPtyListeners(ptyProcess: pty.IPty): void {
+  activePty = ptyProcess;
+
+  ptyProcess.onData((data: string) => {
+    mainWindow?.webContents.send('pty-data', data);
+  });
+
+  ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+    activePty = null;
+    mainWindow?.webContents.send('pty-exit', exitCode);
+  });
+}
+
+// IPC: Get platform support info
+ipcMain.handle('get-platform-support', () => {
+  const sdk = loadSdk();
+  return sdk.getPlatformSupport();
+});
+
+// IPC: Get available tools policy
+ipcMain.handle('get-tools-policy', () => {
+  const sdk = loadSdk();
+  return sdk.getAvailableToolsPolicy();
+});
+
+// IPC: Get user profile policy
+ipcMain.handle('get-profile-policy', () => {
+  const sdk = loadSdk();
+  return sdk.getUserProfilePolicy();
+});
+
+// IPC: Get temp files policy
+ipcMain.handle('get-temp-policy', () => {
+  const sdk = loadSdk();
+  return sdk.getTemporaryFilesPolicy();
+});
+
+// IPC: Simple mode — spawnSandbox(script, policy)
+ipcMain.handle('run-sandbox', (_event, scriptText: string, policyJson: string, debug: boolean, experimental: boolean) => {
+  killActivePty();
+  const sdk = loadSdk();
+
+  try {
+    const policy = JSON.parse(policyJson);
+    const ptyProcess = sdk.spawnSandbox(scriptText, policy, {
+      debug,
+      experimental,
+      executablePath: resolveExecutablePath(), skipPlatformCheck: true,
+    });
+    attachPtyListeners(ptyProcess);
+    return { success: true };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+});
+
+// IPC: Advanced mode — createConfigFromPolicy + spawnSandboxFromConfig
+ipcMain.handle('run-sandbox-advanced', (_event, scriptText: string, policyJson: string, debug: boolean, experimental: boolean) => {
+  killActivePty();
+  const sdk = loadSdk();
+
+  try {
+    const policy = JSON.parse(policyJson);
+    const config = sdk.createConfigFromPolicy(policy);
+    config.process!.commandLine = scriptText;
+    const ptyProcess = sdk.spawnSandboxFromConfig(config, {
+      debug,
+      experimental,
+      executablePath: resolveExecutablePath(), skipPlatformCheck: true,
+    });
+    attachPtyListeners(ptyProcess);
+    return { success: true, config: JSON.stringify(config, null, 2) };
+  } catch (err: any) {
+    return { success: false, error: err.message };
+  }
+});
+
+// IPC: Kill active sandbox
+ipcMain.handle('kill-sandbox', () => {
+  killActivePty();
+  return { success: true };
+});
+
+// IPC: Validate policy — returns the generated ContainerConfig
+ipcMain.handle('validate-policy', (_event, policyJson: string) => {
+  try {
+    const sdk = loadSdk();
+    const policy = JSON.parse(policyJson);
+    const config = sdk.createConfigFromPolicy(policy);
+    return { valid: true, config: JSON.stringify(config, null, 2) };
+  } catch (err: any) {
+    return { valid: false, error: err.message };
+  }
+});
+
+// IPC: Open folder dialog for filesystem path browsing
+ipcMain.handle('open-folder-dialog', async () => {
+  const result = await dialog.showOpenDialog(mainWindow!, {
+    properties: ['openDirectory']
+  });
+  return result.canceled ? null : result.filePaths[0];
+});
+
+// IPC: Detect available shells and resolve paths
+ipcMain.handle('detect-shells', async () => {
+  const { execSync } = require('child_process');
+  const fs = require('fs');
+  const pathMod = require('path');
+
+  // Refresh PATH from registry (picks up new installs without app restart)
+  try {
+    const freshPath = execSync(
+      'powershell.exe -NoProfile -Command "[Environment]::GetEnvironmentVariable(\'Path\',\'Machine\') + \';\' + [Environment]::GetEnvironmentVariable(\'Path\',\'User\')"',
+      { encoding: 'utf-8', timeout: 5000 }
+    ).trim();
+    if (freshPath && freshPath.length > 10) {
+      process.env.PATH = freshPath;
+    }
+  } catch { /* keep existing PATH */ }
+
+  const result: Record<string, any> = {
+    cmd: { available: true },
+    ps51: { available: true },
+    ps7: { available: false },
+    python: { available: false },
+  };
+
+  // PowerShell 7 — use Get-Command for more reliable detection than where.exe
+  // (where.exe only searches PATH; gcm also finds app execution aliases and
+  // PowerShell-registered commands)
+  try {
+    const out = execSync(
+      'powershell.exe -NoProfile -Command "(Get-Command pwsh.exe -ErrorAction SilentlyContinue -All | ForEach-Object { $_.Source }) -join [char]10"',
+      { encoding: 'utf-8', timeout: 10000 }
+    ).trim();
+    if (out) {
+      const paths = out.split('\n').map((p: string) => p.trim()).filter((p: string) => p.length > 0);
+      // Prefer non-WindowsApps path, but accept WindowsApps if it's the only one
+      var preferred = paths.find((p: string) => !p.includes('WindowsApps'));
+      var chosen = preferred || paths[0];
+      result.ps7 = { available: true, exe: chosen, rootDir: pathMod.dirname(chosen) };
+    }
+  } catch {}
+
+  // Python — find the real binary, not the WindowsApps stub or launcher
+  try {
+    const out = execSync('where.exe python.exe', { encoding: 'utf-8' });
+    const paths = out.split('\n').map((p: string) => p.trim()).filter((p: string) => p.length > 0);
+
+    for (const p of paths) {
+      // Skip WindowsApps stubs (these open the Store app)
+      if (p.includes('WindowsApps')) { continue; }
+
+      // Check if this is a per-user Python install with pythoncore-* layout
+      const dir = pathMod.dirname(p);
+      const parent = pathMod.dirname(dir);
+      try {
+        const entries = fs.readdirSync(parent);
+        const coreDir = entries.find((e: string) => e.startsWith('pythoncore-'));
+        if (coreDir) {
+          const realExe = pathMod.join(parent, coreDir, 'python.exe');
+          if (fs.existsSync(realExe)) {
+            result.python = {
+              available: true,
+              exe: realExe,
+              rootDir: parent,
+            };
+            break;
+          }
+        }
+      } catch {}
+
+      // Accept any non-WindowsApps python.exe
+      // Use the parent directory (e.g., AppData\Local\Programs\Python\) to cover all versions
+      var pyDir = pathMod.dirname(p);
+      var pyParent = pathMod.dirname(pyDir);
+      // If parent looks like a Python root (contains multiple version dirs), use it
+      var useParent = false;
+      try {
+        var siblings = fs.readdirSync(pyParent);
+        useParent = siblings.some((s: string) => s.match(/^Python\d/i) || s.startsWith('pythoncore-'));
+      } catch {}
+
+      result.python = {
+        available: true,
+        exe: p,
+        rootDir: useParent ? pyParent : pyDir,
+      };
+      break;
+    }
+
+    // Verify Python actually runs (not a stub that opens the Store)
+    if (result.python.available && result.python.exe) {
+      try {
+        execSync('"' + result.python.exe + '" --version', { encoding: 'utf-8', timeout: 5000 });
+      } catch {
+        result.python = { available: false };
+      }
+    }
+  } catch {}
+
+  // Also check system-wide Python dirs (C:\Python*)
+  if (!result.python.available || !result.python.exe) {
+    try {
+      const entries = fs.readdirSync('C:\\');
+      for (const e of entries) {
+        if (e.toLowerCase().startsWith('python')) {
+          const exe = pathMod.join('C:\\', e, 'python.exe');
+          if (fs.existsSync(exe)) {
+            result.python = { available: true, exe, rootDir: pathMod.join('C:\\', e) };
+            break;
+          }
+        }
+      }
+    } catch {}
+  }
+
+  // Check if Python install has ALL APPLICATION PACKAGES ACL
+  if (result.python.available && result.python.rootDir) {
+    try {
+      var pyAclOut = execSync('icacls "' + result.python.rootDir + '"', { encoding: 'utf-8', timeout: 5000 });
+      var pyHasAcl = pyAclOut.includes('APPLICATION PACKAGES');
+      result.python.needsAcl = !pyHasAcl;
+      result.python.isPerUser = result.python.rootDir.includes('AppData');
+    } catch {
+      result.python.needsAcl = false;
+    }
+  }
+
+  // Check if PS7 install has ALL APPLICATION PACKAGES ACL
+  if (result.ps7.available && result.ps7.rootDir) {
+    if (result.ps7.rootDir.includes('WindowsApps')) {
+      result.ps7.needsAcl = true;
+      result.ps7.isPerUser = true;
+
+      // Resolve the actual MSIX package install directory for BFS brokering.
+      // WindowsApps has restricted ACLs — the sandbox needs the real package
+      // path in readonlyPaths so BFS can broker access.
+      try {
+        const msixInstallDir = execSync(
+          'powershell.exe -NoProfile -Command "(Get-AppxPackage Microsoft.PowerShell | Select-Object -First 1).InstallLocation"',
+          { encoding: 'utf-8', timeout: 10000 }
+        ).trim();
+        if (msixInstallDir && fs.existsSync(msixInstallDir)) {
+          result.ps7.msixPackageDir = msixInstallDir;
+        }
+      } catch { /* Get-AppxPackage unavailable */ }
+    } else {
+      try {
+        var ps7AclOut = execSync('icacls "' + result.ps7.rootDir + '"', { encoding: 'utf-8', timeout: 5000 });
+        var ps7HasAcl = ps7AclOut.includes('APPLICATION PACKAGES');
+        result.ps7.needsAcl = !ps7HasAcl;
+        result.ps7.isPerUser = result.ps7.rootDir.includes('AppData');
+      } catch {
+        result.ps7.needsAcl = false;
+      }
+    }
+  }
+
+  return result;
+});
+
+// IPC: Fix Python ACL (requires admin UAC prompt)
+ipcMain.handle('fix-python-acl', async (_event, runtimePath: string) => {
+  const { execSync } = require('child_process');
+  try {
+    execSync(
+      'powershell.exe -NoProfile -Command "Start-Process icacls -ArgumentList \'' + runtimePath + ' /grant \\\"ALL APPLICATION PACKAGES:(OI)(CI)(RX)\\\" /T\' -Verb RunAs -Wait"',
+      { encoding: 'utf-8', timeout: 60000 }
+    );
+    var aclOut = execSync('icacls "' + runtimePath + '"', { encoding: 'utf-8', timeout: 5000 });
+    return { success: aclOut.includes('APPLICATION PACKAGES') };
+  } catch (e: any) {
+    return { success: false, error: e.message };
+  }
+});
+
+// IPC: Install a runtime via winget
+ipcMain.handle('install-runtime', async (_event, runtime: string) => {
+  const { execSync } = require('child_process');
+  const packages: Record<string, string> = {
+    python: 'Python.Python.3.14',
+    ps7: 'Microsoft.PowerShell',
+  };
+  const pkg = packages[runtime];
+  if (!pkg) { return { success: false, error: 'Unknown runtime: ' + runtime, log: '' }; }
+
+  try {
+    // Single elevated script: install + detect path + icacls
+    const script = `
+$ErrorActionPreference = 'Continue'
+Write-Output '=== Installing ${pkg} ==='
+winget install ${pkg} --accept-package-agreements --accept-source-agreements 2>&1 | ForEach-Object { $_ }
+Write-Output ''
+Write-Output '=== Refreshing PATH ==='
+$freshPath = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')
+$env:PATH = $freshPath
+Write-Output ''
+Write-Output '=== Finding install location ==='
+$exe = Get-Command ${runtime === 'python' ? 'python.exe' : 'pwsh.exe'} -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($exe) {
+  $dir = Split-Path $exe.Source
+  Write-Output "Found at: $dir"
+  Write-Output ''
+  Write-Output '=== Setting permissions ==='
+  icacls $dir /grant "ALL APPLICATION PACKAGES:(OI)(CI)(RX)" /T 2>&1 | Select-Object -First 5
+  Write-Output 'Done.'
+} else {
+  Write-Output 'WARNING: Could not find executable on PATH after install.'
+}
+`;
+    // Write script to temp file and run elevated
+    const fs = require('fs');
+    const tempScript = require('path').join(require('os').tmpdir(), 'mxc-install.ps1');
+    fs.writeFileSync(tempScript, script, 'utf-8');
+
+    const log = execSync(
+      'powershell.exe -NoProfile -Command "Start-Process powershell.exe -ArgumentList \'-NoProfile -ExecutionPolicy Bypass -File \\\"' + tempScript + '\\\" > \\\"%TEMP%\\\\mxc-install.log\\\" 2>&1\' -Verb RunAs -Wait; Get-Content $env:TEMP\\mxc-install.log"',
+      { encoding: 'utf-8', timeout: 180000 }
+    );
+
+    // Clean up
+    try { fs.unlinkSync(tempScript); } catch {}
+
+    // Refresh PATH in this process
+    try {
+      const freshPath = execSync(
+        'powershell.exe -NoProfile -Command "[Environment]::GetEnvironmentVariable(\'Path\',\'Machine\') + \';\' + [Environment]::GetEnvironmentVariable(\'Path\',\'User\')"',
+        { encoding: 'utf-8', timeout: 5000 }
+      ).trim();
+      if (freshPath && freshPath.length > 10) { process.env.PATH = freshPath; }
+    } catch {}
+
+    return { success: true, log };
+  } catch (e: any) {
+    return { success: false, error: e.message, log: '' };
+  }
+});
+
+// IPC: Detect all Python versions installed
+ipcMain.handle('detect-python-versions', async () => {
+  const { execSync } = require('child_process');
+  const fs = require('fs');
+  const pathMod = require('path');
+  const versions: { version: string; exe: string; rootDir: string; hasAcl: boolean }[] = [];
+
+  // Check common install locations
+  const searchDirs = [
+    'C:\\Program Files',
+    'C:\\Program Files (x86)',
+    process.env.LOCALAPPDATA ? pathMod.join(process.env.LOCALAPPDATA, 'Programs', 'Python') : '',
+    process.env.LOCALAPPDATA ? pathMod.join(process.env.LOCALAPPDATA, 'Python') : '',
+  ].filter(Boolean);
+
+  for (const base of searchDirs) {
+    try {
+      const entries = fs.readdirSync(base);
+      for (const e of entries) {
+        if (!e.match(/^Python\d/i) && !e.startsWith('pythoncore-')) { continue; }
+        const exe = pathMod.join(base, e, 'python.exe');
+        if (!fs.existsSync(exe)) { continue; }
+        // Get version
+        try {
+          const ver = execSync('"' + exe + '" --version', { encoding: 'utf-8', timeout: 5000 }).trim();
+          const verMatch = ver.match(/Python\s+(\S+)/);
+          // Check ACL
+          var aclOut = execSync('icacls "' + pathMod.join(base, e) + '"', { encoding: 'utf-8', timeout: 5000 });
+          versions.push({
+            version: verMatch ? verMatch[1] : e,
+            exe,
+            rootDir: pathMod.join(base, e),
+            hasAcl: aclOut.includes('APPLICATION PACKAGES'),
+          });
+        } catch { /* skip broken installs */ }
+      }
+    } catch { /* dir doesn't exist */ }
+  }
+
+  return versions;
+});
+
+// IPC: Ensure directories exist for write scenarios
+ipcMain.handle('ensure-dirs', (_event, dirs: string[]) => {
+  const fs = require('fs');
+  for (const dir of dirs) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch { /* ignore */ }
+  }
+  return { success: true };
+});
+
+ipcMain.handle('save-log-file', async (_event, content: string) => {
+  const fs = require('fs');
+  const { dialog } = require('electron');
+  const result = await dialog.showSaveDialog({
+    title: 'Save Run All Log',
+    defaultPath: 'mxc-playground-results.log',
+    filters: [{ name: 'Log Files', extensions: ['log', 'txt'] }],
+  });
+  if (!result.canceled && result.filePath) {
+    fs.writeFileSync(result.filePath, content, 'utf-8');
+    return { success: true, path: result.filePath };
+  }
+  return { success: false };
+});
+
+// IPC: Get test script path and content
+ipcMain.handle('get-test-script', (_event, scriptName: string) => {
+  const fs = require('fs');
+  let scriptDir: string;
+  if ((process as any).resourcesPath) {
+    scriptDir = path.join((process as any).resourcesPath, 'test-scripts');
+  } else {
+    scriptDir = path.join(__dirname, '..', '..', 'test-scripts');
+  }
+  const scriptPath = path.join(scriptDir, scriptName);
+  try {
+    const content = fs.readFileSync(scriptPath, 'utf-8');
+    return { success: true, path: scriptPath, content };
+  } catch (e: any) {
+    return { success: false, error: e.message };
+  }
+});
+
+// IPC: Run sandbox with raw JSON config (bypass policy creation)
+ipcMain.handle('run-sandbox-raw', (_event, configJson: string, debug: boolean, experimental: boolean) => {
+  killActivePty();
+  const sdk = loadSdk();
+
+  try {
+    const config = JSON.parse(configJson);
+    const ptyProcess = sdk.spawnSandboxFromConfig(config, {
+      debug,
+      experimental,
+      executablePath: resolveExecutablePath(), skipPlatformCheck: true,
+    });
+
+    attachPtyListeners(ptyProcess);
+    return { success: true, config };
+  } catch (e: any) {
+    return { success: false, error: e.message };
+  }
+});
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  killActivePty();
+  app.quit();
+});

--- a/playground/src/main/preload.ts
+++ b/playground/src/main/preload.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('mxc', {
+  getPlatformSupport: () => ipcRenderer.invoke('get-platform-support'),
+  getToolsPolicy: () => ipcRenderer.invoke('get-tools-policy'),
+  getProfilePolicy: () => ipcRenderer.invoke('get-profile-policy'),
+  getTempPolicy: () => ipcRenderer.invoke('get-temp-policy'),
+  runSandbox: (script: string, policyJson: string, debug: boolean, experimental: boolean) =>
+    ipcRenderer.invoke('run-sandbox', script, policyJson, debug, experimental),
+  runSandboxAdvanced: (script: string, policyJson: string, debug: boolean, experimental: boolean) =>
+    ipcRenderer.invoke('run-sandbox-advanced', script, policyJson, debug, experimental),
+  killSandbox: () => ipcRenderer.invoke('kill-sandbox'),
+  validatePolicy: (policyJson: string) =>
+    ipcRenderer.invoke('validate-policy', policyJson),
+  onPtyData: (callback: (data: string) => void) => {
+    ipcRenderer.on('pty-data', (_event, data) => callback(data));
+  },
+  onPtyExit: (callback: (exitCode: number) => void) => {
+    ipcRenderer.on('pty-exit', (_event, exitCode) => callback(exitCode));
+  },
+  openFolderDialog: () => ipcRenderer.invoke('open-folder-dialog'),
+  detectShells: () => ipcRenderer.invoke('detect-shells'),
+  ensureDirs: (dirs: string[]) => ipcRenderer.invoke('ensure-dirs', dirs),
+  saveLogFile: (content: string) => ipcRenderer.invoke('save-log-file', content),
+  getTestScript: (name: string) => ipcRenderer.invoke('get-test-script', name),
+  fixPythonAcl: (path: string) => ipcRenderer.invoke('fix-python-acl', path),
+  installRuntime: (runtime: string) => ipcRenderer.invoke('install-runtime', runtime),
+  detectPythonVersions: () => ipcRenderer.invoke('detect-python-versions'),
+  runSandboxRaw: (configJson: string, debug: boolean, experimental: boolean) =>
+    ipcRenderer.invoke('run-sandbox-raw', configJson, debug, experimental),
+});

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -18,6 +18,7 @@ interface Scenario {
   script: string;
   policy: any;
   shell: 'cmd' | 'ps51' | 'ps7' | 'python';
+  containment?: 'appcontainer' | 'windows_sandbox';
   requiresV05?: boolean;
   /** If set, output must contain this string for a PASS verdict */
   successMarker?: string;
@@ -27,7 +28,7 @@ interface Scenario {
   testScript?: { file: string; shell: string; args?: string };
 }
 
-// Shell detection ΓÇö cached after init
+// Shell detection — cached after init
 var shellAvailability: Record<string, boolean> = {
   cmd: true,
   ps51: true,
@@ -39,17 +40,17 @@ var shellAvailability: Record<string, boolean> = {
 var shellPaths: Record<string, { exe?: string; rootDir?: string; needsAcl?: boolean; msixPackageDir?: string }> = {};
 
 var SHELL_BADGES: Record<string, string> = {
-  cmd: '≡ƒƒó',
-  ps51: '≡ƒö╡',
-  ps7: '≡ƒƒú',
-  python: '≡ƒÉì',
+  cmd: '🟢',
+  ps51: '🔵',
+  ps7: '🟣',
+  python: '🐍',
 };
 
 var SHELL_LABELS: Record<string, string> = {
-  cmd: 'Γ¼¢ cmd.exe',
-  ps51: '≡ƒö╖ PowerShell 5.1',
-  ps7: '≡ƒƒª PowerShell 7+',
-  python: '≡ƒÉì Python',
+  cmd: '⬛ cmd.exe',
+  ps51: '🔷 PowerShell 5.1',
+  ps7: '🟦 PowerShell 7+',
+  python: '🐍 Python',
 };
 
 var SHELL_SHORT: Record<string, string> = {
@@ -62,7 +63,7 @@ var SHELL_SHORT: Record<string, string> = {
 function updateRunAllLabel(): void {
   var shell = $sel('shellSelect').value;
   var name = SHELL_SHORT[shell] || shell;
-  $('btnRunAll').textContent = 'Γû╢Γû╢ Run All ' + name + ' Tests';
+  $('btnRunAll').textContent = '▶▶ Run All ' + name + ' Tests';
 }
 
 function updatePythonAclWarning(): void {
@@ -78,16 +79,16 @@ function updatePythonAclWarning(): void {
   if (!isInstalled) {
     if (shell === 'python') {
       $('pythonAclWarning').innerHTML =
-        '<div>ΓÜá∩╕Å ' + name + ' is not installed.</div>' +
+        '<div>⚠️ ' + name + ' is not installed.</div>' +
         '<div style="font-size:11px; margin-top:6px;">Install via terminal:</div>' +
         '<code style="display:block; margin:4px 0; padding:4px 8px; background:var(--bg-input); border-radius:4px; font-size:11px; user-select:all;">winget install Python.Python.3.14</code>' +
-        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click ≡ƒöä after installation to refresh.</div>';
+        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click 🔄 after installation to refresh.</div>';
     } else {
       $('pythonAclWarning').innerHTML =
-        '<div>ΓÜá∩╕Å ' + name + ' is not installed.</div>' +
-        '<div style="font-size:11px; margin-top:6px;"><a href="https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-msi-package" target="_blank" style="color:var(--accent);">Install the MSI package ΓåÆ</a></div>' +
-        '<div style="font-size:11px; color:var(--text-dim); margin-top:4px;">Γä╣∩╕Å Only MSI-installed PowerShell 7+ is supported. MSIX and Microsoft Store versions are not yet supported.</div>' +
-        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click ≡ƒöä after installation to refresh.</div>';
+        '<div>⚠️ ' + name + ' is not installed.</div>' +
+        '<div style="font-size:11px; margin-top:6px;"><a href="https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-msi-package" target="_blank" style="color:var(--accent);">Install the MSI package →</a></div>' +
+        '<div style="font-size:11px; color:var(--text-dim); margin-top:4px;">ℹ️ Only MSI-installed PowerShell 7+ is supported. MSIX and Microsoft Store versions are not yet supported.</div>' +
+        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click 🔄 after installation to refresh.</div>';
     }
     $('pythonAclWarning').classList.remove('hidden');
     return;
@@ -111,55 +112,55 @@ function updateShellDropdown(): void {
 
 var SCENARIOS: Scenario[] = [
   // ========== cmd.exe ==========
-  { id: 'cmd-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'cmd',
+  { id: 'cmd-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'cmd',
     description: 'Runs a simple echo command to verify basic execution.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'cmd.exe /c echo Hello from sandbox!',
     policy: { ui: { allowWindows: true } }, successMarker: 'Hello from sandbox!' },
-  { id: 'cmd-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+  { id: 'cmd-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '📁', shell: 'cmd',
     description: 'Reads the hosts file using read-only access.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'cmd.exe /c type C:\\Windows\\System32\\drivers\\etc\\hosts',
     policy: { filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] }, ui: { allowWindows: true } },
     successMarker: 'sample HOSTS file' },
-  { id: 'cmd-fs-read-blocked', name: 'Read without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+  { id: 'cmd-fs-read-blocked', name: 'Read without permission', category: 'File Access Tests', categoryIcon: '📁', shell: 'cmd',
     description: 'Tries to read from a user directory without filesystem access. Should be denied.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'cmd.exe /c type "%USERPROFILE%\\NTUSER.DAT"',
     policy: { ui: { allowWindows: true } } },
-  { id: 'cmd-fs-write-spaces', name: 'Write to path with spaces', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+  { id: 'cmd-fs-write-spaces', name: 'Write to path with spaces', category: 'File Access Tests', categoryIcon: '📁', shell: 'cmd',
     description: 'Writes to a path containing spaces.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'cmd.exe /c echo SUCCESS > "C:\\Users\\Public\\mxc bfs test\\test_output.txt" && type "C:\\Users\\Public\\mxc bfs test\\test_output.txt"',
     policy: { filesystem: { readwritePaths: ['C:\\Users\\Public\\mxc bfs test'] } },
     requiresV05: true, successMarker: 'SUCCESS' },
-  { id: 'cmd-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'cmd',
+  { id: 'cmd-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '🌐', shell: 'cmd',
     description: 'Makes an HTTPS request with outbound network enabled.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'curl.exe -s --max-time 10 https://www.example.com',
     policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
     successMarker: 'Example Domain' },
-  { id: 'cmd-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'cmd',
+  { id: 'cmd-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '🌐', shell: 'cmd',
     description: 'Tries to reach example.com with no network access. Should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'curl.exe -s --max-time 5 https://www.example.com',
     policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
-  { id: 'cmd-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'cmd',
+  { id: 'cmd-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '🖥️', shell: 'cmd',
     description: 'Runs with Win32k disabled. cmd.exe does not need Win32k so it should still work.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'cmd.exe /c echo PASS: Win32k disabled', policy: { ui: { allowWindows: false } },
     requiresV05: true, successMarker: 'PASS:' },
-  { id: 'cmd-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'cmd',
+  { id: 'cmd-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'cmd',
     description: 'Runs a command that waits 30 seconds with a 5-second timeout.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: 'cmd.exe /c ping -n 30 127.0.0.1',
     policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
-  { id: 'cmd-bad-exe', name: 'Non-existent executable', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'cmd',
+  { id: 'cmd-bad-exe', name: 'Non-existent executable', category: 'Error Cases', categoryIcon: '⚠️', shell: 'cmd',
     description: 'Tries to run an executable that does not exist.',
     expectedOutcome: 'show-error', expectedLabel: 'Should fail',
     script: 'this-command-does-not-exist-12345',
     policy: { ui: { allowWindows: true } } },
-  { id: 'cmd-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'cmd',
+  { id: 'cmd-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '🔄', shell: 'cmd',
     description: 'Writes a file and reads it back. Exercises filesystem + desktop together.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'cmd.exe /c echo CMD_WRITE_OK > C:\\temp\\mxc-full-test\\cmd-result.txt && type C:\\temp\\mxc-full-test\\cmd-result.txt && echo ALL_OK',
@@ -167,55 +168,55 @@ var SCENARIOS: Scenario[] = [
     successMarker: 'ALL_OK' },
 
   // ========== PowerShell 5.1 ==========
-  { id: 'ps51-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps51',
+  { id: 'ps51-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
     description: 'Runs Write-Output to verify PowerShell works inside the sandbox.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -Command "Write-Output \'Hello from PowerShell\'"',
     policy: { ui: { allowWindows: true } }, successMarker: 'Hello from PowerShell' },
-  { id: 'ps51-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps51',
+  { id: 'ps51-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
     description: 'Displays the PowerShell version table.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -Command "$PSVersionTable"',
     policy: { ui: { allowWindows: true } }, successMarker: 'PSVersion' },
-  { id: 'ps51-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+  { id: 'ps51-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps51',
     description: 'Writes a file to a brokered temp directory.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-write-test\\ps-output.txt -Value hello; Write-Output WRITE_OK"',
     policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] }, ui: { allowWindows: true } },
     successMarker: 'WRITE_OK' },
-  { id: 'ps51-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+  { id: 'ps51-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps51',
     description: 'Tries to write to C:\\Windows. Access should be denied.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'powershell.exe -Command "try { Set-Content -Path \\"C:\\Windows\\mxc-test.txt\\" -Value \\"test\\" -ErrorAction Stop; Write-Output \\"UNEXPECTED\\" } catch { Write-Output \\"EXPECTED: $_\\" }"',
     policy: { ui: { allowWindows: true } }, failureMarker: 'UNEXPECTED' },
-  { id: 'ps51-fs-read-root', name: 'Read from C:\\ root', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+  { id: 'ps51-fs-read-root', name: 'Read from C:\\ root', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps51',
     description: 'Lists C:\\ as a read-only path. Tests trailing backslash handling.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -NoProfile -Command "Get-ChildItem C:\\ | Select-Object -First 3 | ForEach-Object { Write-Output $_.Name }; Write-Output READ_ROOT_OK"',
     policy: { filesystem: { readonlyPaths: ['C:\\'] }, ui: { allowWindows: true } },
     requiresV05: true, successMarker: 'READ_ROOT_OK' },
-  { id: 'ps51-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps51',
+  { id: 'ps51-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '🌐', shell: 'ps51',
     description: 'Makes an HTTPS request with outbound network enabled.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -NoProfile -Command "$ProgressPreference=\'SilentlyContinue\'; (Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 10).Content"',
     policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
     successMarker: 'Example Domain' },
-  { id: 'ps51-net-blocked',name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps51',
+  { id: 'ps51-net-blocked',name: 'Internet blocked', category: 'Network Tests', categoryIcon: '🌐', shell: 'ps51',
     description: 'Tries to make an HTTPS request with no network access. Should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'powershell.exe -NoProfile -Command "try { $h=New-Object -ComObject WinHttp.WinHttpRequest.5.1; $h.Open(\'GET\',\'https://www.example.com\',$false); $h.Send(); Write-Output $h.ResponseText } catch { Write-Output \'BLOCKED\' }"',
     policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
-  { id: 'ps51-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'ps51',
+  { id: 'ps51-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '🖥️', shell: 'ps51',
     description: 'Runs with Win32k disabled. PowerShell needs Win32k and should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should fail (needs Win32k)',
     script: 'powershell.exe -NoProfile -Command "Write-Output PS_OK"',
     policy: { ui: { allowWindows: false } }, requiresV05: true },
-  { id: 'ps51-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'ps51',
+  { id: 'ps51-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'ps51',
     description: 'Runs a sleep with a 5-second timeout.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: 'powershell.exe -NoProfile -Command Start-Sleep -Seconds 30',
     policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
-  { id: 'ps51-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'ps51',
+  { id: 'ps51-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '🔄', shell: 'ps51',
     description: 'Writes a file, reads it back, reports environment info.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'powershell.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-full-test\\result.txt -Value \'STEP1_OK\'; $c=Get-Content C:\\temp\\mxc-full-test\\result.txt; Write-Output $c; Write-Output (\'User: \' + $env:USERNAME); Write-Output \'ALL_OK\'"',
@@ -223,55 +224,55 @@ var SCENARIOS: Scenario[] = [
     successMarker: 'ALL_OK' },
 
   // ========== PowerShell 7 ==========
-  { id: 'ps7-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps7',
+  { id: 'ps7-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps7',
     description: 'Runs a hello world in PowerShell 7+.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command "Write-Output \'Hello from PowerShell 7\'"',
     policy: { ui: { allowWindows: true } }, successMarker: 'Hello from PowerShell 7' },
-  { id: 'ps7-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps7',
+  { id: 'ps7-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps7',
     description: 'Gets PowerShell 7 version table.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command $PSVersionTable',
     policy: { ui: { allowWindows: true } }, successMarker: 'PSVersion' },
-  { id: 'ps7-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+  { id: 'ps7-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps7',
     description: 'Writes a file to a brokered path.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-write-test\\ps7-output.txt -Value hello; Write-Output WRITE_OK"',
     policy: { ui: { allowWindows: true }, filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] } },
     successMarker: 'WRITE_OK' },
-  { id: 'ps7-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+  { id: 'ps7-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps7',
     description: 'Reads the hosts file from a brokered read-only path.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command Get-Content C:\\Windows\\System32\\drivers\\etc\\hosts',
     policy: { ui: { allowWindows: true }, filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] } },
     successMarker: 'sample HOSTS file' },
-  { id: 'ps7-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+  { id: 'ps7-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '📁', shell: 'ps7',
     description: 'Tries to write to a system directory. Should be denied.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'pwsh.exe -NoProfile -Command "try { Set-Content C:\\Windows\\test.txt -Value fail -ErrorAction Stop; exit 1 } catch { Write-Output BLOCKED; exit 0 }"',
     policy: { ui: { allowWindows: true } } },
-  { id: 'ps7-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps7',
+  { id: 'ps7-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '🌐', shell: 'ps7',
     description: 'Makes an HTTPS request with outbound network enabled.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command "(Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 10).Content"',
     policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
     successMarker: 'Example Domain' },
-  { id: 'ps7-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps7',
+  { id: 'ps7-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '🌐', shell: 'ps7',
     description: 'Tries to make an HTTPS request with no network access. Should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'pwsh.exe -NoProfile -Command "try { (Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 5).Content } catch { Write-Output \'BLOCKED\' }"',
     policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
-  { id: 'ps7-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'ps7',
+  { id: 'ps7-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '🖥️', shell: 'ps7',
     description: 'Runs with Win32k disabled. PowerShell 7 needs Win32k and should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should fail (needs Win32k)',
     script: 'pwsh.exe -NoProfile -Command "Write-Output PS7_OK"',
     policy: { ui: { allowWindows: false } }, requiresV05: true },
-  { id: 'ps7-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'ps7',
+  { id: 'ps7-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'ps7',
     description: 'Runs a sleep with a 5-second timeout.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: 'pwsh.exe -NoProfile -Command Start-Sleep -Seconds 30',
     policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
-  { id: 'ps7-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'ps7',
+  { id: 'ps7-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '🔄', shell: 'ps7',
     description: 'Writes a file, reads it back, reports environment info.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'pwsh.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-full-test\\ps7-result.txt -Value \'STEP1_OK\'; $c=Get-Content C:\\temp\\mxc-full-test\\ps7-result.txt; Write-Output $c; Write-Output (\'User: \' + $env:USERNAME); Write-Output \'ALL_OK\'"',
@@ -279,50 +280,94 @@ var SCENARIOS: Scenario[] = [
     successMarker: 'ALL_OK' },
 
   // ========== Python ==========
-  { id: 'py-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'python',
+  { id: 'py-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
     description: 'Runs a hello world in Python.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "print(\'Hello from Python\')"',
     policy: { ui: { allowWindows: true } }, successMarker: 'Hello from Python' },
-  { id: 'py-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'python',
+  { id: 'py-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
     description: 'Gets Python version.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "import sys; print(f\'Python {sys.version}\')"',
     policy: { ui: { allowWindows: true } }, successMarker: 'Python' },
-  { id: 'py-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'python',
+  { id: 'py-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '📁', shell: 'python',
     description: 'Writes a file to a brokered read-write path.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "f=open(r\'C:\\temp\\mxc-write-test\\py-output.txt\',\'w\'); f.write(\'hello\'); f.close(); print(\'WRITE_OK\')"',
     policy: { ui: { allowWindows: true }, filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] } },
     successMarker: 'WRITE_OK' },
-  { id: 'py-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'python',
+  { id: 'py-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '📁', shell: 'python',
     description: 'Reads the hosts file from a brokered read-only path.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "print(open(r\'C:\\Windows\\System32\\drivers\\etc\\hosts\').read()[:200])"',
     policy: { ui: { allowWindows: true }, filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] } },
     successMarker: 'sample HOSTS file' },
-  { id: 'py-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'python',
+  { id: 'py-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '🌐', shell: 'python',
     description: 'Makes an HTTPS request with outbound network enabled.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "import urllib.request; print(urllib.request.urlopen(\'https://www.example.com\',timeout=10).read().decode()[:200])"',
     policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
     successMarker: 'Example Domain' },
-  { id: 'py-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'python',
+  { id: 'py-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '🌐', shell: 'python',
     description: 'Tries to make an HTTPS request with no network access. Should fail.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
     script: 'python -c "import urllib.request; print(urllib.request.urlopen(\'https://www.example.com\',timeout=5).read().decode())"',
     policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
-  { id: 'py-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'python',
+  { id: 'py-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
     description: 'Runs a sleep with a 5-second timeout.',
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: 'python -c "import time; time.sleep(30)"',
     policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
-  { id: 'py-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'python',
+  { id: 'py-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '🔄', shell: 'python',
     description: 'Writes a file, reads it back using Python.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -c "f=open(r\'C:\\temp\\mxc-full-test\\py-result.txt\',\'w\'); f.write(\'STEP1_OK\'); f.close(); c=open(r\'C:\\temp\\mxc-full-test\\py-result.txt\').read(); print(c); print(\'ALL_OK\')"',
     policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-full-test'] }, ui: { allowWindows: true } },
     successMarker: 'ALL_OK' },
+
+  // ========== Windows Sandbox ==========
+  { id: 'ws-echo', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'cmd',
+    containment: 'windows_sandbox',
+    description: 'Runs a simple echo command inside the Windows Sandbox VM.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'echo Hello from sandbox!',
+    policy: {}, successMarker: 'Hello from sandbox!' },
+  { id: 'ws-python', name: 'Python version', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'windows_sandbox',
+    description: 'Runs Python inside the sandbox to verify the mapped host Python works.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -S -B -c "import sys; print(\'Hello from Windows Sandbox!\'); print(f\'Python version: {sys.version}\'); print(\'Script executed successfully in sandbox isolation\')"',
+    policy: {}, successMarker: 'executed successfully' },
+  { id: 'ws-powershell', name: 'PowerShell hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
+    containment: 'windows_sandbox',
+    description: 'Runs PowerShell inside the sandbox and prints version info.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell -NoProfile -Command "Write-Output \'PowerShell works\'; $PSVersionTable.PSVersion.ToString()"',
+    policy: {}, successMarker: 'PowerShell works' },
+  { id: 'ws-ps-env', name: 'PowerShell environment', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
+    containment: 'windows_sandbox',
+    description: 'Shows environment info (computer name, user, process count) inside the sandbox.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell -NoProfile -Command "Write-Output (\'ComputerName=\' + $env:COMPUTERNAME); Write-Output (\'User=\' + $env:USERNAME); Write-Output (\'ProcessCount=\' + (Get-Process | Measure-Object).Count)"',
+    policy: {}, successMarker: 'ComputerName=' },
+  { id: 'ws-stderr', name: 'Stdout & stderr', category: 'Quick Tests', categoryIcon: '🎯', shell: 'cmd',
+    containment: 'windows_sandbox',
+    description: 'Writes to both stdout and stderr. Both should be captured.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'echo stdout-message && echo stderr-message 1>&2',
+    policy: {}, successMarker: 'stdout-message' },
+  { id: 'ws-exit-code', name: 'Exit code', category: 'Error Cases', categoryIcon: '⚠️', shell: 'cmd',
+    containment: 'windows_sandbox',
+    description: 'Exits with code 42. Verifies exit codes are propagated from the sandbox.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should exit 42',
+    script: 'exit /b 42',
+    policy: {} },
+  { id: 'ws-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'cmd',
+    containment: 'windows_sandbox',
+    description: 'Runs a long ping with a 5-second timeout. Should be terminated.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: 'ping -n 30 127.0.0.1',
+    policy: { timeoutMs: 5000 } },
 ];
 
 // ============================================================
@@ -542,7 +587,9 @@ function getCurrentScript(): string {
   }
 
   // Replace bare 'python' with resolved full path for BaseContainer compatibility
-  if (shellPaths.python?.exe && script.match(/^python\s/)) {
+  // (skip for Windows Sandbox — it uses mapped Python from the host)
+  var containment = $sel('containmentSelect').value;
+  if (containment !== 'windows_sandbox' && shellPaths.python?.exe && script.match(/^python\s/)) {
     script = '"' + shellPaths.python.exe + '"' + script.substring(6);
   }
 
@@ -570,7 +617,7 @@ function updateContainmentDropdown(): void {
   for (var i = 0; i < select.options.length; i++) {
     var opt = select.options[i];
     if (opt.value === 'appcontainer') {
-      opt.textContent = isV05 ? '≡ƒ¢í∩╕Å Base Process Container' : '≡ƒ¢í∩╕Å AppContainer';
+      opt.textContent = isV05 ? '🛡️ Base Process Container' : '🛡️ AppContainer';
     } else {
       // Experimental types only on 0.5.0+
       opt.disabled = !isV05;
@@ -597,15 +644,15 @@ function getPermsSummary(): string {
   var fs = state.fsEnabled ? 'limited' : 'off';
   var net = state.netEnabled ? 'on' : 'off';
   var ui = state.uiAllowWindows ? 'on' : 'off';
-  return 'Files: ' + fs + ' ┬╖ Internet: ' + net + ' ┬╖ Desktop: ' + ui;
+  return 'Files: ' + fs + ' · Internet: ' + net + ' · Desktop: ' + ui;
 }
 
 function updatePermsSummary(): void {
   var summary = getPermsSummary();
   $('permissionsSummaryLine').textContent = summary;
   $('runSummary').textContent = 'Internet: ' + (state.netEnabled ? 'on' : 'off') +
-    ' ┬╖ Files: ' + (state.fsEnabled ? 'limited' : 'off') +
-    ' ┬╖ Desktop: ' + (state.uiAllowWindows ? 'on' : 'off');
+    ' · Files: ' + (state.fsEnabled ? 'limited' : 'off') +
+    ' · Desktop: ' + (state.uiAllowWindows ? 'on' : 'off');
 }
 
 // ============================================================
@@ -634,7 +681,7 @@ function renderPathList(containerId: string, paths: string[], onRemove: (index: 
 
     var removeBtn = document.createElement('button');
     removeBtn.className = 'path-remove';
-    removeBtn.textContent = '├ù';
+    removeBtn.textContent = '×';
     removeBtn.title = 'Remove';
     removeBtn.addEventListener('click', function() {
       onRemove(i);
@@ -665,7 +712,7 @@ function refreshPathLists(): void {
 function setResultIdle(): void {
   var card = $('resultCard');
   card.className = 'result-card result-idle';
-  $('resultIcon').textContent = '≡ƒÆí';
+  $('resultIcon').textContent = '💡';
   $('resultTitle').textContent = 'Select a scenario and click Run in Sandbox';
   $('resultDetail').textContent = '';
   $('resultActions').classList.add('hidden');
@@ -675,8 +722,8 @@ function setResultIdle(): void {
 function setResultRunning(): void {
   var card = $('resultCard');
   card.className = 'result-card result-running';
-  $('resultIcon').textContent = 'ΓÅ│';
-  $('resultTitle').textContent = 'RunningΓÇª';
+  $('resultIcon').textContent = '⏳';
+  $('resultTitle').textContent = 'Running…';
   $('resultDetail').textContent = 'Script is executing inside the sandbox';
   $('resultActions').classList.add('hidden');
 }
@@ -684,7 +731,7 @@ function setResultRunning(): void {
 function setResultSuccess(exitCode: number): void {
   var card = $('resultCard');
   card.className = 'result-card result-success';
-  $('resultIcon').textContent = 'Γ£à';
+  $('resultIcon').textContent = '✅';
   $('resultTitle').textContent = 'Script completed successfully (exit code ' + formatExitCode(exitCode) + ')';
   $('resultDetail').textContent = '';
   showResultActions('success');
@@ -693,9 +740,9 @@ function setResultSuccess(exitCode: number): void {
 function setResultError(exitCode: number): void {
   var card = $('resultCard');
   card.className = 'result-card result-error';
-  $('resultIcon').textContent = 'Γ¥î';
+  $('resultIcon').textContent = '❌';
   if (exitCode === -1) {
-    $('resultTitle').textContent = 'Script was blocked ΓÇö access denied';
+    $('resultTitle').textContent = 'Script was blocked — access denied';
   } else {
     $('resultTitle').textContent = 'Script failed (exit code ' + formatExitCode(exitCode) + ')';
   }
@@ -713,7 +760,7 @@ function showResultActions(type: string): void {
   if (type === 'error') {
     if (!state.netEnabled) {
       suggestions.push({
-        label: '≡ƒîÉ Try with internet enabled',
+        label: '🌐 Try with internet enabled',
         action: function() {
           $chk('netToggle').checked = true;
           state.netEnabled = true;
@@ -724,7 +771,7 @@ function showResultActions(type: string): void {
     }
     if (!state.fsEnabled) {
       suggestions.push({
-        label: '≡ƒôü Try with file access',
+        label: '📁 Try with file access',
         action: function() {
           $chk('fsToggle').checked = true;
           state.fsEnabled = true;
@@ -800,7 +847,13 @@ function populateScenarios(): void {
   var select = $sel('scenarioSelect');
   select.innerHTML = '';
 
-  var filtered = SCENARIOS.filter(function(s) { return s.shell === shell; });
+  var containment = $sel('containmentSelect').value;
+  var isWS = containment === 'windows_sandbox';
+  var filtered = SCENARIOS.filter(function(s) {
+    if (s.shell !== shell) return false;
+    if (isWS) return s.containment === 'windows_sandbox';
+    return !s.containment || s.containment === 'appcontainer';
+  });
 
   // Group by category
   var categories: string[] = [];
@@ -821,7 +874,7 @@ function populateScenarios(): void {
       if (s.requiresV05 && state.version !== '0.5.0-dev') { return; }
       var opt = document.createElement('option');
       opt.value = s.id;
-      var marker = s.expectedOutcome === 'succeed' ? 'Γ£ô' : 'Γ£ù';
+      var marker = s.expectedOutcome === 'succeed' ? '✓' : '✗';
       opt.textContent = marker + ' ' + s.name;
       group.appendChild(opt);
     });
@@ -859,7 +912,7 @@ function loadScenario(id: string): void {
   $('scenarioOutcome').className = 'outcome-badge ' + scenario.expectedOutcome;
 
   if (!shellAvail) {
-    $('scenarioDesc').textContent = 'ΓÜá∩╕Å ' + scenario.shell + ' is not installed. ' + scenario.description;
+    $('scenarioDesc').textContent = '⚠️ ' + scenario.shell + ' is not installed. ' + scenario.description;
   }
 
   // Collapse script section for presets
@@ -914,7 +967,7 @@ function loadScenario(id: string): void {
   $chk('uiInjection').checked = state.uiInjection;
   updateUiDetails();
 
-  // Include helpers ΓÇö default ON for scenarios
+  // Include helpers — default ON for scenarios
   state.fsIncludeTools = true;
   state.fsIncludeTemp = true;
   $chk('fsIncludeTools').checked = true;
@@ -948,7 +1001,7 @@ function loadScenario(id: string): void {
 async function runSandbox(): Promise<void> {
   if (state.running) return;
 
-  // Raw JSON Config mode ΓÇö bypass policy builder entirely
+  // Raw JSON Config mode — bypass policy builder entirely
   var currentShell = $sel('shellSelect').value;
   if (currentShell === 'rawjson') {
     var rawJson = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
@@ -982,6 +1035,53 @@ async function runSandbox(): Promise<void> {
     return;
   }
 
+  // Windows Sandbox mode — build raw wxc-exec JSON config and use runSandboxRaw
+  var currentContainment = $sel('containmentSelect').value;
+  if (currentContainment === 'windows_sandbox') {
+    var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+    if (!wsScript) {
+      termError('No script specified');
+      return;
+    }
+
+    var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+    var wsConfig: any = {
+      containment: 'windows_sandbox',
+      process: {
+        commandLine: wsScript,
+        timeout: wsTimeout,
+      },
+    };
+
+    state.running = true;
+    if (!runAllInProgress) {
+      ($('btnRun') as HTMLButtonElement).disabled = true;
+      $('btnKill').classList.remove('hidden');
+      $('btnRun').classList.add('hidden');
+      setResultRunning();
+      termClear();
+    }
+    terminalFullText = '';
+
+    termInfo('[Playground] Running via Windows Sandbox');
+    if (state.selectedScenario) {
+      termInfo('[Playground] Scenario: ' + state.selectedScenario.name + ' (' + state.selectedScenario.id + ')');
+    }
+    termInfo('[Playground] Script: ' + wsScript);
+    termInfo('[MXC] API: spawnSandboxFromConfig (raw config)');
+    termDim('[MXC] Note: First run may take 3-5 minutes while the sandbox VM boots.');
+
+    var wsDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+    var wsResult = await mxc.runSandboxRaw(JSON.stringify(wsConfig), wsDebug, true);
+    if (!wsResult.success) {
+      termError('[MXC] Failed to start sandbox: ' + wsResult.error);
+      onSandboxExit(-1);
+    } else {
+      termDim('[MXC] Config accepted');
+    }
+    return;
+  }
+
   var script = getCurrentScript();
 
   // Resolve test script file if scenario uses one
@@ -992,7 +1092,7 @@ async function runSandbox(): Promise<void> {
       script = ts.shell + ' -NoProfile -ExecutionPolicy Bypass -File "' + scriptInfo.path + '"' + (ts.args ? ' ' + ts.args : '');
       termDim('[Playground] Using test script: ' + scriptInfo.path);
     } else {
-      termError('[Playground] Could not find test script: ' + ts.file + ' ΓÇö ' + scriptInfo.error);
+      termError('[Playground] Could not find test script: ' + ts.file + ' — ' + scriptInfo.error);
       return;
     }
   }
@@ -1005,7 +1105,7 @@ async function runSandbox(): Promise<void> {
   // Warn and trim leading/trailing whitespace
   if (script !== script.trim()) {
     script = script.trim();
-    termDim('[Playground] ΓÜá Trimmed leading/trailing whitespace from script');
+    termDim('[Playground] ⚠ Trimmed leading/trailing whitespace from script');
   }
 
   state.running = true;
@@ -1026,7 +1126,7 @@ async function runSandbox(): Promise<void> {
     var currentSnapshot = JSON.stringify(policy);
     if (currentSnapshot !== state.scenarioPolicySnapshot) {
       scenarioModified = true;
-      termDim('[Playground] ΓÜá Note: You modified settings from the original scenario. Verdict may not match the expected outcome.');
+      termDim('[Playground] ⚠ Note: You modified settings from the original scenario. Verdict may not match the expected outcome.');
     }
   }
 
@@ -1066,7 +1166,7 @@ async function runSandbox(): Promise<void> {
   // Ensure write directories exist before running
   var allWritePaths = policy.filesystem?.readwritePaths || [];
   if (allWritePaths.length > 0) {
-    termDim('[Playground] Setup: ensuring directories exist ΓÇö ' + allWritePaths.join(', '));
+    termDim('[Playground] Setup: ensuring directories exist — ' + allWritePaths.join(', '));
     await mxc.ensureDirs(allWritePaths);
   }
 
@@ -1080,7 +1180,7 @@ async function runSandbox(): Promise<void> {
   }
   termInfo('[Playground] Script: ' + script);
   if (useAdvanced) {
-    termInfo('[MXC] API: createConfigFromPolicy ΓåÆ spawnSandboxFromConfig');
+    termInfo('[MXC] API: createConfigFromPolicy → spawnSandboxFromConfig');
   } else {
     termInfo('[MXC] API: spawnSandbox()');
   }
@@ -1107,7 +1207,7 @@ async function runSandbox(): Promise<void> {
 }
 
 async function killSandbox(): Promise<void> {
-  termInfo('[Playground] Stopping sandboxΓÇª');
+  termInfo('[Playground] Stopping sandbox…');
   await mxc.killSandbox();
   onSandboxExit(-1);
 }
@@ -1124,15 +1224,19 @@ async function runAllScenarios(): Promise<void> {
   runAllInProgress = true;
   ($('btnRun') as HTMLButtonElement).disabled = true;
   ($('btnRunAll') as HTMLButtonElement).disabled = true;
-  $('btnRunAll').textContent = 'ΓÅ│ RunningΓÇª';
+  $('btnRunAll').textContent = '⏳ Running…';
 
   var debugEnabled = (document.getElementById('debugToggle') as HTMLInputElement).checked;
   var version = state.version;
   var currentShell = $sel('shellSelect').value;
 
-  // Filter scenarios: current shell, available runtimes, version-appropriate
+  // Filter scenarios: current shell, containment, available runtimes, version-appropriate
+  var currentContainment = $sel('containmentSelect').value;
+  var isWS = currentContainment === 'windows_sandbox';
   var scenariosToRun = SCENARIOS.filter(function(s) {
     if (s.shell !== currentShell) { return false; }
+    if (isWS) { if (s.containment !== 'windows_sandbox') return false; }
+    else { if (s.containment === 'windows_sandbox') return false; }
     if (s.shell === 'ps7' && !shellAvailability['ps7']) { return false; }
     if (s.shell === 'python' && !shellAvailability['python']) { return false; }
     if (s.requiresV05 && version !== '0.5.0-dev') { return false; }
@@ -1145,7 +1249,7 @@ async function runAllScenarios(): Promise<void> {
   var total = scenariosToRun.length;
   var results: { scenario: Scenario; verdict: string; pass: boolean; exitCode: number }[] = [];
 
-  logLines.push('=== MXC Playground ΓÇö Run All Results ===');
+  logLines.push('=== MXC Playground — Run All Results ===');
   logLines.push('Date: ' + new Date().toISOString());
   logLines.push('Schema: ' + version);
   logLines.push('Runtime: ' + currentShell);
@@ -1155,12 +1259,12 @@ async function runAllScenarios(): Promise<void> {
 
   // Show running state in result card
   $('resultCard').className = 'result-card result-running';
-  $('resultIcon').textContent = 'ΓÅ│';
-  $('resultTitle').textContent = 'Running all ' + total + ' testsΓÇª';
+  $('resultIcon').textContent = '⏳';
+  $('resultTitle').textContent = 'Running all ' + total + ' tests…';
   $('resultDetail').textContent = '0/' + total + ' complete';
 
   termClear();
-  termInfo('[Playground] Γû╢Γû╢ Running all ' + total + ' tests for ' + currentShell + 'ΓÇª');
+  termInfo('[Playground] ▶▶ Running all ' + total + ' tests for ' + currentShell + '…');
   termInfo('');
 
   for (var i = 0; i < scenariosToRun.length; i++) {
@@ -1168,7 +1272,7 @@ async function runAllScenarios(): Promise<void> {
     logLines.push('--- [' + (i + 1) + '/' + total + '] ' + scenario.name + ' (' + scenario.id + ') ---');
 
     // Update progress
-    $('resultDetail').textContent = (i) + '/' + total + ' complete ΓÇö running: ' + scenario.name;
+    $('resultDetail').textContent = (i) + '/' + total + ' complete — running: ' + scenario.name;
 
     // Load the scenario into state
     loadScenario(scenario.id);
@@ -1187,7 +1291,7 @@ async function runAllScenarios(): Promise<void> {
     // Wait for it to finish
     var result = await resultPromise;
 
-    var verdict = result.pass ? 'Γ£à PASS' : 'Γ¥î FAIL';
+    var verdict = result.pass ? '✅ PASS' : '❌ FAIL';
     if (result.pass) { passed++; } else { failed++; }
     results.push({ scenario, verdict, pass: result.pass, exitCode: result.exitCode });
 
@@ -1201,7 +1305,7 @@ async function runAllScenarios(): Promise<void> {
     logLines.push('--- End ---');
     logLines.push('');
 
-    termInfo('[Playground] [' + (i + 1) + '/' + total + '] ' + verdict + ' ΓÇö ' + scenario.name);
+    termInfo('[Playground] [' + (i + 1) + '/' + total + '] ' + verdict + ' — ' + scenario.name);
   }
 
   // Summary
@@ -1212,47 +1316,47 @@ async function runAllScenarios(): Promise<void> {
   termInfo('');
 
   // Render test report in terminal
-  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
-  termWrite('  TEST REPORT ΓÇö ' + currentShell.toUpperCase() + '  (' + new Date().toLocaleString() + ')', 'line-info');
-  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
+  termWrite('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━', 'line-info');
+  termWrite('  TEST REPORT — ' + currentShell.toUpperCase() + '  (' + new Date().toLocaleString() + ')', 'line-info');
+  termWrite('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━', 'line-info');
   termWrite('', 'line-info');
 
   for (var r = 0; r < results.length; r++) {
     var res = results[r];
-    var icon = res.pass ? 'Γ£à' : 'Γ¥î';
+    var icon = res.pass ? '✅' : '❌';
     var label = res.scenario.name;
     var exitStr = res.exitCode === 0 ? '' : '  (exit ' + res.exitCode + ')';
     termWrite('  ' + icon + '  ' + label + exitStr, res.pass ? 'line-success' : 'line-error');
   }
 
   termWrite('', 'line-info');
-  var summaryLine = '  ' + passed + ' passed, ' + failed + ' failed ΓÇö ' + total + ' total';
+  var summaryLine = '  ' + passed + ' passed, ' + failed + ' failed — ' + total + ' total';
   if (failed === 0) {
-    termWrite('  Γ£à ALL TESTS PASSED', 'line-success');
+    termWrite('  ✅ ALL TESTS PASSED', 'line-success');
   } else {
-    termWrite('  Γ¥î ' + failed + ' TEST(S) FAILED', 'line-error');
+    termWrite('  ❌ ' + failed + ' TEST(S) FAILED', 'line-error');
   }
   termWrite(summaryLine, 'line-info');
-  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
+  termWrite('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━', 'line-info');
 
   // Update result card
   if (failed === 0) {
     $('resultCard').className = 'result-card result-success';
-    $('resultIcon').textContent = 'Γ£à';
+    $('resultIcon').textContent = '✅';
     $('resultTitle').textContent = 'All ' + total + ' tests passed';
   } else {
     $('resultCard').className = 'result-card result-error';
-    $('resultIcon').textContent = 'Γ¥î';
+    $('resultIcon').textContent = '❌';
     $('resultTitle').textContent = passed + ' passed, ' + failed + ' failed';
   }
-  $('resultDetail').textContent = currentShell + ' ┬╖ ' + version + ' ┬╖ ' + new Date().toLocaleTimeString();
+  $('resultDetail').textContent = currentShell + ' · ' + version + ' · ' + new Date().toLocaleTimeString();
 
   // Offer optional save via a link in the terminal
   var logContent = logLines.join('\n');
   termWrite('', 'line-info');
   var saveLink = document.createElement('div');
   saveLink.className = 'line-info';
-  saveLink.innerHTML = '<a href="#" id="saveReportLink" style="color:var(--accent); cursor:pointer; text-decoration:underline;">≡ƒÆ╛ Save report to fileΓÇª</a>';
+  saveLink.innerHTML = '<a href="#" id="saveReportLink" style="color:var(--accent); cursor:pointer; text-decoration:underline;">💾 Save report to file…</a>';
   $('terminal').appendChild(saveLink);
   $('terminal').scrollTop = $('terminal').scrollHeight;
   document.getElementById('saveReportLink')!.addEventListener('click', async function(e) {
@@ -1281,24 +1385,24 @@ function onSandboxExit(exitCode: number): void {
   var scenario = state.selectedScenario;
   var isCustomMode = !scenario || $sel('shellSelect').value === 'custom' || $sel('shellSelect').value === 'rawjson';
 
-  // For custom/raw JSON: no expected outcome ΓÇö show neutral result
+  // For custom/raw JSON: no expected outcome — show neutral result
   if (isCustomMode) {
     var analysis = exitCode !== 0 ? analyzeOutput(terminalFullText, exitCode) : null;
     if (exitCode === 0) {
-      termDim('[Playground] ΓÜá Completed (exit code 0) ΓÇö inspect output to verify the result');
+      termDim('[Playground] ⚠ Completed (exit code 0) — inspect output to verify the result');
       var card = $('resultCard');
       card.className = 'result-card result-neutral';
-      $('resultIcon').textContent = 'ΓÜá';
-      $('resultTitle').textContent = 'Completed ΓÇö exit code 0';
+      $('resultIcon').textContent = '⚠';
+      $('resultTitle').textContent = 'Completed — exit code 0';
       $('resultDetail').textContent = 'Custom script finished. Review the output above to confirm it worked as expected.';
       showResultActions('success');
     } else {
-      termError('[Playground] ΓÜá Completed with exit code ' + formatExitCode(exitCode) + ' ΓÇö inspect output');
+      termError('[Playground] ⚠ Completed with exit code ' + formatExitCode(exitCode) + ' — inspect output');
       var card = $('resultCard');
       card.className = 'result-card result-neutral';
-      $('resultIcon').textContent = 'ΓÜá';
-      $('resultTitle').textContent = 'Completed ΓÇö exit code ' + formatExitCode(exitCode);
-      $('resultDetail').textContent = analysis ? analysis.explanation + ' ≡ƒÆí ' + analysis.suggestion : 'Non-zero exit code. Review the output above.';
+      $('resultIcon').textContent = '⚠';
+      $('resultTitle').textContent = 'Completed — exit code ' + formatExitCode(exitCode);
+      $('resultDetail').textContent = analysis ? analysis.explanation + ' 💡 ' + analysis.suggestion : 'Non-zero exit code. Review the output above.';
       showResultActions('error');
     }
 
@@ -1318,12 +1422,12 @@ function onSandboxExit(exitCode: number): void {
   var outputOverride = false;
   if (scenario && exitCode === 0) {
     if (scenario.failureMarker && terminalFullText.includes(scenario.failureMarker)) {
-      // Script printed its own failure marker ΓÇö the operation didn't actually work
+      // Script printed its own failure marker — the operation didn't actually work
       actualOutcome = 'be-blocked';
       outputOverride = true;
       termDim('[Playground] Output contains failure marker: "' + scenario.failureMarker + '"');
     } else if (scenario.successMarker && !terminalFullText.includes(scenario.successMarker)) {
-      // Script didn't print expected success marker ΓÇö something went wrong
+      // Script didn't print expected success marker — something went wrong
       actualOutcome = 'be-blocked';
       outputOverride = true;
       termDim('[Playground] Output missing expected marker: "' + scenario.successMarker + '"');
@@ -1346,34 +1450,34 @@ function onSandboxExit(exitCode: number): void {
   var analysis = exitCode !== 0 ? analyzeOutput(terminalFullText, exitCode) : null;
 
   if (verdictPass && exitCode === 0) {
-    termSuccess('[Playground] Γ£à PASS ΓÇö Script succeeded as expected (exit code 0)');
+    termSuccess('[Playground] ✅ PASS — Script succeeded as expected (exit code 0)');
     setResultSuccess(exitCode);
     $('resultDetail').textContent = scenario ? 'Expected: ' + scenario.expectedLabel : '';
   } else if (verdictPass && exitCode !== 0) {
-    // Expected failure ΓÇö this is a PASS
+    // Expected failure — this is a PASS
     var card = $('resultCard');
     card.className = 'result-card result-success';
-    $('resultIcon').textContent = 'Γ£à';
-    $('resultTitle').textContent = 'PASS ΓÇö Script was blocked as expected (exit code ' + formatExitCode(exitCode) + ')';
+    $('resultIcon').textContent = '✅';
+    $('resultTitle').textContent = 'PASS — Script was blocked as expected (exit code ' + formatExitCode(exitCode) + ')';
     $('resultDetail').textContent = analysis ? analysis.explanation : (scenario ? scenario.expectedLabel : '');
-    termSuccess('[Playground] Γ£à PASS ΓÇö Blocked as expected (exit code ' + formatExitCode(exitCode) + ')');
+    termSuccess('[Playground] ✅ PASS — Blocked as expected (exit code ' + formatExitCode(exitCode) + ')');
     showResultActions('success');
   } else if (!verdictPass && exitCode === 0) {
-    // Expected failure but it succeeded ΓÇö unexpected
+    // Expected failure but it succeeded — unexpected
     var card = $('resultCard');
     card.className = 'result-card result-error';
-    $('resultIcon').textContent = 'ΓÜá∩╕Å';
-    $('resultTitle').textContent = 'UNEXPECTED ΓÇö Script succeeded but was expected to be blocked';
+    $('resultIcon').textContent = '⚠️';
+    $('resultTitle').textContent = 'UNEXPECTED — Script succeeded but was expected to be blocked';
     $('resultDetail').textContent = 'The sandbox may not be enforcing the expected restriction.';
-    termError('[Playground] ΓÜá∩╕Å UNEXPECTED ΓÇö Succeeded but expected: ' + (scenario?.expectedLabel || 'blocked'));
+    termError('[Playground] ⚠️ UNEXPECTED — Succeeded but expected: ' + (scenario?.expectedLabel || 'blocked'));
     showResultActions('error');
   } else {
     // Unexpected failure
-    termError('[Playground] Γ¥î FAIL ΓÇö exit code ' + formatExitCode(exitCode));
+    termError('[Playground] ❌ FAIL — exit code ' + formatExitCode(exitCode));
     setResultError(exitCode);
     if (analysis) {
       $('resultTitle').textContent = analysis.title;
-      $('resultDetail').textContent = analysis.explanation + ' ≡ƒÆí ' + analysis.suggestion;
+      $('resultDetail').textContent = analysis.explanation + ' 💡 ' + analysis.suggestion;
     }
   }
 
@@ -1405,12 +1509,12 @@ var ERROR_PATTERNS = [
   { pattern: 'is not recognized', title: 'Command not found', explanation: 'The command was not found inside the sandbox. PATH directories may not be accessible.', suggestion: 'Enable "Include common tools" in File Access to add PATH directories.' },
   { pattern: 'The remote name could not be resolved', title: 'DNS resolution failed', explanation: 'The script could not resolve a hostname. Internet access may be blocked.', suggestion: 'Enable Internet access in the Policy section.' },
   { pattern: 'network is not available', title: 'Network blocked', explanation: 'Outbound network connections are blocked by the sandbox policy.', suggestion: 'Enable "Allow internet access" in Policy.' },
-  { pattern: 'version is required', title: 'Missing version', explanation: 'The sandbox policy requires a version field.', suggestion: 'This is a bug in the playground ΓÇö please report it.' },
+  { pattern: 'version is required', title: 'Missing version', explanation: 'The sandbox policy requires a version field.', suggestion: 'This is a bug in the playground — please report it.' },
   { pattern: 'newer than supported', title: 'Version too new', explanation: 'The schema version is newer than what the SDK supports.', suggestion: 'Use version 0.4.0-alpha or 0.5.0-dev.' },
   { pattern: 'The system cannot find the file', title: 'File not found', explanation: 'The executable or file was not found. It may not be accessible from inside the container.', suggestion: 'Add the file\'s directory to read-only paths in File Access.' },
   { pattern: 'PermissionError', title: 'Permission denied (Python)', explanation: 'Python could not access a file or directory due to sandbox restrictions.', suggestion: 'Add the path to read-write or read-only paths in File Access.' },
   { pattern: 'script is required', title: 'No script provided', explanation: 'No command was provided to run.', suggestion: 'Enter a script command or select a scenario.' },
-  { pattern: 'WIN32_ERROR(1920)', title: 'File cannot be accessed', explanation: 'The executable cannot be loaded by the sandbox. The install directory may not be accessible to the container process.', suggestion: 'The runtime may need its install directory added to File Access. Try clicking ≡ƒöä refresh and running again.' },
+  { pattern: 'WIN32_ERROR(1920)', title: 'File cannot be accessed', explanation: 'The executable cannot be loaded by the sandbox. The install directory may not be accessible to the container process.', suggestion: 'The runtime may need its install directory added to File Access. Try clicking 🔄 refresh and running again.' },
 ];
 
 var EXIT_CODE_PATTERNS: Record<number, { title: string; explanation: string; suggestion: string }> = {};
@@ -1426,7 +1530,7 @@ EXIT_CODE_PATTERNS[1920] = { // ERROR_FILE_CANNOT_BE_ACCESSED
 };
 
 function analyzeOutput(terminalText: string, exitCode: number): { title: string; explanation: string; suggestion: string } | null {
-  // Check exit code first ΓÇö with dynamic paths
+  // Check exit code first — with dynamic paths
   if (exitCode === -1073741790) { // 0xC0000022 STATUS_ACCESS_DENIED
     var aclPath = shellPaths.python?.rootDir || '';
     var isPerUser = aclPath.includes('AppData');
@@ -1490,19 +1594,48 @@ function showJsonPanel(tab: string): void {
   $('jsonPanel').classList.remove('hidden');
 
   if (tab === 'policy') {
-    var policyStr = JSON.stringify(buildPolicy(), null, 2);
-    $('jsonContent').innerHTML = highlightJson(escapeHtml(policyStr));
+    var containment = $sel('containmentSelect').value;
+    if (containment === 'windows_sandbox') {
+      var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+      var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+      var wsConfig = {
+        containment: 'windows_sandbox',
+        process: {
+          commandLine: wsScript || '(no script)',
+          timeout: wsTimeout,
+        },
+      };
+      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig, null, 2)));
+    } else {
+      var policyStr = JSON.stringify(buildPolicy(), null, 2);
+      $('jsonContent').innerHTML = highlightJson(escapeHtml(policyStr));
+    }
   } else {
-    $('jsonContent').innerHTML = '<span class="line-dim">Loading configΓÇª</span>';
-    var policyJson = JSON.stringify(buildPolicy());
-    mxc.validatePolicy(policyJson).then(function(result: any) {
-      if (result.valid) {
-        var formatted = JSON.stringify(JSON.parse(result.config), null, 2);
-        $('jsonContent').innerHTML = highlightJson(escapeHtml(formatted));
-      } else {
-        $('jsonContent').innerHTML = '<span class="line-error">Error: ' + escapeHtml(result.error) + '</span>';
-      }
-    });
+    var containment2 = $sel('containmentSelect').value;
+    if (containment2 === 'windows_sandbox') {
+      // WS Config tab — show the same raw config (no SDK policy validation)
+      var wsScript2 = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+      var wsTimeout2 = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+      var wsConfig2 = {
+        containment: 'windows_sandbox',
+        process: {
+          commandLine: wsScript2 || '(no script)',
+          timeout: wsTimeout2,
+        },
+      };
+      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig2, null, 2)));
+    } else {
+      $('jsonContent').innerHTML = '<span class="line-dim">Loading config…</span>';
+      var policyJson = JSON.stringify(buildPolicy());
+      mxc.validatePolicy(policyJson).then(function(result: any) {
+        if (result.valid) {
+          var formatted = JSON.stringify(JSON.parse(result.config), null, 2);
+          $('jsonContent').innerHTML = highlightJson(escapeHtml(formatted));
+        } else {
+          $('jsonContent').innerHTML = '<span class="line-error">Error: ' + escapeHtml(result.error) + '</span>';
+        }
+      });
+    }
   }
 }
 
@@ -1530,10 +1663,27 @@ function updateDevSidebar(): void {
   if ($('devSidebar').classList.contains('hidden')) return;
 
   var currentShell = $sel('shellSelect').value;
+  var currentContainment = $sel('containmentSelect').value;
 
-  // Raw JSON mode ΓÇö show only the raw config, no policy
+  // Windows Sandbox mode — show the raw WS config
+  if (currentContainment === 'windows_sandbox' && currentShell !== 'rawjson') {
+    var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+    var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+    var wsConfig = {
+      containment: 'windows_sandbox',
+      process: {
+        commandLine: wsScript || '(no script)',
+        timeout: wsTimeout,
+      },
+    };
+    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — Windows Sandbox bypasses policy generation</span>';
+    $('devConfigJson').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig, null, 2)));
+    return;
+  }
+
+  // Raw JSON mode — show only the raw config, no policy
   if (currentShell === 'rawjson') {
-    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A ΓÇö MXC JSON mode skips policy generation</span>';
+    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — MXC JSON mode skips policy generation</span>';
     var rawText = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
     if (rawText) {
       try {
@@ -1553,7 +1703,7 @@ function updateDevSidebar(): void {
   var policyStr = JSON.stringify(policy, null, 2);
   $('devPolicyJson').innerHTML = highlightJson(escapeHtml(policyStr));
 
-  $('devConfigJson').innerHTML = '<span class="line-dim">LoadingΓÇª</span>';
+  $('devConfigJson').innerHTML = '<span class="line-dim">Loading…</span>';
   var policyJson = JSON.stringify(policy);
   mxc.validatePolicy(policyJson).then(function(result: any) {
     if (result.valid) {
@@ -1622,8 +1772,8 @@ function init(): void {
   // Platform check
   mxc.getPlatformSupport().then(function(info: any) {
     $('platformBadge').textContent = info.isSupported
-      ? 'Γ£ô Platform supported'
-      : 'Γ£ù ' + (info.reason || 'Not supported');
+      ? '✓ Platform supported'
+      : '✗ ' + (info.reason || 'Not supported');
   });
 
   // === Welcome view buttons ===
@@ -1664,7 +1814,7 @@ function init(): void {
   // === Refresh shells ===
   $('btnRefreshShells').addEventListener('click', function() {
     var btn = $('btnRefreshShells');
-    btn.textContent = 'ΓÅ│';
+    btn.textContent = '⏳';
     btn.setAttribute('disabled', 'true');
     mxc.detectShells().then(function(shells: Record<string, any>) {
       var found: string[] = [];
@@ -1684,18 +1834,18 @@ function init(): void {
       }
       updateShellDropdown();
       populateScenarios();
-      btn.textContent = '≡ƒöä';
+      btn.textContent = '🔄';
       btn.removeAttribute('disabled');
       // Show summary in scenario description area
-      var msg = 'Γ£à Found: ' + (found.length > 0 ? found.join(', ') : 'none');
-      if (notFound.length > 0) { msg += '\nΓ¥î Not found: ' + notFound.join(', '); }
+      var msg = '✅ Found: ' + (found.length > 0 ? found.join(', ') : 'none');
+      if (notFound.length > 0) { msg += '\n❌ Not found: ' + notFound.join(', '); }
       $('refreshStatus').classList.remove('hidden');
       $('refreshStatusText').innerText = msg;
       // Re-trigger shell change to update button visibility
       $sel('shellSelect').dispatchEvent(new Event('change'));
       updatePythonAclWarning();
     }).catch(function() {
-      btn.textContent = '≡ƒöä';
+      btn.textContent = '🔄';
       btn.removeAttribute('disabled');
     });
   });
@@ -1707,21 +1857,43 @@ function init(): void {
   // === Containment select ===
   $sel('containmentSelect').addEventListener('change', function() {
     var containment = $sel('containmentSelect').value;
-    if (containment !== 'appcontainer') {
-      // Experimental containment ΓÇö hide runtime, force MXC JSON mode
-      $('runtimeRow').classList.add('hidden');
-      $('categoryRow').classList.add('hidden');
-      $sel('shellSelect').value = 'rawjson';
-      $sel('shellSelect').dispatchEvent(new Event('change'));
-      $('experimentalCaution').classList.remove('hidden');
-    } else {
-      // Process Container ΓÇö show runtime
+    if (containment === 'windows_sandbox') {
+      // Windows Sandbox — show runtime/scenarios, auto-enable experimental
       $('runtimeRow').classList.remove('hidden');
       $sel('shellSelect').disabled = false;
       $('experimentalCaution').classList.add('hidden');
+      // Hide policy controls — WS ignores filesystem/network/UI policies
+      $('policySectionWrapper').classList.add('hidden');
+      // Auto-enable experimental (WS requires it) and lock the toggle
+      ($('experimentalToggle') as HTMLInputElement).checked = true;
+      ($('experimentalToggle') as HTMLInputElement).disabled = true;
       if ($sel('shellSelect').value === 'rawjson') {
         $sel('shellSelect').value = 'cmd';
         $sel('shellSelect').dispatchEvent(new Event('change'));
+      } else {
+        populateScenarios();
+      }
+    } else if (containment !== 'appcontainer') {
+      // Other experimental containment — hide runtime, force MXC JSON mode
+      $('runtimeRow').classList.add('hidden');
+      $('categoryRow').classList.add('hidden');
+      $('policySectionWrapper').classList.remove('hidden');
+      $sel('shellSelect').value = 'rawjson';
+      $sel('shellSelect').dispatchEvent(new Event('change'));
+      $('experimentalCaution').classList.remove('hidden');
+      ($('experimentalToggle') as HTMLInputElement).disabled = false;
+    } else {
+      // Process Container — show runtime
+      $('runtimeRow').classList.remove('hidden');
+      $sel('shellSelect').disabled = false;
+      $('experimentalCaution').classList.add('hidden');
+      $('policySectionWrapper').classList.remove('hidden');
+      ($('experimentalToggle') as HTMLInputElement).disabled = false;
+      if ($sel('shellSelect').value === 'rawjson') {
+        $sel('shellSelect').value = 'cmd';
+        $sel('shellSelect').dispatchEvent(new Event('change'));
+      } else {
+        populateScenarios();
       }
     }
     updateContainmentDropdown();
@@ -1735,7 +1907,9 @@ function init(): void {
       $('categoryRow').classList.add('hidden');
       $('scriptSection').classList.remove('hidden');
       $('rawJsonSection').classList.add('hidden');
-      $('policySectionWrapper').classList.remove('hidden');
+      if ($sel('containmentSelect').value !== 'windows_sandbox') {
+        $('policySectionWrapper').classList.remove('hidden');
+      }
       $('btnRun').classList.remove('hidden');
       $('btnRunAll').classList.add('hidden');
       updateUiDetails();
@@ -1755,7 +1929,7 @@ function init(): void {
       $('btnRun').classList.remove('hidden');
       $('btnRunAll').classList.add('hidden');
       state.selectedScenario = null;
-      $('scenarioDesc').textContent = 'Paste a ContainerConfig JSON. Runs via spawnSandboxFromConfig ΓÇö no policy generation step.';
+      $('scenarioDesc').textContent = 'Paste a ContainerConfig JSON. Runs via spawnSandboxFromConfig — no policy generation step.';
       $('scenarioOutcome').textContent = '';
       $('scenarioOutcome').className = 'outcome-badge';
       $chk('experimentalToggle').checked = true;
@@ -1768,7 +1942,9 @@ function init(): void {
         populateScenarios();
         $('btnRun').classList.remove('hidden');
         $('btnRunAll').classList.remove('hidden');
-        $('policySectionWrapper').classList.remove('hidden');
+        if ($sel('containmentSelect').value !== 'windows_sandbox') {
+          $('policySectionWrapper').classList.remove('hidden');
+        }
         if (document.getElementById('advancedSectionWrapper')) {
           $('advancedSectionWrapper').classList.remove('hidden');
         }
@@ -1835,13 +2011,13 @@ function init(): void {
         updateContainmentDropdown();
       }
 
-      var info = '<span style="color:#4ec9b0;">Γ£ô Valid JSON</span>';
-      if (parsed.version) { info += ' ┬╖ version: ' + parsed.version; }
-      if (parsed.process?.commandLine) { info += ' ┬╖ <code>' + escapeHtml(parsed.process.commandLine) + '</code>'; }
-      if (parsed.containment) { info += ' ┬╖ containment: ' + parsed.containment; }
+      var info = '<span style="color:#4ec9b0;">✓ Valid JSON</span>';
+      if (parsed.version) { info += ' · version: ' + parsed.version; }
+      if (parsed.process?.commandLine) { info += ' · <code>' + escapeHtml(parsed.process.commandLine) + '</code>'; }
+      if (parsed.containment) { info += ' · containment: ' + parsed.containment; }
       $('jsonEditorPreview').innerHTML = info;
     } catch (e: any) {
-      $('jsonEditorPreview').innerHTML = '<span class="line-error">Γ£ù ' + escapeHtml(e.message) + '</span>';
+      $('jsonEditorPreview').innerHTML = '<span class="line-error">✗ ' + escapeHtml(e.message) + '</span>';
     }
   }
 
@@ -2084,15 +2260,15 @@ function init(): void {
   // === Copy buttons in dev sidebar ===
   $('copyPolicy').addEventListener('click', function() {
     navigator.clipboard.writeText($('devPolicyJson').textContent || '');
-    (this as HTMLElement).textContent = 'Γ£à';
+    (this as HTMLElement).textContent = '✅';
     var btn = this as HTMLElement;
-    setTimeout(function() { btn.textContent = '≡ƒôï'; }, 1000);
+    setTimeout(function() { btn.textContent = '📋'; }, 1000);
   });
   $('copyConfig').addEventListener('click', function() {
     navigator.clipboard.writeText($('devConfigJson').textContent || '');
-    (this as HTMLElement).textContent = 'Γ£à';
+    (this as HTMLElement).textContent = '✅';
     var btn = this as HTMLElement;
-    setTimeout(function() { btn.textContent = '≡ƒôï'; }, 1000);
+    setTimeout(function() { btn.textContent = '📋'; }, 1000);
   });
 
   // === Dev mode toggle ===

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -1,0 +1,2153 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+var mxc = (window as any).mxc;
+
+// ============================================================
+// Scenarios
+// ============================================================
+
+interface Scenario {
+  id: string;
+  name: string;
+  category: string;
+  categoryIcon: string;
+  description: string;
+  expectedOutcome: 'succeed' | 'be-blocked' | 'show-error';
+  expectedLabel: string;
+  script: string;
+  policy: any;
+  shell: 'cmd' | 'ps51' | 'ps7' | 'python';
+  requiresV05?: boolean;
+  /** If set, output must contain this string for a PASS verdict */
+  successMarker?: string;
+  /** If set, output containing this string means the script itself reported failure */
+  failureMarker?: string;
+  /** If set, resolve this test-script file and use it as the script command */
+  testScript?: { file: string; shell: string; args?: string };
+}
+
+// Shell detection ΓÇö cached after init
+var shellAvailability: Record<string, boolean> = {
+  cmd: true,
+  ps51: true,
+  ps7: false,
+  python: false,
+};
+
+// Resolved shell paths (populated by detect-shells)
+var shellPaths: Record<string, { exe?: string; rootDir?: string; needsAcl?: boolean; msixPackageDir?: string }> = {};
+
+var SHELL_BADGES: Record<string, string> = {
+  cmd: '≡ƒƒó',
+  ps51: '≡ƒö╡',
+  ps7: '≡ƒƒú',
+  python: '≡ƒÉì',
+};
+
+var SHELL_LABELS: Record<string, string> = {
+  cmd: 'Γ¼¢ cmd.exe',
+  ps51: '≡ƒö╖ PowerShell 5.1',
+  ps7: '≡ƒƒª PowerShell 7+',
+  python: '≡ƒÉì Python',
+};
+
+var SHELL_SHORT: Record<string, string> = {
+  cmd: 'cmd',
+  ps51: 'PS 5.1',
+  ps7: 'PS 7',
+  python: 'Python',
+};
+
+function updateRunAllLabel(): void {
+  var shell = $sel('shellSelect').value;
+  var name = SHELL_SHORT[shell] || shell;
+  $('btnRunAll').textContent = 'Γû╢Γû╢ Run All ' + name + ' Tests';
+}
+
+function updatePythonAclWarning(): void {
+  var shell = $sel('shellSelect').value;
+  if (shell !== 'python' && shell !== 'ps7') {
+    $('pythonAclWarning').classList.add('hidden');
+    return;
+  }
+
+  var isInstalled = shellAvailability[shell] !== false;
+  var name = shell === 'python' ? 'Python' : 'PowerShell 7';
+
+  if (!isInstalled) {
+    if (shell === 'python') {
+      $('pythonAclWarning').innerHTML =
+        '<div>ΓÜá∩╕Å ' + name + ' is not installed.</div>' +
+        '<div style="font-size:11px; margin-top:6px;">Install via terminal:</div>' +
+        '<code style="display:block; margin:4px 0; padding:4px 8px; background:var(--bg-input); border-radius:4px; font-size:11px; user-select:all;">winget install Python.Python.3.14</code>' +
+        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click ≡ƒöä after installation to refresh.</div>';
+    } else {
+      $('pythonAclWarning').innerHTML =
+        '<div>ΓÜá∩╕Å ' + name + ' is not installed.</div>' +
+        '<div style="font-size:11px; margin-top:6px;"><a href="https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-msi-package" target="_blank" style="color:var(--accent);">Install the MSI package ΓåÆ</a></div>' +
+        '<div style="font-size:11px; color:var(--text-dim); margin-top:4px;">Γä╣∩╕Å Only MSI-installed PowerShell 7+ is supported. MSIX and Microsoft Store versions are not yet supported.</div>' +
+        '<div style="font-size:11px; color:var(--text-muted); margin-top:6px;">Click ≡ƒöä after installation to refresh.</div>';
+    }
+    $('pythonAclWarning').classList.remove('hidden');
+    return;
+  }
+
+  $('pythonAclWarning').classList.add('hidden');
+}
+
+function updateShellDropdown(): void {
+  var select = document.getElementById('shellSelect') as HTMLSelectElement;
+  for (var i = 0; i < select.options.length; i++) {
+    var opt = select.options[i];
+    var shell = opt.value;
+    if (shell === 'custom' || shell === 'rawjson') { continue; }
+    var avail = shellAvailability[shell] !== false;
+    var label = SHELL_LABELS[shell] || shell;
+    opt.textContent = avail ? label : label + ' (not installed)';
+    opt.style.opacity = avail ? '1' : '0.6';
+  }
+}
+
+var SCENARIOS: Scenario[] = [
+  // ========== cmd.exe ==========
+  { id: 'cmd-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'cmd',
+    description: 'Runs a simple echo command to verify basic execution.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'cmd.exe /c echo Hello from sandbox!',
+    policy: { ui: { allowWindows: true } }, successMarker: 'Hello from sandbox!' },
+  { id: 'cmd-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+    description: 'Reads the hosts file using read-only access.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'cmd.exe /c type C:\\Windows\\System32\\drivers\\etc\\hosts',
+    policy: { filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] }, ui: { allowWindows: true } },
+    successMarker: 'sample HOSTS file' },
+  { id: 'cmd-fs-read-blocked', name: 'Read without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+    description: 'Tries to read from a user directory without filesystem access. Should be denied.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'cmd.exe /c type "%USERPROFILE%\\NTUSER.DAT"',
+    policy: { ui: { allowWindows: true } } },
+  { id: 'cmd-fs-write-spaces', name: 'Write to path with spaces', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'cmd',
+    description: 'Writes to a path containing spaces.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'cmd.exe /c echo SUCCESS > "C:\\Users\\Public\\mxc bfs test\\test_output.txt" && type "C:\\Users\\Public\\mxc bfs test\\test_output.txt"',
+    policy: { filesystem: { readwritePaths: ['C:\\Users\\Public\\mxc bfs test'] } },
+    requiresV05: true, successMarker: 'SUCCESS' },
+  { id: 'cmd-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'cmd',
+    description: 'Makes an HTTPS request with outbound network enabled.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'curl.exe -s --max-time 10 https://www.example.com',
+    policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
+    successMarker: 'Example Domain' },
+  { id: 'cmd-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'cmd',
+    description: 'Tries to reach example.com with no network access. Should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'curl.exe -s --max-time 5 https://www.example.com',
+    policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
+  { id: 'cmd-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'cmd',
+    description: 'Runs with Win32k disabled. cmd.exe does not need Win32k so it should still work.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'cmd.exe /c echo PASS: Win32k disabled', policy: { ui: { allowWindows: false } },
+    requiresV05: true, successMarker: 'PASS:' },
+  { id: 'cmd-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'cmd',
+    description: 'Runs a command that waits 30 seconds with a 5-second timeout.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: 'cmd.exe /c ping -n 30 127.0.0.1',
+    policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
+  { id: 'cmd-bad-exe', name: 'Non-existent executable', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'cmd',
+    description: 'Tries to run an executable that does not exist.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should fail',
+    script: 'this-command-does-not-exist-12345',
+    policy: { ui: { allowWindows: true } } },
+  { id: 'cmd-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'cmd',
+    description: 'Writes a file and reads it back. Exercises filesystem + desktop together.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'cmd.exe /c echo CMD_WRITE_OK > C:\\temp\\mxc-full-test\\cmd-result.txt && type C:\\temp\\mxc-full-test\\cmd-result.txt && echo ALL_OK',
+    policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-full-test'] }, ui: { allowWindows: true } },
+    successMarker: 'ALL_OK' },
+
+  // ========== PowerShell 5.1 ==========
+  { id: 'ps51-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps51',
+    description: 'Runs Write-Output to verify PowerShell works inside the sandbox.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -Command "Write-Output \'Hello from PowerShell\'"',
+    policy: { ui: { allowWindows: true } }, successMarker: 'Hello from PowerShell' },
+  { id: 'ps51-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps51',
+    description: 'Displays the PowerShell version table.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -Command "$PSVersionTable"',
+    policy: { ui: { allowWindows: true } }, successMarker: 'PSVersion' },
+  { id: 'ps51-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+    description: 'Writes a file to a brokered temp directory.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-write-test\\ps-output.txt -Value hello; Write-Output WRITE_OK"',
+    policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] }, ui: { allowWindows: true } },
+    successMarker: 'WRITE_OK' },
+  { id: 'ps51-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+    description: 'Tries to write to C:\\Windows. Access should be denied.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'powershell.exe -Command "try { Set-Content -Path \\"C:\\Windows\\mxc-test.txt\\" -Value \\"test\\" -ErrorAction Stop; Write-Output \\"UNEXPECTED\\" } catch { Write-Output \\"EXPECTED: $_\\" }"',
+    policy: { ui: { allowWindows: true } }, failureMarker: 'UNEXPECTED' },
+  { id: 'ps51-fs-read-root', name: 'Read from C:\\ root', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps51',
+    description: 'Lists C:\\ as a read-only path. Tests trailing backslash handling.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -NoProfile -Command "Get-ChildItem C:\\ | Select-Object -First 3 | ForEach-Object { Write-Output $_.Name }; Write-Output READ_ROOT_OK"',
+    policy: { filesystem: { readonlyPaths: ['C:\\'] }, ui: { allowWindows: true } },
+    requiresV05: true, successMarker: 'READ_ROOT_OK' },
+  { id: 'ps51-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps51',
+    description: 'Makes an HTTPS request with outbound network enabled.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -NoProfile -Command "$ProgressPreference=\'SilentlyContinue\'; (Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 10).Content"',
+    policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
+    successMarker: 'Example Domain' },
+  { id: 'ps51-net-blocked',name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps51',
+    description: 'Tries to make an HTTPS request with no network access. Should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'powershell.exe -NoProfile -Command "try { $h=New-Object -ComObject WinHttp.WinHttpRequest.5.1; $h.Open(\'GET\',\'https://www.example.com\',$false); $h.Send(); Write-Output $h.ResponseText } catch { Write-Output \'BLOCKED\' }"',
+    policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
+  { id: 'ps51-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'ps51',
+    description: 'Runs with Win32k disabled. PowerShell needs Win32k and should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should fail (needs Win32k)',
+    script: 'powershell.exe -NoProfile -Command "Write-Output PS_OK"',
+    policy: { ui: { allowWindows: false } }, requiresV05: true },
+  { id: 'ps51-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'ps51',
+    description: 'Runs a sleep with a 5-second timeout.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: 'powershell.exe -NoProfile -Command Start-Sleep -Seconds 30',
+    policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
+  { id: 'ps51-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'ps51',
+    description: 'Writes a file, reads it back, reports environment info.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'powershell.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-full-test\\result.txt -Value \'STEP1_OK\'; $c=Get-Content C:\\temp\\mxc-full-test\\result.txt; Write-Output $c; Write-Output (\'User: \' + $env:USERNAME); Write-Output \'ALL_OK\'"',
+    policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-full-test'] }, ui: { allowWindows: true } },
+    successMarker: 'ALL_OK' },
+
+  // ========== PowerShell 7 ==========
+  { id: 'ps7-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps7',
+    description: 'Runs a hello world in PowerShell 7+.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command "Write-Output \'Hello from PowerShell 7\'"',
+    policy: { ui: { allowWindows: true } }, successMarker: 'Hello from PowerShell 7' },
+  { id: 'ps7-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'ps7',
+    description: 'Gets PowerShell 7 version table.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command $PSVersionTable',
+    policy: { ui: { allowWindows: true } }, successMarker: 'PSVersion' },
+  { id: 'ps7-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+    description: 'Writes a file to a brokered path.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-write-test\\ps7-output.txt -Value hello; Write-Output WRITE_OK"',
+    policy: { ui: { allowWindows: true }, filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] } },
+    successMarker: 'WRITE_OK' },
+  { id: 'ps7-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+    description: 'Reads the hosts file from a brokered read-only path.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command Get-Content C:\\Windows\\System32\\drivers\\etc\\hosts',
+    policy: { ui: { allowWindows: true }, filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] } },
+    successMarker: 'sample HOSTS file' },
+  { id: 'ps7-fs-write-blocked', name: 'Write without permission', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'ps7',
+    description: 'Tries to write to a system directory. Should be denied.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'pwsh.exe -NoProfile -Command "try { Set-Content C:\\Windows\\test.txt -Value fail -ErrorAction Stop; exit 1 } catch { Write-Output BLOCKED; exit 0 }"',
+    policy: { ui: { allowWindows: true } } },
+  { id: 'ps7-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps7',
+    description: 'Makes an HTTPS request with outbound network enabled.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command "(Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 10).Content"',
+    policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
+    successMarker: 'Example Domain' },
+  { id: 'ps7-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'ps7',
+    description: 'Tries to make an HTTPS request with no network access. Should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'pwsh.exe -NoProfile -Command "try { (Invoke-WebRequest -Uri \'https://www.example.com\' -UseBasicParsing -TimeoutSec 5).Content } catch { Write-Output \'BLOCKED\' }"',
+    policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
+  { id: 'ps7-win32k-off', name: 'Win32k disabled', category: 'Desktop & UI Tests', categoryIcon: '≡ƒûÑ∩╕Å', shell: 'ps7',
+    description: 'Runs with Win32k disabled. PowerShell 7 needs Win32k and should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should fail (needs Win32k)',
+    script: 'pwsh.exe -NoProfile -Command "Write-Output PS7_OK"',
+    policy: { ui: { allowWindows: false } }, requiresV05: true },
+  { id: 'ps7-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'ps7',
+    description: 'Runs a sleep with a 5-second timeout.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: 'pwsh.exe -NoProfile -Command Start-Sleep -Seconds 30',
+    policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
+  { id: 'ps7-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'ps7',
+    description: 'Writes a file, reads it back, reports environment info.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'pwsh.exe -NoProfile -Command "Set-Content -Path C:\\temp\\mxc-full-test\\ps7-result.txt -Value \'STEP1_OK\'; $c=Get-Content C:\\temp\\mxc-full-test\\ps7-result.txt; Write-Output $c; Write-Output (\'User: \' + $env:USERNAME); Write-Output \'ALL_OK\'"',
+    policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-full-test'] }, ui: { allowWindows: true } },
+    successMarker: 'ALL_OK' },
+
+  // ========== Python ==========
+  { id: 'py-hello', name: 'Echo Hello', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'python',
+    description: 'Runs a hello world in Python.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "print(\'Hello from Python\')"',
+    policy: { ui: { allowWindows: true } }, successMarker: 'Hello from Python' },
+  { id: 'py-version', name: 'Version info', category: 'Quick Tests', categoryIcon: '≡ƒÄ»', shell: 'python',
+    description: 'Gets Python version.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "import sys; print(f\'Python {sys.version}\')"',
+    policy: { ui: { allowWindows: true } }, successMarker: 'Python' },
+  { id: 'py-fs-write', name: 'Write to allowed folder', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'python',
+    description: 'Writes a file to a brokered read-write path.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "f=open(r\'C:\\temp\\mxc-write-test\\py-output.txt\',\'w\'); f.write(\'hello\'); f.close(); print(\'WRITE_OK\')"',
+    policy: { ui: { allowWindows: true }, filesystem: { readwritePaths: ['C:\\temp\\mxc-write-test'] } },
+    successMarker: 'WRITE_OK' },
+  { id: 'py-fs-read', name: 'Read system file', category: 'File Access Tests', categoryIcon: '≡ƒôü', shell: 'python',
+    description: 'Reads the hosts file from a brokered read-only path.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "print(open(r\'C:\\Windows\\System32\\drivers\\etc\\hosts\').read()[:200])"',
+    policy: { ui: { allowWindows: true }, filesystem: { readonlyPaths: ['C:\\Windows\\System32\\drivers\\etc'] } },
+    successMarker: 'sample HOSTS file' },
+  { id: 'py-net-ok', name: 'Internet allowed', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'python',
+    description: 'Makes an HTTPS request with outbound network enabled.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "import urllib.request; print(urllib.request.urlopen(\'https://www.example.com\',timeout=10).read().decode()[:200])"',
+    policy: { network: { allowOutbound: true }, ui: { allowWindows: true } },
+    successMarker: 'Example Domain' },
+  { id: 'py-net-blocked', name: 'Internet blocked', category: 'Network Tests', categoryIcon: '≡ƒîÉ', shell: 'python',
+    description: 'Tries to make an HTTPS request with no network access. Should fail.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be blocked',
+    script: 'python -c "import urllib.request; print(urllib.request.urlopen(\'https://www.example.com\',timeout=5).read().decode())"',
+    policy: { ui: { allowWindows: true } }, failureMarker: 'Example Domain' },
+  { id: 'py-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: 'ΓÜá∩╕Å', shell: 'python',
+    description: 'Runs a sleep with a 5-second timeout.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: 'python -c "import time; time.sleep(30)"',
+    policy: { ui: { allowWindows: true }, timeoutMs: 5000 } },
+  { id: 'py-full-access', name: 'Full access', category: 'Combined Tests', categoryIcon: '≡ƒöä', shell: 'python',
+    description: 'Writes a file, reads it back using Python.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: 'python -c "f=open(r\'C:\\temp\\mxc-full-test\\py-result.txt\',\'w\'); f.write(\'STEP1_OK\'); f.close(); c=open(r\'C:\\temp\\mxc-full-test\\py-result.txt\').read(); print(c); print(\'ALL_OK\')"',
+    policy: { filesystem: { readwritePaths: ['C:\\temp\\mxc-full-test'] }, ui: { allowWindows: true } },
+    successMarker: 'ALL_OK' },
+];
+
+// ============================================================
+// State
+// ============================================================
+
+var state = {
+  currentView: 'main' as 'welcome' | 'main',
+  selectedScenario: null as Scenario | null,
+  customScript: '',
+  version: '0.5.0-dev',
+  timeoutSeconds: 30,
+  advancedMode: false,
+  // Filesystem
+  fsEnabled: false,
+  rwPaths: [] as string[],
+  roPaths: [] as string[],
+  fsIncludeTools: false,
+  fsIncludeTemp: false,
+  // Network
+  netEnabled: false,
+  // UI
+  uiAllowWindows: true,
+  uiClipboard: 'none' as string,
+  uiInjection: false,
+  // Running
+  running: false,
+  // Track original scenario policy for modification detection
+  scenarioPolicySnapshot: '' as string,
+  // JSON tab
+  activeJsonTab: null as string | null,
+  // Section visibility
+  permissionsOpen: false,
+  advancedOpen: false,
+  terminalOpen: true,
+};
+
+// ============================================================
+// DOM Helpers
+// ============================================================
+
+function $(id: string): HTMLElement {
+  return document.getElementById(id)!;
+}
+
+function $sel(id: string): HTMLSelectElement {
+  return document.getElementById(id) as HTMLSelectElement;
+}
+
+function $chk(id: string): HTMLInputElement {
+  return document.getElementById(id) as HTMLInputElement;
+}
+
+function $num(id: string): HTMLInputElement {
+  return document.getElementById(id) as HTMLInputElement;
+}
+
+// ============================================================
+// ANSI Stripping
+// ============================================================
+
+function stripAnsi(text: string): string {
+  return text
+    .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
+    .replace(/\x1b\][^\x07]*\x07/g, '')
+    .replace(/\x1b\[\?[0-9;]*[a-zA-Z]/g, '');
+}
+
+// ============================================================
+// JSON Syntax Highlighting
+// ============================================================
+
+function highlightJson(json: string): string {
+  return json.replace(
+    /("(?:\\.|[^"\\])*")\s*:/g,
+    '<span class="json-key">$1</span>:'
+  ).replace(
+    /:\s*("(?:\\.|[^"\\])*")/g,
+    function(match, val) { return ': <span class="json-string">' + val + '</span>'; }
+  ).replace(
+    /:\s*(\d+(?:\.\d+)?)/g,
+    ': <span class="json-number">$1</span>'
+  ).replace(
+    /:\s*(true|false)/g,
+    ': <span class="json-boolean">$1</span>'
+  ).replace(
+    /:\s*(null)/g,
+    ': <span class="json-null">$1</span>'
+  );
+}
+
+// ============================================================
+// Terminal
+// ============================================================
+
+function termClear(): void {
+  $('terminal').innerHTML = '';
+}
+
+function termWrite(text: string, cls: string): void {
+  var el = $('terminal');
+  var span = document.createElement('span');
+  span.className = cls;
+  span.textContent = text + '\n';
+  el.appendChild(span);
+  el.scrollTop = el.scrollHeight;
+}
+
+function termInfo(msg: string): void { termWrite(msg, 'line-info'); }
+function termSuccess(msg: string): void { termWrite(msg, 'line-success'); }
+function termError(msg: string): void { termWrite(msg, 'line-error'); }
+function termDim(msg: string): void { termWrite(msg, 'line-dim'); }
+function termOutput(text: string): void { termWrite(text, 'line-output'); }
+
+// ============================================================
+// Auto-detect advanced mode
+// ============================================================
+
+function isAdvancedNeeded(): boolean {
+  var isolation = $sel('uiIsolation').value;
+  var desktopControl = $chk('uiDesktopControl').checked;
+  var systemSettings = $sel('uiSystemSettings').value;
+  var ime = $chk('uiIME').checked;
+  if (isolation !== 'container') return true;
+  if (desktopControl) return true;
+  if (systemSettings !== 'none') return true;
+  if (ime) return true;
+  if (state.version === '0.5.0-dev') return true;
+  return false;
+}
+
+// ============================================================
+// Build Policy
+// ============================================================
+
+function buildPolicy(): any {
+  var policy: any = { version: state.version };
+
+  // Filesystem
+  if (state.fsEnabled) {
+    var rwPaths = state.rwPaths.slice();
+    var roPaths = state.roPaths.slice();
+    if (rwPaths.length > 0 || roPaths.length > 0) {
+      policy.filesystem = {};
+      if (rwPaths.length > 0) policy.filesystem.readwritePaths = rwPaths;
+      if (roPaths.length > 0) policy.filesystem.readonlyPaths = roPaths;
+    }
+  }
+
+  // Network
+  if (state.netEnabled) {
+    policy.network = { allowOutbound: true };
+    var proxyVal = $sel('proxySelect').value;
+    if (proxyVal === 'builtin') {
+      policy.network.proxy = { builtinTestServer: true };
+    } else if (proxyVal === 'localhost') {
+      var port = parseInt($num('proxyPort').value, 10);
+      if (port > 0 && port <= 65535) {
+        policy.network.proxy = { localhost: port };
+      }
+    } else if (proxyVal === 'url') {
+      var urlVal = ($('proxyUrl') as HTMLInputElement).value.trim();
+      if (urlVal) {
+        policy.network.proxy = { url: urlVal };
+      }
+    }
+  }
+
+  // UI
+  policy.ui = { allowWindows: state.uiAllowWindows };
+  if (state.uiClipboard !== 'none') policy.ui.clipboard = state.uiClipboard;
+  if (state.uiInjection) policy.ui.allowInputInjection = true;
+
+  // Timeout
+  if (state.timeoutSeconds > 0) {
+    policy.timeoutMs = state.timeoutSeconds * 1000;
+  }
+
+  // Auto-include Python path for Python scenarios
+  if (state.selectedScenario?.shell === 'python' && shellPaths.python?.rootDir) {
+    policy.filesystem = policy.filesystem || {};
+    policy.filesystem.readwritePaths = policy.filesystem.readwritePaths || [];
+    if (policy.filesystem.readwritePaths.indexOf(shellPaths.python.rootDir) === -1) {
+      policy.filesystem.readwritePaths.push(shellPaths.python.rootDir);
+    }
+  }
+
+  // Auto-include PS7 path for PS7 scenarios
+  if (state.selectedScenario?.shell === 'ps7' && shellPaths.ps7?.rootDir) {
+    policy.filesystem = policy.filesystem || {};
+    policy.filesystem.readonlyPaths = policy.filesystem.readonlyPaths || [];
+    if (policy.filesystem.readonlyPaths.indexOf(shellPaths.ps7.rootDir) === -1) {
+      policy.filesystem.readonlyPaths.push(shellPaths.ps7.rootDir);
+    }
+    // For MSIX installs (WindowsApps), also add the resolved package directory
+    // so BFS can broker access to the actual PS7 binaries/DLLs.
+    if (shellPaths.ps7.msixPackageDir) {
+      if (policy.filesystem.readonlyPaths.indexOf(shellPaths.ps7.msixPackageDir) === -1) {
+        policy.filesystem.readonlyPaths.push(shellPaths.ps7.msixPackageDir);
+      }
+    }
+  }
+
+  return policy;
+}
+
+// ============================================================
+// Get current script
+// ============================================================
+
+function getCurrentScript(): string {
+  var script = '';
+  if (state.selectedScenario && state.selectedScenario.id !== 'custom') {
+    script = state.selectedScenario.script;
+  } else {
+    script = state.customScript || '';
+  }
+
+  // Replace bare 'python' with resolved full path for BaseContainer compatibility
+  if (shellPaths.python?.exe && script.match(/^python\s/)) {
+    script = '"' + shellPaths.python.exe + '"' + script.substring(6);
+  }
+
+  return script;
+}
+
+// ============================================================
+// Containment badge
+// ============================================================
+
+var CONTAINMENT_LABELS: Record<string, string> = {
+  appcontainer: 'Base Process Container',
+  windows_sandbox: 'Windows Sandbox',
+  microvm: 'MicroVM (NanVix)',
+  wslc: 'WSLC',
+  lxc: 'LXC',
+  vm: 'VM',
+};
+
+function updateContainmentDropdown(): void {
+  var version = state.version;
+  var select = $sel('containmentSelect');
+  var isV05 = version === '0.5.0-dev';
+
+  for (var i = 0; i < select.options.length; i++) {
+    var opt = select.options[i];
+    if (opt.value === 'appcontainer') {
+      opt.textContent = isV05 ? '≡ƒ¢í∩╕Å Base Process Container' : '≡ƒ¢í∩╕Å AppContainer';
+    } else {
+      // Experimental types only on 0.5.0+
+      opt.disabled = !isV05;
+      opt.style.display = isV05 ? '' : 'none';
+    }
+  }
+
+  // If on 0.4.0 and an experimental type was selected, reset to appcontainer
+  if (!isV05 && select.value !== 'appcontainer') {
+    select.value = 'appcontainer';
+    select.dispatchEvent(new Event('change'));
+  }
+}
+
+function isExperimentalContainment(): boolean {
+  return $sel('containmentSelect').value !== 'appcontainer';
+}
+
+// ============================================================
+// Policy summary
+// ============================================================
+
+function getPermsSummary(): string {
+  var fs = state.fsEnabled ? 'limited' : 'off';
+  var net = state.netEnabled ? 'on' : 'off';
+  var ui = state.uiAllowWindows ? 'on' : 'off';
+  return 'Files: ' + fs + ' ┬╖ Internet: ' + net + ' ┬╖ Desktop: ' + ui;
+}
+
+function updatePermsSummary(): void {
+  var summary = getPermsSummary();
+  $('permissionsSummaryLine').textContent = summary;
+  $('runSummary').textContent = 'Internet: ' + (state.netEnabled ? 'on' : 'off') +
+    ' ┬╖ Files: ' + (state.fsEnabled ? 'limited' : 'off') +
+    ' ┬╖ Desktop: ' + (state.uiAllowWindows ? 'on' : 'off');
+}
+
+// ============================================================
+// Path list rendering
+// ============================================================
+
+function renderPathList(containerId: string, paths: string[], onRemove: (index: number) => void): void {
+  var container = $(containerId);
+  container.innerHTML = '';
+  if (paths.length === 0) {
+    var empty = document.createElement('div');
+    empty.className = 'path-empty';
+    empty.textContent = 'No folders added';
+    container.appendChild(empty);
+    return;
+  }
+  paths.forEach(function(p, i) {
+    var item = document.createElement('div');
+    item.className = 'path-item';
+
+    var text = document.createElement('span');
+    text.className = 'path-text';
+    text.textContent = p;
+    text.title = p;
+    item.appendChild(text);
+
+    var removeBtn = document.createElement('button');
+    removeBtn.className = 'path-remove';
+    removeBtn.textContent = '├ù';
+    removeBtn.title = 'Remove';
+    removeBtn.addEventListener('click', function() {
+      onRemove(i);
+    });
+    item.appendChild(removeBtn);
+
+    container.appendChild(item);
+  });
+}
+
+function refreshPathLists(): void {
+  renderPathList('rwPathList', state.rwPaths, function(i) {
+    state.rwPaths.splice(i, 1);
+    refreshPathLists();
+    updateDevSidebar();
+  });
+  renderPathList('roPathList', state.roPaths, function(i) {
+    state.roPaths.splice(i, 1);
+    refreshPathLists();
+    updateDevSidebar();
+  });
+}
+
+// ============================================================
+// Result card
+// ============================================================
+
+function setResultIdle(): void {
+  var card = $('resultCard');
+  card.className = 'result-card result-idle';
+  $('resultIcon').textContent = '≡ƒÆí';
+  $('resultTitle').textContent = 'Select a scenario and click Run in Sandbox';
+  $('resultDetail').textContent = '';
+  $('resultActions').classList.add('hidden');
+  $('resultActions').innerHTML = '';
+}
+
+function setResultRunning(): void {
+  var card = $('resultCard');
+  card.className = 'result-card result-running';
+  $('resultIcon').textContent = 'ΓÅ│';
+  $('resultTitle').textContent = 'RunningΓÇª';
+  $('resultDetail').textContent = 'Script is executing inside the sandbox';
+  $('resultActions').classList.add('hidden');
+}
+
+function setResultSuccess(exitCode: number): void {
+  var card = $('resultCard');
+  card.className = 'result-card result-success';
+  $('resultIcon').textContent = 'Γ£à';
+  $('resultTitle').textContent = 'Script completed successfully (exit code ' + formatExitCode(exitCode) + ')';
+  $('resultDetail').textContent = '';
+  showResultActions('success');
+}
+
+function setResultError(exitCode: number): void {
+  var card = $('resultCard');
+  card.className = 'result-card result-error';
+  $('resultIcon').textContent = 'Γ¥î';
+  if (exitCode === -1) {
+    $('resultTitle').textContent = 'Script was blocked ΓÇö access denied';
+  } else {
+    $('resultTitle').textContent = 'Script failed (exit code ' + formatExitCode(exitCode) + ')';
+  }
+  $('resultDetail').textContent = '';
+  showResultActions('error');
+}
+
+function showResultActions(type: string): void {
+  var container = $('resultActions');
+  container.innerHTML = '';
+  container.classList.remove('hidden');
+
+  var suggestions: { label: string; action: () => void }[] = [];
+
+  if (type === 'error') {
+    if (!state.netEnabled) {
+      suggestions.push({
+        label: '≡ƒîÉ Try with internet enabled',
+        action: function() {
+          $chk('netToggle').checked = true;
+          state.netEnabled = true;
+          updatePermsSummary();
+          updateNetDetails();
+        },
+      });
+    }
+    if (!state.fsEnabled) {
+      suggestions.push({
+        label: '≡ƒôü Try with file access',
+        action: function() {
+          $chk('fsToggle').checked = true;
+          state.fsEnabled = true;
+          updatePermsSummary();
+          updateFsDetails();
+        },
+      });
+    }
+  }
+
+  suggestions.forEach(function(s) {
+    var btn = document.createElement('button');
+    btn.className = 'btn btn-small btn-text';
+    btn.textContent = s.label;
+    btn.addEventListener('click', s.action);
+    container.appendChild(btn);
+  });
+}
+
+// ============================================================
+// Toggle visibility helpers
+// ============================================================
+
+function updateFsDetails(): void {
+  var details = $('fsDetails');
+  if (state.fsEnabled) {
+    details.classList.remove('hidden');
+  } else {
+    details.classList.add('hidden');
+  }
+}
+
+function updateNetDetails(): void {
+  var details = $('netDetails');
+  if (state.netEnabled) {
+    details.classList.remove('hidden');
+    $('proxySection').style.display = '';
+  } else {
+    details.classList.add('hidden');
+    $('proxySection').style.display = 'none';
+  }
+}
+
+function updateUiDetails(): void {
+  var isV05 = state.version === '0.5.0-dev';
+  var shell = $sel('shellSelect').value;
+  var isBuiltinUnavailable = (shell === 'ps7' || shell === 'python') && !shellAvailability[shell];
+
+  // Desktop UI Access and Advanced only exist for 0.5.0+, and only when runtime is available
+  var showAdvanced = isV05 && !isBuiltinUnavailable;
+  $('uiGroupWrapper').classList.toggle('hidden', !showAdvanced);
+  $('advancedSectionWrapper').classList.toggle('hidden', !showAdvanced);
+
+  if (state.uiAllowWindows) {
+    $('uiNoteOn').classList.remove('hidden');
+    $('uiNoteOff').classList.add('hidden');
+    $('uiClipboardRow').classList.remove('hidden');
+  } else {
+    $('uiNoteOn').classList.add('hidden');
+    $('uiNoteOff').classList.remove('hidden');
+    $('uiClipboardRow').classList.add('hidden');
+  }
+}
+
+// ============================================================
+// Scenario loading
+// ============================================================
+
+function populateScenarios(): void {
+  var shell = $sel('shellSelect').value;
+  if (shell === 'custom') return;
+
+  var select = $sel('scenarioSelect');
+  select.innerHTML = '';
+
+  var filtered = SCENARIOS.filter(function(s) { return s.shell === shell; });
+
+  // Group by category
+  var categories: string[] = [];
+  filtered.forEach(function(s) {
+    if (categories.indexOf(s.category) === -1) categories.push(s.category);
+  });
+
+  categories.forEach(function(cat) {
+    var group = document.createElement('optgroup');
+    var icon = '';
+    filtered.forEach(function(s) {
+      if (s.category === cat) icon = s.categoryIcon;
+    });
+    group.label = icon + ' ' + cat;
+    filtered.forEach(function(s) {
+      if (s.category !== cat) return;
+      // Hide scenarios requiring 0.5.0+ when on 0.4.0
+      if (s.requiresV05 && state.version !== '0.5.0-dev') { return; }
+      var opt = document.createElement('option');
+      opt.value = s.id;
+      var marker = s.expectedOutcome === 'succeed' ? 'Γ£ô' : 'Γ£ù';
+      opt.textContent = marker + ' ' + s.name;
+      group.appendChild(opt);
+    });
+    select.appendChild(group);
+  });
+
+  // Auto-select first enabled scenario
+  var firstEnabled = select.querySelector('option:not([disabled])') as HTMLOptionElement;
+  if (firstEnabled) {
+    select.value = firstEnabled.value;
+    loadScenario(firstEnabled.value);
+  }
+}
+
+function loadScenario(id: string): void {
+  if (id === 'custom') {
+    state.selectedScenario = null;
+    $('scenarioDesc').textContent = 'Write your own script and configure policy.';
+    $('scenarioOutcome').textContent = '';
+    $('scenarioOutcome').className = 'outcome-badge';
+    $('scriptSection').classList.remove('hidden');
+    return;
+  }
+
+  var scenario = SCENARIOS.filter(function(s) { return s.id === id; })[0];
+  if (!scenario) return;
+
+  state.selectedScenario = scenario;
+
+  // Update scenario info
+  var shellBadge = SHELL_BADGES[scenario.shell] || '';
+  var shellAvail = shellAvailability[scenario.shell] !== false;
+  $('scenarioDesc').textContent = scenario.description;
+  $('scenarioOutcome').textContent = scenario.expectedLabel;
+  $('scenarioOutcome').className = 'outcome-badge ' + scenario.expectedOutcome;
+
+  if (!shellAvail) {
+    $('scenarioDesc').textContent = 'ΓÜá∩╕Å ' + scenario.shell + ' is not installed. ' + scenario.description;
+  }
+
+  // Collapse script section for presets
+  $('scriptSection').classList.add('hidden');
+
+  // Version comes from global dropdown, not per-scenario
+
+  // Filesystem
+  if (scenario.policy.filesystem) {
+    state.fsEnabled = true;
+    state.rwPaths = (scenario.policy.filesystem.readwritePaths || []).slice();
+    state.roPaths = (scenario.policy.filesystem.readonlyPaths || []).slice();
+  } else {
+    state.fsEnabled = false;
+    state.rwPaths = [];
+    state.roPaths = [];
+  }
+  $chk('fsToggle').checked = state.fsEnabled;
+  updateFsDetails();
+  refreshPathLists();
+
+  // Network
+  state.netEnabled = !!(scenario.policy.network && scenario.policy.network.allowOutbound);
+  $chk('netToggle').checked = state.netEnabled;
+
+  // Proxy
+  if (scenario.policy.network && scenario.policy.network.proxy) {
+    var p = scenario.policy.network.proxy;
+    if (p.builtinTestServer) {
+      $sel('proxySelect').value = 'builtin';
+    } else if (p.localhost) {
+      $sel('proxySelect').value = 'localhost';
+      $num('proxyPort').value = p.localhost.toString();
+    } else if (p.url) {
+      $sel('proxySelect').value = 'url';
+      ($('proxyUrl') as HTMLInputElement).value = p.url;
+    }
+  } else {
+    $sel('proxySelect').value = 'none';
+  }
+  $('proxyPort').style.display = $sel('proxySelect').value === 'localhost' ? '' : 'none';
+  $('proxyUrl').style.display = $sel('proxySelect').value === 'url' ? '' : 'none';
+
+  updateNetDetails();
+
+  // UI
+  state.uiAllowWindows = scenario.policy.ui ? scenario.policy.ui.allowWindows !== false : true;
+  $chk('uiToggle').checked = state.uiAllowWindows;
+  state.uiClipboard = (scenario.policy.ui && scenario.policy.ui.clipboard) || 'none';
+  $sel('uiClipboard').value = state.uiClipboard;
+  state.uiInjection = !!(scenario.policy.ui && scenario.policy.ui.allowInputInjection);
+  $chk('uiInjection').checked = state.uiInjection;
+  updateUiDetails();
+
+  // Include helpers ΓÇö default ON for scenarios
+  state.fsIncludeTools = true;
+  state.fsIncludeTemp = true;
+  $chk('fsIncludeTools').checked = true;
+  $chk('fsIncludeTemp').checked = true;
+
+  // Timeout from scenario policy
+  if (scenario.policy.timeoutMs) {
+    state.timeoutSeconds = scenario.policy.timeoutMs / 1000;
+  } else {
+    state.timeoutSeconds = 30;
+  }
+  ($('timeoutInput') as HTMLInputElement).value = state.timeoutSeconds.toString();
+
+  updatePermsSummary();
+  setResultIdle();
+  termClear();
+  termInfo('Loaded scenario: ' + scenario.name);
+  termDim(scenario.description);
+  termDim('Expected: ' + scenario.expectedLabel);
+
+  // Snapshot the policy so we can detect user modifications later
+  state.scenarioPolicySnapshot = JSON.stringify(buildPolicy());
+
+  updateDevSidebar();
+}
+
+// ============================================================
+// Run / Kill
+// ============================================================
+
+async function runSandbox(): Promise<void> {
+  if (state.running) return;
+
+  // Raw JSON Config mode ΓÇö bypass policy builder entirely
+  var currentShell = $sel('shellSelect').value;
+  if (currentShell === 'rawjson') {
+    var rawJson = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
+    if (!rawJson) {
+      termError('No JSON config provided');
+      return;
+    }
+
+    state.running = true;
+    if (!runAllInProgress) {
+      ($('btnRun') as HTMLButtonElement).disabled = true;
+      $('btnKill').classList.remove('hidden');
+      $('btnRun').classList.add('hidden');
+      setResultRunning();
+      termClear();
+    }
+    terminalFullText = '';
+
+    termInfo('[Playground] Running MXC JSON config');
+    termInfo('[MXC] API: spawnSandboxFromConfig');
+
+    var rawDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+    var rawExperimental = (document.getElementById('experimentalToggle') as HTMLInputElement).checked;
+    var result = await mxc.runSandboxRaw(rawJson, rawDebug, rawExperimental);
+    if (!result.success) {
+      termError('[MXC] Failed to start sandbox: ' + result.error);
+      onSandboxExit(-1);
+    } else {
+      termDim('[MXC] Config accepted');
+    }
+    return;
+  }
+
+  var script = getCurrentScript();
+
+  // Resolve test script file if scenario uses one
+  if (state.selectedScenario?.testScript) {
+    var ts = state.selectedScenario.testScript;
+    var scriptInfo = await mxc.getTestScript(ts.file);
+    if (scriptInfo.success) {
+      script = ts.shell + ' -NoProfile -ExecutionPolicy Bypass -File "' + scriptInfo.path + '"' + (ts.args ? ' ' + ts.args : '');
+      termDim('[Playground] Using test script: ' + scriptInfo.path);
+    } else {
+      termError('[Playground] Could not find test script: ' + ts.file + ' ΓÇö ' + scriptInfo.error);
+      return;
+    }
+  }
+
+  if (!script.trim()) {
+    termError('No script specified');
+    return;
+  }
+
+  // Warn and trim leading/trailing whitespace
+  if (script !== script.trim()) {
+    script = script.trim();
+    termDim('[Playground] ΓÜá Trimmed leading/trailing whitespace from script');
+  }
+
+  state.running = true;
+  if (!runAllInProgress) {
+    ($('btnRun') as HTMLButtonElement).disabled = true;
+    $('btnKill').classList.remove('hidden');
+    $('btnRun').classList.add('hidden');
+    setResultRunning();
+    termClear();
+  }
+  terminalFullText = '';
+
+  var policy = buildPolicy();
+
+  // Detect if user modified the pre-made scenario's settings
+  var scenarioModified = false;
+  if (state.selectedScenario && state.scenarioPolicySnapshot) {
+    var currentSnapshot = JSON.stringify(policy);
+    if (currentSnapshot !== state.scenarioPolicySnapshot) {
+      scenarioModified = true;
+      termDim('[Playground] ΓÜá Note: You modified settings from the original scenario. Verdict may not match the expected outcome.');
+    }
+  }
+
+  // Merge auto-include paths
+  try {
+    if (state.fsIncludeTools) {
+      var tools = await mxc.getToolsPolicy();
+      if (tools.readonlyPaths) {
+        policy.filesystem = policy.filesystem || {};
+        policy.filesystem.readonlyPaths = (policy.filesystem.readonlyPaths || []).concat(tools.readonlyPaths);
+      }
+    }
+    if (state.fsIncludeTemp) {
+      var temp = await mxc.getTempPolicy();
+      if (temp.readwritePaths) {
+        policy.filesystem = policy.filesystem || {};
+        policy.filesystem.readwritePaths = (policy.filesystem.readwritePaths || []).concat(temp.readwritePaths);
+      }
+    }
+  } catch (e: any) {
+    termError('Failed to get auto-include paths: ' + e.message);
+  }
+
+  // Auto-add test-scripts directory to readonlyPaths if using a test script
+  if (state.selectedScenario?.testScript) {
+    var scriptInfo2 = await mxc.getTestScript(state.selectedScenario.testScript.file);
+    if (scriptInfo2.success) {
+      var scriptDir = scriptInfo2.path.substring(0, scriptInfo2.path.lastIndexOf('\\'));
+      policy.filesystem = policy.filesystem || {};
+      policy.filesystem.readonlyPaths = policy.filesystem.readonlyPaths || [];
+      if (policy.filesystem.readonlyPaths.indexOf(scriptDir) === -1) {
+        policy.filesystem.readonlyPaths.push(scriptDir);
+      }
+    }
+  }
+
+  // Ensure write directories exist before running
+  var allWritePaths = policy.filesystem?.readwritePaths || [];
+  if (allWritePaths.length > 0) {
+    termDim('[Playground] Setup: ensuring directories exist ΓÇö ' + allWritePaths.join(', '));
+    await mxc.ensureDirs(allWritePaths);
+  }
+
+  var policyJson = JSON.stringify(policy, null, 2);
+
+  var useAdvanced = isAdvancedNeeded();
+
+  termInfo('[Playground] Running via @microsoft/mxc-sdk');
+  if (state.selectedScenario) {
+    termInfo('[Playground] Scenario: ' + state.selectedScenario.name + ' (' + state.selectedScenario.id + ')');
+  }
+  termInfo('[Playground] Script: ' + script);
+  if (useAdvanced) {
+    termInfo('[MXC] API: createConfigFromPolicy ΓåÆ spawnSandboxFromConfig');
+  } else {
+    termInfo('[MXC] API: spawnSandbox()');
+  }
+  termInfo('[MXC] Schema: ' + state.version);
+
+  const debugEnabled = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+  const experimentalEnabled = (document.getElementById('experimentalToggle') as HTMLInputElement).checked;
+
+  if (useAdvanced) {
+    var result = await mxc.runSandboxAdvanced(script, policyJson, debugEnabled, experimentalEnabled);
+    if (!result.success) {
+      termError('[MXC] Failed to start sandbox: ' + result.error);
+      onSandboxExit(-1);
+    } else if (result.config) {
+      termDim('[MXC] Config generated successfully');
+    }
+  } else {
+    var result = await mxc.runSandbox(script, policyJson, debugEnabled, experimentalEnabled);
+    if (!result.success) {
+      termError('[MXC] Failed to start sandbox: ' + result.error);
+      onSandboxExit(-1);
+    }
+  }
+}
+
+async function killSandbox(): Promise<void> {
+  termInfo('[Playground] Stopping sandboxΓÇª');
+  await mxc.killSandbox();
+  onSandboxExit(-1);
+}
+
+// ============================================================
+// Run All Scenarios
+// ============================================================
+
+var runAllResolve: ((result: { exitCode: number; pass: boolean; scenario?: Scenario; output: string }) => void) | null = null;
+var runAllInProgress = false;
+
+async function runAllScenarios(): Promise<void> {
+  if (runAllInProgress || state.running) { return; }
+  runAllInProgress = true;
+  ($('btnRun') as HTMLButtonElement).disabled = true;
+  ($('btnRunAll') as HTMLButtonElement).disabled = true;
+  $('btnRunAll').textContent = 'ΓÅ│ RunningΓÇª';
+
+  var debugEnabled = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+  var version = state.version;
+  var currentShell = $sel('shellSelect').value;
+
+  // Filter scenarios: current shell, available runtimes, version-appropriate
+  var scenariosToRun = SCENARIOS.filter(function(s) {
+    if (s.shell !== currentShell) { return false; }
+    if (s.shell === 'ps7' && !shellAvailability['ps7']) { return false; }
+    if (s.shell === 'python' && !shellAvailability['python']) { return false; }
+    if (s.requiresV05 && version !== '0.5.0-dev') { return false; }
+    return true;
+  });
+
+  var logLines: string[] = [];
+  var passed = 0;
+  var failed = 0;
+  var total = scenariosToRun.length;
+  var results: { scenario: Scenario; verdict: string; pass: boolean; exitCode: number }[] = [];
+
+  logLines.push('=== MXC Playground ΓÇö Run All Results ===');
+  logLines.push('Date: ' + new Date().toISOString());
+  logLines.push('Schema: ' + version);
+  logLines.push('Runtime: ' + currentShell);
+  logLines.push('Debug: ' + (debugEnabled ? 'ON' : 'OFF'));
+  logLines.push('Scenarios: ' + total);
+  logLines.push('');
+
+  // Show running state in result card
+  $('resultCard').className = 'result-card result-running';
+  $('resultIcon').textContent = 'ΓÅ│';
+  $('resultTitle').textContent = 'Running all ' + total + ' testsΓÇª';
+  $('resultDetail').textContent = '0/' + total + ' complete';
+
+  termClear();
+  termInfo('[Playground] Γû╢Γû╢ Running all ' + total + ' tests for ' + currentShell + 'ΓÇª');
+  termInfo('');
+
+  for (var i = 0; i < scenariosToRun.length; i++) {
+    var scenario = scenariosToRun[i];
+    logLines.push('--- [' + (i + 1) + '/' + total + '] ' + scenario.name + ' (' + scenario.id + ') ---');
+
+    // Update progress
+    $('resultDetail').textContent = (i) + '/' + total + ' complete ΓÇö running: ' + scenario.name;
+
+    // Load the scenario into state
+    loadScenario(scenario.id);
+
+    // Wait a tick for UI to update
+    await new Promise(function(r) { setTimeout(r, 100); });
+
+    // Create a promise that resolves when the sandbox exits
+    var resultPromise = new Promise<{ exitCode: number; pass: boolean; scenario?: Scenario; output: string }>(function(resolve) {
+      runAllResolve = resolve;
+    });
+
+    // Run it
+    await runSandbox();
+
+    // Wait for it to finish
+    var result = await resultPromise;
+
+    var verdict = result.pass ? 'Γ£à PASS' : 'Γ¥î FAIL';
+    if (result.pass) { passed++; } else { failed++; }
+    results.push({ scenario, verdict, pass: result.pass, exitCode: result.exitCode });
+
+    logLines.push('Script: ' + scenario.script);
+    logLines.push('Expected: ' + scenario.expectedOutcome + ' (' + scenario.expectedLabel + ')');
+    logLines.push('Exit code: ' + result.exitCode);
+    logLines.push('Verdict: ' + verdict);
+    logLines.push('');
+    logLines.push('--- Output ---');
+    logLines.push(result.output || '(no output)');
+    logLines.push('--- End ---');
+    logLines.push('');
+
+    termInfo('[Playground] [' + (i + 1) + '/' + total + '] ' + verdict + ' ΓÇö ' + scenario.name);
+  }
+
+  // Summary
+  logLines.push('=== SUMMARY ===');
+  logLines.push('Total: ' + total + '  Passed: ' + passed + '  Failed: ' + failed);
+  logLines.push('');
+
+  termInfo('');
+
+  // Render test report in terminal
+  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
+  termWrite('  TEST REPORT ΓÇö ' + currentShell.toUpperCase() + '  (' + new Date().toLocaleString() + ')', 'line-info');
+  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
+  termWrite('', 'line-info');
+
+  for (var r = 0; r < results.length; r++) {
+    var res = results[r];
+    var icon = res.pass ? 'Γ£à' : 'Γ¥î';
+    var label = res.scenario.name;
+    var exitStr = res.exitCode === 0 ? '' : '  (exit ' + res.exitCode + ')';
+    termWrite('  ' + icon + '  ' + label + exitStr, res.pass ? 'line-success' : 'line-error');
+  }
+
+  termWrite('', 'line-info');
+  var summaryLine = '  ' + passed + ' passed, ' + failed + ' failed ΓÇö ' + total + ' total';
+  if (failed === 0) {
+    termWrite('  Γ£à ALL TESTS PASSED', 'line-success');
+  } else {
+    termWrite('  Γ¥î ' + failed + ' TEST(S) FAILED', 'line-error');
+  }
+  termWrite(summaryLine, 'line-info');
+  termWrite('ΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöüΓöü', 'line-info');
+
+  // Update result card
+  if (failed === 0) {
+    $('resultCard').className = 'result-card result-success';
+    $('resultIcon').textContent = 'Γ£à';
+    $('resultTitle').textContent = 'All ' + total + ' tests passed';
+  } else {
+    $('resultCard').className = 'result-card result-error';
+    $('resultIcon').textContent = 'Γ¥î';
+    $('resultTitle').textContent = passed + ' passed, ' + failed + ' failed';
+  }
+  $('resultDetail').textContent = currentShell + ' ┬╖ ' + version + ' ┬╖ ' + new Date().toLocaleTimeString();
+
+  // Offer optional save via a link in the terminal
+  var logContent = logLines.join('\n');
+  termWrite('', 'line-info');
+  var saveLink = document.createElement('div');
+  saveLink.className = 'line-info';
+  saveLink.innerHTML = '<a href="#" id="saveReportLink" style="color:var(--accent); cursor:pointer; text-decoration:underline;">≡ƒÆ╛ Save report to fileΓÇª</a>';
+  $('terminal').appendChild(saveLink);
+  $('terminal').scrollTop = $('terminal').scrollHeight;
+  document.getElementById('saveReportLink')!.addEventListener('click', async function(e) {
+    e.preventDefault();
+    var saveResult = await mxc.saveLogFile(logContent);
+    if (saveResult.success) {
+      termSuccess('[Playground] Log saved to: ' + saveResult.path);
+    }
+  });
+
+  runAllInProgress = false;
+  ($('btnRun') as HTMLButtonElement).disabled = false;
+  ($('btnRunAll') as HTMLButtonElement).disabled = false;
+  updateRunAllLabel();
+}
+
+function onSandboxExit(exitCode: number): void {
+  state.running = false;
+  if (!runAllInProgress) {
+    ($('btnRun') as HTMLButtonElement).disabled = false;
+    $('btnRun').classList.remove('hidden');
+    $('btnKill').classList.add('hidden');
+  }
+
+  // Assertion-based verdict
+  var scenario = state.selectedScenario;
+  var isCustomMode = !scenario || $sel('shellSelect').value === 'custom' || $sel('shellSelect').value === 'rawjson';
+
+  // For custom/raw JSON: no expected outcome ΓÇö show neutral result
+  if (isCustomMode) {
+    var analysis = exitCode !== 0 ? analyzeOutput(terminalFullText, exitCode) : null;
+    if (exitCode === 0) {
+      termDim('[Playground] ΓÜá Completed (exit code 0) ΓÇö inspect output to verify the result');
+      var card = $('resultCard');
+      card.className = 'result-card result-neutral';
+      $('resultIcon').textContent = 'ΓÜá';
+      $('resultTitle').textContent = 'Completed ΓÇö exit code 0';
+      $('resultDetail').textContent = 'Custom script finished. Review the output above to confirm it worked as expected.';
+      showResultActions('success');
+    } else {
+      termError('[Playground] ΓÜá Completed with exit code ' + formatExitCode(exitCode) + ' ΓÇö inspect output');
+      var card = $('resultCard');
+      card.className = 'result-card result-neutral';
+      $('resultIcon').textContent = 'ΓÜá';
+      $('resultTitle').textContent = 'Completed ΓÇö exit code ' + formatExitCode(exitCode);
+      $('resultDetail').textContent = analysis ? analysis.explanation + ' ≡ƒÆí ' + analysis.suggestion : 'Non-zero exit code. Review the output above.';
+      showResultActions('error');
+    }
+
+    if (runAllResolve) {
+      runAllResolve({ exitCode, pass: exitCode === 0, scenario: scenario || undefined, output: terminalFullText });
+      runAllResolve = null;
+    }
+    terminalFullText = '';
+    return;
+  }
+
+  var expected = scenario.expectedOutcome || 'succeed';
+  var actualOutcome = exitCode === 0 ? 'succeed' : 'be-blocked';
+
+  // Output-based validation: check successMarker/failureMarker in terminal output
+  var termLower = terminalFullText.toLowerCase();
+  var outputOverride = false;
+  if (scenario && exitCode === 0) {
+    if (scenario.failureMarker && terminalFullText.includes(scenario.failureMarker)) {
+      // Script printed its own failure marker ΓÇö the operation didn't actually work
+      actualOutcome = 'be-blocked';
+      outputOverride = true;
+      termDim('[Playground] Output contains failure marker: "' + scenario.failureMarker + '"');
+    } else if (scenario.successMarker && !terminalFullText.includes(scenario.successMarker)) {
+      // Script didn't print expected success marker ΓÇö something went wrong
+      actualOutcome = 'be-blocked';
+      outputOverride = true;
+      termDim('[Playground] Output missing expected marker: "' + scenario.successMarker + '"');
+    }
+  }
+
+  // For "be-blocked" scenarios: check terminal for denial markers (script may catch and exit 0)
+  var blockedInOutput = termLower.includes('blocked') || termLower.includes('access denied') ||
+    termLower.includes('is denied') || termLower.includes('could not be resolved') ||
+    termLower.includes('permissionerror') || termLower.includes('unauthorized');
+  if (expected === 'be-blocked' && exitCode === 0 && blockedInOutput) {
+    actualOutcome = 'be-blocked';
+  }
+
+  var verdictPass = (expected === actualOutcome) ||
+    (expected === 'be-blocked' && exitCode !== 0) ||
+    (expected === 'show-error' && exitCode !== 0);
+
+  // Error analysis
+  var analysis = exitCode !== 0 ? analyzeOutput(terminalFullText, exitCode) : null;
+
+  if (verdictPass && exitCode === 0) {
+    termSuccess('[Playground] Γ£à PASS ΓÇö Script succeeded as expected (exit code 0)');
+    setResultSuccess(exitCode);
+    $('resultDetail').textContent = scenario ? 'Expected: ' + scenario.expectedLabel : '';
+  } else if (verdictPass && exitCode !== 0) {
+    // Expected failure ΓÇö this is a PASS
+    var card = $('resultCard');
+    card.className = 'result-card result-success';
+    $('resultIcon').textContent = 'Γ£à';
+    $('resultTitle').textContent = 'PASS ΓÇö Script was blocked as expected (exit code ' + formatExitCode(exitCode) + ')';
+    $('resultDetail').textContent = analysis ? analysis.explanation : (scenario ? scenario.expectedLabel : '');
+    termSuccess('[Playground] Γ£à PASS ΓÇö Blocked as expected (exit code ' + formatExitCode(exitCode) + ')');
+    showResultActions('success');
+  } else if (!verdictPass && exitCode === 0) {
+    // Expected failure but it succeeded ΓÇö unexpected
+    var card = $('resultCard');
+    card.className = 'result-card result-error';
+    $('resultIcon').textContent = 'ΓÜá∩╕Å';
+    $('resultTitle').textContent = 'UNEXPECTED ΓÇö Script succeeded but was expected to be blocked';
+    $('resultDetail').textContent = 'The sandbox may not be enforcing the expected restriction.';
+    termError('[Playground] ΓÜá∩╕Å UNEXPECTED ΓÇö Succeeded but expected: ' + (scenario?.expectedLabel || 'blocked'));
+    showResultActions('error');
+  } else {
+    // Unexpected failure
+    termError('[Playground] Γ¥î FAIL ΓÇö exit code ' + formatExitCode(exitCode));
+    setResultError(exitCode);
+    if (analysis) {
+      $('resultTitle').textContent = analysis.title;
+      $('resultDetail').textContent = analysis.explanation + ' ≡ƒÆí ' + analysis.suggestion;
+    }
+  }
+
+  // If running all scenarios, notify the runner (capture output before clearing)
+  if (runAllResolve) {
+    runAllResolve({ exitCode, pass: verdictPass, scenario: scenario || undefined, output: terminalFullText });
+    runAllResolve = null;
+  }
+
+  terminalFullText = '';
+}
+
+// ============================================================
+// Error pattern analysis
+// ============================================================
+
+var ERROR_PATTERNS = [
+  { pattern: 'CreateProcessW failed', title: 'Process creation failed', explanation: 'Windows could not create the sandboxed process. The executable may not be accessible inside the container.', suggestion: 'Add the executable\'s directory to File Access read-only paths.' },
+  { pattern: 'CreateProcessW failed.*0x80070002', title: 'Executable not found', explanation: 'The executable was not found inside the container.', suggestion: 'The executable was not found. Enable \'Include common tools\' in File Access to add PATH directories.' },
+  { pattern: '0x80070005', title: 'Access denied (firewall)', explanation: 'An operation was denied, possibly due to firewall rules.', suggestion: 'Firewall rules require administrator privileges. Try running the app as administrator.' },
+  { pattern: 'firewall rule blocked', title: 'Firewall blocked', explanation: 'A firewall rule blocked the operation.', suggestion: 'Firewall rules require administrator privileges. Try running the app as administrator.' },
+  { pattern: 'Experimental_CreateProcessInSandbox failed', title: 'Sandbox API failed', explanation: 'The CreateProcessInSandbox API returned an error. Check the error code for details.', suggestion: 'Enable Debug Mode for more details.' },
+  { pattern: 'LoadLibraryExW(processmodel.dll) failed', title: 'BaseContainer not available', explanation: 'processmodel.dll could not be loaded. BaseContainer requires Windows builds that support the v0.5.0+ schema.', suggestion: 'Use version 0.4.0-alpha instead of 0.5.0-dev.' },
+  { pattern: 'Access is denied', title: 'Access denied', explanation: 'The script tried to access a resource that the sandbox blocks.', suggestion: 'Enable File Access and add the needed path, or enable Internet if the script needs network.' },
+  { pattern: 'Unable to open file', title: 'BFS path not found', explanation: 'BFS could not open a brokered path. The directory may not exist or the path contains unresolved environment variables.', suggestion: 'Ensure the path exists on disk. Use resolved paths (e.g., C:\\Users\\...\\Temp) not environment variables like %TEMP%.' },
+  { pattern: 'Unable to perform policy operation', title: 'BFS policy failed', explanation: 'The filesystem broker (BFS) could not apply the path policy. bfscfg.exe may not be available on this OS build.', suggestion: 'BFS requires Windows v0.5.0+. Remove filesystem paths or upgrade the OS.' },
+  { pattern: 'bfscfg.exe was not found', title: 'BFS not available', explanation: 'Filesystem brokering (BFS) component was not found.', suggestion: 'Filesystem brokering (BFS) requires Windows v0.5.0+. The OS may not support it.' },
+  { pattern: 'BFS error', title: 'BFS error', explanation: 'Filesystem brokering (BFS) encountered an error.', suggestion: 'Filesystem brokering (BFS) requires Windows v0.5.0+. The OS may not support it.' },
+  { pattern: 'is not recognized', title: 'Command not found', explanation: 'The command was not found inside the sandbox. PATH directories may not be accessible.', suggestion: 'Enable "Include common tools" in File Access to add PATH directories.' },
+  { pattern: 'The remote name could not be resolved', title: 'DNS resolution failed', explanation: 'The script could not resolve a hostname. Internet access may be blocked.', suggestion: 'Enable Internet access in the Policy section.' },
+  { pattern: 'network is not available', title: 'Network blocked', explanation: 'Outbound network connections are blocked by the sandbox policy.', suggestion: 'Enable "Allow internet access" in Policy.' },
+  { pattern: 'version is required', title: 'Missing version', explanation: 'The sandbox policy requires a version field.', suggestion: 'This is a bug in the playground ΓÇö please report it.' },
+  { pattern: 'newer than supported', title: 'Version too new', explanation: 'The schema version is newer than what the SDK supports.', suggestion: 'Use version 0.4.0-alpha or 0.5.0-dev.' },
+  { pattern: 'The system cannot find the file', title: 'File not found', explanation: 'The executable or file was not found. It may not be accessible from inside the container.', suggestion: 'Add the file\'s directory to read-only paths in File Access.' },
+  { pattern: 'PermissionError', title: 'Permission denied (Python)', explanation: 'Python could not access a file or directory due to sandbox restrictions.', suggestion: 'Add the path to read-write or read-only paths in File Access.' },
+  { pattern: 'script is required', title: 'No script provided', explanation: 'No command was provided to run.', suggestion: 'Enter a script command or select a scenario.' },
+  { pattern: 'WIN32_ERROR(1920)', title: 'File cannot be accessed', explanation: 'The executable cannot be loaded by the sandbox. The install directory may not be accessible to the container process.', suggestion: 'The runtime may need its install directory added to File Access. Try clicking ≡ƒöä refresh and running again.' },
+];
+
+var EXIT_CODE_PATTERNS: Record<number, { title: string; explanation: string; suggestion: string }> = {};
+EXIT_CODE_PATTERNS[-1073741502] = { // 0xC0000142 STATUS_DLL_INIT_FAILED
+  title: 'DLL init failed (Win32k)',
+  explanation: 'A required DLL could not initialize. This usually means the process needs Win32k (desktop UI access).',
+  suggestion: 'Enable Desktop UI Access in the Policy section, or switch to cmd.exe which does not need Win32k.'
+};
+EXIT_CODE_PATTERNS[1920] = { // ERROR_FILE_CANNOT_BE_ACCESSED
+  title: 'File cannot be accessed',
+  explanation: 'The executable cannot be accessed from inside the container. MSIX/Store packages install to a protected location that the container cannot reach.',
+  suggestion: 'For PowerShell 7+, install the MSI package instead of the MSIX/Store version. See https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows'
+};
+
+function analyzeOutput(terminalText: string, exitCode: number): { title: string; explanation: string; suggestion: string } | null {
+  // Check exit code first ΓÇö with dynamic paths
+  if (exitCode === -1073741790) { // 0xC0000022 STATUS_ACCESS_DENIED
+    var aclPath = shellPaths.python?.rootDir || '';
+    var isPerUser = aclPath.includes('AppData');
+    return {
+      title: 'Access denied (ACL)',
+      explanation: isPerUser
+        ? 'Per-user Python installs lack the sandbox ACL. The sandbox runs under a restricted identity that cannot access per-user directories.'
+        : 'The executable directory lacks the ALL APPLICATION PACKAGES ACL required for sandbox access.',
+      suggestion: isPerUser
+        ? 'Fix: reinstall Python with "winget install Python.Python.3.14" which installs to a location accessible by the container.'
+        : 'Run as admin: icacls "' + aclPath + '" /grant "ALL APPLICATION PACKAGES:(OI)(CI)(RX)" /T',
+    };
+  }
+  if (EXIT_CODE_PATTERNS[exitCode]) {
+    return EXIT_CODE_PATTERNS[exitCode];
+  }
+  for (var p of ERROR_PATTERNS) {
+    if (terminalText.includes(p.pattern)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+// ============================================================
+// PTY handlers
+// ============================================================
+
+var terminalFullText = '';
+
+mxc.onPtyData(function(data: string) {
+  var clean = stripAnsi(data);
+  terminalFullText += clean;
+  if (clean.trim()) {
+    termOutput(clean);
+  }
+});
+
+mxc.onPtyExit(function(exitCode: number) {
+  // Small delay to let pending PTY data events flush before verdict
+  setTimeout(function() { onSandboxExit(exitCode); }, 100);
+});
+
+// ============================================================
+// JSON panel
+// ============================================================
+
+function showJsonPanel(tab: string): void {
+  if (state.activeJsonTab === tab) {
+    // Toggle off
+    state.activeJsonTab = null;
+    $('jsonPanel').classList.add('hidden');
+    $('tabPolicy').classList.remove('active');
+    $('tabConfig').classList.remove('active');
+    return;
+  }
+
+  state.activeJsonTab = tab;
+  $('tabPolicy').classList.toggle('active', tab === 'policy');
+  $('tabConfig').classList.toggle('active', tab === 'config');
+  $('jsonPanel').classList.remove('hidden');
+
+  if (tab === 'policy') {
+    var policyStr = JSON.stringify(buildPolicy(), null, 2);
+    $('jsonContent').innerHTML = highlightJson(escapeHtml(policyStr));
+  } else {
+    $('jsonContent').innerHTML = '<span class="line-dim">Loading configΓÇª</span>';
+    var policyJson = JSON.stringify(buildPolicy());
+    mxc.validatePolicy(policyJson).then(function(result: any) {
+      if (result.valid) {
+        var formatted = JSON.stringify(JSON.parse(result.config), null, 2);
+        $('jsonContent').innerHTML = highlightJson(escapeHtml(formatted));
+      } else {
+        $('jsonContent').innerHTML = '<span class="line-error">Error: ' + escapeHtml(result.error) + '</span>';
+      }
+    });
+  }
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function formatExitCode(code: number): string {
+  if (code === -1 || code === 0) { return code.toString(); }
+  if (code < 0) {
+    // Negative = unsigned 32-bit NTSTATUS
+    return '0x' + ((code >>> 0).toString(16)).toUpperCase();
+  }
+  if (code > 255) {
+    return '0x' + code.toString(16).toUpperCase();
+  }
+  return code.toString();
+}
+
+// ============================================================
+// Dev sidebar
+// ============================================================
+
+function updateDevSidebar(): void {
+  if ($('devSidebar').classList.contains('hidden')) return;
+
+  var currentShell = $sel('shellSelect').value;
+
+  // Raw JSON mode ΓÇö show only the raw config, no policy
+  if (currentShell === 'rawjson') {
+    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A ΓÇö MXC JSON mode skips policy generation</span>';
+    var rawText = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
+    if (rawText) {
+      try {
+        var parsed = JSON.parse(rawText);
+        var formatted = JSON.stringify(parsed, null, 2);
+        $('devConfigJson').innerHTML = highlightJson(escapeHtml(formatted));
+      } catch (e: any) {
+        $('devConfigJson').innerHTML = '<span class="line-error">Invalid JSON: ' + escapeHtml(e.message) + '</span>';
+      }
+    } else {
+      $('devConfigJson').innerHTML = '<span class="line-dim">Paste a ContainerConfig JSON above</span>';
+    }
+    return;
+  }
+
+  var policy = buildPolicy();
+  var policyStr = JSON.stringify(policy, null, 2);
+  $('devPolicyJson').innerHTML = highlightJson(escapeHtml(policyStr));
+
+  $('devConfigJson').innerHTML = '<span class="line-dim">LoadingΓÇª</span>';
+  var policyJson = JSON.stringify(policy);
+  mxc.validatePolicy(policyJson).then(function(result: any) {
+    if (result.valid) {
+      var config = JSON.parse(result.config);
+      config.process.commandLine = getCurrentScript();
+      // Overlay advanced process container UI fields
+      if (config.appContainer && config.appContainer.ui) {
+        config.appContainer.ui.isolation = $sel('uiIsolation').value || 'container';
+        config.appContainer.ui.desktopSystemControl = $chk('uiDesktopControl').checked || false;
+        config.appContainer.ui.systemSettings = $sel('uiSystemSettings').value || 'none';
+        config.appContainer.ui.ime = $chk('uiIME').checked || false;
+      }
+      var formatted = JSON.stringify(config, null, 2);
+      $('devConfigJson').innerHTML = highlightJson(escapeHtml(formatted));
+    } else {
+      $('devConfigJson').innerHTML = '<span class="line-error">Error: ' + escapeHtml(result.error) + '</span>';
+    }
+  });
+}
+
+// ============================================================
+// View switching
+// ============================================================
+
+function showMainView(): void {
+  state.currentView = 'main';
+  $('welcomeView').classList.add('hidden');
+  $('mainView').classList.remove('hidden');
+}
+
+function showWelcomeView(): void {
+  state.currentView = 'welcome';
+  $('welcomeView').classList.remove('hidden');
+  $('mainView').classList.add('hidden');
+}
+
+// ============================================================
+// Init
+// ============================================================
+
+function init(): void {
+  populateScenarios();
+  updatePermsSummary();
+  refreshPathLists();
+  updateFsDetails();
+  updateNetDetails();
+  updateUiDetails();
+
+  // Detect available shells and re-render scenario list
+  mxc.detectShells().then(function(shells: Record<string, any>) {
+    // Map new format to availability booleans
+    for (var key in shells) {
+      if (typeof shells[key] === 'object') {
+        shellAvailability[key] = shells[key].available;
+        if (shells[key].exe) {
+          shellPaths[key] = { exe: shells[key].exe, rootDir: shells[key].rootDir, needsAcl: shells[key].needsAcl, msixPackageDir: shells[key].msixPackageDir };
+        }
+      } else {
+        shellAvailability[key] = !!shells[key];
+      }
+    }
+    updateShellDropdown();
+    populateScenarios();
+  }).catch(function() { /* use defaults */ });
+
+  // Platform check
+  mxc.getPlatformSupport().then(function(info: any) {
+    $('platformBadge').textContent = info.isSupported
+      ? 'Γ£ô Platform supported'
+      : 'Γ£ù ' + (info.reason || 'Not supported');
+  });
+
+  // === Welcome view buttons ===
+  $('btnTrySample').addEventListener('click', function() {
+    showMainView();
+    $sel('shellSelect').value = 'cmd';
+    $('categoryRow').classList.remove('hidden');
+    $('scriptSection').classList.add('hidden');
+    populateScenarios();
+    $sel('scenarioSelect').value = 'basic-cmd';
+    loadScenario('basic-cmd');
+    runSandbox();
+  });
+
+  $('btnStartScratch').addEventListener('click', function() {
+    showMainView();
+    $sel('shellSelect').value = 'custom';
+    $('categoryRow').classList.add('hidden');
+    $('scriptSection').classList.remove('hidden');
+    state.selectedScenario = null;
+    loadScenario('custom');
+  });
+
+  $('welcomeShowStartup').addEventListener('change', function() {
+    if (!$chk('welcomeShowStartup').checked) {
+      localStorage.setItem('mxc-hide-welcome', '1');
+    } else {
+      localStorage.removeItem('mxc-hide-welcome');
+    }
+  });
+
+  $('welcomeLearnMore').addEventListener('click', function(e) {
+    e.preventDefault();
+    showMainView();
+    ($('helpDialog') as HTMLDialogElement).showModal();
+  });
+
+  // === Refresh shells ===
+  $('btnRefreshShells').addEventListener('click', function() {
+    var btn = $('btnRefreshShells');
+    btn.textContent = 'ΓÅ│';
+    btn.setAttribute('disabled', 'true');
+    mxc.detectShells().then(function(shells: Record<string, any>) {
+      var found: string[] = [];
+      var notFound: string[] = [];
+      for (var key in shells) {
+        if (typeof shells[key] === 'object') {
+          shellAvailability[key] = shells[key].available;
+          if (shells[key].exe) {
+            shellPaths[key] = { exe: shells[key].exe, rootDir: shells[key].rootDir, needsAcl: shells[key].needsAcl, msixPackageDir: shells[key].msixPackageDir };
+          }
+        } else {
+          shellAvailability[key] = !!shells[key];
+        }
+        var label = SHELL_LABELS[key] || key;
+        if (shellAvailability[key]) { found.push(label); }
+        else if (key !== 'cmd' && key !== 'ps51') { notFound.push(label); }
+      }
+      updateShellDropdown();
+      populateScenarios();
+      btn.textContent = '≡ƒöä';
+      btn.removeAttribute('disabled');
+      // Show summary in scenario description area
+      var msg = 'Γ£à Found: ' + (found.length > 0 ? found.join(', ') : 'none');
+      if (notFound.length > 0) { msg += '\nΓ¥î Not found: ' + notFound.join(', '); }
+      $('refreshStatus').classList.remove('hidden');
+      $('refreshStatusText').innerText = msg;
+      // Re-trigger shell change to update button visibility
+      $sel('shellSelect').dispatchEvent(new Event('change'));
+      updatePythonAclWarning();
+    }).catch(function() {
+      btn.textContent = '≡ƒöä';
+      btn.removeAttribute('disabled');
+    });
+  });
+
+  $('btnDismissRefresh').addEventListener('click', function() {
+    $('refreshStatus').classList.add('hidden');
+  });
+
+  // === Containment select ===
+  $sel('containmentSelect').addEventListener('change', function() {
+    var containment = $sel('containmentSelect').value;
+    if (containment !== 'appcontainer') {
+      // Experimental containment ΓÇö hide runtime, force MXC JSON mode
+      $('runtimeRow').classList.add('hidden');
+      $('categoryRow').classList.add('hidden');
+      $sel('shellSelect').value = 'rawjson';
+      $sel('shellSelect').dispatchEvent(new Event('change'));
+      $('experimentalCaution').classList.remove('hidden');
+    } else {
+      // Process Container ΓÇö show runtime
+      $('runtimeRow').classList.remove('hidden');
+      $sel('shellSelect').disabled = false;
+      $('experimentalCaution').classList.add('hidden');
+      if ($sel('shellSelect').value === 'rawjson') {
+        $sel('shellSelect').value = 'cmd';
+        $sel('shellSelect').dispatchEvent(new Event('change'));
+      }
+    }
+    updateContainmentDropdown();
+    updateDevSidebar();
+  });
+
+  // === Scenario select ===
+  $sel('shellSelect').addEventListener('change', function() {
+    var shell = $sel('shellSelect').value;
+    if (shell === 'custom') {
+      $('categoryRow').classList.add('hidden');
+      $('scriptSection').classList.remove('hidden');
+      $('rawJsonSection').classList.add('hidden');
+      $('policySectionWrapper').classList.remove('hidden');
+      $('btnRun').classList.remove('hidden');
+      $('btnRunAll').classList.add('hidden');
+      updateUiDetails();
+      state.selectedScenario = null;
+      $('scenarioDesc').textContent = 'Write your own script and configure policy.';
+      $('scenarioOutcome').textContent = '';
+      $('scenarioOutcome').className = 'outcome-badge';
+      updateDevSidebar();
+      updateContainmentDropdown();
+    } else if (shell === 'rawjson') {
+      $('categoryRow').classList.add('hidden');
+      $('scriptSection').classList.add('hidden');
+      $('rawJsonSection').classList.remove('hidden');
+      $('policySectionWrapper').classList.add('hidden');
+      $('advancedSectionWrapper').classList.add('hidden');
+      $('uiGroupWrapper').classList.add('hidden');
+      $('btnRun').classList.remove('hidden');
+      $('btnRunAll').classList.add('hidden');
+      state.selectedScenario = null;
+      $('scenarioDesc').textContent = 'Paste a ContainerConfig JSON. Runs via spawnSandboxFromConfig ΓÇö no policy generation step.';
+      $('scenarioOutcome').textContent = '';
+      $('scenarioOutcome').className = 'outcome-badge';
+      $chk('experimentalToggle').checked = true;
+      updateDevSidebar();
+      updateContainmentDropdown();
+    } else {
+      var shellAvail = shellAvailability[shell] !== false;
+      if (shellAvail) {
+        $('categoryRow').classList.remove('hidden');
+        populateScenarios();
+        $('btnRun').classList.remove('hidden');
+        $('btnRunAll').classList.remove('hidden');
+        $('policySectionWrapper').classList.remove('hidden');
+        if (document.getElementById('advancedSectionWrapper')) {
+          $('advancedSectionWrapper').classList.remove('hidden');
+        }
+      } else {
+        $('categoryRow').classList.add('hidden');
+        $('btnRun').classList.add('hidden');
+        $('btnRunAll').classList.add('hidden');
+        $('policySectionWrapper').classList.add('hidden');
+        if (document.getElementById('advancedSectionWrapper')) {
+          $('advancedSectionWrapper').classList.add('hidden');
+        }
+        // Clear stale content from previous mode
+        $('scenarioDesc').textContent = '';
+        $('scenarioOutcome').textContent = '';
+        $('scenarioOutcome').className = 'outcome-badge';
+        state.selectedScenario = null;
+      }
+      $('scriptSection').classList.add('hidden');
+      $('rawJsonSection').classList.add('hidden');
+      updateUiDetails();
+      updateDevSidebar();
+      updateContainmentDropdown();
+    }
+    updatePythonAclWarning();
+    updateRunAllLabel();
+  });
+
+  $sel('scenarioSelect').addEventListener('change', function() {
+    loadScenario($sel('scenarioSelect').value);
+  });
+
+  // === Raw JSON textarea live update ===
+  // === JSON Editor Dialog ===
+  function updateJsonEditorPreview(): void {
+    var text = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
+    if (!text) {
+      $('jsonEditorPreview').innerHTML = '<span class="line-dim">Enter JSON above</span>';
+      return;
+    }
+    try {
+      var parsed = JSON.parse(text);
+
+      // Sync schema version dropdown from pasted config
+      if (parsed.version) {
+        var versionSelect = $sel('versionSelect');
+        for (var i = 0; i < versionSelect.options.length; i++) {
+          if (versionSelect.options[i].value === parsed.version) {
+            versionSelect.value = parsed.version;
+            state.version = parsed.version;
+            break;
+          }
+        }
+      }
+
+      // Sync containment dropdown from pasted config
+      if (parsed.containment) {
+        var containmentSelect = $sel('containmentSelect');
+        for (var j = 0; j < containmentSelect.options.length; j++) {
+          if (containmentSelect.options[j].value === parsed.containment) {
+            containmentSelect.value = parsed.containment;
+            break;
+          }
+        }
+        updateContainmentDropdown();
+      }
+
+      var info = '<span style="color:#4ec9b0;">Γ£ô Valid JSON</span>';
+      if (parsed.version) { info += ' ┬╖ version: ' + parsed.version; }
+      if (parsed.process?.commandLine) { info += ' ┬╖ <code>' + escapeHtml(parsed.process.commandLine) + '</code>'; }
+      if (parsed.containment) { info += ' ┬╖ containment: ' + parsed.containment; }
+      $('jsonEditorPreview').innerHTML = info;
+    } catch (e: any) {
+      $('jsonEditorPreview').innerHTML = '<span class="line-error">Γ£ù ' + escapeHtml(e.message) + '</span>';
+    }
+  }
+
+  $('btnOpenJsonEditor').addEventListener('click', function() {
+    ($('jsonEditorDialog') as HTMLDialogElement).showModal();
+    updateJsonEditorPreview();
+  });
+  $('jsonEditorClose').addEventListener('click', function() {
+    ($('jsonEditorDialog') as HTMLDialogElement).close();
+    updateDevSidebar();
+  });
+  $('rawJsonText').addEventListener('input', function() {
+    updateJsonEditorPreview();
+    updateContainmentDropdown();
+    updateDevSidebar();
+  });
+  $('jsonEditorApply').addEventListener('click', function() {
+    ($('jsonEditorDialog') as HTMLDialogElement).close();
+    updateContainmentDropdown();
+    updateDevSidebar();
+  });
+  $('jsonEditorRun').addEventListener('click', function() {
+    ($('jsonEditorDialog') as HTMLDialogElement).close();
+    runSandbox();
+  });
+
+  // === Drag & drop JSON files ===
+  var rawArea = $('rawJsonText') as HTMLTextAreaElement;
+  rawArea.addEventListener('dragover', function(e: DragEvent) {
+    e.preventDefault();
+    rawArea.style.borderColor = 'var(--accent)';
+  });
+  rawArea.addEventListener('dragleave', function() {
+    rawArea.style.borderColor = '';
+  });
+  rawArea.addEventListener('drop', function(e: DragEvent) {
+    e.preventDefault();
+    rawArea.style.borderColor = '';
+    if (e.dataTransfer && e.dataTransfer.files.length > 0) {
+      var file = e.dataTransfer.files[0];
+      if (file.name.endsWith('.json')) {
+        var reader = new FileReader();
+        reader.onload = function() {
+          var text = reader.result as string;
+          try { rawArea.value = JSON.stringify(JSON.parse(text), null, 2); }
+          catch { rawArea.value = text; }
+          updateJsonEditorPreview();
+          updateDevSidebar();
+        };
+        reader.readAsText(file);
+      }
+    }
+  });
+
+  // Drag & drop anywhere on the window opens the JSON editor
+  document.body.addEventListener('dragover', function(e: DragEvent) { e.preventDefault(); });
+  document.body.addEventListener('drop', function(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer && e.dataTransfer.files.length > 0) {
+      var file = e.dataTransfer.files[0];
+      if (file.name.endsWith('.json')) {
+        var reader = new FileReader();
+        reader.onload = function() {
+          var text = reader.result as string;
+          try { ($('rawJsonText') as HTMLTextAreaElement).value = JSON.stringify(JSON.parse(text), null, 2); }
+          catch { ($('rawJsonText') as HTMLTextAreaElement).value = text; }
+          showMainView();
+          $sel('shellSelect').value = 'rawjson';
+          $sel('shellSelect').dispatchEvent(new Event('change'));
+          ($('jsonEditorDialog') as HTMLDialogElement).showModal();
+          updateJsonEditorPreview();
+          updateDevSidebar();
+        };
+        reader.readAsText(file);
+      }
+    }
+  });
+
+  // === Version select (sidebar) ===
+  $sel('versionSelect').addEventListener('change', function() {
+    state.version = $sel('versionSelect').value;
+    // Auto-toggle experimental: on for 0.5.0+, off for 0.4.0
+    $chk('experimentalToggle').checked = state.version === '0.5.0-dev';
+    populateScenarios();
+    updateUiDetails();
+    updateContainmentDropdown();
+    updateDevSidebar();
+
+    // Sync version into MXC JSON editor if in that mode
+    if ($sel('shellSelect').value === 'rawjson') {
+      var text = ($('rawJsonText') as HTMLTextAreaElement).value.trim();
+      if (text) {
+        try {
+          var parsed = JSON.parse(text);
+          parsed.version = state.version;
+          ($('rawJsonText') as HTMLTextAreaElement).value = JSON.stringify(parsed, null, 2);
+          updateJsonEditorPreview();
+        } catch { /* leave as-is if invalid */ }
+      }
+    }
+  });
+
+  // === Script textarea ===
+  ($('scriptText') as HTMLTextAreaElement).addEventListener('input', function() {
+    state.customScript = ($('scriptText') as HTMLTextAreaElement).value;
+    updateDevSidebar();
+  });
+
+  // === Policy toggle ===
+  $('permissionsToggle').addEventListener('click', function() {
+    state.permissionsOpen = !state.permissionsOpen;
+    $('permissionsBody').classList.toggle('hidden', !state.permissionsOpen);
+    $('permissionsChevron').classList.toggle('open', state.permissionsOpen);
+    if (state.permissionsOpen) {
+      $('permissionsSummaryLine').classList.add('hidden');
+    } else {
+      $('permissionsSummaryLine').classList.remove('hidden');
+    }
+  });
+
+  // === File access toggle ===
+  $chk('fsToggle').addEventListener('change', function() {
+    state.fsEnabled = $chk('fsToggle').checked;
+    updateFsDetails();
+    updatePermsSummary();
+    updateDevSidebar();
+  });
+
+  // === File path buttons ===
+  $('rwBrowse').addEventListener('click', async function() {
+    var folder = await mxc.openFolderDialog();
+    if (folder) {
+      state.rwPaths.push(folder);
+      refreshPathLists();
+      updateDevSidebar();
+    }
+  });
+  $('rwManual').addEventListener('click', function() {
+    var input = ($('rwManualInput') as HTMLInputElement).value.trim();
+    if (input) {
+      state.rwPaths.push(input);
+      ($('rwManualInput') as HTMLInputElement).value = '';
+      refreshPathLists();
+      updateDevSidebar();
+    }
+  });
+  $('roBrowse').addEventListener('click', async function() {
+    var folder = await mxc.openFolderDialog();
+    if (folder) {
+      state.roPaths.push(folder);
+      refreshPathLists();
+      updateDevSidebar();
+    }
+  });
+  $('roManual').addEventListener('click', function() {
+    var input = ($('roManualInput') as HTMLInputElement).value.trim();
+    if (input) {
+      state.roPaths.push(input);
+      ($('roManualInput') as HTMLInputElement).value = '';
+      refreshPathLists();
+      updateDevSidebar();
+    }
+  });
+
+  // === Include checkboxes ===
+  $chk('fsIncludeTools').addEventListener('change', function() {
+    state.fsIncludeTools = $chk('fsIncludeTools').checked;
+  });
+  $chk('fsIncludeTemp').addEventListener('change', function() {
+    state.fsIncludeTemp = $chk('fsIncludeTemp').checked;
+  });
+
+  // === Network toggle ===
+  $chk('netToggle').addEventListener('change', function() {
+    state.netEnabled = $chk('netToggle').checked;
+    updateNetDetails();
+    updatePermsSummary();
+    updateDevSidebar();
+  });
+
+  // === UI toggle ===
+  $chk('uiToggle').addEventListener('change', function() {
+    state.uiAllowWindows = $chk('uiToggle').checked;
+    updateUiDetails();
+    updatePermsSummary();
+    updateDevSidebar();
+  });
+
+  $sel('uiClipboard').addEventListener('change', function() {
+    state.uiClipboard = $sel('uiClipboard').value;
+    updateDevSidebar();
+  });
+
+  $chk('uiInjection').addEventListener('change', function() {
+    state.uiInjection = $chk('uiInjection').checked;
+    updateDevSidebar();
+  });
+
+  ($('timeoutInput') as HTMLInputElement).addEventListener('change', function() {
+    state.timeoutSeconds = parseInt((this as HTMLInputElement).value, 10) || 0;
+    updateDevSidebar();
+  });
+
+  // === Advanced toggle ===
+  $('advancedToggle').addEventListener('click', function() {
+    state.advancedOpen = !state.advancedOpen;
+    $('advancedBody').classList.toggle('hidden', !state.advancedOpen);
+    $('advancedChevron').classList.toggle('open', state.advancedOpen);
+  });
+
+  // === Container type toggle ===
+  // === Advanced UI field listeners ===
+  $sel('uiIsolation').addEventListener('change', function() {
+    updateDevSidebar();
+  });
+  $sel('uiSystemSettings').addEventListener('change', function() {
+    updateDevSidebar();
+  });
+  $chk('uiDesktopControl').addEventListener('change', function() {
+    updateDevSidebar();
+  });
+  $chk('uiIME').addEventListener('change', function() {
+    updateDevSidebar();
+  });
+
+  // === Proxy listeners ===
+  $sel('proxySelect').addEventListener('change', function() {
+    var val = $sel('proxySelect').value;
+    $('proxyPort').style.display = val === 'localhost' ? '' : 'none';
+    $('proxyUrl').style.display = val === 'url' ? '' : 'none';
+    updateDevSidebar();
+  });
+  $num('proxyPort').addEventListener('change', function() {
+    updateDevSidebar();
+  });
+  $('proxyUrl').addEventListener('input', function() {
+    updateDevSidebar();
+  });
+
+  // === Copy buttons in dev sidebar ===
+  $('copyPolicy').addEventListener('click', function() {
+    navigator.clipboard.writeText($('devPolicyJson').textContent || '');
+    (this as HTMLElement).textContent = 'Γ£à';
+    var btn = this as HTMLElement;
+    setTimeout(function() { btn.textContent = '≡ƒôï'; }, 1000);
+  });
+  $('copyConfig').addEventListener('click', function() {
+    navigator.clipboard.writeText($('devConfigJson').textContent || '');
+    (this as HTMLElement).textContent = 'Γ£à';
+    var btn = this as HTMLElement;
+    setTimeout(function() { btn.textContent = '≡ƒôï'; }, 1000);
+  });
+
+  // === Dev mode toggle ===
+  $('devModeToggle').addEventListener('change', function() {
+    var sidebar = $('devSidebar');
+    if ((this as HTMLInputElement).checked) {
+      sidebar.classList.remove('hidden');
+      updateDevSidebar();
+    } else {
+      sidebar.classList.add('hidden');
+    }
+  });
+
+  // === Run / Kill / Run All ===
+  $('btnRun').addEventListener('click', function() {
+    runSandbox();
+  });
+  $('btnRunAll').addEventListener('click', function() {
+    runAllScenarios();
+  });
+  $('btnKill').addEventListener('click', function() {
+    killSandbox();
+  });
+
+  // === Terminal toggle ===
+  $('terminalToggle').addEventListener('click', function() {
+    state.terminalOpen = !state.terminalOpen;
+    $('terminal').classList.toggle('hidden', !state.terminalOpen);
+    $('terminalChevron').classList.toggle('collapsed', !state.terminalOpen);
+  });
+
+  // === JSON tabs ===
+  $('tabPolicy').addEventListener('click', function() {
+    showJsonPanel('policy');
+  });
+  $('tabConfig').addEventListener('click', function() {
+    showJsonPanel('config');
+  });
+  $('jsonCopy').addEventListener('click', function() {
+    var text = $('jsonContent').textContent || '';
+    navigator.clipboard.writeText(text);
+  });
+
+  // === Help ===
+  $('btnHelp').addEventListener('click', function() {
+    ($('helpDialog') as HTMLDialogElement).showModal();
+  });
+  $('helpClose').addEventListener('click', function() {
+    ($('helpDialog') as HTMLDialogElement).close();
+  });
+
+  // === Decide initial view ===
+  showMainView();
+  loadScenario('custom');
+  updateDevSidebar();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/playground/src/renderer/index.html
+++ b/playground/src/renderer/index.html
@@ -1,0 +1,472 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) Microsoft Corporation.
+  Licensed under the MIT License.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';">
+  <title>MXC Playground v0.1.0-alpha.1</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+  <!-- ========== WELCOME VIEW ========== -->
+  <div id="welcomeView" class="welcome-view hidden">
+    <div class="welcome-content">
+      <div class="welcome-logo">🔒</div>
+      <h1 class="welcome-title">MXC Playground</h1>
+      <p class="welcome-subtitle">Test scripts inside secure Windows sandboxes. Choose a pre-made scenario or write your own command — then see what gets allowed and what gets blocked.</p>
+
+      <div class="welcome-cards">
+        <div class="welcome-card">
+          <div class="welcome-card-icon">🎯</div>
+          <div class="welcome-card-title">Pick a scenario</div>
+          <div class="welcome-card-desc">Choose from ready-made tests or write your own</div>
+        </div>
+        <div class="welcome-card">
+          <div class="welcome-card-icon">🔐</div>
+          <div class="welcome-card-title">Set policy</div>
+          <div class="welcome-card-desc">Control what the script can access</div>
+        </div>
+        <div class="welcome-card">
+          <div class="welcome-card-icon">▶️</div>
+          <div class="welcome-card-title">Run and observe</div>
+          <div class="welcome-card-desc">Watch the results in real time</div>
+        </div>
+      </div>
+
+      <div class="welcome-actions">
+        <button id="btnTrySample" class="btn btn-primary btn-large">▶ Try a Sample</button>
+        <button id="btnStartScratch" class="btn btn-secondary btn-large">Start from Scratch</button>
+      </div>
+
+      <label class="welcome-checkbox">
+        <input type="checkbox" id="welcomeShowStartup">
+        <span>Show this on startup</span>
+      </label>
+
+      <div class="welcome-footer">
+        <a href="#" id="welcomeLearnMore">Learn more about MXC →</a>
+      </div>
+    </div>
+  </div>
+
+  <!-- ========== MAIN VIEW ========== -->
+  <div id="mainView" class="main-view">
+
+    <!-- Top bar -->
+    <header class="topbar">
+      <div class="topbar-left">
+        <span class="topbar-logo">🔒 MXC Playground v0.1.0-α1</span>
+        <button id="btnHelp" class="btn-help-inline" title="Quick Start Guide">Help</button>
+      </div>
+      <div class="topbar-right">
+        <label class="dev-toggle">
+          <input type="checkbox" id="experimentalToggle" checked>
+          <span class="dev-toggle-label">Experimental</span>
+          <span class="topbar-info" title="Pass --experimental flag to wxc-exec. Enables experimental features.">ℹ️</span>
+        </label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="debugToggle">
+          <span class="dev-toggle-label">Debug Mode</span>
+          <span class="topbar-info" title="Show debug output from wxc-exec and the MXC SDK">ℹ️</span>
+        </label>
+        <label class="dev-toggle">
+          <input type="checkbox" id="devModeToggle" checked>
+          <span class="dev-toggle-label">Developer View</span>
+        </label>
+        <span id="platformBadge" class="platform-badge"></span>
+      </div>
+    </header>
+
+    <!-- Content area -->
+    <div class="content-area">
+
+      <!-- Left sidebar -->
+      <aside class="sidebar" id="sidebar">
+        <div class="sidebar-scroll">
+
+        <!-- Section 1: Scenario -->
+        <section class="sidebar-section">
+          <div class="section-header">
+            <h2 class="section-title">Scenario</h2>
+          </div>
+          <div class="section-body">
+            <div class="field-row" style="margin-bottom: 8px;">
+              <label class="field-label">Schema Version</label>
+              <select id="versionSelect" class="scenario-select">
+                <option value="0.5.0-dev" selected>0.5.0-dev (latest)</option>
+                <option value="0.4.0-alpha">0.4.0-alpha</option>
+              </select>
+            </div>
+            <div class="field-row" style="margin-bottom: 8px;">
+              <label class="field-label">Containment</label>
+              <select id="containmentSelect" class="scenario-select">
+                <option value="appcontainer">🛡️ Base Process Container</option>
+                <option value="windows_sandbox">🧪 Windows Sandbox</option>
+                <option value="microvm">🧪 MicroVM (NanVix)</option>
+                <option value="wslc">🧪 WSLC</option>
+              </select>
+              <div id="experimentalCaution" class="experimental-caution hidden">
+                ⚠️ Experimental — still being developed. Use MXC JSON Config with your own configuration.
+                <a href="https://github.com/microsoft/mxc/tree/main/test_configs" target="_blank" class="caution-link">View sample configs →</a>
+              </div>
+            </div>
+            <div class="field-row" id="runtimeRow">
+              <label class="field-label">Runtime</label>
+              <div class="field-row-inline">
+                <select id="shellSelect" class="perm-select" style="flex:1;">
+                  <option value="cmd" selected>⬛ cmd.exe</option>
+                  <option value="ps51">🔷 PowerShell 5.1</option>
+                  <option value="ps7">🟦 PowerShell 7+</option>
+                  <option value="python">🐍 Python</option>
+                  <option value="custom">✏️ Custom</option>
+                  <option value="rawjson">📋 MXC JSON Config</option>
+                </select>
+                <button id="btnRefreshShells" class="btn-refresh" title="Refresh shell availability">🔄</button>
+              </div>
+            </div>
+            <div id="refreshStatus" class="hidden" style="font-size:11px; color:var(--text-muted); padding:4px 0; position:relative;">
+              <span id="refreshStatusText"></span>
+              <button id="btnDismissRefresh" style="position:absolute; top:2px; right:0; background:none; border:none; color:var(--text-dim); cursor:pointer; font-size:12px; padding:0 4px;" title="Dismiss">✕</button>
+            </div>
+            <div id="pythonAclWarning" class="experimental-caution hidden">
+              ⚠️ Python is installed per-user and lacks sandbox ACL permissions. Scripts will fail with access denied.
+              <button id="btnFixPythonAcl" class="btn btn-small" style="margin-top:4px;">🔧 Fix permissions (requires admin)</button>
+              <div id="pythonAclStatus" style="font-size:11px; margin-top:4px;"></div>
+            </div>
+            <div id="categoryRow" class="field-row">
+              <label class="field-label">Test</label>
+              <select id="scenarioSelect" class="perm-select"></select>
+            </div>
+            <div id="scenarioInfo" class="scenario-info">
+              <div id="scenarioDesc" class="scenario-desc"></div>
+              <span id="scenarioOutcome" class="outcome-badge"></span>
+            </div>
+            <div id="scriptSection" class="script-section hidden">
+              <label class="field-label">Script (inline command)</label>
+              <textarea id="scriptText" class="script-textarea" rows="4" spellcheck="false" placeholder='e.g. cmd.exe /c echo hello  or  powershell.exe -Command "Get-Date"'></textarea>
+              <div style="font-size:11px; color:var(--text-muted); margin-top:4px;">
+                Enter a single command line. For script files, use the full path (e.g., <code>powershell.exe -File C:\scripts\test.ps1</code>).
+              </div>
+            </div>
+            <div id="rawJsonSection" class="script-section hidden">
+              <button id="btnOpenJsonEditor" class="btn btn-run" style="width:100%;">📋 Open JSON Editor</button>
+              <div style="font-size:11px; color:var(--text-muted); margin-top:6px;">
+                ⚠️ MXC JSON mode skips policy generation. Config is passed to spawnSandboxFromConfig.
+              </div>
+              <div id="dropZone" class="drop-zone">
+                <span class="drop-zone-icon">＋</span>
+                <span>Drag & drop a .json config file here</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section 2: Policy -->
+        <section class="sidebar-section" id="policySectionWrapper">
+          <div class="section-header section-header-toggle" id="permissionsToggle">
+            <h2 class="section-title">Policy</h2>
+            <span class="section-chevron" id="permissionsChevron">▸</span>
+          </div>
+          <div id="permissionsSummaryLine" class="permissions-summary">
+            Files: off · Network: off · Desktop: on
+          </div>
+          <div id="permissionsBody" class="section-body hidden">
+
+            <!-- File Access -->
+            <div class="perm-group">
+              <div class="perm-header">
+                <span class="perm-icon">📁</span>
+                <span class="perm-label">File Access</span>
+                <span class="topbar-info" title="Controls which folders the sandboxed script can read from and write to. Disabled = no filesystem access beyond system defaults.">ℹ️</span>
+                <label class="toggle-switch">
+                  <input type="checkbox" id="fsToggle">
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+              <div id="fsDetails" class="perm-details hidden">
+                <div class="perm-sub">
+                  <label class="field-label">Writable folders</label>
+                  <div id="rwPathList" class="path-list"></div>
+                  <div class="path-actions">
+                    <button class="btn btn-small" id="rwBrowse">Browse</button>
+                    <input type="text" id="rwManualInput" class="perm-input" placeholder="C:\path\to\folder" style="flex:1; margin: 0 4px;">
+                    <button class="btn btn-small" id="rwManual">Add</button>
+                  </div>
+                </div>
+                <div class="perm-sub">
+                  <label class="field-label">Read-only folders</label>
+                  <div id="roPathList" class="path-list"></div>
+                  <div class="path-actions">
+                    <button class="btn btn-small" id="roBrowse">Browse</button>
+                    <input type="text" id="roManualInput" class="perm-input" placeholder="C:\path\to\folder" style="flex:1; margin: 0 4px;">
+                    <button class="btn btn-small" id="roManual">Add</button>
+                  </div>
+                </div>
+                <div class="perm-checkboxes">
+                  <label class="checkbox-row" title="Adds tool directories like Python, Node so executables can be found">
+                    <input type="checkbox" id="fsIncludeTools">
+                    <span>Include common tools</span>
+                  </label>
+                  <label class="checkbox-row" title="Allows writing to the temp folder">
+                    <input type="checkbox" id="fsIncludeTemp">
+                    <span>Include temp directory</span>
+                  </label>
+                </div>
+              </div>
+            </div>
+
+            <!-- Network Access -->
+            <div class="perm-group">
+              <div class="perm-header">
+                <span class="perm-icon">🌐</span>
+                <span class="perm-label">Network Access</span>
+                <span class="topbar-info" title="Controls outbound network connections. Disabled = all network traffic blocked.">ℹ️</span>
+                <label class="toggle-switch">
+                  <input type="checkbox" id="netToggle">
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+              <div id="netDetails" class="perm-details hidden">
+                <p class="perm-note">The script can make outbound HTTP/HTTPS connections</p>
+                <div class="perm-detail" id="proxySection" style="display:none; margin-top:8px;">
+                  <label class="perm-label">Proxy</label>
+                  <select id="proxySelect" class="perm-select">
+                    <option value="none">None</option>
+                    <option value="builtin">Built-in test server</option>
+                    <option value="localhost">Localhost port</option>
+                    <option value="url">URL</option>
+                  </select>
+                  <input type="number" id="proxyPort" class="perm-input" placeholder="Port" style="display:none; width:100px; margin-top:4px;" min="1" max="65535">
+                  <input type="text" id="proxyUrl" class="perm-input" placeholder="http://proxy:8080" style="display:none; width:200px; margin-top:4px;">
+                </div>
+              </div>
+            </div>
+
+            <!-- Desktop UI Access (0.5.0+ only) -->
+            <div class="perm-group" id="uiGroupWrapper">
+              <div class="perm-header">
+                <span class="perm-icon">🖥️</span>
+                <span class="perm-label">Desktop UI Access</span>
+                <span class="topbar-info" title="Controls access to the Win32k subsystem (windows, desktop, UI). Disabled = Win32k blocked. Some scripts may need this enabled to run.">ℹ️</span>
+                <label class="toggle-switch">
+                  <input type="checkbox" id="uiToggle" checked>
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+              <div id="uiDetails" class="perm-details">
+                <p id="uiNoteOn" class="perm-note">Script can use Win32k (windows, desktop features)</p>
+                <p id="uiNoteOff" class="perm-note perm-warning hidden">⚠️ Win32k disabled — some scripts may fail if they depend on UI subsystems</p>
+                <div id="uiClipboardRow" class="perm-sub">
+                  <label class="field-label">Clipboard</label>
+                  <select id="uiClipboard" class="perm-select">
+                    <option value="none">None</option>
+                    <option value="read">Read only</option>
+                    <option value="write">Write only</option>
+                    <option value="all">Full access</option>
+                  </select>
+                </div>
+                <label class="checkbox-row perm-sub">
+                  <input type="checkbox" id="uiInjection">
+                  <span>Allow input injection ⚠️</span>
+                </label>
+              </div>
+            </div>
+
+            <!-- Timeout -->
+            <div class="perm-row">
+              <div class="perm-header">
+                <span class="perm-icon">⏱️</span>
+                <span class="perm-label">Timeout</span>
+              </div>
+              <div class="perm-sub">
+                <label class="field-label">Seconds (0 = no timeout)</label>
+                <input type="number" id="timeoutInput" class="perm-input" value="30" min="0" step="5" style="width:100px">
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Section 3: Advanced -->
+        <section class="sidebar-section" id="advancedSectionWrapper">
+          <div class="section-header section-header-toggle" id="advancedToggle">
+            <h2 class="section-title">Advanced</h2>
+            <span class="section-chevron" id="advancedChevron">▸</span>
+          </div>
+          <div id="advancedBody" class="section-body hidden">
+            <div id="advancedProcessUI" class="advanced-process-ui">
+              <div class="advanced-row">
+                <label class="field-label">Isolation</label>
+                <select id="uiIsolation" class="perm-select">
+                  <option value="desktop">desktop</option>
+                  <option value="handles">handles</option>
+                  <option value="atoms">atoms</option>
+                  <option value="container">container</option>
+                </select>
+              </div>
+              <label class="checkbox-row">
+                <input type="checkbox" id="uiDesktopControl">
+                <span>Desktop system control</span>
+              </label>
+              <div class="advanced-row">
+                <label class="field-label">System settings</label>
+                <select id="uiSystemSettings" class="perm-select">
+                  <option value="none">none</option>
+                  <option value="parameters">parameters</option>
+                  <option value="display">display</option>
+                  <option value="all">all</option>
+                </select>
+              </div>
+              <label class="checkbox-row">
+                <input type="checkbox" id="uiIME">
+                <span>IME (Input Method Editor)</span>
+              </label>
+            </div>
+          </div>
+        </section>
+        </div><!-- end sidebar-scroll -->
+
+        <!-- Run button area -->
+        <div class="sidebar-run">
+          <button id="btnRun" class="btn btn-run">▶ Run in Sandbox</button>
+          <button id="btnRunAll" class="btn btn-run-all">▶▶ Run All cmd Tests</button>
+          <button id="btnKill" class="btn btn-kill hidden">■ Stop</button>
+          <div id="runSummary" class="run-summary">Network: off · Files: off · Desktop: on</div>
+        </div>
+      </aside>
+
+      <!-- Main area -->
+      <main class="main-area">
+
+        <!-- Result card -->
+        <div id="resultCard" class="result-card result-idle">
+          <div id="resultIcon" class="result-icon">💡</div>
+          <div class="result-body">
+            <div id="resultTitle" class="result-title">Select a scenario and click Run in Sandbox</div>
+            <div id="resultDetail" class="result-detail"></div>
+          </div>
+        </div>
+        <div id="resultActions" class="result-actions hidden"></div>
+
+        <!-- Terminal -->
+        <div class="terminal-wrapper">
+          <div class="terminal-header" id="terminalToggle">
+            <span>📋 Logs</span>
+            <span class="terminal-chevron" id="terminalChevron">▾</span>
+          </div>
+          <div id="terminal" class="terminal"></div>
+        </div>
+
+        <!-- Bottom bar: JSON tabs (hidden — dev sidebar replaces this) -->
+        <div class="json-bar" style="display:none;">
+          <div class="json-tabs">
+            <button class="json-tab" id="tabPolicy" data-tab="policy">Policy JSON</button>
+            <button class="json-tab" id="tabConfig" data-tab="config">Config JSON</button>
+          </div>
+          <div id="jsonPanel" class="json-panel hidden">
+            <div class="json-actions">
+              <button class="btn btn-small" id="jsonCopy">Copy</button>
+            </div>
+            <pre id="jsonContent" class="json-content"></pre>
+          </div>
+        </div>
+      </main>
+
+      <!-- Dev sidebar (hidden by default) -->
+      <aside id="devSidebar" class="dev-sidebar">
+        <div class="dev-sidebar-header">
+          <span>🛠 Developer View</span>
+        </div>
+        <div class="dev-section">
+          <div class="dev-section-title">Sandbox Policy <button class="btn-copy" id="copyPolicy" title="Copy to clipboard">📋</button></div>
+          <pre id="devPolicyJson" class="dev-json"></pre>
+        </div>
+        <div class="dev-section">
+          <div class="dev-section-title">Container Config <button class="btn-copy" id="copyConfig" title="Copy to clipboard">📋</button></div>
+          <pre id="devConfigJson" class="dev-json"></pre>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <!-- ========== JSON EDITOR DIALOG ========== -->
+  <dialog id="jsonEditorDialog" class="json-editor-dialog">
+    <div class="dialog-header">
+      <h2>Container Config JSON</h2>
+      <button class="dialog-close" id="jsonEditorClose">✕</button>
+    </div>
+    <div class="json-editor-body">
+      <div class="json-editor-note">
+        ⚠️ MXC JSON mode skips policy generation — the config is passed to spawnSandboxFromConfig.
+      </div>
+      <textarea id="rawJsonText" class="json-editor-textarea" spellcheck="false" placeholder="Paste or type your MXC ContainerConfig JSON here..."></textarea>
+      <div class="json-editor-preview">
+        <div class="json-editor-preview-title">Validation</div>
+        <pre id="jsonEditorPreview" class="dev-json"></pre>
+      </div>
+      <div class="json-editor-actions">
+        <button id="jsonEditorRun" class="btn btn-run">▶ Run</button>
+        <button id="jsonEditorApply" class="btn btn-secondary">Apply & Close</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- ========== HELP DIALOG ========== -->
+  <dialog id="helpDialog">
+    <div class="dialog-header">
+      <h2>MXC Playground — Quick Start</h2>
+      <button class="dialog-close" id="helpClose">✕</button>
+    </div>
+    <div class="help-content">
+      <div class="help-section">
+        <h3>What is MXC?</h3>
+        <p>MXC runs scripts inside isolated containers, controlling access to files, network, and desktop features.</p>
+      </div>
+      <div class="help-section">
+        <h3>Getting Started</h3>
+        <ol>
+          <li><strong>Choose containment</strong> — Select a containment type. Process Container is the default and supports pre-made scenarios.</li>
+          <li><strong>Pick a runtime</strong> — cmd.exe, PowerShell, Python, Custom, or MXC JSON Config. Not installed? Follow the install instructions shown.</li>
+          <li><strong>Select a test</strong> — Pre-made scenarios auto-configure policy. ✓ = should succeed, ✗ = should be blocked.</li>
+          <li><strong>Run</strong> — Click "▶ Run in Sandbox" to run one test, or "▶▶ Run All Tests" to run all tests for the selected runtime.</li>
+        </ol>
+      </div>
+      <div class="help-section">
+        <h3>Runtime Installation</h3>
+        <ul>
+          <li>🐍 <strong>Python</strong> — Install via <code>winget install Python.Python.3.14</code>. Works out of the box.</li>
+          <li>🟦 <strong>PowerShell 7+</strong> — Supports MSI package installed version. MSIX and Microsoft Store versions are not yet supported. <a href="https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows?view=powershell-7.6#install-the-msi-package" target="_blank" style="color:var(--accent);">Install MSI package →</a></li>
+        </ul>
+      </div>
+      <div class="help-section">
+        <h3>Containment Types</h3>
+        <ul>
+          <li>🛡️ <strong>Base Process Container</strong> — Default for 0.5.0-dev. Uses CreateProcessInSandbox. Supports all pre-made scenarios.</li>
+          <li>🛡️ <strong>AppContainer</strong> — Default for 0.4.0-alpha. Standard Windows AppContainer isolation.</li>
+          <li>🧪 <strong>Windows Sandbox / MicroVM / WSLC</strong> — Experimental. Select from the Containment dropdown — these only support MXC JSON Config mode (paste your own config).</li>
+        </ul>
+      </div>
+      <div class="help-section">
+        <h3>Top Bar Controls</h3>
+        <ul>
+          <li>🧪 <strong>Experimental</strong> — On by default. Passes <code>--experimental</code> to wxc-exec to enable experimental features.</li>
+          <li>🐛 <strong>Debug Mode</strong> — Shows detailed wxc-exec output.</li>
+          <li>👁️ <strong>Developer View</strong> — Live Sandbox Policy and Container Config JSON on the right.</li>
+        </ul>
+      </div>
+      <div class="help-section">
+        <h3>Notes</h3>
+        <ul>
+          <li>📝 Scripts are inline commands. For .ps1/.py files, use full paths.</li>
+        </ul>
+      </div>
+    </div>
+  </dialog>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/playground/src/renderer/styles.css
+++ b/playground/src/renderer/styles.css
@@ -1,0 +1,1185 @@
+/* Copyright (c) Microsoft Corporation. Licensed under the MIT License. */
+
+/* ===== CSS Variables — Dark Theme (default) ===== */
+:root {
+  --bg: #1e1e1e;
+  --bg-surface: #252526;
+  --bg-elevated: #2d2d30;
+  --bg-input: #3c3c3c;
+  --bg-hover: #2a2d2e;
+  --bg-terminal: #0c0c0c;
+  --border: #3e3e42;
+  --border-light: #333336;
+  --border-focus: #007acc;
+  --text: #cccccc;
+  --text-bright: #e8e8e8;
+  --text-dim: #808080;
+  --text-muted: #6a6a6a;
+  --accent: #007acc;
+  --accent-hover: #1a8ad4;
+  --primary: #0e639c;
+  --primary-hover: #1177bb;
+  --primary-text: #ffffff;
+  --danger: #c4200d;
+  --danger-bg: #a1260d;
+  --success: #4ec9b0;
+  --success-bg: rgba(78, 201, 176, 0.12);
+  --success-border: rgba(78, 201, 176, 0.4);
+  --error: #f44747;
+  --error-bg: rgba(244, 71, 71, 0.12);
+  --error-border: rgba(244, 71, 71, 0.4);
+  --info: #569cd6;
+  --warning: #cca700;
+  --warning-bg: rgba(204, 167, 0, 0.12);
+  --toggle-on: #4ec9b0;
+  --toggle-off: #555;
+  --font-ui: "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, sans-serif;
+  --font-mono: "Cascadia Code", "Fira Code", Consolas, "Courier New", monospace;
+  --radius: 6px;
+  --radius-lg: 10px;
+  --sidebar-width: 350px;
+  --topbar-height: 44px;
+  --json-key: #9cdcfe;
+  --json-string: #ce9178;
+  --json-number: #b5cea8;
+  --json-boolean: #569cd6;
+  --json-null: #808080;
+}
+
+/* ===== Light Theme ===== */
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff;
+    --bg-surface: #f5f5f5;
+    --bg-elevated: #ebebeb;
+    --bg-input: #ffffff;
+    --bg-hover: #e8e8e8;
+    --bg-terminal: #0c0c0c;
+    --border: #d4d4d4;
+    --border-light: #e0e0e0;
+    --border-focus: #007acc;
+    --text: #1e1e1e;
+    --text-bright: #000000;
+    --text-dim: #6e6e6e;
+    --text-muted: #999999;
+    --accent: #007acc;
+    --accent-hover: #005a9e;
+    --primary: #0e639c;
+    --primary-hover: #005a9e;
+    --primary-text: #ffffff;
+    --danger: #c4200d;
+    --danger-bg: #c4200d;
+    --success: #16825d;
+    --success-bg: rgba(22, 130, 93, 0.08);
+    --success-border: rgba(22, 130, 93, 0.3);
+    --error: #cd3131;
+    --error-bg: rgba(205, 49, 49, 0.08);
+    --error-border: rgba(205, 49, 49, 0.3);
+    --info: #0451a5;
+    --warning: #bf8803;
+    --warning-bg: rgba(191, 136, 3, 0.08);
+    --toggle-on: #16825d;
+    --toggle-off: #ccc;
+    --json-key: #0451a5;
+    --json-string: #a31515;
+    --json-number: #098658;
+    --json-boolean: #0000ff;
+    --json-null: #808080;
+  }
+}
+
+/* ===== Reset ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.hidden { display: none !important; }
+
+/* ===== WELCOME VIEW ===== */
+.welcome-view {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background: var(--bg);
+  padding: 40px 20px;
+}
+
+.welcome-content {
+  max-width: 640px;
+  text-align: center;
+}
+
+.welcome-logo {
+  font-size: 56px;
+  margin-bottom: 8px;
+}
+
+.welcome-title {
+  font-size: 32px;
+  font-weight: 700;
+  color: var(--text-bright);
+  margin-bottom: 8px;
+  letter-spacing: -0.5px;
+}
+
+.welcome-subtitle {
+  font-size: 16px;
+  color: var(--text-dim);
+  margin-bottom: 40px;
+  line-height: 1.6;
+}
+
+.welcome-cards {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 36px;
+}
+
+.welcome-card {
+  flex: 1;
+  padding: 24px 16px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.welcome-card:hover {
+  border-color: var(--accent);
+  background: var(--bg-elevated);
+}
+
+.welcome-card-icon {
+  font-size: 28px;
+  margin-bottom: 10px;
+}
+
+.welcome-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 6px;
+}
+
+.welcome-card-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+
+.welcome-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.welcome-checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-bottom: 24px;
+  cursor: pointer;
+}
+
+.welcome-footer {
+  font-size: 12px;
+}
+
+.welcome-footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.welcome-footer a:hover {
+  text-decoration: underline;
+}
+
+/* ===== BUTTONS ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-input);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  white-space: nowrap;
+}
+
+.btn:hover { background: var(--bg-hover); }
+.btn:active { transform: scale(0.98); }
+
+.btn-primary {
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-text);
+}
+.btn-primary:hover { background: var(--primary-hover); }
+
+.btn-secondary {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+.btn-secondary:hover { background: var(--bg-elevated); }
+
+.btn-large {
+  padding: 10px 28px;
+  font-size: 15px;
+  border-radius: 8px;
+}
+
+.btn-small {
+  padding: 4px 10px;
+  font-size: 11px;
+}
+
+.btn-text {
+  background: transparent;
+  border-color: transparent;
+  color: var(--accent);
+}
+.btn-text:hover { background: var(--bg-hover); }
+
+.btn-run {
+  width: 100%;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-text);
+  border-radius: 8px;
+}
+.btn-run:hover { background: var(--primary-hover); }
+.btn-run:disabled { opacity: 0.5; cursor: default; }
+
+.btn-run-all {
+  width: 100%;
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  background: var(--bg-input);
+  border-color: var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  margin-top: 4px;
+}
+.btn-run-all:hover { background: var(--bg-hover); border-color: var(--accent); }
+.btn-run-all:disabled { opacity: 0.5; cursor: default; }
+
+.btn-kill {
+  width: 100%;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  background: var(--danger-bg);
+  border-color: var(--danger);
+  color: var(--primary-text);
+  border-radius: 8px;
+}
+
+/* ===== MAIN VIEW LAYOUT ===== */
+.main-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* ===== TOP BAR ===== */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--topbar-height);
+  padding: 0 16px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  -webkit-app-region: drag;
+}
+
+.topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.topbar-logo {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-bright);
+  letter-spacing: -0.3px;
+}
+
+.topbar-version {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  -webkit-app-region: no-drag;
+}
+
+.platform-badge {
+  font-size: 11px;
+  color: var(--text-dim);
+  padding: 2px 8px;
+  background: var(--bg-elevated);
+  border-radius: 10px;
+}
+
+.topbar-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg-input);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: var(--font-ui);
+  -webkit-app-region: no-drag;
+}
+.topbar-btn:hover { background: var(--bg-hover); border-color: var(--accent); }
+.topbar-info { cursor: help; font-size: 12px; opacity: 0.6; margin-left: 2px; }
+
+.btn-help-inline {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  margin-left: 8px;
+  font-family: var(--font-ui);
+  -webkit-app-region: no-drag;
+}
+.btn-help-inline:hover { color: var(--text); border-color: var(--accent); }
+
+/* ===== CONTENT AREA ===== */
+.content-area {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* ===== SIDEBAR ===== */
+.sidebar {
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+}
+
+.sidebar-scroll {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.sidebar-section {
+  border-bottom: 1px solid var(--border-light);
+}
+
+.section-header {
+  padding: 12px 16px 4px;
+}
+
+.section-header-toggle {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  user-select: none;
+}
+
+.section-header-toggle:hover {
+  background: var(--bg-hover);
+}
+
+.section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.section-chevron {
+  font-size: 12px;
+  color: var(--text-dim);
+  transition: transform 0.15s;
+}
+
+.section-chevron.open {
+  transform: rotate(90deg);
+}
+
+.section-body {
+  padding: 0 16px 12px;
+}
+
+/* ===== SCENARIO ===== */
+.scenario-select {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-ui);
+  cursor: pointer;
+}
+.scenario-select:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.scenario-info {
+  margin-top: 8px;
+  padding: 8px 0;
+}
+
+.scenario-desc {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+
+.outcome-badge {
+  display: inline-block;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-weight: 500;
+}
+.outcome-badge.succeed {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.outcome-badge.be-blocked {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error-border);
+}
+.outcome-badge.show-error {
+  background: var(--warning-bg);
+  color: var(--warning);
+  border: 1px solid rgba(204, 167, 0, 0.3);
+}
+
+.script-section {
+  margin-top: 8px;
+}
+
+.script-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 12px;
+  font-family: var(--font-mono);
+  background: var(--bg-input);
+  color: var(--text-bright);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: vertical;
+  min-height: 60px;
+}
+.script-textarea:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+/* ===== PERMISSIONS ===== */
+.permissions-summary {
+  padding: 0 16px 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.perm-group {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+.perm-group:last-child { border-bottom: none; }
+
+.perm-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.perm-icon {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.perm-label {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-bright);
+}
+
+.perm-details {
+  margin-top: 10px;
+  padding-left: 28px;
+}
+
+.perm-sub {
+  margin-bottom: 10px;
+}
+
+.perm-note {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  margin-bottom: 6px;
+}
+
+.perm-warning {
+  color: var(--warning);
+}
+
+.perm-hint {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.perm-select, .perm-input {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-family: var(--font-ui);
+}
+.perm-select:focus, .perm-input:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+
+.btn-refresh {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  font-size: 14px;
+  cursor: pointer;
+  color: var(--text);
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.btn-refresh:hover {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+}
+
+.perm-checkboxes {
+  margin-top: 8px;
+}
+
+.field-label {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-bottom: 4px;
+}
+
+.field-row-inline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.containment-badge {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text);
+  padding: 4px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  display: inline-block;
+}
+
+.experimental-caution {
+  margin-top: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  color: #d4a017;
+  background: rgba(212, 160, 23, 0.08);
+  border: 1px solid rgba(212, 160, 23, 0.2);
+  border-radius: var(--radius);
+}
+.caution-link {
+  display: block;
+  margin-top: 4px;
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 11px;
+}
+.caution-link:hover { text-decoration: underline; }
+
+.drop-zone {
+  margin-top: 8px;
+  padding: 16px;
+  border: 2px dashed var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.drop-zone:hover, .drop-zone.drag-over {
+  border-color: var(--accent);
+  background: rgba(0,120,212,0.05);
+}
+.drop-zone-icon {
+  display: block;
+  font-size: 20px;
+  margin-bottom: 4px;
+  opacity: 0.5;
+}
+
+/* ===== iOS-STYLE TOGGLE ===== */
+.toggle-switch {
+  position: relative;
+  display: inline-block;
+  width: 36px;
+  height: 20px;
+  flex-shrink: 0;
+  cursor: pointer;
+  margin: 0;
+}
+
+.toggle-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: var(--toggle-off);
+  border-radius: 20px;
+  transition: background 0.2s;
+}
+
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+}
+
+.toggle-switch input:checked + .toggle-slider {
+  background: var(--toggle-on);
+}
+
+.toggle-switch input:checked + .toggle-slider::before {
+  transform: translateX(16px);
+}
+
+/* ===== CHECKBOX ===== */
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.checkbox-row input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+/* ===== PATH LIST ===== */
+.path-list {
+  max-height: 100px;
+  overflow-y: auto;
+  margin-bottom: 6px;
+}
+
+.path-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  border-radius: 3px;
+}
+.path-item:hover { background: var(--bg-hover); }
+
+.path-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
+}
+
+.path-remove {
+  background: none;
+  border: none;
+  color: var(--error);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+  opacity: 0.6;
+}
+.path-remove:hover { opacity: 1; }
+
+.path-actions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.path-empty {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 4px 0;
+}
+
+/* ===== ADVANCED ===== */
+.advanced-row {
+  margin-bottom: 10px;
+}
+
+.advanced-process-ui {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-light);
+}
+
+/* ===== SIDEBAR RUN BUTTON ===== */
+.sidebar-run {
+  margin-top: auto;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.run-summary {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+  text-align: center;
+}
+
+/* ===== MAIN AREA ===== */
+.main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+/* ===== RESULT CARD ===== */
+.result-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  margin: 12px 16px 0;
+  border-radius: var(--radius-lg);
+  border-left: 4px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.result-idle {
+  border-left-color: var(--text-dim);
+}
+.result-success {
+  border-left-color: var(--success);
+  background: var(--success-bg);
+}
+.result-error {
+  border-left-color: var(--error);
+  background: var(--error-bg);
+}
+.result-running {
+  border-left-color: var(--accent);
+}
+.result-neutral {
+  border-left-color: #f0ad4e;
+  background: rgba(240, 173, 78, 0.08);
+}
+
+.result-icon {
+  font-size: 24px;
+  flex-shrink: 0;
+}
+
+.result-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.result-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.result-detail {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 2px;
+}
+
+.result-actions {
+  padding: 6px 20px 0;
+  margin: 0 16px;
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* ===== TERMINAL ===== */
+.terminal-wrapper {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  margin: 12px 16px 0;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  overflow: hidden;
+  background: var(--bg-terminal);
+  min-height: 0;
+}
+
+.terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px;
+  background: #181818;
+  color: #888;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+.terminal-header:hover { background: #1f1f1f; }
+
+.terminal-chevron {
+  font-size: 12px;
+  transition: transform 0.15s;
+}
+.terminal-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+
+.terminal {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: #ccc;
+}
+
+.terminal .line-info { color: var(--info); }
+.terminal .line-success { color: var(--success); }
+.terminal .line-error { color: #f44747; }
+.terminal .line-dim { color: #666; }
+.terminal .line-output { color: #ccc; }
+
+/* ===== JSON BAR ===== */
+.json-bar {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.json-tabs {
+  display: flex;
+  gap: 0;
+}
+
+.json-tab {
+  flex: 1;
+  padding: 7px 16px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  font-weight: 500;
+  color: var(--text-dim);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s;
+}
+.json-tab:hover { color: var(--text); }
+.json-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.json-panel {
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0 14px 12px;
+  position: relative;
+}
+
+.json-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 0;
+}
+
+.json-content {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--text);
+  margin: 0;
+}
+
+.json-content .json-key { color: var(--json-key); }
+.json-content .json-string { color: var(--json-string); }
+.json-content .json-number { color: var(--json-number); }
+.json-content .json-boolean { color: var(--json-boolean); }
+.json-content .json-null { color: var(--json-null); }
+
+/* ===== HELP DIALOG ===== */
+dialog {
+  margin: auto;
+  max-width: 700px;
+  width: 90%;
+  background: var(--bg-surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 24px 28px;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.5);
+}
+dialog::backdrop {
+  background: rgba(0,0,0,0.5);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.dialog-header h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-bright);
+}
+
+.dialog-close {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+}
+.dialog-close:hover { background: var(--bg-hover); color: var(--text); }
+
+.json-editor-dialog {
+  max-width: 800px;
+  width: 90%;
+}
+.json-editor-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.json-editor-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  padding: 8px 12px;
+  background: var(--bg-input);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+.json-editor-textarea {
+  width: 100%;
+  min-height: 250px;
+  max-height: 50vh;
+  padding: 12px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--bg-input);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  resize: vertical;
+  tab-size: 2;
+}
+.json-editor-textarea:focus {
+  outline: none;
+  border-color: var(--border-focus);
+}
+.json-editor-preview {
+  max-height: 150px;
+  overflow-y: auto;
+}
+.json-editor-preview-title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.json-editor-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.help-content {
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.help-section {
+  margin-bottom: 20px;
+}
+
+.help-section h3 {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-bright);
+  margin-bottom: 6px;
+}
+
+.help-section p, .help-section li {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.6;
+}
+
+.help-section ol {
+  padding-left: 20px;
+  margin-top: 6px;
+}
+
+.help-section ol li {
+  margin-bottom: 4px;
+}
+
+/* ===== SCROLLBAR ===== */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: rgba(128,128,128,0.3); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: rgba(128,128,128,0.5); }
+
+/* ===== DEV SIDEBAR ===== */
+.dev-sidebar {
+  width: 380px;
+  min-width: 300px;
+  border-left: 1px solid var(--border);
+  background: var(--bg-surface);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+.dev-sidebar.hidden { display: none; }
+.dev-sidebar-header {
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.dev-section { padding: 8px 12px; border-bottom: 1px solid var(--border); }
+.dev-section-title { display: flex; align-items: center; justify-content: space-between; font-size: 11px; font-weight: 600; color: var(--text-dim); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+.btn-copy { background: none; border: none; cursor: pointer; font-size: 12px; padding: 2px; opacity: 0.7; }
+.btn-copy:hover { opacity: 1; }
+.dev-json {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 40vh;
+  overflow-y: auto;
+  padding: 6px;
+  background: var(--bg);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  margin: 0;
+}
+.dev-info { font-family: var(--font-mono); font-size: 12px; color: var(--accent); }
+.dev-toggle { display: flex; align-items: center; gap: 4px; cursor: pointer; font-size: 12px; }
+.dev-toggle input { cursor: pointer; }
+.dev-toggle-label { color: var(--text-dim); }

--- a/playground/test-scripts/winhttp-proxy-test.ps1
+++ b/playground/test-scripts/winhttp-proxy-test.ps1
@@ -1,0 +1,54 @@
+# MXC Proxy Test Script — uses native WinHTTP COM to test proxy routing
+# This script creates a WinHTTP request and reports the response.
+# It uses the WinHttp.WinHttpRequest.5.1 COM object which goes through
+# the OS WinHTTP stack (not .NET HttpClient or curl).
+
+param(
+    [string]$Url = "https://www.example.com",
+    [int]$TimeoutSeconds = 15
+)
+
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+
+Write-Output "=== MXC WinHTTP Proxy Test ==="
+Write-Output "URL: $Url"
+Write-Output "Timeout: ${TimeoutSeconds}s"
+Write-Output ""
+
+try {
+    $h = New-Object -ComObject WinHttp.WinHttpRequest.5.1
+
+    # Set timeouts (resolve, connect, send, receive) in milliseconds
+    $ms = $TimeoutSeconds * 1000
+    $h.SetTimeouts($ms, $ms, $ms, $ms)
+
+    # Use automatic proxy detection (picks up OS-configured proxy)
+    $h.SetProxy(1) # HTTPREQUEST_PROXYSETTING_DEFAULT
+
+    $h.Open('GET', $Url, $false)
+    $h.Send()
+
+    $status = $h.Status
+    $statusText = $h.StatusText
+    $body = $h.ResponseText
+
+    Write-Output "Status: $status $statusText"
+    Write-Output "Body length: $($body.Length) bytes"
+    Write-Output ""
+
+    if ($body.Length -gt 500) {
+        Write-Output $body.Substring(0, 500)
+        Write-Output "... (truncated)"
+    } else {
+        Write-Output $body
+    }
+
+    Write-Output ""
+    Write-Output "WINHTTP_OK"
+} catch {
+    Write-Output "ERROR: $_"
+    Write-Output ""
+    Write-Output "WINHTTP_FAILED"
+    exit 1
+}

--- a/playground/tsconfig.main.json
+++ b/playground/tsconfig.main.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "dist/main",
+    "rootDir": "src/main",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/main/**/*"]
+}

--- a/playground/tsconfig.renderer.json
+++ b/playground/tsconfig.renderer.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "none",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "outDir": "dist/renderer",
+    "rootDir": "src/renderer",
+    "strict": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/renderer/**/*"]
+}

--- a/schemas/stable/mxc-config.schema.0.5.0-alpha.json
+++ b/schemas/stable/mxc-config.schema.0.5.0-alpha.json
@@ -147,6 +147,16 @@
               },
               "required": ["builtinTestServer"],
               "additionalProperties": false
+            },
+            {
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "description": "Full proxy URL including port (e.g., http://proxy.example.com:8080)."
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
             }
           ]
         }

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -15,11 +15,75 @@
       "devDependencies": {
         "@types/node": "^20.10.0",
         "@types/semver": "^7.7.1",
+        "node-gyp": "^12.2.0",
         "rimraf": "^6.1.3",
         "typescript": "^5.3.3"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@types/node": {
@@ -38,6 +102,26 @@
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/balanced-match": {
       "version": "4.0.3",
@@ -62,6 +146,104 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -80,6 +262,86 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
@@ -88,6 +350,30 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/minimatch": {
@@ -116,11 +402,176 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/node-pty": {
       "version": "1.2.0-beta.12",
@@ -130,6 +581,35 @@
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -156,6 +636,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
@@ -176,6 +679,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -186,6 +697,94 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
     "node_modules/typescript": {
@@ -208,6 +807,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     }
   }
 }

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "^20.10.0",
     "@types/semver": "^7.7.1",
+    "node-gyp": "^12.2.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.3.3"
   },

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -260,6 +260,10 @@ export function findWxcExecutable(): string | null {
  */
 function verifyExecutable(execPath: string): boolean {
   try {
+    // Paths inside Electron's app.asar exist to fs but can't be executed
+    if (execPath.includes('.asar')) {
+      return false;
+    }
     if (!fs.existsSync(execPath) || !fs.statSync(execPath).isFile()) {
       return false;
     }

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -367,6 +367,12 @@ export interface SandboxSpawnOptions {
   executablePath?: string;
 
   /**
+   * Skip platform support check. Use when you know the platform
+   * is compatible and want to bypass build version validation.
+   */
+  skipPlatformCheck?: boolean;
+
+  /**
    * PTY options to pass to node-pty (only used by spawnSandbox)
    */
   ptyOptions?: pty.IPtyForkOptions;

--- a/src/.cargo/config.toml
+++ b/src/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/src/.cargo/config.toml
+++ b/src/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/src/wxc_test_proxy/src/proxy.rs
+++ b/src/wxc_test_proxy/src/proxy.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Minimal HTTP CONNECT proxy for testing.
+//! Minimal HTTP proxy for testing — supports CONNECT tunnels and HTTP forwarding.
 
-use http_body_util::Empty;
-use hyper::body::Incoming;
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
@@ -12,12 +12,12 @@ use hyper_util::rt::TokioIo;
 use tokio::net::{TcpListener, TcpStream};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
-type ProxyResponse = Response<Empty<bytes::Bytes>>;
 
-fn empty_response(status: StatusCode) -> ProxyResponse {
-    let mut resp = Response::new(Empty::new());
-    *resp.status_mut() = status;
-    resp
+fn empty_response(status: StatusCode) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
 }
 
 /// Start the test proxy. Binds to port 0 (OS-assigned) and returns the actual port.
@@ -50,16 +50,20 @@ pub async fn start() -> u16 {
     port
 }
 
-async fn handle_request(req: Request<Incoming>) -> Result<ProxyResponse, BoxError> {
-    if req.method() != Method::CONNECT {
-        eprintln!(
-            "[wxc-test-proxy] rejected non-CONNECT: {} {}",
-            req.method(),
-            req.uri()
-        );
-        return Ok(empty_response(StatusCode::METHOD_NOT_ALLOWED));
+async fn handle_request(
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
+    if req.method() == Method::CONNECT {
+        return handle_connect(req).await;
     }
 
+    // HTTP forwarding — forward GET/POST/etc to the target
+    handle_forward(req).await
+}
+
+async fn handle_connect(
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
     let authority = req
         .uri()
         .authority()
@@ -96,4 +100,73 @@ async fn handle_request(req: Request<Incoming>) -> Result<ProxyResponse, BoxErro
     });
 
     Ok(empty_response(StatusCode::OK))
+}
+
+async fn handle_forward(
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
+    let uri = req.uri().clone();
+    let method = req.method().clone();
+
+    eprintln!("[wxc-test-proxy] {} {}", method, uri);
+
+    // Extract host from the absolute URI
+    let host = uri.host().ok_or("missing host in URI")?;
+    let port = uri.port_u16().unwrap_or(80);
+    let addr = format!("{}:{}", host, port);
+
+    // Connect to target
+    let stream = TcpStream::connect(&addr).await.map_err(|err| {
+        eprintln!("[wxc-test-proxy] forward connect error for {}: {}", addr, err);
+        err
+    })?;
+
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            eprintln!("[wxc-test-proxy] forward connection error: {}", err);
+        }
+    });
+
+    // Build the forwarded request with a relative URI (path + query only)
+    let path = uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or("/");
+
+    let mut forward_req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("Host", format!("{}:{}", host, port));
+
+    // Copy headers from original request
+    for (key, value) in req.headers() {
+        if key != "host" {
+            forward_req = forward_req.header(key, value);
+        }
+    }
+
+    let body = req.collect().await?.to_bytes();
+    let forward_req = forward_req.body(Full::new(body))?;
+
+    let resp = sender.send_request(forward_req).await?;
+
+    // Collect response body and forward back
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let resp_body = resp.collect().await?.to_bytes();
+
+    let mut response = Response::builder().status(status);
+    for (key, value) in headers.iter() {
+        response = response.header(key, value);
+    }
+
+    eprintln!(
+        "[wxc-test-proxy] forwarded {} → {} ({} bytes)",
+        uri, status, resp_body.len()
+    );
+
+    Ok(response.body(Full::new(resp_body))?)
 }

--- a/src/wxc_test_proxy/src/proxy.rs
+++ b/src/wxc_test_proxy/src/proxy.rs
@@ -50,9 +50,7 @@ pub async fn start() -> u16 {
     port
 }
 
-async fn handle_request(
-    req: Request<Incoming>,
-) -> Result<Response<Full<Bytes>>, BoxError> {
+async fn handle_request(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, BoxError> {
     if req.method() == Method::CONNECT {
         return handle_connect(req).await;
     }
@@ -61,9 +59,7 @@ async fn handle_request(
     handle_forward(req).await
 }
 
-async fn handle_connect(
-    req: Request<Incoming>,
-) -> Result<Response<Full<Bytes>>, BoxError> {
+async fn handle_connect(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, BoxError> {
     let authority = req
         .uri()
         .authority()
@@ -102,9 +98,7 @@ async fn handle_connect(
     Ok(empty_response(StatusCode::OK))
 }
 
-async fn handle_forward(
-    req: Request<Incoming>,
-) -> Result<Response<Full<Bytes>>, BoxError> {
+async fn handle_forward(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, BoxError> {
     let uri = req.uri().clone();
     let method = req.method().clone();
 
@@ -117,7 +111,10 @@ async fn handle_forward(
 
     // Connect to target
     let stream = TcpStream::connect(&addr).await.map_err(|err| {
-        eprintln!("[wxc-test-proxy] forward connect error for {}: {}", addr, err);
+        eprintln!(
+            "[wxc-test-proxy] forward connect error for {}: {}",
+            addr, err
+        );
         err
     })?;
 
@@ -131,10 +128,7 @@ async fn handle_forward(
     });
 
     // Build the forwarded request with a relative URI (path + query only)
-    let path = uri
-        .path_and_query()
-        .map(|pq| pq.as_str())
-        .unwrap_or("/");
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
 
     let mut forward_req = Request::builder()
         .method(method)
@@ -165,7 +159,9 @@ async fn handle_forward(
 
     eprintln!(
         "[wxc-test-proxy] forwarded {} → {} ({} bytes)",
-        uri, status, resp_body.len()
+        uri,
+        status,
+        resp_body.len()
     );
 
     Ok(response.body(Full::new(resp_body))?)

--- a/src/wxc_windows_sandbox_daemon/src/pipe_server.rs
+++ b/src/wxc_windows_sandbox_daemon/src/pipe_server.rs
@@ -21,7 +21,8 @@ const MAX_LAUNCH_ATTEMPTS: u32 = 3;
 const LAUNCH_BACKOFF_SECS: [u64; 3] = [0, 10, 20];
 
 /// Maximum time (seconds) to wait for the guest agent's rendezvous file.
-const RENDEZVOUS_TIMEOUT_SECS: u64 = 120;
+/// First VM boot can take 3-5+ minutes; 360s covers worst-case cold starts.
+const RENDEZVOUS_TIMEOUT_SECS: u64 = 360;
 
 /// Polling interval (milliseconds) when checking for the rendezvous file.
 const RENDEZVOUS_POLL_INTERVAL_MS: u64 = 500;
@@ -132,44 +133,41 @@ async fn execute_request(
         locked.last_activity = std::time::Instant::now();
     }
 
-    // Execute on the guest.
-    let result = {
-        let mut locked = state.lock().await;
-        let conn = locked
-            .guest_connection
-            .as_mut()
-            .context("no guest connection")?;
+    // Execute on the guest and reconnect data streams for the next
+    // execution.  Both operations must run under a single lock acquisition
+    // so that a concurrent client cannot send a new EXEC (or consume the
+    // StreamsReady message) while we are between execute and reconnect.
+    let mut locked = state.lock().await;
+    let addr = locked.guest_addr.context("no guest address")?;
+    let conn = locked
+        .guest_connection
+        .as_mut()
+        .context("no guest connection")?;
 
-        let exec_id = uuid::Uuid::new_v4().to_string();
-        tcp_bridge::execute_on_guest(
-            conn,
-            &exec_id,
-            &req.script_code,
-            &req.working_directory,
-            req.timeout_ms,
-            &[],
-        )
-        .await?
-    };
+    let exec_id = uuid::Uuid::new_v4().to_string();
+    let result = tcp_bridge::execute_on_guest(
+        conn,
+        &exec_id,
+        &req.script_code,
+        &req.working_directory,
+        req.timeout_ms,
+        &[],
+    )
+    .await?;
 
-    // Reconnect data streams for the next execution. The agent will
+    // Reconnect data streams for the next execution. The guest will
     // re-accept 3 new data connections and signal StreamsReady.
+    if let Err(err) =
+        tcp_bridge::reconnect_data_streams(conn, addr, result.control_residual).await
     {
-        let mut locked = state.lock().await;
-        let addr = locked.guest_addr.context("no guest address")?;
-        if let Some(conn) = locked.guest_connection.as_mut() {
-            if let Err(err) =
-                tcp_bridge::reconnect_data_streams(conn, addr, result.control_residual).await
-            {
-                eprintln!("[daemon] failed to reconnect data streams: {:#}", err);
-                // Full reset so the next request tears down and relaunches
-                // rather than waiting for a rendezvous that won't appear.
-                locked.guest_connection = None;
-                locked.guest_addr = None;
-                locked.sandbox_running = false;
-            }
-        }
+        eprintln!("[daemon] failed to reconnect data streams: {:#}", err);
+        // Full reset so the next request tears down and relaunches
+        // rather than waiting for a rendezvous that won't appear.
+        locked.guest_connection = None;
+        locked.guest_addr = None;
+        locked.sandbox_running = false;
     }
+    drop(locked);
 
     Ok(DaemonResult {
         exit_code: result.exit_code,
@@ -183,9 +181,13 @@ async fn execute_request(
 /// Ensure the sandbox VM is running and we have a guest connection.
 ///
 /// Retries once on failure — tears down the sandbox and relaunches.
+///
+/// Updates `last_activity` before starting work so the idle watchdog
+/// does not fire during the multi-minute VM boot + rendezvous.
 async fn ensure_sandbox_ready(state: &Arc<Mutex<DaemonState>>) -> Result<()> {
     {
-        let s = state.lock().await;
+        let mut s = state.lock().await;
+        s.last_activity = std::time::Instant::now();
         if s.guest_connection.is_some() {
             return Ok(());
         }
@@ -279,7 +281,13 @@ async fn try_launch_and_connect(
         }
     }
 
-    // Poll for rendezvous without holding the lock (can take 15-60s).
+    // Poll for rendezvous without holding the lock (can take 2-5+ minutes
+    // for the first VM boot).  Refresh last_activity so the idle watchdog
+    // does not fire while we wait.
+    {
+        let mut s = state.lock().await;
+        s.last_activity = std::time::Instant::now();
+    }
     let guest_addr = rendezvous::wait_for_rendezvous(
         rendezvous_dir,
         std::time::Duration::from_secs(RENDEZVOUS_TIMEOUT_SECS),
@@ -288,7 +296,8 @@ async fn try_launch_and_connect(
     .await
     .context("rendezvous failed")?;
 
-    // Connect to the guest agent.
+    // Connect to the guest agent.  Refresh activity again after the
+    // potentially long rendezvous wait.
     let conn = tcp_bridge::connect_to_guest(
         guest_addr,
         std::time::Duration::from_secs(GUEST_CONNECT_TIMEOUT_SECS),
@@ -299,6 +308,7 @@ async fn try_launch_and_connect(
     let mut locked = state.lock().await;
     locked.guest_connection = Some(conn);
     locked.guest_addr = Some(guest_addr);
+    locked.last_activity = std::time::Instant::now();
 
     Ok(())
 }

--- a/src/wxc_windows_sandbox_daemon/src/pipe_server.rs
+++ b/src/wxc_windows_sandbox_daemon/src/pipe_server.rs
@@ -157,8 +157,7 @@ async fn execute_request(
 
     // Reconnect data streams for the next execution. The guest will
     // re-accept 3 new data connections and signal StreamsReady.
-    if let Err(err) =
-        tcp_bridge::reconnect_data_streams(conn, addr, result.control_residual).await
+    if let Err(err) = tcp_bridge::reconnect_data_streams(conn, addr, result.control_residual).await
     {
         eprintln!("[daemon] failed to reconnect data streams: {:#}", err);
         // Full reset so the next request tears down and relaunches

--- a/src/wxc_windows_sandbox_daemon/src/tcp_bridge.rs
+++ b/src/wxc_windows_sandbox_daemon/src/tcp_bridge.rs
@@ -176,25 +176,28 @@ pub async fn execute_on_guest(
             }
             buf.extend_from_slice(&tmp[..bytes_read]);
 
-            match decode_message(&buf).context("decode control")? {
-                DecodeResult::Message {
-                    message: ControlMessage::Exit(exit),
-                    consumed,
-                } => {
-                    buf.drain(..consumed);
-                    return Ok((exit.exit_code, exit.error_message, buf));
+            // Drain all complete messages before reading more data.
+            loop {
+                match decode_message(&buf).context("decode control")? {
+                    DecodeResult::Message {
+                        message: ControlMessage::Exit(exit),
+                        consumed,
+                    } => {
+                        buf.drain(..consumed);
+                        return Ok((exit.exit_code, exit.error_message, buf));
+                    }
+                    DecodeResult::Message {
+                        message: ControlMessage::Pong,
+                        consumed,
+                    } => {
+                        buf.drain(..consumed);
+                        // Continue inner loop to decode the next message.
+                    }
+                    DecodeResult::Message { message, .. } => {
+                        anyhow::bail!("unexpected control message: {:?}", message);
+                    }
+                    DecodeResult::Incomplete => break,
                 }
-                DecodeResult::Message {
-                    message: ControlMessage::Pong,
-                    consumed,
-                } => {
-                    buf.drain(..consumed);
-                    continue;
-                }
-                DecodeResult::Message { message, .. } => {
-                    anyhow::bail!("unexpected control message: {:?}", message);
-                }
-                DecodeResult::Incomplete => continue,
             }
         }
     };
@@ -285,7 +288,9 @@ pub async fn reconnect_data_streams(
         }
 
         // Need more data from the control channel.
-        let remaining = deadline - tokio::time::Instant::now();
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or(Duration::ZERO);
         let bytes_read = tokio::time::timeout(remaining, conn.control.read(&mut tmp))
             .await
             .context("timeout waiting for StreamsReady")?


### PR DESCRIPTION
## Summary

Three changes bundled in this PR:

### 1. fix: Windows Sandbox daemon connection and watchdog reliability
- **Race condition**: Mutex was released between \xecute_on_guest\ and \econnect_data_streams\, allowing concurrent clients to corrupt the control channel. Fixed by holding a single lock across both operations.
- **Idle watchdog**: The 5-min watchdog fired during the 3-5 minute VM boot because \last_activity\ wasn't refreshed during \nsure_sandbox_ready\. Fixed by updating timestamps before rendezvous polling and after guest connection.
- **Deadline panic**: \deadline - now()\ could underflow in \econnect_data_streams\. Fixed with \checked_duration_since\.
- **Rendezvous timeout**: Increased from 120s to 360s to cover worst-case cold VM boot.

### 2. feat: add MXC Playground app
Merges @bbonaby's MXC Playground — an Electron-based visual sandbox testing tool with runtime detection, pre-built test scenarios, Run All mode, policy builder, and dev sidebar.

### 3. feat: add Windows Sandbox support to MXC Playground
Adds first-class Windows Sandbox containment support to the Playground instead of requiring raw JSON config mode:
- 7 WS test scenarios mirroring \	est_configs/windows_sandbox_*.json\
- Raw wxc-exec JSON config builder (WS bypasses SDK policy)
- Policy controls hidden for WS (not applicable)
- Dev sidebar / JSON panel show WS raw config
- Scenario filtering by containment backend

## Testing
- All 10 Windows Sandbox E2E tests pass (\un_windows_sandbox_tests.ps1 -Release\)
- SDK integration tests: 13 pass (remaining 20 are known environment limitations)
- Playground tested manually with WS containment — verified via \User: WDAGUtilityAccount\ output
- Adversarial GPT-5.5 code review performed; findings addressed

## Known follow-ups (not in this PR)
- Concurrent cold-start race in daemon startup (needs startup lock)
- Host-side timeout cap for mutex held during execution
- Explicit startup state flag for watchdog
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/324)