### PR TITLE
[MXC] Add checks and fixes for Python and App Execution Aliases

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -122,6 +122,91 @@ popd
 
 echo.
 echo Build complete.
+
+:: Non-blocking prerequisite check for E2E tests
+echo.
+echo === Checking E2E test prerequisites ===
+set "PREREQ_WARN=0"
+set "PYTHON_MISSING=0"
+set "ALIAS_ISSUE=0"
+
+:: Check Python is available and not a Store alias
+where python.exe >nul 2>&1
+if errorlevel 1 (
+    echo   WARNING: python.exe not found. E2E tests require a system-wide Python install.
+    set "PREREQ_WARN=1"
+    set "PYTHON_MISSING=1"
+) else (
+    for /f "tokens=*" %%P in ('where python.exe') do (
+        echo %%P | findstr /i "WindowsApps" >nul 2>&1
+        if not errorlevel 1 (
+            echo   WARNING: python.exe resolves to a Store alias.
+            echo            Store aliases cannot be launched inside sandbox containers.
+            set "PREREQ_WARN=1"
+            set "PYTHON_MISSING=1"
+            set "ALIAS_ISSUE=1"
+            set "ALIAS_ISSUE=1"
+        )
+    )
+)
+
+:: Check pwsh.exe is available and not a Store alias
+where pwsh.exe >nul 2>&1
+if errorlevel 1 (
+    echo   WARNING: pwsh.exe not found. PowerShell 7 tests will be skipped.
+    set "PREREQ_WARN=1"
+) else (
+    for /f "tokens=*" %%P in ('where pwsh.exe') do (
+        echo %%P | findstr /i "WindowsApps" >nul 2>&1
+        if not errorlevel 1 (
+            echo   WARNING: pwsh.exe resolves to a Store alias.
+            echo            Store aliases cannot be launched inside sandbox containers.
+            set "PREREQ_WARN=1"
+            set "ALIAS_ISSUE=1"
+        )
+        goto :pwsh_check_done
+    )
+)
+:pwsh_check_done
+
+if "%PREREQ_WARN%"=="0" (
+    echo   All E2E test prerequisites met.
+    goto :done
+)
+
+:: Check if running elevated
+net session >nul 2>&1
+if errorlevel 1 (
+    echo.
+    echo   Not running as Administrator. To fix these issues, run from an elevated prompt:
+    echo     scripts\setup-test-prereqs.ps1
+    goto :done
+)
+
+:: Running elevated — offer single combined fix
+echo.
+set /p "FIX_ALL=  Fix issues and install Python? [Y/n] "
+if /i "!FIX_ALL!"=="n" goto :done
+
+if "%PYTHON_MISSING%"=="1" (
+    echo   Installing Python 3.12 via winget...
+    winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
+)
+
+if "%ALIAS_ISSUE%"=="1" (
+    echo   Removing Store aliases...
+    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe"  del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe"  2>nul && echo     Removed python.exe alias
+    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe" del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe" 2>nul && echo     Removed python3.exe alias
+    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe"    del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe"    2>nul && echo     Removed pwsh.exe alias
+)
+
+echo.
+echo   Prerequisites fixed. Starting a fresh terminal to pick up PATH changes...
+echo.
+start cmd /k "cd /d %~dp0 && echo Ready. Run your tests now."
+
+:done
+
 exit /b 0
 
 :error

--- a/build.bat
+++ b/build.bat
@@ -127,35 +127,26 @@ echo Build complete.
 echo.
 echo === Checking E2E test prerequisites ===
 set "PREREQ_WARN=0"
-set "PYTHON_MISSING=0"
-set "ALIAS_ISSUE=0"
 
 :: Check Python is available and first match is not a Store alias
-set "PYTHON_FIRST_ALIAS=0"
 where python.exe >nul 2>&1
 if errorlevel 1 (
     echo   WARNING: python.exe not found. E2E tests require a system-wide Python install.
     set "PREREQ_WARN=1"
-    set "PYTHON_MISSING=1"
 ) else (
     for /f "tokens=*" %%P in ('where python.exe') do (
         echo %%P | findstr /i "WindowsApps" >nul 2>&1
         if not errorlevel 1 (
-            set "PYTHON_FIRST_ALIAS=1"
+            echo   WARNING: python.exe first resolves to a Store alias.
+            echo            Store aliases shadow real installs and cannot be launched inside sandbox containers.
+            set "PREREQ_WARN=1"
         )
         goto :python_check_done
     )
 )
 :python_check_done
-if "!PYTHON_FIRST_ALIAS!"=="1" (
-    echo   WARNING: python.exe first resolves to a Store alias.
-    echo            Store aliases shadow real installs and cannot be launched inside sandbox containers.
-    set "PREREQ_WARN=1"
-    set "PYTHON_MISSING=1"
-    set "ALIAS_ISSUE=1"
-)
 
-:: Check pwsh.exe exists at the expected path
+:: Check pwsh.exe exists at the expected path used by test configs
 if not exist "C:\Program Files\PowerShell\7\pwsh.exe" (
     echo   WARNING: PowerShell 7 not found at C:\Program Files\PowerShell\7\pwsh.exe.
     echo            pwsh sandbox tests will fail.
@@ -164,46 +155,11 @@ if not exist "C:\Program Files\PowerShell\7\pwsh.exe" (
 
 if "%PREREQ_WARN%"=="0" (
     echo   All E2E test prerequisites met.
-    goto :done
-)
-
-:: Check if running elevated
-net session >nul 2>&1
-if errorlevel 1 (
+) else (
     echo.
-    echo   Not running as Administrator. To fix these issues, run from an elevated prompt:
-    echo     scripts\setup-test-prereqs.ps1
-    goto :done
+    echo   To fix, run from an elevated PowerShell prompt:
+    echo     .\scripts\setup-test-prereqs.ps1
 )
-
-:: Running elevated — offer single combined fix
-echo.
-set /p "FIX_ALL=  Fix issues and install Python? [Y/n] "
-if /i "!FIX_ALL!"=="n" goto :done
-
-if "%PYTHON_MISSING%"=="1" (
-    where winget >nul 2>&1
-    if errorlevel 1 (
-        echo   ERROR: winget not available. Install Python 3.12 manually from https://python.org
-        echo          Choose 'Install for all users' during setup.
-    ) else (
-        echo   Installing Python 3.12 via winget...
-        winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
-        if errorlevel 1 echo   WARNING: winget install may have failed. Verify with: where python.exe
-    )
-)
-
-if "%ALIAS_ISSUE%"=="1" (
-    echo   Removing Store aliases...
-    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe"  del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe"  2>nul && echo     Removed python.exe alias
-    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe" del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\python3.exe" 2>nul && echo     Removed python3.exe alias
-    if exist "%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe"    del /f "%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe"    2>nul && echo     Removed pwsh.exe alias
-)
-
-echo.
-echo   Prerequisites fixed. Starting a fresh terminal to pick up PATH changes...
-echo.
-start cmd /k "cd /d %~dp0 && echo Ready. Run your tests now."
 
 :done
 

--- a/build.bat
+++ b/build.bat
@@ -123,22 +123,25 @@ popd
 echo.
 echo Build complete.
 
-:: Non-blocking prerequisite check for E2E tests
+:: Non-blocking prerequisite check for E2E tests.
+:: We check whether the *first* python.exe in PATH is the user's App Execution
+:: Alias reparse point at %LOCALAPPDATA%\Microsoft\WindowsApps\python.exe.
+:: When that alias resolves first, sandbox containers cannot launch python.exe
+:: (CreateProcessW returns 0x80070057).
 echo.
 echo === Checking E2E test prerequisites ===
 set "PREREQ_WARN=0"
 
-:: Check Python is available and first match is not a Store alias
+:: Check Python is available and first match is not the App Execution Alias
 where python.exe >nul 2>&1
 if errorlevel 1 (
     echo   WARNING: python.exe not found. E2E tests require a system-wide Python install.
     set "PREREQ_WARN=1"
 ) else (
     for /f "tokens=*" %%P in ('where python.exe') do (
-        echo %%P | findstr /i "WindowsApps" >nul 2>&1
-        if not errorlevel 1 (
-            echo   WARNING: python.exe first resolves to a Store alias.
-            echo            Store aliases shadow real installs and cannot be launched inside sandbox containers.
+        if /i "%%P"=="%LOCALAPPDATA%\Microsoft\WindowsApps\python.exe" (
+            echo   WARNING: python.exe first resolves to an App Execution Alias.
+            echo            The alias reparse point cannot be launched inside sandbox containers.
             set "PREREQ_WARN=1"
         )
         goto :python_check_done
@@ -157,7 +160,7 @@ if "%PREREQ_WARN%"=="0" (
     echo   All E2E test prerequisites met.
 ) else (
     echo.
-    echo   To fix, run from an elevated PowerShell prompt:
+    echo   To install Python and disable the alias, run from an elevated PowerShell prompt:
     echo     .\scripts\setup-test-prereqs.ps1
 )
 

--- a/build.bat
+++ b/build.bat
@@ -131,6 +131,8 @@ set "PYTHON_MISSING=0"
 set "ALIAS_ISSUE=0"
 
 :: Check Python is available and not a Store alias
+set "PYTHON_REAL=0"
+set "PYTHON_ALIAS=0"
 where python.exe >nul 2>&1
 if errorlevel 1 (
     echo   WARNING: python.exe not found. E2E tests require a system-wide Python install.
@@ -139,18 +141,23 @@ if errorlevel 1 (
 ) else (
     for /f "tokens=*" %%P in ('where python.exe') do (
         echo %%P | findstr /i "WindowsApps" >nul 2>&1
-        if not errorlevel 1 (
-            echo   WARNING: python.exe resolves to a Store alias.
-            echo            Store aliases cannot be launched inside sandbox containers.
-            set "PREREQ_WARN=1"
-            set "PYTHON_MISSING=1"
-            set "ALIAS_ISSUE=1"
-            set "ALIAS_ISSUE=1"
+        if errorlevel 1 (
+            set "PYTHON_REAL=1"
+        ) else (
+            set "PYTHON_ALIAS=1"
         )
+    )
+    if "!PYTHON_REAL!"=="0" (
+        echo   WARNING: python.exe only exists as a Store alias.
+        echo            Store aliases cannot be launched inside sandbox containers.
+        set "PREREQ_WARN=1"
+        set "PYTHON_MISSING=1"
+        set "ALIAS_ISSUE=1"
     )
 )
 
 :: Check pwsh.exe is available and not a Store alias
+set "PWSH_REAL=0"
 where pwsh.exe >nul 2>&1
 if errorlevel 1 (
     echo   WARNING: pwsh.exe not found. PowerShell 7 tests will be skipped.
@@ -158,16 +165,17 @@ if errorlevel 1 (
 ) else (
     for /f "tokens=*" %%P in ('where pwsh.exe') do (
         echo %%P | findstr /i "WindowsApps" >nul 2>&1
-        if not errorlevel 1 (
-            echo   WARNING: pwsh.exe resolves to a Store alias.
-            echo            Store aliases cannot be launched inside sandbox containers.
-            set "PREREQ_WARN=1"
-            set "ALIAS_ISSUE=1"
+        if errorlevel 1 (
+            set "PWSH_REAL=1"
         )
-        goto :pwsh_check_done
+    )
+    if "!PWSH_REAL!"=="0" (
+        echo   WARNING: pwsh.exe only exists as a Store alias.
+        echo            Store aliases cannot be launched inside sandbox containers.
+        set "PREREQ_WARN=1"
+        set "ALIAS_ISSUE=1"
     )
 )
-:pwsh_check_done
 
 if "%PREREQ_WARN%"=="0" (
     echo   All E2E test prerequisites met.

--- a/build.bat
+++ b/build.bat
@@ -130,9 +130,8 @@ set "PREREQ_WARN=0"
 set "PYTHON_MISSING=0"
 set "ALIAS_ISSUE=0"
 
-:: Check Python is available and not a Store alias
-set "PYTHON_REAL=0"
-set "PYTHON_ALIAS=0"
+:: Check Python is available and first match is not a Store alias
+set "PYTHON_FIRST_ALIAS=0"
 where python.exe >nul 2>&1
 if errorlevel 1 (
     echo   WARNING: python.exe not found. E2E tests require a system-wide Python install.
@@ -141,40 +140,26 @@ if errorlevel 1 (
 ) else (
     for /f "tokens=*" %%P in ('where python.exe') do (
         echo %%P | findstr /i "WindowsApps" >nul 2>&1
-        if errorlevel 1 (
-            set "PYTHON_REAL=1"
-        ) else (
-            set "PYTHON_ALIAS=1"
+        if not errorlevel 1 (
+            set "PYTHON_FIRST_ALIAS=1"
         )
-    )
-    if "!PYTHON_REAL!"=="0" (
-        echo   WARNING: python.exe only exists as a Store alias.
-        echo            Store aliases cannot be launched inside sandbox containers.
-        set "PREREQ_WARN=1"
-        set "PYTHON_MISSING=1"
-        set "ALIAS_ISSUE=1"
+        goto :python_check_done
     )
 )
-
-:: Check pwsh.exe is available and not a Store alias
-set "PWSH_REAL=0"
-where pwsh.exe >nul 2>&1
-if errorlevel 1 (
-    echo   WARNING: pwsh.exe not found. PowerShell 7 tests will be skipped.
+:python_check_done
+if "!PYTHON_FIRST_ALIAS!"=="1" (
+    echo   WARNING: python.exe first resolves to a Store alias.
+    echo            Store aliases shadow real installs and cannot be launched inside sandbox containers.
     set "PREREQ_WARN=1"
-) else (
-    for /f "tokens=*" %%P in ('where pwsh.exe') do (
-        echo %%P | findstr /i "WindowsApps" >nul 2>&1
-        if errorlevel 1 (
-            set "PWSH_REAL=1"
-        )
-    )
-    if "!PWSH_REAL!"=="0" (
-        echo   WARNING: pwsh.exe only exists as a Store alias.
-        echo            Store aliases cannot be launched inside sandbox containers.
-        set "PREREQ_WARN=1"
-        set "ALIAS_ISSUE=1"
-    )
+    set "PYTHON_MISSING=1"
+    set "ALIAS_ISSUE=1"
+)
+
+:: Check pwsh.exe exists at the expected path
+if not exist "C:\Program Files\PowerShell\7\pwsh.exe" (
+    echo   WARNING: PowerShell 7 not found at C:\Program Files\PowerShell\7\pwsh.exe.
+    echo            pwsh sandbox tests will fail.
+    set "PREREQ_WARN=1"
 )
 
 if "%PREREQ_WARN%"=="0" (

--- a/build.bat
+++ b/build.bat
@@ -182,8 +182,15 @@ set /p "FIX_ALL=  Fix issues and install Python? [Y/n] "
 if /i "!FIX_ALL!"=="n" goto :done
 
 if "%PYTHON_MISSING%"=="1" (
-    echo   Installing Python 3.12 via winget...
-    winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
+    where winget >nul 2>&1
+    if errorlevel 1 (
+        echo   ERROR: winget not available. Install Python 3.12 manually from https://python.org
+        echo          Choose 'Install for all users' during setup.
+    ) else (
+        echo   Installing Python 3.12 via winget...
+        winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
+        if errorlevel 1 echo   WARNING: winget install may have failed. Verify with: where python.exe
+    )
 )
 
 if "%ALIAS_ISSUE%"=="1" (

--- a/scripts/setup-test-prereqs.ps1
+++ b/scripts/setup-test-prereqs.ps1
@@ -9,7 +9,7 @@
     Installs and configures prerequisites needed to run MXC E2E tests:
     - Python 3.12 (system-wide install, accessible from AppContainers)
     - Disables App Execution Aliases for python.exe, python3.exe, and pwsh.exe
-      (Store reparse points are incompatible with AppContainer/BaseContainer sandboxes)
+      (their reparse points are incompatible with AppContainer/BaseContainer sandboxes)
 
     Must be run elevated (Administrator). Only needs to run once per machine.
 
@@ -35,23 +35,23 @@ function Test-Elevated {
     $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
-function Test-StoreAlias {
+function Test-AppExecutionAlias {
     param([string]$ExeName)
     $aliasPath = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\$ExeName"
     return (Test-Path $aliasPath)
 }
 
-function Disable-StoreAlias {
+function Disable-AppExecutionAlias {
     param([string]$ExeName)
     # NOTE: This script is intended for TEST MACHINES ONLY.
     # App Execution Aliases are reparse points at %LOCALAPPDATA%\Microsoft\WindowsApps\<exe>.
     # The Settings UI ("Apps > Advanced app settings > App execution aliases")
     # disables an alias by deleting this file (per Windows OS source:
     # onecore/base/appmodel/AppExecutionAlias/settingshandlers/lib/SettingsHandlers.cpp,
-    # AppAliasListItemSetting::SetValue → DeleteFileIgnoreNotFound).
+    # AppAliasListItemSetting::SetValue -> DeleteFileIgnoreNotFound).
     # Removing the file IS the documented Windows mechanism to disable an alias.
     # Caveats:
-    #   - Windows Updates / Store package updates may restore the reparse point.
+    #   - Windows Updates / packaged app updates may restore the reparse point.
     #   - For legitimately packaged apps (e.g. Store-installed PowerShell), removing
     #     the alias also removes the convenient `pwsh.exe` PATH entry. Tests should
     #     use a fully-qualified install path (e.g. C:\Program Files\PowerShell\7\pwsh.exe).
@@ -61,7 +61,7 @@ function Disable-StoreAlias {
             Remove-Item $userAlias -Force -ErrorAction Stop
             Write-Host "  Disabled user alias: $userAlias" -ForegroundColor Green
         } catch {
-            Write-Host "  WARNING: failed to remove $userAlias`: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Warning "Failed to remove $userAlias`: $($_.Exception.Message)"
         }
     }
 }
@@ -69,7 +69,7 @@ function Disable-StoreAlias {
 function Test-SystemPython {
     $commands = Get-Command python.exe -All -ErrorAction SilentlyContinue
     if (-not $commands) { return $false }
-    # Satisfied if ANY match is a real system-wide install (not Store/AppData)
+    # Satisfied if ANY match is a real system-wide install (not an alias / per-user path)
     foreach ($cmd in $commands) {
         $path = $cmd.Source
         if (($path -notlike "*WindowsApps*") -and ($path -notlike "*AppData*")) {
@@ -96,8 +96,8 @@ if (Test-SystemPython) {
 } else {
     $cmd = Get-Command python.exe -ErrorAction SilentlyContinue
     if ($cmd) {
-        Write-Host " ISSUE (per-user or Store alias: $($cmd.Source))" -ForegroundColor Yellow
-        $issues += "Python is installed per-user or via Store alias. AppContainers cannot access it."
+        Write-Host " ISSUE (per-user or App Execution Alias: $($cmd.Source))" -ForegroundColor Yellow
+        $issues += "Python is installed per-user or only as an App Execution Alias. AppContainers cannot access it."
     } else {
         Write-Host " MISSING" -ForegroundColor Red
         $issues += "Python is not installed."
@@ -108,14 +108,14 @@ if (Test-SystemPython) {
 Write-Host "[2/3] App Execution Aliases..." -NoNewline
 $aliasIssues = @()
 foreach ($exe in @("python.exe", "python3.exe", "pwsh.exe")) {
-    if (Test-StoreAlias $exe) {
+    if (Test-AppExecutionAlias $exe) {
         $aliasIssues += $exe
     }
 }
 if ($aliasIssues.Count -eq 0) {
-    Write-Host " OK (no Store aliases shadowing executables)" -ForegroundColor Green
+    Write-Host " OK (no App Execution Aliases shadowing executables)" -ForegroundColor Green
 } else {
-    Write-Host " ISSUE ($($aliasIssues -join ', ') resolve to Store aliases)" -ForegroundColor Yellow
+    Write-Host " ISSUE ($($aliasIssues -join ', ') resolve to App Execution Aliases)" -ForegroundColor Yellow
     $issues += "App Execution Aliases active for: $($aliasIssues -join ', '). These cause CreateProcessW failures in sandboxed containers."
 }
 
@@ -151,7 +151,7 @@ if ($CheckOnly) {
 # --- Fix mode ---
 
 if (-not (Test-Elevated)) {
-    Write-Host "ERROR: Fixing prerequisites requires elevation. Run as Administrator." -ForegroundColor Red
+    Write-Warning "Fixing prerequisites requires elevation. Run as Administrator."
     exit 1
 }
 
@@ -162,14 +162,12 @@ Write-Host ""
 if (-not (Test-SystemPython)) {
     $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
     if (-not $wingetCmd) {
-        Write-Host "ERROR: winget is not available. Install Python 3.12 manually from https://python.org" -ForegroundColor Red
-        Write-Host "       Choose 'Install for all users' during setup." -ForegroundColor Yellow
+        Write-Warning "winget is not available. Install Python 3.12 manually from https://python.org (choose 'Install for all users')."
     } else {
         Write-Host "Installing Python 3.12 system-wide via winget..." -ForegroundColor Cyan
         winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "ERROR: winget install failed (exit code $LASTEXITCODE)." -ForegroundColor Red
-            Write-Host "       Install Python 3.12 manually from https://python.org (choose 'Install for all users')." -ForegroundColor Yellow
+            Write-Warning "winget install failed (exit code $LASTEXITCODE). Install Python 3.12 manually from https://python.org (choose 'Install for all users')."
         } else {
             # Refresh PATH for current session
             $machinePath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
@@ -180,18 +178,17 @@ if (-not (Test-SystemPython)) {
                 $ver = & python.exe --version 2>&1
                 Write-Host "Python installed successfully ($ver)" -ForegroundColor Green
             } else {
-                Write-Host "WARNING: Python install completed but python.exe not found in PATH." -ForegroundColor Yellow
-                Write-Host "         You may need to restart your terminal." -ForegroundColor Yellow
+                Write-Warning "Python install completed but python.exe not found in PATH. You may need to restart your terminal."
             }
         }
     }
 }
 
-# Fix: Disable Store aliases
+# Fix: Disable App Execution Aliases that shadow real executables
 foreach ($exe in @("python.exe", "python3.exe", "pwsh.exe")) {
-    if (Test-StoreAlias $exe) {
-        Write-Host "Disabling Store alias for $exe..." -ForegroundColor Cyan
-        Disable-StoreAlias $exe
+    if (Test-AppExecutionAlias $exe) {
+        Write-Host "Disabling App Execution Alias for $exe..." -ForegroundColor Cyan
+        Disable-AppExecutionAlias $exe
     }
 }
 

--- a/scripts/setup-test-prereqs.ps1
+++ b/scripts/setup-test-prereqs.ps1
@@ -120,16 +120,14 @@ if ($aliasIssues.Count -eq 0) {
     $issues += "App Execution Aliases active for: $($aliasIssues -join ', '). These cause CreateProcessW failures in sandboxed containers."
 }
 
-# 3. Check PowerShell 7
+# 3. Check PowerShell 7 at expected install path
+$PwshExpectedPath = "C:\Program Files\PowerShell\7\pwsh.exe"
 Write-Host "[3/3] PowerShell 7..." -NoNewline
-$pwshReal = Get-Command pwsh.exe -All -ErrorAction SilentlyContinue | 
-    Where-Object { $_.Source -notlike "*WindowsApps*" } | 
-    Select-Object -First 1
-if ($pwshReal) {
-    Write-Host " OK ($($pwshReal.Source))" -ForegroundColor Green
+if (Test-Path $PwshExpectedPath) {
+    Write-Host " OK ($PwshExpectedPath)" -ForegroundColor Green
 } else {
-    Write-Host " MISSING (no non-Store pwsh.exe found)" -ForegroundColor Red
-    $issues += "PowerShell 7 is not installed (or only available via Store alias)."
+    Write-Host " MISSING (not found at $PwshExpectedPath)" -ForegroundColor Red
+    $issues += "PowerShell 7 is not installed at $PwshExpectedPath (required by test configs)."
 }
 
 Write-Host ""

--- a/scripts/setup-test-prereqs.ps1
+++ b/scripts/setup-test-prereqs.ps1
@@ -68,11 +68,16 @@ function Disable-StoreAlias {
 }
 
 function Test-SystemPython {
-    $cmd = Get-Command python.exe -ErrorAction SilentlyContinue
-    if (-not $cmd) { return $false }
-    $path = $cmd.Source
-    # System-wide installs are NOT under Users\*\AppData
-    return ($path -notlike "*WindowsApps*") -and ($path -notlike "*AppData*")
+    $commands = Get-Command python.exe -All -ErrorAction SilentlyContinue
+    if (-not $commands) { return $false }
+    # Satisfied if ANY match is a real system-wide install (not Store/AppData)
+    foreach ($cmd in $commands) {
+        $path = $cmd.Source
+        if (($path -notlike "*WindowsApps*") -and ($path -notlike "*AppData*")) {
+            return $true
+        }
+    }
+    return $false
 }
 
 # --- Main ---
@@ -158,21 +163,30 @@ Write-Host ""
 
 # Fix: Install Python system-wide
 if (-not (Test-SystemPython)) {
-    Write-Host "Installing Python 3.12 system-wide via winget..." -ForegroundColor Cyan
-    $result = winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements 2>&1
-    Write-Host $result
-    
-    # Refresh PATH for current session
-    $machinePath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
-    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
-    $env:PATH = "$machinePath;$userPath"
-
-    if (Test-SystemPython) {
-        $ver = & python.exe --version 2>&1
-        Write-Host "Python installed successfully ($ver)" -ForegroundColor Green
+    $wingetCmd = Get-Command winget -ErrorAction SilentlyContinue
+    if (-not $wingetCmd) {
+        Write-Host "ERROR: winget is not available. Install Python 3.12 manually from https://python.org" -ForegroundColor Red
+        Write-Host "       Choose 'Install for all users' during setup." -ForegroundColor Yellow
     } else {
-        Write-Host "WARNING: Python install completed but python.exe not found in PATH." -ForegroundColor Yellow
-        Write-Host "         You may need to restart your terminal." -ForegroundColor Yellow
+        Write-Host "Installing Python 3.12 system-wide via winget..." -ForegroundColor Cyan
+        winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "ERROR: winget install failed (exit code $LASTEXITCODE)." -ForegroundColor Red
+            Write-Host "       Install Python 3.12 manually from https://python.org (choose 'Install for all users')." -ForegroundColor Yellow
+        } else {
+            # Refresh PATH for current session
+            $machinePath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+            $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+            $env:PATH = "$machinePath;$userPath"
+
+            if (Test-SystemPython) {
+                $ver = & python.exe --version 2>&1
+                Write-Host "Python installed successfully ($ver)" -ForegroundColor Green
+            } else {
+                Write-Host "WARNING: Python install completed but python.exe not found in PATH." -ForegroundColor Yellow
+                Write-Host "         You may need to restart your terminal." -ForegroundColor Yellow
+            }
+        }
     }
 }
 

--- a/scripts/setup-test-prereqs.ps1
+++ b/scripts/setup-test-prereqs.ps1
@@ -1,0 +1,190 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Sets up test prerequisites for MXC E2E tests on Windows.
+
+.DESCRIPTION
+    Installs and configures prerequisites needed to run MXC E2E tests:
+    - Python 3.12 (system-wide install, accessible from AppContainers)
+    - Disables App Execution Aliases for python.exe, python3.exe, and pwsh.exe
+      (Store reparse points are incompatible with AppContainer/BaseContainer sandboxes)
+
+    Must be run elevated (Administrator). Only needs to run once per machine.
+
+.EXAMPLE
+    # Run from an elevated PowerShell prompt:
+    .\scripts\setup-test-prereqs.ps1
+
+    # Check prerequisites without installing anything:
+    .\scripts\setup-test-prereqs.ps1 -CheckOnly
+#>
+
+param(
+    [switch]$CheckOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Helpers ---
+
+function Test-Elevated {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = [Security.Principal.WindowsPrincipal]$identity
+    $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-StoreAlias {
+    param([string]$ExeName)
+    $cmd = Get-Command $ExeName -ErrorAction SilentlyContinue
+    if (-not $cmd) { return $false }
+    $path = $cmd.Source
+    return ($path -like "*WindowsApps*") -or ($path -like "*AppData*Microsoft*WindowsApps*")
+}
+
+function Disable-StoreAlias {
+    param([string]$ExeName)
+    # App Execution Aliases are stored as reparse points in WindowsApps directories.
+    # Removing them from the user-local path disables the alias for the current user.
+    $userAlias = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\$ExeName"
+    if (Test-Path $userAlias) {
+        Remove-Item $userAlias -Force -ErrorAction SilentlyContinue
+        Write-Host "  Disabled user alias: $userAlias" -ForegroundColor Green
+    }
+
+    # Also check the system-wide WindowsApps path and warn (can't remove without TrustedInstaller)
+    $systemPaths = @(Get-Command $ExeName -All -ErrorAction SilentlyContinue | 
+        Where-Object { $_.Source -like "*WindowsApps*" } |
+        Select-Object -ExpandProperty Source)
+    
+    foreach ($p in $systemPaths) {
+        if ($p -notlike "*$env:LOCALAPPDATA*") {
+            Write-Host "  WARNING: System-wide Store alias exists: $p" -ForegroundColor Yellow
+            Write-Host "           This may still shadow the real executable in some contexts." -ForegroundColor Yellow
+            Write-Host "           Disable it manually: Settings > Apps > Advanced app settings > App execution aliases" -ForegroundColor Yellow
+        }
+    }
+}
+
+function Test-SystemPython {
+    $cmd = Get-Command python.exe -ErrorAction SilentlyContinue
+    if (-not $cmd) { return $false }
+    $path = $cmd.Source
+    # System-wide installs are NOT under Users\*\AppData
+    return ($path -notlike "*WindowsApps*") -and ($path -notlike "*AppData*")
+}
+
+# --- Main ---
+
+Write-Host ""
+Write-Host "MXC E2E Test Prerequisites" -ForegroundColor Cyan
+Write-Host "==========================" -ForegroundColor Cyan
+Write-Host ""
+
+$issues = @()
+
+# 1. Check Python
+Write-Host "[1/3] Python..." -NoNewline
+if (Test-SystemPython) {
+    $ver = & python.exe --version 2>&1
+    Write-Host " OK ($ver, system-wide)" -ForegroundColor Green
+} else {
+    $cmd = Get-Command python.exe -ErrorAction SilentlyContinue
+    if ($cmd) {
+        Write-Host " ISSUE (per-user or Store alias: $($cmd.Source))" -ForegroundColor Yellow
+        $issues += "Python is installed per-user or via Store alias. AppContainers cannot access it."
+    } else {
+        Write-Host " MISSING" -ForegroundColor Red
+        $issues += "Python is not installed."
+    }
+}
+
+# 2. Check App Execution Aliases
+Write-Host "[2/3] App Execution Aliases..." -NoNewline
+$aliasIssues = @()
+foreach ($exe in @("python.exe", "python3.exe", "pwsh.exe")) {
+    if (Test-StoreAlias $exe) {
+        $aliasIssues += $exe
+    }
+}
+if ($aliasIssues.Count -eq 0) {
+    Write-Host " OK (no Store aliases shadowing executables)" -ForegroundColor Green
+} else {
+    Write-Host " ISSUE ($($aliasIssues -join ', ') resolve to Store aliases)" -ForegroundColor Yellow
+    $issues += "App Execution Aliases active for: $($aliasIssues -join ', '). These cause CreateProcessW failures in sandboxed containers."
+}
+
+# 3. Check PowerShell 7
+Write-Host "[3/3] PowerShell 7..." -NoNewline
+$pwshReal = Get-Command pwsh.exe -All -ErrorAction SilentlyContinue | 
+    Where-Object { $_.Source -notlike "*WindowsApps*" } | 
+    Select-Object -First 1
+if ($pwshReal) {
+    Write-Host " OK ($($pwshReal.Source))" -ForegroundColor Green
+} else {
+    Write-Host " MISSING (no non-Store pwsh.exe found)" -ForegroundColor Red
+    $issues += "PowerShell 7 is not installed (or only available via Store alias)."
+}
+
+Write-Host ""
+
+if ($issues.Count -eq 0) {
+    Write-Host "All prerequisites met!" -ForegroundColor Green
+    exit 0
+}
+
+# Report issues
+Write-Host "Issues found:" -ForegroundColor Yellow
+foreach ($issue in $issues) {
+    Write-Host "  - $issue" -ForegroundColor Yellow
+}
+Write-Host ""
+
+if ($CheckOnly) {
+    Write-Host "Run without -CheckOnly to fix these issues (requires elevation)." -ForegroundColor Cyan
+    exit 1
+}
+
+# --- Fix mode ---
+
+if (-not (Test-Elevated)) {
+    Write-Host "ERROR: Fixing prerequisites requires elevation. Run as Administrator." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Fixing issues..." -ForegroundColor Cyan
+Write-Host ""
+
+# Fix: Install Python system-wide
+if (-not (Test-SystemPython)) {
+    Write-Host "Installing Python 3.12 system-wide via winget..." -ForegroundColor Cyan
+    $result = winget install Python.Python.3.12 --scope machine --accept-package-agreements --accept-source-agreements 2>&1
+    Write-Host $result
+    
+    # Refresh PATH for current session
+    $machinePath = [Environment]::GetEnvironmentVariable("PATH", "Machine")
+    $userPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+    $env:PATH = "$machinePath;$userPath"
+
+    if (Test-SystemPython) {
+        $ver = & python.exe --version 2>&1
+        Write-Host "Python installed successfully ($ver)" -ForegroundColor Green
+    } else {
+        Write-Host "WARNING: Python install completed but python.exe not found in PATH." -ForegroundColor Yellow
+        Write-Host "         You may need to restart your terminal." -ForegroundColor Yellow
+    }
+}
+
+# Fix: Disable Store aliases
+foreach ($exe in @("python.exe", "python3.exe", "pwsh.exe")) {
+    if (Test-StoreAlias $exe) {
+        Write-Host "Disabling Store alias for $exe..." -ForegroundColor Cyan
+        Disable-StoreAlias $exe
+    }
+}
+
+Write-Host ""
+Write-Host "Done. Restart your terminal, then verify with:" -ForegroundColor Green
+Write-Host "  .\scripts\setup-test-prereqs.ps1 -CheckOnly" -ForegroundColor Gray
+Write-Host ""

--- a/scripts/setup-test-prereqs.ps1
+++ b/scripts/setup-test-prereqs.ps1
@@ -37,32 +37,31 @@ function Test-Elevated {
 
 function Test-StoreAlias {
     param([string]$ExeName)
-    $cmd = Get-Command $ExeName -ErrorAction SilentlyContinue
-    if (-not $cmd) { return $false }
-    $path = $cmd.Source
-    return ($path -like "*WindowsApps*") -or ($path -like "*AppData*Microsoft*WindowsApps*")
+    $aliasPath = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\$ExeName"
+    return (Test-Path $aliasPath)
 }
 
 function Disable-StoreAlias {
     param([string]$ExeName)
-    # App Execution Aliases are stored as reparse points in WindowsApps directories.
-    # Removing them from the user-local path disables the alias for the current user.
+    # NOTE: This script is intended for TEST MACHINES ONLY.
+    # App Execution Aliases are reparse points at %LOCALAPPDATA%\Microsoft\WindowsApps\<exe>.
+    # The Settings UI ("Apps > Advanced app settings > App execution aliases")
+    # disables an alias by deleting this file (per Windows OS source:
+    # onecore/base/appmodel/AppExecutionAlias/settingshandlers/lib/SettingsHandlers.cpp,
+    # AppAliasListItemSetting::SetValue → DeleteFileIgnoreNotFound).
+    # Removing the file IS the documented Windows mechanism to disable an alias.
+    # Caveats:
+    #   - Windows Updates / Store package updates may restore the reparse point.
+    #   - For legitimately packaged apps (e.g. Store-installed PowerShell), removing
+    #     the alias also removes the convenient `pwsh.exe` PATH entry. Tests should
+    #     use a fully-qualified install path (e.g. C:\Program Files\PowerShell\7\pwsh.exe).
     $userAlias = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\$ExeName"
     if (Test-Path $userAlias) {
-        Remove-Item $userAlias -Force -ErrorAction SilentlyContinue
-        Write-Host "  Disabled user alias: $userAlias" -ForegroundColor Green
-    }
-
-    # Also check the system-wide WindowsApps path and warn (can't remove without TrustedInstaller)
-    $systemPaths = @(Get-Command $ExeName -All -ErrorAction SilentlyContinue | 
-        Where-Object { $_.Source -like "*WindowsApps*" } |
-        Select-Object -ExpandProperty Source)
-    
-    foreach ($p in $systemPaths) {
-        if ($p -notlike "*$env:LOCALAPPDATA*") {
-            Write-Host "  WARNING: System-wide Store alias exists: $p" -ForegroundColor Yellow
-            Write-Host "           This may still shadow the real executable in some contexts." -ForegroundColor Yellow
-            Write-Host "           Disable it manually: Settings > Apps > Advanced app settings > App execution aliases" -ForegroundColor Yellow
+        try {
+            Remove-Item $userAlias -Force -ErrorAction Stop
+            Write-Host "  Disabled user alias: $userAlias" -ForegroundColor Green
+        } catch {
+            Write-Host "  WARNING: failed to remove $userAlias`: $($_.Exception.Message)" -ForegroundColor Yellow
         }
     }
 }

--- a/src/wxc/build.rs
+++ b/src/wxc/build.rs
@@ -12,6 +12,9 @@ fn main() {
 
     // Always emit rerun-if-changed so Cargo doesn't re-run unnecessarily.
     println!("cargo:rerun-if-changed=build.rs");
+    // Re-run prerequisite checks when PATH changes (e.g., after installing Python).
+    #[cfg(windows)]
+    println!("cargo:rerun-if-env-changed=PATH");
 }
 
 /// Emit build warnings when E2E test prerequisites are missing or
@@ -43,7 +46,7 @@ fn check_test_prerequisites() {
                 "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or: winget install Python.Python.3.12 --scope machine"
             );
         }
-        Some(ref path) if path.contains("WindowsApps") => {
+        Some(ref path) if path.to_ascii_lowercase().contains("windowsapps") => {
             println!("cargo:warning=python.exe resolves to a Store alias. Store aliases cannot be launched inside sandbox containers.");
             println!(
                 "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for Python"
@@ -73,7 +76,7 @@ fn check_test_prerequisites() {
                 "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
             );
         }
-        Some(ref path) if path.contains("WindowsApps") => {
+        Some(ref path) if path.to_ascii_lowercase().contains("windowsapps") => {
             println!("cargo:warning=pwsh.exe resolves to a Store alias. Store aliases cannot be launched inside sandbox containers.");
             println!(
                 "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for PowerShell"

--- a/src/wxc/build.rs
+++ b/src/wxc/build.rs
@@ -4,11 +4,83 @@
 //! Build script for wxc — copies NanVix binaries next to the output executable.
 
 fn main() {
+    #[cfg(windows)]
+    check_test_prerequisites();
+
     #[cfg(all(windows, feature = "microvm"))]
     copy_nanvix_binaries();
 
     // Always emit rerun-if-changed so Cargo doesn't re-run unnecessarily.
     println!("cargo:rerun-if-changed=build.rs");
+}
+
+/// Emit build warnings when E2E test prerequisites are missing or
+/// misconfigured. These are non-blocking — the build succeeds regardless.
+#[cfg(windows)]
+fn check_test_prerequisites() {
+    use std::process::Command;
+
+    // Check Python
+    let python_ok = Command::new("where.exe")
+        .arg("python.exe")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if !o.status.success() {
+                return None;
+            }
+            let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+            let first = stdout.lines().next().unwrap_or("").to_string();
+            Some(first)
+        });
+
+    match python_ok {
+        None => {
+            println!(
+                "cargo:warning=python.exe not found. E2E tests require a system-wide Python install."
+            );
+            println!(
+                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or: winget install Python.Python.3.12 --scope machine"
+            );
+        }
+        Some(ref path) if path.contains("WindowsApps") => {
+            println!("cargo:warning=python.exe resolves to a Store alias. Store aliases cannot be launched inside sandbox containers.");
+            println!(
+                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for Python"
+            );
+        }
+        _ => {}
+    }
+
+    // Check pwsh
+    let pwsh_ok = Command::new("where.exe")
+        .arg("pwsh.exe")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if !o.status.success() {
+                return None;
+            }
+            let stdout = String::from_utf8_lossy(&o.stdout).to_string();
+            let first = stdout.lines().next().unwrap_or("").to_string();
+            Some(first)
+        });
+
+    match pwsh_ok {
+        None => {
+            println!("cargo:warning=pwsh.exe not found. PowerShell 7 sandbox tests will fail.");
+            println!(
+                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
+            );
+        }
+        Some(ref path) if path.contains("WindowsApps") => {
+            println!("cargo:warning=pwsh.exe resolves to a Store alias. Store aliases cannot be launched inside sandbox containers.");
+            println!(
+                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for PowerShell"
+            );
+        }
+        _ => {}
+    }
 }
 
 #[cfg(all(windows, feature = "microvm"))]

--- a/src/wxc/build.rs
+++ b/src/wxc/build.rs
@@ -55,34 +55,15 @@ fn check_test_prerequisites() {
         _ => {}
     }
 
-    // Check pwsh
-    let pwsh_ok = Command::new("where.exe")
-        .arg("pwsh.exe")
-        .output()
-        .ok()
-        .and_then(|o| {
-            if !o.status.success() {
-                return None;
-            }
-            let stdout = String::from_utf8_lossy(&o.stdout).to_string();
-            let first = stdout.lines().next().unwrap_or("").to_string();
-            Some(first)
-        });
-
-    match pwsh_ok {
-        None => {
-            println!("cargo:warning=pwsh.exe not found. PowerShell 7 sandbox tests will fail.");
-            println!(
-                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
-            );
-        }
-        Some(ref path) if path.to_ascii_lowercase().contains("windowsapps") => {
-            println!("cargo:warning=pwsh.exe resolves to a Store alias. Store aliases cannot be launched inside sandbox containers.");
-            println!(
-                "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for PowerShell"
-            );
-        }
-        _ => {}
+    // Check pwsh at the expected install path (test configs use a hardcoded path)
+    const PWSH_PATH: &str = r"C:\Program Files\PowerShell\7\pwsh.exe";
+    if !std::path::Path::new(PWSH_PATH).exists() {
+        println!(
+            "cargo:warning=PowerShell 7 not found at {PWSH_PATH}. pwsh sandbox tests will fail."
+        );
+        println!(
+            "cargo:warning=Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
+        );
     }
 }
 

--- a/src/wxc_e2e_tests/src/lib.rs
+++ b/src/wxc_e2e_tests/src/lib.rs
@@ -217,6 +217,80 @@ pub fn has_windows_sandbox_feature() -> bool {
     available
 }
 
+/// Check whether `python.exe` is available and NOT only a Windows Store App
+/// Execution Alias. Store aliases are reparse points under `WindowsApps`
+/// that cannot be launched inside AppContainer/BaseContainer sandboxes.
+///
+/// Panics with a clear remediation message when Python is missing or
+/// only exists as a Store alias.
+pub fn assert_python() {
+    let output = Command::new("where.exe").arg("python.exe").output().ok();
+
+    let Some(output) = output else {
+        panic!(
+            "python.exe not found.\n\
+             E2E tests require a system-wide Python install.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install Python system-wide \
+             (winget install Python.Python.3.12 --scope machine)"
+        );
+    };
+
+    if !output.status.success() {
+        panic!(
+            "python.exe not found.\n\
+             E2E tests require a system-wide Python install.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install Python system-wide \
+             (winget install Python.Python.3.12 --scope machine)"
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let has_real_python = stdout.lines().any(|p| !p.contains("WindowsApps"));
+    if !has_real_python {
+        panic!(
+            "python.exe only exists as a Windows Store alias.\n\
+             Store aliases cannot be launched inside sandbox containers.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for Python"
+        );
+    }
+}
+
+/// Check whether `pwsh.exe` (PowerShell 7) is available via a real install
+/// path, not a Windows Store App Execution Alias.
+///
+/// Panics with a clear remediation message when pwsh is missing.
+/// Since the test config uses a fully qualified path, this only checks
+/// that a real (non-Store) pwsh.exe exists somewhere on the system.
+pub fn assert_pwsh() {
+    let output = Command::new("where.exe").arg("pwsh.exe").output().ok();
+
+    let Some(output) = output else {
+        panic!(
+            "pwsh.exe not found.\n\
+             PowerShell 7 sandbox tests require a system-wide install.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
+        );
+    };
+
+    if !output.status.success() {
+        panic!(
+            "pwsh.exe not found.\n\
+             PowerShell 7 sandbox tests require a system-wide install.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let has_real_pwsh = stdout.lines().any(|p| !p.contains("WindowsApps"));
+    if !has_real_pwsh {
+        panic!(
+            "pwsh.exe only exists as a Windows Store alias.\n\
+             Store aliases cannot be launched inside sandbox containers.\n\
+             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7 system-wide"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Direct process execution
 // ---------------------------------------------------------------------------

--- a/src/wxc_e2e_tests/src/lib.rs
+++ b/src/wxc_e2e_tests/src/lib.rs
@@ -245,7 +245,9 @@ pub fn assert_python() {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let has_real_python = stdout.lines().any(|p| !p.contains("WindowsApps"));
+    let has_real_python = stdout
+        .lines()
+        .any(|p| !p.to_ascii_lowercase().contains("windowsapps"));
     if !has_real_python {
         panic!(
             "python.exe only exists as a Windows Store alias.\n\
@@ -281,7 +283,9 @@ pub fn assert_pwsh() {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let has_real_pwsh = stdout.lines().any(|p| !p.contains("WindowsApps"));
+    let has_real_pwsh = stdout
+        .lines()
+        .any(|p| !p.to_ascii_lowercase().contains("windowsapps"));
     if !has_real_pwsh {
         panic!(
             "pwsh.exe only exists as a Windows Store alias.\n\

--- a/src/wxc_e2e_tests/src/lib.rs
+++ b/src/wxc_e2e_tests/src/lib.rs
@@ -217,12 +217,14 @@ pub fn has_windows_sandbox_feature() -> bool {
     available
 }
 
-/// Check whether `python.exe` is available and NOT only a Windows Store App
-/// Execution Alias. Store aliases are reparse points under `WindowsApps`
-/// that cannot be launched inside AppContainer/BaseContainer sandboxes.
+/// Check whether `python.exe` is available and the *first* match in PATH
+/// is NOT a Windows Store App Execution Alias. Store aliases are reparse
+/// points under `WindowsApps` that cannot be launched inside
+/// AppContainer/BaseContainer sandboxes. Even when a real Python exists
+/// later in PATH, the sandbox will try to launch the first match and fail.
 ///
 /// Panics with a clear remediation message when Python is missing or
-/// only exists as a Store alias.
+/// the first PATH match is a Store alias.
 pub fn assert_python() {
     let output = Command::new("where.exe").arg("python.exe").output().ok();
 
@@ -245,51 +247,30 @@ pub fn assert_python() {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let has_real_python = stdout
-        .lines()
-        .any(|p| !p.to_ascii_lowercase().contains("windowsapps"));
-    if !has_real_python {
+    let first_path = stdout.lines().next().unwrap_or("");
+    if first_path.to_ascii_lowercase().contains("windowsapps") {
         panic!(
-            "python.exe only exists as a Windows Store alias.\n\
-             Store aliases cannot be launched inside sandbox containers.\n\
+            "python.exe first resolves to a Windows Store alias ({first_path}).\n\
+             Store aliases shadow real installs and cannot be launched inside sandbox containers.\n\
              Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or disable App Execution Aliases for Python"
         );
     }
 }
 
-/// Check whether `pwsh.exe` (PowerShell 7) is available via a real install
-/// path, not a Windows Store App Execution Alias.
+/// The hardcoded path used by `pwsh_setlocation.json`.
+const PWSH_PATH: &str = r"C:\Program Files\PowerShell\7\pwsh.exe";
+
+/// Check whether PowerShell 7 is available at the expected path.
+/// The test config `pwsh_setlocation.json` uses a hardcoded fully-qualified
+/// path, so we validate that specific path exists rather than relying on
+/// PATH resolution.
 ///
 /// Panics with a clear remediation message when pwsh is missing.
-/// Since the test config uses a fully qualified path, this only checks
-/// that a real (non-Store) pwsh.exe exists somewhere on the system.
 pub fn assert_pwsh() {
-    let output = Command::new("where.exe").arg("pwsh.exe").output().ok();
-
-    let Some(output) = output else {
+    if !std::path::Path::new(PWSH_PATH).exists() {
         panic!(
-            "pwsh.exe not found.\n\
-             PowerShell 7 sandbox tests require a system-wide install.\n\
-             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
-        );
-    };
-
-    if !output.status.success() {
-        panic!(
-            "pwsh.exe not found.\n\
-             PowerShell 7 sandbox tests require a system-wide install.\n\
-             Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7"
-        );
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let has_real_pwsh = stdout
-        .lines()
-        .any(|p| !p.to_ascii_lowercase().contains("windowsapps"));
-    if !has_real_pwsh {
-        panic!(
-            "pwsh.exe only exists as a Windows Store alias.\n\
-             Store aliases cannot be launched inside sandbox containers.\n\
+            "PowerShell 7 not found at {PWSH_PATH}.\n\
+             The pwsh_setlocation test requires PowerShell 7 installed at this path.\n\
              Fix: Run scripts\\setup-test-prereqs.ps1 (elevated) or install PowerShell 7 system-wide"
         );
     }

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -15,10 +15,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::Serialize;
 use wxc_e2e_tests::{
-    assert_exit, assert_success, assert_success_or_skip_missing_prerequisite, examples_dir,
-    find_binary, has_daemon, has_hyperlight_snapshot, has_nanvix_binaries, has_test_driver,
-    has_windows_sandbox_feature, has_wxc_exe, repo_root, run_test_driver, run_wxc_config,
-    run_wxc_state_aware, test_configs_dir, TempDirs,
+    assert_exit, assert_pwsh, assert_python, assert_success,
+    assert_success_or_skip_missing_prerequisite, examples_dir, find_binary, has_daemon,
+    has_hyperlight_snapshot, has_nanvix_binaries, has_test_driver, has_windows_sandbox_feature,
+    has_wxc_exe, repo_root, run_test_driver, run_wxc_config, run_wxc_state_aware, test_configs_dir,
+    TempDirs,
 };
 
 static HAS_WXC_EXE: OnceLock<bool> = OnceLock::new();
@@ -148,6 +149,7 @@ fn test_processcontainer_basic() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
     with_test_lock(processcontainer_basic);
 }
 
@@ -157,6 +159,7 @@ fn test_processcontainer_lpac() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
     with_test_lock(processcontainer_lpac);
 }
 
@@ -166,6 +169,7 @@ fn test_filesystem_bfs() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
     with_test_lock(filesystem_bfs);
 }
 
@@ -175,6 +179,7 @@ fn test_filesystem_bfs_readonly() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
     with_test_lock(filesystem_bfs_readonly);
 }
 
@@ -184,6 +189,7 @@ fn test_filesystem_bfs_spaces() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
     with_test_lock(filesystem_bfs_spaces);
 }
 
@@ -193,6 +199,7 @@ fn test_pwsh_setlocation() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_pwsh();
     with_test_lock(pwsh_setlocation);
 }
 
@@ -265,6 +272,7 @@ fn test_on_repeat() {
     if !cached_has_wxc_exe() {
         return;
     }
+    assert_python();
 
     with_test_lock(|| {
         for pass in 1..=10 {

--- a/test_configs/basic_lpac.json
+++ b/test_configs/basic_lpac.json
@@ -3,7 +3,7 @@
   "containerId": "CLI-LPAC-Test",
   "containment": "processcontainer",
   "process": {
-    "commandLine": "python -c \"print('import sys; Testing LPAC (Least Privilege AppContainer) mode'); print(f'Python: {sys.version}')\"",
+    "commandLine": "python -c \"import sys; print('Testing LPAC (Least Privilege AppContainer) mode'); print(f'Python: {sys.version}')\"",
     "timeout": 30000
   },
   "processContainer": {

--- a/test_configs/pwsh_setlocation.json
+++ b/test_configs/pwsh_setlocation.json
@@ -3,15 +3,14 @@
   "containerId": "CLI-Pwsh-SetLocation-Test",
   "containment": "processcontainer",
   "process": {
-    "commandLine": "pwsh.exe -nop -nol -c \"Set-PSReadLineOption -HistorySaveStyle SaveNothing; Set-Location c:\\temp\"; Get-ChildItem",
+    "commandLine": "\"C:\\Program Files\\PowerShell\\7\\pwsh.exe\" -nop -nol -c \"Set-PSReadLineOption -HistorySaveStyle SaveNothing; Set-Location c:\\temp\"; Get-ChildItem",
     "timeout": 30000
   },
   "filesystem": {
     "readwritePaths": [
       "C:\\Program Files\\PowerShell\\7",
       "C:\\temp",
-      "C:\\Users",
-      "C:\\Users\\st\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine"
+      "C:\\Users"
     ],
     "readonlyPaths": [
       "C:\\"


### PR DESCRIPTION
## Description

E2E tests failed with cryptic errors (exit `9009`, `CreateProcessW 0x80070057`) when Python was missing/per-user or Windows Store App Execution Aliases shadowed real executables. Store reparse points cannot be launched inside AppContainer/BaseContainer sandboxes.

**Changes:**
- `build.bat`: post-build prereq warnings with interactive fix (install Python via winget + remove Store aliases) when running elevated; opens a fresh terminal after fix for PATH to take effect
- `src/wxc/build.rs`: emit `cargo:warning` during compilation when Python/pwsh are missing or resolve to Store aliases
- `src/wxc_e2e_tests`: `assert_python()`/`assert_pwsh()` fail tests with clear remediation messages instead of cryptic exit codes; checks if any non-Store path exists (not just the first)
- `test_configs/basic_lpac.json`: fix `import sys` being inside `print()` string literal
- `test_configs/pwsh_setlocation.json`: use full path for pwsh.exe, remove hardcoded `C:\Users\st` path
- `scripts/setup-test-prereqs.ps1`: standalone elevated setup script for one-time machine setup

## References

Closes #323

## Validation

- Tested on ARM64 Windows (build 26617) via SSH and interactive terminal
- Verified: build warnings appear during `cargo build`
- Verified: `build.bat` detects missing Python/Store aliases, prompts to fix when elevated, opens fresh terminal
- Verified: tests fail with clear message when Python missing, pass after fix
- Verified: `pwsh_setlocation` passes with full path in config
- All 14 E2E tests pass after prerequisites are installed

## Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/326)