### PR TITLE
Add Ado.Sync.Mirror pipeline template for private ADO repo

### DIFF
--- a/.azure-pipelines/templates/Ado.Sync.Mirror.yml
+++ b/.azure-pipelines/templates/Ado.Sync.Mirror.yml
@@ -1,0 +1,67 @@
+# Sync branches in a mirror repository to a base repo by running this pipeline
+# from the mirror repo, and supplying the base repo as a parameter
+name: $(BuildDefinitionName)_$(date:yyMMdd)$(rev:.r)
+
+parameters:
+  - name: "SourceToTargetBranches"
+    type: object
+    default:
+      main: main
+  - name: "SourceRepository"
+    type: string
+    default: "https://github.com/microsoft/mxc.git"
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: stage
+      jobs:
+        - job: SyncMirror
+          strategy:
+            matrix:
+              ${{ each branches in parameters.SourceToTargetBranches }}:
+                ${{ branches.key }}:
+                  SourceBranch: ${{ branches.key }}
+                  TargetBranch: ${{ branches.value }}
+          dependsOn: []
+          steps:
+            - checkout: self
+              persistCredentials: true
+
+            - task: PowerShell@2
+              inputs:
+                targetType: 'inline'
+                script: |
+                  Write-Host "SourceBranch " + "$(SourceBranch)"
+                  Write-Host "TargetBranch " + "$(TargetBranch)"
+
+                  $repo = "${{ parameters.SourceRepository }}"
+                  git remote add sourcerepo $repo
+                  git remote
+
+                  $target = "$(TargetBranch)"
+                  git fetch origin $target
+                  git checkout $target
+                  git pull origin $target
+
+                  $source = "$(SourceBranch)"
+                  git fetch sourcerepo $source
+                  git pull sourcerepo $source
+
+            - task: CmdLine@2
+              inputs:
+                script: |
+                  git push


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Uses the same azure pipeline template that  many other open source Microsoft Github repositories like [CsWinrt](https://github.com/microsoft/CsWinRT/blob/master/build/AzurePipelineTemplates/CsWinRT-SyncMirror-Pipeline.yml), and [VbsEnclaveTooling ](https://github.com/microsoft/VbsEnclaveTooling/blob/main/AzurePipelineTemplates/SyncMirror-Pipeline-Template.yml), and also [cppwinrt](https://github.com/microsoft/cppwinrt/blob/master/.pipelines/sync-mirror.yml) use to sync Github Changes to a Private ADO fork. This allows for security fixes like MSRCs to be worked on in the private ADO repo and new binaries published quickly. The changes would then come to the GitHub repo through a PR. This will also allow for creating things like vpacks of MXC that can be consumed inside the os.2020 codebase.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->
Resolves ##327

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [x] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/329)