### PR TITLE
[IsolationSession] Filter system-folder paths from filesystem-policy requests

### DIFF
--- a/docs/isolation-session/state-aware-rust-initial-plan.md
+++ b/docs/isolation-session/state-aware-rust-initial-plan.md
@@ -156,6 +156,15 @@ Both modes share the same policy-honor matrix above:
   via `ScriptRunner::validate_runner` then `share_folders` in
   `IsolationSessionRunner::execute`). Rejected at all later state-aware
   phases.
+  - Before forwarding to `ShareFolderBatchAsync`, `share_folders` runs
+    the entries through a small filter (`filter_protected_paths` in
+    `isolation_session_runner.rs`, bracketed by `BEGIN:` / `END:`
+    markers) that silently drops a fixed set of system-folder paths —
+    drive roots, `SystemRoot`, parent of `USERPROFILE`, `ProgramFiles`,
+    `ProgramFiles(x86)`, and `ProgramData`. The mitigation exists
+    because `ShareFolderBatchAsync` applies ACEs with subtree
+    inheritance; the proper fix belongs in the OS API. See the region
+    comment for removal conditions.
 - `policy.filesystem.deniedPaths`, `policy.network`, `policy.ui`, and
   `policy.network.proxy` are rejected at every phase (one-shot via
   `validate_runner`, state-aware via `validate_<phase>` hooks).

--- a/src/wxc_common/src/isolation_session_runner.rs
+++ b/src/wxc_common/src/isolation_session_runner.rs
@@ -499,6 +499,235 @@ pub struct IsolationSessionManager {
     ops: IsoSessionOps,
 }
 
+// =============================================================================
+// BEGIN: filesystem-policy path filter (emergency mitigation, MXC issue #330)
+//
+// Silently drops a fixed set of system-folder paths from filesystem-policy
+// requests before they reach `IsoSessionOps::ShareFolderBatchAsync`. The OS
+// API applies grants with subtree inheritance, so granting these top-level
+// folders propagates an agent SID's ACE through their entire subtrees —
+// catastrophic for drive roots, the Windows directory, the Users root,
+// ProgramFiles, and ProgramData.
+//
+// The proper fix belongs in the OS API. When that lands, delete this entire
+// region and the single call site in `IsolationSessionManager::share_folders`.
+//
+// Known not covered (caller would have to actively pursue these spellings to
+// evade the text match): 8.3 short names (e.g. `PROGRA~1`), symlinks /
+// junctions (no `canonicalize` disk access), UNC paths, `CommonProgramFiles`
+// / `CommonProgramFiles(x86)`. The `\\?\` long-path prefix on a disk path
+// (`\\?\C:\foo`) IS handled — it normalizes to the same canonical form as
+// `C:\foo` so it cannot be used as a textual bypass.
+// =============================================================================
+
+/// Returns the lazily-computed, cached set of canonical paths the filter
+/// rejects. Contents:
+///
+/// - 26 drive roots (`A:\` through `Z:\`) — static, no `GetLogicalDrives`
+///   call so future-mounted drives are also caught.
+/// - The result of normalizing each available env-var-derived path:
+///   `SystemRoot`, parent of `USERPROFILE`, `ProgramFiles`,
+///   `ProgramFiles(x86)`, `ProgramData`, plus the aliases `windir`,
+///   `ProgramW6432`, `AllUsersProfile`, `SYSTEMDRIVE` (each of which
+///   collapses to one of the preceding via normalization-and-dedup).
+///
+/// Missing or empty env vars are silently skipped — pathological host
+/// configuration is not the runner's failure mode.
+fn protected_paths_set() -> &'static std::collections::HashSet<String> {
+    static SET: std::sync::OnceLock<std::collections::HashSet<String>> = std::sync::OnceLock::new();
+    SET.get_or_init(|| build_protected_paths_set(|var| std::env::var(var).ok()))
+}
+
+/// Construction logic for the protected-paths set, parameterised on an
+/// env-var lookup so tests can inject synthetic environments without
+/// touching the process-wide `OnceLock` cache.
+fn build_protected_paths_set(
+    env: impl Fn(&str) -> Option<String>,
+) -> std::collections::HashSet<String> {
+    let mut set = std::collections::HashSet::new();
+    // 26 drive roots, regardless of current mount state.
+    for letter in b'A'..=b'Z' {
+        if let Some(p) = normalize_protected_path(&format!("{}:\\", letter as char)) {
+            set.insert(p);
+        }
+    }
+    // env-var-derived entries; (var name, take-parent flag).
+    for (var, take_parent) in [
+        ("SystemRoot", false),
+        ("windir", false),
+        ("USERPROFILE", true),
+        ("ProgramFiles", false),
+        ("ProgramFiles(x86)", false),
+        ("ProgramW6432", false),
+        ("ProgramData", false),
+        ("AllUsersProfile", false),
+        ("SYSTEMDRIVE", false),
+    ] {
+        let raw = match env(var) {
+            Some(v) if !v.is_empty() => v,
+            _ => continue,
+        };
+        let candidate = if take_parent {
+            std::path::Path::new(&raw)
+                .parent()
+                .map(|p| p.to_string_lossy().into_owned())
+        } else {
+            Some(raw)
+        };
+        if let Some(c) = candidate {
+            if let Some(n) = normalize_protected_path(&c) {
+                set.insert(n);
+            }
+        }
+    }
+    set
+}
+
+/// Normalizes a Windows path for filter-set comparison. Returns `None` for
+/// strings without a recognised disk prefix (only local absolute paths are
+/// filtered). Applied to both filter-set entries and caller-supplied paths
+/// so they compare on the same canonical form.
+///
+/// Handles (so accidental spellings still match):
+/// - Forward slashes → backslashes.
+/// - Trailing slash discipline: drive `C:` → `c:\`; non-root paths drop the
+///   trailing `\` via component re-assembly.
+/// - `.` / `..` collapse, clamped at root (so `C:\..` stays `c:\`).
+/// - Per-component trailing whitespace and dots trim (Win32 silently strips
+///   these at the file-open boundary, making them a real bypass shape).
+/// - Case-insensitive ASCII compare via lowercase-on-output.
+/// - `\\?\` long-path prefix on a disk path (`\\?\C:\foo`): the `\\?\` is
+///   dropped and the rest normalizes the same as `C:\foo`.
+fn normalize_protected_path(input: &str) -> Option<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let replaced = trimmed.replace('/', "\\");
+    let path = std::path::Path::new(&replaced);
+
+    let mut prefix: Option<String> = None;
+    let mut has_root = false;
+    let mut comps: Vec<String> = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::Prefix(pc) => {
+                // Disk prefixes are filtered. `Disk(c)` is the plain `C:`
+                // form; `VerbatimDisk(c)` is the `\\?\C:` long-path form,
+                // which Win32 strips at file-open time — accept it as the
+                // same canonical disk prefix so it cannot be used as a
+                // textual bypass. UNC (`\\server\share`) and verbatim UNC
+                // (`\\?\UNC\server\share`) remain in the documented skip
+                // list — return early so the caller's path passes through.
+                match pc.kind() {
+                    std::path::Prefix::Disk(_) => {
+                        prefix = Some(pc.as_os_str().to_string_lossy().into_owned());
+                    }
+                    std::path::Prefix::VerbatimDisk(letter) => {
+                        prefix = Some(format!("{}:", letter as char));
+                    }
+                    _ => return None,
+                }
+            }
+            std::path::Component::RootDir => {
+                has_root = true;
+            }
+            std::path::Component::CurDir => { /* skip */ }
+            std::path::Component::ParentDir => {
+                // Pop within the components we've collected; clamps at root
+                // because there's nothing to pop when comps is empty.
+                comps.pop();
+            }
+            std::path::Component::Normal(s) => {
+                let mut name = s.to_string_lossy().into_owned();
+                while let Some(ch) = name.chars().last() {
+                    if ch.is_ascii_whitespace() || ch == '.' {
+                        name.pop();
+                    } else {
+                        break;
+                    }
+                }
+                if !name.is_empty() {
+                    comps.push(name);
+                }
+            }
+        }
+    }
+
+    // Drive prefix required for local-path matching. UNC paths and prefix-less
+    // input return None earlier.
+    let prefix = prefix?;
+    let mut out = prefix.to_ascii_lowercase();
+    // Always end the prefix with `\` so drive-root spellings normalize to
+    // `c:\` regardless of whether the input had the explicit RootDir
+    // component (`C:` and `C:\` collapse to the same canonical form).
+    out.push('\\');
+    if !comps.is_empty() {
+        // `C:foo` (prefix + components but no RootDir) is a drive-relative
+        // path — `foo` is resolved against the per-drive current directory.
+        // That's not an absolute spelling of any filter entry; out of scope.
+        if !has_root {
+            return None;
+        }
+        let lowered: Vec<String> = comps.iter().map(|s| s.to_ascii_lowercase()).collect();
+        out.push_str(&lowered.join("\\"));
+    }
+    Some(out)
+}
+
+/// Drops protected paths from `rw` / `ro` slices before they reach
+/// `ShareFolderBatchAsync`. Returns the kept paths in their original
+/// caller spelling so the OS API sees verbatim input.
+///
+/// When `logger` is provided AND at least one entry was dropped, emits a
+/// single trace line summarising originals + canonical matches. The
+/// state-aware `StatefulSandboxBackend::provision` trait method does not
+/// plumb a logger; it passes `None` and silently filters.
+fn filter_protected_paths(
+    rw: &[String],
+    ro: &[String],
+    logger: Option<&mut Logger>,
+) -> (Vec<String>, Vec<String>) {
+    let set = protected_paths_set();
+    let mut dropped: Vec<(String, String, &'static str)> = Vec::new();
+
+    let mut partition = |list: &'static str, paths: &[String]| -> Vec<String> {
+        let mut kept = Vec::with_capacity(paths.len());
+        for p in paths {
+            match normalize_protected_path(p) {
+                Some(n) if set.contains(&n) => {
+                    dropped.push((p.clone(), n, list));
+                }
+                _ => kept.push(p.clone()),
+            }
+        }
+        kept
+    };
+    let rw_kept = partition("rw", rw);
+    let ro_kept = partition("ro", ro);
+
+    if let Some(logger) = logger {
+        if !dropped.is_empty() {
+            let summary: Vec<String> = dropped
+                .iter()
+                .map(|(orig, canon, list)| format!("'{}' ({}, matched {})", orig, list, canon))
+                .collect();
+            let _ = writeln!(
+                logger,
+                "filesystem policy filter dropped {} paths: {}",
+                dropped.len(),
+                summary.join(", "),
+            );
+        }
+    }
+
+    (rw_kept, ro_kept)
+}
+
+// =============================================================================
+// END: filesystem-policy path filter (emergency mitigation, MXC issue #330)
+// =============================================================================
+
 impl IsolationSessionManager {
     /// Activates the `IsoSessionOps` factory, verifies the service is
     /// available, and pegs the manager to the supplied `provisionId`.
@@ -612,8 +841,12 @@ impl IsolationSessionManager {
         &self,
         readwrite_paths: &[String],
         readonly_paths: &[String],
+        logger: Option<&mut Logger>,
     ) -> Result<(), IsolationSessionError> {
-        let requests = build_share_folder_requests(readwrite_paths, readonly_paths);
+        // STOPGAP (MXC issue #330): filter protected paths before forwarding.
+        // See the filesystem-policy path filter region above.
+        let (rw_kept, ro_kept) = filter_protected_paths(readwrite_paths, readonly_paths, logger);
+        let requests = build_share_folder_requests(&rw_kept, &ro_kept);
         if requests.is_empty() {
             return Ok(());
         }
@@ -1101,6 +1334,7 @@ impl ScriptRunner for IsolationSessionRunner {
         if let Err(e) = manager.share_folders(
             &request.policy.readwrite_paths,
             &request.policy.readonly_paths,
+            Some(logger),
         ) {
             let _ = manager.deprovision_agent_user();
             let _ = manager.unregister_client();
@@ -1230,6 +1464,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         if let Err(e) = manager.share_folders(
             &request.policy.readwrite_paths,
             &request.policy.readonly_paths,
+            None,
         ) {
             let _ = manager.deprovision_agent_user();
             let _ = manager.unregister_client();
@@ -2337,5 +2572,289 @@ mod tests {
             ..Default::default()
         };
         runner.validate_runner(&req).unwrap();
+    }
+
+    // -- Filesystem-policy path filter (emergency mitigation) tests ---------
+
+    #[test]
+    fn normalize_drive_root_variants_collapse_to_canonical_form() {
+        assert_eq!(normalize_protected_path("C:").as_deref(), Some("c:\\"));
+        assert_eq!(normalize_protected_path("C:\\").as_deref(), Some("c:\\"));
+        assert_eq!(normalize_protected_path("c:\\").as_deref(), Some("c:\\"));
+        assert_eq!(normalize_protected_path("C:/").as_deref(), Some("c:\\"));
+    }
+
+    #[test]
+    fn normalize_handles_case_and_slash_direction() {
+        assert_eq!(
+            normalize_protected_path("C:\\Windows").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("c:/windows").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\WINDOWS").as_deref(),
+            Some("c:\\windows")
+        );
+    }
+
+    #[test]
+    fn normalize_drops_trailing_slash_for_non_root() {
+        assert_eq!(
+            normalize_protected_path("C:\\Windows\\").as_deref(),
+            Some("c:\\windows")
+        );
+    }
+
+    #[test]
+    fn normalize_collapses_dot_components() {
+        assert_eq!(
+            normalize_protected_path("C:\\Windows\\.").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\.\\Windows").as_deref(),
+            Some("c:\\windows")
+        );
+    }
+
+    #[test]
+    fn normalize_pops_parent_components_clamped_at_root() {
+        assert_eq!(
+            normalize_protected_path("C:\\Windows\\..").as_deref(),
+            Some("c:\\")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\Windows\\System32\\..").as_deref(),
+            Some("c:\\windows")
+        );
+        // Excess pops clamp at root.
+        assert_eq!(
+            normalize_protected_path("C:\\..\\..").as_deref(),
+            Some("c:\\")
+        );
+    }
+
+    #[test]
+    fn normalize_trims_trailing_whitespace_and_dots_per_component() {
+        // Win32 silently strips these at the file-open boundary, so they're
+        // a real bypass shape (not just a curiosity).
+        assert_eq!(
+            normalize_protected_path("C:\\Windows ").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\Windows.").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\Windows...").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("C:\\Windows . .").as_deref(),
+            Some("c:\\windows")
+        );
+        // Trim applies to every component, not only the last.
+        assert_eq!(
+            normalize_protected_path("C:\\Windows \\System32").as_deref(),
+            Some("c:\\windows\\system32")
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_paths_without_drive_prefix() {
+        assert_eq!(normalize_protected_path(""), None);
+        assert_eq!(normalize_protected_path("   "), None);
+        assert_eq!(normalize_protected_path("relative\\path"), None);
+        // UNC: prefix is `\\server\share`, not a drive — out of filter scope.
+        assert_eq!(normalize_protected_path("\\\\server\\share\\Windows"), None);
+        // Verbatim UNC (`\\?\UNC\server\share\...`): not a disk prefix.
+        assert_eq!(
+            normalize_protected_path("\\\\?\\UNC\\server\\share\\Windows"),
+            None
+        );
+        // Drive-relative (`C:foo`, no RootDir): `foo` is resolved against the
+        // per-drive cwd, not absolute. Out of filter scope.
+        assert_eq!(normalize_protected_path("C:foo"), None);
+    }
+
+    #[test]
+    fn normalize_verbatim_disk_prefix_collapses_to_canonical_form() {
+        // `\\?\C:\foo` normalizes to the same canonical form as `C:\foo`, so
+        // the long-path prefix cannot be used as a textual filter bypass.
+        assert_eq!(
+            normalize_protected_path("\\\\?\\C:\\Windows").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("\\\\?\\c:\\windows\\").as_deref(),
+            Some("c:\\windows")
+        );
+        assert_eq!(
+            normalize_protected_path("\\\\?\\Z:\\").as_deref(),
+            Some("z:\\")
+        );
+    }
+
+    #[test]
+    fn build_set_includes_all_26_drive_roots_with_empty_env() {
+        let set = build_protected_paths_set(|_| None);
+        assert_eq!(set.len(), 26);
+        for letter in b'A'..=b'Z' {
+            let key = format!("{}:\\", (letter as char).to_ascii_lowercase());
+            assert!(set.contains(&key), "missing drive-root entry {}", key);
+        }
+    }
+
+    #[test]
+    fn build_set_includes_canonical_forms_of_supplied_env_vars() {
+        let env = |var: &str| {
+            Some(match var {
+                "SystemRoot" => "C:\\Windows".to_string(),
+                "USERPROFILE" => "C:\\Users\\me".to_string(),
+                "ProgramFiles" => "C:\\Program Files".to_string(),
+                "ProgramFiles(x86)" => "C:\\Program Files (x86)".to_string(),
+                "ProgramData" => "C:\\ProgramData".to_string(),
+                _ => return None,
+            })
+        };
+        let set = build_protected_paths_set(env);
+        assert!(set.contains("c:\\windows"));
+        assert!(set.contains("c:\\users")); // USERPROFILE parent
+        assert!(set.contains("c:\\program files"));
+        assert!(set.contains("c:\\program files (x86)"));
+        assert!(set.contains("c:\\programdata"));
+    }
+
+    #[test]
+    fn build_set_aliases_dedupe_into_their_canonical_entries() {
+        let env = |var: &str| {
+            Some(match var {
+                "SystemRoot" => "C:\\Windows".to_string(),
+                "windir" => "C:\\Windows".to_string(),
+                "ProgramFiles" => "C:\\Program Files".to_string(),
+                "ProgramW6432" => "C:\\Program Files".to_string(),
+                "ProgramData" => "C:\\ProgramData".to_string(),
+                "AllUsersProfile" => "C:\\ProgramData".to_string(),
+                "SYSTEMDRIVE" => "C:".to_string(),
+                _ => return None,
+            })
+        };
+        let set = build_protected_paths_set(env);
+        // 26 drive roots + 3 unique env entries. SYSTEMDRIVE folds into the
+        // drive-root set; the named aliases collapse into their primary.
+        assert_eq!(set.len(), 26 + 3);
+    }
+
+    #[test]
+    fn build_set_silently_skips_missing_or_empty_env_vars() {
+        let env = |var: &str| match var {
+            "SystemRoot" => Some(String::new()), // empty
+            "ProgramFiles" => Some("C:\\Program Files".to_string()),
+            _ => None, // everything else missing
+        };
+        let set = build_protected_paths_set(env);
+        // Drive roots + only ProgramFiles (SystemRoot was empty, others missing).
+        assert_eq!(set.len(), 26 + 1);
+        assert!(set.contains("c:\\program files"));
+    }
+
+    #[test]
+    fn build_set_handles_userprofile_at_drive_root() {
+        // Pathological: USERPROFILE = "C:\" → parent is None → silently skipped.
+        let env = |var: &str| match var {
+            "USERPROFILE" => Some("C:\\".to_string()),
+            _ => None,
+        };
+        let set = build_protected_paths_set(env);
+        assert_eq!(set.len(), 26); // no extra entry from USERPROFILE
+    }
+
+    #[test]
+    fn filter_drops_protected_drive_roots() {
+        // Drive roots are always in the real set regardless of env, so this
+        // composition test is hermetic.
+        let (rw, _) = filter_protected_paths(
+            &[
+                "C:\\".to_string(),
+                "C:\\Users\\Alice\\work".to_string(),
+                "Z:\\".to_string(),
+            ],
+            &[],
+            None,
+        );
+        assert!(!rw.iter().any(|p| p == "C:\\"));
+        assert!(!rw.iter().any(|p| p == "Z:\\"));
+        assert!(rw.contains(&"C:\\Users\\Alice\\work".to_string()));
+    }
+
+    #[test]
+    fn filter_applies_to_readonly_paths_too() {
+        let (_, ro) = filter_protected_paths(
+            &[],
+            &["D:\\".to_string(), "C:\\Users\\Alice\\data".to_string()],
+            None,
+        );
+        assert!(!ro.iter().any(|p| p == "D:\\"));
+        assert!(ro.contains(&"C:\\Users\\Alice\\data".to_string()));
+    }
+
+    #[test]
+    fn filter_preserves_caller_spelling_for_kept_entries() {
+        // Kept paths come out byte-for-byte as the caller supplied them
+        // (the OS API gets the verbatim string, not the canonical form).
+        let (rw, _) = filter_protected_paths(&["C:/Users/Alice/work".to_string()], &[], None);
+        assert_eq!(rw, vec!["C:/Users/Alice/work".to_string()]);
+    }
+
+    #[test]
+    fn filter_empty_input_yields_empty_output() {
+        let (rw, ro) = filter_protected_paths(&[], &[], None);
+        assert!(rw.is_empty());
+        assert!(ro.is_empty());
+    }
+
+    #[test]
+    fn filter_subdirectory_of_protected_path_passes_through() {
+        // Exact-match-only: subdirectories of protected folders are not filtered.
+        let (rw, _) = filter_protected_paths(
+            &[
+                "C:\\subdir-of-drive-root".to_string(),
+                "Z:\\my\\subdir".to_string(),
+            ],
+            &[],
+            None,
+        );
+        assert!(rw.contains(&"C:\\subdir-of-drive-root".to_string()));
+        assert!(rw.contains(&"Z:\\my\\subdir".to_string()));
+    }
+
+    #[test]
+    fn filter_catches_drive_root_bypass_attempts() {
+        // Exercises the composition of normalize + set lookup for the
+        // always-present drive-root entries.
+        let (rw, _) = filter_protected_paths(
+            &[
+                "c:\\".to_string(),
+                "C:/".to_string(),
+                "C:".to_string(),
+                "c:".to_string(),
+                "C:\\..".to_string(),      // .. clamps at root
+                "C:\\.".to_string(),       // . skipped
+                "C:\\ ".to_string(),       // trailing space (after slash, this empties → root)
+                "\\\\?\\C:\\".to_string(), // verbatim disk drive root
+                "\\\\?\\Z:\\".to_string(),
+            ],
+            &[],
+            None,
+        );
+        assert!(
+            rw.is_empty(),
+            "drive-root bypass variants should drop, got {:?}",
+            rw
+        );
     }
 }

--- a/test_configs/isolation_session_filtered.json
+++ b/test_configs/isolation_session_filtered.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "isolation-session-filtered",
+  "containment": "isolation_session",
+  "process": {
+    "commandLine": "type C:\\mxc_filter_test_oneshot\\marker.txt",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": ["C:\\Windows", "C:\\", "C:\\mxc_filter_test_oneshot"]
+  }
+}

--- a/test_configs/isolation_session_state_aware_provision_with_filter.json
+++ b/test_configs/isolation_session_state_aware_provision_with_filter.json
@@ -1,0 +1,7 @@
+{
+    "phase": "provision",
+    "containment": "isolation_session",
+    "filesystem": {
+        "readwritePaths": ["C:\\Windows", "C:\\", "C:\\mxc_filter_test\\rw"]
+    }
+}

--- a/test_scripts/run_isolation_session_state_aware_tests.ps1
+++ b/test_scripts/run_isolation_session_state_aware_tests.ps1
@@ -318,6 +318,7 @@ function Run-StateAwareTest {
 # the control test would not actually demonstrate that share_folders is
 # what enables access in Lifecycle B.
 $script:TestRoot = 'C:\mxc_share_test'
+$script:FilterTestRoot = 'C:\mxc_filter_test'
 $script:RoMarkerContent = 'readonly-marker-content'
 $script:RestrictedMarkerContent = 'restricted-marker-content'
 Setup-LockedDownTestDir $script:TestRoot
@@ -326,6 +327,8 @@ New-Item -Path "$script:TestRoot\ro" -ItemType Directory -Force | Out-Null
 New-Item -Path "$script:TestRoot\restricted" -ItemType Directory -Force | Out-Null
 $script:RoMarkerContent | Set-Content -Path "$script:TestRoot\ro\marker.txt" -NoNewline
 $script:RestrictedMarkerContent | Set-Content -Path "$script:TestRoot\restricted\marker.txt" -NoNewline
+Setup-LockedDownTestDir $script:FilterTestRoot
+New-Item -Path "$script:FilterTestRoot\rw" -ItemType Directory -Force | Out-Null
 
 # Outer try-finally: ensures the host directory tree is removed even if a
 # test panics. The summary at the end runs after the cleanup.
@@ -807,6 +810,128 @@ try {
     }
 }
 
+# ---------------- Lifecycle BF: filesystem-policy path filter ----------------
+#
+# Verifies the wxc-exec filesystem-policy path filter (MXC issue #330).
+# Provisions with a mix of protected (drive root, C:\Windows) and
+# non-protected (C:\mxc_filter_test\rw) paths in readwritePaths. Expected:
+# provision succeeds (the filter is silent -- no error returned, no
+# filter-specific metadata field added), the protected paths get NO new
+# agent ACE (filter dropped them before ShareFolderBatchAsync), and the
+# non-protected path receives the agent's ACE as normal (positive control:
+# legitimate path not accidentally dropped).
+#
+# Test-dir setup happens at file scope alongside $script:TestRoot so the
+# outer try-finally can clean both up between runs; without that cleanup
+# a stale $script:FilterTestRoot from a prior run causes Setup-LockedDownTestDir
+# to fail with SeSecurityPrivilege (Set-Acl on an existing
+# inheritance-disabled directory writes the SACL slot, which non-elevated
+# admins cannot do).
+
+# Translates a local-account name to its SID. Returns $null if the
+# translation fails (e.g., the user no longer exists).
+function Get-LocalAccountSid {
+    param([string]$Name)
+    try {
+        $nt = New-Object System.Security.Principal.NTAccount($Name)
+        $nt.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    } catch {
+        $null
+    }
+}
+
+# Returns $true if the ACL on $Path has any access rule whose
+# IdentityReference translates to $TargetSid.
+function Test-AclContainsSid {
+    param([string]$Path, [string]$TargetSid)
+    $acl = Get-Acl $Path
+    foreach ($ace in $acl.Access) {
+        try {
+            $aceSid = $ace.IdentityReference.Translate(
+                [System.Security.Principal.SecurityIdentifier]).Value
+            if ($aceSid -eq $TargetSid) { return $true }
+        } catch {
+            # IdentityReference may be untranslatable (orphan SID etc.); skip.
+        }
+    }
+    $false
+}
+
+$script:filterSandboxId = $null
+$script:filterAgentUserName = $null
+$filterDeprovisionedOk = $false
+try {
+    $filterProvisionedOk = Run-StateAwareTest "filter: provision (protected + non-protected paths)" {
+        $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_provision_with_filter.json' -Experimental
+        $envObj = Parse-Envelope -Stdout $r.Stdout
+        $arm = Envelope-Arm $envObj
+        if ($arm -ne 'result') {
+            Write-Host "  Envelope arm: $arm" -ForegroundColor Red
+            Write-Host "  Stdout: $($r.Stdout)" -ForegroundColor Gray
+            Write-Host "  Stderr: $($r.Stderr)" -ForegroundColor Gray
+            Assert-True $false "filter provision returned a result envelope (filter is silent -- no error expected)"
+        } else {
+            Assert-True ($r.ExitCode -eq 0) "exit code = 0 (filter dropped protected paths silently)"
+            $script:filterSandboxId = $envObj.result.sandboxId
+            Assert-True ($script:filterSandboxId -match '^iso:wxc-[0-9a-f]{8}$') `
+                "sandbox_id matches iso:wxc-<8-hex> ($script:filterSandboxId)"
+            $script:filterAgentUserName = if ($envObj.result.metadata) { [string]$envObj.result.metadata.agentUserName } else { '<absent>' }
+            Write-Host "  filter test provisioned: agentUserName=$($script:filterAgentUserName)" -ForegroundColor DarkGray
+        }
+    }
+
+    if ($filterProvisionedOk -and $script:filterAgentUserName -and $script:filterAgentUserName -ne '<absent>') {
+        $filterAgentSid = Get-LocalAccountSid -Name $script:filterAgentUserName
+
+        Run-StateAwareTest "filter: agent user name translates to SID" {
+            Assert-True ($null -ne $filterAgentSid) `
+                "translated '$($script:filterAgentUserName)' to SID ($filterAgentSid)"
+        } | Out-Null
+
+        if ($null -ne $filterAgentSid) {
+            Run-StateAwareTest "filter: protected drive root receives no agent ACE" {
+                Assert-True (-not (Test-AclContainsSid -Path 'C:\' -TargetSid $filterAgentSid)) `
+                    "agent SID is NOT in ACL of C:\ (drive root filter dropped the entry)"
+            } | Out-Null
+
+            Run-StateAwareTest "filter: protected SystemRoot receives no agent ACE" {
+                Assert-True (-not (Test-AclContainsSid -Path 'C:\Windows' -TargetSid $filterAgentSid)) `
+                    "agent SID is NOT in ACL of C:\Windows (SystemRoot filter dropped the entry)"
+            } | Out-Null
+
+            Run-StateAwareTest "filter: non-protected path receives agent ACE (positive control)" {
+                $nonProtected = Join-Path $script:FilterTestRoot 'rw'
+                Assert-True (Test-AclContainsSid -Path $nonProtected -TargetSid $filterAgentSid) `
+                    "agent SID IS in ACL of $nonProtected (filter passed legitimate path through)"
+            } | Out-Null
+        }
+    }
+
+    if ($filterProvisionedOk) {
+        $filterDeprovPassed = Run-StateAwareTest "filter: deprovision" {
+            $r = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:filterSandboxId -Experimental
+            $envObj = Parse-Envelope -Stdout $r.Stdout
+            $arm = Envelope-Arm $envObj
+            if ($arm -ne 'result') {
+                Assert-True $false "filter deprovision returned a result envelope (got $arm)"
+            } else {
+                Assert-True ($r.ExitCode -eq 0) "exit code = 0"
+            }
+        }
+        if ($filterDeprovPassed) { $filterDeprovisionedOk = $true }
+    }
+} finally {
+    if ($null -ne $script:filterSandboxId -and -not $filterDeprovisionedOk) {
+        Write-Host ""
+        Write-Host "[cleanup] best-effort deprovision of $script:filterSandboxId" -ForegroundColor DarkGray
+        try {
+            $null = Invoke-StateAware -ConfigFile 'isolation_session_state_aware_deprovision.json' -SandboxId $script:filterSandboxId -Experimental
+        } catch {
+            Write-Host "  cleanup deprovision threw: $($_.Exception.Message)" -ForegroundColor DarkGray
+        }
+    }
+}
+
 # ---------------- Lifecycle C: Medium configurationId ----------------
 
 # A separate, throwaway sandbox that exercises the Medium config-id end-to-end.
@@ -1222,9 +1347,13 @@ try {
 }
 
 } finally {
-    # Outer-try finally: remove the locked-down test tree. Runs even if a
-    # test panics so we don't leak the directory between runs.
+    # Outer-try finally: remove the locked-down test trees. Runs even if a
+    # test panics so we don't leak the directories between runs. Cleanup is
+    # necessary: re-running Setup-LockedDownTestDir on an existing locked-down
+    # directory fails non-elevated because Set-Acl tries to write the SACL
+    # slot, which requires SeSecurityPrivilege.
     Remove-Item -Recurse -Force $script:TestRoot -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $script:FilterTestRoot -ErrorAction SilentlyContinue
 }
 
 # ---------------- Summary ----------------

--- a/test_scripts/run_isolation_session_tests.ps1
+++ b/test_scripts/run_isolation_session_tests.ps1
@@ -282,9 +282,26 @@ function Setup-LockedDownTestDir {
 [System.Collections.ArrayList]$results = @()
 
 # Filesystem-policy test scaffolding: a locked-down dir the test expects
-# the agent to read via a readwritePaths grant.
+# the agent to read via a readwritePaths grant. Setup runs at file scope,
+# BEFORE the outer try and BEFORE any agent provision/deprovision cycles.
+# Empirically, running Setup-LockedDownTestDir AFTER agent lifecycles have
+# happened in this cmd.exe session causes Set-Acl to fail with
+# SeSecurityPrivilege on non-elevated consoles; running it BEFORE works
+# (state-aware uses this same ordering for its host-side dirs).
 $FsTestRoot = 'C:\mxc_share_test_oneshot'
 $FsMarkerContent = 'oneshot-marker-content'
+Setup-LockedDownTestDir $FsTestRoot
+$FsMarkerContent | Set-Content -Path (Join-Path $FsTestRoot 'marker.txt') -NoNewline
+
+# Filter test scaffolding: same file-scope ordering as $FsTestRoot above.
+# The outer-try finally also cleans this up between runs so a stale
+# inheritance-disabled directory does not require SeSecurityPrivilege on
+# re-run (Set-Acl on an existing inheritance-disabled directory writes
+# the SACL slot, which non-elevated admins cannot do).
+$FilterTestRoot = 'C:\mxc_filter_test_oneshot'
+$FilterMarkerContent = 'oneshot-filter-marker-content'
+Setup-LockedDownTestDir $FilterTestRoot
+$FilterMarkerContent | Set-Content -Path (Join-Path $FilterTestRoot 'marker.txt') -NoNewline
 
 try {
 
@@ -315,14 +332,23 @@ $null = $results.Add((Run-IsolationSessionTest "isolation_session_stdout_stderr_
 # the agent to exit with code 1.
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_timeout.json" `
     -ExpectedExit 1))
-# Filesystem policy: provision the agent with a readwritePaths grant on a
-# locked-down host dir that has a pre-populated marker; agent reads it.
+# Filesystem policy: agent has a readwritePaths grant on $FsTestRoot which
+# was locked-down and populated with a marker file at file scope above.
 # The `type` exit being 0 + the marker content in stdout proves the grant
 # was applied and the agent has read access.
-Setup-LockedDownTestDir $FsTestRoot
-$FsMarkerContent | Set-Content -Path (Join-Path $FsTestRoot 'marker.txt') -NoNewline
 $null = $results.Add((Run-IsolationSessionTest "isolation_session_filesystem.json" `
     -OutputContains @($FsMarkerContent)))
+
+# Filter test: readwritePaths contains both protected (C:\Windows, C:\) and
+# non-protected ($FilterTestRoot, locked-down and populated at file scope
+# above) entries. The wxc-exec filesystem-policy path filter (MXC issue
+# #330) drops the protected entries silently, leaves the non-protected one
+# in place, and provisioning continues. The `type ...marker.txt` exit being
+# 0 + marker content in stdout proves the non-protected grant was applied
+# (positive control); the absence of any error envelope proves the protected
+# entries were dropped without surfacing.
+$null = $results.Add((Run-IsolationSessionTest "isolation_session_filtered.json" `
+    -OutputContains @($FilterMarkerContent)))
 
 # One-shot rejection: experimental.isolation_session.user is only honored on
 # the state-aware path. validate_runner rejects any one-shot request that
@@ -547,6 +573,7 @@ try {
 
 } finally {
     Remove-Item -Recurse -Force $FsTestRoot -ErrorAction SilentlyContinue
+    Remove-Item -Recurse -Force $FilterTestRoot -ErrorAction SilentlyContinue
 }
 
 # Summary -- wrap each filtered pipeline in @(...) to force array context.


### PR DESCRIPTION
## 📖 Description

`IsoSessionOps::ShareFolderBatchAsync` applies ACEs with subtree inheritance. Granting these on broad system folders is expensive (the OS service must walk and apply the inherited ACE to every file and directory in the subtree, which can be prohibitively slow on deep system trees like `C:\Windows`) and unsafe (the agent gains the granted right across every file in the subtree).

This PR adds a client-side filter inside `IsolationSessionManager::share_folders` that silently drops a fixed set of paths from `readwritePaths` and `readonlyPaths` before forwarding to the OS API: drive roots, `SystemRoot`, parent of `USERPROFILE`, `ProgramFiles`, `ProgramFiles(x86)`, and `ProgramData`. Caller-visible behavior is unchanged — no error, no metadata field, no wire-format change.

The filter region in `isolation_session_runner.rs` is bracketed by `BEGIN:` / `END:` markers, with a matching one-line marker at the call site. All three carry the tracking issue number; removal is a mechanical delete of the bracketed region plus the call-site line.

## 🔗 References

### Related Issues

- #330

## 🔍 Validation

Local 7-gate × 2-mode (build / test / clippy / fmt with and without `--features isolation_session`); release build of `wxc-exec` with `isolation_session`; ARM64 Windows cross-compile (`--target aarch64-pc-windows-msvc`) clean in both modes.

Test counts: 451 default-feature, 532 with `isolation_session` (+19 new filter unit tests covering normalizer rules, filter-set construction with synthetic env-var fixtures, and bypass-attempt spellings including the `\\?\` long-path verbatim-disk form).

VM integration on Windows `26619.260514-1700`: state-aware 65/65 (+6 new filter assertions verifying protected folders receive no agent ACE and a positive-control non-protected folder does); one-shot 13/13 (+1 new `isolation_session_filtered.json` fixture).

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/331)