### PR TITLE
hyperlight: update to v0.5.0 release

### DIFF
--- a/.github/workflows/hyperlight-e2e.yml
+++ b/.github/workflows/hyperlight-e2e.yml
@@ -67,10 +67,11 @@ jobs:
           $pyhlHome = Join-Path $env:LOCALAPPDATA "pyhl"
           New-Item -ItemType Directory -Force -Path $pyhlHome | Out-Null
 
-          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-kernel:latest kernel.tar
+          $tag = "v0.5.0"
+          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-kernel:$tag kernel.tar
           tar -xf kernel.tar -C $pyhlHome kernel
 
-          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-initrd:latest initrd.tar
+          .\crane.exe export ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-initrd:$tag initrd.tar
           tar -xf initrd.tar -C $pyhlHome initrd.cpio
 
           Write-Host "Downloaded to ${pyhlHome}:"

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -843,18 +843,21 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.4.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?branch=main#0bcbd386ce5a00c8a3f6a594bfc5eca267db6da0"
+version = "0.5.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.5.0#ca05c5af35f1728bbce94e17677a18200b7247a6"
 dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "flate2",
  "hyperlight-host",
  "libc",
  "memmap2",
  "nix",
  "serde_json",
  "socket2 0.5.10",
+ "tar",
+ "ureq",
  "windows-sys 0.61.2",
 ]
 
@@ -1608,6 +1611,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1663,6 +1680,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2078,6 +2130,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2088,6 +2175,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2260,6 +2353,15 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -21,7 +21,7 @@ getrandom = { workspace = true }
 semver = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", branch = "main", optional = true }
+hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.5.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true }

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -201,7 +201,7 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     let opts = pyhl::InstallOptions {
         home: &home,
         source: pyhl::InstallSource::Ghcr {
-            tag: Some("v0.4.0"),
+            tag: Some("v0.5.0"),
         },
         mounts: &[],
         network: None,


### PR DESCRIPTION
## Summary
- Pin hyperlight-unikraft dependency to tag v0.5.0 (was tracking branch main at v0.4.0)
- Update GHCR image tag from v0.4.0 to v0.5.0

## What's in hyperlight-unikraft v0.5.0
- Security hardening: loopback blocking, resource caps on fs_read/net_send/dns, socket timeouts, mount-root guard
- Fix: Windows socket state corruption in net_connect
- Fix: ZipInfo timestamp clamping (openpyxl XLSX generation no longer crashes)
- Fix: Python UTF-8 mode enabled by default
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/333)