### PR TITLE
[LXC] Enforces request.script_timeout in attach_run

### DIFF
--- a/src/lxc_common/src/lxc_bindings.rs
+++ b/src/lxc_common/src/lxc_bindings.rs
@@ -223,11 +223,15 @@ impl LxcContainer {
     /// Stdout/stderr are streamed live via the master fd; the returned
     /// strings are always empty. Callers needing captured output should run
     /// a self-contained `commandLine` and read it back from a file.
+    ///
+    /// `timeout: Some(d)` kills the child if it runs longer than `d` and
+    /// returns `Err("script timed out after {ms}ms")`.
     #[cfg(target_os = "linux")]
     pub fn attach_run(
         &self,
         command: &str,
         _working_directory: &str,
+        timeout: Option<std::time::Duration>,
     ) -> Result<(i32, String, String), String> {
         use mxc_pty::{run_with_pty, PtyOptions, PtyOutcome, Signal};
 
@@ -238,9 +242,7 @@ impl LxcContainer {
 
         let options = PtyOptions {
             unblock_signals: UNBLOCK,
-            // TODO: thread request.script_timeout through to here so the
-            // LXC backend can enforce script-level timeouts the same way
-            // the Seatbelt backend already does.
+            timeout,
             ..PtyOptions::default()
         };
 
@@ -248,9 +250,10 @@ impl LxcContainer {
             PtyOutcome::Exited(status) => {
                 Ok((status.code().unwrap_or(-1), String::new(), String::new()))
             }
-            // Unreachable today because we pass `timeout: None`, but cover
-            // it explicitly so the compiler catches future changes.
-            PtyOutcome::TimedOut => Err("lxc-attach timed out".to_string()),
+            PtyOutcome::TimedOut => {
+                let ms = timeout.map(|d| d.as_millis()).unwrap_or(0);
+                Err(format!("script timed out after {}ms", ms))
+            }
         }
     }
 
@@ -260,6 +263,7 @@ impl LxcContainer {
         &self,
         _command: &str,
         _working_directory: &str,
+        _timeout: Option<std::time::Duration>,
     ) -> Result<(i32, String, String), String> {
         Err("LxcContainer::attach_run is only supported on Linux".to_string())
     }

--- a/src/lxc_common/src/lxc_runner.rs
+++ b/src/lxc_common/src/lxc_runner.rs
@@ -206,10 +206,16 @@ impl LxcScriptRunner {
             }
         }
 
-        // Execute the script using lxc-attach (container is already running)
-        // TODO: Thread request.script_timeout through to attach_run for timeout enforcement.
+        // Execute the script using lxc-attach (container is already running).
+        // `script_timeout == 0` means "no timeout" per the SDK contract.
+        let timeout = if request.script_timeout == 0 {
+            None
+        } else {
+            Some(Duration::from_millis(u64::from(request.script_timeout)))
+        };
         let _ = writeln!(logger, "Executing script inside container...");
-        let result = container.attach_run(&request.script_code, &request.working_directory);
+        let result =
+            container.attach_run(&request.script_code, &request.working_directory, timeout);
 
         let response = match result {
             Ok((exit_code, stdout, stderr)) => ScriptResponse {

--- a/test_configs/lxc_timeout.json
+++ b/test_configs/lxc_timeout.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-LXC-Timeout-Test",
+  "containment": "lxc",
+  "platform": "linux",
+  "process": {
+    "commandLine": "echo 'Starting long task'; sleep 120; echo 'Should not reach here'",
+    "timeout": 5000
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "lxc": {
+    "distribution": "alpine",
+    "release": "3.23"
+  }
+}

--- a/test_scripts/run_lxc_all_tests.sh
+++ b/test_scripts/run_lxc_all_tests.sh
@@ -43,6 +43,7 @@ run_test() {
 run_test "Basic LXC" "$SCRIPT_DIR/run_lxc_basic_test.sh"
 run_test "LXC Filesystem" "$SCRIPT_DIR/run_lxc_filesystem_test.sh"
 run_test "LXC Network" "$SCRIPT_DIR/run_lxc_network_test.sh"
+run_test "LXC Timeout" "$SCRIPT_DIR/run_lxc_timeout_test.sh"
 
 echo "================================"
 echo "Results: $PASSED passed, $FAILED failed"

--- a/test_scripts/run_lxc_timeout_test.sh
+++ b/test_scripts/run_lxc_timeout_test.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# LXC script-timeout enforcement test.
+#
+# Regression coverage for issue #84: the LXC backend used to ignore
+# `process.timeout` from the config JSON, so a runaway script would run
+# forever inside the container. After the fix, attach_run threads the
+# timeout into `mxc_pty::PtyOptions` and the inner shell is killed and
+# reaped once the deadline passes.
+#
+# The config asks for a 120s sleep with a 5s timeout. A correct backend
+# kills it around the 5s mark with a non-zero exit code and a
+# "timed out" message on stderr.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+echo "Running LXC timeout test (5s timeout vs 120s sleep)..."
+
+STDERR_FILE=$(mktemp)
+trap 'rm -f "$STDERR_FILE"' EXIT
+
+START=$(date +%s)
+set +e
+"$LXC_EXEC" "$REPO_DIR/test_configs/lxc_timeout.json" 2>"$STDERR_FILE"
+EXIT_CODE=$?
+set -e
+ELAPSED=$(($(date +%s) - START))
+
+echo "Elapsed: ${ELAPSED}s, exit=$EXIT_CODE"
+echo "--- stderr ---"
+cat "$STDERR_FILE"
+echo "--- end stderr ---"
+
+# Exit code -1 from the runner becomes 255 on Unix. Anything non-zero
+# proves the run aborted; the message and elapsed checks below pin down
+# *why* it aborted so a future regression can't pass for the wrong reason.
+if [ "$EXIT_CODE" -eq 0 ]; then
+    echo "FAIL: Expected non-zero exit code for timed-out script, got 0."
+    exit 1
+fi
+
+if ! grep -q "timed out" "$STDERR_FILE"; then
+    echo "FAIL: stderr did not contain a 'timed out' message."
+    exit 1
+fi
+
+# Generous upper bound: 5s timeout + alpine boot/cleanup overhead. If the
+# script ran the full 120s, the timeout was clearly ignored.
+if [ "$ELAPSED" -gt 60 ]; then
+    echo "FAIL: Script ran for ${ELAPSED}s; timeout was not enforced."
+    exit 1
+fi
+
+echo "PASS: LXC script timeout enforced (~${ELAPSED}s, signaled via stderr)."


### PR DESCRIPTION
## 📖 Description
Wires `request.script_timeout` through to the LXC backend's `attach_run` so the inner shell is killed and reaped once the deadline elapses. Closes #84.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/342)