### PR TITLE
ci: enable Hyperlight backend in Windows x64 release build

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -71,6 +71,7 @@ extends:
                 os: windows
                 arch: x64
                 component: WXC
+                features: hyperlight
               - name: windows_arm64
                 os: windows
                 arch: arm64

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -112,6 +112,15 @@ jobs:
           testAllTargets: false
           buildAllTargets: false
 
+      # When the matrix entry specifies extra Cargo features (e.g.
+      # hyperlight), rebuild incrementally so the final binary includes
+      # them. Runs after the 1ES base build and before ESRP signing so
+      # the signed binary is the feature-enabled one.
+      - ${{ if item.features }}:
+        - script: cargo build --locked --release --target $(triplet) -p wxc --features ${{ item.features }}
+          displayName: Rebuild with features (${{ item.features }})
+          workingDirectory: $(workingDirectory)
+
       # Run clippy via plain cargo so the 1ES Setup task doesn't have to
       # source-install clippy-sarif (~8 min). The toolchain ships clippy
       # itself; `-D warnings` keeps the build gated.


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [.github/copilot-instructions.md](.github/copilot-instructions.md).

-----

## Summary

Enable the Hyperlight (Unikraft micro-VM) backend in the Windows x64 release build so that wxc-exec.exe ships with Hyperlight compiled in.

### Changes

| File | Change |
|------|--------|
| 1ES.Build.yml | Added eatures: hyperlight to the windows_x64 matrix entry |
| Rust.Build.Job.yml | Added conditional cargo build -p wxc --features hyperlight step after base 1ES build, before ESRP signing |

### How it works

1. 1ES task builds wxc-exec.exe normally (base build + tests + compliance)
2. New step incrementally rebuilds just the wxc crate with --features hyperlight - only recompiles the feature-gated code
3. ESRP signs the feature-enabled binary
4. Existing copy/publish/zip steps pick up the binary as usual

### Design decisions

- **x86_64 only**: hyperlight-unikraft-host is gated behind cfg(target_arch = "x86_64"). Only the Windows x64 matrix entry gets the feature.
- **Incremental rebuild**: Rather than modifying the 1ES Rust task (which does not expose a features input), we add a conditional script step. Since cargo is incremental, this only recompiles the feature-gated code.
- **Scoped to wxc crate**: Uses -p wxc to avoid rebuilding the entire workspace.
- **No new binaries**: Hyperlight compiles into wxc-exec.exe itself - no packaging changes needed.

### Follow-up items

- Add feature-aware test step (tests currently run without HL features)
- This PR also validates that CI has network access to the hyperlight-unikraft-host GitHub repo (git dependency)

Related Issues
- #309

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/344)