### PR TITLE
[WSLC] Remove runtime image auto-pull; add `--setup-wslc` subcommand

### DIFF
--- a/docs/wsl/wsl-container-getting-started.md
+++ b/docs/wsl/wsl-container-getting-started.md
@@ -67,7 +67,40 @@ Verify the binary starts without errors:
 > DLL is loaded at runtime only when the WSLC backend is invoked. All other
 > backends (Process Container, Windows Sandbox) work without it.
 
-## Step 3 — Verify WSLC is working
+## Step 3 — Pre-pull container images
+
+MXC is an execution layer and does **not** pull container images at run
+time. Pre-pull each image you intend to use into the WSLC SDK cache
+before invoking a config that references it:
+
+```powershell
+cd <repo-root>
+.\scripts\setup-wslc.ps1 -Image alpine:latest, python:3.12-alpine
+```
+
+Or pull a single image directly:
+
+```powershell
+.\src\target\x86_64-pc-windows-msvc\release\wxc-exec.exe `
+    --setup-wslc --image alpine:latest
+```
+
+Pulled images persist in the cache until you remove them — pay the
+cost once per image, not once per run.
+
+> **Storage path consistency:** the cache lives under the WSLC
+> `storage_path` (default `%TEMP%\mxc-wslc-sessions`). If your runtime
+> configs override `experimental.wslc.storagePath`, pass the same
+> value here with `-StoragePath` (or `--storage-path` on
+> `wxc-exec.exe`), otherwise the runner will not find what you just
+> pulled.
+
+If you forget this step, the next `wxc-exec.exe` invocation will fail
+fast with an actionable error pointing back at the `--setup-wslc`
+command — your image name pre-filled — so the first-time stumble is
+self-correcting.
+
+## Step 4 — Verify WSLC is working
 
 Run the included hello world example config from the repo root:
 
@@ -82,6 +115,23 @@ Expected output:
 Hello from WSL Container!
 Linux <hostname> 6.6.x-microsoft-standard-WSL2 ... x86_64 Linux
 ```
+
+## Two-step lifecycle
+
+Once setup is done, the day-to-day flow is two distinct commands:
+
+```powershell
+# (one-time per image) pre-pull into the SDK cache
+.\scripts\setup-wslc.ps1 -Image <image>
+
+# (any number of times) execute against the cached image
+.\src\target\x86_64-pc-windows-msvc\release\wxc-exec.exe `
+    --experimental my-config.json
+```
+
+This separation keeps `wxc-exec.exe` hermetic and fast at run time —
+the runner never reaches for the network, never blocks on a pull, and
+its failure modes are decoupled from registry availability.
 
 ## Usage
 
@@ -128,13 +178,25 @@ WSLC-specific settings go under `experimental.wslc` in the JSON config:
 
 ### Image sources
 
-**1. Pull from DockerHub (default):**
+> **All three sources require pre-pulling/importing before the runner
+> can use them.** The runner only checks the local cache; see
+> [Step 3](#step-3--pre-pull-container-images) for the setup commands.
+
+**1. Pre-pulled from DockerHub (default registry):**
+
+```powershell
+.\scripts\setup-wslc.ps1 -Image alpine:latest
+```
 
 ```json
 "experimental": { "wslc": { "image": "alpine:latest" } }
 ```
 
-**2. Pull from a custom registry (no auth):**
+**2. Pre-pulled from a custom registry (no auth):**
+
+```powershell
+.\scripts\setup-wslc.ps1 -Image ghcr.io/linuxserver/baseimage-alpine:3.21
+```
 
 ```json
 "experimental": { "wslc": { "image": "ghcr.io/linuxserver/baseimage-alpine:3.21" } }
@@ -142,7 +204,7 @@ WSLC-specific settings go under `experimental.wslc` in the JSON config:
 
 Tested registries: DockerHub, `mcr.microsoft.com`, `ghcr.io`, `quay.io`.
 
-**3. Import from a local tar file:**
+**3. Import from a local tar file (no pre-pull needed):**
 
 ```json
 "experimental": {
@@ -154,7 +216,8 @@ Tested registries: DockerHub, `mcr.microsoft.com`, `ghcr.io`, `quay.io`.
 ```
 
 Both `docker export` (rootfs) and `docker save` (image archive) formats are
-supported — the format is auto-detected.
+supported — the format is auto-detected. Tar import happens on first use;
+no separate `--setup-wslc` step is required.
 
 ### Network configuration
 
@@ -176,6 +239,7 @@ the container.
 | `WSLC backend not compiled` | Binary built without `--features wslc` | Rebuild with `build.bat --with-wslc` |
 | `Failed to load wslcsdk.dll` | DLL not in same directory as `wxc-exec.exe` | Copy `wslcsdk.dll` next to the binary |
 | `WSLC runtime not available` | WSL version too old or missing components | Update WSL with `wsl --update` or build from the [WSL repo](https://github.com/microsoft/WSL/tree/feature/wsl-for-apps) |
+| `WSLC image '<name>' not found locally` | Image was not pre-pulled, and no `imageTarPath` is set | Run `.\scripts\setup-wslc.ps1 -Image <name>` (or `wxc-exec.exe --setup-wslc --image <name>`); match the `-StoragePath` to your config's `experimental.wslc.storagePath` if set |
 | `WSLC is an experimental feature` | Missing `--experimental` flag | Add `--experimental` to CLI or `{ experimental: true }` in SDK |
 | `experimental mode` error in SDK | `SandboxSpawnOptions.experimental` not set | Pass `{ experimental: true }` to spawn functions |
 | Container exits with code -1 | Process failed or timed out | Check stderr output with `--debug` flag |

--- a/docs/wsl/wsl-container-support-plan.md
+++ b/docs/wsl/wsl-container-support-plan.md
@@ -317,8 +317,8 @@ Port mapping (new capability enabled by WSLC SDK):
 
 ### Phase 5 — CLI Updates & Setup (Future Work)
 
-**Status:** Not yet implemented. The features below are planned for a future
-iteration after the core WSLC backend (Phase 3) is validated.
+**Status:** Setup script implemented (issue #165). CLI `--container` /
+`--image` flags still pending.
 
 **Goal:** Give users a simple way to invoke Linux container execution from the
 command line, and a one-command setup for the WSLC SDK prerequisite.
@@ -331,9 +331,11 @@ CLI (`wxc/src/main.rs` — Clap definition):
 - Update `platform` command to show WSLC SDK status
 
 Setup script (`scripts/setup-wslc.ps1`):
-- Verify WSLC SDK is installed via `WslcCanRun()`
-- Pull default Linux image
-- Run a smoke test
+- ✅ Verifies WSLC SDK is installed via `WslcCanRun()` (inherited from
+  `init_and_load_sdk`) before attempting any pull
+- ✅ Pre-pulls the requested images via `wxc-exec.exe --setup-wslc`
+- ✅ Honors a custom `-StoragePath` so caches outside `%TEMP%` are supported
+- TODO: Run a smoke test after the pull (tracked separately)
 
 **Current workaround:** Users write JSON configs with `"containment": "wslc"`
 and run with `wxc-exec.exe --experimental --debug config.json`.
@@ -370,12 +372,22 @@ These need team decisions before implementation:
 
 ## Supported Image Sources
 
-The WSLC backend supports three ways to provide a container image:
+The WSLC backend supports three ways to provide a container image. MXC is
+an execution layer and **does not pull images at run time** — registry
+pulls are handled out of band, before the runner is invoked. If the
+runner is asked to start a container against an image that is not in the
+local cache, it fails fast with an actionable error pointing at the setup
+script.
 
-### 1. Pull from DockerHub
+### 1. Pre-pulled image from DockerHub
 
-The default path. Specify an image name in the `wslc` config section and the
-WSLC SDK pulls it from DockerHub automatically if not already cached locally.
+The default path. Pre-pull the image via the setup script (or
+`wxc-exec.exe --setup-wslc --image <name>` directly), then reference it
+from the config:
+
+```powershell
+.\scripts\setup-wslc.ps1 -Image alpine:latest
+```
 
 ```json
 {
@@ -390,14 +402,16 @@ WSLC SDK pulls it from DockerHub automatically if not already cached locally.
 }
 ```
 
-No additional setup needed — DockerHub is the default registry.
+### 2. Pre-pulled image from a custom registry (no auth)
 
-### 2. Pull from a custom registry (no auth)
+Specify the full registry URL as the image name. The WSLC SDK resolves
+it during the pull. Currently only registries that do not require
+authentication are supported; private registry auth is planned for a
+future WSLC SDK release.
 
-Specify the full registry URL as the image name. The WSLC SDK resolves it
-directly. Currently only registries that do not require authentication are
-supported. Private registry auth support is planned for a future WSLC SDK
-release.
+```powershell
+.\scripts\setup-wslc.ps1 -Image mcr.microsoft.com/cbl-mariner/base/core:2.0
+```
 
 ```json
 {
@@ -412,15 +426,19 @@ release.
 }
 ```
 
-**Setup:** Network access is required for the pull, so set
-`"defaultPolicy": "allow"` (or at minimum ensure the registry host is
-reachable). No Docker Desktop or local Docker daemon is needed — the WSLC SDK
-handles the pull internally.
+**Setup:** Network access is required at pull time. No Docker Desktop or
+local Docker daemon is needed — the WSLC SDK handles the pull internally.
 
 **Tested registries:**
 - `mcr.microsoft.com` (Microsoft Container Registry)
 - `ghcr.io` (GitHub Container Registry, public images)
 - `quay.io` (Red Hat Quay, public images)
+
+> **Note on storage path:** the setup script and the runner must share
+> the same `storage_path`. The runner default is
+> `%TEMP%\mxc-wslc-sessions`; if your config sets
+> `experimental.wslc.storagePath`, pass the same path to the setup
+> script with `-StoragePath`.
 
 ### 3. Import from a local tar file
 

--- a/scripts/setup-wslc.ps1
+++ b/scripts/setup-wslc.ps1
@@ -1,0 +1,134 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Pre-pull WSLC container images into the local cache.
+
+.DESCRIPTION
+    MXC is an execution layer and does not pull container images at run time.
+    Instead, operators populate the WSLC SDK image cache out of band — this
+    script is the canonical entry point. Each image is pulled via
+    `wxc-exec.exe --setup-wslc --image <name>`, which opens a minimal WSLC
+    session against the configured `storage_path` and invokes
+    `WslcPullSessionImage`. The pulled images persist in that storage path
+    and become visible to subsequent runtime executions.
+
+    The storage path you pass here MUST match the value used at run time
+    (the `experimental.wslc.storagePath` field of the config, or the
+    runner's default of `%TEMP%\mxc-wslc-sessions` when omitted).
+
+.PARAMETER Image
+    One or more image references to pre-pull. Defaults to the images
+    referenced by the in-repo test configs.
+
+.PARAMETER WxcExecPath
+    Explicit path to wxc-exec.exe. When omitted, the script probes the
+    standard cargo target directories.
+
+.PARAMETER StoragePath
+    WSLC storage path to populate. When omitted, the runner default
+    (`%TEMP%\mxc-wslc-sessions`) is used. Set this if your runtime configs
+    override `experimental.wslc.storagePath`.
+
+.PARAMETER DebugLogs
+    Enable verbose logging from wxc-exec (passes `--debug`).
+
+.PARAMETER Force
+    Continue pulling subsequent images even if one fails.
+
+.EXAMPLE
+    .\setup-wslc.ps1
+    Pulls the default image set (alpine:latest, python:3.12-alpine).
+
+.EXAMPLE
+    .\setup-wslc.ps1 -Image alpine:latest, ghcr.io/owner/image:tag
+    Pulls specific images.
+
+.EXAMPLE
+    .\setup-wslc.ps1 -StoragePath C:\wslc-cache
+    Pulls into a non-default cache directory.
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$Image = @("alpine:latest", "python:3.12-alpine"),
+    [string]$WxcExecPath,
+    [string]$StoragePath,
+    [switch]$DebugLogs,
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+# Discover wxc-exec.exe -- prefer explicit path, then probe target dirs.
+$Target = "x86_64-pc-windows-msvc"
+if ($WxcExecPath) {
+    $WxcExec = $WxcExecPath
+} else {
+    $CandidatePaths = @(
+        (Join-Path $RepoRoot "src\target\$Target\release\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\release\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\$Target\debug\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\debug\wxc-exec.exe")
+    )
+    $WxcExec = $CandidatePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+
+if (-not $WxcExec -or -not (Test-Path $WxcExec)) {
+    Write-Host "ERROR: wxc-exec.exe not found." -ForegroundColor Red
+    Write-Host "Build with: cargo build --release --features wslc --target $Target" -ForegroundColor Yellow
+    Write-Host "Or pass -WxcExecPath explicitly." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "`nWSLC image setup" -ForegroundColor Cyan
+Write-Host "================" -ForegroundColor Cyan
+Write-Host "Binary       : $WxcExec" -ForegroundColor Gray
+if ($StoragePath) {
+    Write-Host "Storage path : $StoragePath" -ForegroundColor Gray
+} else {
+    Write-Host "Storage path : (default) %TEMP%\mxc-wslc-sessions" -ForegroundColor Gray
+}
+Write-Host "Images       : $($Image -join ', ')`n" -ForegroundColor Gray
+
+$failed = @()
+foreach ($img in $Image) {
+    Write-Host "  $img ... " -NoNewline
+    $wxcArgs = @("--setup-wslc", "--image", $img)
+    if ($StoragePath) {
+        $wxcArgs += @("--storage-path", $StoragePath)
+    }
+    if ($DebugLogs) {
+        $wxcArgs += "--debug"
+    }
+
+    $prevPref = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $output = & $WxcExec @wxcArgs 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    $ErrorActionPreference = $prevPref
+
+    if ($exitCode -eq 0) {
+        Write-Host "OK" -ForegroundColor Green
+    } else {
+        Write-Host "FAIL (exit $exitCode)" -ForegroundColor Red
+        $output -split "`n" | Where-Object { $_.Trim() -ne "" } | ForEach-Object {
+            Write-Host "    > $($_.TrimEnd())" -ForegroundColor Gray
+        }
+        $failed += $img
+        if (-not $Force) {
+            break
+        }
+    }
+}
+
+Write-Host ""
+if ($failed.Count -eq 0) {
+    Write-Host "All images pulled successfully." -ForegroundColor Green
+    exit 0
+} else {
+    Write-Host "Failed images: $($failed -join ', ')" -ForegroundColor Red
+    exit 1
+}

--- a/scripts/setup-wslc.ps1
+++ b/scripts/setup-wslc.ps1
@@ -19,8 +19,11 @@
     runner's default of `%TEMP%\mxc-wslc-sessions` when omitted).
 
 .PARAMETER Image
-    One or more image references to pre-pull. Defaults to the images
-    referenced by the in-repo test configs.
+    One or more image references to pre-pull. Defaults to a small
+    starter set (alpine:latest, python:3.12-alpine) suitable for a quick
+    smoke test. To populate the cache for the full WSLC test suite, run
+    test_scripts\run_wslc_all_tests.ps1, which invokes this script with
+    the complete image list.
 
 .PARAMETER WxcExecPath
     Explicit path to wxc-exec.exe. When omitted, the script probes the

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -513,14 +513,24 @@ impl WSLContainerRunner {
             // MXC is an execution layer; image management is out of band. The
             // setup script `scripts\setup-wslc.ps1` (or `wxc-exec.exe
             // --setup-wslc --image <name>`) pre-pulls images into the same
-            // WSLC storage_path the runner uses.
+            // WSLC storage_path the runner uses. When the config overrides
+            // `experimental.wslc.storagePath`, include it in the suggested
+            // commands so the operator's first copy-paste lands the image in
+            // the cache the next run will actually read.
+            let (storage_arg_wxc, storage_arg_ps) = match &self.config.storage_path {
+                Some(sp) => (
+                    format!(" --storage-path \"{}\"", sp),
+                    format!(" -StoragePath \"{}\"", sp),
+                ),
+                None => (String::new(), String::new()),
+            };
             return Err(ScriptResponse::error(&format!(
                 "WSLC image '{}' not found locally. Pre-pull it with: \
-                 wxc-exec.exe --setup-wslc --image {} \
-                 (or scripts\\setup-wslc.ps1 -Image {}). \
+                 wxc-exec.exe --setup-wslc --image {}{} \
+                 (or scripts\\setup-wslc.ps1 -Image {}{}). \
                  MXC does not pull images at run time; \
                  see docs/wsl/wsl-container-support-plan.md.",
-                image_name, image_name, image_name
+                image_name, image_name, storage_arg_wxc, image_name, storage_arg_ps,
             )));
         }
 

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -510,36 +510,105 @@ impl WSLContainerRunner {
         } else if let Some(tar_path) = &self.config.image_tar_path {
             Self::import_image_from_tar(sdk, session, image_name, tar_path, logger)?;
         } else {
-            // Pull from registry
-            // TODO: Move image pulling to a setup script (scripts/setup-wslc.ps1) as
-            // described in docs/wsl-container-support-plan.md Phase 5. MXC is an execution
-            // layer — image management should be handled externally. For now, auto-pull is
-            // used during development/testing.
-            let _ = writeln!(
-                logger,
-                "[WSLC] Image '{}' not found locally, attempting pull...",
-                image_name
-            );
-            let uri_cstr = format!("{}\0", image_name);
-            let pull_opts = WslcPullImageOptions {
-                uri: uri_cstr.as_bytes().as_ptr() as PCSTR,
-                progress_callback: None,
-                progress_callback_context: ptr::null_mut(),
-                auth_info: ptr::null(),
-            };
-            let mut err_msg = CoTaskMemPWSTR::null();
-            let hr = (sdk.WslcPullSessionImage)(session, &pull_opts, err_msg.as_mut_ptr());
-            if hr != S_OK {
-                let msg = err_msg.to_string_lossy();
-                return Err(sdk_error(
-                    &format!("Failed to pull image '{}'", image_name),
-                    hr,
-                    &msg,
-                ));
-            }
-            let _ = writeln!(logger, "[WSLC] Image '{}' pulled successfully", image_name);
+            // MXC is an execution layer; image management is out of band. The
+            // setup script `scripts\setup-wslc.ps1` (or `wxc-exec.exe
+            // --setup-wslc --image <name>`) pre-pulls images into the same
+            // WSLC storage_path the runner uses.
+            return Err(ScriptResponse::error(&format!(
+                "WSLC image '{}' not found locally. Pre-pull it with: \
+                 wxc-exec.exe --setup-wslc --image {} \
+                 (or scripts\\setup-wslc.ps1 -Image {}). \
+                 MXC does not pull images at run time; \
+                 see docs/wsl/wsl-container-support-plan.md.",
+                image_name, image_name, image_name
+            )));
         }
 
+        Ok(())
+    }
+
+    /// Pre-pull a WSLC image into the SDK's local image cache.
+    ///
+    /// Loads the SDK, opens a minimal session against `storage_path` (or the
+    /// runner default), pulls `image_name`, then releases the session. The
+    /// image persists in the storage path's cache for subsequent runner
+    /// invocations that pass the same `storage_path`.
+    ///
+    /// # Safety
+    /// Must be called once per process before any other WSLC SDK functions
+    /// (it initialises COM via `init_and_load_sdk`).
+    pub unsafe fn setup_pull_image(
+        image_name: &str,
+        storage_path: Option<&str>,
+        logger: &mut Logger,
+    ) -> Result<(), String> {
+        let sdk = match Self::init_and_load_sdk(logger) {
+            Ok(s) => s,
+            Err(resp) => return Err(resp.error_message),
+        };
+
+        let storage_path_str = storage_path.map(|s| s.to_string()).unwrap_or_else(|| {
+            std::env::temp_dir()
+                .join("mxc-wslc-sessions")
+                .to_string_lossy()
+                .to_string()
+        });
+        let session_name: Vec<u16> = to_wide("mxc-setup-wslc");
+        let storage_path_wide: Vec<u16> = to_wide(&storage_path_str);
+
+        let mut settings = std::mem::zeroed::<WslcSessionSettings>();
+        let hr = (sdk.WslcInitSessionSettings)(
+            session_name.as_ptr(),
+            storage_path_wide.as_ptr(),
+            &mut settings,
+        );
+        if hr != S_OK {
+            return Err(format!(
+                "WslcInitSessionSettings failed (HRESULT 0x{:08X})",
+                hr as u32
+            ));
+        }
+
+        let mut session: WslcSession = ptr::null_mut();
+        let mut create_err = CoTaskMemPWSTR::null();
+        let hr = (sdk.WslcCreateSession)(&mut settings, &mut session, create_err.as_mut_ptr());
+        if hr != S_OK {
+            return Err(format!(
+                "WslcCreateSession failed (HRESULT 0x{:08X}): {}",
+                hr as u32,
+                create_err.to_string_lossy()
+            ));
+        }
+        let _session_guard =
+            WslcSessionGuard::from_raw(session, sdk.WslcTerminateSession, sdk.WslcReleaseSession);
+
+        let _ = writeln!(
+            logger,
+            "[WSLC setup] Pulling image '{}' into {}",
+            image_name, storage_path_str
+        );
+        let uri_cstr = format!("{}\0", image_name);
+        let pull_opts = WslcPullImageOptions {
+            uri: uri_cstr.as_bytes().as_ptr() as PCSTR,
+            progress_callback: None,
+            progress_callback_context: ptr::null_mut(),
+            auth_info: ptr::null(),
+        };
+        let mut pull_err = CoTaskMemPWSTR::null();
+        let hr = (sdk.WslcPullSessionImage)(session, &pull_opts, pull_err.as_mut_ptr());
+        if hr != S_OK {
+            return Err(format!(
+                "WslcPullSessionImage('{}') failed (HRESULT 0x{:08X}): {}",
+                image_name,
+                hr as u32,
+                pull_err.to_string_lossy()
+            ));
+        }
+        let _ = writeln!(
+            logger,
+            "[WSLC setup] Image '{}' pulled successfully",
+            image_name
+        );
         Ok(())
     }
 

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -79,6 +79,25 @@ struct Cli {
     /// the new bits. Requires --setup-hyperlight.
     #[arg(long, requires = "setup_hyperlight")]
     force: bool,
+
+    /// Pre-pull a WSLC container image into the local image cache and exit.
+    /// MXC is an execution layer and does not pull images at run time; this
+    /// flag (or `scripts/setup-wslc.ps1`) is how operators populate the cache.
+    /// Requires `--image` to specify which image to pull.
+    #[arg(long = "setup-wslc")]
+    setup_wslc: bool,
+
+    /// Image reference to pre-pull (e.g. `alpine:latest`,
+    /// `ghcr.io/owner/image:tag`). Required with `--setup-wslc`.
+    #[arg(long = "image", requires = "setup_wslc")]
+    image: Option<String>,
+
+    /// Optional WSLC storage path. When omitted the runner default is used
+    /// (`%TEMP%\mxc-wslc-sessions`). Pass the same value here that your
+    /// runtime configs set in `experimental.wslc.storagePath`, otherwise
+    /// the runner will not find the pulled image. Requires `--setup-wslc`.
+    #[arg(long = "storage-path", requires = "setup_wslc")]
+    storage_path: Option<String>,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -215,6 +234,56 @@ fn main() {
         #[cfg(not(all(feature = "hyperlight", target_arch = "x86_64")))]
         {
             eprintln!("Error: --setup-hyperlight requires x86_64 (Hyperlight needs KVM or WHP)");
+            process::exit(1);
+        }
+    }
+
+    // --setup-wslc: pre-pull a WSLC image into the local cache and exit.
+    // Runs before config parsing so the user doesn't need a JSON file just
+    // to populate images. Clap enforces that `--image` is present.
+    if cli.setup_wslc {
+        #[cfg(feature = "wslc")]
+        {
+            let image = match cli.image.as_deref() {
+                Some(s) if !s.is_empty() => s,
+                _ => {
+                    eprintln!("Error: --setup-wslc requires --image <name>");
+                    process::exit(1);
+                }
+            };
+            let mut logger = Logger::new(if cli.debug {
+                Mode::Console
+            } else {
+                Mode::Buffer
+            });
+            // SAFETY: setup_pull_image is the canonical SDK-loading entry
+            // point for this subcommand and is called exactly once before
+            // process exit. It owns the COM init contract documented on
+            // `init_and_load_sdk`.
+            let result = unsafe {
+                wslc_common::wsl_container_runner::WSLContainerRunner::setup_pull_image(
+                    image,
+                    cli.storage_path.as_deref(),
+                    &mut logger,
+                )
+            };
+            // Flush logger buffer to stderr regardless of outcome so the
+            // user can see what happened.
+            let buf = logger.get_buffer().to_string();
+            if !buf.is_empty() {
+                eprint!("{}", buf);
+            }
+            match result {
+                Ok(()) => process::exit(0),
+                Err(msg) => {
+                    eprintln!("wslc setup failed: {msg}");
+                    process::exit(1);
+                }
+            }
+        }
+        #[cfg(not(feature = "wslc"))]
+        {
+            eprintln!("Error: WSLC backend not compiled. Rebuild with --features wslc.");
             process::exit(1);
         }
     }

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -6,8 +6,15 @@
 # Cannot run in GitHub Actions CI (needs WSL2 + WSLC runtime).
 #
 # Usage:
-#   .\run_wslc_all_tests.ps1              # release build (default)
+#   .\run_wslc_all_tests.ps1              # release build (default), pulls images first
 #   .\run_wslc_all_tests.ps1 -Debug       # debug build
+#   .\run_wslc_all_tests.ps1 -SkipSetup   # skip pre-pull (assume cache is warm)
+#
+# Image pre-pull:
+#   This script invokes scripts\setup-wslc.ps1 as a preflight to populate the
+#   WSLC image cache. MXC's runner no longer auto-pulls images at run time
+#   (see issue #165), so the cache must be warmed before any test that
+#   references a registry image. Pass -SkipSetup to bypass.
 #
 # Prerequisites for tar import tests:
 #
@@ -26,7 +33,8 @@
 
 param(
     [switch]$Debug,
-    [string]$WxcExecPath
+    [string]$WxcExecPath,
+    [switch]$SkipSetup
 )
 
 $ErrorActionPreference = "Stop"
@@ -54,6 +62,34 @@ if (-not $WxcExec -or -not (Test-Path $WxcExec)) {
     Write-Host "Build with: cargo build --features wslc $(if (-not $Debug) { '--release ' })--target $Target" -ForegroundColor Yellow
     Write-Host "Or pass -WxcExecPath explicitly." -ForegroundColor Yellow
     exit 1
+}
+
+# Preflight: ensure the WSLC image cache is populated. The runner no longer
+# auto-pulls (see scripts\setup-wslc.ps1 and #165). Skipping is supported for
+# the common case where the caller has already pre-pulled or wants to test
+# a hermetic environment.
+if (-not $SkipSetup) {
+    $SetupScript = Join-Path $RepoRoot "scripts\setup-wslc.ps1"
+    if (Test-Path $SetupScript) {
+        Write-Host "Pre-pulling WSLC images (pass -SkipSetup to skip)..." -ForegroundColor Cyan
+        # Pull every image referenced by the wslc_*.json test configs except
+        # the tar-import variants (those are imported at run time from the
+        # caller-supplied tar file, not pulled from a registry).
+        $images = @(
+            "alpine:latest",
+            "python:3.12-alpine",
+            "mcr.microsoft.com/cbl-mariner/base/core:2.0",
+            "ghcr.io/linuxserver/baseimage-alpine:3.21",
+            "quay.io/fedora/fedora-minimal:latest"
+        )
+        & $SetupScript -WxcExecPath $WxcExec -Image $images -Force
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "WARN: setup-wslc.ps1 reported failures; continuing with tests anyway." -ForegroundColor Yellow
+        }
+        Write-Host ""
+    } else {
+        Write-Host "WARN: $SetupScript not found; assuming images are pre-pulled." -ForegroundColor Yellow
+    }
 }
 
 # Helper: run a single WSLC test config


### PR DESCRIPTION
## 📖 Description
The WSLC runner currently auto-pulls a missing image at run time from inside `resolve_image`. This PR removes that fallback and moves image management to an explicit, out-of-band setup step:
 
 - `wxc-exec.exe --setup-wslc --image <name> [--storage-path <path>]`
 - `scripts\setup-wslc.ps1 -Image <name> [-StoragePath <path>]`
 
At run time the runner now fails fast with a clear, actionable error message that names the missing image and the exact command to pull it.

Closes #165

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [x] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/345)