### PR TITLE
Address PR #294 review feedback

### DIFF
--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -7,12 +7,10 @@ use std::process;
 use std::time::Instant;
 
 use clap::Parser;
-use windows::Win32::Security::Isolation::DeleteAppContainerProfile;
-use wxc_common::appcontainer_runner::AppContainerScriptRunner;
+use wxc_common::appcontainer_runner::{delete_app_container_profile, AppContainerScriptRunner};
 use wxc_common::base_container_runner::BaseContainerRunner;
 use wxc_common::config_parser::{is_base_container_version, load_mxc_request, ParseError};
 use wxc_common::diagnostic::DiagnosticConfig;
-use wxc_common::filesystem_bfs::FileSystemBfsManager;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
 use wxc_common::hyperlight_runner::HyperlightScriptRunner;
 #[cfg(feature = "isolation_session")]
@@ -146,44 +144,6 @@ fn print_error_envelope(error: &MxcError) {
             println!(
                 r#"{{"error":{{"code":"backend_error","message":"failed to serialise error envelope"}}}}"#
             );
-        }
-    }
-}
-
-fn delete_app_container_profile(name: &str, logger: &mut Logger) -> bool {
-    // Clear BFS policy first. We need an absolute path to `bfscfg.exe`
-    // here for the same security reason as the runner — pass an
-    // authoritative path to `CreateProcessW` rather than a bare name.
-    // If resolution fails (rare; only on hosts where
-    // `GetWindowsDirectoryW` itself returns 0), we log and skip the BFS
-    // clearing step; deleting the AppContainer profile below is still
-    // worth attempting.
-    let bfscfg_path = match wxc_common::fallback_detector::find_bfscfg_exe() {
-        Ok(p) => p,
-        Err(e) => {
-            logger.log_line(&format!(
-                "Skipping BFS policy clear: could not resolve bfscfg.exe ({e})"
-            ));
-            None
-        }
-    };
-    let mut bfs = FileSystemBfsManager::new(name.to_string(), bfscfg_path);
-    bfs.remove_configuration(logger);
-
-    // Delete the AppContainer profile
-    let wide_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
-    let hstring = windows::core::HSTRING::from_wide(&wide_name[..wide_name.len() - 1]);
-    match unsafe { DeleteAppContainerProfile(&hstring) } {
-        Ok(()) => {
-            logger.log_line(&format!("Deleted AppContainer profile: {}", name));
-            true
-        }
-        Err(e) => {
-            logger.log_line(&format!(
-                "Failed to delete AppContainer profile '{}': {}",
-                name, e
-            ));
-            false
         }
     }
 }

--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -7,7 +7,7 @@ use windows::Win32::Foundation::{
     GetLastError, LocalFree, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::Security::Isolation::{
-    CreateAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
+    CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
 use windows::Win32::Security::PSID;
 use windows::Win32::System::Threading::{
@@ -646,6 +646,37 @@ impl ScriptRunner for AppContainerScriptRunner {
         }
 
         response
+    }
+}
+
+/// Delete the AppContainer profile created via [`CreateAppContainerProfile`]
+/// and clear any BFS policy registered against it.
+///
+/// This is the explicit cleanup entry point used by `wxc-exec --delete`,
+/// kept next to the create/setup path on `AppContainerScriptRunner` so
+/// both ends of the profile lifecycle live in the same module.
+///
+/// The BFS-clear step is best-effort: it delegates to
+/// [`FileSystemBfsManager::clear_policy`], which resolves `bfscfg.exe`
+/// itself and logs (rather than fails) when the resolver returns no
+/// path. The profile delete is still attempted in that case.
+pub fn delete_app_container_profile(name: &str, logger: &mut Logger) -> bool {
+    crate::filesystem_bfs::FileSystemBfsManager::clear_policy(name, logger);
+
+    let wide_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
+    let hstring = windows::core::HSTRING::from_wide(&wide_name[..wide_name.len() - 1]);
+    match unsafe { DeleteAppContainerProfile(&hstring) } {
+        Ok(()) => {
+            logger.log_line(&format!("Deleted AppContainer profile: {}", name));
+            true
+        }
+        Err(e) => {
+            logger.log_line(&format!(
+                "Failed to delete AppContainer profile '{}': {}",
+                name, e
+            ));
+            false
+        }
     }
 }
 


### PR DESCRIPTION
Move `delete_app_container_profile` from `src/wxc/src/main.rs` into `src/wxc_common/src/appcontainer_runner.rs`, next to `AppContainerScriptRunner` (which owns the create/setup path). Both ends of the AppContainer profile lifecycle now live in the same module.

While moving the function, replace the open-coded
`FileSystemBfsManager::new(...) + remove_configuration(...)` block with `FileSystemBfsManager::clear_policy(name, logger)`. The original code created a fresh manager and called `remove_configuration` without first setting `configured = true`, so the early-return in `remove_configuration` made the BFS-clear step a silent no-op for `wxc-exec --delete`. `clear_policy` is the helper purpose-built for externally-created sandboxes and sets `configured = true` itself, so the cleanup actually runs now.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/347)