### PR TITLE
Enforce script timeout in Hyperlight runner

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -843,8 +843,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.5.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.5.0#ca05c5af35f1728bbce94e17677a18200b7247a6"
+version = "0.6.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.6.0#d8524a99ad4855c7c9f1d0c17381b884386596b0"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -21,7 +21,7 @@ getrandom = { workspace = true }
 semver = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.5.0", optional = true }
+hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.6.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true }

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -536,7 +536,19 @@ impl ScriptRunner for HyperlightScriptRunner {
             }
         };
 
-        match rt.run_code(&request.script_code) {
+        let result = if request.script_timeout > 0 {
+            let timeout =
+                std::time::Duration::from_millis(u64::from(request.script_timeout));
+            logger.log_line(&format!(
+                "hyperlight: timeout set to {}ms",
+                request.script_timeout
+            ));
+            rt.run_code_with_timeout(&request.script_code, timeout)
+        } else {
+            rt.run_code(&request.script_code)
+        };
+
+        match result {
             Ok(timing) => {
                 logger.log_line(&format!(
                     "hyperlight: run ok (restore={:.1}ms call={:.1}ms exit={})",

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -537,8 +537,7 @@ impl ScriptRunner for HyperlightScriptRunner {
         };
 
         let result = if request.script_timeout > 0 {
-            let timeout =
-                std::time::Duration::from_millis(u64::from(request.script_timeout));
+            let timeout = std::time::Duration::from_millis(u64::from(request.script_timeout));
             logger.log_line(&format!(
                 "hyperlight: timeout set to {}ms",
                 request.script_timeout

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -201,7 +201,7 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     let opts = pyhl::InstallOptions {
         home: &home,
         source: pyhl::InstallSource::Ghcr {
-            tag: Some("v0.5.0"),
+            tag: Some("v0.6.0"),
         },
         mounts: &[],
         network: None,

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -624,7 +624,7 @@ fn hyperlight_suite() {
         },
         HyperlightCase {
             config: "hyperlight_timeout.json",
-            description: "time.sleep(120) killed by 5s timeout",
+            description: "time.sleep(120) killed by 1s timeout",
             expected_exit: -1,
             output_contains: Some("timed out"),
         },

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -622,6 +622,12 @@ fn hyperlight_suite() {
             expected_exit: 0,
             output_contains: Some("BLOCKED"),
         },
+        HyperlightCase {
+            config: "hyperlight_timeout.json",
+            description: "time.sleep(120) killed by 5s timeout",
+            expected_exit: -1,
+            output_contains: Some("timed out"),
+        },
     ];
 
     let mut failures = Vec::new();

--- a/test_configs/hyperlight_timeout.json
+++ b/test_configs/hyperlight_timeout.json
@@ -1,0 +1,7 @@
+{
+    "process": {
+        "commandLine": "import time; time.sleep(120); print('should not reach here')",
+        "timeout": 5000
+    },
+    "containment": "hyperlight"
+}

--- a/test_configs/hyperlight_timeout.json
+++ b/test_configs/hyperlight_timeout.json
@@ -1,7 +1,7 @@
 {
     "process": {
         "commandLine": "import time; time.sleep(120); print('should not reach here')",
-        "timeout": 5000
+        "timeout": 1000
     },
     "containment": "hyperlight"
 }


### PR DESCRIPTION
## Summary

- Update hyperlight-unikraft to v0.6.0 which adds `run_code_with_timeout()` with cancellable host sleep
- When `script_timeout` is set in the config, the Hyperlight runner uses the timeout variant to kill long-running or sleeping guest code promptly; otherwise `run_code()` is used as before
- Add `hyperlight_timeout.json` test config and e2e test case (`time.sleep(120)` killed by 5s timeout)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/351)