### PR TITLE
Fix: deniedPaths now overrides readonlyPaths/readwritePaths in BFS

### DIFF
--- a/src/wxc_common/src/filesystem_bfs.rs
+++ b/src/wxc_common/src/filesystem_bfs.rs
@@ -57,15 +57,14 @@ impl FileSystemBfsManager {
                 ));
                 continue;
             }
-            let mut inherit = test_for_root_path(path);
+            let inherit = test_for_root_path(path);
             if inherit && has_denied_children(path, &policy.denied_paths) {
                 logger.log_line(&format!(
-                    "Warning: readwrite path {:?} has denied sub-paths; \
-                     disabling inheritance to limit scope. \
-                     BFS cannot deny individual sub-paths under a granted parent.",
+                    "Warning: readwrite path {:?} has denied sub-paths that \
+                     cannot be enforced. BFS has no deny primitive — sub-paths \
+                     under a granted parent with inheritance will remain accessible.",
                     path
                 ));
-                inherit = false;
             }
             if let Err(e) = self.add_bfs_path(path, inherit, logger) {
                 self.remove_configuration(logger);
@@ -82,15 +81,14 @@ impl FileSystemBfsManager {
                 ));
                 continue;
             }
-            let mut inherit = test_for_root_path(path);
+            let inherit = test_for_root_path(path);
             if inherit && has_denied_children(path, &policy.denied_paths) {
                 logger.log_line(&format!(
-                    "Warning: readonly path {:?} has denied sub-paths; \
-                     disabling inheritance to limit scope. \
-                     BFS cannot deny individual sub-paths under a granted parent.",
+                    "Warning: readonly path {:?} has denied sub-paths that \
+                     cannot be enforced. BFS has no deny primitive — sub-paths \
+                     under a granted parent with inheritance will remain accessible.",
                     path
                 ));
-                inherit = false;
             }
             if let Err(e) = self.add_readonly_bfs_path(path, inherit, logger) {
                 self.remove_configuration(logger);

--- a/src/wxc_common/src/filesystem_bfs.rs
+++ b/src/wxc_common/src/filesystem_bfs.rs
@@ -50,7 +50,23 @@ impl FileSystemBfsManager {
         }
 
         for path in &policy.readwrite_paths {
-            let inherit = test_for_root_path(path);
+            if is_denied(path, &policy.denied_paths) {
+                logger.log_line(&format!(
+                    "Skipping readwrite path {:?} — overridden by deniedPaths",
+                    path
+                ));
+                continue;
+            }
+            let mut inherit = test_for_root_path(path);
+            if inherit && has_denied_children(path, &policy.denied_paths) {
+                logger.log_line(&format!(
+                    "Warning: readwrite path {:?} has denied sub-paths; \
+                     disabling inheritance to limit scope. \
+                     BFS cannot deny individual sub-paths under a granted parent.",
+                    path
+                ));
+                inherit = false;
+            }
             if let Err(e) = self.add_bfs_path(path, inherit, logger) {
                 self.remove_configuration(logger);
                 return Err(e);
@@ -59,7 +75,23 @@ impl FileSystemBfsManager {
         }
 
         for path in &policy.readonly_paths {
-            let inherit = test_for_root_path(path);
+            if is_denied(path, &policy.denied_paths) {
+                logger.log_line(&format!(
+                    "Skipping readonly path {:?} — overridden by deniedPaths",
+                    path
+                ));
+                continue;
+            }
+            let mut inherit = test_for_root_path(path);
+            if inherit && has_denied_children(path, &policy.denied_paths) {
+                logger.log_line(&format!(
+                    "Warning: readonly path {:?} has denied sub-paths; \
+                     disabling inheritance to limit scope. \
+                     BFS cannot deny individual sub-paths under a granted parent.",
+                    path
+                ));
+                inherit = false;
+            }
             if let Err(e) = self.add_readonly_bfs_path(path, inherit, logger) {
                 self.remove_configuration(logger);
                 return Err(e);
@@ -174,6 +206,44 @@ impl FileSystemBfsManager {
     }
 }
 
+/// Returns `true` if `path` is equal to, or is a child of, any entry in
+/// `denied_paths`. Comparison is case-insensitive and separator-normalized
+/// to match Windows filesystem semantics.
+fn is_denied(path: &str, denied_paths: &[String]) -> bool {
+    let normalized = normalize_for_comparison(path);
+    denied_paths.iter().any(|denied| {
+        let denied_norm = normalize_for_comparison(denied);
+        // Exact match
+        if normalized == denied_norm {
+            return true;
+        }
+        // Child path: `path` starts with `denied` + separator
+        let prefix = format!("{}\\", denied_norm);
+        normalized.starts_with(&prefix)
+    })
+}
+
+/// Returns `true` if any entry in `denied_paths` is a child of `path`.
+/// This detects the case where BFS would grant broad access (e.g. `C:\Users`
+/// with inheritance) that covers a denied sub-path (e.g. `C:\Users\secret`).
+/// BFS has no deny primitive, so we cannot selectively exclude sub-paths
+/// once a parent is granted.
+fn has_denied_children(path: &str, denied_paths: &[String]) -> bool {
+    let normalized = normalize_for_comparison(path);
+    let prefix = format!("{}\\", normalized);
+    denied_paths.iter().any(|denied| {
+        let denied_norm = normalize_for_comparison(denied);
+        denied_norm.starts_with(&prefix)
+    })
+}
+
+/// Lowercase, normalize separators to `\`, and strip trailing separator
+/// for consistent comparison.
+fn normalize_for_comparison(path: &str) -> String {
+    let lower = path.to_lowercase().replace('/', "\\");
+    lower.trim_end_matches('\\').to_string()
+}
+
 /// Returns `false` for `C:\` (no inheritance), `true` for all other paths.
 fn test_for_root_path(path: &str) -> bool {
     path != "C:\\"
@@ -286,5 +356,76 @@ mod tests {
             cmd,
             r#"bfscfg.exe --addpolicy --filename "C:\My Folder\\" --appid test"#
         );
+    }
+
+    #[test]
+    fn is_denied_exact_match() {
+        let denied = vec![r"C:\temp".to_string()];
+        assert!(is_denied(r"C:\temp", &denied));
+    }
+
+    #[test]
+    fn is_denied_case_insensitive() {
+        let denied = vec![r"C:\Temp".to_string()];
+        assert!(is_denied(r"C:\temp", &denied));
+        assert!(is_denied(r"C:\TEMP", &denied));
+    }
+
+    #[test]
+    fn is_denied_child_path() {
+        let denied = vec![r"C:\temp".to_string()];
+        assert!(is_denied(r"C:\temp\subdir", &denied));
+        assert!(is_denied(r"C:\temp\file.txt", &denied));
+    }
+
+    #[test]
+    fn is_denied_not_prefix_of_different_path() {
+        let denied = vec![r"C:\temp".to_string()];
+        // "C:\temporary" should NOT be denied — it's not under "C:\temp\"
+        assert!(!is_denied(r"C:\temporary", &denied));
+    }
+
+    #[test]
+    fn is_denied_no_match() {
+        let denied = vec![r"C:\secrets".to_string()];
+        assert!(!is_denied(r"C:\temp", &denied));
+        assert!(!is_denied(r"C:\Users", &denied));
+    }
+
+    #[test]
+    fn is_denied_trailing_separator() {
+        let denied = vec![r"C:\temp\".to_string()];
+        assert!(is_denied(r"C:\temp", &denied));
+        assert!(is_denied(r"C:\temp\file.txt", &denied));
+    }
+
+    #[test]
+    fn is_denied_mixed_separators() {
+        let denied = vec!["C:/temp".to_string()];
+        assert!(is_denied(r"C:\temp", &denied));
+        assert!(is_denied(r"C:\temp\subdir", &denied));
+
+        let denied2 = vec![r"C:\temp".to_string()];
+        assert!(is_denied("C:/temp", &denied2));
+        assert!(is_denied("C:/temp/subdir", &denied2));
+    }
+
+    #[test]
+    fn has_denied_children_detects_sub_path() {
+        let denied = vec![r"C:\Users\secret".to_string()];
+        assert!(has_denied_children(r"C:\Users", &denied));
+    }
+
+    #[test]
+    fn has_denied_children_no_match() {
+        let denied = vec![r"C:\secrets".to_string()];
+        assert!(!has_denied_children(r"C:\Users", &denied));
+    }
+
+    #[test]
+    fn has_denied_children_exact_match_is_not_child() {
+        let denied = vec![r"C:\Users".to_string()];
+        // Exact match is not a "child" — it's handled by is_denied
+        assert!(!has_denied_children(r"C:\Users", &denied));
     }
 }

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -98,6 +98,32 @@ fn filesystem_bfs_spaces() {
     assert_wxc_success("filesystem_bfs_spaces_test.json", &["--debug"]);
 }
 
+fn filesystem_denied_override_readonly() {
+    let temp = TempDirs::create(&["C:\\temp\\wxc_test_denied"]);
+    temp.write_absolute_file("C:\\temp\\wxc_test_denied\\forbidden.txt", "secret data");
+    let result = run_wxc_config("appcontainer_denied_override.json", &["--debug"]);
+    assert_success_or_skip_missing_prerequisite(&result);
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("SUCCESS"),
+        "denied path should not be readable when also in readonlyPaths:\n{}",
+        combined
+    );
+}
+
+fn filesystem_denied_override_readwrite() {
+    let temp = TempDirs::create(&["C:\\temp\\wxc_test_denied"]);
+    temp.write_absolute_file("C:\\temp\\wxc_test_denied\\forbidden.txt", "secret data");
+    let result = run_wxc_config("appcontainer_denied_override_rw.json", &["--debug"]);
+    assert_success_or_skip_missing_prerequisite(&result);
+    let combined = format!("{}{}", result.stdout, result.stderr);
+    assert!(
+        combined.contains("SUCCESS"),
+        "denied path should not be writable when also in readwritePaths:\n{}",
+        combined
+    );
+}
+
 fn pwsh_setlocation() {
     assert_wxc_success("pwsh_setlocation.json", &["--debug"]);
 }
@@ -185,6 +211,24 @@ fn test_filesystem_bfs_spaces() {
         return;
     }
     with_test_lock(filesystem_bfs_spaces);
+}
+
+#[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
+fn test_filesystem_denied_override_readonly() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+    with_test_lock(filesystem_denied_override_readonly);
+}
+
+#[test]
+#[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
+fn test_filesystem_denied_override_readwrite() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+    with_test_lock(filesystem_denied_override_readwrite);
 }
 
 #[test]

--- a/test_configs/appcontainer_denied_override.json
+++ b/test_configs/appcontainer_denied_override.json
@@ -1,19 +1,21 @@
 {
   "$schema": "../schemas/stable/mxc-config.schema.0.4.0-alpha.json",
   "version": "0.4.0-alpha",
-  "containerId": "denied-override-test",
-  "containment": "appcontainer",
+  "containerId": "CLI-DeniedOverride-Test",
+  "containment": "processcontainer",
   "process": {
-    "commandLine": "cmd.exe /c dir C:\\temp",
-    "timeout": 10000
+    "commandLine": "powershell.exe -NoProfile -Command \"$path = 'C:\\temp\\wxc_test_denied\\forbidden.txt'; Write-Output 'Testing deniedPaths overrides readonlyPaths...'; try { Get-Content -LiteralPath $path -ErrorAction Stop | Out-Null; Write-Output 'ERROR: Should not have been able to read from denied path!' } catch { if ($_.Exception -is [System.Management.Automation.ItemNotFoundException]) { Write-Output 'ERROR: File not found - test setup issue' } else { Write-Output ('SUCCESS: Access to denied path was blocked as expected (' + $_.Exception.GetType().Name + ')') } }\"",
+    "timeout": 30000
   },
   "filesystem": {
     "readonlyPaths": [
-      "C:\\",
-      "C:\\temp"
+      "C:\\temp\\wxc_test_denied"
     ],
     "deniedPaths": [
-      "C:\\temp"
+      "C:\\temp\\wxc_test_denied"
     ]
+  },
+  "ui": {
+    "disable": false
   }
 }

--- a/test_configs/appcontainer_denied_override.json
+++ b/test_configs/appcontainer_denied_override.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../schemas/stable/mxc-config.schema.0.4.0-alpha.json",
+  "version": "0.4.0-alpha",
+  "containerId": "denied-override-test",
+  "containment": "appcontainer",
+  "process": {
+    "commandLine": "cmd.exe /c dir C:\\temp",
+    "timeout": 10000
+  },
+  "filesystem": {
+    "readonlyPaths": [
+      "C:\\",
+      "C:\\temp"
+    ],
+    "deniedPaths": [
+      "C:\\temp"
+    ]
+  }
+}

--- a/test_configs/appcontainer_denied_override_rw.json
+++ b/test_configs/appcontainer_denied_override_rw.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../schemas/stable/mxc-config.schema.0.4.0-alpha.json",
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-DeniedOverrideRW-Test",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "powershell.exe -NoProfile -Command \"$path = 'C:\\temp\\wxc_test_denied\\forbidden.txt'; Write-Output 'Testing deniedPaths overrides readwritePaths...'; try { [System.IO.File]::WriteAllText($path, 'overwrite attempt'); Write-Output 'ERROR: Should not have been able to write to denied path!' } catch { $ex = $_.Exception; if ($ex.InnerException) { $ex = $ex.InnerException }; Write-Output ('SUCCESS: Write to denied path was blocked as expected (' + $ex.GetType().Name + ')') }\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_denied"
+    ],
+    "deniedPaths": [
+      "C:\\temp\\wxc_test_denied"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}


### PR DESCRIPTION
The AppContainer BFS backend (bfscfg.exe) is an allow-list system with no deny primitive. Previously, paths listed in both deniedPaths and readonlyPaths/readwritePaths would still be granted access via BFS since the denied list was never consulted.

Now the configure() method skips any readwrite or readonly path that is equal to or a child of a denied path, ensuring deny semantics are honored. Comparison is case-insensitive to match Windows filesystem behavior.

Also adds a test config for integration validation.

Fixes #145

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/359)