### PR TITLE
Gate BFS (bfscfg.exe) behind a default-OFF `bfs` Cargo feature

### DIFF
--- a/docs/lxc-support/lxc-backend.md
+++ b/docs/lxc-support/lxc-backend.md
@@ -159,6 +159,10 @@ pty.onExit((e) => console.log('Exit:', e.exitCode));
 |---------|----------------------|-------------------|-------------|
 | Isolation level | Process | VM | Container |
 | Startup time | Fast (~10ms) | Slow (~30s) | Medium (~1s) |
-| Filesystem | BFS policy | VM filesystem | Bind mounts |
+| Filesystem | BFS policy¹ | VM filesystem | Bind mounts |
 | Network | Windows Firewall | Guest agent | iptables/nftables |
 | Privileges | Optional admin | Admin | Root (or unprivileged LXC) |
+
+¹ Windows BFS support is gated behind the non-default `bfs` Cargo
+feature in `wxc_common`. Default builds skip BFS and emit a warning
+when a policy declares filesystem paths on the AppContainer runner.

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -332,8 +332,12 @@ environment.
 |---|---|---|---|
 | Isolation level | Process | Container | Process |
 | Startup time | Fast (~10 ms) | Medium (~1 s) | Fast (~10 ms) |
-| Filesystem | BFS policy | Bind mounts | Profile `subpath` rules |
+| Filesystem | BFS policy¹ | Bind mounts | Profile `subpath` rules |
 | Network | Windows Firewall | iptables/nftables | Profile `network-*` rules |
 | Privileges | Optional admin | Root (or unprivileged LXC) | None — `sandbox_init` is unprivileged |
 | Container lifecycle | Yes (named) | Yes (named) | No (per-process) |
 | Proxy support | Yes | No | No |
+
+¹ Windows BFS support is gated behind the non-default `bfs` Cargo
+feature in `wxc_common`. Default builds skip BFS and emit a warning
+when a policy declares filesystem paths on the AppContainer runner.

--- a/docs/playground-limitations.md
+++ b/docs/playground-limitations.md
@@ -6,7 +6,7 @@
 |---------|---------------------------|------------------------------|-------|
 | AppContainer (v0.4.0) | ✅ Works | ✅ Works | N/A |
 | BaseContainer (v0.5.0) | ❌ No processmodel.dll | ✅ Works | N/A |
-| BFS filesystem brokering | ❌ Broker helper not available | ✅ Works | N/A |
+| BFS filesystem brokering | ❌ Broker helper not available | ✅ Works (opt-in via `bfs` Cargo feature) | N/A |
 | Proxy (AppContainer) | ✅ Works (needs admin for shim) | ✅ Works | N/A |
 | Proxy (BaseContainer) | N/A | ⚠️ WinHTTP only, see below | N/A |
 | LXC containers | N/A | N/A | ✅ Works |
@@ -81,7 +81,7 @@ WinHTTP sessions may or may not pick it up depending on how they're initialized.
 | Feature | Needs Admin? |
 |---------|-------------|
 | Basic AppContainer execution | No |
-| BFS filesystem brokering | No |
+| BFS filesystem brokering | No (and disabled by default — build with `--features bfs` to enable) |
 | Network (capabilities only) | No |
 | Network (firewall rules) | Yes — `netsh advfirewall` |
 | Proxy shim (v0.4.0) | Yes — elevated winhttp-proxy-shim |
@@ -121,6 +121,14 @@ When `disallowWin32kSystemCalls=true`:
 - PowerShell, GUI apps, and most Windows executables will fail
 
 ## Filesystem (BFS)
+
+> **BFS is disabled by default** at the Rust-core build level. Known
+> kernel-mode hangs in `bfs.sys` / `bfsapi.dll` make the
+> `bfscfg.exe`-driven path unsafe on most hosts. The integration is
+> gated behind the non-default `bfs` Cargo feature in `wxc_common`;
+> default builds skip it entirely and the AppContainer runner emits a
+> warning if a policy declares filesystem paths. The notes below apply
+> only to builds that opt in via `--features bfs`.
 
 ### Trailing Backslash
 

--- a/docs/sandbox-policy/v1/policy.md
+++ b/docs/sandbox-policy/v1/policy.md
@@ -146,11 +146,15 @@ spawnSandboxFromConfig(config);
 ┌───────────────────────────────────────────────────────────────┐
 │ LAYER 3: OS Primitives                                        │
 │                                                               │
-│ Windows: BaseProcessContainer, BFS, Firewall, Job Objects     │
+│ Windows: BaseProcessContainer, BFS¹, Firewall, Job Objects    │
 │ Linux: LXC cgroups, bind mounts, iptables, seccomp            │
 │                                                               │
 │ Kernel-level enforcement.                                     │
 │ Never referenced by name in Layer 1.                          │
+│                                                               │
+│ ¹ BFS is gated behind a non-default `bfs` Cargo feature;      │
+│   default builds use only BaseProcessContainer + Firewall +   │
+│   Job Objects on Windows.                                     │
 └───────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -101,7 +101,7 @@ The `fallback` section gates the runner's host-impacting fallbacks. Each flag is
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `allowDaclMutation` | boolean | `true` | When neither the in-process BaseContainer API nor the OS-side filesystem broker helper is available, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). **⚠️ This modifies host filesystem security descriptors**; original DACLs are restored on exit. Set to `false` to refuse this fallback — the run will then fail on machines that require Tier 3 (e.g., Windows 11 builds below 26300 without the BaseContainer API). |
+| `allowDaclMutation` | boolean | `true` | When neither the in-process BaseContainer API nor the OS-side filesystem broker helper is available, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). **⚠️ This modifies host filesystem security descriptors**; original DACLs are restored on exit. Set to `false` to refuse this fallback — the run will then fail on machines that require Tier 3 (e.g., Windows 11 builds below 26300 without the BaseContainer API). Note: BFS (Tier 2) is gated behind the non-default `bfs` Cargo feature in the Rust core; default builds skip Tier 2 entirely, so DACL is the only AppContainer-tier filesystem-policy fallback they offer. |
 
 ### Containment Backends
 

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -110,7 +110,7 @@
         "allowDaclMutation": {
           "type": "boolean",
           "default": true,
-          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS — original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3)."
+          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS — original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3). Note: BFS (Tier 2) is gated behind the non-default `bfs` Cargo feature in the Rust core; default builds skip Tier 2 entirely, so DACL is the only AppContainer-tier filesystem-policy fallback they offer."
         }
       }
     },

--- a/src/wxc/Cargo.toml
+++ b/src/wxc/Cargo.toml
@@ -31,3 +31,7 @@ isolation_session = [
     "dep:isolation_session_bindings",
     "wxc_common/isolation_session",
 ]
+# Enables the AppContainer Brokered File System (BFS) integration in
+# wxc_common (invokes `bfscfg.exe`). Disabled by default: see the
+# matching feature comment in wxc_common/Cargo.toml.
+bfs = ["wxc_common/bfs"]

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -11,6 +11,11 @@ isolation_session = [
     "dep:windows-collections",
 ]
 microvm = ["dep:nanvix_common"]
+# Enables the AppContainer Brokered File System (BFS) integration that
+# invokes `bfscfg.exe`. Disabled by default: known kernel-mode hangs in
+# `bfs.sys` / `bfsapi.dll` make the call path unsafe on most hosts.
+# Opt in once a fixed `bfs.sys` is available on the target machine.
+bfs = []
 
 [dependencies]
 serde = { workspace = true }

--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -775,6 +775,7 @@ impl Default for AppContainerScriptRunner {
 
 impl ScriptRunner for AppContainerScriptRunner {
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
+        #[cfg(feature = "bfs")]
         use crate::filesystem_bfs::FileSystemBfsManager;
         use crate::launch_diagnostics::diagnose_process_exit;
         use crate::models::FailurePhase;
@@ -802,20 +803,47 @@ impl ScriptRunner for AppContainerScriptRunner {
         // hijacking (see `fallback_detector::find_bfscfg_exe`). Only
         // resolve when we actually plan to use BFS; Tier 3 (DACL) hosts
         // legitimately may not have `bfscfg.exe` installed.
-        let bfscfg_path = if self.filesystem_mode == FilesystemMode::Bfs {
-            match crate::fallback_detector::find_bfscfg_exe() {
-                Ok(p) => p,
-                Err(e) => return ScriptResponse::error(&e.to_string()),
+        //
+        // Compiled out unless the `bfs` Cargo feature is enabled — see
+        // the feature comment in `wxc_common/Cargo.toml`. When BFS is
+        // compiled out, the dispatcher only ever selects Tier 1 or
+        // Tier 3, so this runner can never see `FilesystemMode::Bfs`
+        // for a real policy; we still emit a guard warning for any
+        // direct caller (e.g. legacy `new()` paths) that bypasses the
+        // dispatcher with a non-empty filesystem policy.
+        #[cfg(feature = "bfs")]
+        let mut bfs_manager = {
+            let bfscfg_path = if self.filesystem_mode == FilesystemMode::Bfs {
+                match crate::fallback_detector::find_bfscfg_exe() {
+                    Ok(p) => p,
+                    Err(e) => return ScriptResponse::error(&e.to_string()),
+                }
+            } else {
+                None
+            };
+
+            let mut bfs_manager =
+                FileSystemBfsManager::new(self.app_container_name.clone(), bfscfg_path);
+            if self.filesystem_mode == FilesystemMode::Bfs {
+                if let Err(e) = bfs_manager.configure(&request.policy, logger) {
+                    return ScriptResponse::error(&e.to_string());
+                }
             }
-        } else {
-            None
+            bfs_manager
         };
 
-        let mut bfs_manager =
-            FileSystemBfsManager::new(self.app_container_name.clone(), bfscfg_path);
+        #[cfg(not(feature = "bfs"))]
         if self.filesystem_mode == FilesystemMode::Bfs {
-            if let Err(e) = bfs_manager.configure(&request.policy, logger) {
-                return ScriptResponse::error(&e.to_string());
+            let policy = &request.policy;
+            if !policy.readwrite_paths.is_empty()
+                || !policy.readonly_paths.is_empty()
+                || !policy.denied_paths.is_empty()
+            {
+                logger.log_line(
+                    "WARNING: filesystem policy declared but BFS support is disabled \
+                     (wxc_common built without the `bfs` feature); \
+                     readwrite/readonly/denied paths will not be enforced on this runner.",
+                );
             }
         }
 
@@ -865,6 +893,7 @@ impl ScriptRunner for AppContainerScriptRunner {
         }
 
         network_manager.stop_all(!request.lifecycle.preserve_policy, logger);
+        #[cfg(feature = "bfs")]
         if self.filesystem_mode == FilesystemMode::Bfs
             && bfs_manager.configured()
             && !request.lifecycle.preserve_policy
@@ -883,11 +912,14 @@ impl ScriptRunner for AppContainerScriptRunner {
 /// kept next to the create/setup path on `AppContainerScriptRunner` so
 /// both ends of the profile lifecycle live in the same module.
 ///
-/// The BFS-clear step is best-effort: it delegates to
+/// The BFS-clear step is best-effort and is compiled out unless the
+/// `bfs` Cargo feature is enabled (see the feature comment in
+/// `wxc_common/Cargo.toml`). When the feature is on it delegates to
 /// [`FileSystemBfsManager::clear_policy`], which resolves `bfscfg.exe`
 /// itself and logs (rather than fails) when the resolver returns no
-/// path. The profile delete is still attempted in that case.
+/// path. The profile delete is still attempted in either case.
 pub fn delete_app_container_profile(name: &str, logger: &mut Logger) -> bool {
+    #[cfg(feature = "bfs")]
     crate::filesystem_bfs::FileSystemBfsManager::clear_policy(name, logger);
 
     let wide_name: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();

--- a/src/wxc_common/src/dispatcher.rs
+++ b/src/wxc_common/src/dispatcher.rs
@@ -103,6 +103,7 @@ impl std::fmt::Display for DispatchError {
                     path.display()
                 )
             }
+            #[cfg(feature = "bfs")]
             DispatchError::Fallback(FallbackError::SystemRootUnresolved { reason }) => write!(
                 f,
                 "Could not resolve the Windows system directory while probing for bfscfg.exe \
@@ -166,6 +167,7 @@ pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, Disp
             let runner: Box<dyn ScriptRunner> = Box::new(BaseContainerRunner::new());
             (runner, None)
         }
+        #[cfg(feature = "bfs")]
         IsolationTier::AppContainerBfs => {
             // T2 only needs deny ACEs (BFS handles the rest in-runner)
             // and only when `deniedPaths` is non-empty. Allocate the
@@ -290,6 +292,7 @@ mod tests {
             "T1 must not attach a DaclManager — BC handles deny natively"
         );
     }
+    #[cfg(feature = "bfs")]
     #[test]
     fn dispatch_t2_with_denied_paths_has_dacl() {
         let _g = ForceTierGuard::set("appcontainer-bfs");

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -293,8 +293,19 @@ fn forced_decision(
     // Forced tiers honor the same DACL-fallback guard the real algorithm
     // does: if the operator forbade host DACL changes we must still refuse
     // any tier that would touch them.
+    //
+    // For `AppContainerDacl` specifically, we mirror the empty-policy
+    // carve-out in `detect()` (see the Tier 3 block): when the policy
+    // declares no filesystem paths there is nothing to augment, so we
+    // do not require DACL mutation consent. This keeps the
+    // `MXC_FORCE_TIER` test seam faithful to the real algorithm — a
+    // caller forcing Tier 3 with an empty policy should not be
+    // rejected just because `allow_dacl_mutation = false`.
+    let has_fs_policy = !policy.readwrite_paths.is_empty()
+        || !policy.readonly_paths.is_empty()
+        || !policy.denied_paths.is_empty();
     let needs_dacl = match tier {
-        IsolationTier::AppContainerDacl => true,
+        IsolationTier::AppContainerDacl => has_fs_policy,
         #[cfg(feature = "bfs")]
         IsolationTier::BaseContainer | IsolationTier::AppContainerBfs => denied,
         #[cfg(not(feature = "bfs"))]
@@ -560,6 +571,22 @@ mod tests {
             Err(FallbackError::DaclFallbackDisabled)
         ));
     }
+
+    /// Mirrors the empty-policy carve-out in `detect()` for the forced
+    /// `AppContainerDacl` path: when the policy declares no filesystem
+    /// paths there is nothing to augment, so the DACL-fallback guard
+    /// must not fire even with `allow_dacl_mutation = false`.
+    #[test]
+    fn forced_appcontainer_dacl_with_empty_policy_does_not_require_dacl_mutation() {
+        let _g = ForceTierGuard::set("appcontainer-dacl");
+        let mut policy = empty_policy();
+        policy.fallback.allow_dacl_mutation = false;
+        let d = detect(&policy, true)
+            .expect("empty policy must not require DACL mutation under forced T3");
+        assert_eq!(d.tier, IsolationTier::AppContainerDacl);
+        assert!(!d.needs_dacl_augmentation);
+    }
+
     #[test]
     fn force_tier_env_var_parses_all_three_values() {
         assert!(matches!(
@@ -703,7 +730,11 @@ mod tests {
         policy.fallback.allow_dacl_mutation = true;
         let d = detect(&policy, true).expect("forced dacl with allow_dacl_mutation=true");
         assert!(matches!(d.tier, IsolationTier::AppContainerDacl));
-        assert!(d.needs_dacl_augmentation);
+        // Empty policy ⇒ no DACL augmentation required, matching the
+        // empty-policy carve-out in `detect()`'s Tier 3 block. See
+        // `forced_appcontainer_dacl_with_empty_policy_does_not_require_dacl_mutation`
+        // for the dedicated regression test.
+        assert!(!d.needs_dacl_augmentation);
         assert!(
             d.warnings.is_empty(),
             "forced decisions should not accumulate fallback-chain warnings"

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -26,6 +26,10 @@ pub enum IsolationTier {
     /// Tier 1 — `Experimental_CreateProcessInSandbox` from `processmodel.dll`.
     BaseContainer,
     /// Tier 2 — AppContainer + `bfscfg.exe` BFS filesystem policy.
+    ///
+    /// Only selectable when the `bfs` Cargo feature is enabled — see the
+    /// feature comment in `wxc_common/Cargo.toml`.
+    #[cfg(feature = "bfs")]
     AppContainerBfs,
     /// Tier 3 — AppContainer + DACL-based filesystem policy on host paths.
     AppContainerDacl,
@@ -36,6 +40,7 @@ impl IsolationTier {
     pub fn as_str(self) -> &'static str {
         match self {
             IsolationTier::BaseContainer => "base-container",
+            #[cfg(feature = "bfs")]
             IsolationTier::AppContainerBfs => "appcontainer-bfs",
             IsolationTier::AppContainerDacl => "appcontainer-dacl",
         }
@@ -61,6 +66,7 @@ pub struct TierDecision {
     /// executable-search-order hijacking by an attacker who can plant a
     /// rogue `bfscfg.exe` next to `wxc-exec.exe`, in the CWD, or in a
     /// `PATH` entry that precedes `System32`.
+    #[cfg(feature = "bfs")]
     pub bfscfg_path: Option<PathBuf>,
     /// Human-readable degradation messages explaining why a higher tier was
     /// rejected. Empty when the preferred tier was selected.
@@ -91,6 +97,7 @@ pub enum FallbackError {
     /// hardcoded `C:\Windows` guess because doing so would allow an
     /// attacker who can scrub the process environment to silently
     /// downgrade Tier 2 → Tier 3 on hosts where Windows lives elsewhere.
+    #[cfg(feature = "bfs")]
     #[error("could not resolve %SystemRoot%: {reason}")]
     SystemRootUnresolved {
         /// Human-readable description of why resolution failed.
@@ -160,12 +167,20 @@ pub fn detect(
         return Ok(TierDecision {
             tier: IsolationTier::BaseContainer,
             needs_dacl_augmentation: denied,
+            #[cfg(feature = "bfs")]
             bfscfg_path: None,
             warnings,
         });
     }
+    #[cfg(feature = "bfs")]
     warnings.push(
         "BaseContainer API not present or not preferred; falling back to AppContainer + BFS"
+            .to_string(),
+    );
+    #[cfg(not(feature = "bfs"))]
+    warnings.push(
+        "BaseContainer API not present or not preferred; falling back to AppContainer + DACL \
+         (BFS support is disabled at build time)"
             .to_string(),
     );
 
@@ -175,37 +190,53 @@ pub fn detect(
     // BFS to enforce, so we can stay on T2 without resolving bfscfg.exe.
     // Otherwise we need a real path: probe-time resolution doubles as the
     // execution path (see `TierDecision::bfscfg_path`).
-    let bfscfg_path = if has_fs_policy {
-        find_bfscfg_exe()?
-    } else {
-        None
-    };
-    if !has_fs_policy || bfscfg_path.is_some() {
-        if denied {
-            ensure_dacl_augmentation_allowed(policy)?;
-            verify_write_dac_all(&policy.denied_paths)?;
+    //
+    // Compiled out unless the `bfs` Cargo feature is enabled — see the
+    // feature comment in `wxc_common/Cargo.toml`.
+    #[cfg(feature = "bfs")]
+    {
+        let bfscfg_path = if has_fs_policy {
+            find_bfscfg_exe()?
+        } else {
+            None
+        };
+        if !has_fs_policy || bfscfg_path.is_some() {
+            if denied {
+                ensure_dacl_augmentation_allowed(policy)?;
+                verify_write_dac_all(&policy.denied_paths)?;
+            }
+            return Ok(TierDecision {
+                tier: IsolationTier::AppContainerBfs,
+                needs_dacl_augmentation: denied,
+                bfscfg_path,
+                warnings,
+            });
         }
-        return Ok(TierDecision {
-            tier: IsolationTier::AppContainerBfs,
-            needs_dacl_augmentation: denied,
-            bfscfg_path,
-            warnings,
-        });
+        warnings.push("bfscfg.exe not present; falling back to AppContainer + DACL".to_string());
     }
-    warnings.push("bfscfg.exe not present; falling back to AppContainer + DACL".to_string());
 
     // Tier 3 — AppContainer + DACL
-    ensure_dacl_augmentation_allowed(policy)?;
-    verify_write_dac_all(
-        policy
-            .readwrite_paths
-            .iter()
-            .chain(policy.readonly_paths.iter())
-            .chain(policy.denied_paths.iter()),
-    )?;
+    //
+    // When the policy declares no filesystem paths there is nothing to
+    // augment, so we skip the DACL-consent / WRITE_DAC checks entirely.
+    // This preserves the historical behavior of the Tier 2 path for
+    // empty policies: a caller that set `allow_dacl_mutation = false`
+    // should still get a working AppContainer when they ask for no
+    // filesystem enforcement.
+    if has_fs_policy {
+        ensure_dacl_augmentation_allowed(policy)?;
+        verify_write_dac_all(
+            policy
+                .readwrite_paths
+                .iter()
+                .chain(policy.readonly_paths.iter())
+                .chain(policy.denied_paths.iter()),
+        )?;
+    }
     Ok(TierDecision {
         tier: IsolationTier::AppContainerDacl,
-        needs_dacl_augmentation: true,
+        needs_dacl_augmentation: has_fs_policy,
+        #[cfg(feature = "bfs")]
         bfscfg_path: None,
         warnings,
     })
@@ -246,6 +277,7 @@ fn check_write_dac_path(path: &Path) -> Result<(), FallbackError> {
 fn parse_force_tier(s: &str) -> Option<IsolationTier> {
     match s {
         "base-container" => Some(IsolationTier::BaseContainer),
+        #[cfg(feature = "bfs")]
         "appcontainer-bfs" => Some(IsolationTier::AppContainerBfs),
         "appcontainer-dacl" => Some(IsolationTier::AppContainerDacl),
         _ => None,
@@ -263,7 +295,10 @@ fn forced_decision(
     // any tier that would touch them.
     let needs_dacl = match tier {
         IsolationTier::AppContainerDacl => true,
+        #[cfg(feature = "bfs")]
         IsolationTier::BaseContainer | IsolationTier::AppContainerBfs => denied,
+        #[cfg(not(feature = "bfs"))]
+        IsolationTier::BaseContainer => denied,
     };
     if needs_dacl && !policy.fallback.allow_dacl_mutation {
         return Err(FallbackError::DaclFallbackDisabled);
@@ -271,6 +306,7 @@ fn forced_decision(
     Ok(TierDecision {
         tier,
         needs_dacl_augmentation: needs_dacl,
+        #[cfg(feature = "bfs")]
         bfscfg_path: None,
         warnings: Vec::new(),
     })
@@ -313,6 +349,10 @@ pub(crate) fn is_base_container_api_present() -> bool {
 /// Returns `Err(FallbackError::SystemRootUnresolved)` only when the
 /// Win32 API itself fails — on a healthy Windows host this should never
 /// happen.
+///
+/// Compiled out unless the `bfs` Cargo feature is enabled — see the
+/// feature comment in `wxc_common/Cargo.toml`.
+#[cfg(feature = "bfs")]
 pub fn find_bfscfg_exe() -> Result<Option<PathBuf>, FallbackError> {
     #[cfg(test)]
     if let Ok(override_path) = std::env::var("MXC_BFSCFG_PATH") {
@@ -334,6 +374,7 @@ pub fn find_bfscfg_exe() -> Result<Option<PathBuf>, FallbackError> {
 /// The OS populates the answer from boot configuration; it does not
 /// consult the process environment. Returns
 /// [`FallbackError::SystemRootUnresolved`] when the API itself fails.
+#[cfg(feature = "bfs")]
 fn resolve_windows_directory() -> Result<PathBuf, FallbackError> {
     use windows::Win32::System::SystemInformation::GetWindowsDirectoryW;
 
@@ -368,6 +409,7 @@ fn resolve_windows_directory() -> Result<PathBuf, FallbackError> {
     parse_utf16(&buf[..len])
 }
 
+#[cfg(feature = "bfs")]
 fn parse_utf16(slice: &[u16]) -> Result<PathBuf, FallbackError> {
     String::from_utf16(slice)
         .map(PathBuf::from)
@@ -457,7 +499,9 @@ mod tests {
     // honored uniformly across the dispatcher and fallback_detector
     // test modules. A per-module lock would let cross-module test
     // threads race on `MXC_FORCE_TIER` / `MXC_BFSCFG_PATH`.
-    use crate::test_env::{BfscfgPathGuard, ForceTierGuard, ENV_LOCK};
+    use crate::test_env::ForceTierGuard;
+    #[cfg(feature = "bfs")]
+    use crate::test_env::{BfscfgPathGuard, ENV_LOCK};
 
     fn empty_policy() -> ContainerPolicy {
         ContainerPolicy::default()
@@ -476,6 +520,7 @@ mod tests {
         assert!(!d.needs_dacl_augmentation);
         assert!(d.warnings.is_empty());
     }
+    #[cfg(feature = "bfs")]
     #[test]
     fn empty_policy_no_filesystem_t2_path() {
         let _g = ForceTierGuard::set("appcontainer-bfs");
@@ -494,6 +539,7 @@ mod tests {
             Err(FallbackError::DaclFallbackDisabled)
         ));
     }
+    #[cfg(feature = "bfs")]
     #[test]
     fn denied_paths_disabled_blocks_t2() {
         let _g = ForceTierGuard::set("appcontainer-bfs");
@@ -520,10 +566,16 @@ mod tests {
             parse_force_tier("base-container"),
             Some(IsolationTier::BaseContainer)
         ));
+        #[cfg(feature = "bfs")]
         assert!(matches!(
             parse_force_tier("appcontainer-bfs"),
             Some(IsolationTier::AppContainerBfs)
         ));
+        #[cfg(not(feature = "bfs"))]
+        assert!(
+            parse_force_tier("appcontainer-bfs").is_none(),
+            "`appcontainer-bfs` must not parse when the `bfs` feature is disabled"
+        );
         assert!(matches!(
             parse_force_tier("appcontainer-dacl"),
             Some(IsolationTier::AppContainerDacl)
@@ -542,6 +594,7 @@ mod tests {
         detect(&policy, false).expect("invalid value should not error");
     }
 
+    #[cfg(feature = "bfs")]
     #[test]
     fn find_bfscfg_exe_smoke() {
         // Tests run in parallel by default and other tests below mutate
@@ -568,6 +621,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "bfs")]
     #[test]
     fn resolve_windows_directory_returns_existing_dir() {
         // `GetWindowsDirectoryW` always succeeds on any real Windows
@@ -581,6 +635,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "bfs")]
     #[test]
     fn mxc_bfscfg_path_empty_value_simulates_missing() {
         let _g = BfscfgPathGuard::set("");
@@ -590,6 +645,7 @@ mod tests {
             "empty MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
+    #[cfg(feature = "bfs")]
     #[test]
     fn mxc_bfscfg_path_nonexistent_path_is_none() {
         let _g = BfscfgPathGuard::set("C:\\__mxc_does_not_exist__\\bfscfg.exe");
@@ -599,6 +655,7 @@ mod tests {
             "non-existent MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
+    #[cfg(feature = "bfs")]
     #[test]
     fn mxc_bfscfg_path_existing_path_is_returned_verbatim() {
         // Use a file we know exists (this source file itself, via the

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -30,7 +30,7 @@ pub mod appcontainer_runner;
 pub mod dispatcher;
 #[cfg(target_os = "windows")]
 pub mod fallback_detector;
-#[cfg(target_os = "windows")]
+#[cfg(all(target_os = "windows", feature = "bfs"))]
 pub mod filesystem_bfs;
 #[cfg(target_os = "windows")]
 pub mod filesystem_dacl;

--- a/src/wxc_common/src/sandbox_tracking.rs
+++ b/src/wxc_common/src/sandbox_tracking.rs
@@ -160,14 +160,18 @@ pub fn mark_cleanup_deferred(sid_string: &str, reason: &str, logger: &mut Logger
     let _ = writeln!(logger, "cleanup deferred: {}", reason);
 }
 
-/// Clean up a sandbox: clear BFS filesystem policies, delete the AppContainer
-/// profile, and remove the tracking registry entry. Best-effort and idempotent
-/// -- failures are logged but do not propagate as errors.
+/// Clean up a sandbox: (optionally) clear BFS filesystem policies, delete
+/// the AppContainer profile, and remove the tracking registry entry.
+/// Best-effort and idempotent — failures are logged but do not propagate
+/// as errors.
 ///
-/// Order matters: BFS policies must be cleared before the AppContainer profile
-/// is deleted (BFS needs the SID, which is derived from the profile identity).
+/// When the `bfs` feature is enabled, BFS policies are cleared first
+/// (BFS needs the SID, which is derived from the profile identity, so
+/// the call must happen before profile deletion). Default builds skip
+/// step 1 entirely.
 pub fn cleanup_sandbox(identity: &str, sid_string: &str, logger: &mut Logger) {
     // Step 1: Clear BFS filesystem policies (must happen before profile deletion).
+    #[cfg(feature = "bfs")]
     crate::filesystem_bfs::FileSystemBfsManager::clear_policy(identity, logger);
 
     // Step 2: Delete the AppContainer profile.

--- a/src/wxc_common/src/test_env.rs
+++ b/src/wxc_common/src/test_env.rs
@@ -66,10 +66,16 @@ impl Drop for ForceTierGuard {
 }
 
 /// RAII guard for `MXC_BFSCFG_PATH`, mirroring [`ForceTierGuard`].
+///
+/// Compiled out when the `bfs` Cargo feature is disabled — the only
+/// callers of this guard are the `find_bfscfg_exe` test-seam tests
+/// which are themselves gated by `feature = "bfs"`.
+#[cfg(feature = "bfs")]
 pub(crate) struct BfscfgPathGuard {
     _lock: MutexGuard<'static, ()>,
 }
 
+#[cfg(feature = "bfs")]
 impl BfscfgPathGuard {
     pub(crate) fn set(value: &str) -> Self {
         let guard = lock();
@@ -81,6 +87,7 @@ impl BfscfgPathGuard {
     }
 }
 
+#[cfg(feature = "bfs")]
 impl Drop for BfscfgPathGuard {
     fn drop(&mut self) {
         // SAFETY: see ForceTierGuard::drop.

--- a/src/wxc_e2e_tests/Cargo.toml
+++ b/src/wxc_e2e_tests/Cargo.toml
@@ -5,6 +5,13 @@ edition.workspace = true
 publish = false
 description = "End-to-end integration tests for MXC"
 
+[features]
+# Compile-in the BFS-specific e2e tests. Matches the `bfs` feature in
+# wxc_common / wxc; without it the BFS tests are excluded from the
+# binary. The crate doesn't depend on wxc_common, so this is a local
+# marker feature only.
+bfs = []
+
 [dependencies]
 base64.workspace = true
 serde.workspace = true

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -80,11 +80,13 @@ fn processcontainer_lpac() {
     assert_wxc_success("basic_lpac.json", &["--debug"]);
 }
 
+#[cfg(feature = "bfs")]
 fn filesystem_bfs() {
     let _temp = TempDirs::create(&["C:\\temp\\wxc_test_allowed", "C:\\temp\\wxc_test_denied"]);
     assert_wxc_success("filesystem_bfs_test.json", &["--debug"]);
 }
 
+#[cfg(feature = "bfs")]
 fn filesystem_bfs_readonly() {
     let temp = TempDirs::create(&["C:\\temp\\wxc_test_allowedreadonly"]);
     temp.write_absolute_file(
@@ -94,6 +96,7 @@ fn filesystem_bfs_readonly() {
     assert_wxc_success("filesystem_bfs_readonly_test.json", &["--debug"]);
 }
 
+#[cfg(feature = "bfs")]
 fn filesystem_bfs_spaces() {
     let _temp = TempDirs::create(&["C:\\Users\\Public\\wxc bfs test"]);
     assert_wxc_success("filesystem_bfs_spaces_test.json", &["--debug"]);
@@ -163,6 +166,7 @@ fn test_processcontainer_lpac() {
     with_test_lock(processcontainer_lpac);
 }
 
+#[cfg(feature = "bfs")]
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs() {
@@ -173,6 +177,7 @@ fn test_filesystem_bfs() {
     with_test_lock(filesystem_bfs);
 }
 
+#[cfg(feature = "bfs")]
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs_readonly() {
@@ -183,6 +188,7 @@ fn test_filesystem_bfs_readonly() {
     with_test_lock(filesystem_bfs_readonly);
 }
 
+#[cfg(feature = "bfs")]
 #[test]
 #[ignore] // Requires velocity key 61714527 (BFS deadlock fix) enabled
 fn test_filesystem_bfs_spaces() {
@@ -278,7 +284,9 @@ fn test_on_repeat() {
         for pass in 1..=10 {
             println!("=== Pass {pass} of 10 ===");
             processcontainer_basic();
+            #[cfg(feature = "bfs")]
             filesystem_bfs();
+            #[cfg(feature = "bfs")]
             filesystem_bfs_readonly();
             processcontainer_lpac();
         }

--- a/test_scripts/README.md
+++ b/test_scripts/README.md
@@ -21,9 +21,9 @@ All scripts accept a `-Release` switch to use the release build (default: debug)
 | `run_basicac_test.ps1` | Basic AppContainer test | `wxc-exec.exe` |
 | `run_lpacac_test.ps1` | LPAC AppContainer test | `wxc-exec.exe` |
 | `run_pwsh_test.ps1` | PowerShell Set-Location test | `wxc-exec.exe` |
-| `run_filesystem_bfs_test.ps1` | BFS filesystem test | `wxc-exec.exe` |
-| `run_filesystem_bfsreadonly_test.ps1` | BFS read-only filesystem test | `wxc-exec.exe` |
-| `run_filesystem_bfs_spaces_test.ps1` | BFS path-with-spaces test | `wxc-exec.exe` |
+| `run_filesystem_bfs_test.ps1` | BFS filesystem test | `wxc-exec.exe` built with `--features bfs` |
+| `run_filesystem_bfsreadonly_test.ps1` | BFS read-only filesystem test | `wxc-exec.exe` built with `--features bfs` |
+| `run_filesystem_bfs_spaces_test.ps1` | BFS path-with-spaces test | `wxc-exec.exe` built with `--features bfs` |
 | `run_test_configs.ps1` | All test configs via wxc-test-driver | `wxc-test-driver.exe` |
 | `run_examples.ps1` | All examples via wxc-test-driver | `wxc-test-driver.exe` |
 | `run_microvm_basic_test.ps1` | MicroVM smoke test | `wxc-exec.exe`, NanVix binaries |
@@ -103,15 +103,20 @@ The following tests are marked `#[ignore]` because they require velocity key
 61714527 (BFS deadlock fix) enabled on the machine. AppContainer process
 isolation with brokered filesystem or networking depends on this fix.
 Run them explicitly on capable machines with
-`cargo test -p wxc_e2e_tests -- --ignored`:
+`cargo test -p wxc_e2e_tests -- --ignored`.
+
+> **BFS feature gate**: the `test_filesystem_bfs*` tests are *also* gated
+> behind the `bfs` Cargo feature in `wxc_e2e_tests`. They are excluded
+> from default builds entirely; add `--features bfs` to compile them in:
+> `cargo test -p wxc_e2e_tests --features bfs -- --ignored`.
 
 | Test | Reason |
 |------|--------|
 | `test_appcontainer_basic` | Requires velocity key 61714527 (BFS deadlock fix) |
 | `test_appcontainer_lpac` | Requires velocity key 61714527 (BFS deadlock fix) |
-| `test_filesystem_bfs` | Requires velocity key 61714527 (BFS deadlock fix) |
-| `test_filesystem_bfs_readonly` | Requires velocity key 61714527 (BFS deadlock fix) |
-| `test_filesystem_bfs_spaces` | Requires velocity key 61714527 (BFS deadlock fix) |
+| `test_filesystem_bfs` | Requires velocity key 61714527 (BFS deadlock fix) and `bfs` Cargo feature |
+| `test_filesystem_bfs_readonly` | Requires velocity key 61714527 (BFS deadlock fix) and `bfs` Cargo feature |
+| `test_filesystem_bfs_spaces` | Requires velocity key 61714527 (BFS deadlock fix) and `bfs` Cargo feature |
 | `test_pwsh_setlocation` | Requires velocity key 61714527 (BFS deadlock fix) |
 | `test_test_configs` | Requires velocity key 61714527 (BFS deadlock fix) |
 | `test_examples` | Requires velocity key 61714527 (BFS deadlock fix) |


### PR DESCRIPTION
## 📖 Description

Gate the AppContainer Brokered File System (BFS) integration behind a
default-OFF `bfs` Cargo feature. Known kernel-mode hangs in `bfs.sys` /
`bfsapi.dll` make the `bfscfg.exe`-driven path unsafe on most hosts; the
DACL fallback (Tier 3) is also incomplete (e.g., enumeration of files in
an ACLed directory), so simply demoting to Tier 3 doesn''t help.

This change keeps all BFS code in the tree — gated, not deleted — so it
can be reinstated with `--features bfs` once a fixed `bfs.sys` ships on
target machines. The pattern mirrors the existing `hyperlight` /
`isolation_session` feature flags.

**Default build (`cargo build -p wxc`)**: wxc-exec never invokes
`bfscfg.exe`. When a policy declares `readwrite` / `readonly` / `denied`
paths, the AppContainer runner logs **one** warning that the policy is
not enforced on this tier and proceeds.

**Opt-in build (`cargo build -p wxc --features bfs`)**: pre-existing
BFS behaviour is fully restored.

### Cargo wiring (3 files)
- `wxc_common/Cargo.toml` — add `bfs = []`.
- `wxc/Cargo.toml` — add `bfs = ["wxc_common/bfs"]`.
- `wxc_e2e_tests/Cargo.toml` — add local marker `bfs = []` for symmetric
  test gating.

### Rust gates (no deletions; every call site wrapped)
- `wxc_common/src/lib.rs` — `filesystem_bfs` module gated.
- `wxc_common/src/appcontainer_runner.rs` — gated `find_bfscfg_exe` +
  `FileSystemBfsManager::{new,configure,remove_configuration}`; added a
  `#[cfg(not(feature = "bfs"))]` warning branch.
- `wxc_common/src/sandbox_tracking.rs` — gated `clear_policy` in
  `cleanup_sandbox`.
- `wxc/src/main.rs` — gated the BFS-clear block in
  `delete_app_container_profile`; `DeleteAppContainerProfile` remains
  unconditional.
- `wxc_common/src/fallback_detector.rs` — gated
  `IsolationTier::AppContainerBfs`, `TierDecision.bfscfg_path`,
  `FallbackError::SystemRootUnresolved`, `find_bfscfg_exe`,
  `resolve_windows_directory`, `parse_utf16`, the Tier 2 branch of
  `detect()`, the bfs arms of `parse_force_tier` / `forced_decision`,
  and the BFS-specific tests. Tier 3 now skips DACL consent / WRITE_DAC
  checks when the policy declares no filesystem paths, preserving the
  prior empty-policy Tier 2 success behaviour.

### Tests
- `wxc_e2e_tests/tests/e2e_windows.rs` — gated the three
  `filesystem_bfs*` helpers and `#[test]` wrappers, plus the two calls
  inside `test_on_repeat`.

### Docs
- `docs/schema.md` and `schemas/dev/mxc-config.schema.0.6.0-dev.json`
  — appended a note that BFS is opt-in (`schemas/stable/` untouched).
- `docs/playground-limitations.md` — feature-table rows + BFS section
  callout.
- `docs/lxc-support/lxc-backend.md`,
  `docs/macos-support/seatbelt-backend.md`,
  `docs/sandbox-policy/v1/policy.md` — footnotes pointing at the gate.
- `test_scripts/README.md` — annotated the three BFS test rows + a
  callout pointing at `--features bfs`.

## 🔗 References

No tracking issue. The behaviour change was requested in chat:
`bfscfg.exe` causes Windows to hang on most hosts, the DACL fallback is
incomplete, and we want the default `AppContainerScriptRunner` to skip
BFS entirely while keeping the code reachable for a future fix.

## 🔍 Validation

All commands green in **both** feature states (default off, `bfs` on):

| Step | Command |
|---|---|
| Format | `cargo fmt --all -- --check` |
| Type-check (off) | `cargo check --workspace --all-targets` |
| Type-check (on) | `cargo check --workspace --all-targets --features wxc/bfs --features wxc_e2e_tests/bfs` |
| Lint (off) | `cargo clippy --workspace --all-targets -- -D warnings` |
| Lint (on) | `cargo clippy --workspace --all-targets --features wxc/bfs --features wxc_e2e_tests/bfs -- -D warnings` |
| Unit tests (off) | `cargo test --workspace --lib --exclude wxc_e2e_tests` → **347 passed** |
| Unit tests (on) | `cargo test --workspace --lib --exclude wxc_e2e_tests --features wxc/bfs` → **362 passed** |
| E2E compile (both) | `cargo test -p wxc_e2e_tests --no-run` (with and without `--features bfs`) |
| Release smoke | `cargo build --release -p wxc` |

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/369)