### PR TITLE
fix sync mirror pipeline so GitHub repo syncs changes back to private mirror

### DIFF
--- a/.azure-pipelines/templates/Ado.Sync.Mirror.yml
+++ b/.azure-pipelines/templates/Ado.Sync.Mirror.yml
@@ -51,8 +51,10 @@ extends:
             inputs:
               targetType: 'inline'
               script: |
-                Write-Host "SourceBranch " + "$(SourceBranch)"
-                Write-Host "TargetBranch " + "$(TargetBranch)"
+                Write-Host "SourceBranch $(SourceBranch)"
+                Write-Host "TargetBranch $(TargetBranch)"
+
+                cd "$(Pipeline.Workspace)\s"
 
                 $repo = "$(Pipeline.Workspace)\source"
                 git remote add sourcerepo $repo
@@ -70,4 +72,5 @@ extends:
           - task: CmdLine@2
             inputs:
               script: |
+                cd /d "$(Pipeline.Workspace)\s"
                 git push

--- a/.azure-pipelines/templates/Ado.Sync.Mirror.yml
+++ b/.azure-pipelines/templates/Ado.Sync.Mirror.yml
@@ -7,9 +7,6 @@ parameters:
     type: object
     default:
       main: main
-  - name: "SourceRepository"
-    type: string
-    default: "https://github.com/microsoft/mxc.git"
 
 resources:
   repositories:
@@ -17,6 +14,12 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
+  - repository: SourceRepo
+    type: github
+    endpoint: MXC-GitHub-Connection
+    name: microsoft/mxc
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
@@ -38,30 +41,33 @@ extends:
                   TargetBranch: ${{ branches.value }}
           dependsOn: []
           steps:
-            - checkout: self
-              persistCredentials: true
+          - checkout: self
+            persistCredentials: true
 
-            - task: PowerShell@2
-              inputs:
-                targetType: 'inline'
-                script: |
-                  Write-Host "SourceBranch " + "$(SourceBranch)"
-                  Write-Host "TargetBranch " + "$(TargetBranch)"
+          - checkout: SourceRepo
+            path: source
 
-                  $repo = "${{ parameters.SourceRepository }}"
-                  git remote add sourcerepo $repo
-                  git remote
+          - task: PowerShell@2
+            inputs:
+              targetType: 'inline'
+              script: |
+                Write-Host "SourceBranch " + "$(SourceBranch)"
+                Write-Host "TargetBranch " + "$(TargetBranch)"
 
-                  $target = "$(TargetBranch)"
-                  git fetch origin $target
-                  git checkout $target
-                  git pull origin $target
+                $repo = "$(Pipeline.Workspace)\source"
+                git remote add sourcerepo $repo
+                git remote
 
-                  $source = "$(SourceBranch)"
-                  git fetch sourcerepo $source
-                  git pull sourcerepo $source
+                $target = "$(TargetBranch)"
+                git fetch origin $target
+                git checkout $target
+                git pull origin $target
 
-            - task: CmdLine@2
-              inputs:
-                script: |
-                  git push
+                $source = "$(SourceBranch)"
+                git fetch sourcerepo $source
+                git pull sourcerepo $source
+
+          - task: CmdLine@2
+            inputs:
+              script: |
+                git push

--- a/.azure-pipelines/templates/Ado.Sync.Mirror.yml
+++ b/.azure-pipelines/templates/Ado.Sync.Mirror.yml
@@ -3,10 +3,10 @@
 name: $(BuildDefinitionName)_$(date:yyMMdd)$(rev:.r)
 
 parameters:
-  - name: "SourceToTargetBranches"
-    type: object
-    default:
-      main: main
+- name: SourceToTargetBranches
+  type: object
+  default:
+    main: main
 
 resources:
   repositories:
@@ -23,54 +23,71 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      sourceRepositoriesToScan:
+        exclude:
+        - repository: SourceRepo
+
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       image: windows-2022
       os: windows
+
     customBuildTags:
     - ES365AIMigrationTooling
+
     stages:
     - stage: stage
       jobs:
-        - job: SyncMirror
-          strategy:
-            matrix:
-              ${{ each branches in parameters.SourceToTargetBranches }}:
-                ${{ branches.key }}:
-                  SourceBranch: ${{ branches.key }}
-                  TargetBranch: ${{ branches.value }}
-          dependsOn: []
-          steps:
-          - checkout: self
-            persistCredentials: true
+      - job: SyncMirror
+        dependsOn: []
+        strategy:
+          matrix:
+            ${{ each branches in parameters.SourceToTargetBranches }}:
+              ${{ branches.key }}:
+                SourceBranch: ${{ branches.key }}
+                TargetBranch: ${{ branches.value }}
 
-          - checkout: SourceRepo
-            path: source
+        steps:
+        - checkout: self
+          persistCredentials: true
+          path: mirror
 
-          - task: PowerShell@2
-            inputs:
-              targetType: 'inline'
-              script: |
-                Write-Host "SourceBranch $(SourceBranch)"
-                Write-Host "TargetBranch $(TargetBranch)"
+        - checkout: SourceRepo
+          path: source
 
-                cd "$(Pipeline.Workspace)\s"
+        - task: PowerShell@2
+          displayName: Sync mirror branch
+          inputs:
+            targetType: inline
+            script: |
+              $ErrorActionPreference = "Stop"
 
-                $repo = "$(Pipeline.Workspace)\source"
-                git remote add sourcerepo $repo
-                git remote
+              $sourceBranch = "$(SourceBranch)"
+              $targetBranch = "$(TargetBranch)"
+              $mirrorPath = "$(Pipeline.Workspace)\mirror"
+              $sourcePath = "$(Pipeline.Workspace)\source"
 
-                $target = "$(TargetBranch)"
-                git fetch origin $target
-                git checkout $target
-                git pull origin $target
+              Write-Host "SourceBranch $sourceBranch"
+              Write-Host "TargetBranch $targetBranch"
+              Write-Host "MirrorPath $mirrorPath"
+              Write-Host "SourcePath $sourcePath"
 
-                $source = "$(SourceBranch)"
-                git fetch sourcerepo $source
-                git pull sourcerepo $source
+              Write-Host "=== source repo ==="
+              cd $sourcePath
+              git fetch origin $sourceBranch
+              git checkout $sourceBranch
+              git pull origin $sourceBranch
 
-          - task: CmdLine@2
-            inputs:
-              script: |
-                cd /d "$(Pipeline.Workspace)\s"
-                git push
+              Write-Host "=== mirror repo ==="
+              cd $mirrorPath
+
+              git fetch origin $targetBranch
+              git checkout $targetBranch
+              git pull origin $targetBranch
+
+              git remote add sourcerepo $sourcePath
+              git fetch sourcerepo $sourceBranch
+              git merge "sourcerepo/$sourceBranch" --no-edit
+
+              git push origin HEAD:$targetBranch

--- a/.azure-pipelines/templates/Ado.Sync.Mirror.yml
+++ b/.azure-pipelines/templates/Ado.Sync.Mirror.yml
@@ -75,12 +75,14 @@ extends:
 
               Write-Host "=== source repo ==="
               cd $sourcePath
+              git remote -v
               git fetch origin $sourceBranch
               git checkout $sourceBranch
               git pull origin $sourceBranch
 
               Write-Host "=== mirror repo ==="
               cd $mirrorPath
+              git remote -v
 
               git fetch origin $targetBranch
               git checkout $targetBranch


### PR DESCRIPTION
## 📖 Description
Since the GitHub repository is private and not public the sync mirror that syncs the public GitHub repo with the private ADO repo fails due to it needing a service connection and token to access microsoft/mxc from Azure. In this PR I have updated the sync mirror yml to account for this and to add some debug statements.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
See Test pipeline that succeeded with this yml here:  https://microsoft.visualstudio.com/Dart/_build/results?buildId=147528490&view=results

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/371)