### PR TITLE
[Playground] Add MicroVM/Hyperlight FS+Network scenarios and harden raw-config

### DIFF
--- a/playground/src/main/main.ts
+++ b/playground/src/main/main.ts
@@ -91,10 +91,12 @@ function attachPtyListeners(ptyProcess: pty.IPty): void {
   activePty = ptyProcess;
 
   ptyProcess.onData((data: string) => {
+    console.log('[main] pty-data:', data.substring(0, 200));
     mainWindow?.webContents.send('pty-data', data);
   });
 
   ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+    console.log('[main] pty-exit: exitCode =', exitCode);
     activePty = null;
     mainWindow?.webContents.send('pty-exit', exitCode);
   });
@@ -514,20 +516,28 @@ ipcMain.handle('get-test-script', (_event, scriptName: string) => {
 
 // IPC: Run sandbox with raw JSON config (bypass policy creation)
 ipcMain.handle('run-sandbox-raw', (_event, configJson: string, debug: boolean, experimental: boolean) => {
+  console.log('[main] run-sandbox-raw: received IPC call');
+  console.log('[main] run-sandbox-raw: config =', configJson);
+  console.log('[main] run-sandbox-raw: debug =', debug, 'experimental =', experimental);
   killActivePty();
   const sdk = loadSdk();
 
   try {
     const config = JSON.parse(configJson);
+    const execPath = resolveExecutablePath();
+    console.log('[main] run-sandbox-raw: resolved executable =', execPath ?? '(SDK default)');
+    console.log('[main] run-sandbox-raw: calling spawnSandboxFromConfig...');
     const ptyProcess = sdk.spawnSandboxFromConfig(config, {
       debug,
       experimental,
-      executablePath: resolveExecutablePath(), skipPlatformCheck: true,
+      executablePath: execPath, skipPlatformCheck: true,
     });
+    console.log('[main] run-sandbox-raw: PTY process spawned, pid =', ptyProcess.pid);
 
     attachPtyListeners(ptyProcess);
     return { success: true, config };
   } catch (e: any) {
+    console.error('[main] run-sandbox-raw: ERROR:', e.message, e.stack);
     return { success: false, error: e.message };
   }
 });

--- a/playground/src/main/main.ts
+++ b/playground/src/main/main.ts
@@ -91,12 +91,10 @@ function attachPtyListeners(ptyProcess: pty.IPty): void {
   activePty = ptyProcess;
 
   ptyProcess.onData((data: string) => {
-    console.log('[main] pty-data:', data.substring(0, 200));
     mainWindow?.webContents.send('pty-data', data);
   });
 
   ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
-    console.log('[main] pty-exit: exitCode =', exitCode);
     activePty = null;
     mainWindow?.webContents.send('pty-exit', exitCode);
   });
@@ -516,28 +514,41 @@ ipcMain.handle('get-test-script', (_event, scriptName: string) => {
 
 // IPC: Run sandbox with raw JSON config (bypass policy creation)
 ipcMain.handle('run-sandbox-raw', (_event, configJson: string, debug: boolean, experimental: boolean) => {
-  console.log('[main] run-sandbox-raw: received IPC call');
-  console.log('[main] run-sandbox-raw: config =', configJson);
-  console.log('[main] run-sandbox-raw: debug =', debug, 'experimental =', experimental);
   killActivePty();
   const sdk = loadSdk();
 
   try {
     const config = JSON.parse(configJson);
     const execPath = resolveExecutablePath();
-    console.log('[main] run-sandbox-raw: resolved executable =', execPath ?? '(SDK default)');
-    console.log('[main] run-sandbox-raw: calling spawnSandboxFromConfig...');
+
+    // MicroVM (nanvixd) requires CWD to be the binary directory
+    let workingDir: string | undefined;
+    if (config.containment === 'microvm') {
+      const fs = require('fs');
+      const candidates = [
+        execPath,
+        path.join(__dirname, '..', '..', '..', 'sdk', 'bin', 'x64'),
+        path.join(__dirname, '..', '..', '..', 'src', 'target', 'release'),
+        path.join(__dirname, '..', '..', '..', 'src', 'target', 'debug'),
+      ].filter(Boolean);
+      for (const c of candidates) {
+        const dir = c!.endsWith('.exe') ? path.dirname(c!) : c!;
+        if (fs.existsSync(path.join(dir, 'nanvixd.exe'))) {
+          workingDir = dir;
+          break;
+        }
+      }
+    }
+
     const ptyProcess = sdk.spawnSandboxFromConfig(config, {
       debug,
       experimental,
       executablePath: execPath, skipPlatformCheck: true,
-    });
-    console.log('[main] run-sandbox-raw: PTY process spawned, pid =', ptyProcess.pid);
+    }, workingDir);
 
     attachPtyListeners(ptyProcess);
     return { success: true, config };
   } catch (e: any) {
-    console.error('[main] run-sandbox-raw: ERROR:', e.message, e.stack);
     return { success: false, error: e.message };
   }
 });

--- a/playground/src/main/main.ts
+++ b/playground/src/main/main.ts
@@ -525,11 +525,19 @@ ipcMain.handle('run-sandbox-raw', (_event, configJson: string, debug: boolean, e
     let workingDir: string | undefined;
     if (config.containment === 'microvm') {
       const fs = require('fs');
+      // Match the SDK's binary discovery layout (sdk/src/platform.ts):
+      // npm-packaged binaries live under sdk/bin/<arch>, local dev builds
+      // under src/target/<triple>/{release,debug}.
+      const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+      const triple = process.arch === 'arm64' ? 'aarch64-pc-windows-msvc' : 'x86_64-pc-windows-msvc';
+      const repoRoot = path.join(__dirname, '..', '..', '..');
       const candidates = [
         execPath,
-        path.join(__dirname, '..', '..', '..', 'sdk', 'bin', 'x64'),
-        path.join(__dirname, '..', '..', '..', 'src', 'target', 'release'),
-        path.join(__dirname, '..', '..', '..', 'src', 'target', 'debug'),
+        path.join(repoRoot, 'sdk', 'bin', arch),
+        path.join(repoRoot, 'src', 'target', triple, 'release'),
+        path.join(repoRoot, 'src', 'target', triple, 'debug'),
+        path.join(repoRoot, 'src', 'target', 'release'),
+        path.join(repoRoot, 'src', 'target', 'debug'),
       ].filter(Boolean);
       for (const c of candidates) {
         const dir = c!.endsWith('.exe') ? path.dirname(c!) : c!;
@@ -537,6 +545,13 @@ ipcMain.handle('run-sandbox-raw', (_event, configJson: string, debug: boolean, e
           workingDir = dir;
           break;
         }
+      }
+      if (!workingDir) {
+        return {
+          success: false,
+          error: `nanvixd.exe not found for arch '${arch}'. Looked in: ${candidates.join('; ')}. ` +
+                 `MicroVM requires nanvixd.exe to be co-located with wxc-exec (and CWD must point at it).`,
+        };
       }
     }
 

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -18,7 +18,7 @@ interface Scenario {
   script: string;
   policy: any;
   shell: 'cmd' | 'ps51' | 'ps7' | 'python';
-  containment?: 'appcontainer' | 'windows_sandbox';
+  containment?: 'appcontainer' | 'windows_sandbox' | 'microvm';
   requiresV05?: boolean;
   /** If set, output must contain this string for a PASS verdict */
   successMarker?: string;
@@ -368,6 +368,50 @@ var SCENARIOS: Scenario[] = [
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: 'ping -n 30 127.0.0.1',
     policy: { timeoutMs: 5000 } },
+
+  // ========== MicroVM (NanVix) ==========
+  { id: 'mv-hello', name: 'Hello from MicroVM', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Runs a simple Python script inside the NanVix micro-VM.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "x = 42\ny = 58\nprint('Hello from MicroVM! sum=%d' % (x + y))",
+    policy: {}, successMarker: 'Hello from MicroVM!' },
+  { id: 'mv-stdlib', name: 'Stdlib (json, math, hashlib)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Imports json, math, hashlib to verify the CPython stdlib is available.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import json, math, hashlib\ndata = {'pi': math.pi, 'e': math.e, 'hash': hashlib.sha256(b'nanvix').hexdigest()[:16]}\nprint(json.dumps(data))",
+    policy: {}, successMarker: 'pi' },
+  { id: 'mv-multiline', name: 'Fibonacci (multiline)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Runs a multi-line Fibonacci function to verify complex scripts work.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "def fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\n\nfor i in range(10):\n    print(f'fib({i}) = {fib(i)}')",
+    policy: {}, successMarker: 'fib(9) = 34' },
+  { id: 'mv-large-output', name: 'Large output (1000 lines)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Prints 1000 lines to verify large output streaming works.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "for i in range(1000):\n    print(f'line {i}: ' + 'x' * 80)",
+    policy: {}, successMarker: 'line 999' },
+  { id: 'mv-exit-code', name: 'Exit code 42', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'microvm',
+    description: 'Exits with code 42. Verifies exit codes propagate from the micro-VM.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should exit 42',
+    script: 'import sys; sys.exit(42)',
+    policy: {} },
+  { id: 'mv-error', name: 'Python error', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'microvm',
+    description: 'Raises a ValueError. Verifies stderr capture from the micro-VM.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should show error',
+    script: "raise ValueError('intentional test error')",
+    policy: {} },
+  { id: 'mv-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'microvm',
+    description: 'Sleeps for 120s with a 5s timeout. MicroVM adds 60s boot grace, so actual ~65s.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: "import time; time.sleep(120); print('should not reach here')",
+    policy: { timeoutMs: 5000 } },
 ];
 
 // ============================================================
@@ -589,7 +633,7 @@ function getCurrentScript(): string {
   // Replace bare 'python' with resolved full path for BaseContainer compatibility
   // (skip for Windows Sandbox — it uses mapped Python from the host)
   var containment = $sel('containmentSelect').value;
-  if (containment !== 'windows_sandbox' && shellPaths.python?.exe && script.match(/^python\s/)) {
+  if (containment !== 'windows_sandbox' && containment !== 'microvm' && shellPaths.python?.exe && script.match(/^python\s/)) {
     script = '"' + shellPaths.python.exe + '"' + script.substring(6);
   }
 
@@ -848,10 +892,10 @@ function populateScenarios(): void {
   select.innerHTML = '';
 
   var containment = $sel('containmentSelect').value;
-  var isWS = containment === 'windows_sandbox';
+  var isRawBackend = containment === 'windows_sandbox' || containment === 'microvm';
   var filtered = SCENARIOS.filter(function(s) {
     if (s.shell !== shell) return false;
-    if (isWS) return s.containment === 'windows_sandbox';
+    if (isRawBackend) return s.containment === containment;
     return !s.containment || s.containment === 'appcontainer';
   });
 
@@ -1035,23 +1079,21 @@ async function runSandbox(): Promise<void> {
     return;
   }
 
-  // Windows Sandbox mode — build raw wxc-exec JSON config and use runSandboxRaw
+  // Windows Sandbox / MicroVM mode — build raw wxc-exec JSON config and use runSandboxRaw
   var currentContainment = $sel('containmentSelect').value;
-  console.log('[renderer] runSandbox: containment =', currentContainment, 'shell =', currentShell);
-  if (currentContainment === 'windows_sandbox') {
-    var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-    console.log('[renderer] WS path: script =', wsScript, 'scenario =', state.selectedScenario?.id);
-    if (!wsScript) {
+  if (currentContainment === 'windows_sandbox' || currentContainment === 'microvm') {
+    var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+    if (!rawScript) {
       termError('No script specified');
       return;
     }
 
-    var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-    var wsConfig: any = {
-      containment: 'windows_sandbox',
+    var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+    var rawConfig: any = {
+      containment: currentContainment,
       process: {
-        commandLine: wsScript,
-        timeout: wsTimeout,
+        commandLine: rawScript,
+        timeout: rawTimeout,
       },
     };
 
@@ -1065,20 +1107,23 @@ async function runSandbox(): Promise<void> {
     }
     terminalFullText = '';
 
-    termInfo('[Playground] Running via Windows Sandbox');
+    var backendLabel = currentContainment === 'microvm' ? 'MicroVM (NanVix)' : 'Windows Sandbox';
+    termInfo('[Playground] Running via ' + backendLabel);
     if (state.selectedScenario) {
       termInfo('[Playground] Scenario: ' + state.selectedScenario.name + ' (' + state.selectedScenario.id + ')');
     }
-    termInfo('[Playground] Script: ' + wsScript);
+    termInfo('[Playground] Script: ' + rawScript);
     termInfo('[MXC] API: spawnSandboxFromConfig (raw config)');
-    termDim('[MXC] Note: First run may take 3-5 minutes while the sandbox VM boots.');
+    if (currentContainment === 'windows_sandbox') {
+      termDim('[MXC] Note: First run may take 3-5 minutes while the sandbox VM boots.');
+    } else {
+      termDim('[MXC] Note: MicroVM boot adds ~60s grace period to the script timeout.');
+    }
 
-    var wsDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
-    console.log('[renderer] WS: calling runSandboxRaw with config:', JSON.stringify(wsConfig));
-    var wsResult = await mxc.runSandboxRaw(JSON.stringify(wsConfig), wsDebug, true);
-    console.log('[renderer] WS: runSandboxRaw returned:', JSON.stringify(wsResult));
-    if (!wsResult.success) {
-      termError('[MXC] Failed to start sandbox: ' + wsResult.error);
+    var rawDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+    var rawResult = await mxc.runSandboxRaw(JSON.stringify(rawConfig), rawDebug, true);
+    if (!rawResult.success) {
+      termError('[MXC] Failed to start sandbox: ' + rawResult.error);
       onSandboxExit(-1);
     } else {
       termDim('[MXC] Config accepted');
@@ -1236,11 +1281,11 @@ async function runAllScenarios(): Promise<void> {
 
   // Filter scenarios: current shell, containment, available runtimes, version-appropriate
   var currentContainment = $sel('containmentSelect').value;
-  var isWS = currentContainment === 'windows_sandbox';
+  var isRawBackend = currentContainment === 'windows_sandbox' || currentContainment === 'microvm';
   var scenariosToRun = SCENARIOS.filter(function(s) {
     if (s.shell !== currentShell) { return false; }
-    if (isWS) { if (s.containment !== 'windows_sandbox') return false; }
-    else { if (s.containment === 'windows_sandbox') return false; }
+    if (isRawBackend) { if (s.containment !== currentContainment) return false; }
+    else { if (s.containment === 'windows_sandbox' || s.containment === 'microvm') return false; }
     if (s.shell === 'ps7' && !shellAvailability['ps7']) { return false; }
     if (s.shell === 'python' && !shellAvailability['python']) { return false; }
     if (s.requiresV05 && version !== '0.5.0-dev') { return false; }
@@ -1599,35 +1644,34 @@ function showJsonPanel(tab: string): void {
 
   if (tab === 'policy') {
     var containment = $sel('containmentSelect').value;
-    if (containment === 'windows_sandbox') {
-      var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-      var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-      var wsConfig = {
-        containment: 'windows_sandbox',
+    if (containment === 'windows_sandbox' || containment === 'microvm') {
+      var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+      var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+      var rawConfig = {
+        containment: containment,
         process: {
-          commandLine: wsScript || '(no script)',
-          timeout: wsTimeout,
+          commandLine: rawScript || '(no script)',
+          timeout: rawTimeout,
         },
       };
-      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig, null, 2)));
+      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig, null, 2)));
     } else {
       var policyStr = JSON.stringify(buildPolicy(), null, 2);
       $('jsonContent').innerHTML = highlightJson(escapeHtml(policyStr));
     }
   } else {
     var containment2 = $sel('containmentSelect').value;
-    if (containment2 === 'windows_sandbox') {
-      // WS Config tab — show the same raw config (no SDK policy validation)
-      var wsScript2 = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-      var wsTimeout2 = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-      var wsConfig2 = {
-        containment: 'windows_sandbox',
+    if (containment2 === 'windows_sandbox' || containment2 === 'microvm') {
+      var rawScript2 = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+      var rawTimeout2 = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+      var rawConfig2 = {
+        containment: containment2,
         process: {
-          commandLine: wsScript2 || '(no script)',
-          timeout: wsTimeout2,
+          commandLine: rawScript2 || '(no script)',
+          timeout: rawTimeout2,
         },
       };
-      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig2, null, 2)));
+      $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig2, null, 2)));
     } else {
       $('jsonContent').innerHTML = '<span class="line-dim">Loading config…</span>';
       var policyJson = JSON.stringify(buildPolicy());
@@ -1669,19 +1713,20 @@ function updateDevSidebar(): void {
   var currentShell = $sel('shellSelect').value;
   var currentContainment = $sel('containmentSelect').value;
 
-  // Windows Sandbox mode — show the raw WS config
-  if (currentContainment === 'windows_sandbox' && currentShell !== 'rawjson') {
-    var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-    var wsTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-    var wsConfig = {
-      containment: 'windows_sandbox',
+  // Windows Sandbox / MicroVM mode — show the raw config
+  if ((currentContainment === 'windows_sandbox' || currentContainment === 'microvm') && currentShell !== 'rawjson') {
+    var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+    var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
+    var rawConfig = {
+      containment: currentContainment,
       process: {
-        commandLine: wsScript || '(no script)',
-        timeout: wsTimeout,
+        commandLine: rawScript || '(no script)',
+        timeout: rawTimeout,
       },
     };
-    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — Windows Sandbox bypasses policy generation</span>';
-    $('devConfigJson').innerHTML = highlightJson(escapeHtml(JSON.stringify(wsConfig, null, 2)));
+    var backendName = currentContainment === 'microvm' ? 'MicroVM' : 'Windows Sandbox';
+    $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — ' + backendName + ' bypasses policy generation</span>';
+    $('devConfigJson').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig, null, 2)));
     return;
   }
 
@@ -1884,6 +1929,22 @@ function init(): void {
       } else {
         populateScenarios();
       }
+    } else if (containment === 'microvm') {
+      // MicroVM (NanVix) — Python only, no filesystem/network policies
+      $('runtimeRow').classList.remove('hidden');
+      $sel('shellSelect').disabled = false;
+      $('experimentalCaution').classList.add('hidden');
+      $('policySectionWrapper').classList.add('hidden');
+      ($('experimentalToggle') as HTMLInputElement).checked = true;
+      ($('experimentalToggle') as HTMLInputElement).disabled = true;
+      // MicroVM only supports Python — hide all other runtimes
+      var mvOpts = $sel('shellSelect').options;
+      for (var mi = 0; mi < mvOpts.length; mi++) {
+        var v = mvOpts[mi].value;
+        (mvOpts[mi] as HTMLOptionElement).hidden = (v !== 'python' && v !== 'custom' && v !== 'rawjson');
+      }
+      $sel('shellSelect').value = 'python';
+      $sel('shellSelect').dispatchEvent(new Event('change'));
     } else if (containment !== 'appcontainer') {
       // Other experimental containment — hide runtime, force MXC JSON mode
       $('runtimeRow').classList.add('hidden');
@@ -1928,7 +1989,7 @@ function init(): void {
       $('categoryRow').classList.add('hidden');
       $('scriptSection').classList.remove('hidden');
       $('rawJsonSection').classList.add('hidden');
-      if ($sel('containmentSelect').value !== 'windows_sandbox') {
+      if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm') {
         $('policySectionWrapper').classList.remove('hidden');
       }
       $('btnRun').classList.remove('hidden');
@@ -1963,7 +2024,7 @@ function init(): void {
         populateScenarios();
         $('btnRun').classList.remove('hidden');
         $('btnRunAll').classList.remove('hidden');
-        if ($sel('containmentSelect').value !== 'windows_sandbox') {
+        if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm') {
           $('policySectionWrapper').classList.remove('hidden');
         }
         if (document.getElementById('advancedSectionWrapper')) {

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -1930,14 +1930,12 @@ function showJsonPanel(tab: string): void {
     var containment = $sel('containmentSelect').value;
     if (containment === 'windows_sandbox' || containment === 'microvm' || containment === 'hyperlight') {
       var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-      var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-      var rawConfig = {
-        containment: containment,
-        process: {
-          commandLine: rawScript || '(no script)',
-          timeout: rawTimeout,
-        },
-      };
+      var rawConfig = buildRawBackendConfig(
+        containment,
+        state.selectedScenario,
+        rawScript || '(no script)',
+        state.timeoutSeconds,
+      );
       $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig, null, 2)));
     } else {
       var policyStr = JSON.stringify(buildPolicy(), null, 2);
@@ -1947,14 +1945,12 @@ function showJsonPanel(tab: string): void {
     var containment2 = $sel('containmentSelect').value;
     if (containment2 === 'windows_sandbox' || containment2 === 'microvm' || containment2 === 'hyperlight') {
       var rawScript2 = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-      var rawTimeout2 = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-      var rawConfig2 = {
-        containment: containment2,
-        process: {
-          commandLine: rawScript2 || '(no script)',
-          timeout: rawTimeout2,
-        },
-      };
+      var rawConfig2 = buildRawBackendConfig(
+        containment2,
+        state.selectedScenario,
+        rawScript2 || '(no script)',
+        state.timeoutSeconds,
+      );
       $('jsonContent').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig2, null, 2)));
     } else {
       $('jsonContent').innerHTML = '<span class="line-dim">Loading config…</span>';

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -18,7 +18,7 @@ interface Scenario {
   script: string;
   policy: any;
   shell: 'cmd' | 'ps51' | 'ps7' | 'python';
-  containment?: 'appcontainer' | 'windows_sandbox' | 'microvm';
+  containment?: 'appcontainer' | 'windows_sandbox' | 'microvm' | 'hyperlight';
   requiresV05?: boolean;
   /** If set, output must contain this string for a PASS verdict */
   successMarker?: string;
@@ -412,6 +412,78 @@ var SCENARIOS: Scenario[] = [
     expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
     script: "import time; time.sleep(120); print('should not reach here')",
     policy: { timeoutMs: 5000 } },
+
+  // ========== Hyperlight ==========
+  { id: 'hl-hello', name: 'Hello from Hyperlight', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Runs a simple Python script inside the Hyperlight+Unikraft micro-VM.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "x = 42\ny = 58\nprint('Hello from Hyperlight! sum=%d' % (x + y))",
+    policy: {}, successMarker: 'Hello from Hyperlight!' },
+  { id: 'hl-stdlib', name: 'Stdlib (json, math, hashlib)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Imports json, math, hashlib to verify CPython stdlib is available in Hyperlight.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import json, math, hashlib\ndata = {'pi': math.pi, 'e': math.e, 'hash': hashlib.sha256(b'hyperlight').hexdigest()[:16]}\nprint(json.dumps(data))",
+    policy: {}, successMarker: 'pi' },
+  { id: 'hl-multiline', name: 'Fibonacci (multiline)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Runs a multi-line Fibonacci function to verify complex scripts work in Hyperlight.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "def fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\n\nfor i in range(10):\n    print(f'fib({i}) = {fib(i)}')",
+    policy: {}, successMarker: 'fib(9) = 34' },
+  { id: 'hl-large-output', name: 'Large output (1000 lines)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Prints 1000 lines to verify large output streaming works in Hyperlight.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "for i in range(1000):\n    print(f'line {i}: ' + 'x' * 80)",
+    policy: {}, successMarker: 'line 999' },
+  { id: 'hl-exit-code', name: 'Exit code 42', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Exits with code 42. Verifies exit codes propagate from Hyperlight.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should exit 42',
+    script: 'import sys; sys.exit(42)',
+    policy: {} },
+  { id: 'hl-error', name: 'Python error', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Raises a ValueError. Verifies stderr capture from Hyperlight.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should show error',
+    script: "raise ValueError('intentional test error')",
+    policy: {} },
+  { id: 'hl-timeout', name: 'Timeout', category: 'Error Cases', categoryIcon: '⚠️', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Sleeps for 120s with a 5s timeout. Should be terminated by the host.',
+    expectedOutcome: 'be-blocked', expectedLabel: 'Should be terminated',
+    script: "import time; time.sleep(120); print('should not reach here')",
+    policy: { timeoutMs: 5000 } },
+
+  // ========== Hyperlight — Networking ==========
+  { id: 'hl-net-http', name: 'HTTP GET (network on)', category: 'Networking', categoryIcon: '🌐', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Makes an HTTP GET request with networking enabled. Verifies outbound network works.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import urllib.request\nresp = urllib.request.urlopen('http://httpbin.org/get', timeout=10)\nprint('HTTP status:', resp.status)\nprint('Network works!')",
+    policy: { network: { enabled: true } }, successMarker: 'Network works!' },
+  { id: 'hl-net-blocked', name: 'HTTP GET (network off)', category: 'Networking', categoryIcon: '🌐', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Attempts HTTP GET with networking disabled. Should fail to connect.',
+    expectedOutcome: 'show-error', expectedLabel: 'Should fail (network blocked)',
+    script: "import urllib.request\ntry:\n    urllib.request.urlopen('http://httpbin.org/get', timeout=5)\n    print('ERROR: request should have failed')\nexcept Exception as e:\n    print('Correctly blocked:', type(e).__name__)",
+    policy: {} },
+
+  // ========== Hyperlight — Filesystem ==========
+  { id: 'hl-fs-write-read', name: 'Write & read file', category: 'Filesystem', categoryIcon: '📁', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Writes a file to a mounted directory and reads it back. Verifies FS mount works.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import os, tempfile\ntd = tempfile.mkdtemp()\nfpath = os.path.join(td, 'test.txt')\nwith open(fpath, 'w') as f:\n    f.write('hello from hyperlight')\nwith open(fpath) as f:\n    data = f.read()\nprint('Read back:', data)\nassert data == 'hello from hyperlight', 'mismatch!'\nprint('FS write/read OK')",
+    policy: {}, successMarker: 'FS write/read OK' },
+  { id: 'hl-fs-stdlib-os', name: 'os module (cwd, pid, env)', category: 'Filesystem', categoryIcon: '📁', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Uses os module to check cwd, pid, and environment. Verifies OS-level introspection.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import os\nprint('PID:', os.getpid())\nprint('CWD:', os.getcwd())\nprint('ENV keys:', len(os.environ))\nprint('os module OK')",
+    policy: {}, successMarker: 'os module OK' },
 ];
 
 // ============================================================
@@ -633,7 +705,7 @@ function getCurrentScript(): string {
   // Replace bare 'python' with resolved full path for BaseContainer compatibility
   // (skip for Windows Sandbox — it uses mapped Python from the host)
   var containment = $sel('containmentSelect').value;
-  if (containment !== 'windows_sandbox' && containment !== 'microvm' && shellPaths.python?.exe && script.match(/^python\s/)) {
+  if (containment !== 'windows_sandbox' && containment !== 'microvm' && containment !== 'hyperlight' && shellPaths.python?.exe && script.match(/^python\s/)) {
     script = '"' + shellPaths.python.exe + '"' + script.substring(6);
   }
 
@@ -648,6 +720,7 @@ var CONTAINMENT_LABELS: Record<string, string> = {
   appcontainer: 'Base Process Container',
   windows_sandbox: 'Windows Sandbox',
   microvm: 'MicroVM (NanVix)',
+  hyperlight: 'Hyperlight',
   wslc: 'WSLC',
   lxc: 'LXC',
   vm: 'VM',
@@ -680,11 +753,37 @@ function isExperimentalContainment(): boolean {
   return $sel('containmentSelect').value !== 'appcontainer';
 }
 
+// Cached platform support result for badge updates
+var cachedPlatformSupport: { isSupported: boolean; reason?: string } | null = null;
+
+/** Update the platform badge based on the selected containment backend. */
+function updatePlatformBadgeForContainment(containment: string): void {
+  if (containment === 'microvm' || containment === 'hyperlight') {
+    // HL/MV don't depend on a specific Windows build version
+    var label = CONTAINMENT_LABELS[containment] || containment;
+    $('platformBadge').textContent = '✓ ' + label + ' (no OS version requirement)';
+  } else if (cachedPlatformSupport) {
+    // Restore the real platform check result
+    $('platformBadge').textContent = cachedPlatformSupport.isSupported
+      ? '✓ Platform supported'
+      : '✗ ' + (cachedPlatformSupport.reason || 'Not supported');
+  }
+}
+
 // ============================================================
 // Policy summary
 // ============================================================
 
+function isVmBackend(): boolean {
+  var c = $sel('containmentSelect').value;
+  return c === 'microvm' || c === 'hyperlight' || c === 'windows_sandbox';
+}
+
 function getPermsSummary(): string {
+  if (isVmBackend()) {
+    var label = CONTAINMENT_LABELS[$sel('containmentSelect').value] || $sel('containmentSelect').value;
+    return label + ' — VM-level isolation';
+  }
   var fs = state.fsEnabled ? 'limited' : 'off';
   var net = state.netEnabled ? 'on' : 'off';
   var ui = state.uiAllowWindows ? 'on' : 'off';
@@ -694,9 +793,13 @@ function getPermsSummary(): string {
 function updatePermsSummary(): void {
   var summary = getPermsSummary();
   $('permissionsSummaryLine').textContent = summary;
-  $('runSummary').textContent = 'Internet: ' + (state.netEnabled ? 'on' : 'off') +
-    ' · Files: ' + (state.fsEnabled ? 'limited' : 'off') +
-    ' · Desktop: ' + (state.uiAllowWindows ? 'on' : 'off');
+  if (isVmBackend()) {
+    $('runSummary').textContent = summary;
+  } else {
+    $('runSummary').textContent = 'Internet: ' + (state.netEnabled ? 'on' : 'off') +
+      ' · Files: ' + (state.fsEnabled ? 'limited' : 'off') +
+      ' · Desktop: ' + (state.uiAllowWindows ? 'on' : 'off');
+  }
 }
 
 // ============================================================
@@ -892,7 +995,7 @@ function populateScenarios(): void {
   select.innerHTML = '';
 
   var containment = $sel('containmentSelect').value;
-  var isRawBackend = containment === 'windows_sandbox' || containment === 'microvm';
+  var isRawBackend = containment === 'windows_sandbox' || containment === 'microvm' || containment === 'hyperlight';
   var filtered = SCENARIOS.filter(function(s) {
     if (s.shell !== shell) return false;
     if (isRawBackend) return s.containment === containment;
@@ -1081,7 +1184,7 @@ async function runSandbox(): Promise<void> {
 
   // Windows Sandbox / MicroVM mode — build raw wxc-exec JSON config and use runSandboxRaw
   var currentContainment = $sel('containmentSelect').value;
-  if (currentContainment === 'windows_sandbox' || currentContainment === 'microvm') {
+  if (currentContainment === 'windows_sandbox' || currentContainment === 'microvm' || currentContainment === 'hyperlight') {
     var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
     if (!rawScript) {
       termError('No script specified');
@@ -1097,6 +1200,16 @@ async function runSandbox(): Promise<void> {
       },
     };
 
+    // Merge scenario policy fields (e.g. network, filesystem) into raw config
+    var scenarioPolicy = state.selectedScenario ? state.selectedScenario.policy : {};
+    if (scenarioPolicy.network && scenarioPolicy.network.enabled) {
+      rawConfig.policy = rawConfig.policy || {};
+      rawConfig.policy.defaultNetworkPolicy = 'allow';
+    }
+    if (scenarioPolicy.timeoutMs) {
+      rawConfig.process.timeout = scenarioPolicy.timeoutMs;
+    }
+
     state.running = true;
     if (!runAllInProgress) {
       ($('btnRun') as HTMLButtonElement).disabled = true;
@@ -1107,7 +1220,7 @@ async function runSandbox(): Promise<void> {
     }
     terminalFullText = '';
 
-    var backendLabel = currentContainment === 'microvm' ? 'MicroVM (NanVix)' : 'Windows Sandbox';
+    var backendLabel = CONTAINMENT_LABELS[currentContainment] || currentContainment;
     termInfo('[Playground] Running via ' + backendLabel);
     if (state.selectedScenario) {
       termInfo('[Playground] Scenario: ' + state.selectedScenario.name + ' (' + state.selectedScenario.id + ')');
@@ -1116,8 +1229,10 @@ async function runSandbox(): Promise<void> {
     termInfo('[MXC] API: spawnSandboxFromConfig (raw config)');
     if (currentContainment === 'windows_sandbox') {
       termDim('[MXC] Note: First run may take 3-5 minutes while the sandbox VM boots.');
-    } else {
+    } else if (currentContainment === 'microvm') {
       termDim('[MXC] Note: MicroVM boot adds ~60s grace period to the script timeout.');
+    } else if (currentContainment === 'hyperlight') {
+      termDim('[MXC] Note: First run may take longer while Hyperlight warms up the snapshot.');
     }
 
     var rawDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
@@ -1281,11 +1396,11 @@ async function runAllScenarios(): Promise<void> {
 
   // Filter scenarios: current shell, containment, available runtimes, version-appropriate
   var currentContainment = $sel('containmentSelect').value;
-  var isRawBackend = currentContainment === 'windows_sandbox' || currentContainment === 'microvm';
+  var isRawBackend = currentContainment === 'windows_sandbox' || currentContainment === 'microvm' || currentContainment === 'hyperlight';
   var scenariosToRun = SCENARIOS.filter(function(s) {
     if (s.shell !== currentShell) { return false; }
     if (isRawBackend) { if (s.containment !== currentContainment) return false; }
-    else { if (s.containment === 'windows_sandbox' || s.containment === 'microvm') return false; }
+    else { if (s.containment === 'windows_sandbox' || s.containment === 'microvm' || s.containment === 'hyperlight') return false; }
     if (s.shell === 'ps7' && !shellAvailability['ps7']) { return false; }
     if (s.shell === 'python' && !shellAvailability['python']) { return false; }
     if (s.requiresV05 && version !== '0.5.0-dev') { return false; }
@@ -1644,7 +1759,7 @@ function showJsonPanel(tab: string): void {
 
   if (tab === 'policy') {
     var containment = $sel('containmentSelect').value;
-    if (containment === 'windows_sandbox' || containment === 'microvm') {
+    if (containment === 'windows_sandbox' || containment === 'microvm' || containment === 'hyperlight') {
       var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
       var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
       var rawConfig = {
@@ -1661,7 +1776,7 @@ function showJsonPanel(tab: string): void {
     }
   } else {
     var containment2 = $sel('containmentSelect').value;
-    if (containment2 === 'windows_sandbox' || containment2 === 'microvm') {
+    if (containment2 === 'windows_sandbox' || containment2 === 'microvm' || containment2 === 'hyperlight') {
       var rawScript2 = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
       var rawTimeout2 = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
       var rawConfig2 = {
@@ -1713,8 +1828,8 @@ function updateDevSidebar(): void {
   var currentShell = $sel('shellSelect').value;
   var currentContainment = $sel('containmentSelect').value;
 
-  // Windows Sandbox / MicroVM mode — show the raw config
-  if ((currentContainment === 'windows_sandbox' || currentContainment === 'microvm') && currentShell !== 'rawjson') {
+  // Windows Sandbox / MicroVM / Hyperlight mode — show the raw config
+  if ((currentContainment === 'windows_sandbox' || currentContainment === 'microvm' || currentContainment === 'hyperlight') && currentShell !== 'rawjson') {
     var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
     var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
     var rawConfig = {
@@ -1724,7 +1839,7 @@ function updateDevSidebar(): void {
         timeout: rawTimeout,
       },
     };
-    var backendName = currentContainment === 'microvm' ? 'MicroVM' : 'Windows Sandbox';
+    var backendName = CONTAINMENT_LABELS[currentContainment] || currentContainment;
     $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — ' + backendName + ' bypasses policy generation</span>';
     $('devConfigJson').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig, null, 2)));
     return;
@@ -1820,6 +1935,7 @@ function init(): void {
 
   // Platform check
   mxc.getPlatformSupport().then(function(info: any) {
+    cachedPlatformSupport = info;
     $('platformBadge').textContent = info.isSupported
       ? '✓ Platform supported'
       : '✗ ' + (info.reason || 'Not supported');
@@ -1913,6 +2029,8 @@ function init(): void {
       $('experimentalCaution').classList.add('hidden');
       // Hide policy controls — WS ignores filesystem/network/UI policies
       $('policySectionWrapper').classList.add('hidden');
+      $('advancedSectionWrapper').classList.add('hidden');
+      $('uiGroupWrapper').classList.add('hidden');
       // Auto-enable experimental (WS requires it) and lock the toggle
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
@@ -1930,11 +2048,13 @@ function init(): void {
         populateScenarios();
       }
     } else if (containment === 'microvm') {
-      // MicroVM (NanVix) — Python only, no filesystem/network policies
+      // MicroVM (NanVix) — Python only, no filesystem/network/UI policies
       $('runtimeRow').classList.remove('hidden');
       $sel('shellSelect').disabled = false;
       $('experimentalCaution').classList.add('hidden');
       $('policySectionWrapper').classList.add('hidden');
+      $('advancedSectionWrapper').classList.add('hidden');
+      $('uiGroupWrapper').classList.add('hidden');
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
       // MicroVM only supports Python — hide all other runtimes
@@ -1945,6 +2065,26 @@ function init(): void {
       }
       $sel('shellSelect').value = 'python';
       $sel('shellSelect').dispatchEvent(new Event('change'));
+      updatePlatformBadgeForContainment(containment);
+    } else if (containment === 'hyperlight') {
+      // Hyperlight — Python only, no filesystem/network/UI policies
+      $('runtimeRow').classList.remove('hidden');
+      $sel('shellSelect').disabled = false;
+      $('experimentalCaution').classList.add('hidden');
+      $('policySectionWrapper').classList.add('hidden');
+      $('advancedSectionWrapper').classList.add('hidden');
+      $('uiGroupWrapper').classList.add('hidden');
+      ($('experimentalToggle') as HTMLInputElement).checked = true;
+      ($('experimentalToggle') as HTMLInputElement).disabled = true;
+      // Hyperlight only supports Python — hide all other runtimes
+      var hlOpts = $sel('shellSelect').options;
+      for (var hi = 0; hi < hlOpts.length; hi++) {
+        var hv = hlOpts[hi].value;
+        (hlOpts[hi] as HTMLOptionElement).hidden = (hv !== 'python' && hv !== 'custom' && hv !== 'rawjson');
+      }
+      $sel('shellSelect').value = 'python';
+      $sel('shellSelect').dispatchEvent(new Event('change'));
+      updatePlatformBadgeForContainment(containment);
     } else if (containment !== 'appcontainer') {
       // Other experimental containment — hide runtime, force MXC JSON mode
       $('runtimeRow').classList.add('hidden');
@@ -1977,9 +2117,11 @@ function init(): void {
       } else {
         populateScenarios();
       }
+      updatePlatformBadgeForContainment(containment);
     }
     updateContainmentDropdown();
     updateDevSidebar();
+    updatePermsSummary();
   });
 
   // === Scenario select ===
@@ -1989,7 +2131,7 @@ function init(): void {
       $('categoryRow').classList.add('hidden');
       $('scriptSection').classList.remove('hidden');
       $('rawJsonSection').classList.add('hidden');
-      if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm') {
+      if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm' && $sel('containmentSelect').value !== 'hyperlight') {
         $('policySectionWrapper').classList.remove('hidden');
       }
       $('btnRun').classList.remove('hidden');
@@ -2024,7 +2166,7 @@ function init(): void {
         populateScenarios();
         $('btnRun').classList.remove('hidden');
         $('btnRunAll').classList.remove('hidden');
-        if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm') {
+        if ($sel('containmentSelect').value !== 'windows_sandbox' && $sel('containmentSelect').value !== 'microvm' && $sel('containmentSelect').value !== 'hyperlight') {
           $('policySectionWrapper').classList.remove('hidden');
         }
         if (document.getElementById('advancedSectionWrapper')) {

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -338,7 +338,7 @@ var SCENARIOS: Scenario[] = [
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: 'python -S -B -c "import sys; print(\'Hello from Windows Sandbox!\'); print(f\'Python version: {sys.version}\'); print(\'Script executed successfully in sandbox isolation\')"',
     policy: {}, successMarker: 'executed successfully' },
-  { id: 'ws-powershell', name: 'PowerShell hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
+  { id: 'ws-ps-hello', name: 'PowerShell hello', category: 'Quick Tests', categoryIcon: '🎯', shell: 'ps51',
     containment: 'windows_sandbox',
     description: 'Runs PowerShell inside the sandbox and prints version info.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
@@ -1037,8 +1037,10 @@ async function runSandbox(): Promise<void> {
 
   // Windows Sandbox mode — build raw wxc-exec JSON config and use runSandboxRaw
   var currentContainment = $sel('containmentSelect').value;
+  console.log('[renderer] runSandbox: containment =', currentContainment, 'shell =', currentShell);
   if (currentContainment === 'windows_sandbox') {
     var wsScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
+    console.log('[renderer] WS path: script =', wsScript, 'scenario =', state.selectedScenario?.id);
     if (!wsScript) {
       termError('No script specified');
       return;
@@ -1072,7 +1074,9 @@ async function runSandbox(): Promise<void> {
     termDim('[MXC] Note: First run may take 3-5 minutes while the sandbox VM boots.');
 
     var wsDebug = (document.getElementById('debugToggle') as HTMLInputElement).checked;
+    console.log('[renderer] WS: calling runSandboxRaw with config:', JSON.stringify(wsConfig));
     var wsResult = await mxc.runSandboxRaw(JSON.stringify(wsConfig), wsDebug, true);
+    console.log('[renderer] WS: runSandboxRaw returned:', JSON.stringify(wsResult));
     if (!wsResult.success) {
       termError('[MXC] Failed to start sandbox: ' + wsResult.error);
       onSandboxExit(-1);
@@ -1867,7 +1871,14 @@ function init(): void {
       // Auto-enable experimental (WS requires it) and lock the toggle
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
-      if ($sel('shellSelect').value === 'rawjson') {
+      // Hide PowerShell 7+ runtime — not available in WS VM
+      var shellOpts = $sel('shellSelect').options;
+      for (var i = 0; i < shellOpts.length; i++) {
+        if (shellOpts[i].value === 'ps7') {
+          (shellOpts[i] as HTMLOptionElement).hidden = true;
+        }
+      }
+      if ($sel('shellSelect').value === 'rawjson' || $sel('shellSelect').value === 'ps7') {
         $sel('shellSelect').value = 'cmd';
         $sel('shellSelect').dispatchEvent(new Event('change'));
       } else {
@@ -1878,6 +1889,11 @@ function init(): void {
       $('runtimeRow').classList.add('hidden');
       $('categoryRow').classList.add('hidden');
       $('policySectionWrapper').classList.remove('hidden');
+      // Restore PowerShell runtimes
+      var shellOpts2 = $sel('shellSelect').options;
+      for (var j = 0; j < shellOpts2.length; j++) {
+        (shellOpts2[j] as HTMLOptionElement).hidden = false;
+      }
       $sel('shellSelect').value = 'rawjson';
       $sel('shellSelect').dispatchEvent(new Event('change'));
       $('experimentalCaution').classList.remove('hidden');
@@ -1889,6 +1905,11 @@ function init(): void {
       $('experimentalCaution').classList.add('hidden');
       $('policySectionWrapper').classList.remove('hidden');
       ($('experimentalToggle') as HTMLInputElement).disabled = false;
+      // Restore PowerShell runtimes
+      var shellOpts3 = $sel('shellSelect').options;
+      for (var k = 0; k < shellOpts3.length; k++) {
+        (shellOpts3[k] as HTMLOptionElement).hidden = false;
+      }
       if ($sel('shellSelect').value === 'rawjson') {
         $sel('shellSelect').value = 'cmd';
         $sel('shellSelect').dispatchEvent(new Event('change'));

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -1332,7 +1332,20 @@ async function runSandbox(): Promise<void> {
     // any dirs the scenario mounts (e.g. C:\Users\Public\MXCPlaygroundTests).
     if (currentContainment === 'microvm' && rawConfig.filesystem && rawConfig.filesystem.readwritePaths) {
       try {
-        await mxc.ensureDirs(rawConfig.filesystem.readwritePaths);
+        var ensureDirsResult = await mxc.ensureDirs(rawConfig.filesystem.readwritePaths);
+        if (ensureDirsResult && typeof ensureDirsResult === 'object') {
+          if ((ensureDirsResult as any).success === false) {
+            throw new Error((ensureDirsResult as any).error || (ensureDirsResult as any).message || 'Unknown error');
+          }
+          if (Array.isArray(ensureDirsResult)) {
+            var failedEnsureDir = ensureDirsResult.find(function (entry: any) {
+              return entry && typeof entry === 'object' && entry.success === false;
+            });
+            if (failedEnsureDir) {
+              throw new Error(failedEnsureDir.error || failedEnsureDir.message || 'Unknown error');
+            }
+          }
+        }
       } catch (e: any) {
         termError('[Playground] Failed to pre-create RW mount dirs: ' + (e && e.message ? e.message : String(e)));
         onSandboxExit(-1);

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -467,9 +467,9 @@ var SCENARIOS: Scenario[] = [
   { id: 'hl-net-blocked', name: 'HTTP GET (network off)', category: 'Networking', categoryIcon: '🌐', shell: 'python',
     containment: 'hyperlight',
     description: 'Attempts HTTP GET with networking disabled. Should fail to connect.',
-    expectedOutcome: 'show-error', expectedLabel: 'Should fail (network blocked)',
+    expectedOutcome: 'succeed', expectedLabel: 'Should block network request',
     script: "import urllib.request\ntry:\n    urllib.request.urlopen('http://httpbin.org/get', timeout=5)\n    print('ERROR: request should have failed')\nexcept Exception as e:\n    print('Correctly blocked:', type(e).__name__)",
-    policy: {} },
+    policy: {}, successMarker: 'Correctly blocked' },
 
   // ========== Hyperlight — Filesystem ==========
   { id: 'hl-fs-write-read', name: 'Write & read file', category: 'Filesystem', categoryIcon: '📁', shell: 'python',
@@ -1202,10 +1202,9 @@ async function runSandbox(): Promise<void> {
 
     // Merge scenario policy fields (e.g. network, filesystem) into raw config
     var scenarioPolicy = state.selectedScenario ? state.selectedScenario.policy : {};
-    if (scenarioPolicy.network && scenarioPolicy.network.enabled) {
-      rawConfig.policy = rawConfig.policy || {};
-      rawConfig.policy.defaultNetworkPolicy = 'allow';
-    }
+    rawConfig.network = {
+      defaultPolicy: (scenarioPolicy.network && scenarioPolicy.network.enabled) ? 'allow' : 'block',
+    };
     if (scenarioPolicy.timeoutMs) {
       rawConfig.process.timeout = scenarioPolicy.timeoutMs;
     }
@@ -1724,16 +1723,28 @@ function analyzeOutput(terminalText: string, exitCode: number): { title: string;
 // ============================================================
 
 var terminalFullText = '';
+var ptyLineBuffer = '';
 
 mxc.onPtyData(function(data: string) {
   var clean = stripAnsi(data);
   terminalFullText += clean;
-  if (clean.trim()) {
-    termOutput(clean);
+  ptyLineBuffer += clean;
+  var lines = ptyLineBuffer.split('\n');
+  // Keep the last (possibly incomplete) chunk in the buffer
+  ptyLineBuffer = lines.pop() || '';
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i].trim()) {
+      termOutput(lines[i]);
+    }
   }
 });
 
 mxc.onPtyExit(function(exitCode: number) {
+  // Flush any remaining buffered output
+  if (ptyLineBuffer.trim()) {
+    termOutput(ptyLineBuffer);
+  }
+  ptyLineBuffer = '';
   // Small delay to let pending PTY data events flush before verdict
   setTimeout(function() { onSandboxExit(exitCode); }, 100);
 });

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -1882,17 +1882,15 @@ mxc.onPtyData(function(data: string) {
   terminalFullText += clean;
   // termWrite() appends '\n' to each call, so split chunks on newline and
   // hold the final (possibly partial) fragment until the next chunk to avoid
-  // mid-line breaks or duplicate blank lines.
+  // mid-line breaks or duplicate blank lines. Blank lines from the underlying
+  // stdout are preserved.
   ptyLineBuffer += clean;
   var lines = ptyLineBuffer.split('\n');
   ptyLineBuffer = lines.pop() || '';
   for (var i = 0; i < lines.length; i++) {
     // Strip trailing \r from CRLF sequences so the terminal doesn't render
     // a stray carriage return.
-    var line = lines[i].replace(/\r+$/, '');
-    if (line.length > 0) {
-      termOutput(line);
-    }
+    termOutput(lines[i].replace(/\r+$/, ''));
   }
 });
 
@@ -2213,7 +2211,9 @@ function init(): void {
         populateScenarios();
       }
     } else if (containment === 'microvm') {
-      // MicroVM (NanVix) — Python only, no filesystem/network/UI policies
+      // MicroVM (NanVix) — the policy-generator UI is hidden because MicroVM
+      // does not consume the SandboxPolicy schema; scenarios may still set
+      // filesystem (and other) fields in the raw config sent to wxc-exec.
       $('runtimeRow').classList.remove('hidden');
       $sel('shellSelect').disabled = false;
       $('experimentalCaution').classList.add('hidden');
@@ -2232,7 +2232,9 @@ function init(): void {
       $sel('shellSelect').dispatchEvent(new Event('change'));
       updatePlatformBadgeForContainment(containment);
     } else if (containment === 'hyperlight') {
-      // Hyperlight — Python only, no filesystem/network/UI policies
+      // Hyperlight — the policy-generator UI is hidden because Hyperlight
+      // does not consume the SandboxPolicy schema; scenarios may still set
+      // filesystem/network fields in the raw config sent to wxc-exec.
       $('runtimeRow').classList.remove('hidden');
       $sel('shellSelect').disabled = false;
       $('experimentalCaution').classList.add('hidden');

--- a/playground/src/renderer/app.ts
+++ b/playground/src/renderer/app.ts
@@ -17,7 +17,7 @@ interface Scenario {
   expectedLabel: string;
   script: string;
   policy: any;
-  shell: 'cmd' | 'ps51' | 'ps7' | 'python';
+  shell: 'cmd' | 'ps51' | 'ps7' | 'python' | 'networking' | 'filesystem';
   containment?: 'appcontainer' | 'windows_sandbox' | 'microvm' | 'hyperlight';
   requiresV05?: boolean;
   /** If set, output must contain this string for a PASS verdict */
@@ -34,6 +34,8 @@ var shellAvailability: Record<string, boolean> = {
   ps51: true,
   ps7: false,
   python: false,
+  networking: true,
+  filesystem: true,
 };
 
 // Resolved shell paths (populated by detect-shells)
@@ -44,6 +46,8 @@ var SHELL_BADGES: Record<string, string> = {
   ps51: '🔵',
   ps7: '🟣',
   python: '🐍',
+  networking: '🌐',
+  filesystem: '📁',
 };
 
 var SHELL_LABELS: Record<string, string> = {
@@ -51,6 +55,8 @@ var SHELL_LABELS: Record<string, string> = {
   ps51: '🔷 PowerShell 5.1',
   ps7: '🟦 PowerShell 7+',
   python: '🐍 Python',
+  networking: '🌐 Networking',
+  filesystem: '📁 Filesystem',
 };
 
 var SHELL_SHORT: Record<string, string> = {
@@ -58,6 +64,8 @@ var SHELL_SHORT: Record<string, string> = {
   ps51: 'PS 5.1',
   ps7: 'PS 7',
   python: 'Python',
+  networking: 'Network',
+  filesystem: 'FS',
 };
 
 function updateRunAllLabel(): void {
@@ -413,7 +421,33 @@ var SCENARIOS: Scenario[] = [
     script: "import time; time.sleep(120); print('should not reach here')",
     policy: { timeoutMs: 5000 } },
 
-  // ========== Hyperlight ==========
+  // ========== MicroVM — Filesystem ==========
+  { id: 'mv-fs-write-read', name: 'Write & read file (FS mount)', category: 'Filesystem', categoryIcon: '📁', shell: 'filesystem',
+    containment: 'microvm',
+    description: 'Writes a file to a readwritePaths mount and reads it back. Verifies staging dir works.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import os\ntest_dir = 'C:\\\\Users\\\\Public\\\\MXCPlaygroundTests'\nfpath = os.path.join(test_dir, 'mxc-mv-test.txt')\ntry:\n    with open(fpath, 'w') as f:\n        f.write('hello from microvm')\n    with open(fpath) as f:\n        data = f.read()\n    print('Read back:', data)\n    assert data == 'hello from microvm', 'mismatch!'\n    print('MV FS write/read OK')\nfinally:\n    try: os.remove(fpath)\n    except OSError: pass",
+    policy: { filesystem: { readwritePaths: ['C:\\Users\\Public\\MXCPlaygroundTests'] } }, successMarker: 'MV FS write/read OK' },
+  { id: 'mv-fs-list-dir', name: 'List directory contents', category: 'Filesystem', categoryIcon: '📁', shell: 'filesystem',
+    containment: 'microvm',
+    description: 'Creates and lists files in a readwritePaths mount. Verifies directory operations.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import os\ntest_dir = 'C:\\\\Users\\\\Public\\\\MXCPlaygroundTests'\nnames = ['mxc-a.txt', 'mxc-b.txt', 'mxc-c.txt']\ntry:\n    for name in names:\n        with open(os.path.join(test_dir, name), 'w') as f:\n            f.write(name)\n    entries = [e for e in os.listdir(test_dir) if e.startswith('mxc-')]\n    print('MXC files:', sorted(entries))\n    assert 'mxc-a.txt' in entries and 'mxc-c.txt' in entries\n    print('MV dir listing OK')\nfinally:\n    for name in names:\n        try: os.remove(os.path.join(test_dir, name))\n        except OSError: pass",
+    policy: { filesystem: { readwritePaths: ['C:\\Users\\Public\\MXCPlaygroundTests'] } }, successMarker: 'MV dir listing OK' },
+
+  // ========== MicroVM — Stdlib ==========
+  { id: 'mv-stdlib-broad', name: 'Stdlib (re, datetime, collections)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Imports re, datetime, collections to verify broader stdlib availability.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import re, datetime, collections\nm = re.match(r'(\\w+)@(\\w+)', 'user@host')\nprint('regex:', m.group(1), m.group(2))\nnow = datetime.datetime(2025, 1, 15, 12, 0)\nprint('datetime:', now.isoformat())\nc = collections.Counter('abracadabra')\nprint('counter:', c.most_common(3))\nprint('broad stdlib OK')",
+    policy: {}, successMarker: 'broad stdlib OK' },
+  { id: 'mv-memory', name: 'Memory stress (10MB list)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'microvm',
+    description: 'Allocates a 10MB list to verify the VM handles non-trivial memory.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "data = list(range(1_000_000))\nprint('Allocated', len(data), 'items')\nprint('Sum:', sum(data[:100]))\nprint('Memory OK')",
+    policy: {}, successMarker: 'Memory OK' },
   { id: 'hl-hello', name: 'Hello from Hyperlight', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
     containment: 'hyperlight',
     description: 'Runs a simple Python script inside the Hyperlight+Unikraft micro-VM.',
@@ -458,32 +492,65 @@ var SCENARIOS: Scenario[] = [
     policy: { timeoutMs: 5000 } },
 
   // ========== Hyperlight — Networking ==========
-  { id: 'hl-net-http', name: 'HTTP GET (network on)', category: 'Networking', categoryIcon: '🌐', shell: 'python',
+  { id: 'hl-net-socket-api', name: 'Socket API available', category: 'Networking', categoryIcon: '🌐', shell: 'networking',
     containment: 'hyperlight',
-    description: 'Makes an HTTP GET request with networking enabled. Verifies outbound network works.',
+    description: 'Verifies the socket module loads and socket creation works (no actual connection).',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import socket\ns = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\nprint('Socket created:', s.fileno())\nprint('Family:', s.family.name)\nprint('Type:', s.type.name)\ns.close()\nprint('Socket API OK')",
+    policy: { network: { enabled: true } }, successMarker: 'Socket API OK' },
+  { id: 'hl-net-modules', name: 'Network stdlib modules', category: 'Networking', categoryIcon: '🌐', shell: 'networking',
+    containment: 'hyperlight',
+    description: 'Imports ssl, http.client, urllib to verify network stdlib is available.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import ssl\nimport http.client\nimport urllib.request\nimport urllib.parse\nprint('ssl version:', ssl.OPENSSL_VERSION)\nprint('http.client OK')\nprint('urllib OK')\nprint('Net modules OK')",
+    policy: {}, successMarker: 'Net modules OK' },
+  { id: 'hl-net-http-allow', name: 'HTTP GET (network on)', category: 'Networking', categoryIcon: '🌐', shell: 'networking',
+    containment: 'hyperlight',
+    description: 'Makes an HTTP GET request with networking enabled. Verifies real outbound connectivity.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: "import urllib.request\nresp = urllib.request.urlopen('http://httpbin.org/get', timeout=10)\nprint('HTTP status:', resp.status)\nprint('Network works!')",
     policy: { network: { enabled: true } }, successMarker: 'Network works!' },
-  { id: 'hl-net-blocked', name: 'HTTP GET (network off)', category: 'Networking', categoryIcon: '🌐', shell: 'python',
+  { id: 'hl-net-http-blocked', name: 'HTTP GET (network off)', category: 'Networking', categoryIcon: '🌐', shell: 'networking',
     containment: 'hyperlight',
-    description: 'Attempts HTTP GET with networking disabled. Should fail to connect.',
+    description: 'Attempts HTTP GET with networking disabled. Should fail to connect (verdict passes when blocked).',
     expectedOutcome: 'succeed', expectedLabel: 'Should block network request',
     script: "import urllib.request\ntry:\n    urllib.request.urlopen('http://httpbin.org/get', timeout=5)\n    print('ERROR: request should have failed')\nexcept Exception as e:\n    print('Correctly blocked:', type(e).__name__)",
-    policy: {}, successMarker: 'Correctly blocked' },
+    policy: {}, successMarker: 'Correctly blocked', failureMarker: 'ERROR: request should have failed' },
 
   // ========== Hyperlight — Filesystem ==========
-  { id: 'hl-fs-write-read', name: 'Write & read file', category: 'Filesystem', categoryIcon: '📁', shell: 'python',
+  { id: 'hl-fs-write-read', name: 'Write & read file', category: 'Filesystem', categoryIcon: '📁', shell: 'filesystem',
     containment: 'hyperlight',
     description: 'Writes a file to a mounted directory and reads it back. Verifies FS mount works.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: "import os, tempfile\ntd = tempfile.mkdtemp()\nfpath = os.path.join(td, 'test.txt')\nwith open(fpath, 'w') as f:\n    f.write('hello from hyperlight')\nwith open(fpath) as f:\n    data = f.read()\nprint('Read back:', data)\nassert data == 'hello from hyperlight', 'mismatch!'\nprint('FS write/read OK')",
     policy: {}, successMarker: 'FS write/read OK' },
-  { id: 'hl-fs-stdlib-os', name: 'os module (cwd, pid, env)', category: 'Filesystem', categoryIcon: '📁', shell: 'python',
+  { id: 'hl-fs-stdlib-os', name: 'os module (cwd, pid, env)', category: 'Filesystem', categoryIcon: '📁', shell: 'filesystem',
     containment: 'hyperlight',
     description: 'Uses os module to check cwd, pid, and environment. Verifies OS-level introspection.',
     expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
     script: "import os\nprint('PID:', os.getpid())\nprint('CWD:', os.getcwd())\nprint('ENV keys:', len(os.environ))\nprint('os module OK')",
     policy: {}, successMarker: 'os module OK' },
+
+  // ========== Hyperlight — Networking (advanced) ==========
+  // ========== Hyperlight — Stdlib & ML stack ==========
+  { id: 'hl-stdlib-broad', name: 'Stdlib (re, datetime, collections)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Imports re, datetime, collections to verify broader stdlib availability.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import re, datetime, collections\nm = re.match(r'(\\w+)@(\\w+)', 'user@host')\nprint('regex:', m.group(1), m.group(2))\nnow = datetime.datetime(2025, 1, 15, 12, 0)\nprint('datetime:', now.isoformat())\nc = collections.Counter('abracadabra')\nprint('counter:', c.most_common(3))\nprint('broad stdlib OK')",
+    policy: {}, successMarker: 'broad stdlib OK' },
+  { id: 'hl-numpy', name: 'numpy import & compute', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Imports numpy and does basic array ops. Verifies the preloaded ML stack.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "import numpy as np\narr = np.arange(100).reshape(10, 10)\nprint('Shape:', arr.shape)\nprint('Sum:', arr.sum())\nprint('Mean:', arr.mean())\nprint('numpy OK')",
+    policy: {}, successMarker: 'numpy OK' },
+  { id: 'hl-memory', name: 'Memory stress (10MB list)', category: 'Quick Tests', categoryIcon: '🎯', shell: 'python',
+    containment: 'hyperlight',
+    description: 'Allocates a 10MB list to verify the VM handles non-trivial memory.',
+    expectedOutcome: 'succeed', expectedLabel: 'Should succeed',
+    script: "data = list(range(1_000_000))\nprint('Allocated', len(data), 'items')\nprint('Sum:', sum(data[:100]))\nprint('Memory OK')",
+    policy: {}, successMarker: 'Memory OK' },
 ];
 
 // ============================================================
@@ -1142,6 +1209,55 @@ function loadScenario(id: string): void {
 }
 
 // ============================================================
+// Raw-backend config builder (shared by run + dev sidebar)
+// ============================================================
+
+function buildRawBackendConfig(
+  containment: string,
+  scenario: Scenario | null,
+  script: string,
+  timeoutSeconds: number,
+): any {
+  var scenarioPolicy: any = scenario ? scenario.policy : {};
+  var timeoutMs = timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0;
+  var config: any = {
+    containment: containment,
+    process: {
+      commandLine: script,
+      timeout: timeoutMs,
+    },
+  };
+  if (scenarioPolicy.network && scenarioPolicy.network.enabled) {
+    config.network = { defaultPolicy: 'allow' };
+    if (scenarioPolicy.network.allowedHosts) {
+      config.network.allowedHosts = scenarioPolicy.network.allowedHosts;
+    }
+    if (scenarioPolicy.network.blockedHosts) {
+      config.network.blockedHosts = scenarioPolicy.network.blockedHosts;
+    }
+  }
+  if (scenarioPolicy.filesystem) {
+    config.filesystem = {};
+    if (scenarioPolicy.filesystem.readwritePaths) {
+      config.filesystem.readwritePaths = scenarioPolicy.filesystem.readwritePaths;
+    }
+    if (scenarioPolicy.filesystem.readonlyPaths) {
+      config.filesystem.readonlyPaths = scenarioPolicy.filesystem.readonlyPaths;
+    }
+  }
+  // Hyperlight defaults to network-allowed when `network` is omitted; explicitly
+  // block unless the scenario opts in. MicroVM/NanVix rejects `defaultPolicy: block`,
+  // so leave its network field unset in that case.
+  if (containment === 'hyperlight' && !config.network) {
+    config.network = { defaultPolicy: 'block' };
+  }
+  if (scenarioPolicy.timeoutMs) {
+    config.process.timeout = scenarioPolicy.timeoutMs;
+  }
+  return config;
+}
+
+// ============================================================
 // Run / Kill
 // ============================================================
 
@@ -1155,6 +1271,20 @@ async function runSandbox(): Promise<void> {
     if (!rawJson) {
       termError('No JSON config provided');
       return;
+    }
+
+    // Apply Hyperlight default-block defense-in-depth: if the user-pasted config
+    // targets Hyperlight and omits `network`, inject `{ defaultPolicy: 'block' }`
+    // so we don't silently inherit the backend's default-allow.
+    try {
+      var rawParsed = JSON.parse(rawJson);
+      if (rawParsed && rawParsed.containment === 'hyperlight' && !rawParsed.network) {
+        rawParsed.network = { defaultPolicy: 'block' };
+        rawJson = JSON.stringify(rawParsed);
+        termDim('[Playground] Hyperlight: injected network.defaultPolicy=block (no network field provided)');
+      }
+    } catch {
+      // Let the backend surface the parse error.
     }
 
     state.running = true;
@@ -1191,22 +1321,23 @@ async function runSandbox(): Promise<void> {
       return;
     }
 
-    var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-    var rawConfig: any = {
-      containment: currentContainment,
-      process: {
-        commandLine: rawScript,
-        timeout: rawTimeout,
-      },
-    };
+    var rawConfig: any = buildRawBackendConfig(
+      currentContainment,
+      state.selectedScenario,
+      rawScript,
+      state.timeoutSeconds,
+    );
 
-    // Merge scenario policy fields (e.g. network, filesystem) into raw config
-    var scenarioPolicy = state.selectedScenario ? state.selectedScenario.policy : {};
-    rawConfig.network = {
-      defaultPolicy: (scenarioPolicy.network && scenarioPolicy.network.enabled) ? 'allow' : 'block',
-    };
-    if (scenarioPolicy.timeoutMs) {
-      rawConfig.process.timeout = scenarioPolicy.timeoutMs;
+    // MicroVM staging requires readwritePaths to exist on the host. Pre-create
+    // any dirs the scenario mounts (e.g. C:\Users\Public\MXCPlaygroundTests).
+    if (currentContainment === 'microvm' && rawConfig.filesystem && rawConfig.filesystem.readwritePaths) {
+      try {
+        await mxc.ensureDirs(rawConfig.filesystem.readwritePaths);
+      } catch (e: any) {
+        termError('[Playground] Failed to pre-create RW mount dirs: ' + (e && e.message ? e.message : String(e)));
+        onSandboxExit(-1);
+        return;
+      }
     }
 
     state.running = true;
@@ -1397,7 +1528,15 @@ async function runAllScenarios(): Promise<void> {
   var currentContainment = $sel('containmentSelect').value;
   var isRawBackend = currentContainment === 'windows_sandbox' || currentContainment === 'microvm' || currentContainment === 'hyperlight';
   var scenariosToRun = SCENARIOS.filter(function(s) {
-    if (s.shell !== currentShell) { return false; }
+    // When the user picks "python" on a raw backend (MicroVM/Hyperlight), also
+    // pull in the pseudo-shell categories (networking, filesystem) since those
+    // scenarios are Python-backed and would otherwise be silently skipped.
+    var shellMatch = (s.shell === currentShell);
+    if (!shellMatch && isRawBackend && currentShell === 'python' &&
+        (s.shell === 'networking' || s.shell === 'filesystem')) {
+      shellMatch = true;
+    }
+    if (!shellMatch) { return false; }
     if (isRawBackend) { if (s.containment !== currentContainment) return false; }
     else { if (s.containment === 'windows_sandbox' || s.containment === 'microvm' || s.containment === 'hyperlight') return false; }
     if (s.shell === 'ps7' && !shellAvailability['ps7']) { return false; }
@@ -1728,21 +1867,27 @@ var ptyLineBuffer = '';
 mxc.onPtyData(function(data: string) {
   var clean = stripAnsi(data);
   terminalFullText += clean;
+  // termWrite() appends '\n' to each call, so split chunks on newline and
+  // hold the final (possibly partial) fragment until the next chunk to avoid
+  // mid-line breaks or duplicate blank lines.
   ptyLineBuffer += clean;
   var lines = ptyLineBuffer.split('\n');
-  // Keep the last (possibly incomplete) chunk in the buffer
   ptyLineBuffer = lines.pop() || '';
   for (var i = 0; i < lines.length; i++) {
-    if (lines[i].trim()) {
-      termOutput(lines[i]);
+    // Strip trailing \r from CRLF sequences so the terminal doesn't render
+    // a stray carriage return.
+    var line = lines[i].replace(/\r+$/, '');
+    if (line.length > 0) {
+      termOutput(line);
     }
   }
 });
 
 mxc.onPtyExit(function(exitCode: number) {
   // Flush any remaining buffered output
-  if (ptyLineBuffer.trim()) {
-    termOutput(ptyLineBuffer);
+  var tail = ptyLineBuffer.replace(/\r+$/, '');
+  if (tail.length > 0) {
+    termOutput(tail);
   }
   ptyLineBuffer = '';
   // Small delay to let pending PTY data events flush before verdict
@@ -1842,14 +1987,12 @@ function updateDevSidebar(): void {
   // Windows Sandbox / MicroVM / Hyperlight mode — show the raw config
   if ((currentContainment === 'windows_sandbox' || currentContainment === 'microvm' || currentContainment === 'hyperlight') && currentShell !== 'rawjson') {
     var rawScript = state.selectedScenario ? state.selectedScenario.script : (state.customScript || '').trim();
-    var rawTimeout = state.timeoutSeconds > 0 ? state.timeoutSeconds * 1000 : 0;
-    var rawConfig = {
-      containment: currentContainment,
-      process: {
-        commandLine: rawScript || '(no script)',
-        timeout: rawTimeout,
-      },
-    };
+    var rawConfig = buildRawBackendConfig(
+      currentContainment,
+      state.selectedScenario,
+      rawScript || '(no script)',
+      state.timeoutSeconds,
+    );
     var backendName = CONTAINMENT_LABELS[currentContainment] || currentContainment;
     $('devPolicyJson').innerHTML = '<span class="line-dim">N/A — ' + backendName + ' bypasses policy generation</span>';
     $('devConfigJson').innerHTML = highlightJson(escapeHtml(JSON.stringify(rawConfig, null, 2)));
@@ -2045,10 +2188,12 @@ function init(): void {
       // Auto-enable experimental (WS requires it) and lock the toggle
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
-      // Hide PowerShell 7+ runtime — not available in WS VM
+      // Hide PowerShell 7+ runtime — not available in WS VM. Also hide the
+      // pseudo-shells (networking/filesystem) which only apply to MV/HL.
       var shellOpts = $sel('shellSelect').options;
       for (var i = 0; i < shellOpts.length; i++) {
-        if (shellOpts[i].value === 'ps7') {
+        var sv = shellOpts[i].value;
+        if (sv === 'ps7' || sv === 'networking' || sv === 'filesystem') {
           (shellOpts[i] as HTMLOptionElement).hidden = true;
         }
       }
@@ -2068,11 +2213,11 @@ function init(): void {
       $('uiGroupWrapper').classList.add('hidden');
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
-      // MicroVM only supports Python — hide all other runtimes
+      // MicroVM supports Python + Filesystem test categories
       var mvOpts = $sel('shellSelect').options;
       for (var mi = 0; mi < mvOpts.length; mi++) {
         var v = mvOpts[mi].value;
-        (mvOpts[mi] as HTMLOptionElement).hidden = (v !== 'python' && v !== 'custom' && v !== 'rawjson');
+        (mvOpts[mi] as HTMLOptionElement).hidden = (v !== 'python' && v !== 'filesystem' && v !== 'custom' && v !== 'rawjson');
       }
       $sel('shellSelect').value = 'python';
       $sel('shellSelect').dispatchEvent(new Event('change'));
@@ -2087,11 +2232,11 @@ function init(): void {
       $('uiGroupWrapper').classList.add('hidden');
       ($('experimentalToggle') as HTMLInputElement).checked = true;
       ($('experimentalToggle') as HTMLInputElement).disabled = true;
-      // Hyperlight only supports Python — hide all other runtimes
+      // Hyperlight supports Python + Networking + Filesystem test categories
       var hlOpts = $sel('shellSelect').options;
       for (var hi = 0; hi < hlOpts.length; hi++) {
         var hv = hlOpts[hi].value;
-        (hlOpts[hi] as HTMLOptionElement).hidden = (hv !== 'python' && hv !== 'custom' && hv !== 'rawjson');
+        (hlOpts[hi] as HTMLOptionElement).hidden = (hv !== 'python' && hv !== 'networking' && hv !== 'filesystem' && hv !== 'custom' && hv !== 'rawjson');
       }
       $sel('shellSelect').value = 'python';
       $sel('shellSelect').dispatchEvent(new Event('change'));
@@ -2101,10 +2246,12 @@ function init(): void {
       $('runtimeRow').classList.add('hidden');
       $('categoryRow').classList.add('hidden');
       $('policySectionWrapper').classList.remove('hidden');
-      // Restore PowerShell runtimes
+      // Restore PowerShell runtimes (but keep pseudo-shells hidden — they only
+      // apply to MicroVM/Hyperlight, where Python is the runtime).
       var shellOpts2 = $sel('shellSelect').options;
       for (var j = 0; j < shellOpts2.length; j++) {
-        (shellOpts2[j] as HTMLOptionElement).hidden = false;
+        var sv2 = shellOpts2[j].value;
+        (shellOpts2[j] as HTMLOptionElement).hidden = (sv2 === 'networking' || sv2 === 'filesystem');
       }
       $sel('shellSelect').value = 'rawjson';
       $sel('shellSelect').dispatchEvent(new Event('change'));
@@ -2117,10 +2264,12 @@ function init(): void {
       $('experimentalCaution').classList.add('hidden');
       $('policySectionWrapper').classList.remove('hidden');
       ($('experimentalToggle') as HTMLInputElement).disabled = false;
-      // Restore PowerShell runtimes
+      // Restore PowerShell runtimes (but keep pseudo-shells hidden — they only
+      // apply to MicroVM/Hyperlight, where Python is the runtime).
       var shellOpts3 = $sel('shellSelect').options;
       for (var k = 0; k < shellOpts3.length; k++) {
-        (shellOpts3[k] as HTMLOptionElement).hidden = false;
+        var sv3 = shellOpts3[k].value;
+        (shellOpts3[k] as HTMLOptionElement).hidden = (sv3 === 'networking' || sv3 === 'filesystem');
       }
       if ($sel('shellSelect').value === 'rawjson') {
         $sel('shellSelect').value = 'cmd';

--- a/playground/src/renderer/index.html
+++ b/playground/src/renderer/index.html
@@ -124,6 +124,8 @@
                   <option value="ps51">🔷 PowerShell 5.1</option>
                   <option value="ps7">🟦 PowerShell 7+</option>
                   <option value="python">🐍 Python</option>
+                  <option value="networking" hidden>🌐 Networking</option>
+                  <option value="filesystem" hidden>📁 Filesystem</option>
                   <option value="custom">✏️ Custom</option>
                   <option value="rawjson">📋 MXC JSON Config</option>
                 </select>

--- a/playground/src/renderer/index.html
+++ b/playground/src/renderer/index.html
@@ -108,6 +108,7 @@
                 <option value="appcontainer">🛡️ Base Process Container</option>
                 <option value="windows_sandbox">🧪 Windows Sandbox</option>
                 <option value="microvm">🧪 MicroVM (NanVix)</option>
+                <option value="hyperlight">🧪 Hyperlight</option>
                 <option value="wslc">🧪 WSLC</option>
               </select>
               <div id="experimentalCaution" class="experimental-caution hidden">

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -7,8 +7,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -163,7 +163,6 @@ export function resolveExecutableAndArgs(
     // at run time, so the SDK accepts them without checking against the
     // host's concrete backend list.
     const isIntent = (ContainmentTypes as readonly string[]).includes(config.containment);
-    const isExperimental = (ExperimentalBackends as readonly string[]).includes(config.containment);
     const isAvailable = platformSupport.availableMethods.includes(config.containment as ContainmentBackend);
     if (!isIntent && !isExperimental && !isAvailable) {
       throw new Error(

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -72,7 +72,7 @@ export function resolveBinaryAndCommonArgs(
   options: SandboxSpawnOptions,
 ): { executablePath: string; args: string[] } {
   const platformSupport = getPlatformSupport();
-  if (!platformSupport.isSupported) {
+  if (!platformSupport.isSupported && !options.skipPlatformCheck) {
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
 
@@ -146,7 +146,7 @@ export function resolveExecutableAndArgs(
   const platformSupport = getPlatformSupport();
   const isExperimental = !!config.containment &&
     (ExperimentalBackends as readonly string[]).includes(config.containment);
-  if (!platformSupport.isSupported && !isExperimental) {
+  if (!platformSupport.isSupported && !isExperimental && !options.skipPlatformCheck) {
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
 

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -150,11 +150,15 @@ export function resolveExecutableAndArgs(
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
 
+  // Hard platform requirement: microvm needs WHP/Hyper-V on Windows. This guard
+  // runs even when `skipPlatformCheck` is set because it's not a build-version
+  // check — the backend literally cannot run on non-Windows hosts.
+  if (config.containment === 'microvm' && os.platform() !== 'win32') {
+    throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
+  }
+
   // Validate containment against platform
   if (config.containment && !options.skipPlatformCheck) {
-    if (config.containment === 'microvm' && os.platform() !== 'win32') {
-      throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
-    }
     // Abstract intents (process, microvm) are resolved by the native binary
     // at run time, so the SDK accepts them without checking against the
     // host's concrete backend list.

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -151,7 +151,7 @@ export function resolveExecutableAndArgs(
   }
 
   // Validate containment against platform
-  if (config.containment) {
+  if (config.containment && !options.skipPlatformCheck) {
     if (config.containment === 'microvm' && os.platform() !== 'win32') {
       throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
     }

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -95,6 +95,22 @@ function checkWindowsBuildVersion(): boolean {
 }
 
 /**
+ * Check if Windows Sandbox feature is enabled via DISM.
+ * @returns true if the Containers-DisposableClientVM feature is enabled
+ */
+function isWindowsSandboxAvailable(): boolean {
+  try {
+    const output = execSync(
+      'dism /online /get-featureinfo /featurename:Containers-DisposableClientVM',
+      { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
+    );
+    return /State\s*:\s*Enabled/i.test(output);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Get platform support information
  * @returns Platform support details including available sandboxing methods
  */
@@ -140,6 +156,9 @@ export function getPlatformSupport(): PlatformSupport {
   if (buildSupported) {
     support.isSupported = true;
     support.availableMethods = ['processcontainer'];
+    if (isWindowsSandboxAvailable()) {
+      support.availableMethods.push('windows_sandbox');
+    }
     return support;
   }
 

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -112,7 +112,17 @@ function isWindowsSandboxAvailable(): boolean {
     );
     windowsSandboxAvailableCache = /State\s*:\s*Enabled/i.test(output);
   } catch {
-    windowsSandboxAvailableCache = false;
+    // `dism /online` typically requires elevation, so a non-elevated session
+    // throws here and we can't distinguish "disabled" from "no permission".
+    // Fall back to checking for the sandbox executable — Windows installs it
+    // under System32 only when the Containers-DisposableClientVM feature is
+    // enabled, and the path is readable without admin.
+    const sandboxExe = path.join(
+      process.env.SystemRoot || 'C:\\Windows',
+      'System32',
+      'WindowsSandbox.exe',
+    );
+    windowsSandboxAvailableCache = fs.existsSync(sandboxExe);
   }
 
   return windowsSandboxAvailableCache;

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -94,20 +94,28 @@ function checkWindowsBuildVersion(): boolean {
   return true;
 }
 
+let windowsSandboxAvailableCache: boolean | undefined;
+
 /**
  * Check if Windows Sandbox feature is enabled via DISM.
  * @returns true if the Containers-DisposableClientVM feature is enabled
  */
 function isWindowsSandboxAvailable(): boolean {
+  if (windowsSandboxAvailableCache !== undefined) {
+    return windowsSandboxAvailableCache;
+  }
+
   try {
     const output = execSync(
       'dism /online /get-featureinfo /featurename:Containers-DisposableClientVM',
       { encoding: 'utf-8', stdio: 'pipe', timeout: 10000 },
     );
-    return /State\s*:\s*Enabled/i.test(output);
+    windowsSandboxAvailableCache = /State\s*:\s*Enabled/i.test(output);
   } catch {
-    return false;
+    windowsSandboxAvailableCache = false;
   }
+
+  return windowsSandboxAvailableCache;
 }
 
 /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -77,6 +77,7 @@ export type ContainmentBackend =
   | 'wslc'
   | 'lxc'
   | 'microvm'
+  | 'hyperlight'
   | 'seatbelt'
   | 'isolation_session'
   | 'bubblewrap';
@@ -85,7 +86,7 @@ export type ContainmentBackend =
  * Containment values (abstract intent or concrete backend) that require
  * the `--experimental` flag.
  */
-export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'wslc', 'seatbelt', 'bubblewrap'];
+export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'hyperlight', 'wslc', 'seatbelt', 'bubblewrap'];
 
 /**
  * Clipboard access policy levels


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Adds MicroVM and Hyperlight backends, adds new filesystem and networking scenarios, and fixes several correctness issues uncovered by code review.

### Scenarios
- New `networking` / `filesystem` pseudo-shells to categorise Python-backed scenarios that exercise net/FS surface (badges, labels, and dropdown options added; hidden outside MicroVM/Hyperlight).
- New MicroVM scenarios: `mv-fs-write-read`, `mv-fs-list-dir` (mount a dedicated `C:\Users\Public\MXCPlaygroundTests` subdir with `try/finally` cleanup), `mv-stdlib-broad`, `mv-memory`.
- New Hyperlight scenarios: socket API, network stdlib modules, real HTTP GET (allow), HTTP GET (blocked), stdlib breadth, numpy, memory.