### PR TITLE
Add os vpack pipeline

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -16,7 +16,6 @@ resources:
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
-# Parameters for ESRP signing info will be passed from the ADO UI.
 parameters:
   - name: officialBuild
     displayName: Build Official or Unofficial
@@ -31,15 +30,24 @@ parameters:
     type: boolean
     default: false
 
+  # Reused by Rust/Mac/NpmSdk templates. Values come from MXC-ESRP-Signing
+  # on Official runs; sign steps are gated, so missing values on Unofficial
+  # runs are harmless.
+  - name: ESRPInfo
+    type: object
+    default:
+      serviceName: $(serviceName)
+      tenantId: $(tenantId)
+      azureKeyVaultName: $(azureKeyVaultName)
+      authCertName: $(authCertName)
+      signCertName: $(signCertName)
+      clientId: $(clientId)
+
 variables:
   # Prevents failure when no Rust tests are found; pipeline runs will still fail if present
   # tests do not pass.
   - name: NEXTEST_NO_TESTS
     value: pass
-  # Pull ESRP signing credentials from the variable group only for Official
-  # builds. PR / unofficial runs skip the sign step (see Rust.Build.Job.yml
-  # condition `eq(parameters.isOfficialBuild, true)`), so the group isn't
-  # needed and we avoid surfacing it on pull requests.
   - ${{ if eq(parameters.officialBuild, 'Official') }}:
     - group: MXC-ESRP-Signing
 
@@ -81,14 +89,7 @@ extends:
                 arch: arm64
                 component: LXC
 
-            ${{ if eq(parameters.officialBuild, 'Official') }}:
-              ESRPInfo:
-                serviceName: $(serviceName)
-                tenantId: $(tenantId)
-                azureKeyVaultName: $(azureKeyVaultName)
-                authCertName: $(authCertName)
-                signCertName: $(signCertName)
-                clientId: $(clientId)
+            ESRPInfo: ${{ parameters.ESRPInfo }}
 
         # macOS uses a separate template because it runs on a different
         # pool (Microsoft-hosted). The produced artifact name follows the same
@@ -96,14 +97,7 @@ extends:
         - template: .azure-pipelines/templates/Mac.Build.Job.yml@self
           parameters:
             isOfficialBuild: ${{ eq(parameters.officialBuild, 'Official') }}
-            ${{ if eq(parameters.officialBuild, 'Official') }}:
-              ESRPInfo:
-                serviceName: $(serviceName)
-                tenantId: $(tenantId)
-                azureKeyVaultName: $(azureKeyVaultName)
-                authCertName: $(authCertName)
-                signCertName: $(signCertName)
-                clientId: $(clientId)
+            ESRPInfo: ${{ parameters.ESRPInfo }}
 
     - stage: Package_MXC
       displayName: 'Package MXC'
@@ -123,14 +117,7 @@ extends:
             - artifact: mxc-binaries-aarch64-apple-darwin
               sdkArch: arm64
 
-          ${{ if eq(parameters.officialBuild, 'Official') }}:
-            ESRPInfo:
-              serviceName: $(serviceName)
-              tenantId: $(tenantId)
-              azureKeyVaultName: $(azureKeyVaultName)
-              authCertName: $(authCertName)
-              signCertName: $(signCertName)
-              clientId: $(clientId)
+          ESRPInfo: ${{ parameters.ESRPInfo }}
 
       - template: .azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml@self
 

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -26,16 +26,6 @@ parameters:
       - Official
       - Unofficial
 
-  - name: ESRPInfo
-    type: object
-    default:
-      serviceName: ''
-      tenantId: ''
-      azureKeyVaultName: ''
-      authCertName: ''
-      signCertName: ''
-      clientId: ''
-
   - name: debug
     displayName: Enable debug output for SDK tests
     type: boolean
@@ -44,7 +34,14 @@ parameters:
 variables:
   # Prevents failure when no Rust tests are found; pipeline runs will still fail if present
   # tests do not pass.
-  NEXTEST_NO_TESTS: pass
+  - name: NEXTEST_NO_TESTS
+    value: pass
+  # Pull ESRP signing credentials from the variable group only for Official
+  # builds. PR / unofficial runs skip the sign step (see Rust.Build.Job.yml
+  # condition `eq(parameters.isOfficialBuild, true)`), so the group isn't
+  # needed and we avoid surfacing it on pull requests.
+  - ${{ if eq(parameters.officialBuild, 'Official') }}:
+    - group: MXC-ESRP-Signing
 
 extends:
   template: v1/1ES.${{parameters.officialBuild}}.PipelineTemplate.yml@1ESPipelineTemplates
@@ -84,7 +81,14 @@ extends:
                 arch: arm64
                 component: LXC
 
-            ESRPInfo: ${{ parameters.ESRPInfo }}
+            ${{ if eq(parameters.officialBuild, 'Official') }}:
+              ESRPInfo:
+                serviceName: $(serviceName)
+                tenantId: $(tenantId)
+                azureKeyVaultName: $(azureKeyVaultName)
+                authCertName: $(authCertName)
+                signCertName: $(signCertName)
+                clientId: $(clientId)
 
         # macOS uses a separate template because it runs on a different
         # pool (Microsoft-hosted). The produced artifact name follows the same
@@ -92,7 +96,14 @@ extends:
         - template: .azure-pipelines/templates/Mac.Build.Job.yml@self
           parameters:
             isOfficialBuild: ${{ eq(parameters.officialBuild, 'Official') }}
-            ESRPInfo: ${{ parameters.ESRPInfo }}
+            ${{ if eq(parameters.officialBuild, 'Official') }}:
+              ESRPInfo:
+                serviceName: $(serviceName)
+                tenantId: $(tenantId)
+                azureKeyVaultName: $(azureKeyVaultName)
+                authCertName: $(authCertName)
+                signCertName: $(signCertName)
+                clientId: $(clientId)
 
     - stage: Package_MXC
       displayName: 'Package MXC'
@@ -112,7 +123,14 @@ extends:
             - artifact: mxc-binaries-aarch64-apple-darwin
               sdkArch: arm64
 
-          ESRPInfo: ${{ parameters.ESRPInfo }}
+          ${{ if eq(parameters.officialBuild, 'Official') }}:
+            ESRPInfo:
+              serviceName: $(serviceName)
+              tenantId: $(tenantId)
+              azureKeyVaultName: $(azureKeyVaultName)
+              authCertName: $(authCertName)
+              signCertName: $(signCertName)
+              clientId: $(clientId)
 
       - template: .azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml@self
 

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -84,6 +84,7 @@ jobs:
       outputDirectory: $(srcDir)/out
       ob_outputDirectory: $(outputDirectory)
       artifactBaseName: $(artifactPrefix)-$(targetTriple)
+      configTomlPath: $(srcDir)/.cargo/config.toml
 
     templateContext:
       rust:
@@ -92,6 +93,10 @@ jobs:
           version: 'ms-prod-1.93'
           additionalTargets: $(triplet)
         workingDirectory: $(workingDirectory)
+        authenticateOptions:
+          configFile: $(configTomlPath)
+        installOptions:
+          configFile: $(configTomlPath)
         cacheOptions:
           enableTargetCache: true
 
@@ -107,7 +112,7 @@ jobs:
 
       # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
       - powershell: |
-          Add-Content -Path "$(srcDir)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(srcDir)/.azure-pipelines/.cargo/config.toml"))
+          Add-Content -Path "$(configTomlPath)" -Value ("`n" + (Get-Content -Raw "$(srcDir)/.azure-pipelines/.cargo/config.toml"))
         displayName: Setup Cargo Config
 
       - task: 1ES.Build.Rust.Setup@1

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -99,6 +99,9 @@ jobs:
           configFile: $(configTomlPath)
         cacheOptions:
           enableTargetCache: true
+        setupOptions:
+          setupPython: ${{ parameters.useOneBranchPool }}
+          pythonArtifactFeeds: 'https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/pypi/simple/'
 
     steps:
       - checkout: self

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -11,6 +11,9 @@ parameters:
 - name: ESRPInfo
   type: object
   default: {}
+- name: vPackEnv
+  type: boolean
+  default: false
 
 jobs:
 - ${{ each item in parameters.matrix }}:
@@ -18,11 +21,14 @@ jobs:
     displayName: 'Build (${{ item.arch }} ${{ item.component }})'
     dependsOn: []
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      ${{ if eq(item.os, 'windows') }}:
+      ${{ if eq(item.os, 'windows') and eq(vPackEnv, false)}}:
+        name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-latest #x64 host
         os: windows
+      ${{ if eq(item.os, 'windows') and eq(vPackEnv, true)}}:
+        type: windows
       ${{ if eq(item.os, 'linux') }}:
+        name: Azure-Pipelines-1ESPT-ExDShared
         image: ubuntu-latest #x64 host
         os: linux
 

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -127,8 +127,15 @@ jobs:
           command: build
           profile: release
           target: $(triplet)
-          testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
-          enableTest: $(isX64)
+          # Skip cargo tests in the OneBranch container pool: the container image is
+          # missing runtime DLLs that --all-features test binaries depend on (e.g.
+          # hyperlight). Other pipelines (Azure-Pipelines-1ESPT-ExDShared) run tests.
+          ${{ if eq(parameters.useOneBranchPool, true) }}:
+            testCondition: "eq(variables['isX64'], 'false')"
+            enableTest: false
+          ${{ else }}:
+            testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
+            enableTest: $(isX64)
           publishTestResults: false
           enableClippy: false
           useNextest: false

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -16,7 +16,7 @@ jobs:
 - ${{ each item in parameters.matrix }}:
   - job: 'build_${{ item.arch }}_${{ item.component }}'
     displayName: 'Build (${{ item.arch }} ${{ item.component }})'
-
+    dependsOn: []
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       ${{ if eq(item.os, 'windows') }}:

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -11,9 +11,6 @@ parameters:
 - name: ESRPInfo
   type: object
   default: {}
-- name: useOneBranchPool
-  type: boolean
-  default: false
 
 jobs:
 - ${{ each item in parameters.matrix }}:
@@ -21,17 +18,11 @@ jobs:
     displayName: 'Build (${{ item.arch }} ${{ item.component }})'
     dependsOn: []
     pool:
-      
-      ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, false)) }}:
-        name: Azure-Pipelines-1ESPT-ExDShared
+      name: Azure-Pipelines-1ESPT-ExDShared
+      ${{ if eq(item.os, 'windows') }}:
         image: windows-latest
         os: windows
-
-      ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, true)) }}:
-        type: windows
-
       ${{ if eq(item.os, 'linux') }}:
-        name: Azure-Pipelines-1ESPT-ExDShared
         image: ubuntu-latest #x64 host
         os: linux
 
@@ -47,16 +38,11 @@ jobs:
       ${{ if and(eq(item.os, 'linux'), eq(item.arch, 'arm64')) }}:
         triplet: aarch64-unknown-linux-gnu
 
-      ${{ if eq(parameters.useOneBranchPool, true) }}:
-        srcDir: $(Build.SourcesDirectory)/mxc
-      ${{ else }}:
-        srcDir: $(Build.SourcesDirectory)
-
       # Windows specific variables
       ${{ if eq(item.os, 'windows') }}:
         CARGO_TARGET_DIR: c:/t/target
         artifactPrefix: wxc-binaries
-        workingDirectory: $(srcDir)/src
+        workingDirectory: $(Build.SourcesDirectory)/src
         signPattern: |
             wxc-exec.exe
             winhttp-proxy-shim.exe
@@ -68,7 +54,7 @@ jobs:
       ${{ if eq(item.os, 'linux') }}:
         CARGO_TARGET_DIR: /tmp/target
         artifactPrefix: lxc-binaries
-        workingDirectory: $(srcDir)/src/lxc
+        workingDirectory: $(Build.SourcesDirectory)/src/lxc
         signPattern: |
           lxc-exec
 
@@ -81,10 +67,9 @@ jobs:
       # Paths
       targetTriple: $(triplet)
       targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
-      outputDirectory: $(srcDir)/out
-      ob_outputDirectory: $(outputDirectory)
+      outputDirectory: $(Build.SourcesDirectory)/out
       artifactBaseName: $(artifactPrefix)-$(targetTriple)
-      configTomlPath: $(srcDir)/.cargo/config.toml
+      configTomlPath: $(Build.SourcesDirectory)/.cargo/config.toml
 
     templateContext:
       rust:
@@ -99,9 +84,6 @@ jobs:
           configFile: $(configTomlPath)
         cacheOptions:
           enableTargetCache: true
-        setupOptions:
-          setupPython: ${{ parameters.useOneBranchPool }}
-          pythonArtifactFeeds: 'Dart/Mxc-Azure-Feed'
 
     steps:
       - checkout: self
@@ -115,7 +97,7 @@ jobs:
 
       # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
       - powershell: |
-          Add-Content -Path "$(configTomlPath)" -Value ("`n" + (Get-Content -Raw "$(srcDir)/.azure-pipelines/.cargo/config.toml"))
+          Add-Content -Path "$(configTomlPath)" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
         displayName: Setup Cargo Config
 
       - task: 1ES.Build.Rust.Setup@1
@@ -127,15 +109,8 @@ jobs:
           command: build
           profile: release
           target: $(triplet)
-          # Skip cargo tests in the OneBranch container pool: the container image is
-          # missing runtime DLLs that --all-features test binaries depend on (e.g.
-          # hyperlight). Other pipelines (Azure-Pipelines-1ESPT-ExDShared) run tests.
-          ${{ if eq(parameters.useOneBranchPool, true) }}:
-            testCondition: "eq(variables['isX64'], 'false')"
-            enableTest: false
-          ${{ else }}:
-            testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
-            enableTest: $(isX64)
+          testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
+          enableTest: $(isX64)
           publishTestResults: false
           enableClippy: false
           useNextest: false

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -11,7 +11,7 @@ parameters:
 - name: ESRPInfo
   type: object
   default: {}
-- name: vPackEnv
+- name: useOneBranchPool
   type: boolean
   default: false
 
@@ -21,11 +21,12 @@ jobs:
     displayName: 'Build (${{ item.arch }} ${{ item.component }})'
     dependsOn: []
     pool:
-      ${{ if eq(item.os, 'windows') and eq(vPackEnv, false)}}:
+      
+      ${{ if eq(item.os, 'windows') and eq(parameters.useOneBranchPool, false)}}:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-latest #x64 host
         os: windows
-      ${{ if eq(item.os, 'windows') and eq(vPackEnv, true)}}:
+      ${{ if eq(item.os, 'windows') and eq(parameters.useOneBranchPool, true)}}:
         type: windows
       ${{ if eq(item.os, 'linux') }}:
         name: Azure-Pipelines-1ESPT-ExDShared

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -77,6 +77,7 @@ jobs:
       targetTriple: $(triplet)
       targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
       outputDirectory: $(Build.SourcesDirectory)/out
+      ob_outputDirectory: $(outputDirectory)
       artifactBaseName: $(artifactPrefix)-$(targetTriple)
 
     templateContext:

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -101,7 +101,7 @@ jobs:
           enableTargetCache: true
         setupOptions:
           setupPython: ${{ parameters.useOneBranchPool }}
-          pythonArtifactFeeds: 'https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/pypi/simple/'
+          pythonArtifactFeeds: 'Dart/Mxc-Azure-Feed'
 
     steps:
       - checkout: self

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -23,9 +23,9 @@ jobs:
     pool:
       
       ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, false)) }}:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-latest
-      os: windows
+        name: Azure-Pipelines-1ESPT-ExDShared
+        image: windows-latest
+        os: windows
 
       ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, true)) }}:
         type: windows

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -100,9 +100,30 @@ jobs:
         displayName: Install ARM64 toolchain
         condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
 
+      - powershell: |
+          Write-Host "Build.SourcesDirectory=$(Build.SourcesDirectory)"
+          Write-Host "System.DefaultWorkingDirectory=$(System.DefaultWorkingDirectory)"
+          Write-Host "Pipeline.Workspace=$(Pipeline.Workspace)"
+
+          Get-ChildItem "$(Build.SourcesDirectory)" -Force
+          Get-ChildItem "$(Build.SourcesDirectory)\.azure-pipelines" -Force -ErrorAction SilentlyContinue
+          Get-ChildItem "$(Build.SourcesDirectory)\.azure-pipelines\.cargo" -Force -ErrorAction SilentlyContinue
+        displayName: Debug checkout layout
+
       # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
       - powershell: |
-          Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+          $workspaceConfig = "$(Build.SourcesDirectory)\.cargo\config.toml"
+          $pipelineConfig = "$(Build.SourcesDirectory)\.azure-pipelines\.cargo\config.toml"
+
+          if (!(Test-Path $pipelineConfig)) {
+            Write-Host "Expected config not found: $pipelineConfig"
+            Write-Host "Searching for config.toml files..."
+            Get-ChildItem "$(Build.SourcesDirectory)" -Recurse -Filter config.toml -Force | Select-Object -ExpandProperty FullName
+            throw "Pipeline Cargo config missing"
+          }
+
+          New-Item -ItemType Directory -Force -Path (Split-Path $workspaceConfig) | Out-Null
+          Add-Content -Path $workspaceConfig -Value ("`n" + (Get-Content -Raw $pipelineConfig))
         displayName: Setup Cargo Config
 
       - task: 1ES.Build.Rust.Setup@1

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -47,11 +47,16 @@ jobs:
       ${{ if and(eq(item.os, 'linux'), eq(item.arch, 'arm64')) }}:
         triplet: aarch64-unknown-linux-gnu
 
+      ${{ if eq(parameters.useOneBranchPool, true) }}:
+        srcDir: $(Build.SourcesDirectory)/mxc
+      ${{ else }}:
+        srcDir: $(Build.SourcesDirectory)
+
       # Windows specific variables
       ${{ if eq(item.os, 'windows') }}:
         CARGO_TARGET_DIR: c:/t/target
         artifactPrefix: wxc-binaries
-        workingDirectory: src
+        workingDirectory: $(srcDir)/src
         signPattern: |
             wxc-exec.exe
             winhttp-proxy-shim.exe
@@ -63,7 +68,7 @@ jobs:
       ${{ if eq(item.os, 'linux') }}:
         CARGO_TARGET_DIR: /tmp/target
         artifactPrefix: lxc-binaries
-        workingDirectory: $(Build.SourcesDirectory)/src/lxc
+        workingDirectory: $(srcDir)/src/lxc
         signPattern: |
           lxc-exec
 
@@ -76,7 +81,7 @@ jobs:
       # Paths
       targetTriple: $(triplet)
       targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
-      outputDirectory: $(Build.SourcesDirectory)/out
+      outputDirectory: $(srcDir)/out
       ob_outputDirectory: $(outputDirectory)
       artifactBaseName: $(artifactPrefix)-$(targetTriple)
 
@@ -100,30 +105,9 @@ jobs:
         displayName: Install ARM64 toolchain
         condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
 
-      - powershell: |
-          Write-Host "Build.SourcesDirectory=$(Build.SourcesDirectory)"
-          Write-Host "System.DefaultWorkingDirectory=$(System.DefaultWorkingDirectory)"
-          Write-Host "Pipeline.Workspace=$(Pipeline.Workspace)"
-
-          Get-ChildItem "$(Build.SourcesDirectory)" -Force
-          Get-ChildItem "$(Build.SourcesDirectory)\.azure-pipelines" -Force -ErrorAction SilentlyContinue
-          Get-ChildItem "$(Build.SourcesDirectory)\.azure-pipelines\.cargo" -Force -ErrorAction SilentlyContinue
-        displayName: Debug checkout layout
-
       # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
       - powershell: |
-          $workspaceConfig = "$(Build.SourcesDirectory)\.cargo\config.toml"
-          $pipelineConfig = "$(Build.SourcesDirectory)\.azure-pipelines\.cargo\config.toml"
-
-          if (!(Test-Path $pipelineConfig)) {
-            Write-Host "Expected config not found: $pipelineConfig"
-            Write-Host "Searching for config.toml files..."
-            Get-ChildItem "$(Build.SourcesDirectory)" -Recurse -Filter config.toml -Force | Select-Object -ExpandProperty FullName
-            throw "Pipeline Cargo config missing"
-          }
-
-          New-Item -ItemType Directory -Force -Path (Split-Path $workspaceConfig) | Out-Null
-          Add-Content -Path $workspaceConfig -Value ("`n" + (Get-Content -Raw $pipelineConfig))
+          Add-Content -Path "$(srcDir)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(srcDir)/.azure-pipelines/.cargo/config.toml"))
         displayName: Setup Cargo Config
 
       - task: 1ES.Build.Rust.Setup@1

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -22,12 +22,14 @@ jobs:
     dependsOn: []
     pool:
       
-      ${{ if eq(item.os, 'windows') and eq(parameters.useOneBranchPool, false)}}:
-        name: Azure-Pipelines-1ESPT-ExDShared
-        image: windows-latest #x64 host
-        os: windows
-      ${{ if eq(item.os, 'windows') and eq(parameters.useOneBranchPool, true)}}:
+      ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, false)) }}:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+
+      ${{ if and(eq(item.os, 'windows'), eq(parameters.useOneBranchPool, true)) }}:
         type: windows
+
       ${{ if eq(item.os, 'linux') }}:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: ubuntu-latest #x64 host

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -114,3 +114,7 @@ extends:
                   $src = "$(Pipeline.Workspace)\MXC"
                   Copy-Item -Recurse -Force "$src\wxc-binaries-x86_64-pc-windows-msvc"  "$(ob_outputDirectory)\x64"
                   Copy-Item -Recurse -Force "$src\wxc-binaries-aarch64-pc-windows-msvc" "$(ob_outputDirectory)\arm64"
+                  # OneBranch's "Publish VPack SBOM Manifest" step expects
+                  # _manifest/spdx_2.2/ at the top of VPackContents. The
+                  # per-arch SBOMs are identical source-wise, so promote x64's.
+                  Copy-Item -Recurse -Force "$(ob_outputDirectory)\x64\_manifest" "$(ob_outputDirectory)\_manifest"

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -73,7 +73,7 @@ extends:
             ob_createvpack_minorVer: $(SdkMinor)         # set by 'Set vpack version' step
             ob_createvpack_patchVer: $(SdkPatch)         # set by 'Set vpack version' step
             ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
-            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
+            # ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
             - task: PowerShell@2
@@ -87,15 +87,16 @@ extends:
                   Write-Host "##vso[task.setvariable variable=SdkMinor]$($parts[1])"
                   Write-Host "##vso[task.setvariable variable=SdkPatch]$($parts[2])"
 
-            # `patterns` filters the download to only wxc-exec.exe + its pdb,
-            # keeping the vpack small. Files land at
-            # $(Pipeline.Workspace)/MXC/<artifactName>/...
+            # `patterns` filters the download to the binary + its pdb + the
+            # SBOM (_manifest/), keeping the vpack small while preserving
+            # provenance metadata OneBranch's post-vpack publish requires.
             - download: MXC
               displayName: Download wxc x64 (filtered)
               artifact: wxc-binaries-x86_64-pc-windows-msvc
               patterns: |
                 wxc-exec.exe
                 symbols/wxc-exec.pdb
+                _manifest/**
 
             - download: MXC
               displayName: Download wxc arm64 (filtered)
@@ -103,6 +104,7 @@ extends:
               patterns: |
                 wxc-exec.exe
                 symbols/wxc-exec.pdb
+                _manifest/**
 
             - task: PowerShell@2
               displayName: Stage binaries for vpack

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -80,6 +80,7 @@ extends:
             ob_createvpack_description: 'Microsoft Execution Containers'
             ob_createvpack_provData: true
             ob_createvpack_versionAs: string
+            ob_createvpack_version: $(VPackVersion) # set by the 'Set vpack version' step below
             ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
@@ -93,4 +94,4 @@ extends:
                 script: |
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
                   $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
-                  Write-Host "##vso[task.setvariable variable=ob_createvpack_version]$vpackVersion"
+                  Write-Host "##vso[task.setvariable variable=VPackVersion]$vpackVersion"

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -1,0 +1,110 @@
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+- name: VersionDate
+  value: "$[format('{0:yyMMdd}', pipeline.startTime)]"
+- name: VersionCounter
+  value: "$[counter(variables['VersionDate'], 1)]"
+- group: MXC-ESRP-Signing
+
+trigger: none
+
+pool:
+  type: windows
+
+resources:
+  repositories: 
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+
+extends:
+  template: v2/Microsoft.NonOfficial.yml@templates
+  parameters:
+    platform:     
+      name: 'windows_undocked'
+    
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+            
+    cloudvault:
+      enabled: false
+          
+    stages:
+    - stage: Build
+      displayName: 'Build Executables'
+      jobs:
+        - job: Set_Version
+          displayName: Set version
+          dependsOn: []
+          pool:
+            type: windows
+          variables:
+            ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+          steps:
+            - task: PowerShell@2
+              displayName: Set vpack version
+              inputs:
+                targetType: inline
+                script: |
+                  $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
+                  $vpackVersion = "$sdkVersion$(VersionDate)$(VersionCounter)"
+                  Write-Host "##vso[task.setvariable variable=VPackVersion;isOutput=true]$vpackVersion"
+        - template: .azure-pipelines/templates/Rust.Build.Job.yml@self
+          parameters:
+            isOfficialBuild: true
+            matrix:
+              - name: windows_x64
+                os: windows
+                arch: x64
+                component: WXC
+              - name: windows_arm64
+                os: windows
+                arch: arm64
+                component: WXC
+
+            ESRPInfo:
+              serviceName: $(serviceName)
+              tenantId: $(tenantId)
+              azureKeyVaultName: $(azureKeyVaultName)
+              authCertName: $(authCertName)
+              signCertName: $(signCertName)
+              clientId: $(clientId)
+
+    - stage: vpack
+      dependsOn: Build
+      displayName: 'Create OS vpack'
+      condition: succeeded()
+      jobs:
+      - job: Packaging
+        pool:
+          type: windows
+        variables:
+          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+          ob_createvpack_enabled: true
+          ob_createvpack_packagename: MXC
+          ob_createvpack_owneralias: Tessera-mxc-admin
+          ob_createvpack_description: Microsoft Execution Containers
+          ob_createvpack_provData: true
+          ob_createvpack_versionAs: string
+          ob_createvpack_version: $(VPackVersion)
+          ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
+
+        steps:
+          # Download the wxc binaries and pdbs for each architecture
+          - task: DownloadPipelineArtifact@2
+            displayName: Download wxc x64 artifact
+            inputs:
+              artifact: wxc-binaries-x86_64-pc-windows-msvc
+              path: $(ob_outputDirectory)/x64
+          - task: DownloadPipelineArtifact@2
+            displayName: Download wxc arm64 artifact
+            inputs:
+              artifact: wxc-binaries-aarch64-pc-windows-msvc
+              path: $(ob_outputDirectory)/arm64

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -41,12 +41,12 @@ extends:
     stages:
     - stage: Build
       displayName: 'Build Executables'
-      pool:
-        type: windows
       jobs:
         - job: Set_Version
           displayName: Set version
           dependsOn: []
+          pool:
+            type: windows
           variables:
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           steps:
@@ -62,6 +62,7 @@ extends:
         - template: .azure-pipelines/templates/Rust.Build.Job.yml@self
           parameters:
             isOfficialBuild: true
+            useOneBranchPool: true
             matrix:
               - name: windows_x64
                 os: windows

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -38,7 +38,7 @@ resources:
       trigger: none
 
 extends:
-  template: v2/Microsoft.NonOfficial.yml@templates
+  template: v2/Microsoft.Official.yml@templates
   parameters:
     platform:
       name: 'windows_undocked'

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -65,11 +65,6 @@ extends:
             ob_createvpack_owneralias: 'Tessera-mxc-admin'
             ob_createvpack_description: 'Microsoft Execution Containers'
             ob_createvpack_provData: true
-            # provData calls GitHub's commits API to embed provenance.json into
-            # the vpack; the Official flow's downstream ORAS step then requires
-            # that file. The repo is private so we pass a PAT from the variable
-            # group. Set githubToken in MXC-ESRP-Signing (scope: repo read).
-            ob_createvpack_githubToken: $(githubToken)
             # Use semver parts: keep major.minor.patch in sync with the SDK and
             # encode the build date + per-day counter as the prerelease tag.
             # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.0-260521.1

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -10,6 +10,8 @@ variables:
 - name: VersionCounter
   value: "$[counter(variables['VersionDate'], 1)]"
 - group: MXC-ESRP-Signing
+- name: WindowsContainerImage
+  value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 trigger: none
 

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -64,11 +64,7 @@ extends:
             ob_createvpack_packagename: 'MXC'
             ob_createvpack_owneralias: 'Tessera-mxc-admin'
             ob_createvpack_description: 'Microsoft Execution Containers'
-            ob_createvpack_provData: true
-            # provData needs to call GitHub's commits API; the repo is private so
-            # an unauthenticated request 404s. Token comes from MXC-ESRP-Signing
-            # (or whichever variable group exposes a GitHub PAT with repo:read).
-            ob_createvpack_githubToken: $(githubToken)
+            ob_createvpack_provData: false
             # Use semver parts: keep major.minor.patch in sync with the SDK and
             # encode the build date + per-day counter as the prerelease tag.
             # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.0-260521.1

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -30,13 +30,12 @@ resources:
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
   pipelines:
-    - pipeline: officialBuild
-      project: Dart
-      source: MXC-Official-Build
-      trigger:
-        branches:
-          include:
-            - main
+    # Source of the signed wxc binaries. Mirrors the alias used in
+    # 1ES.Release.yml. `trigger: none` because the build-completion
+    # trigger is configured in the ADO UI.
+    - pipeline: MXC
+      source: 'MXC-Official-Build'
+      trigger: none
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates
@@ -58,6 +57,20 @@ extends:
         - job: Packaging
           pool:
             type: windows
+          templateContext:
+            # Declarative artifact downloads (same pattern as 1ES.Release.yml).
+            # 1ES PT injects the equivalent DownloadPipelineArtifact steps and
+            # lands the files directly under ob_outputDirectory so the vpack
+            # creation step picks them up without any extra staging.
+            inputs:
+              - input: pipelineArtifact
+                pipeline: MXC
+                artifactName: wxc-binaries-x86_64-pc-windows-msvc
+                targetPath: '$(Build.SourcesDirectory)\out\x64'
+              - input: pipelineArtifact
+                pipeline: MXC
+                artifactName: wxc-binaries-aarch64-pc-windows-msvc
+                targetPath: '$(Build.SourcesDirectory)\out\arm64'
           variables:
             # Note: all files placed in the output directory will be included in the vpack
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
@@ -81,25 +94,3 @@ extends:
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
                   $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=ob_createvpack_version]$vpackVersion"
-
-            - task: DownloadPipelineArtifact@2
-              displayName: Download wxc x64 artifact
-              inputs:
-                source: specific
-                project: Dart
-                pipeline: MXC-Official-Build
-                runVersion: latestFromBranch
-                runBranch: main
-                artifact: wxc-binaries-x86_64-pc-windows-msvc
-                path: $(ob_outputDirectory)/x64
-
-            - task: DownloadPipelineArtifact@2
-              displayName: Download wxc arm64 artifact
-              inputs:
-                source: specific
-                project: Dart
-                pipeline: MXC-Official-Build
-                runVersion: latestFromBranch
-                runBranch: main
-                artifact: wxc-binaries-aarch64-pc-windows-msvc
-                path: $(ob_outputDirectory)/arm64

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -64,7 +64,12 @@ extends:
             ob_createvpack_packagename: 'MXC'
             ob_createvpack_owneralias: 'Tessera-mxc-admin'
             ob_createvpack_description: 'Microsoft Execution Containers'
-            ob_createvpack_provData: false
+            ob_createvpack_provData: true
+            # provData calls GitHub's commits API to embed provenance.json into
+            # the vpack; the Official flow's downstream ORAS step then requires
+            # that file. The repo is private so we pass a PAT from the variable
+            # group. Set githubToken in MXC-ESRP-Signing (scope: repo read).
+            ob_createvpack_githubToken: $(githubToken)
             # Use semver parts: keep major.minor.patch in sync with the SDK and
             # encode the build date + per-day counter as the prerelease tag.
             # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.0-260521.1
@@ -73,7 +78,6 @@ extends:
             ob_createvpack_minorVer: $(SdkMinor)         # set by 'Set vpack version' step
             ob_createvpack_patchVer: $(SdkPatch)         # set by 'Set vpack version' step
             ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
-            # ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
             - task: PowerShell@2

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -1,17 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# MXC VPack publishing pipeline.
-#
-# This pipeline does NOT build anything. It consumes already-signed binaries
-# produced by the official build pipeline (1ES.Build.yml run with
-# `officialBuild: Official`) and packages them into a vpack.
-#
-# Expected upstream pipeline name in ADO: `MXC-Official-Build` (override below
-# if the pipeline is created under a different name in ADO UI).
-#
-# The build-completion trigger that fires this pipeline when the official build
-# succeeds is configured in the ADO UI (Edit pipeline -> Triggers).
+# Consumes signed wxc binaries from MXC-Official-Build and packages them
+# as a vpack. The build-completion trigger is set in the ADO UI.
 
 parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'debug'
@@ -39,10 +30,6 @@ resources:
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
   pipelines:
-    # Pre-built, signed binaries come from the official build pipeline.
-    # The build-completion trigger is configured in the ADO UI; this resource
-    # declaration is what enables `DownloadPipelineArtifact@2 source: specific`
-    # and the `pipeline.officialBuild.*` runtime variables.
     - pipeline: officialBuild
       project: Dart
       source: MXC-Official-Build
@@ -104,12 +91,6 @@ extends:
             ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
-            # Pull pre-built, signed wxc binaries from the upstream official build.
-            # `source: specific` + `runVersion: latestFromBranch` consumes the most
-            # recent successful run on the configured branch; the build-completion
-            # trigger ensures this pipeline runs against the build that just
-            # completed, but the variable group / pipeline resource alias makes
-            # the artifacts available regardless of how this run was queued.
             - task: DownloadPipelineArtifact@2
               displayName: Download wxc x64 artifact
               inputs:

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -41,12 +41,12 @@ extends:
     stages:
     - stage: Build
       displayName: 'Build Executables'
+      pool:
+        type: windows
       jobs:
         - job: Set_Version
           displayName: Set version
           dependsOn: []
-          pool:
-            type: windows
           variables:
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           steps:

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -50,6 +50,12 @@ extends:
     cloudvault:
       enabled: false
 
+    # Disable TSA: it tries to register a codebase named "microsoft_Dart_microsoft/mxc"
+    # (illegal slash) and there's no source build to analyze in this pipeline anyway.
+    sdl:
+      tsa:
+        enabled: false
+
     stages:
     - stage: vpack
       displayName: 'Create OS vpack'

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -93,9 +93,9 @@ extends:
           # Note: all files placed in the output directory will be included in the vpack
           ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           ob_createvpack_enabled: true
-          ob_createvpack_packagename: MXC
-          ob_createvpack_owneralias: Tessera-mxc-admin
-          ob_createvpack_description: Microsoft Execution Containers
+          ob_createvpack_packagename: 'MXC'
+          ob_createvpack_owneralias: 'Tessera-mxc-admin'
+          ob_createvpack_description: 'Microsoft Execution Containers'
           ob_createvpack_provData: true
           ob_createvpack_versionAs: string
           ob_createvpack_version: $(VPackVersion)

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -57,20 +57,6 @@ extends:
         - job: Packaging
           pool:
             type: windows
-          templateContext:
-            # Declarative artifact downloads (same pattern as 1ES.Release.yml).
-            # 1ES PT injects the equivalent DownloadPipelineArtifact steps and
-            # lands the files directly under ob_outputDirectory so the vpack
-            # creation step picks them up without any extra staging.
-            inputs:
-              - input: pipelineArtifact
-                pipeline: MXC
-                artifactName: wxc-binaries-x86_64-pc-windows-msvc
-                targetPath: '$(Build.SourcesDirectory)\out\x64'
-              - input: pipelineArtifact
-                pipeline: MXC
-                artifactName: wxc-binaries-aarch64-pc-windows-msvc
-                targetPath: '$(Build.SourcesDirectory)\out\arm64'
           variables:
             # Note: all files placed in the output directory will be included in the vpack
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
@@ -96,16 +82,28 @@ extends:
                   $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=VPackVersion]$vpackVersion"
 
+            # `patterns` filters the download to only wxc-exec.exe + its pdb,
+            # keeping the vpack small. Files land at
+            # $(Pipeline.Workspace)/MXC/<artifactName>/...
+            - download: MXC
+              displayName: Download wxc x64 (filtered)
+              artifact: wxc-binaries-x86_64-pc-windows-msvc
+              patterns: |
+                wxc-exec.exe
+                symbols/wxc-exec.pdb
+
+            - download: MXC
+              displayName: Download wxc arm64 (filtered)
+              artifact: wxc-binaries-aarch64-pc-windows-msvc
+              patterns: |
+                wxc-exec.exe
+                symbols/wxc-exec.pdb
+
             - task: PowerShell@2
-              displayName: Prune artifacts to wxc-exec only
+              displayName: Stage binaries for vpack
               inputs:
                 targetType: inline
-                # Keep only wxc-exec.exe + its pdb per-arch. Everything else
-                # in the downloaded artifact (other exes, wslcsdk.dll, other
-                # pdbs/dwps) is dropped to shrink the vpack.
                 script: |
-                  foreach ($arch in 'x64','arm64') {
-                    $dir = "$(ob_outputDirectory)\$arch"
-                    Get-ChildItem -Path $dir -File | Where-Object { $_.Name -ne 'wxc-exec.exe' } | Remove-Item -Force
-                    Get-ChildItem -Path "$dir\symbols" -File | Where-Object { $_.Name -ne 'wxc-exec.pdb' } | Remove-Item -Force
-                  }
+                  $src = "$(Pipeline.Workspace)\MXC"
+                  Copy-Item -Recurse -Force "$src\wxc-binaries-x86_64-pc-windows-msvc"  "$(ob_outputDirectory)\x64"
+                  Copy-Item -Recurse -Force "$src\wxc-binaries-aarch64-pc-windows-msvc" "$(ob_outputDirectory)\arm64"

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -68,9 +68,12 @@ extends:
               displayName: Set vpack version
               inputs:
                 targetType: inline
+                # Vpack requires major.minor.patch. We keep major.minor from the
+                # SDK and pack date + per-day counter into the patch slot.
+                # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.02605211
                 script: |
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
-                  $vpackVersion = "$sdkVersion$(VersionDate)$(VersionCounter)"
+                  $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=VPackVersion;isOutput=true]$vpackVersion"
 
         - job: Packaging

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -56,6 +56,7 @@ extends:
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
                   $vpackVersion = "$sdkVersion$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=VPackVersion;isOutput=true]$vpackVersion"
+
         - template: .azure-pipelines/templates/Rust.Build.Job.yml@self
           parameters:
             isOfficialBuild: true
@@ -86,6 +87,7 @@ extends:
         pool:
           type: windows
         variables:
+          # Note: all files placed in the output directory will be included in the vpack
           ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           ob_createvpack_enabled: true
           ob_createvpack_packagename: MXC

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -55,16 +55,22 @@ extends:
     - stage: vpack
       displayName: 'Create OS vpack'
       jobs:
-        - job: Set_Version
-          displayName: Set version
-          dependsOn: []
+        - job: Packaging
           pool:
             type: windows
           variables:
+            # Note: all files placed in the output directory will be included in the vpack
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+            ob_createvpack_enabled: true
+            ob_createvpack_packagename: 'MXC'
+            ob_createvpack_owneralias: 'Tessera-mxc-admin'
+            ob_createvpack_description: 'Microsoft Execution Containers'
+            ob_createvpack_provData: true
+            ob_createvpack_versionAs: string
+            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
+
           steps:
             - task: PowerShell@2
-              name: setVpackVersion
               displayName: Set vpack version
               inputs:
                 targetType: inline
@@ -74,26 +80,8 @@ extends:
                 script: |
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
                   $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
-                  Write-Host "##vso[task.setvariable variable=VPackVersion;isOutput=true]$vpackVersion"
+                  Write-Host "##vso[task.setvariable variable=ob_createvpack_version]$vpackVersion"
 
-        - job: Packaging
-          dependsOn: Set_Version
-          pool:
-            type: windows
-          variables:
-            VPackVersion: $[ dependencies.Set_Version.outputs['setVpackVersion.VPackVersion'] ]
-            # Note: all files placed in the output directory will be included in the vpack
-            ob_outputDirectory: '$(Build.SourcesDirectory)\out'
-            ob_createvpack_enabled: true
-            ob_createvpack_packagename: 'MXC'
-            ob_createvpack_owneralias: 'Tessera-mxc-admin'
-            ob_createvpack_description: 'Microsoft Execution Containers'
-            ob_createvpack_provData: true
-            ob_createvpack_versionAs: string
-            ob_createvpack_version: $(VPackVersion)
-            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
-
-          steps:
             - task: DownloadPipelineArtifact@2
               displayName: Download wxc x64 artifact
               inputs:

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -95,3 +95,17 @@ extends:
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
                   $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=VPackVersion]$vpackVersion"
+
+            - task: PowerShell@2
+              displayName: Prune artifacts to wxc-exec only
+              inputs:
+                targetType: inline
+                # Keep only wxc-exec.exe + its pdb per-arch. Everything else
+                # in the downloaded artifact (other exes, wslcsdk.dll, other
+                # pdbs/dwps) is dropped to shrink the vpack.
+                script: |
+                  foreach ($arch in 'x64','arm64') {
+                    $dir = "$(ob_outputDirectory)\$arch"
+                    Get-ChildItem -Path $dir -File | Where-Object { $_.Name -ne 'wxc-exec.exe' } | Remove-Item -Force
+                    Get-ChildItem -Path "$dir\symbols" -File | Where-Object { $_.Name -ne 'wxc-exec.pdb' } | Remove-Item -Force
+                  }

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -73,6 +73,7 @@ extends:
             ob_createvpack_minorVer: $(SdkMinor)         # set by 'Set vpack version' step
             ob_createvpack_patchVer: $(SdkPatch)         # set by 'Set vpack version' step
             ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
+            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
             - task: PowerShell@2

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -50,12 +50,6 @@ extends:
     cloudvault:
       enabled: false
 
-    # Disable TSA: it tries to register a codebase named "microsoft_Dart_microsoft/mxc"
-    # (illegal slash) and there's no source build to analyze in this pipeline anyway.
-    sdl:
-      tsa:
-        enabled: false
-
     stages:
     - stage: vpack
       displayName: 'Create OS vpack'

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -1,3 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# MXC VPack publishing pipeline.
+#
+# This pipeline does NOT build anything. It consumes already-signed binaries
+# produced by the official build pipeline (1ES.Build.yml run with
+# `officialBuild: Official`) and packages them into a vpack.
+#
+# Expected upstream pipeline name in ADO: `MXC-Official-Build` (override below
+# if the pipeline is created under a different name in ADO UI).
+#
+# The build-completion trigger that fires this pipeline when the official build
+# succeeds is configured in the ADO UI (Edit pipeline -> Triggers).
+
 parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'debug'
   displayName: 'Enable debug output'
@@ -9,7 +24,6 @@ variables:
   value: "$[format('{0:yyMMdd}', pipeline.startTime)]"
 - name: VersionCounter
   value: "$[counter(variables['VersionDate'], 1)]"
-- group: MXC-ESRP-Signing
 - name: WindowsContainerImage
   value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
@@ -19,28 +33,40 @@ pool:
   type: windows
 
 resources:
-  repositories: 
+  repositories:
     - repository: templates
       type: git
       name: OneBranch.Pipelines/GovernedTemplates
       ref: refs/heads/main
+  pipelines:
+    # Pre-built, signed binaries come from the official build pipeline.
+    # The build-completion trigger is configured in the ADO UI; this resource
+    # declaration is what enables `DownloadPipelineArtifact@2 source: specific`
+    # and the `pipeline.officialBuild.*` runtime variables.
+    - pipeline: officialBuild
+      project: Dart
+      source: MXC-Official-Build
+      trigger:
+        branches:
+          include:
+            - main
 
 extends:
   template: v2/Microsoft.NonOfficial.yml@templates
   parameters:
-    platform:     
+    platform:
       name: 'windows_undocked'
-    
+
     featureFlags:
       WindowsHostVersion:
         Version: 2022
-            
+
     cloudvault:
       enabled: false
-          
+
     stages:
-    - stage: Build
-      displayName: 'Build Executables'
+    - stage: vpack
+      displayName: 'Create OS vpack'
       jobs:
         - job: Set_Version
           displayName: Set version
@@ -51,6 +77,7 @@ extends:
             ob_outputDirectory: '$(Build.SourcesDirectory)\out'
           steps:
             - task: PowerShell@2
+              name: setVpackVersion
               displayName: Set vpack version
               inputs:
                 targetType: inline
@@ -59,57 +86,48 @@ extends:
                   $vpackVersion = "$sdkVersion$(VersionDate)$(VersionCounter)"
                   Write-Host "##vso[task.setvariable variable=VPackVersion;isOutput=true]$vpackVersion"
 
-        - template: .azure-pipelines/templates/Rust.Build.Job.yml@self
-          parameters:
-            isOfficialBuild: true
-            useOneBranchPool: true
-            matrix:
-              - name: windows_x64
-                os: windows
-                arch: x64
-                component: WXC
-              - name: windows_arm64
-                os: windows
-                arch: arm64
-                component: WXC
+        - job: Packaging
+          dependsOn: Set_Version
+          pool:
+            type: windows
+          variables:
+            VPackVersion: $[ dependencies.Set_Version.outputs['setVpackVersion.VPackVersion'] ]
+            # Note: all files placed in the output directory will be included in the vpack
+            ob_outputDirectory: '$(Build.SourcesDirectory)\out'
+            ob_createvpack_enabled: true
+            ob_createvpack_packagename: 'MXC'
+            ob_createvpack_owneralias: 'Tessera-mxc-admin'
+            ob_createvpack_description: 'Microsoft Execution Containers'
+            ob_createvpack_provData: true
+            ob_createvpack_versionAs: string
+            ob_createvpack_version: $(VPackVersion)
+            ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
-            ESRPInfo:
-              serviceName: $(serviceName)
-              tenantId: $(tenantId)
-              azureKeyVaultName: $(azureKeyVaultName)
-              authCertName: $(authCertName)
-              signCertName: $(signCertName)
-              clientId: $(clientId)
+          steps:
+            # Pull pre-built, signed wxc binaries from the upstream official build.
+            # `source: specific` + `runVersion: latestFromBranch` consumes the most
+            # recent successful run on the configured branch; the build-completion
+            # trigger ensures this pipeline runs against the build that just
+            # completed, but the variable group / pipeline resource alias makes
+            # the artifacts available regardless of how this run was queued.
+            - task: DownloadPipelineArtifact@2
+              displayName: Download wxc x64 artifact
+              inputs:
+                source: specific
+                project: Dart
+                pipeline: MXC-Official-Build
+                runVersion: latestFromBranch
+                runBranch: main
+                artifact: wxc-binaries-x86_64-pc-windows-msvc
+                path: $(ob_outputDirectory)/x64
 
-    - stage: vpack
-      dependsOn: Build
-      displayName: 'Create OS vpack'
-      condition: succeeded()
-      jobs:
-      - job: Packaging
-        pool:
-          type: windows
-        variables:
-          # Note: all files placed in the output directory will be included in the vpack
-          ob_outputDirectory: '$(Build.SourcesDirectory)\out'
-          ob_createvpack_enabled: true
-          ob_createvpack_packagename: 'MXC'
-          ob_createvpack_owneralias: 'Tessera-mxc-admin'
-          ob_createvpack_description: 'Microsoft Execution Containers'
-          ob_createvpack_provData: true
-          ob_createvpack_versionAs: string
-          ob_createvpack_version: $(VPackVersion)
-          ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
-
-        steps:
-          # Download the wxc binaries and pdbs for each architecture
-          - task: DownloadPipelineArtifact@2
-            displayName: Download wxc x64 artifact
-            inputs:
-              artifact: wxc-binaries-x86_64-pc-windows-msvc
-              path: $(ob_outputDirectory)/x64
-          - task: DownloadPipelineArtifact@2
-            displayName: Download wxc arm64 artifact
-            inputs:
-              artifact: wxc-binaries-aarch64-pc-windows-msvc
-              path: $(ob_outputDirectory)/arm64
+            - task: DownloadPipelineArtifact@2
+              displayName: Download wxc arm64 artifact
+              inputs:
+                source: specific
+                project: Dart
+                pipeline: MXC-Official-Build
+                runVersion: latestFromBranch
+                runBranch: main
+                artifact: wxc-binaries-aarch64-pc-windows-msvc
+                path: $(ob_outputDirectory)/arm64

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -65,8 +65,18 @@ extends:
             ob_createvpack_owneralias: 'Tessera-mxc-admin'
             ob_createvpack_description: 'Microsoft Execution Containers'
             ob_createvpack_provData: true
-            ob_createvpack_versionAs: string
-            ob_createvpack_version: $(VPackVersion) # set by the 'Set vpack version' step below
+            # provData needs to call GitHub's commits API; the repo is private so
+            # an unauthenticated request 404s. Token comes from MXC-ESRP-Signing
+            # (or whichever variable group exposes a GitHub PAT with repo:read).
+            ob_createvpack_githubToken: $(githubToken)
+            # Use semver parts: keep major.minor.patch in sync with the SDK and
+            # encode the build date + per-day counter as the prerelease tag.
+            # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.0-260521.1
+            ob_createvpack_versionAs: parts
+            ob_createvpack_majorVer: $(SdkMajor)         # set by 'Set vpack version' step
+            ob_createvpack_minorVer: $(SdkMinor)         # set by 'Set vpack version' step
+            ob_createvpack_patchVer: $(SdkPatch)         # set by 'Set vpack version' step
+            ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
             ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
           steps:
@@ -74,13 +84,12 @@ extends:
               displayName: Set vpack version
               inputs:
                 targetType: inline
-                # Vpack requires major.minor.patch. We keep major.minor from the
-                # SDK and pack date + per-day counter into the patch slot.
-                # Example: sdk 0.2.0, first build on 2026-05-21 -> 0.2.02605211
                 script: |
                   $sdkVersion = (Get-Content "$(System.DefaultWorkingDirectory)/sdk/package.json" | ConvertFrom-Json).version
-                  $vpackVersion = "${sdkVersion}$(VersionDate)$(VersionCounter)"
-                  Write-Host "##vso[task.setvariable variable=VPackVersion]$vpackVersion"
+                  $parts = $sdkVersion.Split('.')
+                  Write-Host "##vso[task.setvariable variable=SdkMajor]$($parts[0])"
+                  Write-Host "##vso[task.setvariable variable=SdkMinor]$($parts[1])"
+                  Write-Host "##vso[task.setvariable variable=SdkPatch]$($parts[2])"
 
             # `patterns` filters the download to only wxc-exec.exe + its pdb,
             # keeping the vpack small. Files land at


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
This PR adds a pipeline that will produce an OS vpack which contains wxc-exe.exe + pdbs that can be consumed inside the OS.
The pipeline will run daily based on the code checked into the GitHub repository which is then sync'd into the private ADO mirror repository [here](https://microsoft.visualstudio.com/Dart/_git/mxc). With this, OS tests can consume these vpacks and use the latest changes of MXC for their testpasses. It's important that we have this so we can create testpasses in the OS lab builds that use wxc-exec directly to spin up sandbox processes. This will help catch regressions in wxc-exec early on latest builds.

The pipeline will be triggered every time an official build pipeline succeeds.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/381)