### PR TITLE
Phase 3.5: --prepare-system-drive flag for AppContainer host setup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -142,6 +142,7 @@ Core references:
 - `docs/authoring-a-new-feature.md` — step-by-step guide for adding experimental features (which files to touch, in what order)
 - `docs/examples.md` — annotated configuration examples (see also `examples/` and `test_configs/`)
 - `docs/diagnostics.md` — diagnostic logging knobs (env vars, log file format)
+- `docs/host-prep.md` — `wxc-exec --prepare-system-drive` / `--unprepare-system-drive` host setup (metadata-only ACEs on the system-drive root for the AppContainer well-known SIDs, so `cmd.exe` / `pwsh.exe` / `node.exe` can stat `C:\` inside an AppContainer). Hand-test helpers live in `scripts/host-prep/`.
 - `docs/sandbox-policy/v1/policy.md` — sandbox policy v1 specification
 
 Per-backend guides:

--- a/docs/host-prep.md
+++ b/docs/host-prep.md
@@ -1,0 +1,109 @@
+# Host preparation: `--prepare-system-drive`
+
+The `wxc-exec --prepare-system-drive` flag adds two persistent allow ACEs to
+the system-drive root (typically `C:\`) so that AppContainer-isolated
+processes can read directory metadata of the drive. Many common tools —
+`cmd.exe`, `powershell.exe`, `pwsh.exe`, `node.exe` — call APIs like
+`GetFileAttributesW("C:\\")`, `_stat("C:\\")`, or
+`[IO.DirectoryInfo]::GetAccessControl` during startup and fail with
+`ERROR_ACCESS_DENIED` inside an AppContainer because the well-known
+AppContainer SIDs are not granted any rights on the system-drive root
+by default.
+
+This is a one-time, host-wide setup step — it does not need to be re-run
+per container or per session.
+
+## What it grants
+
+| Trustee | SID | Access mask | Inheritance |
+| --- | --- | --- | --- |
+| `ALL APPLICATION PACKAGES` | `S-1-15-2-1` | `FILE_READ_ATTRIBUTES \| FILE_READ_EA \| READ_CONTROL \| SYNCHRONIZE` (`0x00120088`) | none |
+| `ALL RESTRICTED APPLICATION PACKAGES` | `S-1-15-2-2` | same | none |
+
+What this **does not** grant:
+
+- `FILE_LIST_DIRECTORY` — the container still cannot enumerate `C:\`.
+- `FILE_READ_DATA` — irrelevant on a directory, but explicit.
+- any write rights.
+
+Because the ACEs are non-inheriting, descendant files and subdirectories
+of `C:\` are not affected — the change is scoped to the directory object
+itself.
+
+## Usage
+
+```
+wxc-exec --prepare-system-drive
+```
+
+The flag self-elevates via UAC. If the current process is not already
+elevated, Windows shows a UAC prompt; the elevated child does the DACL
+write and exits, and the unelevated parent reports success.
+
+```
+wxc-exec --unprepare-system-drive
+```
+
+Removes ACEs the prepare step added. Uses **precise tuple matching**:
+only ACEs whose `(access mask, ACE type, inheritance flags)` exactly
+match what `--prepare-system-drive` would have authored are removed.
+Other explicit ACEs for the same SIDs — e.g. an existing
+`icacls C:\ /grant "ALL APPLICATION PACKAGES":(R)` written by a
+third-party tool — are preserved. This is symmetric with the PowerShell
+`Unprepare-SystemDriveForAppContainer.ps1` script's
+`RemoveAccessRuleSpecific` semantics.
+
+Re-running either flag is safe: `SetEntriesInAclW(GRANT_ACCESS)` merges
+into the existing ACE if one already exists, and the precise-revoke
+path is idempotent — running it again finds no matching ACE and reports
+"no matching ACE; nothing to do".
+
+## Verifying the result
+
+After running `--prepare-system-drive`, the two ACEs should be visible
+in the system-drive root's DACL:
+
+```powershell
+(Get-Acl C:\).Access |
+    Where-Object { [uint32]$_.FileSystemRights -eq 0x00120088 -and -not $_.IsInherited }
+```
+
+You should see two entries — one each for the two AppContainer groups —
+both with `FileSystemRights` listing
+`ReadAttributes, ReadExtendedAttributes, ReadPermissions, Synchronize`,
+`AccessControlType` of `Allow`, and `InheritanceFlags` of `None`.
+
+## Implementation notes
+
+- Windows does not allow a running process to elevate its own token, so
+  the unelevated parent re-launches itself with `ShellExecuteExW` and the
+  `runas` verb. A hidden `--internal-elevated-helper` flag is set on the
+  child; if that flag is observed in a process whose token is not
+  elevated (which should be unreachable in practice because
+  `ShellExecuteExW(runas)` either elevates or returns `Err`), the helper
+  refuses to recurse — defense in depth against unforeseen spawn loops.
+- The unelevated parent resolves the target path once (from
+  `%SystemDrive%`) and passes it to the elevated child via
+  `--internal-target-path`. The child does **not** re-read
+  `%SystemDrive%` from environment — which would otherwise let an
+  unelevated user steer the elevated DACL write at an arbitrary drive
+  via inherited env. The child validates the passed path is a literal
+  drive root (`X:\`) before touching its DACL.
+- The elevated child writes its console output to
+  `%TEMP%\wxc-exec-prepare-system-drive.log`. The unelevated parent
+  reads this file on non-zero child exit and prints the contents to
+  stderr, so the user sees a real diagnostic instead of just
+  `ChildFailed(<code>)`.
+- The DACL operations use the same `GetNamedSecurityInfoW` →
+  `SetEntriesInAclW` → `SetNamedSecurityInfoW` sequence as
+  `wxc_common::filesystem_dacl`. Apply ACEs are *not* tracked by
+  `DaclManager` because the change is intentionally persistent across
+  process exit. The precise-revoke path scans the existing DACL via
+  `GetAce` to find ACEs matching our exact tuple, then issues a single
+  `REVOKE_ACCESS` for the SID followed by replay of any non-matching
+  explicit ACEs — symmetric with `restore_one`'s pattern.
+- Unit tests redirect the target path to a tempdir via the debug-only
+  `MXC_PREPARE_PATH_OVERRIDE` env var. The elevation flow itself is
+  verified manually with the PowerShell scripts in
+  [`scripts/host-prep/`](../scripts/host-prep/), which mirror the Rust
+  implementation for hand-testing without rebuilding `wxc-exec`.

--- a/scripts/host-prep/Prepare-SystemDriveForAppContainer.ps1
+++ b/scripts/host-prep/Prepare-SystemDriveForAppContainer.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+    Grants the AppContainer "ALL APPLICATION PACKAGES" and "ALL RESTRICTED
+    APPLICATION PACKAGES" groups the minimum rights needed to stat the
+    system-drive root (e.g. C:\).
+
+.DESCRIPTION
+    AppContainers do not, by default, have any rights on the system-drive
+    root, so calls like _stat("C:\\"), GetFileAttributesW("C:\\"),
+    [System.IO.DirectoryInfo]::new("C:\\").GetAccessControl(), etc., fail
+    with ERROR_ACCESS_DENIED inside an AppContainer process. That makes
+    many common tools (cmd.exe, powershell.exe, pwsh.exe, node.exe) error
+    out during startup.
+
+    This script adds two persistent, non-inheriting allow ACEs to the
+    system-drive root for the two well-known AppContainer groups:
+        S-1-15-2-1  ALL APPLICATION PACKAGES
+        S-1-15-2-2  ALL RESTRICTED APPLICATION PACKAGES
+
+    The granted mask is metadata-only — no FILE_LIST_DIRECTORY, no
+    FILE_READ_DATA, no write rights:
+        FILE_READ_ATTRIBUTES  (0x00000080)
+        FILE_READ_EA          (0x00000008)
+        READ_CONTROL          (0x00020000)
+        SYNCHRONIZE           (0x00100000)
+        ----------------------------------
+        total                 (0x00120088)
+
+    The ACEs are applied to the system-drive root only (no inheritance),
+    so descendant files and directories are unaffected.
+
+    Re-running this script is safe: AddAccessRule merges into the existing
+    ACE if one already exists for the same (SID, type, flags) tuple.
+
+.PARAMETER Path
+    The path to grant the ACE on. Defaults to $env:SystemDrive + '\'.
+
+.EXAMPLE
+    PS C:\> .\Prepare-SystemDriveForAppContainer.ps1
+    Prepares C:\ (or whatever the system drive is) with default settings.
+
+.EXAMPLE
+    PS C:\> .\Prepare-SystemDriveForAppContainer.ps1 -WhatIf
+    Prints what would change without committing.
+
+.NOTES
+    Must run elevated. To undo, see Unprepare-SystemDriveForAppContainer.ps1.
+#>
+
+#Requires -RunAsAdministrator
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter()]
+    [string]$Path = ($env:SystemDrive + '\')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Verify elevation explicitly (in addition to #Requires -RunAsAdministrator,
+# which only fires when the script is invoked from a script file in some
+# hosts). Failing here gives a clear message instead of a confusing ACL
+# error 20 lines later.
+$identity  = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "This script must run elevated. Re-run from an Administrator PowerShell prompt."
+}
+
+# Metadata-only mask: FILE_READ_ATTRIBUTES | FILE_READ_EA | READ_CONTROL | SYNCHRONIZE.
+$rights = [System.Security.AccessControl.FileSystemRights]'ReadAttributes, ReadExtendedAttributes, ReadPermissions, Synchronize'
+
+$trustees = @(
+    @{ Name = 'ALL APPLICATION PACKAGES';            Sid = 'S-1-15-2-1' },
+    @{ Name = 'ALL RESTRICTED APPLICATION PACKAGES'; Sid = 'S-1-15-2-2' }
+)
+
+Write-Host "Target path : $Path"
+Write-Host ("Rights mask : {0} (0x{1:X8})" -f $rights, [uint32]$rights)
+
+$acl = Get-Acl -LiteralPath $Path
+
+foreach ($t in $trustees) {
+    $sid = [System.Security.Principal.SecurityIdentifier]::new($t.Sid)
+
+    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $sid,
+        $rights,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+
+    $acl.AddAccessRule($rule)
+    Write-Host ("  + {0,-45} ({1})" -f $t.Name, $t.Sid)
+}
+
+if ($PSCmdlet.ShouldProcess($Path, "Add metadata-read ACEs for AppContainer groups")) {
+    Set-Acl -LiteralPath $Path -AclObject $acl
+    Write-Host "Done." -ForegroundColor Green
+} else {
+    Write-Host "(WhatIf) ACL changes not committed." -ForegroundColor Yellow
+}

--- a/scripts/host-prep/Unprepare-SystemDriveForAppContainer.ps1
+++ b/scripts/host-prep/Unprepare-SystemDriveForAppContainer.ps1
@@ -1,0 +1,78 @@
+<#
+.SYNOPSIS
+    Removes the persistent allow ACEs added by
+    Prepare-SystemDriveForAppContainer.ps1.
+
+.DESCRIPTION
+    Uses RemoveAccessRuleSpecific so only ACEs that exactly match the tuple
+    we added (SID + rights mask + inheritance flags + propagation flags +
+    Allow) are removed. ACEs for the same SIDs that were authored by
+    something else (different rights or inheritance) are left untouched.
+
+    Safe to run when the ACEs are already absent — no-op in that case.
+
+.PARAMETER Path
+    The path to revoke the ACE from. Defaults to $env:SystemDrive + '\'.
+
+.EXAMPLE
+    PS C:\> .\Unprepare-SystemDriveForAppContainer.ps1
+
+.EXAMPLE
+    PS C:\> .\Unprepare-SystemDriveForAppContainer.ps1 -WhatIf
+
+.NOTES
+    Must run elevated.
+#>
+
+#Requires -RunAsAdministrator
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter()]
+    [string]$Path = ($env:SystemDrive + '\')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$identity  = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = [System.Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "This script must run elevated. Re-run from an Administrator PowerShell prompt."
+}
+
+# Must match exactly what Prepare-* added.
+$rights = [System.Security.AccessControl.FileSystemRights]'ReadAttributes, ReadExtendedAttributes, ReadPermissions, Synchronize'
+
+$trustees = @(
+    @{ Name = 'ALL APPLICATION PACKAGES';            Sid = 'S-1-15-2-1' },
+    @{ Name = 'ALL RESTRICTED APPLICATION PACKAGES'; Sid = 'S-1-15-2-2' }
+)
+
+Write-Host "Target path : $Path"
+Write-Host ("Rights mask : {0} (0x{1:X8})" -f $rights, [uint32]$rights)
+
+$acl = Get-Acl -LiteralPath $Path
+
+foreach ($t in $trustees) {
+    $sid = [System.Security.Principal.SecurityIdentifier]::new($t.Sid)
+
+    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+        $sid,
+        $rights,
+        [System.Security.AccessControl.InheritanceFlags]::None,
+        [System.Security.AccessControl.PropagationFlags]::None,
+        [System.Security.AccessControl.AccessControlType]::Allow
+    )
+
+    # RemoveAccessRuleSpecific is a no-op when no matching ACE exists.
+    $acl.RemoveAccessRuleSpecific($rule)
+    Write-Host ("  - {0,-45} ({1})" -f $t.Name, $t.Sid)
+}
+
+if ($PSCmdlet.ShouldProcess($Path, "Remove metadata-read ACEs for AppContainer groups")) {
+    Set-Acl -LiteralPath $Path -AclObject $acl
+    Write-Host "Done." -ForegroundColor Green
+} else {
+    Write-Host "(WhatIf) ACL changes not committed." -ForegroundColor Yellow
+}

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -97,6 +97,54 @@ struct Cli {
     /// the runner will not find the pulled image. Requires `--setup-wslc`.
     #[arg(long = "storage-path", requires = "setup_wslc")]
     storage_path: Option<String>,
+
+    /// Grant the AppContainer "ALL APPLICATION PACKAGES" and
+    /// "ALL RESTRICTED APPLICATION PACKAGES" groups the minimum rights
+    /// needed to stat the system-drive root (e.g. `C:\`). Persistent —
+    /// survives across runs. Requests elevation via UAC if not already
+    /// elevated. See `wxc_common::system_drive_prep`.
+    #[cfg(target_os = "windows")]
+    #[arg(
+        long = "prepare-system-drive",
+        conflicts_with_all = [
+            "unprepare_system_drive",
+            "setup_hyperlight",
+            "setup_wslc",
+            "delete",
+            "dry_run",
+        ]
+    )]
+    prepare_system_drive: bool,
+
+    /// Remove the ACEs added by `--prepare-system-drive`. Uses precise
+    /// tuple matching: only ACEs the matching `--prepare-system-drive`
+    /// invocation would have written are removed. Other explicit ACEs
+    /// for the same SIDs are preserved.
+    #[cfg(target_os = "windows")]
+    #[arg(
+        long = "unprepare-system-drive",
+        conflicts_with_all = [
+            "setup_hyperlight",
+            "setup_wslc",
+            "delete",
+            "dry_run",
+        ]
+    )]
+    unprepare_system_drive: bool,
+
+    /// Internal — set by `--prepare-system-drive` / `--unprepare-system-drive`
+    /// when re-launching with elevation. Not for user use.
+    #[cfg(target_os = "windows")]
+    #[arg(long = "internal-elevated-helper", hide = true)]
+    internal_elevated_helper: bool,
+
+    /// Internal — the target path resolved by the unelevated parent,
+    /// passed to the elevated child so the child does not re-read
+    /// `%SystemDrive%` from a potentially attacker-controlled
+    /// environment. Validated as a drive root by the child.
+    #[cfg(target_os = "windows")]
+    #[arg(long = "internal-target-path", hide = true)]
+    internal_target_path: Option<String>,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -204,6 +252,28 @@ fn main() {
     }
 
     let cli = Cli::parse();
+
+    // --prepare-system-drive / --unprepare-system-drive: host DACL prep.
+    // Modifies the DACL of the system drive root to grant the well-known
+    // AppContainer SIDs metadata-read access. Self-elevates via UAC.
+    // Runs before config parsing so the user doesn't need a JSON file.
+    // Mutual exclusion with other top-level "do and exit" flags is
+    // enforced by clap (conflicts_with_all).
+    #[cfg(target_os = "windows")]
+    {
+        if cli.prepare_system_drive {
+            process::exit(wxc_common::system_drive_prep::run_prepare(
+                cli.internal_elevated_helper,
+                cli.internal_target_path.as_deref(),
+            ));
+        }
+        if cli.unprepare_system_drive {
+            process::exit(wxc_common::system_drive_prep::run_unprepare(
+                cli.internal_elevated_helper,
+                cli.internal_target_path.as_deref(),
+            ));
+        }
+    }
 
     // --setup-hyperlight: warm up the snapshot and exit. Runs before
     // config parsing so the user doesn't need a JSON file on disk

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -903,25 +903,49 @@ fn trustee_for(sid: &OwnedSid) -> TRUSTEE_W {
 /// [`AppliedAce::prior_state`] so [`restore_one`] can correctly unwind
 /// by issuing `REVOKE_ACCESS` plus a regrant of the captured state.
 fn apply_ace(entry: &AppliedAce) -> Result<(), DaclError> {
-    let sid = OwnedSid::parse(&entry.sid_string)?;
+    apply_explicit_ace(
+        &entry.canonical_path,
+        &entry.sid_string,
+        entry.access_mask,
+        entry.ace_type,
+        entry.inheritable,
+    )
+}
 
-    let inheritance: u32 = if entry.inheritable {
+/// Apply a single explicit ACE to `path`'s DACL without any restore
+/// tracking. Used by [`apply_ace`] (which adds prior-state capture and
+/// persistence on top) and by host-prep entry points that want a
+/// persistent ACE outside the [`DaclManager`] lifecycle.
+///
+/// The caller is responsible for ensuring the process has `WRITE_DAC`
+/// on the path. No state is recorded; the change persists across
+/// process exit.
+pub(crate) fn apply_explicit_ace(
+    path: &Path,
+    sid_str: &str,
+    access_mask: u32,
+    ace_type: AceType,
+    inheritable: bool,
+) -> Result<(), DaclError> {
+    let sid = OwnedSid::parse(sid_str)?;
+
+    let inheritance: u32 = if inheritable {
         OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0
     } else {
         0
     };
-    let mode = match entry.ace_type {
+    let mode = match ace_type {
         AceType::Allow => GRANT_ACCESS,
         AceType::Deny => DENY_ACCESS,
     };
     let ea = EXPLICIT_ACCESS_W {
-        grfAccessPermissions: entry.access_mask,
+        grfAccessPermissions: access_mask,
         grfAccessMode: mode,
         grfInheritance: ACE_FLAGS(inheritance),
         Trustee: trustee_for(&sid),
     };
 
-    let path_w = wide(&entry.canonical_path);
+    let path_w = wide(path);
     let object_name = PCWSTR(path_w.as_ptr());
 
     let mut existing_dacl: *mut ACL = ptr::null_mut();
@@ -939,11 +963,7 @@ fn apply_ace(entry: &AppliedAce) -> Result<(), DaclError> {
         )
     };
     if rc != ERROR_SUCCESS {
-        return Err(win32_err(
-            &entry.canonical_path,
-            "GetNamedSecurityInfoW",
-            rc,
-        ));
+        return Err(win32_err(path, "GetNamedSecurityInfoW", rc));
     }
 
     let mut new_dacl: *mut ACL = ptr::null_mut();
@@ -954,13 +974,12 @@ fn apply_ace(entry: &AppliedAce) -> Result<(), DaclError> {
             &mut new_dacl,
         )
     };
-    let _ = ea;
 
     if rc != ERROR_SUCCESS {
         unsafe {
             let _ = LocalFree(Some(HLOCAL(sd.0)));
         }
-        return Err(win32_err(&entry.canonical_path, "SetEntriesInAclW", rc));
+        return Err(win32_err(path, "SetEntriesInAclW", rc));
     }
 
     let rc = unsafe {
@@ -985,18 +1004,162 @@ fn apply_ace(entry: &AppliedAce) -> Result<(), DaclError> {
     if rc != ERROR_SUCCESS {
         if rc.0 == 5 {
             return Err(DaclError::WriteDacDenied {
-                path: entry.canonical_path.clone(),
+                path: path.to_path_buf(),
                 reason: format!("SetNamedSecurityInfoW: {rc:?}"),
             });
         }
-        return Err(win32_err(
-            &entry.canonical_path,
-            "SetNamedSecurityInfoW",
-            rc,
-        ));
+        return Err(win32_err(path, "SetNamedSecurityInfoW", rc));
     }
 
     Ok(())
+}
+
+/// Revoke explicit ACEs on `path` for `sid_str` whose `(access_mask,
+/// ace_type, inherit_flags)` tuple exactly matches the requested one.
+/// Mirrors [`apply_explicit_ace`] in reverse: any non-matching
+/// explicit ACE for the same SID — including those authored by other
+/// tools (e.g. `icacls C:\ /grant "ALL APPLICATION PACKAGES":(R)`) —
+/// is preserved.
+///
+/// Returns the count of ACEs removed. `Ok(0)` is the no-op case (no
+/// matching ACE exists) and is *not* an error.
+///
+/// Implementation: scan the existing DACL for explicit ACEs attached
+/// to the SID; partition into matches/keeps; if any matches, replace
+/// all the SID's contributions with a single `REVOKE_ACCESS` + replay
+/// of the keeps. Inherited ACEs are not touched.
+pub(crate) fn revoke_specific_aces_for_sid(
+    path: &Path,
+    sid_str: &str,
+    access_mask: u32,
+    ace_type: AceType,
+    inheritable: bool,
+) -> Result<usize, DaclError> {
+    // Compute the inherit-flags byte we'd have applied (matches the
+    // logic in `apply_explicit_ace`). Inherited ACEs are masked off by
+    // `scan_explicit_aces_for_sid` so the captured `inherit_flags`
+    // contains only OI/CI/NP/IO bits.
+    let expected_inherit_flags: u8 = if inheritable {
+        (OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0) as u8
+    } else {
+        0
+    };
+
+    let priors = scan_explicit_aces_for_sid(path, sid_str)?;
+    let mut keeps: Vec<PriorAce> = Vec::new();
+    let mut removed = 0usize;
+    for p in priors {
+        if p.access_mask == access_mask
+            && p.ace_type == ace_type
+            && p.inherit_flags == expected_inherit_flags
+        {
+            removed += 1;
+        } else {
+            keeps.push(p);
+        }
+    }
+
+    if removed == 0 {
+        return Ok(0);
+    }
+
+    let sid = OwnedSid::parse(sid_str)?;
+    let path_w = wide(path);
+    let object_name = PCWSTR(path_w.as_ptr());
+
+    let mut existing_dacl: *mut ACL = ptr::null_mut();
+    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    let rc = unsafe {
+        GetNamedSecurityInfoW(
+            object_name,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(&mut existing_dacl),
+            None,
+            &mut sd,
+        )
+    };
+    if rc != ERROR_SUCCESS {
+        return Err(win32_err(path, "GetNamedSecurityInfoW", rc));
+    }
+    if existing_dacl.is_null() {
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        // Scan said there were matches; this would imply a TOCTOU
+        // where the DACL was cleared between scan and revoke. Either
+        // way our target state (no matching ACE) is already true.
+        return Ok(removed);
+    }
+
+    let trustee = trustee_for(&sid);
+    let mut batch: Vec<EXPLICIT_ACCESS_W> = Vec::with_capacity(keeps.len() + 1);
+    batch.push(EXPLICIT_ACCESS_W {
+        grfAccessPermissions: 0,
+        grfAccessMode: REVOKE_ACCESS,
+        grfInheritance: ACE_FLAGS(0),
+        Trustee: trustee,
+    });
+    for k in &keeps {
+        let mode = match k.ace_type {
+            AceType::Allow => GRANT_ACCESS,
+            AceType::Deny => DENY_ACCESS,
+        };
+        batch.push(EXPLICIT_ACCESS_W {
+            grfAccessPermissions: k.access_mask,
+            grfAccessMode: mode,
+            grfInheritance: ACE_FLAGS(k.inherit_flags as u32),
+            Trustee: trustee,
+        });
+    }
+
+    let mut new_dacl: *mut ACL = ptr::null_mut();
+    let rc = unsafe {
+        SetEntriesInAclW(
+            Some(&batch),
+            Some(existing_dacl as *const ACL),
+            &mut new_dacl,
+        )
+    };
+    if rc != ERROR_SUCCESS {
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        return Err(win32_err(path, "SetEntriesInAclW", rc));
+    }
+
+    let rc = unsafe {
+        SetNamedSecurityInfoW(
+            object_name,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(new_dacl as *const ACL),
+            None,
+        )
+    };
+
+    unsafe {
+        if !new_dacl.is_null() {
+            let _ = LocalFree(Some(HLOCAL(new_dacl as *mut c_void)));
+        }
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+
+    if rc != ERROR_SUCCESS {
+        if rc.0 == 5 {
+            return Err(DaclError::WriteDacDenied {
+                path: path.to_path_buf(),
+                reason: format!("SetNamedSecurityInfoW: {rc:?}"),
+            });
+        }
+        return Err(win32_err(path, "SetNamedSecurityInfoW", rc));
+    }
+
+    Ok(removed)
 }
 
 /// Restore the target's DACL to its pre-apply state by:

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -47,6 +47,8 @@ pub mod sandbox_protocol;
 #[cfg(target_os = "windows")]
 pub mod string_util;
 #[cfg(target_os = "windows")]
+pub mod system_drive_prep;
+#[cfg(target_os = "windows")]
 pub mod windows_sandbox_runner;
 
 // Diagnostic logging (registry/env-controlled real-time output)

--- a/src/wxc_common/src/system_drive_prep.rs
+++ b/src/wxc_common/src/system_drive_prep.rs
@@ -1,0 +1,609 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Host-prep tooling: `--prepare-system-drive` / `--unprepare-system-drive`.
+//!
+//! Adds (or removes) metadata-only allow ACEs for the well-known
+//! AppContainer groups "ALL APPLICATION PACKAGES" (S-1-15-2-1) and
+//! "ALL RESTRICTED APPLICATION PACKAGES" (S-1-15-2-2) on the
+//! system-drive root.
+//!
+//! # Why
+//!
+//! AppContainer processes can't, by default, read metadata of the
+//! system-drive root via APIs such as `GetFileAttributesW`, `_stat`,
+//! or `[IO.DirectoryInfo]::GetAccessControl`. Common tools (cmd.exe,
+//! powershell.exe, pwsh.exe, node.exe) hit these during startup and
+//! fail with `ERROR_ACCESS_DENIED` inside an AppContainer. Granting
+//! the two AppContainer SIDs a tiny metadata-only access mask on `C:\`
+//! unblocks those tools without exposing the contents of the drive.
+//!
+//! # What we grant
+//!
+//! Mask: `FILE_READ_ATTRIBUTES | FILE_READ_EA | READ_CONTROL | SYNCHRONIZE`
+//! (`0x00120088`). This is the metadata-read set used by
+//! `GetFileAttributesW`, `_stat`, and `GetAccessControl`. Notably
+//! *not* `FILE_LIST_DIRECTORY` (the AppContainer still cannot
+//! enumerate `C:\`) and *not* `FILE_READ_DATA`.
+//!
+//! Inheritance: none. Only the directory object itself is modified;
+//! descendant files and subdirectories are unaffected.
+//!
+//! # Elevation model
+//!
+//! Modifying the DACL on `C:\` requires `WRITE_DAC`, which normal
+//! users don't hold. Windows does not allow a running process to
+//! elevate its own token, so the unelevated parent re-launches itself
+//! via `ShellExecuteExW(runas)` with the `--internal-elevated-helper`
+//! flag, waits for the elevated child, and propagates the exit code.
+//! A UAC prompt is expected on the first invocation.
+//!
+//! The parent resolves the target path *once* (before elevation) and
+//! passes it to the child via `--internal-target-path` so the
+//! elevated child does not re-read `%SystemDrive%` from a potentially
+//! attacker-controlled environment. The child validates the received
+//! path is a literal drive root (`X:\`) before touching its DACL.
+
+#![cfg(target_os = "windows")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use windows::core::PCWSTR;
+use windows::Win32::Foundation::{CloseHandle, HANDLE, HWND, WAIT_OBJECT_0};
+use windows::Win32::Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY};
+use windows::Win32::System::Threading::{
+    GetCurrentProcess, GetExitCodeProcess, OpenProcessToken, WaitForSingleObject, INFINITE,
+};
+use windows::Win32::UI::Shell::{
+    ShellExecuteExW, SEE_MASK_NOASYNC, SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW,
+};
+
+use crate::filesystem_dacl::{
+    apply_explicit_ace, revoke_specific_aces_for_sid, AceType, DaclError,
+};
+use crate::string_util::to_wide;
+
+/// `SW_SHOWNORMAL` is defined in `Win32_UI_WindowsAndMessaging`, which
+/// is not currently enabled in this workspace's `windows` features. Use
+/// the documented integer value directly to avoid a feature-set change.
+const SW_SHOWNORMAL_I32: i32 = 1;
+
+/// Well-known SID for the AppContainer "ALL APPLICATION PACKAGES" group.
+const SID_ALL_APP_PACKAGES: &str = "S-1-15-2-1";
+
+/// Well-known SID for the AppContainer "ALL RESTRICTED APPLICATION PACKAGES" group.
+const SID_ALL_RESTRICTED_APP_PACKAGES: &str = "S-1-15-2-2";
+
+/// Trustees iterated by [`run_prepare`] / [`run_unprepare`]: (display name, SID string).
+const TRUSTEES: &[(&str, &str)] = &[
+    ("ALL APPLICATION PACKAGES", SID_ALL_APP_PACKAGES),
+    (
+        "ALL RESTRICTED APPLICATION PACKAGES",
+        SID_ALL_RESTRICTED_APP_PACKAGES,
+    ),
+];
+
+/// Access mask granted on the target path: metadata read only.
+///
+/// `FILE_READ_ATTRIBUTES (0x80) | FILE_READ_EA (0x08) | READ_CONTROL (0x20000) | SYNCHRONIZE (0x100000)`
+const STAT_ACCESS_MASK: u32 = 0x0012_0088;
+
+/// Internal env var used by unit tests to redirect the target path
+/// onto a tempdir. Debug builds only — release ignores it. Mirrors
+/// the `MXC_FORCE_TIER` test seam in `fallback_detector`.
+#[cfg(debug_assertions)]
+const PATH_OVERRIDE_ENV: &str = "MXC_PREPARE_PATH_OVERRIDE";
+
+/// Errors produced by the prepare/unprepare flow.
+#[derive(Debug, thiserror::Error)]
+pub enum PrepError {
+    /// Querying the current process token failed.
+    #[error("could not query process token: {0}")]
+    TokenQuery(String),
+    /// Re-launch with the `runas` verb failed.
+    #[error("elevation failed: {0}")]
+    Elevation(String),
+    /// The elevated child exited non-zero. The log path the child
+    /// wrote diagnostic output to is included.
+    #[error("elevated helper exited with code {code}; see {log_path}")]
+    ChildFailed { code: i32, log_path: PathBuf },
+    /// The DACL operation against the system drive root failed.
+    #[error("DACL operation failed: {0}")]
+    Dacl(#[from] DaclError),
+    /// `--internal-elevated-helper` was set on a non-elevated process.
+    /// Defense in depth: should not be reachable in practice because
+    /// `ShellExecuteExW(runas)` either elevates or returns `Err`.
+    #[error(
+        "--internal-elevated-helper invoked without an elevated token; aborting to avoid loops"
+    )]
+    UnelevatedReentry,
+    /// Could not resolve `%SystemDrive%`.
+    #[error("could not resolve system drive root: {0}")]
+    SystemDriveUnresolved(String),
+    /// Could not determine `current_exe`.
+    #[error("could not resolve current executable path: {0}")]
+    CurrentExeUnresolved(String),
+    /// `--internal-target-path` was set but the value did not pass the
+    /// drive-root sanity check.
+    #[error(
+        "--internal-target-path must be a drive root (e.g. `C:\\`); got `{0}`. Refusing to ACL \
+         arbitrary paths via the elevated helper."
+    )]
+    InvalidTargetPath(String),
+}
+
+/// Resolve the target path in the unelevated parent.
+///
+/// Production: `%SystemDrive%\`. Debug + `MXC_PREPARE_PATH_OVERRIDE`
+/// set: honored verbatim (for unit tests).
+fn target_path() -> Result<PathBuf, PrepError> {
+    #[cfg(debug_assertions)]
+    if let Ok(p) = std::env::var(PATH_OVERRIDE_ENV) {
+        if !p.is_empty() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    match std::env::var("SystemDrive") {
+        Ok(d) if !d.is_empty() => Ok(PathBuf::from(format!("{d}\\"))),
+        Ok(_) => Err(PrepError::SystemDriveUnresolved(
+            "%SystemDrive% is empty".to_string(),
+        )),
+        Err(e) => Err(PrepError::SystemDriveUnresolved(e.to_string())),
+    }
+}
+
+/// Sanity-check a path received from `--internal-target-path`.
+///
+/// Production allows only literal drive roots (`X:\`). This prevents
+/// an attacker who can control the unelevated parent's CLI invocation
+/// (or who finds a way to forge the internal flag) from steering the
+/// elevated helper at arbitrary paths.
+///
+/// In debug builds the check is bypassed when `MXC_PREPARE_PATH_OVERRIDE`
+/// is set in the *child* — needed so tests can drive the helper
+/// against tempdirs without crafting a fake drive root.
+fn validate_target_path(p: &Path) -> Result<(), PrepError> {
+    #[cfg(debug_assertions)]
+    if std::env::var(PATH_OVERRIDE_ENV).is_ok_and(|v| !v.is_empty()) {
+        return Ok(());
+    }
+    let s = p.to_string_lossy();
+    let bytes = s.as_bytes();
+    let ok =
+        bytes.len() == 3 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' && bytes[2] == b'\\';
+    if ok {
+        Ok(())
+    } else {
+        Err(PrepError::InvalidTargetPath(s.into_owned()))
+    }
+}
+
+/// Apply allow ACEs for every well-known trustee on `path`. Idempotent.
+fn apply_all(path: &Path) -> Result<(), PrepError> {
+    for (name, sid) in TRUSTEES {
+        println!("  + {name:<45} ({sid})");
+        apply_explicit_ace(path, sid, STAT_ACCESS_MASK, AceType::Allow, false)?;
+    }
+    Ok(())
+}
+
+/// Revoke ACEs matching our exact `(mask, type, inheritance)` tuple
+/// for every well-known trustee on `path`. Non-matching explicit ACEs
+/// for the same SIDs (e.g. ones authored by `icacls C:\ /grant
+/// "ALL APPLICATION PACKAGES":(R)`) are preserved.
+fn revoke_all(path: &Path) -> Result<(), PrepError> {
+    for (name, sid) in TRUSTEES {
+        let removed =
+            revoke_specific_aces_for_sid(path, sid, STAT_ACCESS_MASK, AceType::Allow, false)?;
+        if removed > 0 {
+            println!("  - {name:<45} ({sid}) [{removed} ACE(s) removed]");
+        } else {
+            println!("  · {name:<45} ({sid}) [no matching ACE; nothing to do]");
+        }
+    }
+    Ok(())
+}
+
+/// Returns whether the current process is running with an elevated
+/// token (`TokenIsElevated != 0`).
+fn is_token_elevated() -> Result<bool, PrepError> {
+    let mut token: HANDLE = HANDLE::default();
+    unsafe {
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .map_err(|e| PrepError::TokenQuery(format!("OpenProcessToken: {e}")))?;
+    }
+    let mut info = TOKEN_ELEVATION::default();
+    let mut size = 0u32;
+    let result = unsafe {
+        GetTokenInformation(
+            token,
+            TokenElevation,
+            Some(&mut info as *mut _ as *mut std::ffi::c_void),
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut size,
+        )
+    };
+    unsafe {
+        let _ = CloseHandle(token);
+    }
+    result.map_err(|e| PrepError::TokenQuery(format!("GetTokenInformation: {e}")))?;
+    Ok(info.TokenIsElevated != 0)
+}
+
+/// Path the elevated child writes its console output to, so the
+/// unelevated parent can surface it on failure. The child's console
+/// window closes immediately on exit; without this redirection the
+/// user sees only `ChildFailed(<code>)` with no diagnostic.
+fn helper_log_path() -> PathBuf {
+    std::env::temp_dir().join("wxc-exec-prepare-system-drive.log")
+}
+
+/// Re-launch the current executable with `action_flag`, the resolved
+/// `target_path` (passed via `--internal-target-path` so the child
+/// does not re-read `%SystemDrive%`), and `--internal-elevated-helper`.
+/// Uses `ShellExecuteExW` with the `runas` verb (UAC prompt). Waits
+/// for the elevated child to exit and returns its exit code.
+fn spawn_elevated_self_and_wait(action_flag: &str, target_path: &Path) -> Result<i32, PrepError> {
+    let exe =
+        std::env::current_exe().map_err(|e| PrepError::CurrentExeUnresolved(e.to_string()))?;
+    let exe_str = exe
+        .to_str()
+        .ok_or_else(|| PrepError::CurrentExeUnresolved("non-UTF-8 path".to_string()))?;
+    let exe_w = to_wide(exe_str);
+
+    let target_str = target_path
+        .to_str()
+        .ok_or_else(|| PrepError::CurrentExeUnresolved("non-UTF-8 target path".to_string()))?;
+    let params =
+        format!("{action_flag} --internal-elevated-helper --internal-target-path \"{target_str}\"");
+    let params_w = to_wide(&params);
+    let verb_w = to_wide("runas");
+
+    // Truncate the log file so the parent only reports output from
+    // this elevated invocation. Best-effort: if the temp dir is
+    // unwritable the child will discover that itself.
+    let _ = fs::write(helper_log_path(), b"");
+
+    // SAFETY: zero-initializing SHELLEXECUTEINFOW is the documented
+    // pattern; cbSize is required to be set before the call. The
+    // PCWSTR pointers reference local `Vec<u16>` buffers that live
+    // until the end of this function, which is past the synchronous
+    // `ShellExecuteExW` call (SEE_MASK_NOASYNC).
+    let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
+    info.cbSize = std::mem::size_of::<SHELLEXECUTEINFOW>() as u32;
+    info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
+    info.hwnd = HWND::default();
+    info.lpVerb = PCWSTR(verb_w.as_ptr());
+    info.lpFile = PCWSTR(exe_w.as_ptr());
+    info.lpParameters = PCWSTR(params_w.as_ptr());
+    info.lpDirectory = PCWSTR::null();
+    info.nShow = SW_SHOWNORMAL_I32;
+
+    unsafe {
+        ShellExecuteExW(&mut info)
+            .map_err(|e| PrepError::Elevation(format!("ShellExecuteExW: {e}")))?;
+    }
+
+    let process = info.hProcess;
+    let wait = unsafe { WaitForSingleObject(process, INFINITE) };
+    if wait != WAIT_OBJECT_0 {
+        unsafe {
+            let _ = CloseHandle(process);
+        }
+        return Err(PrepError::Elevation(format!(
+            "WaitForSingleObject returned 0x{:08X} (expected WAIT_OBJECT_0)",
+            wait.0
+        )));
+    }
+    let mut exit_code = 0u32;
+    let exit_result = unsafe { GetExitCodeProcess(process, &mut exit_code) };
+    unsafe {
+        let _ = CloseHandle(process);
+    }
+    exit_result.map_err(|e| PrepError::Elevation(format!("GetExitCodeProcess: {e}")))?;
+    Ok(exit_code as i32)
+}
+
+/// Append a single line to the helper log file. Best-effort: errors
+/// are swallowed because the alternative — propagating an I/O error
+/// from the elevated child — would corrupt the exit-code signal the
+/// parent uses for success/failure.
+fn helper_log(line: &str) {
+    use std::io::Write;
+    if let Ok(mut f) = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(helper_log_path())
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+/// CLI entry point for `--prepare-system-drive`. Returns the process
+/// exit code to propagate (0 = success, 1 = failure).
+///
+/// `internal_elevated_helper` reflects whether the caller passed
+/// `--internal-elevated-helper`; `internal_target_path` reflects the
+/// optional `--internal-target-path <PATH>` arg the unelevated parent
+/// passes to the elevated child (so the child does not re-read
+/// `%SystemDrive%`).
+pub fn run_prepare(internal_elevated_helper: bool, internal_target_path: Option<&str>) -> i32 {
+    finish(run_action(
+        Action::Prepare,
+        internal_elevated_helper,
+        internal_target_path,
+    ))
+}
+
+/// CLI entry point for `--unprepare-system-drive`. Returns the process
+/// exit code to propagate (0 = success, 1 = failure).
+pub fn run_unprepare(internal_elevated_helper: bool, internal_target_path: Option<&str>) -> i32 {
+    finish(run_action(
+        Action::Unprepare,
+        internal_elevated_helper,
+        internal_target_path,
+    ))
+}
+
+fn finish(result: Result<(), PrepError>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("error: {e}");
+            // If the failure was a ChildFailed, dump the captured
+            // helper-log contents so the user sees what went wrong.
+            if let PrepError::ChildFailed { log_path, .. } = &e {
+                if let Ok(contents) = fs::read_to_string(log_path) {
+                    if !contents.trim().is_empty() {
+                        eprintln!("--- elevated helper log ({}) ---", log_path.display());
+                        eprintln!("{}", contents.trim_end());
+                        eprintln!("--- end log ---");
+                    }
+                }
+            }
+            1
+        }
+    }
+}
+
+enum Action {
+    Prepare,
+    Unprepare,
+}
+
+impl Action {
+    fn flag(&self) -> &'static str {
+        match self {
+            Action::Prepare => "--prepare-system-drive",
+            Action::Unprepare => "--unprepare-system-drive",
+        }
+    }
+    fn description(&self) -> &'static str {
+        match self {
+            Action::Prepare => "Adding metadata-read ACEs",
+            Action::Unprepare => "Removing metadata-read ACEs",
+        }
+    }
+}
+
+fn run_action(
+    action: Action,
+    internal_elevated_helper: bool,
+    internal_target_path: Option<&str>,
+) -> Result<(), PrepError> {
+    // Resolve the path differently depending on which side of the
+    // elevation boundary we're on:
+    //   - Elevated child (helper flag set): use the path the parent
+    //     passed in, validate it's a drive root, do not consult env.
+    //   - Unelevated parent: read %SystemDrive% (or test override).
+    let (path, in_child_role) = if internal_elevated_helper {
+        let p = internal_target_path.ok_or_else(|| {
+            PrepError::Elevation(
+                "--internal-elevated-helper requires --internal-target-path".to_string(),
+            )
+        })?;
+        let path = PathBuf::from(p);
+        validate_target_path(&path)?;
+        (path, true)
+    } else {
+        (target_path()?, false)
+    };
+
+    if is_token_elevated()? {
+        // We hold the elevated token (either as the actual user, or
+        // as the spawned helper). Do the work.
+        let header = format!("{} on {}", action.description(), path.display());
+        let mask_line = format!(
+            "  mask : 0x{:08X} (FILE_READ_ATTRIBUTES | FILE_READ_EA | READ_CONTROL | SYNCHRONIZE)",
+            STAT_ACCESS_MASK
+        );
+        println!("{header}");
+        println!("{mask_line}");
+        if in_child_role {
+            helper_log(&header);
+            helper_log(&mask_line);
+        }
+
+        let work = match action {
+            Action::Prepare => apply_all(&path),
+            Action::Unprepare => revoke_all(&path),
+        };
+        if let Err(e) = &work {
+            let msg = format!("error during ACL operation: {e}");
+            eprintln!("{msg}");
+            if in_child_role {
+                helper_log(&msg);
+            }
+        }
+        work?;
+
+        println!("Done.");
+        if in_child_role {
+            helper_log("Done.");
+        }
+        return Ok(());
+    }
+
+    if internal_elevated_helper {
+        // Re-launched with the helper flag but our token isn't
+        // elevated. Refuse to recurse.
+        return Err(PrepError::UnelevatedReentry);
+    }
+
+    println!(
+        "This operation modifies the DACL of {} and requires elevation.",
+        path.display()
+    );
+    println!("Requesting elevation (UAC prompt)…");
+    let exit = spawn_elevated_self_and_wait(action.flag(), &path)?;
+    if exit == 0 {
+        println!("Elevated helper completed successfully.");
+        Ok(())
+    } else {
+        Err(PrepError::ChildFailed {
+            code: exit,
+            log_path: helper_log_path(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // These tests cover the apply/revoke pair against a tempdir
+    // (redirected via MXC_PREPARE_PATH_OVERRIDE). They do *not*
+    // exercise the elevation flow, which requires UAC and is verified
+    // manually with the PowerShell scripts in `scripts/host-prep/`.
+
+    use super::*;
+    use std::sync::Mutex;
+
+    // Serialize tests that mutate process-wide env vars.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct OverrideGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+    impl OverrideGuard {
+        fn set(p: &Path) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: serialized against our own writes via ENV_LOCK.
+            // We assume no other concurrent reader/writer of env in
+            // this process during the guard's lifetime (test threads
+            // sharing env vars are the actual race Rust 1.81 flagged
+            // by marking set_var unsafe).
+            unsafe {
+                std::env::set_var(PATH_OVERRIDE_ENV, p);
+            }
+            OverrideGuard { _lock: lock }
+        }
+    }
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            // SAFETY: see set().
+            unsafe {
+                std::env::remove_var(PATH_OVERRIDE_ENV);
+            }
+        }
+    }
+
+    #[test]
+    fn target_path_honors_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = OverrideGuard::set(tmp.path());
+        let resolved = target_path().unwrap();
+        assert_eq!(resolved, tmp.path());
+    }
+
+    #[test]
+    fn apply_then_revoke_round_trip_on_tempdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = OverrideGuard::set(tmp.path());
+
+        // Start clean: a fresh tempdir has no S-1-15-2-* ACEs, so the
+        // first revoke is a no-op.
+        revoke_all(tmp.path()).unwrap();
+
+        // Apply both ACEs.
+        apply_all(tmp.path()).unwrap();
+        // Re-applying is idempotent (SetEntriesInAclW merges).
+        apply_all(tmp.path()).unwrap();
+
+        // Revoke removes the ACEs.
+        revoke_all(tmp.path()).unwrap();
+        // Revoke is idempotent.
+        revoke_all(tmp.path()).unwrap();
+    }
+
+    #[test]
+    fn revoke_preserves_non_matching_ace_for_same_sid() {
+        // The reviewer's MF-1 concern: a sysadmin previously ran
+        // `icacls <path> /grant "ALL APPLICATION PACKAGES":(R)` and
+        // we must not nuke that ACE.
+        let tmp = tempfile::tempdir().unwrap();
+        let _g = OverrideGuard::set(tmp.path());
+
+        // Apply our metadata-only ACE.
+        apply_all(tmp.path()).unwrap();
+
+        // Independently grant the same SID a different mask
+        // (FILE_GENERIC_READ = 0x00120089 — differs from ours by the
+        // FILE_READ_DATA bit). This simulates a pre-existing
+        // third-party ACE.
+        const FILE_GENERIC_READ: u32 = 0x0012_0089;
+        apply_explicit_ace(
+            tmp.path(),
+            SID_ALL_APP_PACKAGES,
+            FILE_GENERIC_READ,
+            AceType::Allow,
+            false,
+        )
+        .unwrap();
+
+        // Our revoke must only remove the metadata-only ACE, not the
+        // GENERIC_READ one.
+        revoke_all(tmp.path()).unwrap();
+
+        // The exact-tuple `FILE_GENERIC_READ` ACE is still present —
+        // a follow-up revoke with that mask removes it cleanly.
+        let removed = revoke_specific_aces_for_sid(
+            tmp.path(),
+            SID_ALL_APP_PACKAGES,
+            FILE_GENERIC_READ,
+            AceType::Allow,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            removed, 1,
+            "the pre-existing third-party ACE must survive our revoke_all"
+        );
+    }
+
+    #[test]
+    fn validate_target_path_accepts_drive_roots() {
+        // Bypass the debug short-circuit: clear any test override
+        // while holding the lock.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized by ENV_LOCK.
+        unsafe { std::env::remove_var(PATH_OVERRIDE_ENV) };
+
+        for p in ["C:\\", "D:\\", "Z:\\", "a:\\"] {
+            validate_target_path(Path::new(p))
+                .unwrap_or_else(|e| panic!("expected `{p}` to validate, got {e}"));
+        }
+        for p in [
+            "C:\\Windows",
+            "C:",
+            "\\\\server\\share",
+            "C:\\\\",
+            "",
+            "1:\\",
+        ] {
+            assert!(
+                validate_target_path(Path::new(p)).is_err(),
+                "expected `{p}` to be rejected"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## ≡ƒôû Description

Adds `wxc-exec --prepare-system-drive` (and its inverse `--unprepare-system-drive`) ΓÇö a one-time, host-wide setup step that grants the well-known AppContainer SIDs `S-1-15-2-1` (`ALL APPLICATION PACKAGES`) and `S-1-15-2-2` (`ALL RESTRICTED APPLICATION PACKAGES`) a tiny metadata-only access mask on the system-drive root (`C:\`).

### Why

AppContainer processes can't, by default, read directory metadata of the system-drive root via APIs such as `GetFileAttributesW`, `_stat`, or `[IO.DirectoryInfo]::GetAccessControl`. Common tools (`cmd.exe`, `powershell.exe`, `pwsh.exe`, `node.exe`) hit these during startup and fail with `ERROR_ACCESS_DENIED` inside an AppContainer. This blocks most non-trivial agent workloads on the T2/T3 paths landed in phases 3 and 4.

### What we grant

| Trustee | SID | Access mask | Inheritance |
| --- | --- | --- | --- |
| `ALL APPLICATION PACKAGES` | `S-1-15-2-1` | `FILE_READ_ATTRIBUTES \| FILE_READ_EA \| READ_CONTROL \| SYNCHRONIZE` (`0x00120088`) | none |
| `ALL RESTRICTED APPLICATION PACKAGES` | `S-1-15-2-2` | same | none |

The mask is the metadata-read set used by `GetFileAttributesW`, `_stat`, and `GetAccessControl`. It explicitly excludes `FILE_LIST_DIRECTORY` (the container still cannot enumerate `C:\`) and `FILE_READ_DATA`. Inheritance is `None`, so descendant files and subdirectories are unaffected ΓÇö the change is scoped to the directory object itself.

### Code shape

- New `wxc_common::system_drive_prep` module (Windows-only).
- `filesystem_dacl::apply_ace` refactored into a thin wrapper over a new `pub(crate)` helper `apply_explicit_ace(path, sid, mask, type, inheritable)`. Behavior-preserving.
- New `pub(crate)` helper `revoke_specific_aces_for_sid` for tuple-precise revoke (only ACEs matching the apply tuple are removed; non-matching ones ΓÇö e.g. third-party `icacls /grant` ACEs ΓÇö are preserved).
- `wxc/src/main.rs` adds three flags (two visible, one hidden) with clap `conflicts_with_all` against the other top-level "do this and exit" flags.

### Hardenings (from the adversarial review on `330fabd5`)

- **Precise tuple-matching revoke** (MF-1): `--unprepare-system-drive` no longer issues a blunt `SetEntriesInAclW(REVOKE_ACCESS)` for the SID. It scans the existing DACL, partitions explicit ACEs into matches/non-matches against the apply tuple, and only revokes matches. PowerShell scripts and Rust path now genuinely mirror each other.
- **clap mutual exclusion** (MF-2): the new flags carry `conflicts_with_all` against `--setup-hyperlight`, `--setup-wslc`, `--delete`, `--dry-run`, and each other. Invalid combos are rejected at parse time instead of silently dropping the other flag.
- **Elevated child diagnostics + WaitForSingleObject check** (MF-3): the elevated child appends its console output to `%TEMP%\wxc-exec-prepare-system-drive.log`; the unelevated parent reads and prints the contents on non-zero child exit so failures surface a real diagnostic instead of an opaque exit code. `WaitForSingleObject` return value is now checked against `WAIT_OBJECT_0`.
- **`--internal-target-path` for path-resolution hardening** (SF-1): the unelevated parent resolves `%SystemDrive%` once and passes the resolved path to the elevated child as a hidden CLI arg. The child does not re-read `%SystemDrive%` from a potentially attacker-controlled environment and validates the received path is a literal drive root (`X:\`) before touching its DACL.

### Elevation model

Modifying the DACL on `C:\` needs `WRITE_DAC`, which normal users don't hold. Windows does not allow a running process to elevate its own token, so the unelevated parent re-launches itself via `ShellExecuteExW(runas)` with a hidden `--internal-elevated-helper` flag, waits for the elevated child, and propagates the exit code. A UAC prompt is expected on the first invocation.

## ≡ƒöù References

Prerequisite for #296 (Phase 4: dispatcher integration for BaseContainer fallback). Phase 4 will need to be rebased onto this once it lands.

Related to #304 ("T3: directory enumeration fails even on granted paths") ΓÇö does not resolve it (that's about ancestor `FILE_TRAVERSE` rights for `FindFirstFile`, a different problem), but is on the same axis and helps unblock the same "cmd/pwsh inside AppContainer can't start up" symptom.

Stacks on top of #295 (Phase 3: `filesystem_dacl` module). Phase 3 is already merged to `main`, so this PR targets `main` directly.

## ≡ƒöì Validation

### Automated

- `cargo fmt --all -- --check` Γ£à
- `cargo check --workspace --all-targets` Γ£à
- `cargo clippy --workspace --all-targets -- -D warnings` Γ£à
- `cargo test -p wxc_common --lib -- --test-threads=1` Γ£à (345/345 pass, including 4 new tests in `system_drive_prep::tests`: round-trip, override seam, **MF-1 precise-revoke regression**, **SF-1 drive-root validator**)

### Manual (Windows 11 25H2)

Verified end-to-end with `scripts/host-prep/Prepare-SystemDriveForAppContainer.ps1` on real `C:\`. Before the prep, `icacls C:\` showed no explicit ACEs for the AppContainer SIDs. After `wxc-exec --prepare-system-drive`, icacls confirmed both ACEs landed with mask `(Rc,S,REA,RA)` (= `0x00120088`) and no inheritance flags. Re-running `--prepare-system-drive` was idempotent. `--unprepare-system-drive` removed both. The C:\ DACL restored byte-for-byte to baseline (SDDL comparison).

UAC handshake (from a non-elevated PowerShell): observed UAC consent dialog ΓåÆ elevated child runs ΓåÆ unelevated parent prints `Elevated helper completed successfully.` ΓåÆ exit 0.

## Γ£à Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

(Copilot instructions: added `docs/host-prep.md` to the `Key documentation → Core references` list so future agents discover the new doc and the `scripts/host-prep/` hand-test helpers.)

## ≡ƒôï Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task