### PR TITLE
Fix: SDK validator accepts legacy containment wire values

### DIFF
--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger.js';
-import { ContainerConfig, ContainmentBackend, ContainmentTypes, ExperimentalBackends } from './types.js';
+import { ContainerConfig, ContainmentBackend, ContainmentTypes, ExperimentalBackends, LegacyContainmentAliases } from './types.js';
 import { findWxcExecutable, findLxcExecutable, findSeatbeltExecutable, getPlatformSupport } from './platform.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { diagLog } from './diagnostic.js';
@@ -163,7 +163,12 @@ export function resolveExecutableAndArgs(
     // at run time, so the SDK accepts them without checking against the
     // host's concrete backend list.
     const isIntent = (ContainmentTypes as readonly string[]).includes(config.containment);
-    const isAvailable = platformSupport.availableMethods.includes(config.containment as ContainmentBackend);
+    // Legacy wire values accepted by the native binary via serde aliases
+    // (e.g. "appcontainer" → processcontainer, "macos_sandbox" → seatbelt).
+    const resolved = LegacyContainmentAliases[config.containment];
+    const isAvailable = platformSupport.availableMethods.includes(
+      (resolved ?? config.containment) as ContainmentBackend
+    );
     if (!isIntent && !isExperimental && !isAvailable) {
       throw new Error(
         `Containment backend '${config.containment}' is not available on this platform. ` +

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -31,6 +31,7 @@ export {
   SandboxingMethod,
   ContainmentType,
   ContainmentTypes,
+  LegacyContainmentAliases,
   ContainmentBackend,
   ExperimentalBackends,
   ContainerConfig,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -64,6 +64,18 @@ export type ContainmentType = "process" | "vm" | "microvm";
 export const ContainmentTypes: readonly ContainmentType[] = ['process', 'vm', 'microvm'];
 
 /**
+ * Deprecated wire values accepted by the native binary via serde aliases.
+ * Maps each legacy name to the canonical {@link ContainmentBackend} value
+ * so the SDK validator can resolve them before the platform check. Configs
+ * using these values still reach wxc-exec unchanged — the Rust parser
+ * handles the final mapping at run time.
+ */
+export const LegacyContainmentAliases: Readonly<Record<string, ContainmentBackend>> = {
+  appcontainer: 'processcontainer',
+  macos_sandbox: 'seatbelt',
+};
+
+/**
  * Concrete containment backend. Each value names a specific runner
  * implementation in the native binary. Prefer a {@link ContainmentType}
  * value unless you specifically need to force a particular backend.


### PR DESCRIPTION
The Rust parser (wxc-exec) accepts deprecated wire values like `appcontainer` and `macos_sandbox` via serde aliases (PR #268), but the TypeScript SDK validator rejected them before the config reached the binary.

Adds a `LegacyContainmentAliases` map that resolves deprecated wire values to their canonical `ContainmentBackend` before the platform check, matching the Rust parser's backward-compat behavior.

**Changes:**
- `sdk/src/types.ts`: Add `LegacyContainmentAliases` map (`appcontainer` -> `processcontainer`, `macos_sandbox` -> `seatbelt`)
- `sdk/src/helper.ts`: Resolve through aliases before platform check
- `sdk/src/index.ts`: Export the new map

All 131 SDK tests pass.

Fixes #390
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/391)