### PR TITLE
[CI baseline] Noop docs change for baseline timing (do not merge)

### DIFF
--- a/.azure-pipelines/README.md
+++ b/.azure-pipelines/README.md
@@ -2,7 +2,7 @@
 
 ## For Developers
 
-Developers should to use public registries like `crates.io`
+Developers should use public registries like `crates.io`
 and `npmjs` directly so they can iterate quickly.
 
 ## For CI/Pipelines


### PR DESCRIPTION
**DO NOT MERGE** — This is a CI baseline measurement PR.

## Summary

Trivial doc-only fix in `.azure-pipelines/README.md` (`"should to use"` → `"should use"`). The change is functionally a no-op; the purpose of this PR is to capture a reference timing for the `MXC-PR-Build` ADO pipeline as a baseline against which a set of five parallel optimization PRs will be measured.

Companion PRs:
1. Move clippy to a parallel `Lint` stage
2. Enable `cargo-nextest` for parallel test execution
3. Cache `node_modules` across runs (3 Node jobs)
4. Add path filters to skip the build pipeline on docs-only PRs
5. Use `mold` linker for `aarch64-unknown-linux-gnu` cross builds

This PR should be closed (not merged) once timings have been collected from all six runs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/392)