### PR TITLE
[CI] Move clippy + fmt to a parallel Lint stage

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -116,6 +116,12 @@ extends:
 
       - template: .azure-pipelines/templates/Mxc.Binary.Packaging.Job.yml@self
 
+    - stage: Lint
+      displayName: 'Lint'
+      dependsOn: []
+      jobs:
+      - template: .azure-pipelines/templates/Lint.Job.yml@self
+
     - stage: SDK_Unit_Tests
       displayName: 'SDK Unit Tests'
       dependsOn: []

--- a/.azure-pipelines/templates/Lint.Job.yml
+++ b/.azure-pipelines/templates/Lint.Job.yml
@@ -82,10 +82,12 @@ jobs:
         displayName: cargo fmt --check
         workingDirectory: $(workingDirectory)
 
-      # Run clippy via plain cargo (same invocation that used to live inside
-      # Rust.Build.Job.yml) so the toolchain-installed clippy is used directly,
-      # avoiding the ~8min `clippy-sarif` source install that the 1ES task
-      # would otherwise trigger via enableClippy.
-      - script: cargo clippy --locked --workspace --all-targets --all-features --target $(targetTriple) --release -- -D warnings
+      # Run clippy via plain cargo. Note the deliberate lack of `--workspace`:
+      # on Linux this job runs from `src/lxc` which scopes clippy to the lxc
+      # package and its deps (matching the existing build's scope); the
+      # Windows job runs from `src/` (the workspace root with no `[package]`),
+      # so cargo's default expands to all workspace members. This avoids
+      # dragging Windows-only crates (e.g. wxc) into the Linux clippy graph.
+      - script: cargo clippy --locked --all-targets --all-features --target $(targetTriple) --release -- -D warnings
         displayName: cargo clippy --all-features
         workingDirectory: $(workingDirectory)

--- a/.azure-pipelines/templates/Lint.Job.yml
+++ b/.azure-pipelines/templates/Lint.Job.yml
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Standalone Lint stage that runs `cargo fmt --check` and `cargo clippy`
+# (with --all-features) in parallel with the Build_Binaries stage.
+#
+# Why this exists: clippy was previously a step inside Rust.Build.Job.yml
+# that ran AFTER the release build of the workspace finished. Because clippy
+# uses `--all-features` while the build uses default features, the cargo
+# fingerprint cache misses and clippy ends up recompiling the entire
+# workspace from scratch — adding ~10+ minutes to the critical path of the
+# x64 WXC build. Moving clippy into its own job lets it run in parallel
+# with the build, so wall-clock time on the pipeline becomes
+# max(build, clippy) instead of build + clippy.
+#
+# Linting is scoped to the two x64 targets because the existing inline step
+# was already gated on `isX64`. arm64 lint coverage is identical to x64 for
+# the rust source we control.
+
+parameters:
+- name: matrix
+  type: object
+  default:
+    - name: windows_x64
+      os: windows
+      triplet: x86_64-pc-windows-msvc
+      component: WXC
+    - name: linux_x64
+      os: linux
+      triplet: x86_64-unknown-linux-gnu
+      component: LXC
+
+jobs:
+- ${{ each item in parameters.matrix }}:
+  - job: 'lint_${{ item.name }}'
+    displayName: 'Lint (${{ item.component }} ${{ item.os }})'
+
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      ${{ if eq(item.os, 'windows') }}:
+        image: windows-latest
+        os: windows
+      ${{ if eq(item.os, 'linux') }}:
+        image: ubuntu-latest
+        os: linux
+
+    variables:
+      ${{ if eq(item.os, 'windows') }}:
+        CARGO_TARGET_DIR: c:/t/target
+        workingDirectory: src
+      ${{ if eq(item.os, 'linux') }}:
+        CARGO_TARGET_DIR: /tmp/target
+        # LXC build job uses src/lxc as cwd; mirror it so the cargo
+        # target-dir cache key matches and we benefit from any shared cache.
+        workingDirectory: $(Build.SourcesDirectory)/src/lxc
+      targetTriple: ${{ item.triplet }}
+
+    templateContext:
+      rust:
+        rustToolchain:
+          toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
+          version: 'ms-prod-1.93'
+          additionalTargets: $(targetTriple)
+        workingDirectory: $(workingDirectory)
+        cacheOptions:
+          enableTargetCache: true
+
+    steps:
+      - checkout: self
+
+      # Append pipeline-specific Cargo settings (registry, cross-compile linker)
+      # to the workspace config so crate downloads go through the centralized
+      # Azure Artifacts feed. Mirrors the setup in Rust.Build.Job.yml.
+      - powershell: |
+          Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+        displayName: Setup Cargo Config
+
+      - task: 1ES.Build.Rust.Setup@1
+      - task: 1ES.Build.Rust.Restore@1
+
+      - script: cargo fmt --all -- --check
+        displayName: cargo fmt --check
+        workingDirectory: $(workingDirectory)
+
+      # Run clippy via plain cargo (same invocation that used to live inside
+      # Rust.Build.Job.yml) so the toolchain-installed clippy is used directly,
+      # avoiding the ~8min `clippy-sarif` source install that the 1ES task
+      # would otherwise trigger via enableClippy.
+      - script: cargo clippy --locked --workspace --all-targets --all-features --target $(targetTriple) --release -- -D warnings
+        displayName: cargo clippy --all-features
+        workingDirectory: $(workingDirectory)

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -113,13 +113,10 @@ jobs:
           testAllTargets: false
           buildAllTargets: false
 
-      # Run clippy via plain cargo so the 1ES Setup task doesn't have to
-      # source-install clippy-sarif (~8 min). The toolchain ships clippy
-      # itself; `-D warnings` keeps the build gated.
-      - script: cargo clippy --locked --all-targets --all-features --target $(triplet) --release -- -D warnings
-        displayName: Clippy
-        condition: and(succeeded(), eq(variables['isX64'], 'true'))
-        workingDirectory: $(workingDirectory)
+      # Clippy and fmt now run in the parallel Lint stage (see
+      # .azure-pipelines/templates/Lint.Job.yml). Keeping them out of the
+      # critical path here removes ~10+ min of redundant compilation, since
+      # clippy's `--all-features` graph misses the build's fingerprint cache.
 
       - task: EsrpCodeSigning@5
         displayName: Code Sign


### PR DESCRIPTION
## Summary

Move `cargo fmt --check` and `cargo clippy --all-features` out of `Rust.Build.Job.yml` and into a new parallel `Lint` stage (`.azure-pipelines/templates/Lint.Job.yml`).

## Why

Clippy was previously a step inside the build job that ran **after** `1ES.Build.Rust.Run@1` finished. Because clippy uses `--all-features` while the build uses default features, the cargo fingerprint cache misses and clippy recompiles the entire workspace from scratch — adding ~10+ min to the critical path of the x64 WXC build (currently ~24m).

Splitting clippy into its own stage with `dependsOn: []` makes wall-clock time `max(build, clippy)` instead of `build + clippy`.

## Scope

- Two x64 lint jobs (windows + linux), mirroring the existing `isX64` gate.
- arm64 lint coverage is unchanged (the previous inline step was x64-only).
- Mac fmt/clippy steps are left in `Mac.Build.Job.yml` (separate pool, already small).

## Expected impact

- x64 WXC build job: ~24m → ~10–13m
- Pipeline total: ~33m → ~20m

Companion to baseline PR #392 and the four other optimization PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/393)