### PR TITLE
[CI] Enable cargo-nextest for parallel test execution (do not merge)

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -109,7 +109,7 @@ jobs:
           enableTest: $(isX64)
           publishTestResults: false
           enableClippy: false
-          useNextest: false
+          useNextest: true
           testAllTargets: false
           buildAllTargets: false
 


### PR DESCRIPTION
**DO NOT MERGE** — One of five parallel CI optimization PRs being measured against baseline PR #392.

## Summary

Flip `useNextest: false` → `useNextest: true` in the `1ES.Build.Rust.Run@1` task in `Rust.Build.Job.yml`.

## Why

`cargo-nextest` runs tests in parallel processes (vs `cargo test`'s thread-based concurrency within a single process) and is typically 30–60% faster on test-heavy workspaces.

The x64 WXC build is the longest job in the pipeline (~24m) and includes the full `wxc_common` test suite; nextest should trim minutes off that critical path. The x64 LXC build (~11m) benefits proportionally.

The pipeline already declares `NEXTEST_NO_TESTS: pass` in `1ES.Build.yml` (line 47), so the env contract was already prepared for this flip.

## Risk

- Test output format differs from `cargo test` — log readers expecting libtest's format may need updating. Test pass/fail behavior should be unchanged.
- arm64 builds don't run tests, so this only affects x64 windows + x64 linux.

Companion to baseline PR #392 and the four other optimization PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/394)