### PR TITLE
[CI] Cache npm downloads across pipeline runs

### DIFF
--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -28,6 +28,9 @@ jobs:
     outputDirectory: $(Build.SourcesDirectory)/out
     sdkDirectory: $(Build.SourcesDirectory)/sdk
     artifactBaseName: mxc-npm-sdk-package
+    # Cache npm package downloads across runs to avoid re-fetching every dependency
+    # tarball from the Azure Artifacts feed on each pipeline invocation.
+    npm_config_cache: $(Pipeline.Workspace)/.npm
 
   steps:
     - checkout: self
@@ -36,6 +39,14 @@ jobs:
       displayName: Use Node.js 20
       inputs:
         version: '20.x'
+
+    - task: Cache@2
+      displayName: Cache npm
+      inputs:
+        key: 'npm | "$(Agent.OS)" | sdk/package-lock.json'
+        restoreKeys: |
+          npm | "$(Agent.OS)"
+        path: $(npm_config_cache)
 
     # Download all artifacts dynamically
     - ${{ each target in parameters.targets }}:

--- a/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
@@ -44,6 +44,8 @@ jobs:
     variables:
       integrationDirectory: $(Build.SourcesDirectory)/sdk/tests/integration
       sdkPkgDirectory: $(Build.SourcesDirectory)/sdk-pkg
+      # Cache npm package downloads across runs (see Package.NpmSdk.Job.yml).
+      npm_config_cache: $(Pipeline.Workspace)/.npm
 
     steps:
       - checkout: self
@@ -52,6 +54,14 @@ jobs:
         displayName: Use Node.js 20
         inputs:
           version: '20.x'
+
+      - task: Cache@2
+        displayName: Cache npm
+        inputs:
+          key: 'npm | "$(Agent.OS)" | sdk/tests/integration/package-lock.json'
+          restoreKeys: |
+            npm | "$(Agent.OS)"
+          path: $(npm_config_cache)
 
       - task: DownloadPipelineArtifact@2
         displayName: Download SDK package

--- a/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Unit.Test.Job.yml
@@ -29,6 +29,8 @@ jobs:
 
     variables:
       sdkDirectory: $(Build.SourcesDirectory)/sdk
+      # Cache npm package downloads across runs (see Package.NpmSdk.Job.yml).
+      npm_config_cache: $(Pipeline.Workspace)/.npm
 
     steps:
       - checkout: self
@@ -37,6 +39,14 @@ jobs:
         displayName: Use Node.js 20
         inputs:
           version: '20.x'
+
+      - task: Cache@2
+        displayName: Cache npm
+        inputs:
+          key: 'npm | "$(Agent.OS)" | sdk/package-lock.json'
+          restoreKeys: |
+            npm | "$(Agent.OS)"
+          path: $(npm_config_cache)
 
       - task: CopyFiles@2
         displayName: Copy .npmrc to SDK


### PR DESCRIPTION
## Summary

Add the standard ADO `Cache@2` task to the three Node-based templates, keyed on each job's `package-lock.json`:

- `.azure-pipelines/templates/Package.NpmSdk.Job.yml`
- `.azure-pipelines/templates/SDK.Unit.Test.Job.yml`
- `.azure-pipelines/templates/SDK.Integration.Test.Job.yml`

## Why

Each Node job currently does `npm ci` cold — every dependency tarball is re-fetched from the Azure Artifacts feed on every pipeline run. Setting `npm_config_cache` to a cached pipeline-workspace path lets `npm ci` reuse downloaded tarballs across runs while still rebuilding `node_modules` from scratch (so install behavior is unchanged).

## Expected impact

- ~30–60s per Node job
- Six Node job instances per pipeline run (1 `npm pack` + 2 unit-test + 3 integration-test) → ~3–6 min of CI minutes per PR (mostly off the critical path, but real ___BEGIN___COMMAND_DONE_MARKER___$LASTEXITCODE).

## Risk

- First run after this PR lands is a cache miss (no savings).
- The cache key is scoped by `Agent.OS` and the lockfile; lockfile changes invalidate cleanly.

Companion to baseline PR #392 and the four other optimization PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/395)