### PR TITLE
[CI] Skip MXC-PR-Build for docs-only PRs

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -5,9 +5,25 @@ trigger: none
 name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 pr:
-- main
-- feature/*
-- user/*
+  branches:
+    include:
+    - main
+    - feature/*
+    - user/*
+  # Skip the full build pipeline when a PR only touches documentation /
+  # non-shipping content. Any change outside this exclusion list still
+  # triggers the pipeline as before. Keep this list conservative — exclude
+  # only paths that cannot possibly affect built artifacts or test behavior.
+  paths:
+    exclude:
+    - 'docs/**'
+    - 'examples/**'
+    - '.github/ISSUE_TEMPLATE/**'
+    - '.github/PULL_REQUEST_TEMPLATE.md'
+    - '.github/copilot-instructions.md'
+    - '.github/instructions/**'
+    - '**/*.md'
+    - '.editorconfig'
 
 resources:
   repositories:


### PR DESCRIPTION
## Summary

Add `pr.paths.exclude` to the PR trigger in `.azure-pipelines/1ES.Build.yml`. When a PR's diff is **entirely** confined to documentation, examples, issue templates, or other non-shipping content, ADO will not queue the `MXC-PR-Build` pipeline.

## Why

A typo fix in a README or a docs edit currently triggers the full ~33m pipeline including 5 cross-platform Rust builds, package + integration tests, and SDL scans. None of those gates inspect documentation.

## Exclusion list (intentionally conservative)

- `docs/**`
- `examples/**`
- `.github/ISSUE_TEMPLATE/**`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/copilot-instructions.md`
- `.github/instructions/**`
- `**/*.md` (any markdown anywhere)
- `.editorconfig`

Any change to `src/`, `sdk/`, `cli/`, `schemas/`, `scripts/`, `.azure-pipelines/` (except this file itself in the same PR? — ADO evaluates the union, so a mixed PR still triggers), `Cargo.*`, `package*.json`, or any non-markdown file still triggers the pipeline.

## Risk / notes

- ADO `paths.exclude` only skips the pipeline if **every** changed file matches an excluded path. Mixed PRs run normally.
- Schema files (`schemas/**`) are intentionally **not** excluded — they affect runtime behavior.

## Note on this PR

This PR itself touches `.azure-pipelines/1ES.Build.yml`, which is **not** in the exclusion list, so ADO will run on this PR (good — we want the timing measurement).

Companion to baseline PR #392 and the four other optimization PRs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/396)