### PR TITLE
[CI] Use gold linker for aarch64-linux-gnu cross builds (do not merge)

### DIFF
--- a/.azure-pipelines/.cargo/config.toml
+++ b/.azure-pipelines/.cargo/config.toml
@@ -10,6 +10,12 @@ Mxc-Azure-Feed = { index = "sparse+https://microsoft.pkgs.visualstudio.com/Dart/
 [source.crates-io]
 replace-with = "Mxc-Azure-Feed"
 
-# Add linker for arm64 on linux for cross-compilation
+# Add linker for arm64 on linux for cross-compilation.
+# Use the `gold` linker (shipped via binutils-aarch64-linux-gnu with the
+# cross-gcc package) — gold is multi-threaded and substantially faster
+# than the default ld.bfd on large cross-compile builds. Unlike mold,
+# `-fuse-ld=gold` resolves cleanly through the cross-gcc's standard
+# linker search path on stock Ubuntu images.
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+rustflags = ["-C", "link-arg=-fuse-ld=gold"]

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -84,10 +84,15 @@ jobs:
     steps:
       - checkout: self
 
-      # Install Linux ARM64 toolchain for arm64 linux builds
+      # Install Linux ARM64 toolchain for arm64 linux builds.
+      # The gold linker (used via `-fuse-ld=gold` in .azure-pipelines/.cargo/config.toml)
+      # ships in binutils-aarch64-linux-gnu, pulled in transitively by the
+      # cross-gcc package. gold is multi-threaded and substantially faster
+      # than the default ld.bfd on the cross-compile link step, which is
+      # the dominant cost of the arm64 LXC build.
       - script: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
         displayName: Install ARM64 toolchain
         condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
 


### PR DESCRIPTION
**DO NOT MERGE** — One of five parallel CI optimization PRs being measured against baseline PR #392.

## Summary

Configure the arm64 Linux cross build to use the `gold` linker instead of the default `ld.bfd`, by adding `-C link-arg=-fuse-ld=gold` to rustflags in `.azure-pipelines/.cargo/config.toml`. `gold` ships in `binutils-aarch64-linux-gnu` (pulled in transitively by the existing `gcc-aarch64-linux-gnu` apt package; the install line is updated to mention it explicitly for clarity).

## Why

In recent runs (PR #391) the arm64 LXC build is **slower** than the equivalent x64 LXC build:

| Job | Time | Test phase |
|---|---|---|
| Build (x64 LXC) | 10m51s | yes |
| Build (arm64 LXC) | 14m12s | no |

That arm64 is slower despite skipping tests points at the cross-compile link step. `gold` is multi-threaded and typically ~2x faster than `ld.bfd` on workspaces this size.

## Note on iteration

An earlier revision of this PR tried `mold`, which is faster still — but `-fuse-ld=mold` doesn't resolve through the cross-gcc's standard linker search path on stock Ubuntu (`ld.mold` is not symlinked into `/usr/aarch64-linux-gnu/bin/`), causing `collect2: cannot find 'ld'`. Switching to `gold` is the pragmatic choice — it's bundled with binutils so no extra setup is required, and `-fuse-ld=gold` resolves cleanly.

## Expected impact

- arm64 LXC build: ~14m -> ~10-12m.
- No effect on x64 LXC, x64/arm64 WXC, or arm64 Mac jobs.

Companion to baseline PR #392 and the four other optimization PRs.