### PR TITLE
Pin Rust toolchain to match CI (1.93)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 ## Prerequisites
 
+The Rust toolchain version is pinned in [`src/rust-toolchain.toml`](../src/rust-toolchain.toml) to match what CI uses (currently 1.93). The pin is honored automatically by `rustup` — running any `cargo` command from `src/` (or below) downloads and selects that channel on first use. To opt out for one-off testing on a different toolchain, use `cargo +<channel> ...` or set `RUSTUP_TOOLCHAIN`. When bumping the pinned version, bump the matching `version: 'ms-prod-1.<N>'` lines in the two `.azure-pipelines/templates/*.Build.Job.yml` files in the same commit.
+
 LSP servers are configured in `.github/lsp.json` for Rust and TypeScript. Install them before use:
 
 ```

--- a/src/rust-toolchain.toml
+++ b/src/rust-toolchain.toml
@@ -1,0 +1,29 @@
+# Pin the Rust toolchain used for local development to match CI.
+#
+# CI uses `ms-prod-1.93` (Microsoft's internal Rust 1.93 distribution
+# from the Mxc-Azure-Feed) — see
+# `.azure-pipelines/templates/Rust.Build.Job.yml` and
+# `.azure-pipelines/templates/Mac.Build.Job.yml`. Public rustup users
+# get the equivalent open-source channel `1.93` here.
+#
+# Why pin: clippy lints can appear, be downgraded, be reworded, or
+# change defaults between Rust releases. Without this pin, a developer
+# on a newer rustup toolchain can pass local
+# `cargo clippy --all-targets --all-features --release -- -D warnings`
+# and still hit failures in CI on lints introduced in (or differently
+# defaulted by) the older toolchain. Pinning eliminates that skew
+# entirely.
+#
+# Bumping: bump the `version: 'ms-prod-1.<N>'` lines in the two
+# `.azure-pipelines/templates/*.Build.Job.yml` files and `channel`
+# here in the same commit. Then run the standard pre-push ladder
+# (see `.github/copilot-instructions.md` § Verification) against the
+# new toolchain.
+#
+# Opt-out: `cargo +<channel> ...` or `RUSTUP_TOOLCHAIN=<channel> ...`
+# for one-off testing on a different toolchain.
+
+[toolchain]
+channel = "1.93"
+components = ["clippy", "rustfmt"]
+profile = "minimal"


### PR DESCRIPTION
## Summary

Add `src/rust-toolchain.toml` pinning the local Rust toolchain to the same channel CI uses (`ms-prod-1.93` in `.azure-pipelines/templates/Rust.Build.Job.yml` and `Mac.Build.Job.yml`, equivalent to public `1.93`).

## Why

Without this pin, developers on a newer rustup toolchain can pass local `cargo clippy --all-targets --all-features --release -- -D warnings` and still hit failures in CI on lints that were introduced, downgraded, removed, or differently-defaulted between Rust releases. For example, `clippy::duplicated_attributes` is denied in clippy 1.93 but allow-by-default (or absent) in 1.94 — phase 3.5 (#389) hit this on CI despite running clean locally on 1.94. The pin eliminates that whole class of skew.

## What it does

- `src/rust-toolchain.toml` pins `channel = "1.93"` with `components = ["clippy", "rustfmt"]` and `profile = "minimal"`. Any `cargo` invocation from `src/` (or below) auto-selects this channel on first use.
- The file is placed in `src/` next to the workspace `Cargo.toml`, which is what every cargo command in `build.bat`/`build.sh`/`build-mac.sh` already `cd`s into.
- Pinning to the `"1.93"` channel (not `"1.93.0"`) lets rustup track patch releases within 1.93, matching how `ms-prod-1.93` tracks Microsoft's internal patches.
- Local opt-out: `cargo +<channel> ...` or `RUSTUP_TOOLCHAIN=<channel> ...` for one-off testing on a different toolchain.
- Bump procedure documented inline in the file: bump the matching `version: 'ms-prod-1.<N>'` lines in the two `.azure-pipelines/templates/*.Build.Job.yml` files plus `channel` here in the same commit.

## Validation

- Deleted my local 1.93.0 cache, then ran `cargo --version` from `src/`: rustup auto-synced the channel and installed Rust 1.93.1 (latest patch).
- `cargo clippy --target x86_64-pc-windows-msvc --workspace --all-targets --all-features --profile release --locked -- -D warnings` clean under the pinned toolchain. This is the exact CI invocation from `.azure-pipelines/templates/Rust.Build.Job.yml` (line ~119).

## Notes

- The 1ES pipeline's `version: 'ms-prod-1.93'` parameter still controls what CI itself installs — `rust-toolchain.toml` does not override that. The two settings serve as parallel pins on each side. Keeping them in sync is a small lift; the bump procedure documented in the file's header comment lists the exact files to touch.
- Doesn't change any build commands or test commands — just stabilizes the toolchain underneath them.
