### PR TITLE
test(filesystem_dacl): broaden network_path_rejected_e2e matcher

### DIFF
--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -1792,9 +1792,32 @@ mod tests {
             &[PathBuf::from(r"\\someserver\share\foo")],
             &[],
         );
-        assert!(matches!(
-            err,
-            Err(DaclError::NetworkPathRejected(_)) | Err(DaclError::PathNotFound(_))
-        ));
+        // The test's intent is "we never silently succeed on a UNC
+        // path". The exact error variant depends on how
+        // `fs::canonicalize` resolves `\\someserver\share\foo` on the
+        // host running the test:
+        //   * On dev boxes / agents with no DNS resolution for
+        //     `someserver`, canonicalize returns
+        //     `io::ErrorKind::NotFound` → `PathNotFound`.
+        //   * On agents where canonicalize succeeds (rare but
+        //     possible if the share actually exists or is being
+        //     resolved by a redirector), our `ensure_local_canonical_
+        //     prefix` rejects the UNC namespace → `NetworkPathRejected`.
+        //   * On agents where DNS resolves `someserver` to an
+        //     unreachable host or returns a non-NotFound Win32 error
+        //     (e.g. `ERROR_BAD_NETPATH`, `ERROR_LOGON_FAILURE`),
+        //     canonicalize returns a generic IO error that doesn't
+        //     map to `NotFound` → `Win32 { reason: "canonicalize: …" }`.
+        // All three are acceptable. The unit tests of
+        // `ensure_local_canonical_prefix` above verify the
+        // classification function deterministically.
+        match &err {
+            Err(DaclError::NetworkPathRejected(_))
+            | Err(DaclError::PathNotFound(_))
+            | Err(DaclError::Win32 { .. }) => {}
+            other => panic!(
+                "expected NetworkPathRejected | PathNotFound | Win32 for UNC path, got: {other:?}"
+            ),
+        }
     }
 }


### PR DESCRIPTION
## Summary

Broadens the matcher in `filesystem_dacl::tests::network_path_rejected_e2e` (added in #295 / Phase 3) so the test no longer flakes on CI agents whose network environment causes `fs::canonicalize("\\someserver\\share\\foo")` to error with a non-`NotFound` Win32 code such as `ERROR_BAD_NETPATH` or `ERROR_LOGON_FAILURE`.

## Why

The test asserts that `grant_appcontainer_access` on a UNC path errors out cleanly. It previously accepted only `NetworkPathRejected | PathNotFound`:

- **`PathNotFound`** lands when `fs::canonicalize` returns `io::ErrorKind::NotFound` — the common case on dev boxes / agents where `someserver` does not resolve.
- **`NetworkPathRejected`** lands when canonicalize *succeeds* and our `ensure_local_canonical_prefix` rejects the UNC namespace.
- **`Win32 { reason: "canonicalize: …" }`** is the third reachable variant: on agents in a corporate network, DNS may resolve `someserver` to an unreachable host, or the Win32 layer may return `ERROR_BAD_NETPATH` / `ERROR_LOGON_FAILURE`, neither of which maps to `io::ErrorKind::NotFound`. This is what an MXC Phase 3.5 CI run hit while #389 was in flight (build 147648700).

The deterministic verification of the UNC classifier itself lives in `ensure_local_canonical_prefix_rejects_unc_namespace` and `ensure_local_canonical_prefix_rejects_raw_unc` (both unaffected and unchanged).

## What changed

- `network_path_rejected_e2e` now accepts `Win32 { .. }` in addition to the prior two variants — the test's intent ("we never silently succeed on a UNC path") is satisfied by any well-typed error variant.
- The assertion form changes from `assert!(matches!(...))` to a `match` arm that prints the actual error variant on mismatch, so future flakes are diagnostic.
- A comment in the test enumerates the three accepted variants and the host conditions under which each lands.

No production code paths change.

## Validation

```
cargo +1.93 fmt --all -- --check
cargo +1.93 clippy --target x86_64-pc-windows-msvc -p wxc_common --all-targets --all-features --profile release --locked -- -D warnings
cargo +1.93 test --target x86_64-pc-windows-msvc --all-features --profile release --locked -p wxc_common --lib -- network_path --test-threads=1
```

All clean on the CI-matched toolchain (1.93.1; once #399 lands, this will be the default for everyone). Test passes locally — it falls into the `PathNotFound` branch on a dev box (no DNS resolution for `someserver`).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/401)