### PR TITLE
[WSLC] Add port forwarding from Windows host into container (issue #166)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -72,7 +72,10 @@ production configs and the dev schema when working on experimental features:
             "cpuCount": 4,                 // CPU count for WSLC session
             "memoryMb": 2048,              // Memory in MB for WSLC session
             "gpu": false,                  // GPU passthrough
-            "storagePath": "C:\\wslc-storage"  // Image store path
+            "storagePath": "C:\\wslc-storage",  // Image store path
+            "portMappings": [              // Host<->container port forwarding. TCP only -- the WSLC SDK 2.8.1 runtime returns E_NOTIMPL for UDP, so the parser rejects "udp" entries.
+                { "windowsPort": 8080, "containerPort": 80, "protocol": "tcp" }
+            ]
         },
         "seatbelt": {                 // macOS sandbox settings (macOS only)
             "profileOverride": null,       // Optional raw TinyScheme profile (escape hatch)

--- a/docs/wsl/wsl-container-support-plan.md
+++ b/docs/wsl/wsl-container-support-plan.md
@@ -211,7 +211,7 @@ Container APIs:
 - `WslcSetContainerSettingsInitProcess()` — attach process settings before creation
 - `WslcSetContainerSettingsNetworkingMode()` — `NONE` (isolated) or `BRIDGED` (NAT)
 - `WslcSetContainerSettingsVolumes()` — mount Windows paths into Linux container
-- `WslcSetContainerSettingsPortMappings()` — host↔container port forwarding (TCP only)
+- `WslcSetContainerSettingsPortMappings()` — host↔container port forwarding (TCP only; UDP declared in the header but returns E_NOTIMPL in the vendored SDK 2.8.1 runtime, so it's rejected at parse time)
 - `WslcSetContainerSettingsFlags()` — `AUTO_REMOVE`, `ENABLE_GPU`, `PRIVILEGED`
 - `WslcGetContainerInitProcess()` — retrieve process handle after start
 - `WslcStopContainer()` / `WslcDeleteContainer()` / `WslcReleaseContainer()` — teardown
@@ -309,7 +309,7 @@ Network mapping:
 Port mapping (new capability enabled by WSLC SDK):
 | Config field | WSLC SDK equivalent |
 |---|---|
-| `portMappings: [{ windowsPort: 8080, containerPort: 80 }]` | `WslcSetContainerSettingsPortMappings()` with `WslcContainerPortMapping` structs (TCP only) |
+| `portMappings: [{ windowsPort: 8080, containerPort: 80, protocol: "tcp" }]` | `WslcSetContainerSettingsPortMappings()` with `WslcContainerPortMapping` structs (TCP only; `protocol` defaults to `"tcp"`. UDP is declared by the SDK header but returns E_NOTIMPL at runtime in the vendored SDK 2.8.1 and is rejected by the parser.) |
 
 **WSLC SDK advantage:** The `WslcContainerVolume` struct directly models the Windows↔Linux path mapping with `windowsPath` (PCWSTR) and `containerPath` (PCSTR) fields. The runner applies the deterministic `/mnt/<drive>/...` mapping rule and the SDK's 9P filesystem handles the cross-OS bridging internally.
 

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -326,6 +326,36 @@
             "storagePath": {
               "type": "string",
               "description": "Storage path for the WSLC session image store. Omit to use a temporary directory."
+            },
+            "portMappings": {
+              "type": "array",
+              "description": "Host\u2194container port mappings. Each mapping forwards a Windows-host port to a container port. Only TCP is supported by the vendored WSLC SDK runtime (Microsoft.WSL.Containers 2.8.1); UDP is reserved in the schema for forward compatibility but rejected by the parser.",
+              "default": [],
+              "items": {
+                "type": "object",
+                "required": ["windowsPort", "containerPort"],
+                "properties": {
+                  "windowsPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Port on the Windows host."
+                  },
+                  "containerPort": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "description": "Port inside the Linux container."
+                  },
+                  "protocol": {
+                    "type": "string",
+                    "enum": ["tcp"],
+                    "default": "tcp",
+                    "description": "Transport protocol. Only 'tcp' is currently supported."
+                  }
+                },
+                "additionalProperties": false
+              }
             }
           }
         },

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -194,7 +194,12 @@ export interface WslcConfig {
   gpu?: boolean;
   /** Path to a local tar file to import as the container image */
   imageTarPath?: string;
-  /** Host↔container port mappings (TCP only) */
+  /**
+   * Host\u2194container port mappings. Only TCP is currently supported by the
+   * vendored WSLC SDK runtime (Microsoft.WSL.Containers 2.8.1); UDP is
+   * declared in the SDK header but returns E_NOTIMPL at runtime and is
+   * rejected by the parser. The `protocol` field defaults to `"tcp"`.
+   */
   portMappings?: PortMapping[];
 }
 
@@ -206,7 +211,7 @@ export interface PortMapping {
   windowsPort: number;
   /** Port inside the Linux container */
   containerPort: number;
-  /** Protocol: "tcp" or "udp" (default: "tcp") */
+  /** Protocol: only `"tcp"` is currently supported. `"udp"` is reserved but rejected by the parser (WSLC SDK 2.8.1 returns E_NOTIMPL for UDP). Defaults to `"tcp"`. */
   protocol?: string;
 }
 

--- a/sdk/tests/integration/wslc-e2e.test.ts
+++ b/sdk/tests/integration/wslc-e2e.test.ts
@@ -29,7 +29,7 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
   skip: !isWslcAvailable ? 'WSLC tests require MXC_ENABLE_WSLC_TESTS=1 on Windows with WSL2 and WSLC SDK' : undefined,
 }, () => {
 
-  it('should run with all WSLC-specific fields set', async () => {
+  it('should run with all WSLC-specific fields set', { timeout: 120_000 }, async () => {
     // Create temp directories for volume mount and storage.
     // Use short paths under os.tmpdir() — WSLC SDK can fail with very long paths.
     const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mxc-e2e-'));
@@ -54,9 +54,13 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
       config.experimental!.wslc!.image = 'python:3.12-alpine';
       config.experimental!.wslc!.cpuCount = 2;
       config.experimental!.wslc!.memoryMb = 1024;
-      config.experimental!.wslc!.storagePath = storageDir;
+      // Intentionally omit `storagePath` so this test reuses the default
+      // image store where `python:3.12-alpine` has already been pre-pulled
+      // (the docs require operators to pre-pull). Setting storagePath to a
+      // fresh temp directory would point WSLC at an empty image store and
+      // fail with "image not found" — MXC does not pull at runtime.
 
-      const { stdout, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
+      const { stdout, stderr, exitCode } = await new Promise<{ stdout: string; stderr: string; exitCode: number }>((resolve, reject) => {
         const child = sdk.spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
         let stdout = '';
         let stderr = '';
@@ -70,11 +74,146 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
         });
       });
 
-      assert.strictEqual(exitCode, 0);
-      assert.ok(stdout.includes('Python 3.12'));
-      assert.ok(stdout.includes('All fields work'));
+      assert.strictEqual(exitCode, 0, `exit=${exitCode}\nstdout=${stdout}\nstderr=${stderr}`);
+      assert.ok(stdout.includes('Python 3.12'), `Python 3.12 not found in stdout=${stdout}`);
+      assert.ok(stdout.includes('All fields work'), `'All fields work' not found in stdout=${stdout}`);
     } finally {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  it('should forward a TCP port from host to container', { timeout: 120_000 }, async () => {
+    const http = await import('node:http');
+    const HOST_PORT = 38080;
+    const CONTAINER_PORT = 8080;
+
+    const policy = {
+      version: '0.5.0-alpha',
+      network: { allowOutbound: true },
+      filesystem: {},
+    };
+    const config = sdk.createConfigFromPolicy(policy, 'wslc');
+    // The container runs `/bin/sh -c "<script_code>"`. We base64-encode the
+    // Python source and run it via a single-argv `python3 -c "..."` call to
+    // avoid any embedded-newline / shell-pipeline ambiguity through the WSLC
+    // FFI. `handle_request()` serves exactly one request then returns, so
+    // the container exits cleanly once the host probe completes — no
+    // SIGTERM/SIGKILL dance is needed.
+    //
+    // We deliberately do NOT wait for an in-container "ready" marker before
+    // probing: WSLC's stdout pump may delay delivery of bytes from a
+    // long-running process (Test 1 works because each command exits and
+    // flushes its pipe). The host probe retries on ECONNREFUSED, so the
+    // retry loop naturally bridges the bind-then-accept window.
+    const pythonScript = `import http.server, socketserver
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'PORT_MAPPING_TCP_OK')
+    def log_message(self, *a, **k):
+        pass
+srv = socketserver.TCPServer(('0.0.0.0', ${CONTAINER_PORT}), H)
+srv.handle_request()
+`;
+    const scriptB64 = Buffer.from(pythonScript, 'utf8').toString('base64');
+    config.process!.commandLine = `python3 -c "import base64; exec(base64.b64decode('${scriptB64}'))"`;
+    config.experimental!.wslc!.image = 'python:3.12-alpine';
+    config.experimental!.wslc!.portMappings = [
+      { windowsPort: HOST_PORT, containerPort: CONTAINER_PORT, protocol: 'tcp' },
+    ];
+
+    const child = sdk.spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    const closed = new Promise<number | null>((resolve) => {
+      if (child.exitCode !== null) {
+        resolve(child.exitCode);
+      } else {
+        child.on('close', (code: number | null) => resolve(code));
+      }
+    });
+
+    let body = '';
+    let lastErr: Error | undefined;
+    try {
+      // Probe from the Windows host with poll-retry. Retries cover both the
+      // container-start window and the NAT-rule settle window. Each attempt
+      // bails if the child has already exited (avoids 60s of pointless retry
+      // when the container crashed).
+      const probeDeadline = Date.now() + 60_000;
+      while (Date.now() < probeDeadline) {
+        if (child.exitCode !== null) {
+          throw new Error(`Container exited before probe could succeed (code=${child.exitCode}). stdout=${stdout} stderr=${stderr}`);
+        }
+        try {
+          body = await new Promise<string>((resolve, reject) => {
+            const req = http.get({ host: '127.0.0.1', port: HOST_PORT, timeout: 2000 }, (res) => {
+              const chunks: Buffer[] = [];
+              res.on('data', (c) => chunks.push(c));
+              res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+            });
+            req.on('error', reject);
+            req.on('timeout', () => { req.destroy(new Error('http.get timeout')); });
+          });
+          break;
+        } catch (e) {
+          lastErr = e as Error;
+          await new Promise((r) => setTimeout(r, 500));
+        }
+      }
+      assert.strictEqual(body, 'PORT_MAPPING_TCP_OK', `host probe failed; lastErr=${lastErr?.message} stdout=${stdout} stderr=${stderr}`);
+    } finally {
+      // After one served request, the Python server returns from handle_request
+      // and the container exits naturally. Wait up to 20s for clean exit, then
+      // force-kill so a stuck WSLC teardown can never hang the whole suite.
+      const cleanExit = await Promise.race([
+        closed,
+        new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 20_000)),
+      ]);
+      if (cleanExit === 'timeout') {
+        child.kill('SIGKILL');
+        await Promise.race([
+          closed,
+          new Promise((r) => setTimeout(r, 5_000)),
+        ]);
+      }
+    }
+  });
+
+  it('should reject UDP port mapping with a clear SDK-limitation message', { timeout: 60_000 }, async () => {
+    // WSLC SDK 2.8.1 declares WSLC_PORT_PROTOCOL_UDP in its header but its
+    // runtime returns E_NOTIMPL (0x80004001) when UDP is actually requested.
+    // The parser rejects UDP up front so SDK consumers get a clear error at
+    // spawn time rather than a cryptic HRESULT at container-create time.
+    const policy = {
+      version: '0.5.0-alpha',
+      network: { allowOutbound: true },
+      filesystem: {},
+    };
+    const config = sdk.createConfigFromPolicy(policy, 'wslc');
+    config.process!.commandLine = 'echo unreachable';
+    config.experimental!.wslc!.image = 'python:3.12-alpine';
+    config.experimental!.wslc!.portMappings = [
+      { windowsPort: 39000, containerPort: 9000, protocol: 'udp' },
+    ];
+
+    const { exitCode, combined } = await new Promise<{ exitCode: number; combined: string }>((resolve, reject) => {
+      const child = sdk.spawnSandboxFromConfig(config, { experimental: true, debug: true, usePty: false }) as ChildProcess;
+      let combined = '';
+      const onData = (d: Buffer) => { combined += d.toString(); };
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+      child.on('error', reject);
+      child.on('close', (code: number | null) => resolve({ exitCode: code ?? -1, combined }));
+    });
+
+    assert.notStrictEqual(exitCode, 0, `expected non-zero exit when UDP is requested; output=${combined}`);
+    assert.ok(
+      /udp/i.test(combined) && /not supported|not implemented/i.test(combined),
+      `expected SDK-limitation message mentioning UDP; output=${combined}`,
+    );
   });
 });

--- a/src/wslc_common/src/wsl_container_runner.rs
+++ b/src/wslc_common/src/wsl_container_runner.rs
@@ -967,9 +967,44 @@ impl WSLContainerRunner {
             return sdk_error("WslcInitContainerSettings failed", hr, "");
         }
 
-        // TODO: Port mappings (WslcConfig.port_mappings) are parsed but not yet applied.
-        // Requires adding WslcSetContainerSettingsPortMappings and WslcContainerPortMapping
-        // bindings. See wslcsdk.h lines 120-128, 183-186.
+        // -- Port mappings (host<->container) --
+        // Set before networking mode so the SDK has the complete picture when
+        // the container is created. Empty list = no forwarding (default).
+        if !self.config.port_mappings.is_empty() {
+            let mappings: Vec<WslcContainerPortMapping> = self
+                .config
+                .port_mappings
+                .iter()
+                .map(|pm| WslcContainerPortMapping {
+                    windows_port: pm.windows_port,
+                    container_port: pm.container_port,
+                    // Parser validated protocol is "tcp" or "udp".
+                    protocol: if pm.protocol == "udp" {
+                        WslcPortProtocol::Udp
+                    } else {
+                        WslcPortProtocol::Tcp
+                    },
+                    // Default bind address (typically loopback/0.0.0.0 per SDK
+                    // config). Not exposed in the MXC config today.
+                    windows_address: ptr::null(),
+                })
+                .collect();
+
+            let hr = (sdk.WslcSetContainerSettingsPortMappings)(
+                &mut container_settings,
+                mappings.as_ptr(),
+                mappings.len() as u32,
+            );
+            if hr != S_OK {
+                return sdk_error("WslcSetContainerSettingsPortMappings failed", hr, "");
+            }
+            let _ = writeln!(
+                logger,
+                "[WSLC] {} port mapping(s) configured",
+                mappings.len()
+            );
+        }
+
         let (mounts, warnings) = policy_mapping::build_volume_mounts(
             &request.policy.readwrite_paths,
             &request.policy.readonly_paths,

--- a/src/wslc_common/src/wslc_bindings.rs
+++ b/src/wslc_common/src/wslc_bindings.rs
@@ -189,6 +189,27 @@ pub struct WslcContainerVolume {
     pub read_only: BOOL,
 }
 
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WslcPortProtocol {
+    Tcp = 0,
+    Udp = 1,
+}
+
+/// Host\u2194container port mapping passed to
+/// `WslcSetContainerSettingsPortMappings`.
+///
+/// Matches `WslcContainerPortMapping` in `wslcsdk.h`. The trailing
+/// `windows_address` field is an optional override for the host bind address;
+/// MXC always passes `null`, which lets the SDK select the default address.
+#[repr(C)]
+pub struct WslcContainerPortMapping {
+    pub windows_port: u16,
+    pub container_port: u16,
+    pub protocol: WslcPortProtocol,
+    pub windows_address: *const c_void,
+}
+
 pub const WSLC_IMAGE_NAME_LENGTH: usize = 256;
 
 #[repr(C)]
@@ -315,6 +336,11 @@ mod ffi_types {
         *const WslcContainerVolume,
         u32,
     ) -> HRESULT;
+    pub type WslcSetContainerSettingsPortMappingsFn = unsafe extern "system" fn(
+        *mut WslcContainerSettings,
+        *const WslcContainerPortMapping,
+        u32,
+    ) -> HRESULT;
     pub type WslcSetContainerSettingsInitProcessFn =
         unsafe extern "system" fn(*mut WslcContainerSettings, *mut WslcProcessSettings) -> HRESULT;
     pub type WslcCreateContainerFn = unsafe extern "system" fn(
@@ -382,6 +408,7 @@ pub struct WslcSdk {
     pub WslcSetContainerSettingsNetworkingMode: ffi_types::WslcSetContainerSettingsNetworkingModeFn,
     pub WslcSetContainerSettingsFlags: ffi_types::WslcSetContainerSettingsFlagsFn,
     pub WslcSetContainerSettingsVolumes: ffi_types::WslcSetContainerSettingsVolumesFn,
+    pub WslcSetContainerSettingsPortMappings: ffi_types::WslcSetContainerSettingsPortMappingsFn,
     pub WslcSetContainerSettingsInitProcess: ffi_types::WslcSetContainerSettingsInitProcessFn,
     pub WslcCreateContainer: ffi_types::WslcCreateContainerFn,
     pub WslcStartContainer: ffi_types::WslcStartContainerFn,
@@ -468,6 +495,10 @@ impl WslcSdk {
                 WslcSetContainerSettingsVolumes: load_fn!(
                     lib,
                     b"WslcSetContainerSettingsVolumes\0"
+                ),
+                WslcSetContainerSettingsPortMappings: load_fn!(
+                    lib,
+                    b"WslcSetContainerSettingsPortMappings\0"
                 ),
                 WslcSetContainerSettingsInitProcess: load_fn!(
                     lib,
@@ -677,6 +708,20 @@ mod tests {
         );
         assert_eq!(mem::align_of::<WslcContainerSettings>(), 8);
         assert_eq!(mem::align_of::<WslcProcessSettings>(), 8);
+    }
+
+    #[test]
+    fn port_mapping_struct_layout_matches_c_header() {
+        // WslcContainerPortMapping in wslcsdk.h:
+        //   uint16_t windowsPort;                      // offset 0
+        //   uint16_t containerPort;                    // offset 2
+        //   WslcPortProtocol protocol;                 // offset 4 (u32 enum)
+        //   struct sockaddr_storage* windowsAddress;   // offset 8 (pointer, 8-byte aligned)
+        // Total: 16 bytes on 64-bit, 8-byte aligned because of the pointer.
+        assert_eq!(mem::size_of::<WslcContainerPortMapping>(), 16);
+        assert_eq!(mem::align_of::<WslcContainerPortMapping>(), 8);
+        assert_eq!(WslcPortProtocol::Tcp as u32, 0);
+        assert_eq!(WslcPortProtocol::Udp as u32, 1);
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -856,33 +856,108 @@ fn convert_raw_config_inner(
             }
             config
         });
-        let wslc = raw_exp.wslc.map(|cc| {
-            let mut config = WslcConfig::default();
-            if let Some(os) = cc.target_os {
-                config.target_os = os;
-            }
-            if let Some(img) = cc.image {
-                config.image = img;
-            }
-            config.image_tar_path = cc.image_tar_path;
-            config.cpu_count = cc.cpu_count;
-            config.memory_mb = cc.memory_mb;
-            if let Some(gpu) = cc.gpu {
-                config.gpu = gpu;
-            }
-            config.storage_path = cc.storage_path;
-            if let Some(mappings) = cc.port_mappings {
-                config.port_mappings = mappings
-                    .into_iter()
-                    .map(|m| PortMapping {
-                        windows_port: m.windows_port.unwrap_or(0),
-                        container_port: m.container_port.unwrap_or(0),
-                        protocol: m.protocol.unwrap_or_else(|| "tcp".to_string()),
-                    })
-                    .collect();
-            }
-            config
-        });
+        let wslc = raw_exp
+            .wslc
+            .map(|cc| -> Result<WslcConfig, WxcError> {
+                let mut config = WslcConfig::default();
+                if let Some(os) = cc.target_os {
+                    config.target_os = os;
+                }
+                if let Some(img) = cc.image {
+                    config.image = img;
+                }
+                config.image_tar_path = cc.image_tar_path;
+                config.cpu_count = cc.cpu_count;
+                config.memory_mb = cc.memory_mb;
+                if let Some(gpu) = cc.gpu {
+                    config.gpu = gpu;
+                }
+                config.storage_path = cc.storage_path;
+                if let Some(mappings) = cc.port_mappings {
+                    let parsed = mappings
+                        .into_iter()
+                        .enumerate()
+                        .map(|(idx, m)| -> Result<PortMapping, WxcError> {
+                            let windows_port = m.windows_port.ok_or_else(|| {
+                                WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: 'windowsPort' is required"
+                                ))
+                            })?;
+                            let container_port = m.container_port.ok_or_else(|| {
+                                WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: 'containerPort' is required"
+                                ))
+                            })?;
+                            if windows_port == 0 {
+                                return Err(WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: 'windowsPort' must be > 0"
+                                )));
+                            }
+                            if container_port == 0 {
+                                return Err(WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: 'containerPort' must be > 0"
+                                )));
+                            }
+                            let protocol = m
+                                .protocol
+                                .unwrap_or_else(|| "tcp".to_string())
+                                .to_lowercase();
+                            if protocol != "tcp" && protocol != "udp" {
+                                return Err(WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: protocol '{protocol}' not supported; expected 'tcp'"
+                                )));
+                            }
+                            // The WSLC SDK header (Microsoft.WSL.Containers
+                            // 2.8.1, vendored under external/wslc-sdk/)
+                            // declares WSLC_PORT_PROTOCOL_UDP = 1, but the
+                            // shipped runtime returns E_NOTIMPL (0x80004001)
+                            // when UDP is actually passed to
+                            // WslcSetContainerSettingsPortMappings. Reject
+                            // UDP at parse time with a clear message until a
+                            // future SDK version implements it.
+                            if protocol == "udp" {
+                                return Err(WxcError::ConfigParse(format!(
+                                    "wslc.portMappings[{idx}]: protocol 'udp' is not supported by the vendored WSLC SDK runtime (Microsoft.WSL.Containers 2.8.1). Only 'tcp' is currently implemented. UDP support will be enabled when a future SDK version ships it."
+                                )));
+                            }
+                            Ok(PortMapping {
+                                windows_port,
+                                container_port,
+                                protocol,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+
+                    // Reject duplicate windowsPort entries. Same host port on
+                    // TCP+UDP would in principle be legal, but UDP is rejected
+                    // earlier; the second protocol dimension is retained in
+                    // the dedupe key in case UDP support is enabled later.
+                    let mut seen: std::collections::HashSet<(u16, &str)> =
+                        std::collections::HashSet::new();
+                    for pm in &parsed {
+                        if !seen.insert((pm.windows_port, pm.protocol.as_str())) {
+                            return Err(WxcError::ConfigParse(format!(
+                                "wslc.portMappings: duplicate windowsPort {} for protocol '{}'",
+                                pm.windows_port, pm.protocol
+                            )));
+                        }
+                    }
+                    config.port_mappings = parsed;
+                }
+                Ok(config)
+            })
+            .transpose()
+            .inspect_err(|e| {
+                // Surface the parser error message in the logger buffer so
+                // it reaches stderr (main.rs prints `Request error\n{buf}`
+                // on parse failure). Without this, callers see a bare
+                // "Request error" with no detail about what went wrong.
+                let msg = match e {
+                    WxcError::ConfigParse(m) => m.clone(),
+                    other => format!("{:?}", other),
+                };
+                logger.log_line(&msg);
+            })?;
         let isolation_session = raw_exp.isolation_session.map(|as_cfg| {
             let mut config = IsolationSessionConfig::default();
             if let Some(id) = as_cfg.configuration_id {
@@ -2269,6 +2344,147 @@ mod tests {
             wslc.image_tar_path.as_deref(),
             Some("C:\\images\\alpine.tar")
         );
+    }
+
+    // ---------- WSLC port mapping tests ----------
+
+    #[test]
+    fn wslc_port_mapping_basic_tcp_parsed() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080, "containerPort": 80}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let wslc = req.experimental.wslc.unwrap();
+        assert_eq!(wslc.port_mappings.len(), 1);
+        assert_eq!(wslc.port_mappings[0].windows_port, 8080);
+        assert_eq!(wslc.port_mappings[0].container_port, 80);
+        assert_eq!(wslc.port_mappings[0].protocol, "tcp");
+    }
+
+    #[test]
+    fn wslc_port_mapping_udp_rejected_with_sdk_limitation_message() {
+        // The vendored WSLC SDK 2.8.1 runtime returns E_NOTIMPL for UDP. The
+        // parser must reject UDP up front with a clear message until a future
+        // SDK version implements it.
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 5353, "containerPort": 53, "protocol": "udp"}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("udp") && msg.contains("not supported"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_protocol_normalized_to_lowercase() {
+        // "TCP" is normalized to "tcp" and accepted. (UDP rejection is covered
+        // by wslc_port_mapping_udp_rejected_with_sdk_limitation_message.)
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080, "containerPort": 80, "protocol": "TCP"}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let wslc = req.experimental.wslc.unwrap();
+        assert_eq!(wslc.port_mappings[0].protocol, "tcp");
+    }
+
+    #[test]
+    fn wslc_port_mapping_zero_windows_port_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 0, "containerPort": 80}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("windowsPort") && msg.contains("> 0"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_zero_container_port_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080, "containerPort": 0}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("containerPort") && msg.contains("> 0"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_missing_windows_port_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"containerPort": 80}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("windowsPort") && msg.contains("required"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_missing_container_port_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("containerPort") && msg.contains("required"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_unsupported_protocol_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080, "containerPort": 80, "protocol": "sctp"}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("sctp") && (msg.contains("not supported") || msg.contains("tcp")),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_duplicate_host_port_same_protocol_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine", "portMappings": [{"windowsPort": 8080, "containerPort": 80}, {"windowsPort": 8080, "containerPort": 81}]}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("duplicate") && msg.contains("8080"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wslc_port_mapping_empty_list_default() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "alpine"}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let wslc = req.experimental.wslc.unwrap();
+        assert!(wslc.port_mappings.is_empty());
     }
 
     // ---------- Experimental feature tests ----------

--- a/test_configs/wslc_port_mapping_multiple.json
+++ b/test_configs/wslc_port_mapping_multiple.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-port-mapping-multiple",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "for port in 8080 9090; do python3 -c \"import socket; s=socket.socket(socket.AF_INET,socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind(('0.0.0.0',$port)); s.close(); print('bound tcp', $port)\" || { echo bind failed for $port >&2; exit 1; }; done; echo PORT_MAPPING_MULTI_OK"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "python:3.12-alpine",
+      "portMappings": [
+        { "windowsPort": 18080, "containerPort": 8080, "protocol": "tcp" },
+        { "windowsPort": 19090, "containerPort": 9090, "protocol": "tcp" }
+      ]
+    }
+  }
+}

--- a/test_configs/wslc_port_mapping_tcp.json
+++ b/test_configs/wslc_port_mapping_tcp.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-port-mapping-tcp",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "python3 -c 'import socket; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1); s.bind((\"0.0.0.0\",8080)); s.close(); print(\"PORT_MAPPING_TCP_OK\")'"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "python:3.12-alpine",
+      "portMappings": [
+        { "windowsPort": 18080, "containerPort": 8080, "protocol": "tcp" }
+      ]
+    }
+  }
+}

--- a/test_scripts/run_wslc_all_tests.ps1
+++ b/test_scripts/run_wslc_all_tests.ps1
@@ -191,6 +191,8 @@ $null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "R
 
 Write-Host "`n--- Network Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_network_isolated.json"))
+$null = $results.Add((Run-WslcTest "wslc_port_mapping_tcp.json" -OutputContains "PORT_MAPPING_TCP_OK"))
+$null = $results.Add((Run-WslcTest "wslc_port_mapping_multiple.json" -OutputContains "PORT_MAPPING_MULTI_OK"))
 
 Write-Host "`n--- Image Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_python_hello.json" -OutputContains "Hello from Python"))


### PR DESCRIPTION
## 📖 Description
Wires up `WslcSetContainerSettingsPortMappings` end-to-end so MXC users can forward Windows-hostTCP ports to ports inside a WSL container. Previously `experimental.wslc.portMappings` was parsed but silently ignored (see the TODO removed in `wsl_container_runner.rs`).

Note that WSLC SDK header (`Microsoft.WSL.Containers 2.8.1`) declares `WSLC_PORT_PROTOCOL_UDP = 1`, but the shipped runtime returns `E_NOTIMPL` (`0x80004001`) when UDP is actually passed to `WslcSetContainerSettingsPortMappings`. Rather than letting users hit a cryptic HRESULT at container-create time, the parser rejects `"udp"` up front with a message naming the SDK limitation. The enum and runner-side mapping for UDP are kept in place so the only change required to enable it later is removing the parser guard.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/402)