### PR TITLE
[Hyperlight] Update Hyperlight to v0.7.0

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -498,7 +498,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -855,8 +855,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.6.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.6.0#d8524a99ad4855c7c9f1d0c17381b884386596b0"
+version = "0.7.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.7.0#05c4d642b445c17a4cb3f72559b15523ae5ed499"
 dependencies = [
  "anyhow",
  "base64",
@@ -1692,7 +1692,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1985,7 +1985,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2405,7 +2405,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -22,7 +22,7 @@ getrandom = { workspace = true }
 semver = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.6.0", optional = true }
+hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.7.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 nanvix_common = { path = "../nanvix_common", optional = true }

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -201,7 +201,7 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     let opts = pyhl::InstallOptions {
         home: &home,
         source: pyhl::InstallSource::Ghcr {
-            tag: Some("v0.6.0"),
+            tag: Some("v0.7.0"),
         },
         mounts: &[],
         network: None,


### PR DESCRIPTION
## Summary

Updates hyperlight-unikraft from v0.6.0 to v0.7.0.

Closes https://github.com/microsoft/mxc/issues/384
Closes https://github.com/microsoft/mxc/issues/383

### Bug fixes
- **hostfs large writes** (#384): increased Hyperlight I/O buffer size so binary `write()` calls >4 KB no longer fail with `OSError [Errno 5]`
- **zipfile.ZipInfo monkey-patch** (#383): fixed `NameError` that broke zip-based libraries (python-docx, openpyxl) after snapshot restore

### Package expansion (40 → 102 pip packages)

The python-agent-driver rootfs now ships **102 top-level pip packages** (up from 40). Highlights include:

- **Data & ML**: pandas, numpy, scipy, scikit-learn, statsmodels, polars, duckdb, gensim, sympy
- **Document generation**: python-docx, python-pptx, openpyxl, reportlab, fpdf2, xlsxwriter
- **Web & API**: fastapi, uvicorn, httpx, aiohttp, scrapy, requests, boto3, slack-sdk
- **NLP & text**: nltk, textblob, rapidfuzz, wordcloud, trafilatura
- **Visualization**: plotly, bokeh, altair
- **Dev tools**: pytest, coverage, pylint, ruff, hypothesis, bandit

After pulling this change, consumers must regenerate their local snapshot to pick up the new packages and fixes: `wxc-exec --setup-hyperlight --force`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/403)