### PR TITLE
[CI] Enable push trigger on main to warm cache scope

### DIFF
--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -5,16 +5,21 @@
 # target-dir and CARGO_HOME cache scopes for the default branch. PR-triggered
 # runs are branch-scoped on writes and cannot populate `main`'s scope; they
 # can only *read* from it as a fallback. Without a `main` trigger, the
-# `**`-wildcard cache restore in `Rust.Build.Job.yml` always misses, and
-# every PR build does a fully cold cargo compile (~14 min on x64 WXC).
+# 1ES `cacheOptions.enableTargetCache: true` configuration in
+# `Rust.Build.Job.yml` runs every PR with a cold target dir — the
+# auto-generated wildcard restore key (visible in the `🎯 Cache target
+# directory` task log as `…|Rust=<ver>|**`) finds no prior entry in
+# main's scope, so each PR build does a fully cold cargo compile
+# (~14 min on x64 WXC).
 #
 # After this trigger is enabled, the first push to `main` populates the
-# cache; every subsequent PR's restore step finds it and the cargo build
-# step drops to a few minutes.
+# cache; every subsequent PR's restore step finds it via that wildcard
+# fallback and the cargo build step drops to a few minutes.
 #
 # Docs-only commits to `main` don't need to rebuild the whole workspace,
-# so the path exclusion mirrors the conservative list used by the PR
-# trigger below.
+# so the path exclusion list here matches the one added to the `pr:`
+# trigger in PR #396 (kept in sync intentionally — if that PR lands and
+# the lists drift, reconcile them).
 trigger:
   branches:
     include:

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -1,7 +1,38 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-trigger: none
+# Push trigger on `main` exists primarily to populate the Azure Pipelines
+# target-dir and CARGO_HOME cache scopes for the default branch. PR-triggered
+# runs are branch-scoped on writes and cannot populate `main`'s scope; they
+# can only *read* from it as a fallback. Without a `main` trigger, the
+# `**`-wildcard cache restore in `Rust.Build.Job.yml` always misses, and
+# every PR build does a fully cold cargo compile (~14 min on x64 WXC).
+#
+# After this trigger is enabled, the first push to `main` populates the
+# cache; every subsequent PR's restore step finds it and the cargo build
+# step drops to a few minutes.
+#
+# Docs-only commits to `main` don't need to rebuild the whole workspace,
+# so the path exclusion mirrors the conservative list used by the PR
+# trigger below.
+trigger:
+  branches:
+    include:
+    - main
+  paths:
+    exclude:
+    - 'docs/**'
+    - 'examples/**'
+    - '.github/ISSUE_TEMPLATE/**'
+    - '.github/PULL_REQUEST_TEMPLATE.md'
+    - '.github/copilot-instructions.md'
+    - '.github/instructions/**'
+    - '**/*.md'
+    - 'LICENSE'
+    - '.gitignore'
+    - '.gitattributes'
+    - '.editorconfig'
+
 name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 pr:

--- a/.azure-pipelines/1ES.Build.yml
+++ b/.azure-pipelines/1ES.Build.yml
@@ -33,9 +33,6 @@ trigger:
     - '.github/copilot-instructions.md'
     - '.github/instructions/**'
     - '**/*.md'
-    - 'LICENSE'
-    - '.gitignore'
-    - '.gitattributes'
     - '.editorconfig'
 
 name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)


### PR DESCRIPTION
## Summary

Replace `trigger: none` in `.azure-pipelines/1ES.Build.yml` with a push trigger on `main`, with a conservative `paths.exclude` list that mirrors PR #396.

## Why

Azure Pipelines (and 1ES) scope cache **writes** to the build's source branch. PR-triggered runs write to `refs/pull/<n>/merge` scope; only direct pushes to `main` write to `refs/heads/main`. Restore lookups fall back to the default branch — but if no `main` build has ever populated that scope, the fallback finds nothing.

That is exactly what's happening today. From the 1ES cache log on PR #392's baseline run (build 147642230):

```
Resolving restore key:
 - 1ES_PT_Rust | TemplateVersion | OS=Windows_NT | Arch=X64 | JobId=0bd2ad3c…
   | Rust=1.93.1-ms-… | **
Getting a pipeline cache artifact with one of the following fingerprints: …
There is a cache miss.
```

Every x64/arm64 build job logs `Is target directory cache restored? false`. Every PR build runs `cargo build` from scratch, even though `Cargo.lock`/`Cargo.toml`/`.cargo/config.toml` haven't changed.

For comparison: the same `cargo build --locked --offline --target x86_64-pc-windows-msvc --profile release --all-features` invocation takes ~60 seconds on a developer workstation (clean repo, warm CARGO_HOME) vs ~14 minutes in CI. The dominant cause is hardware (Ryzen 9 7950X vs 4 vCPU hosted agent), but cold-cache compounds the gap on every PR.

## Bootstrap behaviour

- The first push to `main` after this lands runs cold (same as today) and populates `main`'s cache scope.
- Every subsequent PR's `Cache target directory` step matches the wildcard restore key and pulls the warm target dir.
- Expected `Cargo build (1ES PT)` on x64 WXC: ~14m → ~1-3m on hits.
- Pipeline total: ~37m → ~22-25m on hits.

## Path exclusions

The `paths.exclude` list mirrors PR #396's `pr.paths.exclude` so docs-only commits to main don't trigger a full rebuild. Code commits run normally.

## Risk

- Adds N additional pipeline runs per release cycle (one per main commit not excluded).
- Signing + SDL + Guardian gates that currently run only on PRs will also run on every main commit. If any of those depend on PR-only context, they may surface differently — worth a sanity check by the 1ES / SDL team before merge.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/404)