### PR TITLE
sdk: tighten legacy containment alias handling (follow-up to #391)

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -298,6 +298,41 @@ stable section, configs that still reference it under `experimental` will receiv
 an error: "feature X has moved to the stable section." The parser will not
 silently fall back — explicit migration is required.
 
+## Deprecation Aliases
+
+When a wire value is renamed (e.g. `appcontainer` → `processcontainer` in
+[#268](https://github.com/microsoft/mxc/pull/268)), the legacy spelling enters a
+deprecation window where both forms are accepted on the wire.
+
+**Policy:** deprecation aliases are **version-agnostic**. The native parser
+accepts the legacy form regardless of `config.version`, and the SDK validator
+mirrors that behavior. We do *not* gate alias acceptance on schema version (i.e.
+"`appcontainer` only allowed for `0.4.0-alpha`/`0.5.0-alpha`") because:
+
+1. **Two layers must agree.** Schema-version gating would mean a config accepted
+   by the binary could be rejected by the SDK validator (or vice versa) based
+   on a string in `config.version`. That class of "works through one entry point
+   but not another" bug is exactly what [#390](https://github.com/microsoft/mxc/issues/390)
+   surfaced.
+2. **Authors don't always control `config.version`.** Configs flowing from
+   external sources (governance services, third-party tooling) may legitimately
+   declare `0.6.0-alpha` while still using legacy vocabulary their generator
+   has not yet been updated for.
+3. **The deprecation window is short.** The stated intent at rename time is
+   removal in a future minor release; gating buys little and costs review
+   complexity in every layer that re-checks containment.
+
+**Observability.** Each legacy-value encounter emits a one-line deprecation hint
+via the existing diagnostic channel (Rust: `Logger`; TypeScript SDK: `diagLog`,
+dedup'd per legacy value per process). The hint names the canonical replacement.
+No throw, no stderr write — the deprecation is observable only to callers who
+opt into the diagnostic stream.
+
+**Removal.** When an alias is removed in a future release, the change goes
+through the same promotion-style migration: a single release that turns the
+silent accept-and-warn into an explicit `unsupported_containment` error.
+Document the removal in the schema bump that drops it.
+
 ## Open Questions
 
 1. **Experimental features on the OS side:** Does

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -35,6 +35,31 @@ export function diagLogVersion(): void {
     }
 }
 
+const legacyContainmentWarned = new Set<string>();
+
+/**
+ * Emit a one-shot deprecation hint via the diagnostic console when a caller
+ * uses a legacy containment wire value. Dedup'd per legacy value per process
+ * so the message doesn't flood the diag stream on repeated spawns.
+ *
+ * Exposed for tests so the latch can be reset between describes.
+ */
+export function warnLegacyContainmentOnce(legacy: string, canonical: string): void {
+    if (!legacyContainmentWarned.has(legacy)) {
+        legacyContainmentWarned.add(legacy);
+        diagLog(
+            `Containment value '${legacy}' is deprecated; use '${canonical}' instead. ` +
+            `The legacy spelling is accepted via a backward-compatibility alias and may be ` +
+            `removed in a future SDK release.`
+        );
+    }
+}
+
+/** @internal Reset the legacy-containment dedup latch. Intended for unit tests. */
+export function _resetLegacyContainmentWarnedForTesting(): void {
+    legacyContainmentWarned.clear();
+}
+
 /**
  * Result of preparing a sandbox spawn — includes the resolved binary,
  * CLI arguments, and optional diagnostic logger.
@@ -135,17 +160,33 @@ export function resolveExecutableAndArgs(
     throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
   }
 
+  // Resolve deprecated wire values (e.g. "appcontainer" → "processcontainer",
+  // "macos_sandbox" → "seatbelt") once, and drive every containment check
+  // from the resolved value. The native binary accepts both spellings via
+  // serde aliases, so the wire payload is forwarded unchanged below — this
+  // resolution is purely for SDK-side validation. Without it, legacy values
+  // bypass the experimental-mode gate (because they are not in
+  // ExperimentalBackends under their alias) and produce a confusing
+  // "not available on this platform" error instead.
+  const rawContainment = config.containment;
+  const effectiveContainment = rawContainment
+    ? (LegacyContainmentAliases[rawContainment] ?? rawContainment)
+    : undefined;
+  if (rawContainment && effectiveContainment !== rawContainment) {
+    warnLegacyContainmentOnce(rawContainment, effectiveContainment as ContainmentBackend);
+  }
+
   // Check experimental mode before anything else so the caller gets a clear
   // message about the missing flag rather than a platform/binary error.
-  if (config.containment && ExperimentalBackends.includes(config.containment) && !options.experimental) {
+  if (effectiveContainment && ExperimentalBackends.includes(effectiveContainment) && !options.experimental) {
     throw new Error(
-      `'${config.containment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
+      `'${rawContainment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
     );
   }
 
   const platformSupport = getPlatformSupport();
-  const isExperimental = !!config.containment &&
-    (ExperimentalBackends as readonly string[]).includes(config.containment);
+  const isExperimental = !!effectiveContainment &&
+    (ExperimentalBackends as readonly string[]).includes(effectiveContainment);
   if (!platformSupport.isSupported && !isExperimental && !options.skipPlatformCheck) {
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
@@ -153,25 +194,22 @@ export function resolveExecutableAndArgs(
   // Hard platform requirement: microvm needs WHP/Hyper-V on Windows. This guard
   // runs even when `skipPlatformCheck` is set because it's not a build-version
   // check — the backend literally cannot run on non-Windows hosts.
-  if (config.containment === 'microvm' && os.platform() !== 'win32') {
+  if (effectiveContainment === 'microvm' && os.platform() !== 'win32') {
     throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
   }
 
   // Validate containment against platform
-  if (config.containment && !options.skipPlatformCheck) {
+  if (effectiveContainment && !options.skipPlatformCheck) {
     // Abstract intents (process, microvm) are resolved by the native binary
     // at run time, so the SDK accepts them without checking against the
     // host's concrete backend list.
-    const isIntent = (ContainmentTypes as readonly string[]).includes(config.containment);
-    // Legacy wire values accepted by the native binary via serde aliases
-    // (e.g. "appcontainer" → processcontainer, "macos_sandbox" → seatbelt).
-    const resolved = LegacyContainmentAliases[config.containment];
+    const isIntent = (ContainmentTypes as readonly string[]).includes(effectiveContainment);
     const isAvailable = platformSupport.availableMethods.includes(
-      (resolved ?? config.containment) as ContainmentBackend
+      effectiveContainment as ContainmentBackend
     );
     if (!isIntent && !isExperimental && !isAvailable) {
       throw new Error(
-        `Containment backend '${config.containment}' is not available on this platform. ` +
+        `Containment backend '${rawContainment}' is not available on this platform. ` +
         `Available methods: ${platformSupport.availableMethods.join(', ')}`
       );
     }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -32,7 +32,6 @@ export {
   IsolationTier,
   ContainmentType,
   ContainmentTypes,
-  LegacyContainmentAliases,
   ContainmentBackend,
   ExperimentalBackends,
   ContainerConfig,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -64,13 +64,25 @@ export type ContainmentType = "process" | "vm" | "microvm";
 export const ContainmentTypes: readonly ContainmentType[] = ['process', 'vm', 'microvm'];
 
 /**
- * Deprecated wire values accepted by the native binary via serde aliases.
- * Maps each legacy name to the canonical {@link ContainmentBackend} value
- * so the SDK validator can resolve them before the platform check. Configs
- * using these values still reach wxc-exec unchanged — the Rust parser
- * handles the final mapping at run time.
+ * Deprecated containment wire values, mapped to their canonical
+ * {@link ContainmentBackend} replacement. The native binary (wxc-exec) accepts
+ * the deprecated form via serde aliases; this map mirrors that behavior in
+ * the SDK validator so legacy configs are not rejected before reaching the
+ * binary.
+ *
+ * The map is intentionally partial: only deprecated keys appear. Use a
+ * presence check (e.g. `LegacyContainmentAliases[value] ?? value`) rather
+ * than indexing blindly.
+ *
+ * The wire payload is forwarded to wxc-exec unchanged — the Rust parser
+ * performs the final mapping at runtime. Resolution here is purely so the
+ * SDK's experimental-mode, platform-support, and availability checks see
+ * the canonical backend.
+ *
+ * Internal to the SDK; not part of the public API. Subject to removal in a
+ * future minor release once the deprecation window closes.
  */
-export const LegacyContainmentAliases: Readonly<Record<string, ContainmentBackend>> = {
+export const LegacyContainmentAliases: Readonly<Partial<Record<string, ContainmentBackend>>> = {
   appcontainer: 'processcontainer',
   macos_sandbox: 'seatbelt',
 };

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -951,4 +951,75 @@ describe('resolveExecutableAndArgs (containment validation)', { skip: platformSk
       resolveExecutableAndArgs(makeConfig('lxc'), { executablePath: fakeExe }),
     );
   });
+
+  // Legacy wire-value aliases (PR #268 deprecation window). The native binary
+  // accepts these via serde aliases; the SDK validator must mirror that so
+  // existing 0.4.0-/0.5.0-alpha configs are not rejected before they reach
+  // wxc-exec. See also Rust parser tests
+  // `legacy_appcontainer_wire_value_aliases_processcontainer` and
+  // `legacy_macos_sandbox_wire_value_aliases_seatbelt`.
+  describe('legacy containment aliases', () => {
+    it('should accept "appcontainer" as an alias of processcontainer (Windows)', function (this: { skip: (reason?: string) => void }) {
+      if (process.platform !== 'win32') {
+        this.skip('processcontainer is Windows-only');
+        return;
+      }
+      assert.doesNotThrow(() =>
+        resolveExecutableAndArgs(makeConfig('appcontainer'), { executablePath: fakeExe }),
+      );
+    });
+
+    it('should reject "appcontainer" on non-Windows hosts with the canonical error', function (this: { skip: (reason?: string) => void }) {
+      if (process.platform === 'win32') {
+        this.skip('appcontainer is the native value on Windows');
+        return;
+      }
+      assert.throws(
+        () => resolveExecutableAndArgs(makeConfig('appcontainer'), { executablePath: fakeExe }),
+        { message: /'appcontainer' is not available on this platform/ },
+      );
+    });
+
+    it('should require experimental mode for "macos_sandbox" (mirrors seatbelt gating)', () => {
+      // Regression: pre-fix, ExperimentalBackends.includes('macos_sandbox') was
+      // false, so the legacy alias bypassed the experimental gate entirely.
+      // The gate must look at the resolved backend, not the raw wire value.
+      assert.throws(
+        () => resolveExecutableAndArgs(makeConfig('macos_sandbox'), { executablePath: fakeExe }),
+        { message: /experimental mode/ },
+      );
+    });
+
+    it('should accept "macos_sandbox" on macOS with the experimental flag set', function (this: { skip: (reason?: string) => void }) {
+      if (process.platform !== 'darwin') {
+        this.skip('seatbelt is macOS-only');
+        return;
+      }
+      assert.doesNotThrow(() =>
+        resolveExecutableAndArgs(makeConfig('macos_sandbox'), {
+          executablePath: fakeExe,
+          experimental: true,
+        }),
+      );
+    });
+
+    it('should forward the legacy wire value to the binary unchanged', () => {
+      // The SDK resolves the alias only for its own validation; the on-wire
+      // string sent to wxc-exec must still be the legacy form, because the
+      // Rust serde alias is the canonical resolution point. Re-decoding the
+      // base64 envelope confirms the wire form is preserved.
+      const { args } = resolveExecutableAndArgs(
+        // Force the validator to accept regardless of host: macOS would
+        // otherwise fail on the experimental gate; Windows/Linux on platform
+        // availability for non-native legacy values.
+        makeConfig('appcontainer'),
+        { executablePath: fakeExe, skipPlatformCheck: true },
+      );
+      const idx = args.indexOf('--config-base64');
+      assert.ok(idx >= 0, '--config-base64 should be present in args');
+      const decoded = Buffer.from(args[idx + 1], 'base64').toString('utf-8');
+      const envelope = JSON.parse(decoded);
+      assert.strictEqual(envelope.containment, 'appcontainer');
+    });
+  });
 });


### PR DESCRIPTION
This PR fixes the SDKs legacy-containment-alias resolution so every containment check in `resolveExecutableAndArgs` sees the canonical backend, not just the platform-availability check. Without this, `containment: "macos_sandbox"` bypasses the SDKs experimental-mode gate because `ExperimentalBackends` lists `seatbelt` but not its alias. Follow-up to #391.

## Details

- Resolve `config.containment` through `LegacyContainmentAliases` once at the top of `resolveExecutableAndArgs` and drive every containment check from the result. Wire payload still forwarded to wxc-exec unchanged.
- Tighten the alias-map type to `Readonly<Partial<Record<...>>>` so the sparse-map contract is enforced at compile time.
- Drop `LegacyContainmentAliases` from the public `index.ts` re-exports - its a deprecation-window mechanism, not API surface.
- Add a deduplicated `diagLog` deprecation hint when a legacy value is accepted (mirrors the Rust-side `Logger` emission).
- Document the version-agnostic deprecation-alias policy in `docs/versioning.md` so SDK and parser dont drift again.

## Tests

- New `legacy containment aliases` describe block in `sdk/tests/unit/sandbox.test.ts`:
  - `appcontainer` accepted on Windows
  - `appcontainer` rejected on non-Windows with the canonical "not available on this platform" error
  - `macos_sandbox` triggers the experimental-mode gate (the regression this PR fixes)
  - `macos_sandbox` accepted on macOS with `experimental: true`
  - Legacy wire value forwarded to wxc-exec unchanged (envelope re-decoded from `--config-base64`)
- `npm test` (sdk): 141 pass, 0 fail, 3 platform-conditional skips. macOS-only and Linux-only branches will run on CI.

Refs #390.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/407)