### PR TITLE
sdk: route containment validation through a version-aware registry

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -333,6 +333,26 @@ through the same promotion-style migration: a single release that turns the
 silent accept-and-warn into an explicit `unsupported_containment` error.
 Document the removal in the schema bump that drops it.
 
+**SDK implementation.** The TypeScript validator routes containment-field
+values through a single declarative registry
+(`sdk/src/version-registry.ts`) and the pure `judge()` function. Each
+registered value carries `addedIn`, optional `deprecatedSince` / `renamedTo`,
+and optional `removeIn` metadata. `judge()` returns one of:
+
+| Verdict | Meaning |
+|---------|---------|
+| `ok` | value is canonical and supported for the declared version |
+| `ok-deprecated` | value is a legacy alias; warn and rewrite to canonical |
+| `removed` | declared version ≥ `removeIn`; reject |
+| `too-new` | value was introduced after the declared version (plumbed but not enforced today) |
+| `unknown` | value not in registry; fall through to the static union check |
+
+This keeps deprecation/sunset metadata co-located with the rest of the
+version information, lets the deprecation warning string be driven by
+registry data (`deprecated since X, will be removed in Y`), and means
+flipping `appcontainer` from accept-with-warn to reject is a one-line
+registry edit when the time comes.
+
 ## Open Questions
 
 1. **Experimental features on the OS side:** Does

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -17,9 +17,9 @@
     },
     "containment": {
       "type": "string",
-      "enum": ["process", "processcontainer", "windows_sandbox", "lxc", "microvm", "wslc", "seatbelt", "isolation_session", "bubblewrap"],
+      "enum": ["process", "processcontainer", "windows_sandbox", "lxc", "microvm", "hyperlight", "wslc", "seatbelt", "isolation_session", "bubblewrap"],
       "default": "processcontainer",
-      "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'microvm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'wslc', 'seatbelt', 'isolation_session', 'bubblewrap'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities. Note: 'windows_sandbox', 'wslc', 'seatbelt', 'isolation_session', and 'bubblewrap' are experimental and require the --experimental CLI flag."
+      "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'microvm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session', 'bubblewrap'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities. Note: 'windows_sandbox', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session', and 'bubblewrap' are experimental and require the --experimental CLI flag."
     },
 
     "phase": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc --watch",
     "clean": "rimraf dist",
     "test": "npm run test:unit",
-    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js dist-tests/tests/unit/platform.test.js",
+    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js dist-tests/tests/unit/platform.test.js dist-tests/tests/unit/version-registry.test.js",
     "test:integration": "cd tests/integration && npm install && npm run build && npm test",
     "prepublishOnly": "npm run build"
   },

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -6,10 +6,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { randomBytes } from 'crypto';
 import { FileLogger } from './logger.js';
-import { ContainerConfig, ContainmentBackend, ContainmentTypes, ExperimentalBackends, LegacyContainmentAliases } from './types.js';
+import { ContainerConfig, ContainmentBackend, ContainmentTypes } from './types.js';
 import { findWxcExecutable, findLxcExecutable, findSeatbeltExecutable, getPlatformSupport } from './platform.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { diagLog } from './diagnostic.js';
+import { ContainmentRegistry, judge, Verdict } from './version-registry.js';
 
 /** SDK version read from package.json at module load time. */
 export const SDK_VERSION: string = (() => {
@@ -42,15 +43,25 @@ const legacyContainmentWarned = new Set<string>();
  * uses a legacy containment wire value. Dedup'd per legacy value per process
  * so the message doesn't flood the diag stream on repeated spawns.
  *
+ * The verdict carries the rename target and version metadata sourced from
+ * `ContainmentRegistry`, so the message stays in sync with the registry
+ * without further plumbing.
+ *
  * Exposed for tests so the latch can be reset between describes.
  */
-export function warnLegacyContainmentOnce(legacy: string, canonical: string): void {
+export function warnLegacyContainmentOnce(
+    legacy: string,
+    verdict: Extract<Verdict, { kind: 'ok-deprecated' }>,
+): void {
     if (!legacyContainmentWarned.has(legacy)) {
         legacyContainmentWarned.add(legacy);
+        const removalNote = verdict.removeIn
+            ? ` and will be removed in ${verdict.removeIn}`
+            : '';
         diagLog(
-            `Containment value '${legacy}' is deprecated; use '${canonical}' instead. ` +
-            `The legacy spelling is accepted via a backward-compatibility alias and may be ` +
-            `removed in a future SDK release.`
+            `Containment value '${legacy}' is deprecated since schema ${verdict.deprecatedSince}${removalNote}; ` +
+            `use '${verdict.canonical}' instead. The legacy spelling is accepted via a ` +
+            `backward-compatibility alias.`
         );
     }
 }
@@ -160,33 +171,56 @@ export function resolveExecutableAndArgs(
     throw new Error('script is required. Set process.commandLine on the config or pass a script to spawnSandbox().');
   }
 
-  // Resolve deprecated wire values (e.g. "appcontainer" → "processcontainer",
-  // "macos_sandbox" → "seatbelt") once, and drive every containment check
-  // from the resolved value. The native binary accepts both spellings via
-  // serde aliases, so the wire payload is forwarded unchanged below — this
-  // resolution is purely for SDK-side validation. Without it, legacy values
-  // bypass the experimental-mode gate (because they are not in
-  // ExperimentalBackends under their alias) and produce a confusing
-  // "not available on this platform" error instead.
+  // Consult the version registry once. The verdict carries the canonical
+  // value (with renames resolved), the entry's experimental/abstract
+  // flags, and version metadata for the deprecation message. The native
+  // binary accepts legacy spellings via serde aliases, so the wire
+  // payload is forwarded unchanged below — `judge` is purely for SDK-side
+  // validation. Without this resolution, legacy values bypass the
+  // experimental-mode gate and produce confusing platform errors.
   const rawContainment = config.containment;
-  const effectiveContainment = rawContainment
-    ? (LegacyContainmentAliases[rawContainment] ?? rawContainment)
-    : undefined;
-  if (rawContainment && effectiveContainment !== rawContainment) {
-    warnLegacyContainmentOnce(rawContainment, effectiveContainment as ContainmentBackend);
+  let effectiveContainment: string | undefined = rawContainment;
+  let isExperimental = false;
+  let isIntent = false;
+  if (rawContainment) {
+    const verdict = judge(ContainmentRegistry, rawContainment, config.version);
+    switch (verdict.kind) {
+      case 'ok-deprecated':
+        warnLegacyContainmentOnce(rawContainment, verdict);
+        effectiveContainment = verdict.canonical;
+        isExperimental = !!verdict.entry.experimental;
+        isIntent = !!verdict.entry.abstract;
+        break;
+      case 'ok':
+      case 'too-new':
+        effectiveContainment = verdict.canonical;
+        isExperimental = !!verdict.entry.experimental;
+        isIntent = !!verdict.entry.abstract;
+        break;
+      case 'removed':
+        throw new Error(
+          `Containment value '${rawContainment}' was removed in schema ${verdict.removedIn}; ` +
+          `use '${verdict.canonical}' instead.`
+        );
+      case 'unknown':
+        // Value not in registry; preserve raw and fall back to the
+        // static `ContainmentTypes` check + platform-availability gate
+        // below. The TS union is still the entry gate for unknown values.
+        effectiveContainment = rawContainment;
+        isIntent = (ContainmentTypes as readonly string[]).includes(rawContainment);
+        break;
+    }
   }
 
   // Check experimental mode before anything else so the caller gets a clear
   // message about the missing flag rather than a platform/binary error.
-  if (effectiveContainment && ExperimentalBackends.includes(effectiveContainment) && !options.experimental) {
+  if (effectiveContainment && isExperimental && !options.experimental) {
     throw new Error(
       `'${rawContainment}' containment requires experimental mode. Set 'experimental: true' in SandboxSpawnOptions.`
     );
   }
 
   const platformSupport = getPlatformSupport();
-  const isExperimental = !!effectiveContainment &&
-    (ExperimentalBackends as readonly string[]).includes(effectiveContainment);
   if (!platformSupport.isSupported && !isExperimental && !options.skipPlatformCheck) {
     throw new Error(`MXC is not supported on this platform: ${platformSupport.reason}`);
   }
@@ -198,12 +232,10 @@ export function resolveExecutableAndArgs(
     throw new Error('The microvm backend is only supported on Windows (requires WHP/Hyper-V).');
   }
 
-  // Validate containment against platform
+  // Validate containment against platform. Abstract intents (process, vm,
+  // microvm) are resolved by the native binary at run time, so the SDK
+  // accepts them without checking against the host's concrete backend list.
   if (effectiveContainment && !options.skipPlatformCheck) {
-    // Abstract intents (process, microvm) are resolved by the native binary
-    // at run time, so the SDK accepts them without checking against the
-    // host's concrete backend list.
-    const isIntent = (ContainmentTypes as readonly string[]).includes(effectiveContainment);
     const isAvailable = platformSupport.availableMethods.includes(
       effectiveContainment as ContainmentBackend
     );

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -6,6 +6,7 @@
  * These types match the wxc-exec JSON configuration schema
  */
 
+import { ExperimentalContainments } from './version-registry.js';
 
 /**
  * Process execution settings
@@ -64,30 +65,6 @@ export type ContainmentType = "process" | "vm" | "microvm";
 export const ContainmentTypes: readonly ContainmentType[] = ['process', 'vm', 'microvm'];
 
 /**
- * Deprecated containment wire values, mapped to their canonical
- * {@link ContainmentBackend} replacement. The native binary (wxc-exec) accepts
- * the deprecated form via serde aliases; this map mirrors that behavior in
- * the SDK validator so legacy configs are not rejected before reaching the
- * binary.
- *
- * The map is intentionally partial: only deprecated keys appear. Use a
- * presence check (e.g. `LegacyContainmentAliases[value] ?? value`) rather
- * than indexing blindly.
- *
- * The wire payload is forwarded to wxc-exec unchanged — the Rust parser
- * performs the final mapping at runtime. Resolution here is purely so the
- * SDK's experimental-mode, platform-support, and availability checks see
- * the canonical backend.
- *
- * Internal to the SDK; not part of the public API. Subject to removal in a
- * future minor release once the deprecation window closes.
- */
-export const LegacyContainmentAliases: Readonly<Partial<Record<string, ContainmentBackend>>> = {
-  appcontainer: 'processcontainer',
-  macos_sandbox: 'seatbelt',
-};
-
-/**
  * Concrete containment backend. Each value names a specific runner
  * implementation in the native binary. Prefer a {@link ContainmentType}
  * value unless you specifically need to force a particular backend.
@@ -105,9 +82,11 @@ export type ContainmentBackend =
 
 /**
  * Containment values (abstract intent or concrete backend) that require
- * the `--experimental` flag.
+ * the `--experimental` flag. Derived from the version registry so the
+ * SDK has a single source of truth for backend metadata.
  */
-export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'hyperlight', 'wslc', 'seatbelt', 'bubblewrap'];
+export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] =
+  ExperimentalContainments as readonly (ContainmentType | ContainmentBackend)[];
 
 /**
  * Clipboard access policy levels

--- a/sdk/src/version-registry.ts
+++ b/sdk/src/version-registry.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { gt as semverGt, gte as semverGte, parse as semverParse } from 'semver';
+
+/**
+ * Semver string, e.g. `"0.6.0-alpha"`. Validated by callers via
+ * `validatePolicyVersion`; the registry helpers below are permissive and
+ * skip version-conditional checks when given an unparsable value.
+ */
+export type SemverString = string;
+
+/**
+ * Per-value metadata describing how a field value relates to the schema
+ * versions the SDK supports. One entry per value the schemas have ever
+ * accepted — canonical names and legacy aliases alike.
+ *
+ * When adding a value: set `addedIn` to the schema version that first
+ * accepted it. When renaming a value: leave the legacy entry in place with
+ * `deprecatedSince`, `renamedTo`, and (optionally) `removeIn` set, and add
+ * a fresh entry for the canonical name with `addedIn` = the rename
+ * version.
+ */
+export interface RegistryEntry {
+    /** First schema version that accepted this value. */
+    addedIn: SemverString;
+    /** Schema version where this value was deprecated. Aliases are still accepted. */
+    deprecatedSince?: SemverString;
+    /** Canonical replacement value when `deprecatedSince` is set. */
+    renamedTo?: string;
+    /** Future schema version where this value will be rejected outright. */
+    removeIn?: SemverString;
+    /** True when the value requires `--experimental` in versions where it is current. */
+    experimental?: boolean;
+    /**
+     * True for abstract intents (e.g. `"process"`, `"vm"`) that the native
+     * binary resolves to a concrete backend at run time.
+     */
+    abstract?: boolean;
+}
+
+/** A registry keyed by field value. */
+export type FieldRegistry = Readonly<Partial<Record<string, RegistryEntry>>>;
+
+/**
+ * Containment-field registry. Single source of truth for legacy aliases,
+ * experimental gating, and abstract-intent recognition.
+ *
+ * The native binary (wxc-exec / lxc-exec / mxc-exec-mac) is the
+ * authoritative validator of the wire payload; this registry mirrors
+ * what the schemas say so the SDK can reject obviously-wrong configs
+ * early and emit useful deprecation messages.
+ */
+export const ContainmentRegistry: FieldRegistry = {
+    // Stable since the earliest supported schema.
+    lxc:                { addedIn: '0.4.0-alpha' },
+
+    // Renamed in 0.6: appcontainer → processcontainer.
+    appcontainer:       { addedIn: '0.4.0-alpha', deprecatedSince: '0.6.0-alpha', renamedTo: 'processcontainer' },
+    processcontainer:   { addedIn: '0.6.0-alpha' },
+
+    // Added in 0.5.
+    windows_sandbox:    { addedIn: '0.5.0-alpha', experimental: true },
+    microvm:            { addedIn: '0.5.0-alpha', experimental: true },
+    wslc:               { addedIn: '0.5.0-alpha', experimental: true },
+
+    // Renamed in 0.6: macos_sandbox → seatbelt.
+    macos_sandbox:      { addedIn: '0.5.0-alpha', deprecatedSince: '0.6.0-alpha', renamedTo: 'seatbelt', experimental: true },
+    seatbelt:           { addedIn: '0.6.0-alpha', experimental: true },
+
+    // Added in 0.6.
+    isolation_session:  { addedIn: '0.6.0-alpha', experimental: true },
+    bubblewrap:         { addedIn: '0.6.0-alpha', experimental: true },
+    hyperlight:         { addedIn: '0.6.0-alpha', experimental: true },
+
+    // Abstract intents.
+    process:            { addedIn: '0.6.0-alpha', abstract: true },
+    vm:                 { addedIn: '0.4.0-alpha', abstract: true },
+};
+
+/**
+ * Verdict returned by {@link judge}. Conveys the version-aware decision
+ * a caller should make about a given (field, value, declaredVersion)
+ * triple. `canonical` is the value that downstream code should treat as
+ * authoritative (the rename target when deprecated, otherwise the raw
+ * value).
+ */
+export type Verdict =
+    | { kind: 'ok'; canonical: string; entry: RegistryEntry }
+    | { kind: 'ok-deprecated'; canonical: string; entry: RegistryEntry; deprecatedSince: SemverString; removeIn?: SemverString }
+    | { kind: 'unknown'; rawValue: string }
+    | { kind: 'too-new'; canonical: string; entry: RegistryEntry; addedIn: SemverString }
+    | { kind: 'removed'; canonical: string; entry: RegistryEntry; removedIn: SemverString };
+
+/**
+ * Evaluate a value against a declared schema version.
+ *
+ * Pure function. No side effects. The caller decides what to do with each
+ * verdict kind; see `helper.ts` for the one-shot containment consumer.
+ *
+ * `'unknown'` is returned for values that are not in the registry. Callers
+ * should treat that as "no version-aware information; fall back to the
+ * static TS union as the entry gate" — the registry is additive, not
+ * replacing the TS union.
+ *
+ * `'too-new'` (anachronism) is plumbed through but not enforced by any
+ * caller today. The verdict carries the metadata to flip to rejection
+ * later without changing the registry shape.
+ */
+export function judge(reg: FieldRegistry, value: string, declaredVersion?: SemverString): Verdict {
+    const entry = reg[value];
+    if (!entry) {
+        return { kind: 'unknown', rawValue: value };
+    }
+
+    const canonicalName = entry.renamedTo ?? value;
+    const canonicalEntry = entry.renamedTo ? (reg[entry.renamedTo] ?? entry) : entry;
+
+    const versionParseable = !!(declaredVersion && semverParse(declaredVersion));
+
+    if (versionParseable && entry.removeIn && semverGte(declaredVersion as string, entry.removeIn)) {
+        return { kind: 'removed', canonical: canonicalName, entry: canonicalEntry, removedIn: entry.removeIn };
+    }
+
+    if (entry.deprecatedSince && entry.renamedTo) {
+        return {
+            kind: 'ok-deprecated',
+            canonical: canonicalName,
+            entry: canonicalEntry,
+            deprecatedSince: entry.deprecatedSince,
+            removeIn: entry.removeIn,
+        };
+    }
+
+    if (versionParseable && semverGt(entry.addedIn, declaredVersion as string)) {
+        return { kind: 'too-new', canonical: canonicalName, entry: canonicalEntry, addedIn: entry.addedIn };
+    }
+
+    return { kind: 'ok', canonical: canonicalName, entry: canonicalEntry };
+}
+
+/**
+ * List of containment values that require `--experimental`. Derived from
+ * the registry — single source of truth.
+ *
+ * Retained as a named export because earlier SDK versions exposed an
+ * `ExperimentalBackends` const; consumers (and the helper itself) can
+ * continue using it without knowing the registry exists.
+ */
+export const ExperimentalContainments: readonly string[] = Object.entries(ContainmentRegistry)
+    .filter(([, e]) => e?.experimental)
+    .map(([k]) => k);

--- a/sdk/tests/unit/version-registry.test.ts
+++ b/sdk/tests/unit/version-registry.test.ts
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  ContainmentRegistry,
+  ExperimentalContainments,
+  judge,
+} from '../../src/version-registry.js';
+import { ContainmentBackend } from '../../src/types.js';
+
+describe('judge (containment)', () => {
+  describe('canonical values', () => {
+    it("returns 'ok' for a stable value in any supported version", () => {
+      for (const v of ['0.4.0-alpha', '0.5.0-alpha', '0.6.0-alpha']) {
+        const verdict = judge(ContainmentRegistry, 'lxc', v);
+        assert.strictEqual(verdict.kind, 'ok', `version ${v}`);
+        if (verdict.kind === 'ok') {
+          assert.strictEqual(verdict.canonical, 'lxc');
+          assert.strictEqual(verdict.entry.experimental, undefined);
+        }
+      }
+    });
+
+    it("returns 'ok' for a value introduced in the declared version", () => {
+      const verdict = judge(ContainmentRegistry, 'processcontainer', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok');
+      if (verdict.kind === 'ok') {
+        assert.strictEqual(verdict.canonical, 'processcontainer');
+      }
+    });
+
+    it('exposes the experimental flag on the verdict entry', () => {
+      const verdict = judge(ContainmentRegistry, 'seatbelt', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok');
+      if (verdict.kind === 'ok') {
+        assert.strictEqual(verdict.entry.experimental, true);
+      }
+    });
+
+    it('exposes the abstract flag on the verdict entry', () => {
+      const verdict = judge(ContainmentRegistry, 'process', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok');
+      if (verdict.kind === 'ok') {
+        assert.strictEqual(verdict.entry.abstract, true);
+      }
+    });
+  });
+
+  describe('deprecated aliases', () => {
+    it("returns 'ok-deprecated' for 'appcontainer' regardless of declared version", () => {
+      for (const v of ['0.4.0-alpha', '0.5.0-alpha', '0.6.0-alpha']) {
+        const verdict = judge(ContainmentRegistry, 'appcontainer', v);
+        assert.strictEqual(verdict.kind, 'ok-deprecated', `version ${v}`);
+        if (verdict.kind === 'ok-deprecated') {
+          assert.strictEqual(verdict.canonical, 'processcontainer');
+          assert.strictEqual(verdict.deprecatedSince, '0.6.0-alpha');
+        }
+      }
+    });
+
+    it("returns 'ok-deprecated' for 'macos_sandbox' with the canonical pointing to seatbelt", () => {
+      const verdict = judge(ContainmentRegistry, 'macos_sandbox', '0.5.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok-deprecated');
+      if (verdict.kind === 'ok-deprecated') {
+        assert.strictEqual(verdict.canonical, 'seatbelt');
+        assert.strictEqual(verdict.entry.experimental, true);
+      }
+    });
+  });
+
+  describe('sunset (removeIn)', () => {
+    it("returns 'removed' once the declared version reaches removeIn", () => {
+      const reg = {
+        ...ContainmentRegistry,
+        appcontainer: {
+          addedIn: '0.4.0-alpha',
+          deprecatedSince: '0.6.0-alpha',
+          renamedTo: 'processcontainer',
+          removeIn: '0.7.0-alpha',
+        },
+      };
+      const verdict = judge(reg, 'appcontainer', '0.7.0-alpha');
+      assert.strictEqual(verdict.kind, 'removed');
+      if (verdict.kind === 'removed') {
+        assert.strictEqual(verdict.removedIn, '0.7.0-alpha');
+        assert.strictEqual(verdict.canonical, 'processcontainer');
+      }
+    });
+
+    it("still returns 'ok-deprecated' below the removeIn threshold", () => {
+      const reg = {
+        ...ContainmentRegistry,
+        appcontainer: {
+          addedIn: '0.4.0-alpha',
+          deprecatedSince: '0.6.0-alpha',
+          renamedTo: 'processcontainer',
+          removeIn: '0.7.0-alpha',
+        },
+      };
+      const verdict = judge(reg, 'appcontainer', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok-deprecated');
+    });
+  });
+
+  describe('anachronism (too-new)', () => {
+    it("returns 'too-new' when the value was added after the declared version", () => {
+      const verdict = judge(ContainmentRegistry, 'isolation_session', '0.5.0-alpha');
+      assert.strictEqual(verdict.kind, 'too-new');
+      if (verdict.kind === 'too-new') {
+        assert.strictEqual(verdict.canonical, 'isolation_session');
+        assert.strictEqual(verdict.addedIn, '0.6.0-alpha');
+      }
+    });
+
+    it("returns 'ok' when the declared version exactly matches addedIn", () => {
+      const verdict = judge(ContainmentRegistry, 'isolation_session', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'ok');
+    });
+  });
+
+  describe('unknown values', () => {
+    it("returns 'unknown' for a value not in the registry", () => {
+      const verdict = judge(ContainmentRegistry, 'definitely-not-real', '0.6.0-alpha');
+      assert.strictEqual(verdict.kind, 'unknown');
+      if (verdict.kind === 'unknown') {
+        assert.strictEqual(verdict.rawValue, 'definitely-not-real');
+      }
+    });
+  });
+
+  describe('version handling', () => {
+    it('treats an unparseable declared version as "no anachronism / no sunset"', () => {
+      // Deprecation still fires (version-agnostic policy), but anachronism
+      // checks are skipped.
+      const v1 = judge(ContainmentRegistry, 'isolation_session', 'not-semver');
+      assert.strictEqual(v1.kind, 'ok');
+      const v2 = judge(ContainmentRegistry, 'appcontainer', 'not-semver');
+      assert.strictEqual(v2.kind, 'ok-deprecated');
+    });
+
+    it('treats a missing declared version the same way', () => {
+      const verdict = judge(ContainmentRegistry, 'isolation_session', undefined);
+      assert.strictEqual(verdict.kind, 'ok');
+    });
+  });
+});
+
+describe('ContainmentRegistry coverage', () => {
+  it('has a registry entry for every value in the ContainmentBackend union', () => {
+    // Defensive: if a new backend lands in the TS union without a registry
+    // entry, the SDK falls back to 'unknown' and loses experimental gating
+    // for that value. The hyperlight drift bug (#TBD) is exactly this.
+    const unionMembers: ContainmentBackend[] = [
+      'processcontainer',
+      'windows_sandbox',
+      'wslc',
+      'lxc',
+      'microvm',
+      'hyperlight',
+      'seatbelt',
+      'isolation_session',
+      'bubblewrap',
+    ];
+    for (const v of unionMembers) {
+      assert.ok(
+        ContainmentRegistry[v],
+        `ContainmentRegistry is missing an entry for '${v}'`,
+      );
+    }
+  });
+
+  it('ExperimentalContainments is derived correctly from the registry', () => {
+    const expected = ['windows_sandbox', 'microvm', 'wslc', 'macos_sandbox', 'seatbelt', 'isolation_session', 'bubblewrap', 'hyperlight'];
+    for (const v of expected) {
+      assert.ok(
+        ExperimentalContainments.includes(v),
+        `ExperimentalContainments missing '${v}'`,
+      );
+    }
+    // Non-experimental values should not appear.
+    for (const v of ['lxc', 'appcontainer', 'processcontainer', 'process', 'vm']) {
+      assert.ok(
+        !ExperimentalContainments.includes(v),
+        `ExperimentalContainments unexpectedly includes '${v}'`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
> Stacked on top of #407 — review that first; this PR's diff is best read against `user/gudge/sdk-legacy-aliases-followup`.

## Summary

Replaces the scattered `LegacyContainmentAliases` map / `ExperimentalBackends` list in the SDK validator with a single declarative registry and a pure `judge()` function. The registry is the one place where every containment value the SDK has ever accepted is annotated with its `addedIn` / `deprecatedSince` / `renamedTo` / `removeIn` / `experimental` / `abstract` metadata; the helper calls `judge()` once and switches on the verdict (`ok` / `ok-deprecated` / `removed` / `too-new` / `unknown`).

Behaviour is preserved end-to-end. Legacy aliases (`appcontainer`, `macos_sandbox`) are still accepted on every supported `policy.version`, the on-wire payload still carries the raw user-supplied value verbatim, and the deprecation diagnostic still fires once per process per value — but the warning string is now driven by registry metadata, and flipping `appcontainer` from accept-with-warn to reject becomes a one-line registry edit once the deprecation window closes.

Also folds in a small drift fix: `hyperlight` was in the SDK `ContainmentBackend` union but missing from the `0.6.0-dev` schema enum.

Related Issues

- #391
- #390

## Why this shape

We considered three shapes during design:

- **A — keep `LegacyContainmentAliases`, add a separate `judge()` helper.** Smaller diff, but leaves two related APIs that can drift.
- **B — single registry + `judge()` (this PR).** One source of truth for every value's version metadata; the alias map becomes a derived view if anyone still wants it.
- **C — bundle the JSON schemas into the SDK and run ajv at runtime.** Duplicates the Rust parser's job and ties the SDK to schema-file churn.

We picked B because it consolidates the four lookups (alias rewrite, experimental gate, abstract recognition, schema-version awareness) behind one entry point.

## What's intentionally not done

- `too-new` is plumbed through the verdict union but not enforced in the helper today — the helper treats it identically to `ok`, matching pre-PR behaviour. The plumbing means enforcement is a one-line flip if/when we want it.
- The on-wire `config.containment` is still forwarded verbatim; only the SDK-local `effectiveContainment` is rewritten on `ok-deprecated`. The "forward the legacy wire value to the binary unchanged" test from #407 continues to pass.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/409)