### PR TITLE
Downlevel Phase 5 - integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,16 @@ jobs:
       - name: Run tests
         run: cargo test --release --target ${{ matrix.target }} --workspace --exclude wxc_e2e_tests
 
+      # Tier-2 (BFS) is off by default — production binaries on Win 11
+      # 25H2 must NOT carry the `tier2_bfs` feature, since `bfscfg.exe`
+      # hangs that host. The feature still has to compile and test
+      # green so the dispatcher's T2 branch stays alive for hosts
+      # where T2 is safe (post-25H2 or with the kernel hotfix). This
+      # step adds the matrix entry the adversarial review flagged as
+      # missing.
+      - name: Run tier2_bfs feature tests (wxc_common)
+        run: cargo test --release --target ${{ matrix.target }} -p wxc_common --features tier2_bfs
+
       - uses: actions/upload-artifact@v4
         with:
           name: wxc-exec-${{ matrix.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,9 @@ output
 
 # Copilot
 .copilot/TEST_COVERAGE_ANALYSIS.md
+.copilot/
 *.pdb
 pathrel_test.exe
+
+# Claude
+.claude/

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc --watch",
     "clean": "rimraf dist",
     "test": "npm run test:unit",
-    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js",
+    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js dist-tests/tests/unit/platform.test.js",
     "test:integration": "cd tests/integration && npm install && npm run build && npm test",
     "prepublishOnly": "npm run build"
   },

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -29,6 +29,7 @@
 export {
   SandboxPolicy,
   SandboxingMethod,
+  IsolationTier,
   ContainmentType,
   ContainmentTypes,
   LegacyContainmentAliases,

--- a/sdk/src/platform.ts
+++ b/sdk/src/platform.ts
@@ -1,9 +1,9 @@
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { fileURLToPath } from 'node:url';
-import { ContainmentBackend, PlatformSupport } from './types.js';
+import { ContainmentBackend, IsolationTier, PlatformSupport } from './types.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -129,12 +129,91 @@ function isWindowsSandboxAvailable(): boolean {
 }
 
 /**
- * Get platform support information
+ * Get platform support information.
+ *
+ * On Windows, when the host build is supported, this also invokes
+ * `wxc-exec --probe` to populate `isolationTier` and (if any) the
+ * `isolationWarnings` array. The result is cached for the lifetime of
+ * the SDK module — the underlying machine state is not expected to
+ * change at runtime.
+ *
  * @returns Platform support details including available sandboxing methods
  */
 export function getPlatformSupport(): PlatformSupport {
+  if (cachedSupport !== null) {
+    return cachedSupport;
+  }
+  const support = computeSupport();
+  cachedSupport = support;
+  return support;
+}
+
+let cachedSupport: PlatformSupport | null = null;
+
+/** @internal Test-only: clear the cached PlatformSupport. */
+export function _resetPlatformSupportCache(): void {
+  cachedSupport = null;
+}
+
+/**
+ * Probe runner injection seam. Spawns `wxc-exec --probe` and returns
+ * its stdout. Replaceable in unit tests via {@link _setProbeRunner}.
+ */
+type ProbeRunner = () => string;
+
+let probeRunner: ProbeRunner = defaultProbeRunner;
+
+/** @internal Test-only: override the probe runner. */
+export function _setProbeRunner(runner: ProbeRunner | null): void {
+  probeRunner = runner ?? defaultProbeRunner;
+}
+
+function defaultProbeRunner(): string {
+  const wxcPath = findWxcExecutable();
+  if (!wxcPath) {
+    throw new Error('wxc-exec not found');
+  }
+  return execFileSync(wxcPath, ['--probe'], {
+    timeout: 5000,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function isValidTier(s: unknown): s is IsolationTier {
+  return s === 'base-container' || s === 'appcontainer-bfs' || s === 'appcontainer-dacl';
+}
+
+/**
+ * Run the probe binary and merge its results into `support`. On any
+ * failure (binary missing, timeout, malformed JSON, unknown tier), the
+ * function silently leaves `support.isolationTier` and
+ * `support.isolationWarnings` unset — callers see the same contract as
+ * pre-Phase-5 SDKs.
+ */
+function populateIsolationFromProbe(support: PlatformSupport): void {
+  try {
+    const stdout = probeRunner();
+    const probe = JSON.parse(stdout);
+    if (probe && typeof probe === 'object') {
+      if (isValidTier(probe.tier)) {
+        support.isolationTier = probe.tier;
+      }
+      if (Array.isArray(probe.warnings) && probe.warnings.length > 0) {
+        const warnings = probe.warnings.filter((w: unknown): w is string => typeof w === 'string');
+        if (warnings.length > 0) {
+          support.isolationWarnings = warnings;
+        }
+      }
+    }
+  } catch {
+    // Graceful degradation: leave isolation fields unset.
+  }
+}
+
+function computeSupport(): PlatformSupport {
   const platform = os.platform();
-  var support : PlatformSupport = { isSupported: false, reason: '', availableMethods: [] };
+  const support: PlatformSupport = { isSupported: false, reason: '', availableMethods: [] };
 
   // Non-Windows platforms
   if (platform === 'darwin') {
@@ -166,7 +245,7 @@ export function getPlatformSupport(): PlatformSupport {
   }
 
   if (platform !== 'win32') {
-        support.reason = 'MXC is not supported on this platform';
+    support.reason = 'MXC is not supported on this platform';
     return support;
   }
 
@@ -177,6 +256,7 @@ export function getPlatformSupport(): PlatformSupport {
     if (isWindowsSandboxAvailable()) {
       support.availableMethods.push('windows_sandbox');
     }
+    populateIsolationFromProbe(support);
     return support;
   }
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -370,6 +370,18 @@ export interface SeatbeltConfig {
 export type SandboxingMethod = ContainmentType | ContainmentBackend;
 
 /**
+ * Isolation tier selected by the runtime fallback detector.
+ *
+ * - `base-container`: full BaseContainer (Experimental_CreateProcessInSandbox)
+ * - `appcontainer-bfs`: AppContainer + BFS filesystem isolation
+ * - `appcontainer-dacl`: AppContainer + host DACL augmentation (last-resort fallback)
+ */
+export type IsolationTier =
+  | 'base-container'
+  | 'appcontainer-bfs'
+  | 'appcontainer-dacl';
+
+/**
  * Platform support information
  */
 export interface PlatformSupport {
@@ -379,4 +391,14 @@ export interface PlatformSupport {
   reason?: string;
   /** Available sandboxing methods on this platform */
   availableMethods: ContainmentBackend[];
+  /**
+   * Tier that would be selected for an empty policy on this system.
+   * Omitted on non-Windows platforms or when the probe fails.
+   */
+  isolationTier?: IsolationTier;
+  /**
+   * Tier degradation warnings (one per fall-through during selection).
+   * Omitted on non-Windows platforms or when the probe fails.
+   */
+  isolationWarnings?: string[];
 }

--- a/sdk/tests/unit/platform.test.ts
+++ b/sdk/tests/unit/platform.test.ts
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getPlatformSupport,
+  _resetPlatformSupportCache,
+  _setProbeRunner,
+  findWxcExecutable,
+} from '../../src/platform.js';
+
+const isWindows = os.platform() === 'win32';
+
+describe('getPlatformSupport probe integration', () => {
+  beforeEach(() => {
+    _resetPlatformSupportCache();
+  });
+
+  afterEach(() => {
+    _setProbeRunner(null);
+    _resetPlatformSupportCache();
+  });
+
+  it('returns isolationTier when probe succeeds', { skip: !isWindows }, () => {
+    let calls = 0;
+    _setProbeRunner(() => {
+      calls += 1;
+      return JSON.stringify({
+        tier: 'appcontainer-bfs',
+        needsDaclAugmentation: false,
+        warnings: ['BaseContainer API not present'],
+        probes: { baseContainerApiPresent: false, bfscfgPresent: true },
+      });
+    });
+    const support = getPlatformSupport();
+    if (!support.isSupported) {
+      // Host build doesn't satisfy the version gate; the probe path is
+      // not taken on this machine. Skip the assertion.
+      return;
+    }
+    assert.strictEqual(support.isolationTier, 'appcontainer-bfs');
+    assert.deepStrictEqual(support.isolationWarnings, ['BaseContainer API not present']);
+    assert.strictEqual(calls, 1);
+  });
+
+  it('omits isolationTier when probe throws', { skip: !isWindows }, () => {
+    _setProbeRunner(() => {
+      throw new Error('boom');
+    });
+    const support = getPlatformSupport();
+    assert.strictEqual(support.isolationTier, undefined);
+    assert.strictEqual(support.isolationWarnings, undefined);
+  });
+
+  it('omits isolationTier when probe returns malformed JSON', { skip: !isWindows }, () => {
+    _setProbeRunner(() => 'not json');
+    const support = getPlatformSupport();
+    assert.strictEqual(support.isolationTier, undefined);
+    assert.strictEqual(support.isolationWarnings, undefined);
+  });
+
+  it('rejects unknown tier strings via type narrowing', { skip: !isWindows }, () => {
+    _setProbeRunner(() =>
+      JSON.stringify({
+        tier: 'future-tier',
+        warnings: [],
+        probes: { baseContainerApiPresent: true, bfscfgPresent: true },
+      }),
+    );
+    const support = getPlatformSupport();
+    assert.strictEqual(support.isolationTier, undefined);
+  });
+
+  it('caches the platform-support result', { skip: !isWindows }, () => {
+    let calls = 0;
+    _setProbeRunner(() => {
+      calls += 1;
+      return JSON.stringify({
+        tier: 'appcontainer-bfs',
+        warnings: [],
+        probes: { baseContainerApiPresent: false, bfscfgPresent: true },
+      });
+    });
+    const a = getPlatformSupport();
+    const b = getPlatformSupport();
+    assert.strictEqual(a, b, 'cached object identity');
+    if (a.isSupported) {
+      assert.strictEqual(calls, 1, 'probe should be invoked exactly once');
+    }
+  });
+
+  it('still returns base PlatformSupport shape on non-Windows', { skip: isWindows }, () => {
+    const support = getPlatformSupport();
+    assert.strictEqual(support.isolationTier, undefined);
+    assert.strictEqual(support.isolationWarnings, undefined);
+    assert.ok(Array.isArray(support.availableMethods));
+  });
+
+  // Partial-JSON tests: the probe binary's output is parsed permissively
+  // — a future schema bump that adds fields must not break older SDKs,
+  // and a downlevel probe that omits fields must not crash callers.
+  // `populateIsolationFromProbe` is the single point of contact; the
+  // tests below stress it via `_setProbeRunner`.
+  it('handles probe JSON with only `tier`', { skip: !isWindows }, () => {
+    _setProbeRunner(() => JSON.stringify({ tier: 'appcontainer-dacl' }));
+    const support = getPlatformSupport();
+    if (!support.isSupported) return;
+    assert.strictEqual(support.isolationTier, 'appcontainer-dacl');
+    assert.strictEqual(
+      support.isolationWarnings,
+      undefined,
+      'missing warnings array must leave isolationWarnings undefined',
+    );
+  });
+
+  it('handles probe JSON with only `warnings`', { skip: !isWindows }, () => {
+    _setProbeRunner(() => JSON.stringify({ warnings: ['msg-1', 'msg-2'] }));
+    const support = getPlatformSupport();
+    if (!support.isSupported) return;
+    // No `tier` field → isolationTier stays unset; warnings still
+    // surface so callers can observe degraded-detection state.
+    assert.strictEqual(support.isolationTier, undefined);
+    assert.deepStrictEqual(support.isolationWarnings, ['msg-1', 'msg-2']);
+  });
+
+  it('handles empty probe JSON object', { skip: !isWindows }, () => {
+    _setProbeRunner(() => JSON.stringify({}));
+    const support = getPlatformSupport();
+    if (!support.isSupported) return;
+    assert.strictEqual(support.isolationTier, undefined);
+    assert.strictEqual(support.isolationWarnings, undefined);
+  });
+
+  it('filters non-string entries out of warnings array', { skip: !isWindows }, () => {
+    _setProbeRunner(() =>
+      JSON.stringify({
+        tier: 'appcontainer-bfs',
+        warnings: ['ok', 42, null, { not: 'a string' }, 'ok2'],
+      }),
+    );
+    const support = getPlatformSupport();
+    if (!support.isSupported) return;
+    assert.deepStrictEqual(support.isolationWarnings, ['ok', 'ok2']);
+  });
+
+  it('omits isolationWarnings when filtered warnings array is empty', { skip: !isWindows }, () => {
+    _setProbeRunner(() =>
+      JSON.stringify({
+        tier: 'appcontainer-bfs',
+        warnings: [42, null], // every entry is non-string → empty after filter
+      }),
+    );
+    const support = getPlatformSupport();
+    if (!support.isSupported) return;
+    assert.strictEqual(support.isolationTier, 'appcontainer-bfs');
+    assert.strictEqual(support.isolationWarnings, undefined);
+  });
+
+  it('treats probe JSON that is a non-object (number, string, null) as unparseable', { skip: !isWindows }, () => {
+    for (const payload of ['42', '"a string"', 'null']) {
+      _resetPlatformSupportCache();
+      _setProbeRunner(() => payload);
+      const support = getPlatformSupport();
+      assert.strictEqual(support.isolationTier, undefined, `payload=${payload}`);
+      assert.strictEqual(support.isolationWarnings, undefined, `payload=${payload}`);
+    }
+  });
+});
+
+// findWxcExecutable failure-mode: the SDK's default probe runner calls
+// findWxcExecutable() and throws if it returns null. Tests below
+// confirm the function never throws — only ever returns a string path
+// or `null` — even under hostile inputs to its env-var search seam.
+describe('findWxcExecutable failure modes', () => {
+  let prevBinDir: string | undefined;
+
+  beforeEach(() => {
+    prevBinDir = process.env.MXC_BIN_DIR;
+  });
+
+  afterEach(() => {
+    if (prevBinDir === undefined) {
+      delete process.env.MXC_BIN_DIR;
+    } else {
+      process.env.MXC_BIN_DIR = prevBinDir;
+    }
+  });
+
+  it('returns a string or null and never throws under a nonexistent MXC_BIN_DIR', () => {
+    // Point MXC_BIN_DIR at a path that definitely doesn't exist. The
+    // function should silently fall through to its standard search,
+    // returning either a real path (dev machine with binaries built)
+    // or null (CI sans binaries). Both are acceptable — the contract
+    // we care about is "does not throw".
+    process.env.MXC_BIN_DIR = path.join(
+      os.tmpdir(),
+      `mxc-sdk-unit-no-such-dir-${process.pid}`,
+    );
+    const result = findWxcExecutable();
+    assert.ok(result === null || typeof result === 'string', `got: ${result}`);
+  });
+
+  it('returns a string or null when MXC_BIN_DIR is empty', () => {
+    process.env.MXC_BIN_DIR = '';
+    const result = findWxcExecutable();
+    assert.ok(result === null || typeof result === 'string');
+  });
+});

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2811,6 +2811,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "wxc_ui_probe"
+version = "0.1.0"
+
+[[package]]
 name = "wxc_windows_sandbox_daemon"
 version = "0.1.0"
 dependencies = [

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "wxc_windows_sandbox_guest",
     "wxc_windows_sandbox_daemon",
     "wxc_winhttp_proxy_shim",
+    "wxc_ui_probe",
     "wxc_e2e_tests",
     "lxc",
     "lxc_common",

--- a/src/wxc/Cargo.toml
+++ b/src/wxc/Cargo.toml
@@ -31,3 +31,5 @@ isolation_session = [
     "dep:isolation_session_bindings",
     "wxc_common/isolation_session",
 ]
+# Forwards wxc_common/tier2_bfs. OFF by default; see wxc_common/Cargo.toml.
+tier2_bfs = ["wxc_common/tier2_bfs"]

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -4,11 +4,14 @@
 use std::fmt::Write;
 use std::fs;
 use std::process;
+use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
 use clap::Parser;
 use wxc_common::appcontainer_runner::{delete_app_container_profile, AppContainerScriptRunner};
-use wxc_common::config_parser::{is_base_container_version, load_mxc_request, ParseError};
+use wxc_common::config_parser::{
+    is_base_container_version, load_mxc_request, load_request, ParseError,
+};
 use wxc_common::diagnostic::DiagnosticConfig;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
 use wxc_common::hyperlight_runner::HyperlightScriptRunner;
@@ -153,6 +156,10 @@ struct Cli {
     #[cfg(target_os = "windows")]
     #[arg(long = "internal-log-path", hide = true)]
     internal_log_path: Option<String>,
+
+    /// Run the fallback detector and emit JSON, without spawning a sandbox.
+    #[arg(long)]
+    probe: bool,
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -224,24 +231,165 @@ fn print_error_envelope(error: &MxcError) {
     }
 }
 
+fn config_input(cli: &Cli) -> Option<(String, bool)> {
+    if let Some(b64) = cli.config_base64.as_ref() {
+        Some((b64.clone(), true))
+    } else if let Some(p) = cli.config.as_ref() {
+        Some((p.clone(), false))
+    } else {
+        cli.config_path.as_ref().map(|p| (p.clone(), false))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Graceful-exit DACL cleanup
+// ---------------------------------------------------------------------------
+//
+// `DaclManager`'s `Drop` is the only thing that restores host ACEs we
+// applied during a Tier 2 / Tier 3 run. We need that `Drop` to fire on
+// every code path that can leave main, including the abnormal ones.
+// There are three:
+//
+// 1. **Normal exit / `process::exit`** — destructors of stack-owned
+//    values run on the former and are SKIPPED on the latter. We deal
+//    with this by explicitly `drop(take_parked_dacl())`-ing before any
+//    `process::exit` site below.
+// 2. **Panic unwind** — destructors of stack-owned values run; the
+//    release profile uses the default `unwind` strategy (see
+//    `src/Cargo.toml`). But the `DaclManager` we extract from
+//    `Dispatched` lives inside a process-global static (so the Ctrl-C
+//    handler can reach it), and statics are NOT touched by unwinding.
+//    To restore on panic we install a stack-owned `ParkedDaclGuard` in
+//    `main` whose `Drop` calls `take_parked_dacl()` and drops the
+//    manager. The guard sits at function scope so the unwind path
+//    threads through it.
+// 3. **Ctrl-C / Ctrl-Break / console close / logoff / shutdown** — the
+//    default Windows handler calls `ExitProcess` directly, skipping
+//    every Rust destructor. We install a `SetConsoleCtrlHandler` that
+//    takes-and-drops the parked manager before yielding to the
+//    default handler.
+//
+// The mutex in the slot serializes the Ctrl-C handler and the guard
+// against each other, so the manager is taken (and therefore
+// `Drop`'d) at most once.
+//
+// Parent-process kill (`TerminateProcess`) still bypasses every
+// handler; any leak there is reaped by `recover_orphaned_state` on
+// the next wxc-exec startup (which we already run at the top of
+// `main`).
+
+static DACL_CLEANUP_SLOT: OnceLock<Mutex<Option<wxc_common::filesystem_dacl::DaclManager>>> =
+    OnceLock::new();
+
+fn dacl_cleanup_slot() -> &'static Mutex<Option<wxc_common::filesystem_dacl::DaclManager>> {
+    DACL_CLEANUP_SLOT.get_or_init(|| Mutex::new(None))
+}
+
+/// Park the DACL manager in the global slot so the Ctrl-C handler can
+/// drop it if a signal arrives before the normal-exit path runs.
+fn park_dacl_for_cleanup(mgr: wxc_common::filesystem_dacl::DaclManager) {
+    let slot = dacl_cleanup_slot();
+    let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
+    *guard = Some(mgr);
+}
+
+/// Take the parked DACL manager (if any) so the caller can drop it,
+/// triggering ACE restore. Returns `None` if either nothing was parked
+/// or another path (the Ctrl-C handler) already took it.
+///
+/// Recovers from `PoisonError` the same way [`park_dacl_for_cleanup`]
+/// does (`into_inner`): a poisoned mutex must NOT silently swallow a
+/// parked manager — that would leak ACEs until the next-startup
+/// recovery scan reaps them.
+fn take_parked_dacl() -> Option<wxc_common::filesystem_dacl::DaclManager> {
+    DACL_CLEANUP_SLOT.get().and_then(|slot| {
+        let mut guard = slot.lock().unwrap_or_else(|p| p.into_inner());
+        guard.take()
+    })
+}
+
+/// Stack-owned witness that ensures `take_parked_dacl()` runs on every
+/// path out of `main`, including panic unwind. The parked
+/// `DaclManager` lives in a process-global static (so the Ctrl-C
+/// handler can reach it), and Rust's unwinder doesn't touch statics —
+/// without this guard, a panic between `park_dacl_for_cleanup` and
+/// the explicit `drop(take_parked_dacl())` near the end of `main`
+/// would leave host ACEs in place until the next startup's recovery
+/// scan.
+///
+/// `Drop` is a no-op if nothing was ever parked or if the Ctrl-C
+/// handler already drained the slot.
+struct ParkedDaclGuard;
+
+impl Drop for ParkedDaclGuard {
+    fn drop(&mut self) {
+        drop(take_parked_dacl());
+    }
+}
+
+/// Windows console-control handler. Called by the OS on Ctrl-C, Ctrl-Break,
+/// console close, logoff, and shutdown. Takes the parked DACL manager and
+/// drops it — `Drop` runs `restore()` which removes the ACEs we applied.
+/// Returns `FALSE` so the default handler still runs (which terminates
+/// the process).
+///
+/// Acquires the slot with a bounded wait (≤5s), not `try_lock`. If the
+/// main thread is mid-`Drop` on the same manager — which can be doing a
+/// `SetNamedSecurityInfoW` — returning FALSE immediately lets the
+/// default handler call `ExitProcess`, terminating that drop mid-Win32
+/// and leaving the host DACL in an inconsistent state. The bounded
+/// wait blocks the default handler until either main finishes (lock
+/// released) or 5s elapses — whichever comes first. On timeout we
+/// proceed anyway; the recovery scan on the next `wxc-exec` startup
+/// reaps anything left behind.
+unsafe extern "system" fn dacl_ctrl_handler(_ctrl_type: u32) -> windows::core::BOOL {
+    if let Some(slot) = DACL_CLEANUP_SLOT.get() {
+        use std::time::{Duration, Instant};
+        // 5s mirrors the WaitForSingleObject pattern recommended for
+        // graceful-shutdown handlers; tuned to be longer than a worst-
+        // case `SetNamedSecurityInfoW` on a deep tree but well under
+        // the Windows default 10s shutdown-handler budget.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(mut guard) = slot.try_lock() {
+                // Either main already took the manager (guard is None)
+                // or it never parked one; dropping `Option::take` is
+                // a no-op in both cases. Either way, the contract — no
+                // restore thread running concurrently with the default
+                // handler's ExitProcess — is satisfied.
+                drop(guard.take());
+                break;
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+    // FALSE = "I did not fully handle this; run the next handler in the
+    // chain (i.e. the default handler that calls ExitProcess)".
+    windows::core::BOOL(0)
+}
+
+/// Install the console-control handler. Idempotent — calling twice
+/// registers the same handler twice, which is harmless because the
+/// take-and-drop is `Option::take`-based.
+fn install_dacl_ctrl_handler() {
+    use windows::Win32::System::Console::SetConsoleCtrlHandler;
+    // SAFETY: `dacl_ctrl_handler` has the correct ABI; the `Add=TRUE`
+    // call merely appends to the OS handler chain.
+    let _ = unsafe { SetConsoleCtrlHandler(Some(dacl_ctrl_handler), true) };
+}
+
 fn main() {
-    // Initialize COM/WinRT for backends that use WinRT APIs (Isolation Session).
-    // COINIT_MULTITHREADED is benign for backends that don't use COM.
-    //
-    // SAFETY: `CoInitializeEx` is sound to call once at process start before
-    // any WinRT or COM activation. `pvReserved` must be `None` per the API
-    // contract. The return value is intentionally ignored — repeat-init
-    // outcomes (`S_FALSE`, `RPC_E_CHANGED_MODE`) are benign here.
-    let _ = unsafe {
-        windows::Win32::System::Com::CoInitializeEx(
-            None,
-            windows::Win32::System::Com::COINIT_MULTITHREADED,
-        )
-    };
+    let cli = Cli::parse();
 
     // Best-effort: reap any orphaned DACL state files left behind by
-    // crashed prior MXC runs. Errors here are non-fatal and only surface
-    // via stderr.
+    // crashed prior MXC runs. Runs BEFORE the `--probe` arm because
+    // `wxc-exec --probe` is the canonical recovery trigger consumers
+    // (Win25H2Safe-Tests Phase 6, SDK warm-start) rely on. Errors here
+    // are non-fatal and only surface via stderr. On a healthy host
+    // with zero state files this is sub-millisecond.
     match wxc_common::filesystem_dacl::recover_orphaned_state() {
         Ok(report) => {
             if report.files_processed > 0 || !report.errors.is_empty() {
@@ -259,7 +407,65 @@ fn main() {
         Err(e) => eprintln!("DACL recovery failed: {e}"),
     }
 
-    let cli = Cli::parse();
+    // --probe is a detection-only fast path used by SDK
+    // `getPlatformSupport()` on every first call. It does not spawn a
+    // sandbox, never parks a DaclManager, and never calls into COM/WinRT.
+    // Run it AFTER recovery (so consumers that rely on `--probe`-as-
+    // reaper still get it) but BEFORE COM init / SetConsoleCtrlHandler
+    // (which probe doesn't need; deferring them shaves cold-start cost
+    // off the SDK warm path).
+    if cli.probe {
+        let policy = if let Some((data, is_b64)) = config_input(&cli) {
+            // Parse using the existing pipeline but route logger output to
+            // an in-memory buffer that we discard — the probe must not
+            // emit anything other than its JSON line on stdout.
+            let mut probe_logger = Logger::new(Mode::Buffer);
+            match load_request(&data, &mut probe_logger, is_b64) {
+                Ok(r) => r.policy,
+                Err(_) => {
+                    eprintln!("Error: failed to load probe config");
+                    eprint!("{}", probe_logger.get_buffer());
+                    process::exit(1);
+                }
+            }
+        } else {
+            wxc_common::models::ContainerPolicy::default()
+        };
+        let output = wxc_common::probe::run_probe(&policy);
+        match wxc_common::probe::to_json_pretty(&output) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("Error: probe serialization failed: {e}");
+                process::exit(1);
+            }
+        }
+        return;
+    }
+
+    // Initialize COM/WinRT for backends that use WinRT APIs (Isolation Session).
+    // COINIT_MULTITHREADED is benign for backends that don't use COM.
+    //
+    // SAFETY: `CoInitializeEx` is sound to call once at process start before
+    // any WinRT or COM activation. `pvReserved` must be `None` per the API
+    // contract. The return value is intentionally ignored — repeat-init
+    // outcomes (`S_FALSE`, `RPC_E_CHANGED_MODE`) are benign here.
+    let _ = unsafe {
+        windows::Win32::System::Com::CoInitializeEx(
+            None,
+            windows::Win32::System::Com::COINIT_MULTITHREADED,
+        )
+    };
+
+    // Install the Ctrl-C / Ctrl-Break handler that drops any parked
+    // DaclManager on signal. Cheap and idempotent.
+    install_dacl_ctrl_handler();
+
+    // Stack-owned witness so a panic anywhere below — between
+    // `park_dacl_for_cleanup` and the explicit `drop(take_parked_dacl())`
+    // near the end of `main` — still drains the slot and runs
+    // `restore()` during unwind. Without it the manager is parked in
+    // a static and unwinding skips destructors of static-owned values.
+    let _dacl_guard = ParkedDaclGuard;
 
     // --prepare-system-drive / --unprepare-system-drive: host DACL prep.
     // Modifies the DACL of the system drive root to grant the well-known
@@ -363,6 +569,9 @@ fn main() {
             process::exit(1);
         }
     }
+
+    // --probe is handled at the top of `main` (before COM init) for
+    // SDK first-call latency. See note there.
 
     // Determine config input and whether it's base64
     let (config_data, is_base64) = if let Some(ref b64) = cli.config_base64 {
@@ -500,30 +709,10 @@ fn main() {
         wxc_common::diagnostic::redacted_request_json(&request)
     );
 
-    // Drop-order contract — DO NOT REORDER, AND DO NOT ADD `process::exit`
-    // BETWEEN THIS DECLARATION AND THE EXPLICIT `drop(_dacl_guard)` LATER
-    // IN main() WITHOUT FIRST GOING THROUGH THAT DROP:
-    //
-    //   `_dacl_guard` is declared BEFORE `runner` so that, by Rust's
-    //   reverse-declaration destructor order, `runner` drops first (its
-    //   internal handles release the child) and the `DaclManager` Drop
-    //   runs afterwards, removing the host filesystem ACEs we applied.
-    //   Inverting the order would yank the ACEs while the child is still
-    //   running. The explicit `drop(runner); drop(_dacl_guard);` later
-    //   in main() is the `process::exit`-safe equivalent — `process::exit`
-    //   skips destructors, so any new exit added between dispatch and
-    //   that explicit drop must run `drop(_dacl_guard)` first or it will
-    //   leak ACEs permanently on the host filesystem.
-    //
-    //   Audit of exit sites at this commit: every `process::exit` after
-    //   `_dacl_guard = dispatched.dacl_manager;` is either (a) on the
-    //   dispatcher's `Err` arm where `_dacl_guard` is still `None`, or
-    //   (b) reached only after the explicit drops. Panic strategy is
-    //   `unwind` (default; no `panic = "abort"` in any `[profile.*]`),
-    //   so panics during `runner.run()` unwind through Drop and restore
-    //   ACEs naturally. If you change either invariant, this comment is
-    //   the place to update.
-    let mut _dacl_guard: Option<wxc_common::filesystem_dacl::DaclManager> = None;
+    // DaclManager parking for the BaseContainer/fallback path. Parked
+    // into a global slot (see `dacl_cleanup_slot`) so the Ctrl-C handler
+    // can drop it on signal as well as the normal-exit path below. The
+    // slot returns `None` if no DACL augmentation was required.
 
     // Run script in selected containment backend.
     // BaseContainer is used when --experimental is passed or schema version >= 0.5.
@@ -556,7 +745,7 @@ fn main() {
                 } else {
                     "--experimental".to_string()
                 };
-                let _ = writeln!(logger, "Using BaseContainer runner ({reason})");
+                let _ = writeln!(logger, "Using BaseContainer-fallback dispatcher ({reason})");
 
                 match wxc_common::dispatcher::dispatch_with_fallback(&request) {
                     Ok(dispatched) => {
@@ -569,11 +758,19 @@ fn main() {
                             dispatched.tier.as_str()
                         );
 
-                        _dacl_guard = dispatched.dacl_manager;
-                        dispatched.runner
+                        let (dispatched_runner, dacl_manager) = dispatched.into_runner_and_guard();
+                        if let Some(mgr) = dacl_manager {
+                            park_dacl_for_cleanup(mgr);
+                        }
+                        dispatched_runner
                     }
                     Err(e) => {
                         eprintln!("error: {e}");
+                        if let wxc_common::dispatcher::DispatchError::Dacl { warnings, .. } = &e {
+                            for w in warnings {
+                                eprintln!("  dacl warning: {w}");
+                            }
+                        }
                         eprint!("{}", logger.get_buffer());
                         process::exit(1);
                     }
@@ -698,13 +895,15 @@ fn main() {
     let run_elapsed = run_start.elapsed();
     let _ = writeln!(logger, "Runner completed in {}ms", run_elapsed.as_millis());
 
-    // Explicitly drop the runner before the DACL guard so any
-    // runner-internal resources holding child handles release first, then
-    // the DaclManager's Drop restores the host filesystem ACEs we applied.
-    // (process::exit below skips destructors, so we must do this manually
-    // for prompt cleanup on the normal path.)
+    // Explicitly drop the runner before retrieving the parked DACL
+    // manager so any runner-internal resources holding child handles
+    // release first; then drop the manager so its `restore()` runs.
+    // (process::exit below skips destructors, so we must do this
+    // manually for prompt cleanup on the normal path. The Ctrl-C
+    // handler covers the abnormal path; recover_orphaned_state on the
+    // next startup covers everything else.)
     drop(runner);
-    drop(_dacl_guard);
+    drop(take_parked_dacl());
 
     if cli.dry_run {
         handle_dry_run_exit(&response, &mut logger);

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -11,6 +11,12 @@ isolation_session = [
     "dep:windows-collections",
 ]
 microvm = ["dep:nanvix_common"]
+# Compile-time gate for Tier 2 (AppContainer + BFS via bfscfg.exe).
+# OFF by default: production wxc-exec cannot resolve or spawn bfscfg.exe,
+# and `fallback_detector::detect` naturally falls through T2 to T3 because
+# `find_bfscfg_exe` returns `Ok(None)`. Enable explicitly on hosts where
+# bfscfg.exe is known safe to invoke.
+tier2_bfs = []
 
 [dependencies]
 serde = { workspace = true }

--- a/src/wxc_common/src/dispatcher.rs
+++ b/src/wxc_common/src/dispatcher.rs
@@ -21,11 +21,21 @@
 //!
 //! See `docs/proposals/downlevel_support/basecontainer-fallback-plan-v2.md`.
 //!
+//! # Why T2 (BFS) also gets DACL deny augmentation
+//!
+//! `bfscfg.exe`'s BFS model expresses read-write / read-only allow lists,
+//! but does **not** model a deny semantic for paths *outside* its allow
+//! list (those are implicitly inaccessible, but a path that lives inside
+//! an allowed parent cannot be selectively denied via BFS). To honor
+//! `policy.denied_paths` on T2 we therefore add deny ACEs targeting the
+//! AppContainer SID alongside the BFS configuration.
+//!
 //! # Drop ordering
 //!
-//! Callers must keep the returned [`Dispatched::dacl_manager`] alive for the
-//! entire duration of the run — its [`Drop`] removes the ACEs we added to
-//! the host filesystem. Dropping it before the runner finishes would yank
+//! Callers must keep the [`DaclManager`] returned by
+//! [`Dispatched::into_runner_and_guard`] alive for the entire duration of
+//! the run — its [`Drop`] removes the ACEs we added to the host
+//! filesystem. Dropping it before the runner finishes would yank
 //! filesystem access mid-execution.
 //!
 //! # Performance
@@ -45,6 +55,15 @@
 //! invocation. Parent-directory ACE rollup and session-scoped
 //! [`DaclManager`] caching are tracked as follow-ups.
 //!
+//! # Known limitation
+//!
+//! Two concurrent runs with the *same* `container_id` derive the same
+//! AppContainer SID and therefore share the same target principal for
+//! ACE bookkeeping. When the second run finishes it issues
+//! `REVOKE_ACCESS` for that SID, which wipes the first run's still-live
+//! grants. This is out of scope for the dispatcher; callers that need
+//! parallel-safe isolation must use distinct `container_id` values.
+//!
 //! Windows-only by virtue of `lib.rs` gating the module behind
 //! `#[cfg(target_os = "windows")]`; no inner attribute is needed.
 
@@ -58,21 +77,55 @@ use crate::filesystem_dacl::{DaclError, DaclManager};
 use crate::models::CodexRequest;
 use crate::script_runner::ScriptRunner;
 
-/// Result of a successful dispatch decision.
+/// Result of a successful dispatch decision: a phased handle holding a
+/// runner and (optionally) a `DaclManager`, with **private fields** so
+/// callers cannot reorder their drops.
 ///
-/// The caller should bind `dacl_manager` to a local that outlives the
-/// runner so its `Drop` removes any ACEs we applied after the child
-/// process completes.
+/// This is *not* a compile-time typestate — there are no
+/// `PhantomData<State>` markers and `Dispatched<Ready>` /
+/// `Dispatched<Spawned>` do not exist. The safety property
+/// ("`DaclManager`'s `Drop` runs AFTER the runner has finished, or the
+/// ACEs we applied would be revoked mid-execution") is enforced
+/// dynamically by the single extraction point
+/// [`Dispatched::into_runner_and_guard`]: it returns a tuple whose
+/// binding order dictates drop order, and callers cannot `.take()`
+/// either half independently because the fields are private.
+///
+/// If you need stronger guarantees (e.g. statically rejecting
+/// `runner.drop()` before `dacl_manager` is taken at the FFI boundary),
+/// promote the struct to a real typestate machine. Today, the
+/// surface area we expose to wxc-exec / SDK doesn't need that.
 pub struct Dispatched {
-    /// Runner ready to execute.
-    pub runner: Box<dyn ScriptRunner>,
-    /// `DaclManager` whose `Drop` restores ACEs. `None` when the chosen
-    /// tier did not require host DACL augmentation.
-    pub dacl_manager: Option<DaclManager>,
+    runner: Box<dyn ScriptRunner>,
+    dacl_manager: Option<DaclManager>,
     /// The selected tier, for telemetry.
     pub tier: IsolationTier,
     /// Operator-visible warnings collected during tier selection.
     pub warnings: Vec<String>,
+}
+
+impl Dispatched {
+    /// Consume `self` and return `(runner, dacl_manager)`. Bind these
+    /// in a single `let` such that the runner is dropped before the
+    /// DACL guard — Rust drops local bindings in reverse declaration
+    /// order, so the standard idiom is:
+    ///
+    /// ```ignore
+    /// let (mut runner, _dacl_guard) = dispatched.into_runner_and_guard();
+    /// // ... use runner ...
+    /// // at end of scope: runner drops first, then _dacl_guard restores ACEs.
+    /// ```
+    pub fn into_runner_and_guard(self) -> (Box<dyn ScriptRunner>, Option<DaclManager>) {
+        (self.runner, self.dacl_manager)
+    }
+
+    /// Read-only check used by unit tests to assert whether the chosen
+    /// tier required DACL augmentation, without exposing the manager
+    /// itself (which would let tests `.take()` it).
+    #[cfg(test)]
+    pub(crate) fn has_dacl_guard(&self) -> bool {
+        self.dacl_manager.is_some()
+    }
 }
 
 /// Errors that can abort dispatch before the runner executes.
@@ -80,8 +133,16 @@ pub struct Dispatched {
 pub enum DispatchError {
     /// Fallback detection refused the request.
     Fallback(FallbackError),
-    /// `DaclManager` failed to apply ACEs.
-    Dacl(DaclError),
+    /// `DaclManager` failed to apply ACEs. `warnings` carries any
+    /// retained-entry messages drained from the manager before the
+    /// failed apply was rolled back via `restore()`. Entries that
+    /// `restore()` itself could not clean up are persisted to disk and
+    /// will be reaped on the next wxc-exec startup by
+    /// `recover_orphaned_state`.
+    Dacl {
+        error: DaclError,
+        warnings: Vec<String>,
+    },
     /// AppContainer SID derivation failed.
     Sid(WxcError),
 }
@@ -108,7 +169,7 @@ impl std::fmt::Display for DispatchError {
                 "Could not resolve the Windows system directory while probing for bfscfg.exe \
                  ({reason}). This indicates a corrupted or unsupported OS configuration."
             ),
-            DispatchError::Dacl(e) => write!(f, "Failed to apply DACL ACEs: {e}"),
+            DispatchError::Dacl { error, .. } => write!(f, "Failed to apply DACL ACEs: {error}"),
             DispatchError::Sid(e) => write!(f, "Failed to derive AppContainer SID: {e}"),
         }
     }
@@ -119,12 +180,6 @@ impl std::error::Error for DispatchError {}
 impl From<FallbackError> for DispatchError {
     fn from(e: FallbackError) -> Self {
         DispatchError::Fallback(e)
-    }
-}
-
-impl From<DaclError> for DispatchError {
-    fn from(e: DaclError) -> Self {
-        DispatchError::Dacl(e)
     }
 }
 
@@ -143,14 +198,97 @@ fn paths_to_pathbufs(paths: &[String]) -> Vec<PathBuf> {
     paths.iter().map(PathBuf::from).collect()
 }
 
+/// Access masks that mirror what
+/// `DaclManager::grant_appcontainer_access` stamps. Kept here (not
+/// imported from `fallback_detector`) because the filter is part of
+/// the dispatcher's apply-side contract; the detector has its own
+/// mirror that must match.
+const T3_RW_MASK: u32 = {
+    use windows::Win32::Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+    FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0
+};
+const T3_RO_MASK: u32 = {
+    use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+    FILE_GENERIC_READ.0
+};
+
+/// Drop paths that already grant `needed_mask` to the well-known
+/// AppContainer SIDs (`ALL APPLICATION PACKAGES`,
+/// `ALL RESTRICTED APPLICATION PACKAGES`, `Everyone`). Mirrors the
+/// same effective-access check that
+/// [`fallback_detector::appcontainer_already_grants`] performs for
+/// the `WRITE_DAC` precheck.
+fn filter_paths_needing_grant(paths: Vec<PathBuf>, needed_mask: u32) -> Vec<PathBuf> {
+    paths
+        .into_iter()
+        .filter(|p| !fallback_detector::appcontainer_already_grants(p, needed_mask))
+        .collect()
+}
+
+/// Wrap a `DaclError` together with any retained-entry warnings from the
+/// manager whose apply failed. Called immediately before `mgr` goes out
+/// of scope (which triggers `restore()` via Drop) so we capture the
+/// apply-time warnings, not whatever `restore()` itself accumulates
+/// while unwinding.
+fn dacl_err(mgr: &DaclManager, error: DaclError) -> DispatchError {
+    DispatchError::Dacl {
+        error,
+        warnings: mgr.warnings().to_vec(),
+    }
+}
+
+/// Build the deny-only DACL manager used by T1 and T2 when
+/// `denied_paths` is non-empty. Returns `Ok(None)` when no DACL work is
+/// required.
+fn build_deny_only_dacl(
+    sid: &str,
+    denied: &[PathBuf],
+) -> Result<Option<DaclManager>, DispatchError> {
+    if denied.is_empty() {
+        return Ok(None);
+    }
+    let mut mgr = DaclManager::new().map_err(|e| DispatchError::Dacl {
+        error: e,
+        warnings: Vec::new(),
+    })?;
+    if let Err(e) = mgr.add_deny_aces(sid, denied) {
+        return Err(dacl_err(&mgr, e));
+    }
+    Ok(Some(mgr))
+}
+
+/// Build the grant + (optional) deny DACL manager used by T3. T3 always
+/// returns a `DaclManager` because grants are mandatory; if grants
+/// succeed and deny fails, the manager's `Drop` rolls back the grants.
+fn build_t3_dacl(
+    sid: &str,
+    readwrite: &[PathBuf],
+    readonly: &[PathBuf],
+    denied: &[PathBuf],
+) -> Result<DaclManager, DispatchError> {
+    let mut mgr = DaclManager::new().map_err(|e| DispatchError::Dacl {
+        error: e,
+        warnings: Vec::new(),
+    })?;
+    if let Err(e) = mgr.grant_appcontainer_access(sid, readwrite, readonly) {
+        return Err(dacl_err(&mgr, e));
+    }
+    if !denied.is_empty() {
+        if let Err(e) = mgr.add_deny_aces(sid, denied) {
+            return Err(dacl_err(&mgr, e));
+        }
+    }
+    Ok(mgr)
+}
+
 /// Build a runner with appropriate DACL augmentation for the
 /// BaseContainer-preferred path. The caller is responsible for the explicit
 /// (no-fallback) AppContainer path.
 ///
 /// On success the returned [`Dispatched`] contains a runner ready to
 /// execute and (when applicable) a [`DaclManager`] that has already
-/// applied its ACEs. The caller MUST keep `dacl_manager` alive through the
-/// run.
+/// applied its ACEs. Use [`Dispatched::into_runner_and_guard`] to
+/// extract both; the manager MUST stay alive through the run.
 pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, DispatchError> {
     let decision = fallback_detector::detect(&request.policy, /*prefer_bc=*/ true)?;
 
@@ -171,17 +309,16 @@ pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, Disp
             // and only when `deniedPaths` is non-empty. Allocate the
             // path Vec and derive the SID inside that branch so the
             // common no-deny case skips both costs.
-            if request.policy.denied_paths.is_empty() {
+            let denied = paths_to_pathbufs(&request.policy.denied_paths);
+            if denied.is_empty() {
                 let runner: Box<dyn ScriptRunner> = Box::new(
                     AppContainerScriptRunner::with_filesystem_mode(FilesystemMode::Bfs),
                 );
                 (runner, None)
             } else {
-                let denied = paths_to_pathbufs(&request.policy.denied_paths);
                 let sid =
                     derive_sid_string(&container_name(request)).map_err(DispatchError::Sid)?;
-                let mut mgr = DaclManager::new()?;
-                mgr.add_deny_aces(&sid, &denied)?;
+                let mgr = build_deny_only_dacl(&sid, &denied)?;
                 // Hand the derived SID string to the runner so it does
                 // not re-run `ConvertSidToStringSidW` for the firewall
                 // principal-id lookup.
@@ -191,22 +328,34 @@ pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, Disp
                         sid,
                     ),
                 );
-                (runner, Some(mgr))
+                (runner, mgr)
             }
         }
         IsolationTier::AppContainerDacl => {
             // T3 always stamps grant ACEs (for readwrite/readonly paths)
             // and optionally deny ACEs. Allocate per-arm so T1/T2 don't
             // pay the cost.
-            let readwrite = paths_to_pathbufs(&request.policy.readwrite_paths);
-            let readonly = paths_to_pathbufs(&request.policy.readonly_paths);
+            //
+            // Skip per-run grant ACEs on paths where the well-known
+            // AppContainer SIDs already grant the equivalent access.
+            // `fallback_detector::detect` performs the same effective-
+            // access check up front so it can skip the `WRITE_DAC`
+            // requirement; this filter is the matching application
+            // side so we don't try (and fail) to stamp a redundant
+            // ACE on a system path the user doesn't own. Denied paths
+            // are not filtered — DENY ACEs are about subtracting
+            // access, which well-known group grants can't do.
+            let readwrite = filter_paths_needing_grant(
+                paths_to_pathbufs(&request.policy.readwrite_paths),
+                T3_RW_MASK,
+            );
+            let readonly = filter_paths_needing_grant(
+                paths_to_pathbufs(&request.policy.readonly_paths),
+                T3_RO_MASK,
+            );
             let denied = paths_to_pathbufs(&request.policy.denied_paths);
             let sid = derive_sid_string(&container_name(request)).map_err(DispatchError::Sid)?;
-            let mut mgr = DaclManager::new()?;
-            mgr.grant_appcontainer_access(&sid, &readwrite, &readonly)?;
-            if !denied.is_empty() {
-                mgr.add_deny_aces(&sid, &denied)?;
-            }
+            let mgr = build_t3_dacl(&sid, &readwrite, &readonly, &denied)?;
             let runner: Box<dyn ScriptRunner> = Box::new(
                 AppContainerScriptRunner::with_filesystem_mode_and_sid_string(
                     FilesystemMode::Dacl,
@@ -234,7 +383,7 @@ mod tests {
     // a dispatcher test and a fallback-detector test running on
     // different threads could each mutate `MXC_FORCE_TIER` under
     // independent locks and race.
-    use crate::test_env::ForceTierGuard;
+    use crate::test_env::{ForceTierGuard, ENV_LOCK};
 
     fn test_request(policy: ContainerPolicy) -> CodexRequest {
         CodexRequest {
@@ -268,7 +417,7 @@ mod tests {
         let d = dispatch_with_fallback(&req).expect("T1 dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));
         assert!(
-            d.dacl_manager.is_none(),
+            !d.has_dacl_guard(),
             "T1 with no denied_paths should not allocate DaclManager"
         );
     }
@@ -286,7 +435,7 @@ mod tests {
         let d = dispatch_with_fallback(&req).expect("T1+deny dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));
         assert!(
-            d.dacl_manager.is_none(),
+            !d.has_dacl_guard(),
             "T1 must not attach a DaclManager — BC handles deny natively"
         );
     }
@@ -297,7 +446,7 @@ mod tests {
         let req = test_request(policy);
         let d = dispatch_with_fallback(&req).expect("T2+deny dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
-        assert!(d.dacl_manager.is_some());
+        assert!(d.has_dacl_guard());
     }
     #[test]
     fn dispatch_t3_always_has_dacl() {
@@ -307,7 +456,7 @@ mod tests {
         let d = dispatch_with_fallback(&req).expect("T3 dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerDacl));
         assert!(
-            d.dacl_manager.is_some(),
+            d.has_dacl_guard(),
             "T3 always requires DaclManager (grants applied)"
         );
     }
@@ -322,24 +471,6 @@ mod tests {
             res,
             Err(DispatchError::Fallback(FallbackError::DaclFallbackDisabled))
         ));
-    }
-    #[test]
-    fn dispatch_warnings_propagated() {
-        // Forced decisions don't synthesize warnings, so trigger the real
-        // chain with an unrecognized force value: the detector ignores it
-        // and walks the probe chain, accumulating "BaseContainer API not
-        // present" or "bfscfg.exe not present" warnings as appropriate on
-        // the test machine.
-        let _g = ForceTierGuard::set("not-a-real-tier");
-        let req = test_request(empty_policy());
-        // We can't predict the tier on arbitrary CI hardware, so just
-        // assert dispatch returns a Dispatched whose warnings field is
-        // honored from the decision.
-        let d = dispatch_with_fallback(&req).expect("real chain on empty policy");
-        // Warnings vector is present (possibly empty if we got T1 on a
-        // BC-capable machine). Just assert it was forwarded from the
-        // decision — the type guarantees this.
-        let _ = d.warnings.len();
     }
 
     #[test]
@@ -359,17 +490,124 @@ mod tests {
         assert!(format!("{s}").contains("AppContainer SID"));
     }
 
+    /// `DispatchError::Dacl { error, warnings }` is the shape consumers
+    /// (SDK envelope, error formatters) depend on. Force an actual
+    /// apply failure by passing a non-existent path through
+    /// `build_deny_only_dacl` — `apply_one` -> `canonicalize_local`
+    /// fails with `io::Error` rooted at the missing path. The
+    /// resulting `DispatchError::Dacl` must:
+    ///   - be the `Dacl` variant (not `Fallback`),
+    ///   - carry a `warnings: Vec<String>` (its presence/empty-or-not
+    ///     is the documented contract; populated entries are added
+    ///     mid-multi-path runs),
+    ///   - format with a message that mentions the offending path
+    ///     via its inner `DaclError`.
     #[test]
-    fn dispatch_t1_runs_trivial_command_when_bc_present() {
+    fn dispatch_error_dacl_variant_shape_on_apply_failure() {
+        use crate::test_env::ScopedStateDir;
+        let _scope = ScopedStateDir::new();
+
+        // Construct a path that is guaranteed not to exist. Using a
+        // tempdir + unique suffix keeps the test resilient against
+        // any pre-existing junk in %TEMP%.
+        let nonexistent = std::env::temp_dir()
+            .join(format!("mxc-dispatcher-error-shape-{}", std::process::id()))
+            .join("does-not-exist");
+        let err = build_deny_only_dacl("S-1-1-0", std::slice::from_ref(&nonexistent))
+            .expect_err("non-existent path should fail apply");
+        match err {
+            DispatchError::Dacl { error, warnings } => {
+                // Shape contract: warnings is Vec<String> (possibly
+                // empty for a first-path apply failure). Every entry,
+                // when present, is non-empty.
+                for w in &warnings {
+                    assert!(!w.is_empty(), "warning entries must be non-empty");
+                }
+                // Inner error references the offending path. The
+                // canonicalize failure may surface as either
+                // `DaclError::Win32` or another path-bearing variant;
+                // both must serialize to a message mentioning the path.
+                let s = format!("{error}");
+                assert!(
+                    s.contains("does-not-exist"),
+                    "inner DaclError message should mention offending path: {s}"
+                );
+            }
+            other => panic!("expected DispatchError::Dacl, got: {other:?}"),
+        }
+    }
+
+    /// `filter_paths_needing_grant` is the per-path side of the
+    /// `ce7713d` optimization ("skip per-run ACE when AC SID already
+    /// has access"). Direct exercise: stamp an Everyone (S-1-1-0)
+    /// grant on a temp dir — Everyone is in every AppContainer
+    /// token's well-known-SID set — and assert
+    /// `filter_paths_needing_grant` drops the path. A tempdir without
+    /// any stamp must survive the filter because %TEMP%'s shadow
+    /// ACLs do not grant the well-known AC SIDs `T3_RW_MASK`.
+    #[test]
+    fn filter_paths_needing_grant_drops_well_known_grant() {
+        use crate::test_env::ScopedStateDir;
+        let _scope = ScopedStateDir::new();
+        let td_grant = tempfile::tempdir().expect("temp dir grant");
+        let td_no_grant = tempfile::tempdir().expect("temp dir no-grant");
+
+        // Stamp an Everyone grant on td_grant via `grant_appcontainer_access`
+        // and persist it for the duration of the test by holding the
+        // manager. Drop at end of scope rolls it back.
+        let mut mgr = crate::filesystem_dacl::DaclManager::new().expect("dacl mgr");
+        mgr.grant_appcontainer_access(
+            "S-1-1-0",
+            std::slice::from_ref(&td_grant.path().to_path_buf()),
+            &[],
+        )
+        .expect("grant");
+
+        let input = vec![
+            td_grant.path().to_path_buf(),
+            td_no_grant.path().to_path_buf(),
+        ];
+        let kept = filter_paths_needing_grant(input, T3_RW_MASK);
+        assert!(
+            !kept.iter().any(|p| p == td_grant.path()),
+            "grant-stamped path should be filtered out: kept={kept:?}"
+        );
+        assert!(
+            kept.iter().any(|p| p == td_no_grant.path()),
+            "non-stamped path should survive the filter: kept={kept:?}"
+        );
+
+        // Best-effort cleanup; Drop will also run restore().
+        mgr.restore().ok();
+    }
+
+    #[test]
+    fn dispatch_t1_naturally_selected_when_bc_present() {
         // Natural T1 selection (no force). Skip on systems where the
-        // BaseContainer API isn't present.
+        // BaseContainer API isn't present. The test asserts only that
+        // the dispatcher resolves to T1 — it does not actually exec
+        // because spinning up BC requires kernel support and fights
+        // the test runner's stdio capture.
+        //
+        // Acquire ENV_LOCK and clear MXC_FORCE_TIER for the duration of
+        // the test so a concurrent `ForceTierGuard`-using test (in this
+        // module or `fallback_detector::tests`) cannot leak a forced
+        // value into our natural-detection call. Without the lock the
+        // probe chain inside `detect` can observe a sibling test's
+        // `set_var("MXC_FORCE_TIER", ...)` and short-circuit to a
+        // non-T1 tier.
+        let _lock = {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
+            unsafe {
+                std::env::remove_var("MXC_FORCE_TIER");
+            }
+            lock
+        };
         if !crate::fallback_detector::is_base_container_api_present() {
             eprintln!("skipping: BaseContainer API not present on this machine");
             return;
         }
-        // Just exercise dispatcher construction; we don't actually exec
-        // here because spinning up BC requires kernel support and fights
-        // the test runner's stdio capture.
         let req = test_request(empty_policy());
         let d = dispatch_with_fallback(&req).expect("dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -196,19 +196,82 @@ pub fn detect(
 
     // Tier 3 — AppContainer + DACL
     ensure_dacl_augmentation_allowed(policy)?;
-    verify_write_dac_all(
-        policy
-            .readwrite_paths
-            .iter()
-            .chain(policy.readonly_paths.iter())
-            .chain(policy.denied_paths.iter()),
-    )?;
+    // For RW / RO paths we only need `WRITE_DAC` if we'd actually have
+    // to add an ACE. When the path's existing DACL already grants the
+    // needed mask to the well-known AppContainer SIDs (typically
+    // installer-set on system paths like `C:\Program Files\…`), the
+    // per-run ACE is redundant — skip both the grant and the
+    // `WRITE_DAC` requirement. See `ensure_path_grantable_for_ac`.
+    // Denied paths always require `WRITE_DAC` because well-known SID
+    // grants don't help us subtract access.
+    for p in &policy.readwrite_paths {
+        ensure_path_grantable_for_ac(Path::new(p), rw_mask())?;
+    }
+    for p in &policy.readonly_paths {
+        ensure_path_grantable_for_ac(Path::new(p), ro_mask())?;
+    }
+    verify_write_dac_all(&policy.denied_paths)?;
     Ok(TierDecision {
         tier: IsolationTier::AppContainerDacl,
         needs_dacl_augmentation: true,
         bfscfg_path: None,
         warnings,
     })
+}
+
+/// Access mask the dispatcher would grant for a `readwritePaths` entry.
+/// Must stay in sync with
+/// [`crate::filesystem_dacl::DaclManager::grant_appcontainer_access`].
+fn rw_mask() -> u32 {
+    use windows::Win32::Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE};
+    FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0
+}
+
+/// Access mask the dispatcher would grant for a `readonlyPaths` entry.
+/// Must stay in sync with the RO branch of
+/// [`crate::filesystem_dacl::DaclManager::grant_appcontainer_access`].
+fn ro_mask() -> u32 {
+    use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+    FILE_GENERIC_READ.0
+}
+
+/// Returns `Ok(true)` if a per-run ACE on `path` is unnecessary because
+/// the path's existing DACL already grants `needed_mask` (or a
+/// superset) to the well-known AppContainer SIDs that every
+/// AppContainer process inherits. See
+/// [`crate::filesystem_dacl::compute_appcontainer_effective_access`].
+///
+/// Always returns `Ok(false)` for paths that don't exist or that fail
+/// the DACL lookup — the caller will fall through to the `WRITE_DAC`
+/// check, which produces a path-specific error.
+pub(crate) fn appcontainer_already_grants(path: &Path, needed_mask: u32) -> bool {
+    match crate::filesystem_dacl::compute_appcontainer_effective_access(path) {
+        Ok(effective) => (effective & needed_mask) == needed_mask,
+        Err(_) => false,
+    }
+}
+
+/// Verify that we can either add an ACE on `path` or skip it because
+/// the AppContainer already has `needed_mask` access via well-known
+/// SIDs. Returns the same [`FallbackError::WriteDacUnavailable`] as
+/// the original blanket check when neither applies.
+///
+/// Order matters for typical-case cost: the WRITE_DAC check is a
+/// single `CreateFileW`, while `appcontainer_already_grants` does a
+/// full `GetNamedSecurityInfoW` + DACL walk + 3 SID allocations. For
+/// the common installer-stamped path that *does* grant WRITE_DAC to
+/// the current user (the case before `ce7713d`), trying WRITE_DAC
+/// first short-circuits before we touch the DACL walk.
+fn ensure_path_grantable_for_ac(path: &Path, needed_mask: u32) -> Result<(), FallbackError> {
+    match check_write_dac_path(path) {
+        Ok(()) => Ok(()),
+        // Only fall through to the expensive walk when WRITE_DAC is
+        // unavailable (the system-path / unowned-installer case that
+        // motivated `ce7713d`). Other errors (e.g. ERROR_FILE_NOT_FOUND)
+        // surface to the caller unchanged.
+        Err(_) if appcontainer_already_grants(path, needed_mask) => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 fn ensure_dacl_augmentation_allowed(policy: &ContainerPolicy) -> Result<(), FallbackError> {
@@ -283,7 +346,7 @@ fn forced_decision(
 /// Returns `true` when `processmodel.dll!Experimental_CreateProcessInSandbox`
 /// can be resolved — i.e. the BaseContainer (Tier 1) API is present on this
 /// machine.
-pub(crate) fn is_base_container_api_present() -> bool {
+pub fn is_base_container_api_present() -> bool {
     crate::base_container_runner::BaseContainerRunner::is_base_container_api_present().is_ok()
 }
 
@@ -295,18 +358,23 @@ pub(crate) fn is_base_container_api_present() -> bool {
 ///
 /// Resolution policy:
 ///
-/// - **Release builds** consult `GetWindowsDirectoryW` exclusively. The
-///   `SystemRoot` environment variable is deliberately ignored to deny
-///   an attacker who can scrub or rewrite the process environment a
-///   Tier 2 → Tier 3 downgrade primitive.
-/// - **Test builds** additionally honor `MXC_BFSCFG_PATH` as a narrow
-///   test seam. Its value is used verbatim as the resolved path; an
-///   empty value simulates "not present" by returning `Ok(None)`.
-///   Production `wxc-exec.exe` (both release and dev binaries) cannot
-///   read this variable at all — the seam is gated by `cfg(test)` so
-///   it compiles in only when building this crate's test binary,
-///   regardless of profile (so CI's `--profile release` test run
-///   exercises these paths).
+/// - **`tier2_bfs` feature OFF (default)** — returns `Ok(None)`
+///   unconditionally, before any disk or environment lookup. The
+///   detector's existing T2→T3 fallback then drops to Tier 3. This is
+///   the load-bearing safety guarantee: Tier 2 is compiled out, so no
+///   code path in this binary can resolve `bfscfg.exe`.
+/// - **`tier2_bfs` feature ON, release builds** consult
+///   `GetWindowsDirectoryW` exclusively. The `SystemRoot` environment
+///   variable is deliberately ignored to deny an attacker who can scrub
+///   or rewrite the process environment a Tier 2 → Tier 3 downgrade
+///   primitive.
+/// - **`tier2_bfs` feature ON, test builds** additionally honor
+///   `MXC_BFSCFG_PATH` as a narrow test seam. Its value is used
+///   verbatim as the resolved path; an empty value simulates "not
+///   present" by returning `Ok(None)`. The seam is gated by
+///   `cfg(test)` so it compiles in only when building this crate's
+///   test binary, regardless of profile (so CI's `--profile release`
+///   test run exercises these paths).
 /// - We deliberately do not look in `SysWOW64`: `bfscfg.exe` is shipped
 ///   only in the native System32 directory.
 ///
@@ -314,19 +382,26 @@ pub(crate) fn is_base_container_api_present() -> bool {
 /// Win32 API itself fails — on a healthy Windows host this should never
 /// happen.
 pub fn find_bfscfg_exe() -> Result<Option<PathBuf>, FallbackError> {
-    #[cfg(test)]
-    if let Ok(override_path) = std::env::var("MXC_BFSCFG_PATH") {
-        if override_path.is_empty() {
-            return Ok(None);
-        }
-        let p = PathBuf::from(override_path);
-        return Ok(if p.exists() { Some(p) } else { None });
+    #[cfg(not(feature = "tier2_bfs"))]
+    {
+        Ok(None)
     }
+    #[cfg(feature = "tier2_bfs")]
+    {
+        #[cfg(test)]
+        if let Ok(override_path) = std::env::var("MXC_BFSCFG_PATH") {
+            if override_path.is_empty() {
+                return Ok(None);
+            }
+            let p = PathBuf::from(override_path);
+            return Ok(if p.exists() { Some(p) } else { None });
+        }
 
-    let mut p = resolve_windows_directory()?;
-    p.push("System32");
-    p.push(crate::filesystem_bfs::BFSCFG_EXE);
-    Ok(if p.exists() { Some(p) } else { None })
+        let mut p = resolve_windows_directory()?;
+        p.push("System32");
+        p.push(crate::filesystem_bfs::BFSCFG_EXE);
+        Ok(if p.exists() { Some(p) } else { None })
+    }
 }
 
 /// Resolve the Windows install directory via `GetWindowsDirectoryW`.
@@ -334,6 +409,7 @@ pub fn find_bfscfg_exe() -> Result<Option<PathBuf>, FallbackError> {
 /// The OS populates the answer from boot configuration; it does not
 /// consult the process environment. Returns
 /// [`FallbackError::SystemRootUnresolved`] when the API itself fails.
+#[cfg(feature = "tier2_bfs")]
 fn resolve_windows_directory() -> Result<PathBuf, FallbackError> {
     use windows::Win32::System::SystemInformation::GetWindowsDirectoryW;
 
@@ -368,6 +444,7 @@ fn resolve_windows_directory() -> Result<PathBuf, FallbackError> {
     parse_utf16(&buf[..len])
 }
 
+#[cfg(feature = "tier2_bfs")]
 fn parse_utf16(slice: &[u16]) -> Result<PathBuf, FallbackError> {
     String::from_utf16(slice)
         .map(PathBuf::from)
@@ -457,7 +534,11 @@ mod tests {
     // honored uniformly across the dispatcher and fallback_detector
     // test modules. A per-module lock would let cross-module test
     // threads race on `MXC_FORCE_TIER` / `MXC_BFSCFG_PATH`.
-    use crate::test_env::{BfscfgPathGuard, ForceTierGuard, ENV_LOCK};
+    use crate::test_env::{ForceTierGuard, ENV_LOCK};
+    // `BfscfgPathGuard` is only meaningful when the `tier2_bfs` feature
+    // is compiled in; without it, `find_bfscfg_exe` ignores the env var.
+    #[cfg(feature = "tier2_bfs")]
+    use crate::test_env::BfscfgPathGuard;
 
     fn empty_policy() -> ContainerPolicy {
         ContainerPolicy::default()
@@ -568,6 +649,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn resolve_windows_directory_returns_existing_dir() {
         // `GetWindowsDirectoryW` always succeeds on any real Windows
@@ -581,6 +663,10 @@ mod tests {
         );
     }
 
+    // The `MXC_BFSCFG_PATH` test seam only takes effect when the
+    // `tier2_bfs` feature is enabled — without it, `find_bfscfg_exe`
+    // returns `Ok(None)` unconditionally and the override is dead.
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn mxc_bfscfg_path_empty_value_simulates_missing() {
         let _g = BfscfgPathGuard::set("");
@@ -590,6 +676,7 @@ mod tests {
             "empty MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn mxc_bfscfg_path_nonexistent_path_is_none() {
         let _g = BfscfgPathGuard::set("C:\\__mxc_does_not_exist__\\bfscfg.exe");
@@ -599,6 +686,7 @@ mod tests {
             "non-existent MXC_BFSCFG_PATH must yield Ok(None), got {result:?}"
         );
     }
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn mxc_bfscfg_path_existing_path_is_returned_verbatim() {
         // Use a file we know exists (this source file itself, via the
@@ -615,6 +703,19 @@ mod tests {
             result.as_deref(),
             Some(cmd_exe.as_path()),
             "MXC_BFSCFG_PATH must be returned verbatim when it exists"
+        );
+    }
+
+    /// With `tier2_bfs` off, `find_bfscfg_exe` must return `Ok(None)`
+    /// regardless of host state, `MXC_BFSCFG_PATH`, or anything else —
+    /// this is the load-bearing safety invariant.
+    #[cfg(not(feature = "tier2_bfs"))]
+    #[test]
+    fn find_bfscfg_exe_is_none_when_feature_off() {
+        let result = find_bfscfg_exe().expect("find_bfscfg_exe must not error with feature off");
+        assert!(
+            result.is_none(),
+            "find_bfscfg_exe must return None when tier2_bfs feature is off, got {result:?}"
         );
     }
 
@@ -651,5 +752,33 @@ mod tests {
             d.warnings.is_empty(),
             "forced decisions should not accumulate fallback-chain warnings"
         );
+    }
+
+    /// `appcontainer_already_grants` must return `false` on a plain
+    /// temp dir (no AC-group ACEs) and `true` after we stamp a
+    /// matching grant for `ALL APPLICATION PACKAGES`.
+    #[test]
+    fn appcontainer_already_grants_respects_explicit_grant() {
+        use crate::filesystem_dacl::DaclManager;
+        use crate::test_env::ScopedStateDir;
+        use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+
+        let _scope = ScopedStateDir::new();
+        let td = tempfile::tempdir().unwrap();
+        let mask = FILE_GENERIC_READ.0;
+
+        assert!(
+            !appcontainer_already_grants(td.path(), mask),
+            "fresh temp dir should not grant AC well-known SIDs"
+        );
+
+        let mut mgr = DaclManager::new().unwrap();
+        mgr.grant_appcontainer_access("S-1-15-2-1", &[], &[td.path().to_path_buf()])
+            .unwrap();
+        assert!(
+            appcontainer_already_grants(td.path(), mask),
+            "after explicit grant on ALL APPLICATION PACKAGES, AC should be covered"
+        );
+        // mgr.Drop restores, returning the path to its original state.
     }
 }

--- a/src/wxc_common/src/filesystem_bfs.rs
+++ b/src/wxc_common/src/filesystem_bfs.rs
@@ -6,10 +6,13 @@ use std::path::PathBuf;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::ContainerPolicy;
+#[cfg(feature = "tier2_bfs")]
 use crate::process_util;
 
+#[cfg(feature = "tier2_bfs")]
 pub(crate) const BFSCFG_EXE: &str = "bfscfg.exe";
 const UNABLE_TO_PERFORM: &str = "Unable to perform policy operation";
+#[cfg(feature = "tier2_bfs")]
 const BFSCFG_TIMEOUT_MS: u32 = 10_000;
 
 /// Manages the BFS (Brokered File System) policy for an AppContainer.
@@ -177,50 +180,66 @@ impl FileSystemBfsManager {
     }
 
     fn run_bfscfg(&self, args: &[&str]) -> Result<String, WxcError> {
-        // Resolved at probe time; `configure` errors before we get here
-        // when this is `None`. The `remove_configuration` path also
-        // requires it via `configured = true`, which only flips after a
-        // successful `configure` (i.e. after a successful resolve).
-        let bfscfg_path = self.bfscfg_path.as_ref().ok_or_else(|| {
-            WxcError::FilesystemPolicy(
-                "bfscfg.exe path not resolved; refusing to invoke by bare name".to_string(),
-            )
-        })?;
-        let bfscfg_path_str = bfscfg_path.to_str().ok_or_else(|| {
-            WxcError::FilesystemPolicy(format!(
-                "bfscfg.exe path is not valid UTF-8: {}",
-                bfscfg_path.display()
+        // Defence-in-depth gate. The primary safety guarantee is in
+        // `fallback_detector::find_bfscfg_exe`, which returns `Ok(None)`
+        // when the `tier2_bfs` feature is off — so `configure()` errors
+        // out before reaching this method. The gate here ensures no
+        // future caller can reach the spawn site without flipping the
+        // feature.
+        #[cfg(not(feature = "tier2_bfs"))]
+        {
+            let _ = (self, args);
+            Err(WxcError::FilesystemPolicy(
+                "bfscfg.exe invocation refused: tier2_bfs feature is not enabled".to_string(),
             ))
-        })?;
-        let cmd_line = build_bfscfg_cmd_line(bfscfg_path_str, args);
-
-        // Pass `lpApplicationName = Some(bfscfg_path_str)` so Windows
-        // loads exactly this binary, bypassing the executable search
-        // order. This is the security-critical half of the absolute-
-        // path execution policy; the command-line argv[0] is purely
-        // cosmetic for the child.
-        let output = process_util::run_process_with_captured_output(
-            Some(bfscfg_path_str),
-            &cmd_line,
-            BFSCFG_TIMEOUT_MS,
-        )?;
-
-        let stdout = output.stdout;
-        let stderr = output.stderr;
-
-        // Only include stderr if the process failed (non-zero exit code)
-        if output.exit_code != 0 {
-            let mut combined = stdout;
-            if !stderr.is_empty() {
-                if !combined.is_empty() {
-                    combined.push('\n');
-                }
-                combined.push_str(&stderr);
-            }
-            return Ok(combined);
         }
+        #[cfg(feature = "tier2_bfs")]
+        {
+            // Resolved at probe time; `configure` errors before we get here
+            // when this is `None`. The `remove_configuration` path also
+            // requires it via `configured = true`, which only flips after a
+            // successful `configure` (i.e. after a successful resolve).
+            let bfscfg_path = self.bfscfg_path.as_ref().ok_or_else(|| {
+                WxcError::FilesystemPolicy(
+                    "bfscfg.exe path not resolved; refusing to invoke by bare name".to_string(),
+                )
+            })?;
+            let bfscfg_path_str = bfscfg_path.to_str().ok_or_else(|| {
+                WxcError::FilesystemPolicy(format!(
+                    "bfscfg.exe path is not valid UTF-8: {}",
+                    bfscfg_path.display()
+                ))
+            })?;
+            let cmd_line = build_bfscfg_cmd_line(bfscfg_path_str, args);
 
-        Ok(stdout)
+            // Pass `lpApplicationName = Some(bfscfg_path_str)` so Windows
+            // loads exactly this binary, bypassing the executable search
+            // order. This is the security-critical half of the absolute-
+            // path execution policy; the command-line argv[0] is purely
+            // cosmetic for the child.
+            let output = process_util::run_process_with_captured_output(
+                Some(bfscfg_path_str),
+                &cmd_line,
+                BFSCFG_TIMEOUT_MS,
+            )?;
+
+            let stdout = output.stdout;
+            let stderr = output.stderr;
+
+            // Only include stderr if the process failed (non-zero exit code)
+            if output.exit_code != 0 {
+                let mut combined = stdout;
+                if !stderr.is_empty() {
+                    if !combined.is_empty() {
+                        combined.push('\n');
+                    }
+                    combined.push_str(&stderr);
+                }
+                return Ok(combined);
+            }
+
+            Ok(stdout)
+        }
     }
 }
 
@@ -239,6 +258,7 @@ fn test_for_root_path(path: &str) -> bool {
 // Note that `lpApplicationName` (passed separately to `CreateProcessW`) is the authoritative
 // source for *which* binary executes; this command line is only what the child sees as its
 // argv. We still include the full absolute path here for tools that scrape it from logs.
+#[cfg(feature = "tier2_bfs")]
 fn build_bfscfg_cmd_line(exe_path: &str, args: &[&str]) -> String {
     let mut cmd_line = if exe_path.contains(' ') {
         let escaped = if exe_path.ends_with('\\') {
@@ -289,6 +309,9 @@ mod tests {
         assert!(!mgr.configured());
     }
 
+    // `build_bfscfg_cmd_line` only exists when the `tier2_bfs` feature
+    // is compiled in; its tests must be gated the same way.
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn test_build_cmd_line_quotes_args_with_spaces() {
         let cmd = build_bfscfg_cmd_line(
@@ -307,6 +330,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn test_build_cmd_line_no_quotes_without_spaces() {
         let cmd = build_bfscfg_cmd_line(
@@ -326,6 +350,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn test_build_cmd_line_trailing_backslash() {
         let cmd = build_bfscfg_cmd_line(
@@ -346,6 +371,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn test_build_cmd_line_path_with_spaces_and_trailing_backslash() {
         let cmd = build_bfscfg_cmd_line(
@@ -365,6 +391,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "tier2_bfs")]
     #[test]
     fn test_build_cmd_line_quotes_exe_path_with_spaces() {
         // Unusual but legal: Windows installed under a path with spaces.

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -66,6 +66,7 @@ use std::io::{self, Write};
 use std::os::windows::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::ptr;
+use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
@@ -77,15 +78,16 @@ use windows::Win32::Foundation::{
 };
 use windows::Win32::Security::Authorization::{
     ConvertStringSidToSidW, GetNamedSecurityInfoW, SetEntriesInAclW, SetNamedSecurityInfoW,
-    EXPLICIT_ACCESS_W, GRANT_ACCESS, REVOKE_ACCESS, SE_FILE_OBJECT, TRUSTEE_IS_SID,
-    TRUSTEE_IS_UNKNOWN, TRUSTEE_W,
+    EXPLICIT_ACCESS_W, GRANT_ACCESS, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_UNKNOWN, TRUSTEE_W,
 };
 // DENY_ACCESS lives on ACCESS_MODE in windows 0.62
 use windows::Win32::Security::Authorization::DENY_ACCESS;
 use windows::Win32::Security::{
-    AclSizeInformation, EqualSid, GetAce, GetAclInformation, IsValidSid, ACCESS_ALLOWED_ACE,
-    ACCESS_DENIED_ACE, ACE_FLAGS, ACE_HEADER, ACL, ACL_SIZE_INFORMATION, CONTAINER_INHERIT_ACE,
-    DACL_SECURITY_INFORMATION, INHERITED_ACE, OBJECT_INHERIT_ACE, PSECURITY_DESCRIPTOR, PSID,
+    AclSizeInformation, AddAccessAllowedAceEx, AddAccessDeniedAceEx, AddAce, EqualSid, GetAce,
+    GetAclInformation, GetLengthSid, InitializeAcl, IsValidSid, ACCESS_ALLOWED_ACE,
+    ACCESS_DENIED_ACE, ACE_FLAGS, ACE_HEADER, ACL, ACL_REVISION, ACL_SIZE_INFORMATION,
+    CONTAINER_INHERIT_ACE, DACL_SECURITY_INFORMATION, INHERITED_ACE, OBJECT_INHERIT_ACE,
+    PSECURITY_DESCRIPTOR, PSID,
 };
 use windows::Win32::Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE};
 use windows::Win32::System::Threading::{
@@ -617,9 +619,46 @@ fn tmp_path_for(path: &Path) -> PathBuf {
 }
 
 fn read_state_file(path: &Path) -> Result<StateFile, DaclError> {
-    let bytes = fs::read(path)?;
-    serde_json::from_slice(&bytes)
-        .map_err(|e| DaclError::StateParse(format!("{}: {e}", path.display())))
+    // Retry on ERROR_SHARING_VIOLATION (Win32 32). A concurrent writer
+    // mid `<path>.tmp` → `<path>` rename briefly holds the destination
+    // open exclusively. Without retry the caller's parse-fallback path
+    // would quarantine a perfectly-good state file to `.corrupt`,
+    // permanently divorcing a live process from its real ACEs.
+    //
+    // ERROR_LOCK_VIOLATION (33) is also retried — antivirus on-access
+    // scanners sometimes surface it transiently when an unrelated
+    // process is still in the open-write-close window.
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const ERROR_LOCK_VIOLATION: i32 = 33;
+    const ATTEMPTS: u32 = 3;
+    let mut last_err: Option<io::Error> = None;
+    for i in 0..ATTEMPTS {
+        match fs::read(path) {
+            Ok(bytes) => {
+                return serde_json::from_slice(&bytes)
+                    .map_err(|e| DaclError::StateParse(format!("{}: {e}", path.display())));
+            }
+            Err(e) => {
+                let transient = matches!(
+                    e.raw_os_error(),
+                    Some(ERROR_SHARING_VIOLATION) | Some(ERROR_LOCK_VIOLATION)
+                );
+                if !transient {
+                    return Err(e.into());
+                }
+                last_err = Some(e);
+                if i + 1 < ATTEMPTS {
+                    // 20ms, 40ms — short enough to be invisible to
+                    // human-driven scenarios; long enough for a
+                    // typical rename to complete.
+                    std::thread::sleep(std::time::Duration::from_millis(20u64 << i));
+                }
+            }
+        }
+    }
+    Err(DaclError::StateIo(last_err.unwrap_or_else(|| {
+        io::Error::other("read_state_file: retries exhausted on transient error")
+    })))
 }
 
 fn generate_run_id() -> String {
@@ -763,6 +802,38 @@ impl Drop for OwnedSid {
             }
         }
     }
+}
+
+// SAFETY: `OwnedSid` wraps a `LocalAlloc`'d PSID whose underlying SID
+// bytes are immutable after `parse()` returns (`ConvertStringSidToSidW`
+// writes once, then we only ever read via `EqualSid` / `GetLengthSid`,
+// both of which are documented reentrant). The pointer is never aliased
+// to another writer. We use this purely for the process-lifetime SID
+// cache in [`well_known_ac_sids`]; a per-stack OwnedSid still moves
+// across thread boundaries safely because we never read past the
+// allocation.
+unsafe impl Send for OwnedSid {}
+unsafe impl Sync for OwnedSid {}
+
+/// Process-wide cache of the three well-known AppContainer-membership
+/// SIDs. `compute_appcontainer_effective_access` used to re-parse these
+/// from string form on every invocation — three `ConvertStringSidToSidW`
+/// + `LocalAlloc` + matching `LocalFree` per call.
+///
+/// The cache is read-only after first init; OnceLock guarantees the
+/// init closure runs exactly once. The cached `OwnedSid`s deliberately
+/// live for the process lifetime (no `Drop` ever runs on them) — the
+/// caller-side hot path becomes a pointer copy.
+fn well_known_ac_sids() -> &'static [OwnedSid] {
+    static CACHE: OnceLock<Vec<OwnedSid>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            WELL_KNOWN_AC_SIDS
+                .iter()
+                .map(|s| OwnedSid::parse(s).expect("well-known AC SID must parse"))
+                .collect()
+        })
+        .as_slice()
 }
 
 // -------------------------------------------------------------------------
@@ -1063,220 +1134,31 @@ pub(crate) fn revoke_specific_aces_for_sid(
         return Ok(0);
     }
 
-    let sid = OwnedSid::parse(sid_str)?;
-    let path_w = wide(path);
-    let object_name = PCWSTR(path_w.as_ptr());
-
-    let mut existing_dacl: *mut ACL = ptr::null_mut();
-    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
-    let rc = unsafe {
-        GetNamedSecurityInfoW(
-            object_name,
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
-            None,
-            None,
-            Some(&mut existing_dacl),
-            None,
-            &mut sd,
-        )
-    };
-    if rc != ERROR_SUCCESS {
-        return Err(win32_err(path, "GetNamedSecurityInfoW", rc));
-    }
-    if existing_dacl.is_null() {
-        unsafe {
-            let _ = LocalFree(Some(HLOCAL(sd.0)));
-        }
-        // Scan said there were matches; this would imply a TOCTOU
-        // where the DACL was cleared between scan and revoke. Either
-        // way our target state (no matching ACE) is already true.
-        return Ok(removed);
-    }
-
-    let trustee = trustee_for(&sid);
-    let mut batch: Vec<EXPLICIT_ACCESS_W> = Vec::with_capacity(keeps.len() + 1);
-    batch.push(EXPLICIT_ACCESS_W {
-        grfAccessPermissions: 0,
-        grfAccessMode: REVOKE_ACCESS,
-        grfInheritance: ACE_FLAGS(0),
-        Trustee: trustee,
-    });
-    for k in &keeps {
-        let mode = match k.ace_type {
-            AceType::Allow => GRANT_ACCESS,
-            AceType::Deny => DENY_ACCESS,
-        };
-        batch.push(EXPLICIT_ACCESS_W {
-            grfAccessPermissions: k.access_mask,
-            grfAccessMode: mode,
-            grfInheritance: ACE_FLAGS(k.inherit_flags as u32),
-            Trustee: trustee,
-        });
-    }
-
-    let mut new_dacl: *mut ACL = ptr::null_mut();
-    let rc = unsafe {
-        SetEntriesInAclW(
-            Some(&batch),
-            Some(existing_dacl as *const ACL),
-            &mut new_dacl,
-        )
-    };
-    if rc != ERROR_SUCCESS {
-        unsafe {
-            let _ = LocalFree(Some(HLOCAL(sd.0)));
-        }
-        return Err(win32_err(path, "SetEntriesInAclW", rc));
-    }
-
-    let rc = unsafe {
-        SetNamedSecurityInfoW(
-            object_name,
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
-            None,
-            None,
-            Some(new_dacl as *const ACL),
-            None,
-        )
-    };
-
-    unsafe {
-        if !new_dacl.is_null() {
-            let _ = LocalFree(Some(HLOCAL(new_dacl as *mut c_void)));
-        }
-        let _ = LocalFree(Some(HLOCAL(sd.0)));
-    }
-
-    if rc != ERROR_SUCCESS {
-        if rc.0 == 5 {
-            return Err(DaclError::WriteDacDenied {
-                path: path.to_path_buf(),
-                reason: format!("SetNamedSecurityInfoW: {rc:?}"),
-            });
-        }
-        return Err(win32_err(path, "SetNamedSecurityInfoW", rc));
-    }
-
+    // Delegate to the manual-rebuild helper. Same reason as
+    // `restore_one`: `SetEntriesInAclW(REVOKE_ACCESS)` doesn't
+    // reliably remove explicit DENY ACEs on Windows 11 25H2, so we
+    // rebuild the DACL by hand.
+    replace_explicit_aces_for_sid(path, sid_str, &keeps)?;
     Ok(removed)
 }
 
 /// Restore the target's DACL to its pre-apply state by:
 /// 1. acquiring the per-path mutex,
-/// 2. issuing a single `SetEntriesInAclW` call carrying
-///    `REVOKE_ACCESS` for our SID followed by one `GRANT_ACCESS` or
-///    `DENY_ACCESS` entry per captured [`PriorAce`].
+/// 2. delegating to [`replace_explicit_aces_for_sid`], which removes
+///    every explicit ACE for our SID and re-adds the captured prior
+///    entries.
 ///
-/// `REVOKE_ACCESS` strips **all** explicit ACEs (allow and deny) for
-/// the given trustee from the input DACL, which atomically removes
-/// our contribution regardless of whether it landed as a separate ACE
-/// or got merged into a pre-existing one. The subsequent
-/// `GRANT`/`DENY` entries replay the original explicit ACEs verbatim.
+/// We intentionally do **not** use `SetEntriesInAclW(REVOKE_ACCESS)`
+/// here — on Windows 11 25H2 it fails to remove explicit
+/// `ACCESS_DENIED` ACEs (see `deny_round_trip_leaves_no_residue`).
+/// Manual ACL surgery via [`replace_explicit_aces_for_sid`] is the
+/// reliable path.
 ///
 /// Returns `Ok(Some(warning))` for idempotent no-ops (e.g. the target
 /// had no DACL); `Ok(None)` on a fully applied restore.
 fn restore_one(entry: &AppliedAce) -> Result<Option<String>, DaclError> {
     let _guard = PathMutexGuard::acquire(&entry.canonical_path)?;
-    let sid = OwnedSid::parse(&entry.sid_string)?;
-
-    let path_w = wide(&entry.canonical_path);
-    let object_name = PCWSTR(path_w.as_ptr());
-
-    let mut existing_dacl: *mut ACL = ptr::null_mut();
-    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
-    let rc = unsafe {
-        GetNamedSecurityInfoW(
-            object_name,
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
-            None,
-            None,
-            Some(&mut existing_dacl),
-            None,
-            &mut sd,
-        )
-    };
-    if rc != ERROR_SUCCESS {
-        return Err(win32_err(
-            &entry.canonical_path,
-            "GetNamedSecurityInfoW",
-            rc,
-        ));
-    }
-    if existing_dacl.is_null() {
-        unsafe {
-            let _ = LocalFree(Some(HLOCAL(sd.0)));
-        }
-        return Ok(Some(format!(
-            "no DACL on {} during restore",
-            entry.canonical_path.display()
-        )));
-    }
-
-    // Build the EXPLICIT_ACCESS_W batch: REVOKE first, then regrant
-    // each prior entry. All share the same trustee.
-    let trustee = trustee_for(&sid);
-    let mut batch: Vec<EXPLICIT_ACCESS_W> = Vec::with_capacity(entry.prior_state.len() + 1);
-    batch.push(EXPLICIT_ACCESS_W {
-        grfAccessPermissions: 0,
-        grfAccessMode: REVOKE_ACCESS,
-        grfInheritance: ACE_FLAGS(0),
-        Trustee: trustee,
-    });
-    for prior in &entry.prior_state {
-        let mode = match prior.ace_type {
-            AceType::Allow => GRANT_ACCESS,
-            AceType::Deny => DENY_ACCESS,
-        };
-        batch.push(EXPLICIT_ACCESS_W {
-            grfAccessPermissions: prior.access_mask,
-            grfAccessMode: mode,
-            grfInheritance: ACE_FLAGS(prior.inherit_flags as u32),
-            Trustee: trustee,
-        });
-    }
-
-    let mut new_dacl: *mut ACL = ptr::null_mut();
-    let rc = unsafe {
-        SetEntriesInAclW(
-            Some(&batch),
-            Some(existing_dacl as *const ACL),
-            &mut new_dacl,
-        )
-    };
-    if rc != ERROR_SUCCESS {
-        unsafe {
-            let _ = LocalFree(Some(HLOCAL(sd.0)));
-        }
-        return Err(win32_err(&entry.canonical_path, "SetEntriesInAclW", rc));
-    }
-
-    let rc = unsafe {
-        SetNamedSecurityInfoW(
-            object_name,
-            SE_FILE_OBJECT,
-            DACL_SECURITY_INFORMATION,
-            None,
-            None,
-            Some(new_dacl as *const ACL),
-            None,
-        )
-    };
-    unsafe {
-        if !new_dacl.is_null() {
-            let _ = LocalFree(Some(HLOCAL(new_dacl as *mut c_void)));
-        }
-        let _ = LocalFree(Some(HLOCAL(sd.0)));
-    }
-
-    if rc != ERROR_SUCCESS {
-        return Err(win32_err(
-            &entry.canonical_path,
-            "SetNamedSecurityInfoW",
-            rc,
-        ));
-    }
+    replace_explicit_aces_for_sid(&entry.canonical_path, &entry.sid_string, &entry.prior_state)?;
     Ok(None)
 }
 
@@ -1373,6 +1255,393 @@ pub(crate) fn scan_explicit_aces_for_sid(
         let _ = LocalFree(Some(HLOCAL(sd.0)));
     }
     Ok(prior)
+}
+
+/// SIDs every AppContainer process token implicitly belongs to. A grant
+/// to any of these is observed by every AppContainer the OS launches.
+///
+/// - `S-1-15-2-1` — `APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES`.
+/// - `S-1-15-2-2` — `APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES`.
+/// - `S-1-1-0`    — `Everyone`. AppContainer tokens DO retain Everyone;
+///   they strip `Authenticated Users` and `Users`, so we deliberately
+///   omit those.
+const WELL_KNOWN_AC_SIDS: &[&str] = &["S-1-15-2-1", "S-1-15-2-2", "S-1-1-0"];
+
+/// Walk the effective DACL on `path` and compute the access mask granted
+/// to a process whose only relevant identities are the well-known
+/// AppContainer-membership SIDs (`ALL APPLICATION PACKAGES`,
+/// `ALL RESTRICTED APPLICATION PACKAGES`, and `Everyone`). Inherited
+/// ACEs are included; per-container explicit grants on a specific
+/// AppContainer SID are NOT — the caller is presumably deciding
+/// whether such a grant is needed.
+///
+/// Walking is canonical: a `DENY` ACE matching one of these SIDs marks
+/// bits as denied, and subsequent `ALLOW` ACEs can only add bits that
+/// haven't been denied. This matches Windows' own access check for the
+/// ALLOW path.
+///
+/// Returns 0 when the DACL is empty / NULL.
+pub(crate) fn compute_appcontainer_effective_access(path: &Path) -> Result<u32, DaclError> {
+    let well_known = well_known_ac_sids();
+
+    let path_w = wide(path);
+    let object_name = PCWSTR(path_w.as_ptr());
+    let mut dacl: *mut ACL = ptr::null_mut();
+    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    let rc = unsafe {
+        GetNamedSecurityInfoW(
+            object_name,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(&mut dacl),
+            None,
+            &mut sd,
+        )
+    };
+    if rc != ERROR_SUCCESS {
+        return Err(win32_err(path, "GetNamedSecurityInfoW", rc));
+    }
+    if dacl.is_null() {
+        // NULL DACL means full access for everyone, but per Microsoft
+        // guidance we treat that as "trust nothing about it" and return
+        // 0 — the caller will fall back to WRITE_DAC + apply.
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        return Ok(0);
+    }
+
+    let mut info = ACL_SIZE_INFORMATION::default();
+    let info_sz = std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32;
+    let scan_res = unsafe {
+        GetAclInformation(
+            dacl,
+            &mut info as *mut _ as *mut c_void,
+            info_sz,
+            AclSizeInformation,
+        )
+    };
+    if let Err(e) = scan_res {
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        return Err(win32_err_str(path, &format!("GetAclInformation: {e}")));
+    }
+
+    let mut allowed: u32 = 0;
+    let mut denied: u32 = 0;
+    for i in 0..info.AceCount {
+        let mut ace_ptr: *mut c_void = ptr::null_mut();
+        if unsafe { GetAce(dacl, i, &mut ace_ptr) }.is_err() {
+            continue;
+        }
+        let header = unsafe { &*(ace_ptr as *const ACE_HEADER) };
+        let ace_type = match header.AceType {
+            0x00 => AceType::Allow,
+            0x01 => AceType::Deny,
+            _ => continue, // ignore object/compound/audit ACEs
+        };
+        let mask_and_sid = ace_ptr as *const ACCESS_ALLOWED_ACE;
+        let ace_mask = unsafe { (*mask_and_sid).Mask };
+        let ace_sid = PSID(unsafe { &(*mask_and_sid).SidStart } as *const _ as *mut c_void);
+        let matches = well_known
+            .iter()
+            .any(|s| unsafe { EqualSid(ace_sid, s.as_psid()).is_ok() });
+        if !matches {
+            continue;
+        }
+        match ace_type {
+            AceType::Deny => {
+                // Bits this ACE denies that haven't been definitively
+                // allowed yet become "denied" for the rest of the walk.
+                denied |= ace_mask & !allowed;
+            }
+            AceType::Allow => {
+                // Bits this ACE allows that haven't been denied yet
+                // become "allowed" for the rest of the walk.
+                allowed |= ace_mask & !denied;
+            }
+        }
+    }
+    // Keep the import live (ACCESS_DENIED_ACE shares prefix with
+    // ACCESS_ALLOWED_ACE; we cast both via the latter).
+    let _ = std::mem::size_of::<ACCESS_DENIED_ACE>();
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+    Ok(allowed)
+}
+
+/// Rebuild `path`'s DACL by dropping every explicit ACE whose trustee
+/// is `sid_str`, then re-appending `replay` ACEs (also for `sid_str`)
+/// in canonical order. Inherited ACEs and explicit ACEs for other
+/// trustees are preserved verbatim.
+///
+/// This exists because `SetEntriesInAclW` with `REVOKE_ACCESS` on
+/// Windows 11 25H2 **fails to remove explicit ACCESS_DENIED ACEs**
+/// from the target DACL (see `deny_round_trip_leaves_no_residue`
+/// regression test). The documented behaviour (REVOKE removes all
+/// trustee ACEs) does not match observed behaviour. We work around
+/// it by building a fresh ACL via `InitializeAcl` + `AddAce`, which
+/// gives us deterministic control over what survives.
+fn replace_explicit_aces_for_sid(
+    path: &Path,
+    sid_str: &str,
+    replay: &[PriorAce],
+) -> Result<(), DaclError> {
+    let sid = OwnedSid::parse(sid_str)?;
+    let path_w = wide(path);
+    let object_name = PCWSTR(path_w.as_ptr());
+
+    let mut existing_dacl: *mut ACL = ptr::null_mut();
+    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    let rc = unsafe {
+        GetNamedSecurityInfoW(
+            object_name,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(&mut existing_dacl),
+            None,
+            &mut sd,
+        )
+    };
+    if rc != ERROR_SUCCESS {
+        return Err(win32_err(path, "GetNamedSecurityInfoW", rc));
+    }
+
+    let result = replace_explicit_aces_for_sid_inner(path, &sid, existing_dacl, replay);
+
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+    result.and_then(|new_acl_dwords| {
+        // `new_acl_dwords` is the freshly-built ACL buffer; we apply
+        // it via `SetNamedSecurityInfoW` outside the inner helper so
+        // the SD cleanup above can still run on the early-return path.
+        let new_acl_ptr = new_acl_dwords.as_ptr() as *const ACL;
+        let rc = unsafe {
+            SetNamedSecurityInfoW(
+                object_name,
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                Some(new_acl_ptr),
+                None,
+            )
+        };
+        if rc != ERROR_SUCCESS {
+            if rc.0 == 5 {
+                return Err(DaclError::WriteDacDenied {
+                    path: path.to_path_buf(),
+                    reason: format!("SetNamedSecurityInfoW: {rc:?}"),
+                });
+            }
+            return Err(win32_err(path, "SetNamedSecurityInfoW", rc));
+        }
+        Ok(())
+    })
+}
+
+/// Canonical-order bucket for an ACE. Smaller bucket = earlier slot
+/// in the rebuilt DACL. Per MS guidance (`AddAce` docs / "Order of
+/// ACEs in a DACL"):
+///   0 — explicit ACCESS_DENIED (type 0x01)
+///   1 — explicit ACCESS_ALLOWED (type 0x00)
+///   2 — explicit other (object ACEs, audit, etc.)
+///   3 — inherited (any type, in original order)
+fn canonical_bucket(ace_type: u8, inherited: bool) -> u8 {
+    if inherited {
+        3
+    } else {
+        match ace_type {
+            0x01 => 0,
+            0x00 => 1,
+            _ => 2,
+        }
+    }
+}
+
+/// The pure-rebuild half of [`replace_explicit_aces_for_sid`]:
+/// walks the existing DACL, filters explicit ACEs for our SID, adds
+/// replay ACEs, and returns a `Vec<u32>` whose bytes are the new ACL
+/// (Vec<u32> guarantees 4-byte alignment, which `InitializeAcl`
+/// requires). Returns an empty vec if there is no work and the
+/// caller can short-circuit.
+fn replace_explicit_aces_for_sid_inner(
+    path: &Path,
+    sid: &OwnedSid,
+    existing_dacl: *mut ACL,
+    replay: &[PriorAce],
+) -> Result<Vec<u32>, DaclError> {
+    // Entries we will emit into the rebuilt ACL. Either a verbatim
+    // copy of an existing ACE (`Kept`) or one of the `replay` slice
+    // entries materialized via `AddAccessAllowed/DeniedAceEx`.
+    // `bucket` is the canonical-order sort key (see `canonical_bucket`).
+    enum Entry<'a> {
+        Kept {
+            ptr: *mut c_void,
+            size: u32,
+            bucket: u8,
+            order: u32,
+        },
+        Replay {
+            prior: &'a PriorAce,
+            bucket: u8,
+            order: u32,
+        },
+    }
+
+    let mut entries: Vec<Entry> = Vec::new();
+    let mut keeps_bytes: u32 = 0;
+    let mut next_order: u32 = 0;
+
+    if !existing_dacl.is_null() {
+        let mut info = ACL_SIZE_INFORMATION::default();
+        let info_sz = std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32;
+        unsafe {
+            GetAclInformation(
+                existing_dacl,
+                &mut info as *mut _ as *mut c_void,
+                info_sz,
+                AclSizeInformation,
+            )
+            .map_err(|e| win32_err_str(path, &format!("GetAclInformation: {e}")))?;
+        }
+        let inherited_bit = INHERITED_ACE.0 as u8;
+        for i in 0..info.AceCount {
+            let mut ace_ptr: *mut c_void = ptr::null_mut();
+            if unsafe { GetAce(existing_dacl, i, &mut ace_ptr) }.is_err() {
+                continue;
+            }
+            let header = unsafe { &*(ace_ptr as *const ACE_HEADER) };
+            let inherited = (header.AceFlags & inherited_bit) != 0;
+            let mut drop_it = false;
+            if !inherited && (header.AceType == 0x00 || header.AceType == 0x01) {
+                // ACCESS_ALLOWED_ACE and ACCESS_DENIED_ACE share the
+                // mask/SID layout. The SID immediately follows the
+                // mask via the `SidStart` inline field.
+                let ace_struct = ace_ptr as *const ACCESS_ALLOWED_ACE;
+                let ace_sid = PSID(unsafe { &(*ace_struct).SidStart } as *const _ as *mut c_void);
+                if unsafe { EqualSid(ace_sid, sid.as_psid()).is_ok() } {
+                    drop_it = true;
+                }
+            }
+            if !drop_it {
+                entries.push(Entry::Kept {
+                    ptr: ace_ptr,
+                    size: header.AceSize as u32,
+                    bucket: canonical_bucket(header.AceType, inherited),
+                    order: next_order,
+                });
+                next_order += 1;
+                keeps_bytes += header.AceSize as u32;
+            }
+        }
+    }
+
+    // Replay ACEs are by construction explicit (non-inherited) — we
+    // only persist explicit prior ACEs for our SID. Bucket them as
+    // explicit-deny / explicit-allow accordingly.
+    for prior in replay {
+        let ace_type_byte = match prior.ace_type {
+            AceType::Allow => 0x00u8,
+            AceType::Deny => 0x01u8,
+        };
+        entries.push(Entry::Replay {
+            prior,
+            bucket: canonical_bucket(ace_type_byte, false),
+            order: next_order,
+        });
+        next_order += 1;
+    }
+
+    // Stable sort by (bucket, original order). Stability preserves the
+    // original DACL ordering inside each bucket so byte layout doesn't
+    // shuffle inherited or unrelated explicit ACEs.
+    entries.sort_by_key(|e| match e {
+        Entry::Kept { bucket, order, .. } | Entry::Replay { bucket, order, .. } => {
+            (*bucket, *order)
+        }
+    });
+
+    // Per-replay-ACE byte size: ACE_HEADER (4) + ACCESS_MASK (4) + SID
+    // bytes. `ACCESS_ALLOWED_ACE`'s `SidStart` field is a `u32`
+    // inline DWORD that's the first 4 bytes of the SID, so we add
+    // `GetLengthSid` to that — but we also include the inline DWORD
+    // size, then subtract the trailing padding. Simpler: ACE header
+    // is 4 bytes; mask is 4; SID is `GetLengthSid` bytes — total is
+    // 8 + GetLengthSid(sid).
+    let sid_len: u32 = unsafe { GetLengthSid(sid.as_psid()) };
+    let per_replay_size: u32 = 8 + sid_len;
+    let replay_bytes: u32 = per_replay_size.saturating_mul(replay.len() as u32);
+
+    let mut new_acl_size: u32 = std::mem::size_of::<ACL>() as u32 + keeps_bytes + replay_bytes;
+    // ACL must be DWORD-aligned and ACL_SIZE_INFORMATION reports
+    // sizes in multiples of `sizeof(DWORD)`. Round up to be safe.
+    new_acl_size = (new_acl_size + 3) & !3;
+    // InitializeAcl rejects a buffer too small to hold even an empty
+    // ACL header (the documented minimum is `sizeof(ACL)`). The
+    // arithmetic above already guarantees this, but the safety net
+    // is cheap.
+    let min_acl_size = std::mem::size_of::<ACL>() as u32;
+    if new_acl_size < min_acl_size {
+        new_acl_size = min_acl_size;
+    }
+
+    // Vec<u32> guarantees 4-byte alignment. The size we pass to
+    // InitializeAcl is in bytes.
+    let dwords = (new_acl_size as usize).div_ceil(4);
+    let mut new_acl_buf: Vec<u32> = vec![0u32; dwords];
+    let new_acl_ptr = new_acl_buf.as_mut_ptr() as *mut ACL;
+
+    unsafe {
+        InitializeAcl(new_acl_ptr, new_acl_size, ACL_REVISION)
+            .map_err(|e| win32_err_str(path, &format!("InitializeAcl: {e}")))?;
+    }
+
+    // Emit ACEs in canonical (bucket-sorted) order. Both `AddAce` and
+    // the typed `AddAccess{Allowed,Denied}AceEx` family append at the
+    // tail of the ACL (despite the latter's name, they do NOT
+    // canonicalize on insert), so we must drive the order ourselves.
+    for entry in &entries {
+        match entry {
+            Entry::Kept { ptr, size, .. } => unsafe {
+                AddAce(new_acl_ptr, ACL_REVISION, u32::MAX, *ptr, *size)
+                    .map_err(|e| win32_err_str(path, &format!("AddAce(keep): {e}")))?;
+            },
+            Entry::Replay { prior, .. } => {
+                let flags = ACE_FLAGS(prior.inherit_flags as u32);
+                let res = unsafe {
+                    match prior.ace_type {
+                        AceType::Allow => AddAccessAllowedAceEx(
+                            new_acl_ptr,
+                            ACL_REVISION,
+                            flags,
+                            prior.access_mask,
+                            sid.as_psid(),
+                        ),
+                        AceType::Deny => AddAccessDeniedAceEx(
+                            new_acl_ptr,
+                            ACL_REVISION,
+                            flags,
+                            prior.access_mask,
+                            sid.as_psid(),
+                        ),
+                    }
+                };
+                res.map_err(|e| {
+                    win32_err_str(path, &format!("AddAccess{:?}AceEx: {e}", prior.ace_type))
+                })?;
+            }
+        }
+    }
+
+    Ok(new_acl_buf)
 }
 
 fn win32_err(path: &Path, op: &str, rc: WIN32_ERROR) -> DaclError {
@@ -1789,6 +2058,258 @@ mod tests {
         assert!(m.applied.is_empty());
     }
 
+    /// Apply a DENY ACE to a temp directory, restore, and assert the
+    /// path's DACL has no residual explicit ACEs for our SID. This
+    /// Walk every ACE in `path`'s DACL (regardless of trustee), returning
+    /// `(ace_type_byte, inherited)` tuples in DACL order. Used by canonical-
+    /// order assertions; replicates just enough of the existing scan to
+    /// see all ACEs, not just our SID's.
+    fn collect_full_dacl_order(path: &Path) -> Vec<(u8, bool)> {
+        let path_w = wide(path);
+        let object_name = PCWSTR(path_w.as_ptr());
+        let mut dacl: *mut ACL = ptr::null_mut();
+        let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+        let rc = unsafe {
+            GetNamedSecurityInfoW(
+                object_name,
+                SE_FILE_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                Some(&mut dacl),
+                None,
+                &mut sd,
+            )
+        };
+        assert_eq!(rc, ERROR_SUCCESS, "GetNamedSecurityInfoW failed: {rc:?}");
+        let mut out: Vec<(u8, bool)> = Vec::new();
+        if !dacl.is_null() {
+            let mut info = ACL_SIZE_INFORMATION::default();
+            let info_sz = std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32;
+            unsafe {
+                GetAclInformation(
+                    dacl,
+                    &mut info as *mut _ as *mut c_void,
+                    info_sz,
+                    AclSizeInformation,
+                )
+                .expect("GetAclInformation");
+            }
+            let inherited_bit = INHERITED_ACE.0 as u8;
+            for i in 0..info.AceCount {
+                let mut ace_ptr: *mut c_void = ptr::null_mut();
+                if unsafe { GetAce(dacl, i, &mut ace_ptr) }.is_err() {
+                    continue;
+                }
+                let header = unsafe { &*(ace_ptr as *const ACE_HEADER) };
+                let inherited = (header.AceFlags & inherited_bit) != 0;
+                out.push((header.AceType, inherited));
+            }
+        }
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        out
+    }
+
+    /// Assert that `aces` (output of `collect_full_dacl_order`) is in
+    /// canonical order: no explicit ACE after any inherited ACE; no
+    /// explicit DENY (0x01) after any explicit ALLOW (0x00). Object/
+    /// audit ACEs (other AceType bytes) are tolerated but expected only
+    /// in the explicit-other bucket between explicit ALLOW and inherited.
+    fn assert_canonical_order(aces: &[(u8, bool)], label: &str) {
+        let mut saw_inherited = false;
+        let mut saw_explicit_allow = false;
+        for (i, (ty, inh)) in aces.iter().enumerate() {
+            if *inh {
+                saw_inherited = true;
+                continue;
+            }
+            assert!(
+                !saw_inherited,
+                "{label}: explicit ACE at index {i} appears AFTER an inherited ACE. order={aces:?}"
+            );
+            if *ty == 0x01 {
+                assert!(
+                    !saw_explicit_allow,
+                    "{label}: explicit DENY at index {i} appears AFTER an explicit ALLOW. order={aces:?}"
+                );
+            } else if *ty == 0x00 {
+                saw_explicit_allow = true;
+            }
+        }
+    }
+
+    /// Round-trip an explicit DENY through the surgical-ACL-rewrite
+    /// path and assert no residue (zero count drift) AND canonical
+    /// order at every observable step. Guards against:
+    ///   (1) `SetEntriesInAclW(REVOKE_ACCESS)` quirk on Windows 25H2
+    ///       where DENY ACEs survive a REVOKE; observed in the field
+    ///       via Win25H2Safe-Tests Phase 3 / Phase 4 "denied ACL
+    ///       restored" failures.
+    ///   (2) `replace_explicit_aces_for_sid_inner` emitting ACEs in
+    ///       non-canonical order, which Windows accepts but resolves
+    ///       per first-match — making a DENY-after-ALLOW silently
+    ///       resolve as ALLOW.
+    #[test]
+    fn deny_round_trip_leaves_no_residue() {
+        let _scope = ScopedStateDir::new();
+        let td = tempfile::tempdir().unwrap();
+        // Use a deterministic AppContainer-shaped SID so we can grep
+        // for it in the post-restore DACL. S-1-1-0 (Everyone) often
+        // appears via inheritance and would create false positives.
+        // S-1-15-2-1 (ALL APPLICATION PACKAGES) does NOT inherit
+        // onto a temp dir under %TEMP%, so any explicit ACE we see
+        // for it after restore is unambiguously residue from us.
+        let sid_str = "S-1-15-2-1";
+
+        // Capture the explicit-ACE count for `sid_str` before apply.
+        let before = scan_explicit_aces_for_sid(td.path(), sid_str).expect("scan before");
+        assert_canonical_order(&collect_full_dacl_order(td.path()), "before apply");
+
+        // First: apply an explicit ALLOW for our SID. This seeds the
+        // explicit-allow slot of the canonical layout.
+        let mut allow_mgr = DaclManager::new().unwrap();
+        allow_mgr
+            .grant_appcontainer_access(sid_str, std::slice::from_ref(&td.path().to_path_buf()), &[])
+            .unwrap();
+        assert_canonical_order(&collect_full_dacl_order(td.path()), "after ALLOW apply");
+
+        // Then: apply an explicit DENY for the same SID via a fresh
+        // manager. The DENY must land in the explicit-deny slot —
+        // BEFORE the existing explicit ALLOW — even though it's
+        // appended last by the rebuild logic. This is exactly the C1
+        // regression seam.
+        let mut deny_mgr = DaclManager::new().unwrap();
+        deny_mgr
+            .add_deny_aces(sid_str, std::slice::from_ref(&td.path().to_path_buf()))
+            .unwrap();
+        let mid_order = collect_full_dacl_order(td.path());
+        assert_canonical_order(&mid_order, "after DENY apply");
+
+        // After apply: at least one explicit ACE for our SID (the
+        // DENY and ALLOW we just added).
+        let mid = scan_explicit_aces_for_sid(td.path(), sid_str).expect("scan mid");
+        assert!(
+            mid.len() > before.len(),
+            "apply should have added explicit ACEs for {sid_str}: before={} mid={}",
+            before.len(),
+            mid.len()
+        );
+
+        // Restore in reverse order (last-in, first-out — what Drop
+        // would do).
+        deny_mgr.restore().unwrap();
+        assert!(deny_mgr.applied.is_empty());
+        assert_canonical_order(&collect_full_dacl_order(td.path()), "after DENY restore");
+
+        allow_mgr.restore().unwrap();
+        assert!(allow_mgr.applied.is_empty());
+
+        // After full restore: explicit-ACE count must match pre-apply
+        // and the DACL must still be canonical.
+        let after = scan_explicit_aces_for_sid(td.path(), sid_str).expect("scan after");
+        assert_eq!(
+            after.len(),
+            before.len(),
+            "restore left {} explicit ACEs for {sid_str} (expected {}). Residue: {after:?}",
+            after.len(),
+            before.len()
+        );
+        assert_canonical_order(&collect_full_dacl_order(td.path()), "after full restore");
+    }
+
+    /// Pre-load a tempdir with N>16 unrelated explicit ACEs (each for
+    /// a distinct AC-family SID), then run an explicit DENY for a
+    /// separate SID through the surgical rewrite path. Asserts:
+    ///   1. every seeded ACE is preserved (the kept-pass copies them
+    ///      verbatim via `AddAce`).
+    ///   2. canonical order is restored (the new DENY lands BEFORE
+    ///      all the unrelated ALLOWs even though it was appended last
+    ///      to the rebuild list — this is the C1 regression seam).
+    ///   3. restore unwinds the DENY without disturbing any seeded
+    ///      ACE.
+    ///
+    /// Uses N=20 to ensure we exercise multi-ACL byte arithmetic
+    /// beyond any small-N short-circuit in `replace_explicit_aces_for_sid_inner`.
+    #[test]
+    fn replace_explicit_aces_preserves_unrelated_and_canonicalizes() {
+        let _scope = ScopedStateDir::new();
+        let td = tempfile::tempdir().unwrap();
+
+        // Seed N distinct AC-family SIDs as ALLOW grants. The
+        // `S-1-15-2-N` family parses to a valid PSID whether or not
+        // any package on the host actually owns that SID; the DACL
+        // accepts them as explicit ALLOW ACEs.
+        const N: u32 = 20;
+        let mut seed_managers: Vec<DaclManager> = Vec::new();
+        for i in 100..(100 + N) {
+            let sid = format!("S-1-15-2-{i}");
+            let mut m = DaclManager::new().unwrap();
+            m.grant_appcontainer_access(&sid, std::slice::from_ref(&td.path().to_path_buf()), &[])
+                .unwrap();
+            seed_managers.push(m);
+        }
+
+        // Snapshot per-SID explicit-ACE counts (each should be 1).
+        let baseline: Vec<(String, usize)> = (100..(100 + N))
+            .map(|i| {
+                let sid = format!("S-1-15-2-{i}");
+                let c = scan_explicit_aces_for_sid(td.path(), &sid).unwrap().len();
+                (sid, c)
+            })
+            .collect();
+        for (sid, c) in &baseline {
+            assert_eq!(*c, 1, "seeded SID {sid} should have 1 explicit ACE");
+        }
+
+        // Apply a DENY for a SID that is NOT one of the seeded grants,
+        // routing through `replace_explicit_aces_for_sid_inner` with
+        // 20 explicit "keep" ACEs in the existing DACL.
+        let our_sid = "S-1-15-2-9999";
+        let mut deny_mgr = DaclManager::new().unwrap();
+        deny_mgr
+            .add_deny_aces(our_sid, std::slice::from_ref(&td.path().to_path_buf()))
+            .unwrap();
+
+        // 1 + 2: every seeded ACE preserved, canonical order holds.
+        let mid_order = collect_full_dacl_order(td.path());
+        assert_canonical_order(&mid_order, "after N=20 keep + 1 deny");
+        for (sid, c) in &baseline {
+            let after = scan_explicit_aces_for_sid(td.path(), sid).unwrap().len();
+            assert_eq!(
+                after, *c,
+                "unrelated SID {sid} lost ACEs through rewrite: before={c} after={after}"
+            );
+        }
+        let our_mid = scan_explicit_aces_for_sid(td.path(), our_sid).unwrap();
+        assert!(
+            our_mid.iter().any(|p| p.ace_type == AceType::Deny),
+            "our DENY should be present in the rewritten DACL"
+        );
+
+        // 3: restore unwinds without disturbing seeded ACEs.
+        deny_mgr.restore().unwrap();
+        assert!(deny_mgr.applied.is_empty());
+        assert_canonical_order(&collect_full_dacl_order(td.path()), "after restore");
+        for (sid, c) in &baseline {
+            let after = scan_explicit_aces_for_sid(td.path(), sid).unwrap().len();
+            assert_eq!(after, *c, "restore disturbed seeded SID {sid}");
+        }
+        let our_after = scan_explicit_aces_for_sid(td.path(), our_sid).unwrap();
+        assert!(
+            our_after.is_empty(),
+            "restore left residue for our SID: {our_after:?}"
+        );
+
+        // Clean up seeded grants (Drop would also do this, but
+        // explicit restore lets us catch any panic before the
+        // tempdir disappears).
+        for mut m in seed_managers.into_iter().rev() {
+            m.restore().ok();
+        }
+    }
+
     #[test]
     fn inheritance_propagation() {
         let _scope = ScopedStateDir::new();
@@ -1940,5 +2461,67 @@ mod tests {
                 "expected NetworkPathRejected | PathNotFound | Win32 for UNC path, got: {other:?}"
             ),
         }
+    }
+
+    /// A fresh temp dir has only user / SYSTEM / admin ACEs — none for
+    /// the well-known AppContainer SIDs — so the effective AC access
+    /// must be exactly 0.
+    #[test]
+    fn effective_ac_access_empty_on_plain_temp_dir() {
+        let td = tempfile::tempdir().unwrap();
+        let access = compute_appcontainer_effective_access(td.path())
+            .expect("effective access should not error on a normal temp dir");
+        assert_eq!(
+            access, 0,
+            "fresh temp dir should have no AC-group grants, got mask 0x{access:08x}"
+        );
+    }
+
+    /// Stamp an explicit grant for `ALL APPLICATION PACKAGES`
+    /// (S-1-15-2-1) on a temp dir, then verify the effective-access
+    /// computation surfaces exactly that grant. Restores via the
+    /// `DaclManager` Drop.
+    #[test]
+    fn effective_ac_access_picks_up_explicit_all_app_packages_grant() {
+        let _scope = ScopedStateDir::new();
+        let td = tempfile::tempdir().unwrap();
+        let mask = FILE_GENERIC_READ.0; // RO grant; what installers typically stamp
+        {
+            let mut m = DaclManager::new().unwrap();
+            m.grant_appcontainer_access("S-1-15-2-1", &[], &[td.path().to_path_buf()])
+                .unwrap();
+            let observed = compute_appcontainer_effective_access(td.path())
+                .expect("effective access should not error after grant");
+            assert!(
+                observed & mask == mask,
+                "expected effective mask to cover at least 0x{mask:08x}, got 0x{observed:08x}"
+            );
+            // Restore happens on drop.
+        }
+        // After restore: back to zero.
+        let post = compute_appcontainer_effective_access(td.path())
+            .expect("effective access after restore");
+        assert_eq!(post, 0, "DaclManager Drop should have removed the ACE");
+    }
+
+    /// `S-1-5-32-545` (BUILTIN\Users) is not one of the SIDs every
+    /// AppContainer token belongs to, so a grant to Users must NOT
+    /// inflate the AppContainer's effective access.
+    #[test]
+    fn effective_ac_access_ignores_unrelated_sid_grants() {
+        let _scope = ScopedStateDir::new();
+        let td = tempfile::tempdir().unwrap();
+        // Adding via DaclManager requires write-DAC, which we have on a
+        // freshly-created temp dir. BUILTIN\Users (S-1-5-32-545) is on
+        // most user-owned paths anyway, but we set it explicitly so the
+        // test is robust to host-specific ACL layouts.
+        let mut m = DaclManager::new().unwrap();
+        m.grant_appcontainer_access("S-1-5-32-545", &[td.path().to_path_buf()], &[])
+            .unwrap();
+        let observed = compute_appcontainer_effective_access(td.path()).unwrap();
+        assert_eq!(
+            observed, 0,
+            "BUILTIN\\Users grant should not affect AC effective access, got 0x{observed:08x}"
+        );
     }
 }

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -39,6 +39,8 @@ pub mod job_object;
 #[cfg(target_os = "windows")]
 pub mod network_manager;
 #[cfg(target_os = "windows")]
+pub mod probe;
+#[cfg(target_os = "windows")]
 pub mod process_mitigation;
 #[cfg(target_os = "windows")]
 pub mod process_util;

--- a/src/wxc_common/src/probe.rs
+++ b/src/wxc_common/src/probe.rs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Read-only fallback-detector probe.
+//!
+//! This module wraps [`crate::fallback_detector`] in a serde-friendly
+//! surface so the SDK can invoke `wxc-exec --probe` and learn which
+//! isolation tier would be selected on the current machine without
+//! actually spawning a sandbox.
+//!
+//! The probe must have no side effects: it does not write logs, modify
+//! the filesystem, or spawn child processes.
+
+use serde::Serialize;
+
+use crate::fallback_detector::{self, FallbackError};
+use crate::models::ContainerPolicy;
+
+/// JSON output emitted by `wxc-exec --probe`.
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeOutput {
+    /// Selected tier (omitted when the detector returned an error).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<&'static str>,
+    /// True when the selected tier needs DACL deny-augmentation on host
+    /// paths. Omitted when the detector returned an error.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub needs_dacl_augmentation: Option<bool>,
+    /// Operator-visible degradation warnings — one per tier fall-through.
+    pub warnings: Vec<String>,
+    /// Raw machine probes, independent of the policy argument.
+    pub probes: ProbeFacts,
+    /// Detector error message (only set when detection failed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Raw machine facts gathered prior to running tier selection.
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeFacts {
+    /// `Experimental_CreateProcessInSandbox` is resolvable.
+    pub base_container_api_present: bool,
+    /// `bfscfg.exe` is on disk in `%SystemRoot%\System32`.
+    ///
+    /// Always `false` when [`Self::bfs_compiled_in`] is `false`, because
+    /// `find_bfscfg_exe` returns `Ok(None)` unconditionally with the
+    /// `tier2_bfs` feature off — i.e. this field reports what the
+    /// detector itself would see, not what is on disk.
+    pub bfscfg_present: bool,
+    /// Whether this binary was compiled with the `tier2_bfs` Cargo
+    /// feature. When `false`, Tier 2 (AppContainer + BFS) is
+    /// unreachable: the detector falls through to Tier 3 on any host
+    /// that would otherwise select T2, and the `bfscfg.exe` spawn site
+    /// is itself gated. Harnesses on hang-prone hosts (e.g. Windows
+    /// 11 25H2 where `bfscfg.exe` locks `bfs.sys`) should refuse to
+    /// run a binary that reports `true` here.
+    pub bfs_compiled_in: bool,
+}
+
+/// Run the fallback detector against `policy` and return a JSON-shaped
+/// summary. The detector is always asked to prefer BaseContainer (Tier 1).
+pub fn run_probe(policy: &ContainerPolicy) -> ProbeOutput {
+    let probes = ProbeFacts {
+        base_container_api_present: fallback_detector::is_base_container_api_present(),
+        bfscfg_present: fallback_detector::find_bfscfg_exe()
+            .ok()
+            .flatten()
+            .is_some(),
+        bfs_compiled_in: cfg!(feature = "tier2_bfs"),
+    };
+    match fallback_detector::detect(policy, /* prefer_base_container */ true) {
+        Ok(decision) => ProbeOutput {
+            tier: Some(decision.tier.as_str()),
+            needs_dacl_augmentation: Some(decision.needs_dacl_augmentation),
+            warnings: decision.warnings,
+            probes,
+            error: None,
+        },
+        Err(e) => ProbeOutput {
+            tier: None,
+            needs_dacl_augmentation: None,
+            warnings: vec![],
+            probes,
+            error: Some(format_fallback_error(&e)),
+        },
+    }
+}
+
+fn format_fallback_error(e: &FallbackError) -> String {
+    match e {
+        FallbackError::DaclFallbackDisabled => {
+            "DACL fallback required but fallback.allowDaclMutation is false".to_string()
+        }
+        FallbackError::WriteDacUnavailable { path, reason } => {
+            format!("WRITE_DAC unavailable on path {}: {reason}", path.display())
+        }
+        FallbackError::SystemRootUnresolved { reason } => {
+            format!("Could not resolve Windows system directory: {reason}")
+        }
+    }
+}
+
+/// Serialize a [`ProbeOutput`] as pretty-printed JSON.
+///
+/// Returns `Err` only if the underlying serializer fails — in practice
+/// this should be infallible for the well-formed `ProbeOutput` we
+/// produce, but we surface the error rather than panic.
+pub fn to_json_pretty(output: &ProbeOutput) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fallback_detector::IsolationTier;
+    use crate::test_env::ForceTierGuard;
+
+    #[test]
+    fn probe_output_serializes() {
+        let out = ProbeOutput {
+            tier: Some("base-container"),
+            needs_dacl_augmentation: Some(false),
+            warnings: vec!["a warning".to_string()],
+            probes: ProbeFacts {
+                base_container_api_present: true,
+                bfscfg_present: false,
+                bfs_compiled_in: false,
+            },
+            error: None,
+        };
+        let json = serde_json::to_string(&out).expect("serialize");
+        let v: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_eq!(v["tier"], "base-container");
+        assert_eq!(v["needsDaclAugmentation"], false);
+        assert_eq!(v["warnings"][0], "a warning");
+        assert_eq!(v["probes"]["baseContainerApiPresent"], true);
+        assert_eq!(v["probes"]["bfscfgPresent"], false);
+        assert_eq!(v["probes"]["bfsCompiledIn"], false);
+        assert!(v.get("error").is_none());
+    }
+
+    #[test]
+    fn tier_strings_stable() {
+        assert_eq!(IsolationTier::BaseContainer.as_str(), "base-container");
+        assert_eq!(IsolationTier::AppContainerBfs.as_str(), "appcontainer-bfs");
+        assert_eq!(
+            IsolationTier::AppContainerDacl.as_str(),
+            "appcontainer-dacl"
+        );
+    }
+
+    #[test]
+    fn run_probe_with_force_tier() {
+        let _g = ForceTierGuard::set("appcontainer-bfs");
+        let policy = ContainerPolicy::default();
+        let out = run_probe(&policy);
+        assert_eq!(out.tier, Some("appcontainer-bfs"));
+        assert_eq!(out.needs_dacl_augmentation, Some(false));
+        assert!(out.error.is_none());
+    }
+
+    #[test]
+    fn run_probe_handles_dacl_disabled_error() {
+        let _g = ForceTierGuard::set("appcontainer-dacl");
+        let mut policy = ContainerPolicy::default();
+        policy.fallback.allow_dacl_mutation = false;
+        let out = run_probe(&policy);
+        assert!(out.tier.is_none());
+        assert!(out.needs_dacl_augmentation.is_none());
+        assert!(out.error.is_some());
+        let msg = out.error.unwrap();
+        assert!(
+            msg.contains("DACL fallback"),
+            "expected DACL fallback message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn omitted_fields_when_error() {
+        let _g = ForceTierGuard::set("appcontainer-dacl");
+        let mut policy = ContainerPolicy::default();
+        policy.fallback.allow_dacl_mutation = false;
+        let out = run_probe(&policy);
+        let v = serde_json::to_value(&out).expect("to_value");
+        let obj = v.as_object().expect("object");
+        assert!(
+            !obj.contains_key("tier"),
+            "tier key should be absent on error, got: {v}"
+        );
+        assert!(
+            !obj.contains_key("needsDaclAugmentation"),
+            "needsDaclAugmentation key should be absent on error, got: {v}"
+        );
+        assert!(obj.contains_key("error"));
+        assert!(obj.contains_key("warnings"));
+        assert!(obj.contains_key("probes"));
+    }
+}

--- a/src/wxc_common/src/test_env.rs
+++ b/src/wxc_common/src/test_env.rs
@@ -66,10 +66,18 @@ impl Drop for ForceTierGuard {
 }
 
 /// RAII guard for `MXC_BFSCFG_PATH`, mirroring [`ForceTierGuard`].
+///
+/// Only compiled in under the `tier2_bfs` feature, because the
+/// `MXC_BFSCFG_PATH` test seam in `fallback_detector::find_bfscfg_exe`
+/// is itself feature-gated — without `tier2_bfs`, `find_bfscfg_exe`
+/// returns `Ok(None)` unconditionally and setting the env var would
+/// have no observable effect.
+#[cfg(feature = "tier2_bfs")]
 pub(crate) struct BfscfgPathGuard {
     _lock: MutexGuard<'static, ()>,
 }
 
+#[cfg(feature = "tier2_bfs")]
 impl BfscfgPathGuard {
     pub(crate) fn set(value: &str) -> Self {
         let guard = lock();
@@ -81,6 +89,7 @@ impl BfscfgPathGuard {
     }
 }
 
+#[cfg(feature = "tier2_bfs")]
 impl Drop for BfscfgPathGuard {
     fn drop(&mut self) {
         // SAFETY: see ForceTierGuard::drop.

--- a/src/wxc_ui_probe/Cargo.toml
+++ b/src/wxc_ui_probe/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wxc_ui_probe"
+version = "0.1.0"
+edition.workspace = true
+
+[[bin]]
+name = "wxc-ui-probe"
+path = "src/main.rs"

--- a/src/wxc_ui_probe/src/main.rs
+++ b/src/wxc_ui_probe/src/main.rs
@@ -1,0 +1,505 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! In-sandbox UI mitigation probe.
+//!
+//! Reports `TAG=PASS` when the corresponding `JOB_OBJECT_UILIMIT_*` bit
+//! (or Win32k mitigation) actually blocks the operation it documents,
+//! `TAG=FAIL` when the operation succeeded, and an additional
+//! `TAG=DIAG <reason>` line when the failure mode was unexpected.
+//!
+//! Critical: `user32.dll` is loaded at runtime via `LoadLibraryW` so the
+//! Win32k syscall-disable mitigation does not kill this process at loader
+//! resolution time. `kernel32` calls are safe to static-link.
+
+use std::env;
+use std::ffi::c_void;
+use std::iter;
+
+type Bool = i32;
+type Dword = u32;
+type Hwnd = *mut c_void;
+type Hmodule = *mut c_void;
+type Hglobal = *mut c_void;
+type Hdesk = *mut c_void;
+type Atom = u16;
+type FarProc = *const c_void;
+type LpcWstr = *const u16;
+type LpVoid = *mut c_void;
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct Msg {
+    hwnd: Hwnd,
+    message: u32,
+    w_param: usize,
+    l_param: isize,
+    time: u32,
+    pt: Point,
+    private: u32,
+}
+
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct SecurityAttributes {
+    n_length: Dword,
+    lp_security_descriptor: LpVoid,
+    b_inherit_handle: Bool,
+}
+
+const CF_TEXT: u32 = 1;
+const SPI_SETMOUSESPEED: u32 = 0x0071;
+const SPIF_SENDCHANGE: u32 = 0x0002;
+const EWX_LOGOFF: u32 = 0x00000000;
+const EWX_FORCEIFHUNG: u32 = 0x00000010;
+const DESKTOP_CREATEWINDOW: u32 = 0x0002;
+const GENERIC_ALL: u32 = 0x10000000;
+
+extern "system" {
+    fn LoadLibraryW(name: LpcWstr) -> Hmodule;
+    fn GetProcAddress(module: Hmodule, name: *const u8) -> FarProc;
+    fn GlobalAddAtomW(name: LpcWstr) -> Atom;
+    fn GlobalDeleteAtom(atom: Atom) -> Atom;
+    fn GetLastError() -> Dword;
+}
+
+fn to_wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(iter::once(0)).collect()
+}
+
+fn load_user32() -> Option<Hmodule> {
+    let wide = to_wide("user32.dll");
+    let h = unsafe { LoadLibraryW(wide.as_ptr()) };
+    if h.is_null() {
+        None
+    } else {
+        Some(h)
+    }
+}
+
+fn get_proc(module: Hmodule, name: &str) -> Option<FarProc> {
+    let mut bytes: Vec<u8> = name.bytes().collect();
+    bytes.push(0);
+    let p = unsafe { GetProcAddress(module, bytes.as_ptr()) };
+    if p.is_null() {
+        None
+    } else {
+        Some(p)
+    }
+}
+
+fn emit_pass(tag: &str) {
+    println!("{}=PASS", tag);
+}
+
+/// Gate on potentially destructive probes (EXITWINDOWS, WIN32K). A
+/// developer running `wxc-ui-probe EXITWINDOWS` directly on an
+/// interactive desktop — without the explicit override — would
+/// otherwise attempt to log out the user session.
+///
+/// The gate is an env-var allow-list rather than `IsAppContainerProcess`
+/// auto-detection: there is no documented kernel32 export with that
+/// name (the supported AC-detection API is
+/// `GetTokenInformation(TokenIsAppContainer)`, which would pull in
+/// advapi32 and re-open the Win32k-loader-resolution concern the
+/// rest of this binary deliberately defers). Harnesses that legitimately
+/// invoke destructive probes (the AppContainer wxc-exec sandbox) must
+/// set `MXC_PROBE_DESTRUCTIVE_OK=1` in the child's environment.
+fn destructive_probe_allowed() -> bool {
+    matches!(env::var("MXC_PROBE_DESTRUCTIVE_OK").as_deref(), Ok("1"))
+}
+
+fn refuse_destructive(tag: &str) {
+    emit_diag(
+        tag,
+        "refused: MXC_PROBE_DESTRUCTIVE_OK!=1 (set =1 to allow inside a sandbox)",
+    );
+    emit_fail(tag);
+}
+
+fn emit_fail(tag: &str) {
+    println!("{}=FAIL", tag);
+}
+
+fn emit_diag(tag: &str, reason: &str) {
+    println!("{}=DIAG {}", tag, reason);
+}
+
+fn probe_globalatoms() {
+    let wide = to_wide("MxcUiProbeAtom");
+    let atom = unsafe { GlobalAddAtomW(wide.as_ptr()) };
+    if atom == 0 {
+        emit_pass("GLOBALATOMS");
+        return;
+    }
+    unsafe {
+        let _ = GlobalDeleteAtom(atom);
+    }
+    emit_fail("GLOBALATOMS");
+}
+
+fn probe_readclipboard(user32: Hmodule) {
+    type OpenClipboardFn = unsafe extern "system" fn(Hwnd) -> Bool;
+    type CloseClipboardFn = unsafe extern "system" fn() -> Bool;
+    type GetClipboardDataFn = unsafe extern "system" fn(u32) -> Hglobal;
+
+    let open = match get_proc(user32, "OpenClipboard") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, OpenClipboardFn>(p) },
+        None => {
+            emit_diag("READCLIPBOARD", "OpenClipboard not resolvable");
+            emit_fail("READCLIPBOARD");
+            return;
+        }
+    };
+    let close = get_proc(user32, "CloseClipboard")
+        .map(|p| unsafe { std::mem::transmute::<FarProc, CloseClipboardFn>(p) });
+    let get_data = match get_proc(user32, "GetClipboardData") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, GetClipboardDataFn>(p) },
+        None => {
+            emit_diag("READCLIPBOARD", "GetClipboardData not resolvable");
+            emit_fail("READCLIPBOARD");
+            return;
+        }
+    };
+
+    let opened = unsafe { open(std::ptr::null_mut()) };
+    if opened == 0 {
+        emit_pass("READCLIPBOARD");
+        return;
+    }
+    let data = unsafe { get_data(CF_TEXT) };
+    if let Some(close) = close {
+        unsafe {
+            let _ = close();
+        }
+    }
+    // If OpenClipboard succeeded, the read path is open. Empty-clipboard
+    // returning NULL from GetClipboardData is not a restriction signal.
+    let _ = data;
+    emit_diag(
+        "READCLIPBOARD",
+        "OpenClipboard succeeded; read path not blocked",
+    );
+    emit_fail("READCLIPBOARD");
+}
+
+fn probe_writeclipboard(user32: Hmodule) {
+    type OpenClipboardFn = unsafe extern "system" fn(Hwnd) -> Bool;
+    type CloseClipboardFn = unsafe extern "system" fn() -> Bool;
+    type EmptyClipboardFn = unsafe extern "system" fn() -> Bool;
+    type SetClipboardDataFn = unsafe extern "system" fn(u32, Hglobal) -> Hglobal;
+
+    let open = match get_proc(user32, "OpenClipboard") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, OpenClipboardFn>(p) },
+        None => {
+            emit_diag("WRITECLIPBOARD", "OpenClipboard not resolvable");
+            emit_fail("WRITECLIPBOARD");
+            return;
+        }
+    };
+    let empty = match get_proc(user32, "EmptyClipboard") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, EmptyClipboardFn>(p) },
+        None => {
+            emit_diag("WRITECLIPBOARD", "EmptyClipboard not resolvable");
+            emit_fail("WRITECLIPBOARD");
+            return;
+        }
+    };
+    let set_data = match get_proc(user32, "SetClipboardData") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, SetClipboardDataFn>(p) },
+        None => {
+            emit_diag("WRITECLIPBOARD", "SetClipboardData not resolvable");
+            emit_fail("WRITECLIPBOARD");
+            return;
+        }
+    };
+    let close = get_proc(user32, "CloseClipboard")
+        .map(|p| unsafe { std::mem::transmute::<FarProc, CloseClipboardFn>(p) });
+
+    let opened = unsafe { open(std::ptr::null_mut()) };
+    if opened == 0 {
+        emit_pass("WRITECLIPBOARD");
+        return;
+    }
+    let emptied = unsafe { empty() };
+    let set_ok = unsafe { set_data(CF_TEXT, std::ptr::null_mut()) };
+    if let Some(close) = close {
+        unsafe {
+            let _ = close();
+        }
+    }
+    if emptied == 0 && set_ok.is_null() {
+        emit_pass("WRITECLIPBOARD");
+    } else {
+        emit_fail("WRITECLIPBOARD");
+    }
+}
+
+fn probe_systemparameters(user32: Hmodule) {
+    type SpiFn = unsafe extern "system" fn(u32, u32, LpVoid, u32) -> Bool;
+    let spi = match get_proc(user32, "SystemParametersInfoW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, SpiFn>(p) },
+        None => {
+            emit_diag("SYSTEMPARAMETERS", "SystemParametersInfoW not resolvable");
+            emit_fail("SYSTEMPARAMETERS");
+            return;
+        }
+    };
+    // Restoring the user's current speed would require GET first; we
+    // intentionally pick a value that's a no-op when the call is allowed:
+    // SPI_SETMOUSESPEED with pvParam = current speed. We can't query under
+    // the mitigation, so use the OS default (10) and accept that an allowed
+    // call slightly perturbs the user setting on the test host.
+    let ok = unsafe { spi(SPI_SETMOUSESPEED, 0, 10usize as LpVoid, SPIF_SENDCHANGE) };
+    if ok == 0 {
+        emit_pass("SYSTEMPARAMETERS");
+    } else {
+        emit_fail("SYSTEMPARAMETERS");
+    }
+}
+
+fn probe_displaysettings(user32: Hmodule) {
+    type CdsFn = unsafe extern "system" fn(LpVoid, u32) -> i32;
+    let cds = match get_proc(user32, "ChangeDisplaySettingsW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, CdsFn>(p) },
+        None => {
+            emit_diag("DISPLAYSETTINGS", "ChangeDisplaySettingsW not resolvable");
+            emit_fail("DISPLAYSETTINGS");
+            return;
+        }
+    };
+    // NULL devmode + flags=0 -> restore registry settings as the active mode.
+    // DISP_CHANGE_SUCCESSFUL = 0. Any non-zero is a refusal.
+    let rc = unsafe { cds(std::ptr::null_mut(), 0) };
+    if rc != 0 {
+        emit_pass("DISPLAYSETTINGS");
+    } else {
+        emit_fail("DISPLAYSETTINGS");
+    }
+}
+
+fn probe_desktop(user32: Hmodule) {
+    type CreateDesktopWFn = unsafe extern "system" fn(
+        LpcWstr,
+        LpcWstr,
+        LpVoid,
+        u32,
+        u32,
+        *const SecurityAttributes,
+    ) -> Hdesk;
+    type CloseDesktopFn = unsafe extern "system" fn(Hdesk) -> Bool;
+
+    let create = match get_proc(user32, "CreateDesktopW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, CreateDesktopWFn>(p) },
+        None => {
+            emit_diag("DESKTOP", "CreateDesktopW not resolvable");
+            emit_fail("DESKTOP");
+            return;
+        }
+    };
+    let close = get_proc(user32, "CloseDesktop")
+        .map(|p| unsafe { std::mem::transmute::<FarProc, CloseDesktopFn>(p) });
+
+    let name = to_wide("mxc_probe_desktop");
+    let h = unsafe {
+        create(
+            name.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            0,
+            DESKTOP_CREATEWINDOW | GENERIC_ALL,
+            std::ptr::null(),
+        )
+    };
+    if h.is_null() {
+        emit_pass("DESKTOP");
+        return;
+    }
+    if let Some(close) = close {
+        unsafe {
+            let _ = close(h);
+        }
+    }
+    emit_fail("DESKTOP");
+}
+
+fn probe_exitwindows(user32: Hmodule) {
+    type ExitWindowsExFn = unsafe extern "system" fn(u32, u32) -> Bool;
+    let ewx = match get_proc(user32, "ExitWindowsEx") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, ExitWindowsExFn>(p) },
+        None => {
+            emit_diag("EXITWINDOWS", "ExitWindowsEx not resolvable");
+            emit_fail("EXITWINDOWS");
+            return;
+        }
+    };
+    // EWX_FORCEIFHUNG | EWX_LOGOFF: if the UI limit is set we get FALSE
+    // immediately; if it's not we get an attempted logoff, which is bad
+    // even when the test host is privileged enough — but the UILIMIT bit
+    // is meant to block this call before any session-side dispatch.
+    let ok = unsafe { ewx(EWX_LOGOFF | EWX_FORCEIFHUNG, 0) };
+    if ok == 0 {
+        emit_pass("EXITWINDOWS");
+    } else {
+        emit_fail("EXITWINDOWS");
+    }
+}
+
+fn probe_handles(user32: Hmodule) {
+    type FindWindowWFn = unsafe extern "system" fn(LpcWstr, LpcWstr) -> Hwnd;
+    let find = match get_proc(user32, "FindWindowW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, FindWindowWFn>(p) },
+        None => {
+            emit_diag("HANDLES", "FindWindowW not resolvable");
+            emit_fail("HANDLES");
+            return;
+        }
+    };
+    // FindWindowW(NULL, NULL) returns the top-level desktop window when
+    // the process can enumerate global window handles. With UILIMIT_HANDLES
+    // set, the call sees only handles created inside the job (none here)
+    // and returns NULL.
+    let hwnd = unsafe { find(std::ptr::null(), std::ptr::null()) };
+    if hwnd.is_null() {
+        emit_pass("HANDLES");
+    } else {
+        emit_fail("HANDLES");
+    }
+}
+
+fn probe_win32k(user32: Hmodule) {
+    type GetMessageWFn = unsafe extern "system" fn(*mut Msg, Hwnd, u32, u32) -> Bool;
+    let get_message = match get_proc(user32, "GetMessageW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, GetMessageWFn>(p) },
+        None => {
+            emit_diag("WIN32K", "GetMessageW not resolvable");
+            emit_fail("WIN32K");
+            return;
+        }
+    };
+    // Win32k mitigation kills the process on the syscall; the harness
+    // treats "WIN32K never printed + non-zero exit" as PASS. If we reach
+    // the line after the call, the mitigation did NOT fire.
+    let mut msg = Msg::default();
+    let _ = unsafe { get_message(&mut msg as *mut Msg, std::ptr::null_mut(), 0, 0) };
+    emit_fail("WIN32K");
+}
+
+fn run_probe(tag: &str, user32: Option<Hmodule>) {
+    match tag {
+        "GLOBALATOMS" => probe_globalatoms(),
+        "READCLIPBOARD" => match user32 {
+            Some(h) => probe_readclipboard(h),
+            None => {
+                emit_diag("READCLIPBOARD", "user32.dll not loadable");
+                emit_fail("READCLIPBOARD");
+            }
+        },
+        "WRITECLIPBOARD" => match user32 {
+            Some(h) => probe_writeclipboard(h),
+            None => {
+                emit_diag("WRITECLIPBOARD", "user32.dll not loadable");
+                emit_fail("WRITECLIPBOARD");
+            }
+        },
+        "SYSTEMPARAMETERS" => match user32 {
+            Some(h) => probe_systemparameters(h),
+            None => {
+                emit_diag("SYSTEMPARAMETERS", "user32.dll not loadable");
+                emit_fail("SYSTEMPARAMETERS");
+            }
+        },
+        "DISPLAYSETTINGS" => match user32 {
+            Some(h) => probe_displaysettings(h),
+            None => {
+                emit_diag("DISPLAYSETTINGS", "user32.dll not loadable");
+                emit_fail("DISPLAYSETTINGS");
+            }
+        },
+        "DESKTOP" => match user32 {
+            Some(h) => probe_desktop(h),
+            None => {
+                emit_diag("DESKTOP", "user32.dll not loadable");
+                emit_fail("DESKTOP");
+            }
+        },
+        "EXITWINDOWS" => match user32 {
+            Some(h) if destructive_probe_allowed() => probe_exitwindows(h),
+            Some(_) => refuse_destructive("EXITWINDOWS"),
+            None => {
+                emit_diag("EXITWINDOWS", "user32.dll not loadable");
+                emit_fail("EXITWINDOWS");
+            }
+        },
+        "HANDLES" => match user32 {
+            Some(h) => probe_handles(h),
+            None => {
+                emit_diag("HANDLES", "user32.dll not loadable");
+                emit_fail("HANDLES");
+            }
+        },
+        "WIN32K" => match user32 {
+            Some(h) if destructive_probe_allowed() => probe_win32k(h),
+            Some(_) => refuse_destructive("WIN32K"),
+            None => {
+                emit_diag("WIN32K", "user32.dll not loadable");
+                emit_fail("WIN32K");
+            }
+        },
+        other => {
+            emit_diag(other, "unknown tag");
+        }
+    }
+    // Flush after each probe so partial output survives a kernel kill.
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+}
+
+fn collect_tags() -> Vec<String> {
+    let mut tags: Vec<String> = env::args().skip(1).collect();
+    if tags.is_empty() {
+        if let Ok(v) = env::var("MXC_UI_PROBE_TAGS") {
+            tags = v
+                .split(|c: char| c == ',' || c.is_whitespace())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect();
+        }
+    }
+    tags
+}
+
+fn main() {
+    let tags = collect_tags();
+    if tags.is_empty() {
+        eprintln!(
+            "usage: wxc-ui-probe <TAG>... (or MXC_UI_PROBE_TAGS=TAG,TAG); \
+             valid tags: GLOBALATOMS READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS \
+             DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES WIN32K"
+        );
+        std::process::exit(2);
+    }
+    let user32 = load_user32();
+    if user32.is_none() {
+        eprintln!("LoadLibraryW(user32.dll) failed: gle={}", unsafe {
+            GetLastError()
+        });
+    }
+
+    // WIN32K is the only probe that may kill the process. Run it last so
+    // every other probe gets a chance to report.
+    let (win32k, rest): (Vec<_>, Vec<_>) = tags.into_iter().partition(|t| t == "WIN32K");
+    for tag in rest {
+        run_probe(&tag, user32);
+    }
+    for tag in win32k {
+        run_probe(&tag, user32);
+    }
+}

--- a/test_scripts/T3-Workloads.ps1
+++ b/test_scripts/T3-Workloads.ps1
@@ -1,0 +1,493 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# T3-Workloads.ps1 — explore what real workloads can run inside the
+# Tier 3 (AppContainer + DACL) sandbox on a 25H2 host.
+#
+# Companion to Win25H2Safe-Tests.ps1: that script proves the T3
+# *primitives* (rw / ro / denied / control matrix, crash recovery, UI
+# mitigations) work; this one asks whether useful programs — pwsh 7
+# and git in particular — can run on top of those primitives.
+#
+# Safety: refuses to run if wxc-exec reports `bfsCompiledIn=true`.
+# Same compile-time gate as the harness. The script only invokes
+# wxc-exec with policies that have non-empty paths, which on a
+# feature-off binary land naturally at T3.
+
+[CmdletBinding()]
+param(
+    [string]$Wxc          = (Join-Path $PSScriptRoot 'src\target\debug\wxc-exec.exe'),
+    [string]$ScratchRoot  = (Join-Path $env:TEMP 'mxc-t3-workloads'),
+    # Subset of workloads to run. Default: all ten.
+    [int[]] $Run          = @(1,2,3,4,5,6,7,8,9,10),
+    # Add a few extra "kitchen sink" RO grants (TEMP, LOCALAPPDATA, ...)
+    # to each workload's policy. Useful for ruling out missing-grant
+    # failures while iterating on a workload.
+    [switch]$Permissive,
+    # Keep scratch dir + config files after the run for post-mortem.
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# -----------------------------------------------------------------------
+# Result accumulator
+# -----------------------------------------------------------------------
+$Script:Results = [System.Collections.Generic.List[object]]::new()
+
+function Record-Workload {
+    param(
+        [Parameter(Mandatory)] [string]$Id,
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [bool]$Pass,
+        [int]$ExitCode = 0,
+        [string]$Detail = '',
+        [string]$Stderr = ''
+    )
+    $entry = [pscustomobject]@{
+        Id        = $Id
+        Name      = $Name
+        Pass      = $Pass
+        ExitCode  = $ExitCode
+        Detail    = $Detail
+        StderrTop = ($Stderr -split "`r?`n" | Select-Object -First 3) -join ' / '
+    }
+    $Script:Results.Add($entry) | Out-Null
+    $tag = if ($Pass) { '[PASS]' } else { '[FAIL]' }
+    $color = if ($Pass) { 'Green' } else { 'Red' }
+    Write-Host ("  {0} {1} :: {2} (exit={3})" -f $tag, $Id, $Name, $ExitCode) -ForegroundColor $color
+    if ($Detail) { Write-Host ("        detail: {0}" -f $Detail) }
+    if (-not $Pass -and $entry.StderrTop) {
+        Write-Host ("        stderr: {0}" -f $entry.StderrTop) -ForegroundColor DarkRed
+    }
+}
+
+function Section {
+    param([string]$Title)
+    Write-Host ''
+    Write-Host ('=' * 72) -ForegroundColor Cyan
+    Write-Host $Title -ForegroundColor Cyan
+    Write-Host ('=' * 72) -ForegroundColor Cyan
+}
+
+# -----------------------------------------------------------------------
+# Pre-flight
+# -----------------------------------------------------------------------
+function Test-Preflight {
+    Section 'Pre-flight'
+    if (-not (Test-Path $Wxc)) {
+        throw "wxc-exec not found at $Wxc. Pass -Wxc <path> or build first."
+    }
+    $probe = & $Wxc --probe 2>$null | ConvertFrom-Json -ErrorAction Stop
+    if (-not $probe.PSObject.Properties['probes'] -or -not $probe.probes.PSObject.Properties['bfsCompiledIn']) {
+        throw "Preflight: probe output missing `bfsCompiledIn`. Rebuild from a tree that has the tier2_bfs gate."
+    }
+    if ($probe.probes.bfsCompiledIn) {
+        throw "Preflight ABORT: $Wxc was built with --features tier2_bfs. On 25H2 this risks an OS hang. Rebuild without the feature."
+    }
+    Write-Host ("wxc-exec:          {0}" -f $Wxc)
+    Write-Host ("bfsCompiledIn:     {0}" -f $probe.probes.bfsCompiledIn)
+    Write-Host ("bcApiPresent:      {0}" -f $probe.probes.baseContainerApiPresent)
+    Write-Host ("scratch:           {0}" -f $ScratchRoot)
+    Write-Host ("permissive grants: {0}" -f $Permissive.IsPresent)
+}
+
+# -----------------------------------------------------------------------
+# Scratch + config helpers
+# -----------------------------------------------------------------------
+function Assert-SafeScratchRoot {
+    # Refuse to nuke arbitrary paths. `Initialize-Scratch` issues a
+    # recursive `Remove-Item -Force` against `$ScratchRoot`; if a user
+    # accidentally passes `-ScratchRoot C:\` (or any other important
+    # directory) the harness must abort BEFORE the destructive call.
+    #
+    # Policy: the path must be non-empty, must resolve to somewhere
+    # under `$env:TEMP`, must NOT be the TEMP root itself, must NOT be
+    # a drive root, and must carry the `mxc-` prefix in its leaf name.
+    if ([string]::IsNullOrWhiteSpace($ScratchRoot)) {
+        throw "Refusing to operate on an empty/whitespace -ScratchRoot."
+    }
+    $resolved = [System.IO.Path]::GetFullPath($ScratchRoot)
+    $tempRoot = [System.IO.Path]::GetFullPath($env:TEMP)
+    if (-not $resolved.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing -ScratchRoot '$resolved': must resolve under `$env:TEMP` ($tempRoot). Recursive deletion of paths outside TEMP is blocked."
+    }
+    if ($resolved.TrimEnd('\','/') -ieq $tempRoot.TrimEnd('\','/')) {
+        throw "Refusing -ScratchRoot '$resolved': cannot equal `$env:TEMP` itself."
+    }
+    $root = [System.IO.Path]::GetPathRoot($resolved)
+    if ($root -and ($resolved.TrimEnd('\','/') -ieq $root.TrimEnd('\','/'))) {
+        throw "Refusing -ScratchRoot '$resolved': drive roots are not valid scratch directories."
+    }
+    $leaf = Split-Path -Path $resolved -Leaf
+    if ($leaf -notlike 'mxc-*') {
+        throw "Refusing -ScratchRoot '$resolved': leaf name '$leaf' must start with 'mxc-' to confirm operator intent."
+    }
+}
+
+function Initialize-Scratch {
+    Assert-SafeScratchRoot
+    if (Test-Path $ScratchRoot) {
+        Remove-Item -Recurse -Force -LiteralPath $ScratchRoot
+    }
+    New-Item -ItemType Directory -Path $ScratchRoot       | Out-Null
+    New-Item -ItemType Directory -Path "$ScratchRoot\rw"  | Out-Null
+    New-Item -ItemType Directory -Path "$ScratchRoot\cfg" | Out-Null
+    New-Item -ItemType Directory -Path "$ScratchRoot\log" | Out-Null
+    # Pre-stage a marker for read-back tests.
+    'mxc-t3-marker' | Out-File -LiteralPath "$ScratchRoot\rw\marker.txt" -Encoding ascii -Force
+}
+
+function New-Config {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [string]$CommandLine,
+        [string[]]$ReadOnly  = @(),
+        [string[]]$ReadWrite = @(),
+        [string]$Cwd = $null,
+        [int]$TimeoutMs = 60000
+    )
+    if ($Permissive) {
+        # Kitchen-sink grants for debugging: TEMP, LOCALAPPDATA cache
+        # dirs that most CLR-using apps touch at startup.
+        $extraRo = @()
+        if ($env:LOCALAPPDATA) { $extraRo += $env:LOCALAPPDATA }
+        $extraRw = @($env:TEMP)
+        $ReadOnly  = @($ReadOnly  + $extraRo) | Select-Object -Unique
+        $ReadWrite = @($ReadWrite + $extraRw) | Select-Object -Unique
+    }
+    $proc = [ordered]@{
+        commandLine = $CommandLine
+        timeout     = $TimeoutMs
+    }
+    if ($Cwd) { $proc['cwd'] = $Cwd }
+    $obj = [ordered]@{
+        version     = '0.5.0-dev'
+        containerId = "MxcT3Workload-$Name"
+        containment = 'appcontainer'
+        process     = $proc
+        fallback    = [ordered]@{ allowDaclMutation = $true }
+        ui          = [ordered]@{ disable = $false }
+    }
+    $fs = [ordered]@{}
+    if ($ReadWrite.Count -gt 0) { $fs['readwritePaths'] = @($ReadWrite) }
+    if ($ReadOnly.Count  -gt 0) { $fs['readonlyPaths']  = @($ReadOnly) }
+    if ($fs.Count -gt 0)        { $obj['filesystem']    = $fs }
+
+    $path = Join-Path "$ScratchRoot\cfg" "$Name.json"
+    ($obj | ConvertTo-Json -Depth 10) | Out-File -LiteralPath $path -Encoding utf8 -Force
+    return $path
+}
+
+function Invoke-Workload {
+    param(
+        [Parameter(Mandatory)] [string]$ConfigPath,
+        [Parameter(Mandatory)] [string]$LogPath,
+        [int]$TimeoutSec = 90
+    )
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Wxc
+    $psi.Arguments = "--config `"$ConfigPath`" --experimental --log-file `"$LogPath`""
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    $p = [System.Diagnostics.Process]::Start($psi)
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+        try { $p.Kill() } catch {}
+        return [pscustomobject]@{ ExitCode = -1; Stdout = ''; Stderr = "TIMEOUT after ${TimeoutSec}s" }
+    }
+    return [pscustomobject]@{
+        ExitCode = $p.ExitCode
+        Stdout   = $p.StandardOutput.ReadToEnd()
+        Stderr   = $p.StandardError.ReadToEnd()
+    }
+}
+
+# -----------------------------------------------------------------------
+# Well-known host paths (probed at script start)
+# -----------------------------------------------------------------------
+function Resolve-HostPaths {
+    $script:PwshDir   = $null
+    $script:GitDir    = $null
+    $pwsh = Get-Command pwsh -ErrorAction SilentlyContinue
+    if ($pwsh) { $script:PwshDir = Split-Path $pwsh.Source }
+    $git  = Get-Command git  -ErrorAction SilentlyContinue
+    if ($git)  { $script:GitDir  = Split-Path (Split-Path $git.Source) }
+    Write-Host ("pwsh dir: {0}" -f ($script:PwshDir ?? '<not found>'))
+    Write-Host ("git  dir: {0}" -f ($script:GitDir  ?? '<not found>'))
+}
+
+# -----------------------------------------------------------------------
+# Workloads
+# -----------------------------------------------------------------------
+function W1-CmdTypeMarker {
+    Section 'W1: cmd /c type marker.txt'
+    $cfg = New-Config -Name 'w1-cmd-type' `
+        -CommandLine "cmd /c type `"$ScratchRoot\rw\marker.txt`"" `
+        -ReadWrite @("$ScratchRoot\rw")
+    $log = "$ScratchRoot\log\w1.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 15
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'mxc-t3-marker')
+    Record-Workload -Id 'W1' -Name 'cmd /c type marker.txt' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W2-PwshReadFile {
+    Section 'W2: pwsh -NoProfile -c "Get-Content marker.txt"'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W2' -Name 'pwsh Get-Content' -Pass $false -Detail 'pwsh not found on PATH'
+        return
+    }
+    # PowerShell's install dir already grants ReadAndExecute to
+    # `ALL APPLICATION PACKAGES`, which our AppContainer SID inherits.
+    # Adding the dir to ReadOnly would force the dispatcher to demand
+    # WRITE_DAC on a system path (admin-only) — we don't need that.
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"Get-Content -LiteralPath '$ScratchRoot\rw\marker.txt'; exit 0`""
+    $cfg = New-Config -Name 'w2-pwsh-read' `
+        -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw")
+    $log = "$ScratchRoot\log\w2.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'mxc-t3-marker')
+    Record-Workload -Id 'W2' -Name 'pwsh Get-Content marker' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W3-PwshGitVersion {
+    Section 'W3: pwsh -NoProfile -c "git --version"'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W3' -Name 'pwsh git --version' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    if (-not $script:GitDir)  {
+        Record-Workload -Id 'W3' -Name 'pwsh git --version' -Pass $false -Detail 'git not found'
+        return
+    }
+    # Git install dir also grants ReadAndExecute to ALL APPLICATION
+    # PACKAGES; no per-run ACE needed (see W2 note). Setting cwd
+    # explicitly inside the rw grant avoids the AppContainer's inability
+    # to read the inherited cwd from the parent process.
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"& git --version; exit `$LASTEXITCODE`""
+    $cfg = New-Config -Name 'w3-git-version' `
+        -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") `
+        -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w3.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'git version')
+    Record-Workload -Id 'W3' -Name 'pwsh git --version' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function Initialize-Repo {
+    param([string]$Dir)
+    # Build a tiny standalone repo via real git, then we'll exercise
+    # it from inside the sandbox.
+    if (Test-Path $Dir) { Remove-Item -Recurse -Force -LiteralPath $Dir }
+    New-Item -ItemType Directory -Path $Dir | Out-Null
+    Push-Location $Dir
+    try {
+        & git init -q
+        & git -c user.email=t3@example.com -c user.name=t3 commit -q --allow-empty -m 'initial'
+        'first' | Out-File -LiteralPath (Join-Path $Dir 'file1.txt') -Encoding ascii -Force
+        & git add file1.txt
+        & git -c user.email=t3@example.com -c user.name=t3 commit -q -m 'add file1'
+        'second' | Out-File -LiteralPath (Join-Path $Dir 'file1.txt') -Encoding ascii -Force
+        & git -c user.email=t3@example.com -c user.name=t3 commit -q -am 'update file1'
+    } finally {
+        Pop-Location
+    }
+}
+
+function W4-PwshGitStatus {
+    Section 'W4: pwsh -NoProfile -c "cd <repo>; git status"'
+    if (-not $script:PwshDir -or -not $script:GitDir) {
+        Record-Workload -Id 'W4' -Name 'pwsh git status' -Pass $false -Detail 'pwsh or git not found'
+        return
+    }
+    $repo = "$ScratchRoot\rw\repo"
+    Initialize-Repo -Dir $repo
+    # Touch a file so `git status` has something to report.
+    'dirty' | Out-File -LiteralPath (Join-Path $repo 'file1.txt') -Encoding ascii -Force
+    # `git -C <dir>` lets git change to <dir> internally, avoiding
+    # pwsh's `Set-Location` which walks ancestor paths and trips on
+    # `C:\Users\...` metadata-access checks that the AppContainer SID
+    # doesn't have grants for.
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"& git -C '$repo' status --porcelain; exit `$LASTEXITCODE`""
+    $cfg = New-Config -Name 'w4-git-status' `
+        -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") `
+        -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w4.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 90
+    # Porcelain output for a modified file looks like " M file1.txt".
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'file1\.txt')
+    Record-Workload -Id 'W4' -Name 'pwsh git status' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W5-PwshGitLog {
+    Section 'W5: pwsh -NoProfile -c "cd <repo>; git log --oneline -n 10"'
+    if (-not $script:PwshDir -or -not $script:GitDir) {
+        Record-Workload -Id 'W5' -Name 'pwsh git log' -Pass $false -Detail 'pwsh or git not found'
+        return
+    }
+    $repo = "$ScratchRoot\rw\repo"
+    if (-not (Test-Path $repo)) {
+        # W5 reuses the repo from W4. If W4 didn't run, set one up.
+        Initialize-Repo -Dir $repo
+    }
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"& git -C '$repo' log --oneline -n 10; exit `$LASTEXITCODE`""
+    $cfg = New-Config -Name 'w5-git-log' `
+        -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") `
+        -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w5.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 90
+    # Each commit line starts with a 7-char SHA. The repo has 3 commits.
+    $pass = ($r.ExitCode -eq 0) -and (($r.Stdout -split "`r?`n" | Where-Object { $_ -match '^[0-9a-f]{7}\s' }).Count -ge 2)
+    Record-Workload -Id 'W5' -Name 'pwsh git log --oneline -n 10' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+# -----------------------------------------------------------------------
+# Extended pwsh-only probes (W6-W10) — bypass git's NUL constraint
+# -----------------------------------------------------------------------
+function W6-PwshListDir {
+    Section 'W6: pwsh Get-ChildItem on rw directory'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W6' -Name 'pwsh Get-ChildItem' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"Get-ChildItem -LiteralPath '$ScratchRoot\rw' | Select-Object -ExpandProperty Name; exit 0`""
+    $cfg = New-Config -Name 'w6-pwsh-ls' -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w6.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'marker\.txt')
+    Record-Workload -Id 'W6' -Name 'pwsh Get-ChildItem rw' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W7-PwshInProcEval {
+    Section 'W7: pwsh in-process script eval (math, env, pipeline)'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W7' -Name 'pwsh in-proc eval' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    $script = '$x = 6 * 7; Write-Output "answer=$x"; 1..3 | ForEach-Object { Write-Output "iter=$_" }; exit 0'
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"$script`""
+    $cfg = New-Config -Name 'w7-pwsh-eval' -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w7.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'answer=42') -and ($r.Stdout -match 'iter=3')
+    Record-Workload -Id 'W7' -Name 'pwsh in-proc eval' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W8-PwshSpawnCmd {
+    Section 'W8: pwsh spawning cmd /c (no NUL)'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W8' -Name 'pwsh spawn cmd' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    # No NUL redirects in the child — just a one-line echo.
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"& cmd /c echo hello-from-cmd; exit `$LASTEXITCODE`""
+    $cfg = New-Config -Name 'w8-pwsh-spawn-cmd' -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w8.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'hello-from-cmd')
+    Record-Workload -Id 'W8' -Name 'pwsh -> cmd /c echo' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W9-PwshWriteReadRoundTrip {
+    Section 'W9: pwsh Set-Content + Get-Content round-trip'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W9' -Name 'pwsh write+read' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    $target = "$ScratchRoot\rw\w9-out.txt"
+    $script = "Set-Content -LiteralPath '$target' -Value 'mxc-w9-payload'; Get-Content -LiteralPath '$target'; exit 0"
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"$script`""
+    $cfg = New-Config -Name 'w9-pwsh-rt' -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w9.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'mxc-w9-payload')
+    Record-Workload -Id 'W9' -Name 'pwsh Set-Content / Get-Content' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+function W10-PwshDotNetIo {
+    Section 'W10: pwsh .NET [System.IO.File]::ReadAllText'
+    if (-not $script:PwshDir) {
+        Record-Workload -Id 'W10' -Name 'pwsh .NET IO' -Pass $false -Detail 'pwsh not found'
+        return
+    }
+    $script = "Write-Output ([System.IO.File]::ReadAllText('$ScratchRoot\rw\marker.txt')); exit 0"
+    $cmd = "pwsh.exe -NoProfile -NoLogo -Command `"$script`""
+    $cfg = New-Config -Name 'w10-pwsh-dotnet' -CommandLine $cmd `
+        -ReadWrite @("$ScratchRoot\rw") -Cwd "$ScratchRoot\rw"
+    $log = "$ScratchRoot\log\w10.log"
+    $r = Invoke-Workload -ConfigPath $cfg -LogPath $log -TimeoutSec 60
+    $pass = ($r.ExitCode -eq 0) -and ($r.Stdout -match 'mxc-t3-marker')
+    Record-Workload -Id 'W10' -Name 'pwsh .NET IO.File.ReadAllText' -Pass $pass `
+        -ExitCode $r.ExitCode -Detail "stdout=$($r.Stdout.Trim())" -Stderr $r.Stderr
+}
+
+# -----------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------
+try {
+    Test-Preflight
+    Resolve-HostPaths
+    Initialize-Scratch
+
+    if (1  -in $Run) { W1-CmdTypeMarker }
+    if (2  -in $Run) { W2-PwshReadFile }
+    if (3  -in $Run) { W3-PwshGitVersion }
+    if (4  -in $Run) { W4-PwshGitStatus }
+    if (5  -in $Run) { W5-PwshGitLog }
+    if (6  -in $Run) { W6-PwshListDir }
+    if (7  -in $Run) { W7-PwshInProcEval }
+    if (8  -in $Run) { W8-PwshSpawnCmd }
+    if (9  -in $Run) { W9-PwshWriteReadRoundTrip }
+    if (10 -in $Run) { W10-PwshDotNetIo }
+}
+catch {
+    Write-Host ''
+    Write-Host "ABORT: $_" -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor DarkRed
+    exit 2
+}
+finally {
+    Section 'Summary'
+    $passed = @($Script:Results | Where-Object { $_.Pass })
+    $failed = @($Script:Results | Where-Object { -not $_.Pass })
+    Write-Host ("Total: {0}    Passed: {1}    Failed: {2}" -f $Script:Results.Count, $passed.Count, $failed.Count)
+    if ($failed.Count -gt 0) {
+        Write-Host ''
+        Write-Host 'Failures:' -ForegroundColor Red
+        foreach ($r in $failed) {
+            Write-Host ("  [{0}] {1} (exit={2})" -f $r.Id, $r.Name, $r.ExitCode) -ForegroundColor Red
+            if ($r.Detail)    { Write-Host ("        detail: {0}" -f $r.Detail) }
+            if ($r.StderrTop) { Write-Host ("        stderr: {0}" -f $r.StderrTop) -ForegroundColor DarkRed }
+        }
+    }
+    Write-Host ''
+    Write-Host ("Scratch / logs: {0}" -f $ScratchRoot)
+    if (-not $KeepArtifacts -and $failed.Count -eq 0 -and $passed.Count -gt 0 -and (Test-Path $ScratchRoot)) {
+        # Re-validate before deletion — `Assert-SafeScratchRoot` ran
+        # at the start of the suite, but the variable could in
+        # principle be mutated mid-run by future refactors. Cheap
+        # belt-and-suspenders against an accidental recursive delete.
+        Assert-SafeScratchRoot
+        Remove-Item -Recurse -Force -LiteralPath $ScratchRoot -ErrorAction SilentlyContinue
+    }
+}

--- a/test_scripts/Win25H2Safe-Tests.ps1
+++ b/test_scripts/Win25H2Safe-Tests.ps1
@@ -1,0 +1,1087 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Win25H2Safe-Tests.ps1
+#
+# Exercises the BaseContainer-fallback work (downlevel-phase5 branch) on a
+# Windows 11 25H2 host without ever invoking bfscfg.exe (which would
+# hard-lock the bfs.sys minifilter on 25H2).
+#
+# Safety model (`tier2_bfs` Cargo feature OFF, the default):
+#   * Test-Preflight refuses to run if either wxc-exec binary reports
+#     `bfsCompiledIn=true` in --probe output. This is the load-bearing
+#     gate; everything else is belt-and-suspenders.
+#   * With `tier2_bfs` off, `fallback_detector::find_bfscfg_exe`
+#     returns `Ok(None)` unconditionally and the spawn site itself is
+#     gated. The dispatcher's natural T2→T3 fallback fires for any
+#     policy with rw/ro/denied paths.
+#   * Empty-policy runs still label the selected tier "appcontainer-bfs"
+#     because `detect()` short-circuits to T2 when there is nothing to
+#     configure. At runtime that path is a no-op — `configure()`
+#     short-circuits before any bfscfg invocation.
+#   * Every run is post-checked: if the captured log contains the
+#     substring "bfscfg" (proof of an actual spawn), the run is
+#     reported as failed and the harness aborts before the next test.
+#   * The harness relies on **natural** tier selection — there is no
+#     `-ForceTier` parameter and no `MXC_FORCE_TIER` env-var manipulation
+#     (the env var is `#[cfg(test)]`-gated and has no effect on the
+#     production wxc-exec binary). With `tier2_bfs` off, the detector
+#     drops to T3 for any policy with rw/ro/denied paths, which is
+#     exactly what the assertions below expect.
+
+[CmdletBinding()]
+param(
+    [string]$RepoRoot       = $PSScriptRoot,
+    [string]$CargoRoot      = (Join-Path $PSScriptRoot 'src'),
+    [string]$WxcDebug       = (Join-Path $PSScriptRoot 'src\target\debug\wxc-exec.exe'),
+    [string]$WxcRelease     = (Join-Path $PSScriptRoot 'src\target\release\wxc-exec.exe'),
+    [string]$UiProbeDebug   = (Join-Path $PSScriptRoot 'src\target\debug\wxc-ui-probe.exe'),
+    [string]$UiProbeRelease = (Join-Path $PSScriptRoot 'src\target\release\wxc-ui-probe.exe'),
+    [string]$ScratchRoot    = (Join-Path $env:TEMP 'mxc-25h2-tests'),
+    # Default results/log files live in $env:TEMP but OUTSIDE $ScratchRoot
+    # so `Initialize-Scratch`'s recursive nuke can't conflict with the
+    # `Start-Transcript` file handle (the script starts the transcript
+    # BEFORE wiping the scratch tree). The previous default landed them
+    # under $ScratchRoot and tripped a "file in use" abort on every run.
+    [string]$ResultsFile    = (Join-Path $env:TEMP 'Win25H2Safe-Tests.results.txt'),
+    [string]$ResultsJson    = (Join-Path $env:TEMP 'Win25H2Safe-Tests.results.json'),
+    [string]$CargoLog       = (Join-Path $env:TEMP 'Win25H2Safe-Tests.cargo.log'),
+    [switch]$SkipBuild,
+    [switch]$SkipReleaseLane,
+    [switch]$KeepArtifacts
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# The UI-mitigation probe binary refuses EXITWINDOWS / WIN32K by
+# default — running those operations outside a sandbox can log out
+# the interactive user. Set the explicit override here so the AC
+# child wxc_ui_probe inherits it via wxc-exec's env-passthrough.
+# Without this, Phase 4b's EXITWINDOWS / WIN32K assertions fail with
+# "DIAG: refused".
+$env:MXC_PROBE_DESTRUCTIVE_OK = '1'
+
+# -----------------------------------------------------------------------
+# Result accumulator
+# -----------------------------------------------------------------------
+$Script:Results = [System.Collections.Generic.List[object]]::new()
+
+function Record-Result {
+    param(
+        [Parameter(Mandatory)] [string]$Phase,
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [bool]$Pass,
+        [string]$Detail = ''
+    )
+    $entry = [pscustomobject]@{
+        Phase  = $Phase
+        Name   = $Name
+        Pass   = $Pass
+        Detail = $Detail
+    }
+    $Script:Results.Add($entry) | Out-Null
+    $tag = if ($Pass) { '[PASS]' } else { '[FAIL]' }
+    $color = if ($Pass) { 'Green' } else { 'Red' }
+    Write-Host ("  {0} {1} :: {2} {3}" -f $tag, $Phase, $Name, $(if ($Detail) { "($Detail)" } else { '' })) -ForegroundColor $color
+}
+
+function Section {
+    param([string]$Title)
+    Write-Host ''
+    Write-Host ('=' * 72) -ForegroundColor Cyan
+    Write-Host $Title -ForegroundColor Cyan
+    Write-Host ('=' * 72) -ForegroundColor Cyan
+}
+
+# -----------------------------------------------------------------------
+# Pre-flight
+# -----------------------------------------------------------------------
+function Test-Preflight {
+    Section 'Pre-flight'
+
+    $os = Get-CimInstance -ClassName Win32_OperatingSystem
+    Write-Host ("OS: {0} (build {1})" -f $os.Caption, $os.BuildNumber)
+
+    $bfsPath = Join-Path $env:SystemRoot 'System32\bfscfg.exe'
+    $bfsPresent = Test-Path $bfsPath
+    Write-Host ("bfscfg.exe present in System32: {0}" -f $bfsPresent)
+    if (-not $bfsPresent) {
+        Write-Warning 'bfscfg.exe was not found in System32. The harness assumes 25H2-shaped hosts.'
+    }
+
+    if (-not $SkipBuild) {
+        if (-not (Test-Path (Join-Path $CargoRoot 'Cargo.toml'))) {
+            throw "No Cargo.toml at $CargoRoot. Pass -CargoRoot <path> if the workspace lives elsewhere."
+        }
+        Write-Host "Building debug + release binaries (workspace: $CargoRoot)..."
+        Push-Location $CargoRoot
+        try {
+            & cargo build -p wxc 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "cargo build (debug) failed" }
+            & cargo build -p wxc --release 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "cargo build (release) failed" }
+            & cargo build -p wxc_ui_probe 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "cargo build wxc_ui_probe (debug) failed" }
+            & cargo build -p wxc_ui_probe --release 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "cargo build wxc_ui_probe (release) failed" }
+        } finally {
+            Pop-Location
+        }
+    }
+
+    if (-not (Test-Path $WxcDebug))   { throw "Debug binary not found at $WxcDebug" }
+    if (-not (Test-Path $WxcRelease)) { throw "Release binary not found at $WxcRelease" }
+    if (-not (Test-Path $UiProbeDebug))   { throw "UI probe debug binary not found at $UiProbeDebug" }
+    if (-not (Test-Path $UiProbeRelease)) { throw "UI probe release binary not found at $UiProbeRelease" }
+
+    # The load-bearing safety check: refuse to run if either binary has
+    # the `tier2_bfs` Cargo feature compiled in. On 25H2 spawning
+    # `bfscfg.exe` hard-locks the OS. The feature gate at compile time
+    # is what makes the harness safe to run; this preflight verifies it.
+    foreach ($pair in @(@{ Path = $WxcDebug; Label = 'debug' }, @{ Path = $WxcRelease; Label = 'release' })) {
+        $probe = & $pair.Path --probe 2>$null | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $probe.probes.bfsCompiledIn) {
+            throw "Preflight: $($pair.Label) binary at $($pair.Path) does not expose `bfsCompiledIn` in its --probe output. Rebuild from a tree that has the tier2_bfs gate."
+        }
+        if ($probe.probes.bfsCompiledIn) {
+            throw "Preflight ABORT: $($pair.Label) binary at $($pair.Path) was built with --features tier2_bfs. On 25H2 this risks an OS hang. Rebuild without the feature (drop --features tier2_bfs) before re-running."
+        }
+        Write-Host ("bfsCompiledIn ({0,-7}): false" -f $pair.Label)
+    }
+}
+
+# -----------------------------------------------------------------------
+# Scratch + helpers
+# -----------------------------------------------------------------------
+function Assert-SafeScratchRoot {
+    # Refuse to nuke arbitrary paths. `Initialize-Scratch` issues a
+    # recursive `Remove-Item -Force` against `$ScratchRoot`; if a user
+    # accidentally passes `-ScratchRoot C:\` (or any other important
+    # directory) the harness must abort BEFORE the destructive call.
+    #
+    # Policy: the path must be non-empty, must resolve to somewhere
+    # under `$env:TEMP`, must NOT be the TEMP root itself, must NOT be
+    # a drive root, and must carry the `mxc-` prefix in its leaf name.
+    if ([string]::IsNullOrWhiteSpace($ScratchRoot)) {
+        throw "Refusing to operate on an empty/whitespace -ScratchRoot."
+    }
+    $resolved = [System.IO.Path]::GetFullPath($ScratchRoot)
+    $tempRoot = [System.IO.Path]::GetFullPath($env:TEMP)
+    if (-not $resolved.StartsWith($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing -ScratchRoot '$resolved': must resolve under `$env:TEMP` ($tempRoot). Recursive deletion of paths outside TEMP is blocked."
+    }
+    if ($resolved.TrimEnd('\','/') -ieq $tempRoot.TrimEnd('\','/')) {
+        throw "Refusing -ScratchRoot '$resolved': cannot equal `$env:TEMP` itself."
+    }
+    # `Path.GetPathRoot` of a drive root returns the same string (e.g.
+    # `C:\` → `C:\`). Any path whose root equals itself is the root.
+    $root = [System.IO.Path]::GetPathRoot($resolved)
+    if ($root -and ($resolved.TrimEnd('\','/') -ieq $root.TrimEnd('\','/'))) {
+        throw "Refusing -ScratchRoot '$resolved': drive roots are not valid scratch directories."
+    }
+    $leaf = Split-Path -Path $resolved -Leaf
+    if ($leaf -notlike 'mxc-*') {
+        throw "Refusing -ScratchRoot '$resolved': leaf name '$leaf' must start with 'mxc-' to confirm operator intent."
+    }
+}
+
+function Initialize-Scratch {
+    Assert-SafeScratchRoot
+    if (Test-Path $ScratchRoot) {
+        Remove-Item -Recurse -Force -LiteralPath $ScratchRoot
+    }
+    New-Item -ItemType Directory -Path $ScratchRoot | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'logs')    | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'configs') | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'rw')      | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'ro')      | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'denied')  | Out-Null
+    # `control` is intentionally NOT named in any policy. Used by the
+    # access-matrix sub-test to confirm AppContainer denies paths that
+    # were never granted, not just ones explicitly denied.
+    New-Item -ItemType Directory -Path (Join-Path $ScratchRoot 'control') | Out-Null
+}
+
+function Get-DaclRestoreDir {
+    Join-Path $env:LOCALAPPDATA 'Microsoft\MXC\dacl-restore'
+}
+
+function Get-StateFiles {
+    # Emits FileInfo objects naturally so pipelines (Where-Object) iterate
+    # element-by-element. Callers that need .Count must wrap with @(...)
+    # because an empty function output materializes as $null at assignment.
+    $dir = Get-DaclRestoreDir
+    if (-not (Test-Path $dir)) { return }
+    Get-ChildItem -LiteralPath $dir -Filter '*.json' -ErrorAction SilentlyContinue
+}
+
+function Clear-StateFiles {
+    # Wipe the dacl-restore directory so a phase can assert
+    # "no NEW state files appeared during this phase".
+    $dir = Get-DaclRestoreDir
+    if (Test-Path $dir) {
+        Get-ChildItem -LiteralPath $dir -Filter '*.json' -ErrorAction SilentlyContinue |
+            Remove-Item -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-Acl-Snapshot {
+    param([string]$Path)
+    # Use icacls' raw text. Strip the trailing summary line so transient
+    # state doesn't perturb the comparison.
+    $raw = & icacls.exe $Path 2>&1
+    ($raw | Where-Object { $_ -notmatch 'Successfully processed' }) -join "`n"
+}
+
+function Read-Log {
+    param([string]$LogPath)
+    if (Test-Path $LogPath) { Get-Content -Raw -LiteralPath $LogPath } else { '' }
+}
+
+function Assert-NoBfscfg {
+    param(
+        [string]$LogContent,
+        [string]$Phase,
+        [string]$Name,
+        # Phases that intentionally exercise the T2-selected, no-invocation
+        # path (P2 empty policy, P3 denied-only) pass this switch. The
+        # `bfscfg` substring check still fires either way — that one
+        # signals actual invocation, which is fatal everywhere.
+        [switch]$AllowBfsTierSelection
+    )
+    # The unique signature of an actual bfscfg.exe invocation is
+    # `Output from bfscfg.exe:` emitted by
+    # filesystem_bfs::execute_bfscfg_operation on a non-empty
+    # stdout/stderr capture. The plain substring `bfscfg` also appears
+    # in legitimate fallback-chain warnings ("bfscfg.exe not present;
+    # falling back to AppContainer + DACL") which are evidence of the
+    # safety gate WORKING, not of invocation. Match only the
+    # spawn-output marker.
+    if ($LogContent -match '(?im)Output from bfscfg\.exe') {
+        throw "[$Phase :: $Name] FATAL: log contains 'Output from bfscfg.exe' (real invocation). Aborting to avoid 25H2 deadlock."
+    }
+    if (-not $AllowBfsTierSelection) {
+        # Logger interleaves a `[timestamp] ` token between every
+        # write fragment, so a single `writeln!(logger, "x: {}", y)`
+        # serializes as `x: [ts] y`. Use `.*?` instead of `\s*` to
+        # bridge that token.
+        if ($LogContent -match '(?im)selected isolation tier:.*?appcontainer-bfs') {
+            throw "[$Phase :: $Name] FATAL: log shows 'selected isolation tier: appcontainer-bfs'. Aborting."
+        }
+    }
+}
+
+# -----------------------------------------------------------------------
+# Config generation
+# -----------------------------------------------------------------------
+function New-Config {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [string]$CommandLine,
+        [string[]]$ReadWrite = @(),
+        [string[]]$ReadOnly  = @(),
+        [string[]]$Denied    = @(),
+        [Nullable[bool]]$AllowDaclMutation = $null,
+        [int]$TimeoutMs = 30000,
+        [Nullable[bool]]$UiDisable          = $null,
+        [string]$BpUiIsolation              = $null,
+        [Nullable[bool]]$BpUiDesktopControl = $null,
+        [string]$BpUiSystemSettings         = $null,
+        [Nullable[bool]]$BpUiIme            = $null,
+        [string]$Clipboard                  = $null,
+        [Nullable[bool]]$Injection          = $null
+    )
+    $obj = [ordered]@{
+        version     = '0.5.0-dev'
+        containerId = "MxcWin25H2-$Name"
+        containment = 'appcontainer'
+        process     = [ordered]@{
+            commandLine = $CommandLine
+            timeout     = $TimeoutMs
+        }
+    }
+    if ($ReadWrite.Count -gt 0 -or $ReadOnly.Count -gt 0 -or $Denied.Count -gt 0) {
+        $fs = [ordered]@{}
+        if ($ReadWrite.Count -gt 0) { $fs['readwritePaths'] = @($ReadWrite) }
+        if ($ReadOnly.Count -gt 0)  { $fs['readonlyPaths']  = @($ReadOnly) }
+        if ($Denied.Count -gt 0)    { $fs['deniedPaths']    = @($Denied) }
+        $obj['filesystem'] = $fs
+    }
+    if ($null -ne $AllowDaclMutation) {
+        $obj['fallback'] = [ordered]@{ allowDaclMutation = [bool]$AllowDaclMutation }
+    }
+    $ui = [ordered]@{ disable = $(if ($null -ne $UiDisable) { [bool]$UiDisable } else { $false }) }
+    if ($Clipboard) { $ui['clipboard'] = $Clipboard }
+    if ($null -ne $Injection) { $ui['injection'] = [bool]$Injection }
+    $obj['ui'] = $ui
+
+    $needBp = ($BpUiIsolation -or $BpUiSystemSettings -or $null -ne $BpUiDesktopControl -or $null -ne $BpUiIme)
+    if ($needBp) {
+        $bp = [ordered]@{}
+        if ($BpUiIsolation)              { $bp['isolation']            = $BpUiIsolation }
+        if ($null -ne $BpUiDesktopControl) { $bp['desktopSystemControl'] = [bool]$BpUiDesktopControl }
+        if ($BpUiSystemSettings)         { $bp['systemSettings']       = $BpUiSystemSettings }
+        if ($null -ne $BpUiIme)          { $bp['ime']                  = [bool]$BpUiIme }
+        $obj['processContainer'] = [ordered]@{ ui = $bp }
+    }
+
+    $path = Join-Path (Join-Path $ScratchRoot 'configs') "$Name.json"
+    ($obj | ConvertTo-Json -Depth 10) | Out-File -LiteralPath $path -Encoding utf8 -Force
+    return $path
+}
+
+# -----------------------------------------------------------------------
+# Test runners
+# -----------------------------------------------------------------------
+function Invoke-Probe {
+    param([string]$Wxc, [string]$ConfigPath = $null, [string]$Phase, [string]$Name)
+    # Use ProcessStartInfo so we can keep stdout (the JSON) separate from
+    # stderr (DACL-recovery messages, build-time warnings).
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Wxc
+    $argList = @('--probe')
+    if ($ConfigPath) { $argList += @('--config', "`"$ConfigPath`"") }
+    $psi.Arguments = ($argList -join ' ')
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow  = $true
+    $p = [System.Diagnostics.Process]::Start($psi)
+    $stdout = $p.StandardOutput.ReadToEnd()
+    $stderr = $p.StandardError.ReadToEnd()
+    if (-not $p.WaitForExit(15000)) {
+        try { $p.Kill() } catch {}
+        Record-Result -Phase $Phase -Name $Name -Pass $false -Detail 'probe timeout'
+        return $null
+    }
+    if ($p.ExitCode -ne 0) {
+        Record-Result -Phase $Phase -Name $Name -Pass $false -Detail "exit=$($p.ExitCode); stderr=$stderr"
+        return $null
+    }
+    try {
+        return $stdout | ConvertFrom-Json
+    } catch {
+        Record-Result -Phase $Phase -Name $Name -Pass $false -Detail "malformed JSON: $_"
+        return $null
+    }
+}
+
+function Invoke-Wxc {
+    param(
+        [Parameter(Mandatory)] [string]$Wxc,
+        [Parameter(Mandatory)] [string]$ConfigPath,
+        [Parameter(Mandatory)] [string]$LogPath,
+        [int]$ExpectExitCode = 0,
+        [int]$TimeoutSec     = 60
+    )
+    # Scrub MXC_FORCE_TIER defensively in case some other process in this
+    # session set it. The env var is `#[cfg(test)]`-gated and has no
+    # effect on production wxc-exec — natural detection drives every
+    # tier-selection assertion below.
+    Remove-Item Env:\MXC_FORCE_TIER -ErrorAction SilentlyContinue
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $Wxc
+    $psi.Arguments = "--config `"$ConfigPath`" --experimental --log-file `"$LogPath`""
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $true
+
+    $p = [System.Diagnostics.Process]::Start($psi)
+    if (-not $p.WaitForExit($TimeoutSec * 1000)) {
+        try { $p.Kill() } catch {}
+        return [pscustomobject]@{ ExitCode = -1; Stdout = ''; Stderr = "TIMEOUT after ${TimeoutSec}s" }
+    }
+    return [pscustomobject]@{
+        ExitCode = $p.ExitCode
+        Stdout   = $p.StandardOutput.ReadToEnd()
+        Stderr   = $p.StandardError.ReadToEnd()
+    }
+}
+
+# -----------------------------------------------------------------------
+# Phase 1 — probes (read-only, never touches bfscfg)
+#
+# Expectations assume the `tier2_bfs` Cargo feature is OFF (Test-Preflight
+# enforces this). With the feature off, `find_bfscfg_exe` returns
+# `Ok(None)` unconditionally, so the detector drops to T3
+# (`appcontainer-dacl`) for any policy with rw/ro/denied paths. The
+# empty-policy probe still labels T2 because `detect()` short-circuits
+# to T2 when there is nothing to configure — the runtime behavior is
+# nonetheless the no-op T2 path, never spawning bfscfg.
+# -----------------------------------------------------------------------
+function Phase-Probes {
+    Section 'Phase 1: --probe (read-only)'
+
+    $rw = Join-Path $ScratchRoot 'rw'
+    $denied = Join-Path $ScratchRoot 'denied'
+
+    $probeEmpty = Invoke-Probe -Wxc $WxcRelease -Phase 'P1' -Name 'probe-no-config'
+    if ($probeEmpty) {
+        Record-Result -Phase 'P1' -Name 'BC API absent on this host' -Pass (-not $probeEmpty.probes.baseContainerApiPresent) -Detail "baseContainerApiPresent=$($probeEmpty.probes.baseContainerApiPresent)"
+        Record-Result -Phase 'P1' -Name 'bfsCompiledIn=false (safety gate)' -Pass (-not $probeEmpty.probes.bfsCompiledIn) -Detail "bfsCompiledIn=$($probeEmpty.probes.bfsCompiledIn)"
+        Record-Result -Phase 'P1' -Name 'bfscfgPresent=false when feature off' -Pass (-not $probeEmpty.probes.bfscfgPresent) -Detail "bfscfgPresent=$($probeEmpty.probes.bfscfgPresent)"
+        Record-Result -Phase 'P1' -Name 'empty policy probe -> tier=appcontainer-bfs (cosmetic: detect() short-circuits)' -Pass ($probeEmpty.tier -eq 'appcontainer-bfs') -Detail "tier=$($probeEmpty.tier)"
+        Record-Result -Phase 'P1' -Name 'empty policy probe -> needsDaclAugmentation=false' -Pass ($probeEmpty.needsDaclAugmentation -eq $false) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
+    }
+
+    $cfgRw = New-Config -Name 'probe-rw' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw)
+    $probeRw = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgRw -Phase 'P1' -Name 'probe-rw-config'
+    if ($probeRw) {
+        Record-Result -Phase 'P1' -Name 'rw-paths probe -> tier=appcontainer-dacl (T2 gated out)' -Pass ($probeRw.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeRw.tier)"
+        Record-Result -Phase 'P1' -Name 'rw-paths probe -> needsDaclAugmentation=true' -Pass ($probeRw.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeRw.needsDaclAugmentation)"
+    }
+
+    $cfgDenied = New-Config -Name 'probe-denied' -CommandLine 'cmd /c exit 0' -Denied @($denied)
+    $probeDenied = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgDenied -Phase 'P1' -Name 'probe-denied-config'
+    if ($probeDenied) {
+        Record-Result -Phase 'P1' -Name 'denied probe -> tier=appcontainer-dacl (T2 gated out)' -Pass ($probeDenied.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeDenied.tier)"
+        Record-Result -Phase 'P1' -Name 'denied probe -> needsDaclAugmentation=true' -Pass ($probeDenied.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeDenied.needsDaclAugmentation)"
+    }
+
+    $cfgRefuse = New-Config -Name 'probe-refuse' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw) -AllowDaclMutation $false
+    $probeRefuse = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgRefuse -Phase 'P1' -Name 'probe-allow-dacl-false'
+    if ($probeRefuse) {
+        # With T2 gated out, rw-paths probe falls through to T3, which
+        # requires DACL augmentation. allowDaclMutation=false therefore
+        # trips DaclFallbackDisabled and the detector returns an error
+        # (tier omitted).
+        #
+        # Under Set-StrictMode -Version Latest, accessing an absent
+        # property throws; check existence via PSObject.Properties
+        # instead of `$null -eq $obj.foo`.
+        $tierMissing = -not [bool]$probeRefuse.PSObject.Properties['tier']
+        $errorStr    = if ($probeRefuse.PSObject.Properties['error']) { [string]$probeRefuse.error } else { '' }
+        Record-Result -Phase 'P1' -Name 'allowDaclMutation=false + rw-paths probe -> error (T3 needs DACL)' -Pass ($tierMissing -and ($errorStr -match 'DACL fallback')) -Detail "tierMissing=$tierMissing; error=$errorStr"
+    }
+}
+
+# -----------------------------------------------------------------------
+# Phase 2 — release-build empty-policy run (safe lane, T2 path but no bfscfg)
+# -----------------------------------------------------------------------
+function Phase-EmptyRelease {
+    if ($SkipReleaseLane) {
+        Section 'Phase 2: SKIPPED (--SkipReleaseLane)'
+        return
+    }
+    Section 'Phase 2: release build, empty FS policy (safe lane)'
+
+    # Use `echo` (a cmd builtin — no external EXE load, no LSA/RPC) and
+    # assert the output round-trips back. Avoid `whoami`, `hostname`,
+    # `set`, etc. which exercise capabilities the empty policy doesn't
+    # grant — those would correctly fail under AppContainer and look
+    # like a regression here.
+    $cfg = New-Config -Name 'empty-release' -CommandLine 'cmd /c echo P2-empty-release-ok'
+    $log = Join-Path $ScratchRoot 'logs\empty-release.log'
+    $r = Invoke-Wxc -Wxc $WxcRelease -ConfigPath $cfg -LogPath $log
+    $logContent = Read-Log $log
+    # Empty-policy run naturally selects T2; the assertion is that
+    # bfscfg.exe was NOT actually invoked (configure() short-circuits).
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P2' -Name 'empty-release' -AllowBfsTierSelection
+
+    Record-Result -Phase 'P2' -Name 'release exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode); stdout=$($r.Stdout.Trim())"
+    Record-Result -Phase 'P2' -Name 'AppContainer ran the child (stdout round-trip)' -Pass ($r.Stdout -match 'P2-empty-release-ok')
+    Record-Result -Phase 'P2' -Name 'selected isolation tier: appcontainer-bfs (expected, no invocation)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-bfs'))
+    Record-Result -Phase 'P2' -Name 'no bfscfg invocation in log' -Pass (-not ($logContent -match '(?im)Output from bfscfg\.exe'))
+    Record-Result -Phase 'P2' -Name 'UI Job Object assigned telemetry' -Pass ([bool]($logContent -match 'UI Job Object assigned'))
+}
+
+# -----------------------------------------------------------------------
+# Phase 3 — release-build deniedPaths-only (safe lane; deny routes via DACL)
+# -----------------------------------------------------------------------
+function Phase-DeniedRelease {
+    if ($SkipReleaseLane) {
+        Section 'Phase 3: SKIPPED (--SkipReleaseLane)'
+        return
+    }
+    Section 'Phase 3: release build, deniedPaths only (safe lane)'
+    Clear-StateFiles
+
+    $denied = Join-Path $ScratchRoot 'denied'
+    $aclBefore = Get-Acl-Snapshot $denied
+
+    $cfg = New-Config -Name 'denied-release' -CommandLine 'cmd /c exit 0' -Denied @($denied)
+    $log = Join-Path $ScratchRoot 'logs\denied-release.log'
+    $r = Invoke-Wxc -Wxc $WxcRelease -ConfigPath $cfg -LogPath $log
+    $logContent = Read-Log $log
+    # With `tier2_bfs` off, denied-only policy falls through T2→T3.
+    # Deny ACEs still route through DaclManager (same code path as
+    # before; only the selected-tier label differs). bfscfg.exe is
+    # not invoked under any tier.
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P3' -Name 'denied-release'
+
+    $aclAfter = Get-Acl-Snapshot $denied
+
+    Record-Result -Phase 'P3' -Name 'release exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode)"
+    Record-Result -Phase 'P3' -Name 'selected isolation tier: appcontainer-dacl (T2 gated out)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P3' -Name 'no bfscfg invocation in log' -Pass (-not ($logContent -match '(?im)Output from bfscfg\.exe'))
+    Record-Result -Phase 'P3' -Name 'denied-path ACL restored after run' -Pass ($aclBefore -eq $aclAfter)
+    Record-Result -Phase 'P3' -Name 'no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
+}
+
+# -----------------------------------------------------------------------
+# Phase 4 — debug build, T3 forced, rw + ro + denied (the real test)
+# -----------------------------------------------------------------------
+function Phase-T3Forced {
+    Section 'Phase 4: debug build, natural detection -> T3 (tier2_bfs off)'
+    Clear-StateFiles
+
+    $rw = Join-Path $ScratchRoot 'rw'
+    $ro = Join-Path $ScratchRoot 'ro'
+    $denied = Join-Path $ScratchRoot 'denied'
+
+    $aclRwBefore     = Get-Acl-Snapshot $rw
+    $aclRoBefore     = Get-Acl-Snapshot $ro
+    $aclDeniedBefore = Get-Acl-Snapshot $denied
+
+    $cmd = "cmd /c echo hello-from-t3 > `"$rw\probe.txt`" && type `"$rw\probe.txt`""
+    $cfg = New-Config -Name 't3-forced' -CommandLine $cmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied @($denied)
+    $log = Join-Path $ScratchRoot 'logs\t3-forced.log'
+    $r = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfg -LogPath $log
+    $logContent = Read-Log $log
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P4' -Name 't3-forced'
+
+    $aclRwAfter     = Get-Acl-Snapshot $rw
+    $aclRoAfter     = Get-Acl-Snapshot $ro
+    $aclDeniedAfter = Get-Acl-Snapshot $denied
+    $stateAfter     = @(Get-StateFiles)
+
+    Record-Result -Phase 'P4' -Name 'child exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode)"
+    Record-Result -Phase 'P4' -Name 'selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P4' -Name 'UI Job Object assigned telemetry' -Pass ([bool]($logContent -match 'UI Job Object assigned'))
+    Record-Result -Phase 'P4' -Name 'Win32k mitigation applied telemetry (ui.disable=false -> not expected)' -Pass (-not ($logContent -match 'Win32k mitigation applied')) -Detail 'this config has ui.disable=false'
+    Record-Result -Phase 'P4' -Name 'rw ACL restored after run'     -Pass ($aclRwBefore -eq $aclRwAfter)
+    Record-Result -Phase 'P4' -Name 'ro ACL restored after run'     -Pass ($aclRoBefore -eq $aclRoAfter)
+    Record-Result -Phase 'P4' -Name 'denied ACL restored after run' -Pass ($aclDeniedBefore -eq $aclDeniedAfter)
+    Record-Result -Phase 'P4' -Name 'no orphan state files'         -Pass ($stateAfter.Count -eq 0) -Detail "files=$($stateAfter.Count)"
+    Record-Result -Phase 'P4' -Name 'child wrote and read inside rw path' -Pass ($r.Stdout -match 'hello-from-t3')
+
+    # And again with ui.disable=true so we hit the Win32k MITIGATION_POLICY path.
+    # cmd.exe will likely fail to initialize under Win32k disable (it loads
+    # user32 indirectly), so we don't assert child exit=0 — only that the
+    # mitigation telemetry was emitted (which happens before CreateProcessW).
+    $cfg2 = New-Config -Name 't3-ui-disable' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw)
+    $json = Get-Content -Raw $cfg2 | ConvertFrom-Json
+    $json.ui.disable = $true
+    ($json | ConvertTo-Json -Depth 10) | Out-File -LiteralPath $cfg2 -Encoding utf8 -Force
+
+    $log2 = Join-Path $ScratchRoot 'logs\t3-ui-disable.log'
+    $r2 = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfg2 -LogPath $log2
+    $logContent2 = Read-Log $log2
+    Assert-NoBfscfg -LogContent $logContent2 -Phase 'P4' -Name 't3-ui-disable'
+
+    Record-Result -Phase 'P4' -Name 'ui.disable=true emits Win32k mitigation applied' -Pass ([bool]($logContent2 -match 'Win32k mitigation applied')) -Detail "child exit=$($r2.ExitCode) (expected to fail; cmd.exe needs Win32k)"
+    Record-Result -Phase 'P4' -Name 'ui.disable=true emits selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContent2 -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    # Even though child crashed, ACEs must still be cleaned up.
+    $aclRwAfterUi = Get-Acl-Snapshot $rw
+    Record-Result -Phase 'P4' -Name 'ui.disable=true rw ACL still cleaned up' -Pass ($aclRwBefore -eq $aclRwAfterUi)
+    Record-Result -Phase 'P4' -Name 'ui.disable=true no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
+
+    # ---------------------------------------------------------------------
+    # Sandbox property test: ping requires raw ICMP sockets, which
+    # AppContainer denies by default (no `internetClient` capability is
+    # not the issue — even with it, raw sockets need elevated
+    # privileges). The child should exit non-zero almost immediately.
+    # If ping ever succeeds here we have a sandbox escape.
+    # ---------------------------------------------------------------------
+    $cfgPing = New-Config -Name 't3-ping-blocked' `
+        -CommandLine 'ping.exe -n 1 -w 1000 127.0.0.1' `
+        -ReadWrite @($rw) -TimeoutMs 10000
+    $logPing = Join-Path $ScratchRoot 'logs\t3-ping-blocked.log'
+
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    $rPing = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgPing -LogPath $logPing -TimeoutSec 30
+    $stopwatch.Stop()
+    $logContentPing = Read-Log $logPing
+    Assert-NoBfscfg -LogContent $logContentPing -Phase 'P4' -Name 't3-ping-blocked'
+
+    $combinedPing = "$($rPing.Stdout)`n$($rPing.Stderr)"
+    $aclRwAfterPing = Get-Acl-Snapshot $rw
+
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping (child exit != 0)' -Pass ($rPing.ExitCode -ne 0) -Detail "exit=$($rPing.ExitCode)"
+    # ping with one attempt and 1s timeout would take ~1.5s if successful;
+    # raw-socket creation failure exits in milliseconds. Use 5s as a
+    # generous upper bound that still detects "ping actually ran".
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping (failed fast, < 5s)' -Pass ($stopwatch.Elapsed.TotalSeconds -lt 5) -Detail ("elapsed={0:N2}s" -f $stopwatch.Elapsed.TotalSeconds)
+    # Best-effort confirmation that the failure mode was access/socket
+    # related, not e.g. ENOENT for ping.exe. Localized OS messages may
+    # vary; we accept several known signatures plus a network-error
+    # pattern. This is informational — the exit code + timing are the
+    # load-bearing assertions.
+    $accessSignal = $combinedPing -match '(?im)access\s*is\s*denied|access\s*denied|socket|10013|ICMP|general\s*failure|unable\s*to\s*contact'
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping (failure looks socket-related)' -Pass ([bool]$accessSignal) -Detail 'best-effort string match'
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentPing -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping: rw ACL still cleaned up' -Pass ($aclRwBefore -eq $aclRwAfterPing)
+    Record-Result -Phase 'P4' -Name 'sandbox blocks ping: no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
+
+    # ---------------------------------------------------------------------
+    # Access matrix: the existing sub-tests verify ACL apply/restore and
+    # that the rw grant *functionally* works (write+read inside rw). They
+    # do NOT verify that:
+    #   - ro is read-only (RO success on read, FAIL on write)
+    #   - denied is actually denied (FAIL on both)
+    #   - paths NOT in any policy are denied too (control row — proves
+    #     the AppContainer is sandboxed at all, not just that explicit
+    #     ACEs work)
+    # We pre-stage a `readme.txt` in each path, run a child that
+    # attempts read+write on each, and parse the resulting matrix.
+    # ---------------------------------------------------------------------
+    $control = Join-Path $ScratchRoot 'control'
+    # Pre-stage host-created files for the negative-side rows. We deliberately
+    # do NOT pre-create one in $rw — the rw row uses a child-created marker
+    # so it tests the grant at face value rather than depending on Windows'
+    # inheritance propagation to pre-existing children.
+    'ro-content'      | Out-File -LiteralPath (Join-Path $ro      'readme.txt') -Encoding ascii -Force
+    'denied-content'  | Out-File -LiteralPath (Join-Path $denied  'readme.txt') -Encoding ascii -Force
+    'control-content' | Out-File -LiteralPath (Join-Path $control 'readme.txt') -Encoding ascii -Force
+
+    $aclControlBefore = Get-Acl-Snapshot $control
+
+    # No outer cmd /c "..." wrapper, no NUL device redirects. Hypothesis
+    # under test: every previously-passing AppContainer command in this
+    # harness uses either a file redirect or no redirect at all. The
+    # earlier matrix attempt was the first test to use `>nul`/`2>nul`,
+    # and every clause failed. AppContainer may not grant access to the
+    # NUL device by default. Dropping the redirects lets `type` dump
+    # the file contents to stdout (parser ignores non-TAG lines) and
+    # lets `echo`'s error messages go to captured stderr.
+    # type's stdout goes to the inherited stdout (the harness captures
+    # it). type's stderr goes to inherited stderr on read failure
+    # (e.g. "Access is denied") — also captured. Both are fine: the
+    # harness's regex parser only consumes lines that match
+    # ^(TAG)=(PASS|FAIL)$ and ignores everything else.
+    function Probe-Read  { param($tag, $path, $name) "(type ""$path\$name"") && echo $tag=PASS || echo $tag=FAIL" }
+    function Probe-Write { param($tag, $path, $name) "(echo data > ""$path\$name"") && echo $tag=PASS || echo $tag=FAIL" }
+    $clauses = @(
+        # RW: child writes a fresh marker, then reads it back. This tests
+        # the grant directly without relying on inheritance propagation.
+        Probe-Write 'RW_WRITE'       $rw      'rw_marker.tmp'
+        Probe-Read  'RW_READ'        $rw      'rw_marker.tmp'
+        # RO: child reads the host-pre-created readme (tests inheritance
+        # propagation of the ALLOW ACE to existing children).
+        Probe-Read  'RO_READ'        $ro      'readme.txt'
+        Probe-Write 'RO_WRITE'       $ro      'rw_marker.tmp'
+        # Denied + control: must fail both ways.
+        Probe-Read  'DENIED_READ'    $denied  'readme.txt'
+        Probe-Write 'DENIED_WRITE'   $denied  'denied_attempt.tmp'
+        Probe-Read  'CONTROL_READ'   $control 'readme.txt'
+        Probe-Write 'CONTROL_WRITE'  $control 'control_attempt.tmp'
+    )
+    $matrixCmd = 'cmd /c ' + ($clauses -join ' & ')
+
+    $cfgMatrix = New-Config -Name 't3-access-matrix' -CommandLine $matrixCmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied @($denied)
+    $logMatrix = Join-Path $ScratchRoot 'logs\t3-access-matrix.log'
+    $rMatrix = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgMatrix -LogPath $logMatrix
+    $logContentMatrix = Read-Log $logMatrix
+    Assert-NoBfscfg -LogContent $logContentMatrix -Phase 'P4' -Name 't3-access-matrix'
+
+    # Parse the matrix from stdout into a hashtable.
+    $matrix = @{}
+    foreach ($line in ($rMatrix.Stdout -split "`r?`n")) {
+        if ($line -match '^(?<k>RW_READ|RW_WRITE|RO_READ|RO_WRITE|DENIED_READ|DENIED_WRITE|CONTROL_READ|CONTROL_WRITE)=(?<v>PASS|FAIL)\s*$') {
+            $matrix[$matches['k']] = $matches['v']
+        }
+    }
+    # Surface the raw matrix for diagnostic value when something fails.
+    $matrixSummary = ($matrix.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ' '
+
+    function Assert-Matrix {
+        param([string]$Key, [string]$Want, [string]$Reason)
+        $got = if ($matrix.ContainsKey($Key)) { $matrix[$Key] } else { '<missing>' }
+        Record-Result -Phase 'P4' -Name "matrix $Key=$Want ($Reason)" -Pass ($got -eq $Want) -Detail "got=$got; full=$matrixSummary"
+    }
+
+    Assert-Matrix 'RW_WRITE'       'PASS' 'rw grant must allow child to create files'
+    Assert-Matrix 'RW_READ'        'PASS' 'rw grant must allow child to read its own file'
+    Assert-Matrix 'RO_READ'        'PASS' 'ro grant must allow reads (tests ACE inheritance to existing children)'
+    Assert-Matrix 'RO_WRITE'       'FAIL' 'ro grant must NOT allow writes'
+    Assert-Matrix 'DENIED_READ'    'FAIL' 'denied path must block reads'
+    Assert-Matrix 'DENIED_WRITE'   'FAIL' 'denied path must block writes'
+    Assert-Matrix 'CONTROL_READ'   'FAIL' 'control path (no policy) must be sandboxed'
+    Assert-Matrix 'CONTROL_WRITE'  'FAIL' 'control path (no policy) must be sandboxed'
+
+    # All four ACLs must round-trip clean even though RO_WRITE / DENIED_*
+    # / CONTROL_* failures left no host-side residue (the failures are
+    # AppContainer-side, not host-side).
+    Record-Result -Phase 'P4' -Name 'matrix: rw ACL restored' -Pass ($aclRwBefore -eq (Get-Acl-Snapshot $rw))
+    Record-Result -Phase 'P4' -Name 'matrix: ro ACL restored' -Pass ($aclRoBefore -eq (Get-Acl-Snapshot $ro))
+    Record-Result -Phase 'P4' -Name 'matrix: denied ACL restored' -Pass ($aclDeniedBefore -eq (Get-Acl-Snapshot $denied))
+    Record-Result -Phase 'P4' -Name 'matrix: control ACL untouched' -Pass ($aclControlBefore -eq (Get-Acl-Snapshot $control))
+    Record-Result -Phase 'P4' -Name 'matrix: no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
+}
+
+# -----------------------------------------------------------------------
+# Phase 4c — Tier 1 (BaseContainer) deny-ACE empirical test
+#
+# Asserts that the deny ACE the dispatcher applies on the T1 path
+# actually denies the BaseContainer-spawned child access to the path.
+# This is the empirical answer to phase-4 review #4 ("BaseContainer
+# might not run under the AppContainer SID, in which case the deny ACE
+# targets a principal the child does not run as → silent no-op").
+#
+# Strategy:
+#   1. Skip the phase entirely if the BaseContainer API is not present on
+#      this host (most current 25H2 hosts). T1 force without the API
+#      backing it cannot exercise the deny.
+#   2. Create a marker file under a denied directory. Force T1. Have the
+#      child try to `type` the marker. The child must exit non-zero AND
+#      not echo the marker contents.
+# -----------------------------------------------------------------------
+function Phase-T1DenyForced {
+    Section 'Phase 4c: T1 deny-ACE empirical test (skipped if BC API absent)'
+    Clear-StateFiles
+
+    # Use the release-build probe to discover BC API presence — same JSON
+    # surface as Phase 1.
+    $probe = Invoke-Probe -Wxc $WxcRelease -Phase 'P4c' -Name 'bc-presence-probe'
+    if (-not $probe) {
+        Record-Result -Phase 'P4c' -Name 'probe succeeded' -Pass $false -Detail 'probe returned null; cannot proceed'
+        return
+    }
+    if (-not $probe.probes.baseContainerApiPresent) {
+        Record-Result -Phase 'P4c' -Name 'BC API present (required for T1 test)' -Pass $true -Detail 'SKIPPED: baseContainerApiPresent=false on this host'
+        return
+    }
+
+    $denied = Join-Path $ScratchRoot 'deniedT1'
+    New-Item -ItemType Directory -Force -Path $denied | Out-Null
+    $marker = Join-Path $denied 'secret.txt'
+    # Use a sentinel string the test can grep for. If the child ever
+    # echoes it, the deny ACE failed silently.
+    $sentinel = 'T1_DENY_SENTINEL_e54a23'
+    Set-Content -LiteralPath $marker -Value $sentinel -Encoding utf8 -Force
+
+    $aclBefore = Get-Acl-Snapshot $denied
+
+    # The child invocation: try to read the marker. cmd.exe's `type`
+    # writes "Access is denied." (or an OS-localized variant) to stderr
+    # and exits with a non-zero code when the file can't be opened.
+    $cmd = "cmd /c type `"$marker`""
+    $cfg = New-Config -Name 't1-deny-forced' -CommandLine $cmd -Denied @($denied)
+    $log = Join-Path $ScratchRoot 'logs\t1-deny-forced.log'
+    $r = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfg -LogPath $log
+    $logContent = Read-Log $log
+
+    $aclAfter = Get-Acl-Snapshot $denied
+    $stateAfter = @(Get-StateFiles)
+
+    Record-Result -Phase 'P4c' -Name 'selected isolation tier: base-container' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?base-container')) -Detail "log saw tier=base-container"
+    Record-Result -Phase 'P4c' -Name 'child did not echo denied-file contents (deny ACE worked)' -Pass (-not ($r.Stdout -match $sentinel)) -Detail "stdout-saw-sentinel=$([bool]($r.Stdout -match $sentinel))"
+    Record-Result -Phase 'P4c' -Name 'child exited non-zero (access denied)' -Pass ($r.ExitCode -ne 0) -Detail "exit=$($r.ExitCode)"
+    Record-Result -Phase 'P4c' -Name 'denied ACL restored after run' -Pass ($aclBefore -eq $aclAfter)
+    Record-Result -Phase 'P4c' -Name 'no orphan state files' -Pass ($stateAfter.Count -eq 0) -Detail "files=$($stateAfter.Count)"
+}
+
+# -----------------------------------------------------------------------
+# Phase 4b — UI mitigation behavior matrix (T3 forced, debug build)
+#
+# Phase 4 already asserts that Win32k mitigation applied telemetry fires
+# when ui.disable=true and that UI Job Object assigned fires unconditionally.
+# Those checks only prove the parent reached the corresponding API. This
+# phase runs an in-sandbox probe binary that *attempts the operations the
+# UI restrictions are documented to block*, then asserts the kernel
+# actually denied them.
+#
+# Scenario A: ui.disable=false + maximal base_process_ui blocks ->
+#   every JOB_OBJECT_UILIMIT_* bit is set. Run all probes EXCEPT WIN32K
+#   and assert each is reported PASS (operation was blocked).
+# Scenario B: ui.disable=true -> Win32k mitigation. Run WIN32K alone and
+#   assert the child process never printed WIN32K=FAIL (mitigation killed
+#   it on the GetMessageW syscall).
+# -----------------------------------------------------------------------
+function Phase-UiMitigationMatrix {
+    Section 'Phase 4b: UI mitigation behavior matrix (T3 forced)'
+
+    $rw = Join-Path $ScratchRoot 'rw'
+
+    # ---------------- Scenario A: maximal UILIMIT bits -----------------
+    # ui: disable=false (so Win32k is allowed but UILIMIT bits gate
+    # specific operations), clipboard=none (block both R+W),
+    # injection=false. base_process_ui: isolation=container (HANDLES +
+    # GLOBALATOMS), desktopSystemControl=false (DESKTOP + EXITWINDOWS),
+    # systemSettings=none (SYSTEMPARAMETERS + DISPLAYSETTINGS), ime=false.
+    $probeArgsA = 'GLOBALATOMS READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES'
+    $cmdA = "`"$UiProbeDebug`" $probeArgsA"
+    $cfgA = New-Config -Name 'ui-matrix-A-allbits' `
+        -CommandLine $cmdA `
+        -ReadWrite @($rw) `
+        -UiDisable $false `
+        -Clipboard 'none' `
+        -Injection $false `
+        -BpUiIsolation 'container' `
+        -BpUiDesktopControl $false `
+        -BpUiSystemSettings 'none' `
+        -BpUiIme $false
+    $logA = Join-Path $ScratchRoot 'logs\ui-matrix-A.log'
+    $rA = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgA -LogPath $logA
+    $logContentA = Read-Log $logA
+    Assert-NoBfscfg -LogContent $logContentA -Phase 'P4b' -Name 'ui-matrix-A'
+
+    $matrixA = @{}
+    foreach ($line in ($rA.Stdout -split "`r?`n")) {
+        if ($line -match '^(?<k>GLOBALATOMS|READCLIPBOARD|WRITECLIPBOARD|SYSTEMPARAMETERS|DISPLAYSETTINGS|DESKTOP|EXITWINDOWS|HANDLES|WIN32K)=(?<v>PASS|FAIL)\s*$') {
+            $matrixA[$matches['k']] = $matches['v']
+        }
+    }
+    $summaryA = ($matrixA.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ' '
+
+    Record-Result -Phase 'P4b' -Name 'scenarioA: UI Job Object assigned telemetry' -Pass ([bool]($logContentA -match 'UI Job Object assigned'))
+    Record-Result -Phase 'P4b' -Name 'scenarioA: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentA -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    # ui.disable=false on this run: Win32k mitigation applied must NOT appear.
+    Record-Result -Phase 'P4b' -Name 'scenarioA: no Win32k mitigation applied (ui.disable=false)' -Pass (-not ($logContentA -match 'Win32k mitigation applied'))
+
+    foreach ($tag in @('GLOBALATOMS','READCLIPBOARD','WRITECLIPBOARD','SYSTEMPARAMETERS','DISPLAYSETTINGS','DESKTOP','EXITWINDOWS','HANDLES')) {
+        $got = if ($matrixA.ContainsKey($tag)) { $matrixA[$tag] } else { '<missing>' }
+        Record-Result -Phase 'P4b' -Name "scenarioA: $tag blocked (probe -> PASS)" -Pass ($got -eq 'PASS') -Detail "got=$got; full=$summaryA"
+    }
+
+    # ---------------- Scenario B: ui.disable=true (Win32k mitigation) ----
+    # WIN32K probe makes a Win32k syscall (GetMessageW). With the
+    # mitigation in place the kernel terminates the process. If the
+    # mitigation is NOT honored the probe prints WIN32K=FAIL and exits 0.
+    $cmdB = "`"$UiProbeDebug`" WIN32K"
+    $cfgB = New-Config -Name 'ui-matrix-B-win32k' `
+        -CommandLine $cmdB `
+        -ReadWrite @($rw) `
+        -UiDisable $true
+    $logB = Join-Path $ScratchRoot 'logs\ui-matrix-B.log'
+    $rB = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgB -LogPath $logB
+    $logContentB = Read-Log $logB
+    Assert-NoBfscfg -LogContent $logContentB -Phase 'P4b' -Name 'ui-matrix-B'
+
+    $printedFail = ($rB.Stdout -match '(?m)^WIN32K=FAIL\s*$')
+    $printedPass = ($rB.Stdout -match '(?m)^WIN32K=PASS\s*$')
+
+    Record-Result -Phase 'P4b' -Name 'scenarioB: Win32k mitigation applied telemetry' -Pass ([bool]($logContentB -match 'Win32k mitigation applied'))
+    Record-Result -Phase 'P4b' -Name 'scenarioB: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentB -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    # Mitigation worked iff the child never reported WIN32K=FAIL. Child
+    # exit code is incidental — under the mitigation the process is killed
+    # by the kernel; without it the probe completes and exits 0.
+    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=FAIL (mitigation honored)' -Pass (-not $printedFail) -Detail "exit=$($rB.ExitCode); stdout=$($rB.Stdout.Trim())"
+    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=PASS' -Pass (-not $printedPass) -Detail 'probe never returns PASS for WIN32K (process is killed before printing)'
+}
+
+# -----------------------------------------------------------------------
+# Phase 5 — allowDaclMutation=false rejection under forced T3
+# -----------------------------------------------------------------------
+function Phase-DaclDisabled {
+    Section 'Phase 5: debug build, T3 forced, allowDaclMutation=false'
+    Clear-StateFiles
+
+    $rw = Join-Path $ScratchRoot 'rw'
+    $aclBefore = Get-Acl-Snapshot $rw
+
+    $cfg = New-Config -Name 't3-refuse' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw) -AllowDaclMutation $false
+    $log = Join-Path $ScratchRoot 'logs\t3-refuse.log'
+    $r = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfg -LogPath $log
+    $logContent = Read-Log $log
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P5' -Name 't3-refuse'
+
+    $aclAfter = Get-Acl-Snapshot $rw
+    $stateAfter = @(Get-StateFiles)
+
+    Record-Result -Phase 'P5' -Name 'dispatch refused (exit != 0)' -Pass ($r.ExitCode -ne 0) -Detail "exit=$($r.ExitCode)"
+    Record-Result -Phase 'P5' -Name 'rw ACL untouched' -Pass ($aclBefore -eq $aclAfter)
+    Record-Result -Phase 'P5' -Name 'no state file written' -Pass ($stateAfter.Count -eq 0)
+    $stderrOrLog = ($r.Stderr + "`n" + $logContent)
+    Record-Result -Phase 'P5' -Name 'error message mentions DACL fallback' -Pass ([bool]($stderrOrLog -match '(?i)DACL fallback'))
+}
+
+# -----------------------------------------------------------------------
+# Phase 6 — crash-recovery
+# -----------------------------------------------------------------------
+function Phase-CrashRecovery {
+    Section 'Phase 6: debug build, T3 forced, taskkill mid-run (crash recovery)'
+    Clear-StateFiles
+
+    $rw = Join-Path $ScratchRoot 'rw'
+    $aclBefore = Get-Acl-Snapshot $rw
+
+    # Need a long-sleeper that does NOT need raw sockets (AppContainer
+    # blocks them, so `ping` exits in milliseconds with "Access denied").
+    # PowerShell's Start-Sleep just calls WaitForSingleObject — no
+    # privilege required.
+    $cfg = New-Config -Name 't3-crash' -CommandLine 'powershell.exe -NoLogo -NoProfile -Command "Start-Sleep -Seconds 20"' -ReadWrite @($rw) -TimeoutMs 60000
+    $log = Join-Path $ScratchRoot 'logs\t3-crash.log'
+
+    # Natural detection with `tier2_bfs` off lands at T3 for any
+    # policy with rw paths, so no MXC_FORCE_TIER manipulation is
+    # needed (and it would be a no-op against the production binary
+    # in any case).
+    $proc = Start-Process -FilePath $WxcDebug `
+        -ArgumentList @('--config', "`"$cfg`"", '--experimental', '--log-file', "`"$log`"") `
+        -PassThru -WindowStyle Hidden -RedirectStandardOutput (Join-Path $ScratchRoot 'logs\t3-crash.stdout') `
+                                      -RedirectStandardError  (Join-Path $ScratchRoot 'logs\t3-crash.stderr')
+
+    # Wait until the dispatcher writes a state file (ACEs applied) or 10s.
+    $deadline = (Get-Date).AddSeconds(10)
+    while ((Get-Date) -lt $deadline) {
+        $sf = @(Get-StateFiles | Where-Object { $_.Name -match "pid-$($proc.Id)-" })
+        if ($sf.Count -gt 0) { break }
+        Start-Sleep -Milliseconds 200
+    }
+    $stateMid = @(Get-StateFiles | Where-Object { $_.Name -match "pid-$($proc.Id)-" })
+    $aclMid = Get-Acl-Snapshot $rw
+
+    Record-Result -Phase 'P6' -Name 'state file present mid-run' -Pass ($stateMid.Count -gt 0)
+    Record-Result -Phase 'P6' -Name 'ACEs visible mid-run' -Pass ($aclBefore -ne $aclMid)
+
+    # Kill — simulate hard crash.
+    try { Stop-Process -Id $proc.Id -Force -ErrorAction Stop } catch {
+        Write-Warning "Could not kill PID $($proc.Id): $_"
+    }
+    Wait-Process -Id $proc.Id -ErrorAction SilentlyContinue
+
+    $aclAfterKill = Get-Acl-Snapshot $rw
+    $stateAfterKill = @(Get-StateFiles | Where-Object { $_.Name -match "pid-$($proc.Id)-" })
+    Record-Result -Phase 'P6' -Name 'state file orphaned after kill' -Pass ($stateAfterKill.Count -gt 0)
+    Record-Result -Phase 'P6' -Name 'ACEs still on path after kill' -Pass ($aclAfterKill -ne $aclBefore)
+
+    # Next wxc-exec invocation should reap the orphan via recover_orphaned_state.
+    $recoveryStdout = & $WxcRelease --probe 2>&1
+    Start-Sleep -Milliseconds 300
+    $aclAfterRecovery = Get-Acl-Snapshot $rw
+    $stateAfterRecovery = @(Get-StateFiles)
+
+    Record-Result -Phase 'P6' -Name 'orphan reaped on next launch'   -Pass ($stateAfterRecovery.Count -eq 0) -Detail "remaining=$($stateAfterRecovery.Count)"
+    Record-Result -Phase 'P6' -Name 'ACL restored after recovery'    -Pass ($aclBefore -eq $aclAfterRecovery)
+    Record-Result -Phase 'P6' -Name 'startup log mentions DACL recovery' -Pass ([bool](($recoveryStdout -join "`n") -match 'DACL recovery'))
+}
+
+# -----------------------------------------------------------------------
+# Phase 7 — Rust unit tests
+# -----------------------------------------------------------------------
+function Invoke-CargoTest {
+    # Run a `cargo test` invocation, append its full output to $CargoLog,
+    # surface only summary / error lines to the transcript.
+    param(
+        [Parameter(Mandatory)] [string[]]$Arguments,
+        [Parameter(Mandatory)] [string]$Label
+    )
+    "" | Add-Content -LiteralPath $CargoLog
+    "===== $Label  (cargo $($Arguments -join ' ')) =====" | Add-Content -LiteralPath $CargoLog
+    $output = & cargo @Arguments 2>&1
+    $exit = $LASTEXITCODE
+    $output | Out-File -LiteralPath $CargoLog -Append -Encoding utf8
+
+    # Surface load-bearing lines to the transcript:
+    # - "test result:" — pass/fail summary per test binary
+    # - "error[" / "error:" / "warning:" — compile / link diagnostics
+    # - "Compiling " / "Finished " — high-level cargo progress
+    $summary = $output | Where-Object {
+        $_ -match '^(test result:|error(\[|:)|warning:|\s+Compiling |\s+Finished )'
+    }
+    if ($summary) {
+        $summary | ForEach-Object { Write-Host "  $_" }
+    } else {
+        # Fallback: surface the last 10 lines so a silent failure doesn't
+        # disappear into the side log.
+        Write-Host '  (no summary lines matched — last 10 lines:)'
+        $output | Select-Object -Last 10 | ForEach-Object { Write-Host "    $_" }
+    }
+    return $exit
+}
+
+function Phase-UnitTests {
+    Section 'Phase 7: cargo test'
+    # Truncate the cargo log at the start of each run.
+    Set-Content -LiteralPath $CargoLog -Value "Win25H2Safe-Tests cargo log — $(Get-Date -Format 'o')`n" -Encoding utf8
+    Push-Location $CargoRoot
+    try {
+        $exit1 = Invoke-CargoTest -Arguments @('test', '-p', 'wxc_common', '--lib') -Label 'wxc_common --lib'
+        Record-Result -Phase 'P7' -Name 'cargo test -p wxc_common' -Pass ($exit1 -eq 0) -Detail "exit=$exit1; full log: $CargoLog"
+        # `wxc` is a binary-only crate — no --lib target. Run its bin tests.
+        $exit2 = Invoke-CargoTest -Arguments @('test', '-p', 'wxc', '--bins') -Label 'wxc --bins'
+        Record-Result -Phase 'P7' -Name 'cargo test -p wxc --bins' -Pass ($exit2 -eq 0) -Detail "exit=$exit2; full log: $CargoLog"
+    } finally {
+        Pop-Location
+    }
+}
+
+# -----------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------
+# Capture all host output (Write-Host, Section banners, cargo build/test
+# output) to a transcript file so the user can paste a single path
+# instead of scrolling the terminal. Stop-Transcript runs in finally so
+# even an abort produces a complete transcript.
+try { Stop-Transcript | Out-Null } catch {}  # close any orphaned transcript
+$null = Start-Transcript -Path $ResultsFile -Force -IncludeInvocationHeader
+
+try {
+    Test-Preflight
+    Initialize-Scratch
+
+    Phase-UnitTests
+    Phase-Probes
+    Phase-EmptyRelease
+    Phase-DeniedRelease
+    Phase-T3Forced
+    Phase-T1DenyForced
+    Phase-UiMitigationMatrix
+    Phase-DaclDisabled
+    Phase-CrashRecovery
+}
+catch {
+    Write-Host ''
+    Write-Host "HARNESS ABORTED: $_" -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor DarkRed
+    # Record the abort as a failure so the cleanup logic in `finally`
+    # preserves the scratch dir for post-mortem inspection.
+    Record-Result -Phase 'ABORT' -Name 'harness aborted' -Pass $false -Detail "$_"
+}
+finally {
+    Section 'Summary'
+    # Force pipeline output to an array — under StrictMode, $null.Count throws.
+    $passed = @($Script:Results | Where-Object { $_.Pass })
+    $failed = @($Script:Results | Where-Object { -not $_.Pass })
+    $pass = $passed.Count
+    $fail = $failed.Count
+    Write-Host ("Total: {0}    Passed: {1}    Failed: {2}" -f ($pass + $fail), $pass, $fail)
+    if ($fail -gt 0) {
+        Write-Host ''
+        Write-Host 'Failures:' -ForegroundColor Red
+        foreach ($r in $failed) {
+            Write-Host ("  [{0}] {1} :: {2}" -f $r.Phase, $r.Name, $r.Detail) -ForegroundColor Red
+        }
+    }
+
+    # Structured JSON for programmatic consumption.
+    $summary = [pscustomobject]@{
+        timestamp   = (Get-Date).ToString('o')
+        host        = $env:COMPUTERNAME
+        os          = (Get-CimInstance Win32_OperatingSystem).Caption
+        osBuild     = (Get-CimInstance Win32_OperatingSystem).BuildNumber
+        total       = $pass + $fail
+        passed      = $pass
+        failed      = $fail
+        results     = $Script:Results
+    }
+    try {
+        ($summary | ConvertTo-Json -Depth 6) | Out-File -LiteralPath $ResultsJson -Encoding utf8 -Force
+    } catch {
+        Write-Host "warning: could not write JSON results: $_" -ForegroundColor Yellow
+    }
+
+    Write-Host ''
+    if (Test-Path $ScratchRoot) {
+        Write-Host ("Logs and configs: {0}" -f $ScratchRoot)
+    }
+    Write-Host ("Transcript:        {0}" -f $ResultsFile)
+    Write-Host ("JSON summary:      {0}" -f $ResultsJson)
+    if (Test-Path $CargoLog) {
+        Write-Host ("Cargo full log:    {0}" -f $CargoLog)
+    }
+    if (-not $KeepArtifacts -and $fail -eq 0 -and $pass -gt 0 -and (Test-Path $ScratchRoot)) {
+        # Re-validate before deletion — `Assert-SafeScratchRoot` ran at
+        # the start of the suite, but the variable could in principle
+        # be mutated mid-run by future refactors. Cheap belt-and-
+        # suspenders against an accidental recursive delete escape.
+        Assert-SafeScratchRoot
+        Remove-Item -Recurse -Force -LiteralPath $ScratchRoot -ErrorAction SilentlyContinue
+    }
+    try { Stop-Transcript | Out-Null } catch {}
+    if ($fail -gt 0 -or $pass -eq 0) { exit 1 } else { exit 0 }
+}


### PR DESCRIPTION
This PR integrates the downlevel work done in previous phases such that the
feature works end-to-end. Currently only T3 is supported downlevel. There is a
compile-time `tier2_bfs` feature that keeps T2 unreachable in production
builds on hosts where `bfscfg.exe` hangs the OS (Windows 11 25H2).
Crash-safe host-DACL augmentation backs T3.

Details:
- New `tier2_bfs` Cargo feature; off by default; gates both probe-time
  discovery and runtime spawn of `bfscfg.exe`.
- `DaclManager` with per-process state files under
  `%LOCALAPPDATA%\Microsoft\MXC\dacl-restore`, surgical canonical-order
  DACL rewrite, and orphan reaping on next `wxc-exec --probe`.
- `wxc-exec --probe` exposes tier decision + warnings; SDK
  `getPlatformSupport()` surfaces them as `isolationTier` /
  `isolationWarnings`.
- New `wxc_ui_probe` binary for in-sandbox JOB_OBJECT_UILIMIT and
  Win32k-mitigation telemetry.

Test:
- Win25H2Safe-Tests.ps1 harness: 78/81 (3 known UI-policy gaps).
- T3-Workloads.ps1 smoke suite: 7/10 (3 known AC NUL-device denials).
- wxc_common cargo test: 388/388 feature-off, 396/396 feature-on.
- SDK npm test: 151 pass.
- CI matrix now exercises `--features tier2_bfs` on x64 + arm64.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/410)