### PR TITLE
Fix: exempt abstract 'process' on macOS from allowOutbound precheck

### DIFF
--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -313,8 +313,9 @@ export function createConfigFromPolicy(
         // WSLC supports block + allowedHosts via iptables (Bridged networking
         // with per-host filtering). macOS sandbox supports it natively via
         // per-host Seatbelt rules. Bubblewrap and LXC support it via iptables.
-        // Abstract `'process'` on Linux resolves to Bubblewrap server-side, so
-        // treat it the same as explicit `'bubblewrap'` here.
+        // Abstract `'process'` on Linux resolves to Bubblewrap server-side, and
+        // on macOS resolves to Seatbelt, so treat both the same as their
+        // explicit backend counterparts here.
         // Other backends require allowOutbound for host filtering since it
         // maps to AppContainer capabilities.
         const resolvesToHostFilteringBackend =
@@ -322,7 +323,8 @@ export function createConfigFromPolicy(
             containment === 'seatbelt' ||
             containment === 'bubblewrap' ||
             containment === 'lxc' ||
-            (containment === 'process' && platform === 'linux');
+            (containment === 'process' && platform === 'linux') ||
+            (containment === 'process' && platform === 'darwin');
         if (!resolvesToHostFilteringBackend) {
             if ((policy.network.allowedHosts?.length || policy.network.blockedHosts?.length) && !policy.network.allowOutbound) {
                 throw new Error('allowedHosts/blockedHosts require allowOutbound to be true');

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -629,10 +629,11 @@ describe('createConfigFromPolicy', () => {
       try {
         const config = createConfigFromPolicy({
           version: '0.5.0-alpha',
-          network: { allowOutbound: true, blockedHosts: ['evil.com'] },
+          network: { blockedHosts: ['evil.com'] },
         });
         assert.strictEqual(config.containment, 'seatbelt');
         assert.deepStrictEqual(config.network!.blockedHosts, ['evil.com']);
+        assert.strictEqual(config.network!.defaultPolicy, 'block');
       } finally {
         restore();
       }

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -593,6 +593,67 @@ describe('createConfigFromPolicy', () => {
     });
   });
 
+  describe('macOS', () => {
+    let originalPlatform: PropertyDescriptor | undefined;
+
+    const mockDarwin = () => {
+      originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+      Object.defineProperty(process, 'platform', { value: 'darwin' });
+    };
+
+    const restore = () => {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform);
+      }
+    };
+
+    it('should allow allowedHosts without allowOutbound on macOS (seatbelt supports per-host filtering)', () => {
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.5.0-alpha',
+          network: { allowedHosts: ['api.github.com'] },
+        });
+        // Abstract 'process' on macOS resolves to 'seatbelt' in the wire format
+        // (unlike Linux where the binary resolves it server-side).
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.network!.allowedHosts, ['api.github.com']);
+        assert.strictEqual(config.network!.defaultPolicy, 'block');
+      } finally {
+        restore();
+      }
+    });
+
+    it('should allow blockedHosts without allowOutbound on macOS', () => {
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.5.0-alpha',
+          network: { allowOutbound: true, blockedHosts: ['evil.com'] },
+        });
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.network!.blockedHosts, ['evil.com']);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject proxy configuration on macOS', () => {
+      mockDarwin();
+      try {
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.4.0-alpha',
+            network: { proxy: { builtinTestServer: true } },
+          }),
+          { message: /not supported on macOS/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('network validation', () => {
     // These tests assert the "allowOutbound required for host filtering"
     // gate. The gate applies to backends that map host filtering to


### PR DESCRIPTION
On macOS, the abstract containment 'process' resolves to the seatbelt backend, which supports per-host network filtering natively via sandbox-exec profiles. The SDK precheck incorrectly required allowOutbound=true for allowedHosts/blockedHosts when using the default 'process' containment on macOS, despite the explicit 'seatbelt' backend being correctly exempted.

Add 'darwin' platform check to resolvesToHostFilteringBackend alongside the existing 'linux' check (which maps to bubblewrap). Add unit tests mirroring the Linux coverage from PR #368.

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/411)