### PR TITLE
Dedup DACL masks into a single source of truth

### DIFF
--- a/src/wxc_common/src/dispatcher.rs
+++ b/src/wxc_common/src/dispatcher.rs
@@ -73,7 +73,7 @@ use crate::appcontainer_runner::{derive_sid_string, AppContainerScriptRunner, Fi
 use crate::base_container_runner::BaseContainerRunner;
 use crate::error::WxcError;
 use crate::fallback_detector::{self, FallbackError, IsolationTier};
-use crate::filesystem_dacl::{DaclError, DaclManager};
+use crate::filesystem_dacl::{DaclError, DaclManager, RO_MASK, RW_MASK};
 use crate::models::CodexRequest;
 use crate::script_runner::ScriptRunner;
 
@@ -197,20 +197,6 @@ fn container_name(request: &CodexRequest) -> String {
 fn paths_to_pathbufs(paths: &[String]) -> Vec<PathBuf> {
     paths.iter().map(PathBuf::from).collect()
 }
-
-/// Access masks that mirror what
-/// `DaclManager::grant_appcontainer_access` stamps. Kept here (not
-/// imported from `fallback_detector`) because the filter is part of
-/// the dispatcher's apply-side contract; the detector has its own
-/// mirror that must match.
-const T3_RW_MASK: u32 = {
-    use windows::Win32::Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE};
-    FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0
-};
-const T3_RO_MASK: u32 = {
-    use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
-    FILE_GENERIC_READ.0
-};
 
 /// Drop paths that already grant `needed_mask` to the well-known
 /// AppContainer SIDs (`ALL APPLICATION PACKAGES`,
@@ -347,11 +333,11 @@ pub fn dispatch_with_fallback(request: &CodexRequest) -> Result<Dispatched, Disp
             // access, which well-known group grants can't do.
             let readwrite = filter_paths_needing_grant(
                 paths_to_pathbufs(&request.policy.readwrite_paths),
-                T3_RW_MASK,
+                RW_MASK,
             );
             let readonly = filter_paths_needing_grant(
                 paths_to_pathbufs(&request.policy.readonly_paths),
-                T3_RO_MASK,
+                RO_MASK,
             );
             let denied = paths_to_pathbufs(&request.policy.denied_paths);
             let sid = derive_sid_string(&container_name(request)).map_err(DispatchError::Sid)?;
@@ -544,7 +530,7 @@ mod tests {
     /// token's well-known-SID set — and assert
     /// `filter_paths_needing_grant` drops the path. A tempdir without
     /// any stamp must survive the filter because %TEMP%'s shadow
-    /// ACLs do not grant the well-known AC SIDs `T3_RW_MASK`.
+    /// ACLs do not grant the well-known AC SIDs `RW_MASK`.
     #[test]
     fn filter_paths_needing_grant_drops_well_known_grant() {
         use crate::test_env::ScopedStateDir;
@@ -567,7 +553,7 @@ mod tests {
             td_grant.path().to_path_buf(),
             td_no_grant.path().to_path_buf(),
         ];
-        let kept = filter_paths_needing_grant(input, T3_RW_MASK);
+        let kept = filter_paths_needing_grant(input, RW_MASK);
         assert!(
             !kept.iter().any(|p| p == td_grant.path()),
             "grant-stamped path should be filtered out: kept={kept:?}"

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -205,10 +205,10 @@ pub fn detect(
     // Denied paths always require `WRITE_DAC` because well-known SID
     // grants don't help us subtract access.
     for p in &policy.readwrite_paths {
-        ensure_path_grantable_for_ac(Path::new(p), rw_mask())?;
+        ensure_path_grantable_for_ac(Path::new(p), crate::filesystem_dacl::RW_MASK)?;
     }
     for p in &policy.readonly_paths {
-        ensure_path_grantable_for_ac(Path::new(p), ro_mask())?;
+        ensure_path_grantable_for_ac(Path::new(p), crate::filesystem_dacl::RO_MASK)?;
     }
     verify_write_dac_all(&policy.denied_paths)?;
     Ok(TierDecision {
@@ -217,22 +217,6 @@ pub fn detect(
         bfscfg_path: None,
         warnings,
     })
-}
-
-/// Access mask the dispatcher would grant for a `readwritePaths` entry.
-/// Must stay in sync with
-/// [`crate::filesystem_dacl::DaclManager::grant_appcontainer_access`].
-fn rw_mask() -> u32 {
-    use windows::Win32::Storage::FileSystem::{DELETE, FILE_GENERIC_READ, FILE_GENERIC_WRITE};
-    FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0
-}
-
-/// Access mask the dispatcher would grant for a `readonlyPaths` entry.
-/// Must stay in sync with the RO branch of
-/// [`crate::filesystem_dacl::DaclManager::grant_appcontainer_access`].
-fn ro_mask() -> u32 {
-    use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
-    FILE_GENERIC_READ.0
 }
 
 /// Returns `Ok(true)` if a per-run ACE on `path` is unnecessary because

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -96,6 +96,40 @@ use windows::Win32::System::Threading::{
 };
 
 // -------------------------------------------------------------------------
+// Access masks — single source of truth
+// -------------------------------------------------------------------------
+//
+// These are the masks `DaclManager::grant_appcontainer_access` actually
+// stamps onto host paths. Other modules (the dispatcher's
+// `filter_paths_needing_grant`, the fallback detector's
+// `ensure_path_grantable_for_ac` precheck) must observe the SAME
+// values or they'll predict / filter against a different mask than
+// what we apply, silently breaking the "skip per-run ACE when AC SID
+// already has access" optimization and the WRITE_DAC precheck.
+//
+// Keep these as the only definitions in the crate; the constants
+// are `pub(crate)` so dispatcher and fallback_detector can import
+// them rather than re-derive the bit pattern.
+
+/// Access mask granted on `readwritePaths` entries: read + write + delete.
+pub(crate) const RW_MASK: u32 = FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0;
+
+/// Access mask granted on `readonlyPaths` entries: read only.
+pub(crate) const RO_MASK: u32 = FILE_GENERIC_READ.0;
+
+// Compile-time guarantee that the masks above keep their well-known
+// shape. Any change to [`RW_MASK`] or [`RO_MASK`] that breaks one of
+// these invariants fails to build, preventing silent drift inside
+// the dispatcher's `filter_paths_needing_grant` and the detector's
+// `ensure_path_grantable_for_ac` (both of which read the constants
+// directly from this module).
+const _: () = {
+    assert!(RW_MASK == FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0);
+    assert!(RO_MASK == FILE_GENERIC_READ.0);
+    assert!((RW_MASK & RO_MASK) == RO_MASK);
+};
+
+// -------------------------------------------------------------------------
 // Public API
 // -------------------------------------------------------------------------
 
@@ -278,13 +312,11 @@ impl DaclManager {
         readwrite: &[PathBuf],
         readonly: &[PathBuf],
     ) -> Result<(), DaclError> {
-        let rw_mask = FILE_GENERIC_READ.0 | FILE_GENERIC_WRITE.0 | DELETE.0;
-        let ro_mask = FILE_GENERIC_READ.0;
         for p in readwrite {
-            self.apply_one(appcontainer_sid_str, p, rw_mask, AceType::Allow)?;
+            self.apply_one(appcontainer_sid_str, p, RW_MASK, AceType::Allow)?;
         }
         for p in readonly {
-            self.apply_one(appcontainer_sid_str, p, ro_mask, AceType::Allow)?;
+            self.apply_one(appcontainer_sid_str, p, RO_MASK, AceType::Allow)?;
         }
         Ok(())
     }
@@ -1769,6 +1801,12 @@ fn process_creation_filetime() -> Result<u64, DaclError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Note: the analogous compile-time `const _: () = assert!(...)`
+    // block at module level (above) covers RW_MASK/RO_MASK shape
+    // invariants. Putting them there means a value drift fails the
+    // build instead of silently passing tests on hosts where the
+    // suite is filtered.
 
     #[test]
     fn state_file_roundtrip() {


### PR DESCRIPTION
This PR collapses three local definitions of the RW / RO access masks
(in dispatcher, fallback_detector, and filesystem_dacl) into one set
of `pub(crate)` constants owned by filesystem_dacl — the module that
actually stamps them. The three sites now import the same constants
instead of re-deriving the same bit pattern.

Details:
- Add `RW_MASK` / `RO_MASK` as `pub(crate) const` in filesystem_dacl,
  next to `grant_appcontainer_access` which applies them.
- Remove `T3_RW_MASK` / `T3_RO_MASK` from dispatcher and `rw_mask()` /
  `ro_mask()` from fallback_detector. Both modules now import from
  filesystem_dacl.
- Add a module-level `const _: () = assert!(...)` that pins the
  bit-pattern of each mask at compile time, so a future drift in
  either constant fails the build rather than silently shifting the
  filter / precheck behavior.

Test:
- wxc_common cargo test: 388/388 (unchanged — pure refactor; values
  byte-identical to before).
- cargo clippy --all-targets -- -D warnings: clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/412)