### PR TITLE
Replace hand-rolled Win32 constants with windows-rs re-exports

### DIFF
--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -4,18 +4,22 @@
 use std::ptr;
 
 use windows::Win32::Foundation::{
-    GetLastError, LocalFree, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    GetLastError, LocalFree, ERROR_ALREADY_EXISTS, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
 use windows::Win32::Security::{FreeSid, PSID};
+use windows::Win32::System::SystemServices::SE_GROUP_ENABLED;
 use windows::Win32::System::Threading::{
     CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
     InitializeProcThreadAttributeList, ResumeThread, TerminateProcess, UpdateProcThreadAttribute,
-    WaitForSingleObject, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_CREATION_FLAGS, PROCESS_INFORMATION,
-    PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, STARTUPINFOEXW, STARTUPINFOW,
+    WaitForSingleObject, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
+    EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_CREATION_FLAGS,
+    PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
+    PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+    STARTUPINFOEXW, STARTUPINFOW,
 };
 use windows_core::{PCWSTR, PWSTR};
 
@@ -27,19 +31,12 @@ use crate::process_util::{get_capability_sid_from_name, OwnedHandle, SidAndAttri
 use crate::script_runner::{get_timeout_milliseconds, ScriptRunner};
 use crate::{process_mitigation, string_util, ui_policy};
 
-// Attribute list constants (not always exported by the windows crate)
-const PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES: usize = 0x0002_0009;
-const PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY: usize = 0x0002_000F;
+/// `UpdateProcThreadAttribute` value for
+/// `PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY` that opts the
+/// process out of inheriting `ALL APPLICATION PACKAGES` grants. This
+/// specific *value* (not the attribute id) is not currently exported
+/// by the windows crate.
 const PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT: u32 = 1;
-const EXTENDED_STARTUPINFO_PRESENT: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(0x0008_0000);
-const CREATE_UNICODE_ENVIRONMENT: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(0x0000_0400);
-const CREATE_SUSPENDED: PROCESS_CREATION_FLAGS = PROCESS_CREATION_FLAGS(0x0000_0004);
-
-/// SE_GROUP_ENABLED attribute value for SID_AND_ATTRIBUTES.
-const SE_GROUP_ENABLED: u32 = 0x0000_0004;
-
-/// HRESULT value for ERROR_ALREADY_EXISTS (183 / 0xB7).
-const HRESULT_ERROR_ALREADY_EXISTS: i32 = 0x8007_00B7u32 as i32;
 
 /// Proxy-related env var names to strip/override when building the child env block.
 const PROXY_VAR_NAMES: &[&str] = &["HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY"];
@@ -324,7 +321,7 @@ impl AppContainerScriptRunner {
 
         match result {
             Ok(sid) => Ok(sid),
-            Err(e) if e.code().0 == HRESULT_ERROR_ALREADY_EXISTS => {
+            Err(e) if e.code() == ERROR_ALREADY_EXISTS.to_hresult() => {
                 // Profile already exists — derive the SID from the name.
                 let sid = unsafe {
                     DeriveAppContainerSidFromAppContainerName(pcwstr_name).map_err(|e2| {
@@ -393,7 +390,7 @@ impl AppContainerScriptRunner {
                 Ok(sid_ptr) => {
                     sid_attrs.push(SidAndAttributes {
                         sid: PSID(sid_ptr),
-                        attributes: SE_GROUP_ENABLED,
+                        attributes: SE_GROUP_ENABLED as u32,
                     });
                     capability_sid_guard.push(sid_ptr);
                 }
@@ -466,7 +463,7 @@ impl AppContainerScriptRunner {
             UpdateProcThreadAttribute(
                 attr_list,
                 0,
-                PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
+                PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES as usize,
                 Some(
                     &security_capabilities as *const SecurityCapabilities
                         as *const core::ffi::c_void,
@@ -490,7 +487,7 @@ impl AppContainerScriptRunner {
                 UpdateProcThreadAttribute(
                     attr_list,
                     0,
-                    PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
+                    PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY as usize,
                     Some(&lpac_value as *const u32 as *const core::ffi::c_void),
                     std::mem::size_of::<u32>(),
                     None,

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -39,8 +39,7 @@ use sandbox_spec::base_container_layout::{
     NetworkPolicy as FbsNetworkPolicy, NetworkPolicyArgs, SandboxSpec, SandboxSpecArgs,
 };
 
-/// `CREATE_UNICODE_ENVIRONMENT` -- tells the API that the environment block is UTF-16 encoded.
-const CREATE_UNICODE_ENVIRONMENT: u32 = 0x0000_0400;
+use windows::Win32::System::Threading::CREATE_UNICODE_ENVIRONMENT;
 
 /// Serialize `KEY=VALUE` pairs into a double-null-terminated UTF-16 environment block.
 ///
@@ -580,7 +579,7 @@ impl ScriptRunner for BaseContainerRunner {
             .map(|b| b.as_ptr() as *const c_void)
             .unwrap_or(ptr::null());
         let creation_flags = if env_block.is_some() {
-            CREATE_UNICODE_ENVIRONMENT
+            CREATE_UNICODE_ENVIRONMENT.0
         } else {
             0
         };

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -453,11 +453,9 @@ pub(crate) fn has_write_dac(path: &Path) -> Result<bool, std::io::Error> {
     use windows::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED};
     use windows::Win32::Storage::FileSystem::{
         CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE, FILE_SHARE_READ,
-        FILE_SHARE_WRITE, OPEN_EXISTING,
+        FILE_SHARE_WRITE, OPEN_EXISTING, WRITE_DAC,
     };
     use windows_core::PCWSTR;
-
-    const WRITE_DAC: u32 = 0x0004_0000;
 
     let path_str = path
         .to_str()
@@ -470,7 +468,7 @@ pub(crate) fn has_write_dac(path: &Path) -> Result<bool, std::io::Error> {
     let handle = unsafe {
         CreateFileW(
             PCWSTR(wide.as_ptr()),
-            WRITE_DAC,
+            WRITE_DAC.0,
             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             None,
             OPEN_EXISTING,

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -660,8 +660,7 @@ fn read_state_file(path: &Path) -> Result<StateFile, DaclError> {
     // ERROR_LOCK_VIOLATION (33) is also retried — antivirus on-access
     // scanners sometimes surface it transiently when an unrelated
     // process is still in the open-write-close window.
-    const ERROR_SHARING_VIOLATION: i32 = 32;
-    const ERROR_LOCK_VIOLATION: i32 = 33;
+    use windows::Win32::Foundation::{ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION};
     const ATTEMPTS: u32 = 3;
     let mut last_err: Option<io::Error> = None;
     for i in 0..ATTEMPTS {
@@ -672,8 +671,8 @@ fn read_state_file(path: &Path) -> Result<StateFile, DaclError> {
             }
             Err(e) => {
                 let transient = matches!(
-                    e.raw_os_error(),
-                    Some(ERROR_SHARING_VIOLATION) | Some(ERROR_LOCK_VIOLATION)
+                    e.raw_os_error().map(|c| c as u32),
+                    Some(c) if c == ERROR_SHARING_VIOLATION.0 || c == ERROR_LOCK_VIOLATION.0
                 );
                 if !transient {
                     return Err(e.into());

--- a/src/wxc_common/src/isolation_session/error.rs
+++ b/src/wxc_common/src/isolation_session/error.rs
@@ -136,8 +136,8 @@ mod tests {
         // HRESULT_FROM_WIN32(ERROR_NOT_FOUND) = 0x80070000 | (1168 & 0xFFFF)
         // = 0x80070490. A regression in this constant would silently downgrade
         // stale-id detection to backend_error.
-        const ERROR_NOT_FOUND: u32 = 1168;
-        let expected = 0x8007_0000u32 | (ERROR_NOT_FOUND & 0xFFFF);
+        use windows::Win32::Foundation::ERROR_NOT_FOUND;
+        let expected = 0x8007_0000u32 | (ERROR_NOT_FOUND.0 & 0xFFFF);
         assert_eq!(ERROR_NOT_FOUND_HRESULT, expected);
         assert_eq!(ERROR_NOT_FOUND_HRESULT, 0x80070490);
     }

--- a/src/wxc_common/src/isolation_session/manager.rs
+++ b/src/wxc_common/src/isolation_session/manager.rs
@@ -572,7 +572,10 @@ impl IsolationSessionManager {
 /// `STILL_ACTIVE` so a transient read failure does not short-circuit the
 /// escalation.
 fn wait_with_graceful_shutdown(process: &IsoSessionProcess) -> Result<i32, IsolationSessionError> {
-    const STILL_ACTIVE: i32 = 0x103;
+    // `STILL_ACTIVE` (0x103) is exposed by the `windows` crate as
+    // `STATUS_PENDING: NTSTATUS` — same numeric value, different name.
+    use windows::Win32::Foundation::STATUS_PENDING;
+    const STILL_ACTIVE: i32 = STATUS_PENDING.0;
     let mut exit_code = process
         .ExitCode()
         .map_err(|e| lifecycle_err(format!("get ExitCode failed: {}", e)))?;

--- a/src/wxc_common/src/launch_diagnostics.rs
+++ b/src/wxc_common/src/launch_diagnostics.rs
@@ -40,7 +40,7 @@ pub fn diagnose_create_process_failure(
     readonly_paths: &[String],
 ) -> LaunchDiagnostic {
     // Check for feature-not-enabled (velocity keys).
-    if win32_error == ERROR_CALL_NOT_IMPLEMENTED || win32_error == E_NOTIMPL {
+    if win32_error == ERROR_CALL_NOT_IMPLEMENTED.0 || win32_error == E_NOTIMPL.0 as u32 {
         return diagnose_api_not_implemented();
     }
 
@@ -79,21 +79,17 @@ pub fn diagnose_process_exit(
 
 // -- Constants ---------------------------------------------------------------
 
-/// Windows error code for a function that exists but is not implemented.
-const ERROR_CALL_NOT_IMPLEMENTED: u32 = 120;
-
-/// HRESULT E_NOTIMPL -- the OS may set this via GetLastError when the
-/// feature is gated behind velocity keys.
-const E_NOTIMPL: u32 = 0x8000_4001;
-
 /// Velocity key IDs required by the BaseContainer feature.
 const REQUIRED_VELOCITY_KEYS: &[(u32, &str)] = &[
     (61389575, "BaseContainer core"),
     (61155944, "BaseContainer sandbox spec"),
 ];
 
-/// STATUS_DLL_INIT_FAILED -- typically means Win32k (UI subsystem) was blocked.
-const STATUS_DLL_INIT_FAILED: u32 = 0xC000_0142;
+// `ERROR_CALL_NOT_IMPLEMENTED`, `E_NOTIMPL`, and `STATUS_DLL_INIT_FAILED`
+// are re-exported from the `windows` crate. Comparisons against them
+// flow through `u32`, which matches the existing public surface of
+// this module (`diagnose_create_process_failure` takes `u32`).
+use windows::Win32::Foundation::{ERROR_CALL_NOT_IMPLEMENTED, E_NOTIMPL, STATUS_DLL_INIT_FAILED};
 
 // -- Internal heuristics -----------------------------------------------------
 
@@ -116,7 +112,7 @@ fn check_exe_heuristics(
         });
     }
 
-    if exit_code == Some(STATUS_DLL_INIT_FAILED) && is_powershell(exe_path) {
+    if exit_code == Some(STATUS_DLL_INIT_FAILED.0 as u32) && is_powershell(exe_path) {
         return Some(LaunchDiagnostic {
             kind: "dll_init_failed_ui_required",
             message: "PowerShell exited with STATUS_DLL_INIT_FAILED (0xC0000142). \
@@ -406,14 +402,14 @@ mod tests {
 
     #[test]
     fn api_not_implemented_triggers_feature_diagnostic() {
-        let diag = diagnose_create_process_failure(ERROR_CALL_NOT_IMPLEMENTED, "pwsh.exe", &[]);
+        let diag = diagnose_create_process_failure(ERROR_CALL_NOT_IMPLEMENTED.0, "pwsh.exe", &[]);
         assert_eq!(diag.kind, "feature_not_enabled");
         assert!(diag.message.contains("velocity"));
     }
 
     #[test]
     fn e_notimpl_triggers_feature_diagnostic() {
-        let diag = diagnose_create_process_failure(E_NOTIMPL, "pwsh.exe", &[]);
+        let diag = diagnose_create_process_failure(E_NOTIMPL.0 as u32, "pwsh.exe", &[]);
         assert_eq!(diag.kind, "feature_not_enabled");
     }
 
@@ -441,7 +437,7 @@ mod tests {
             r#""C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile"#,
             &["C:\\".to_string()],
             &[],
-            STATUS_DLL_INIT_FAILED,
+            STATUS_DLL_INIT_FAILED.0 as u32,
         );
         assert!(diag.is_some());
         let d = diag.unwrap();
@@ -456,7 +452,7 @@ mod tests {
             r#""C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe""#,
             &["C:\\".to_string()],
             &[],
-            STATUS_DLL_INIT_FAILED,
+            STATUS_DLL_INIT_FAILED.0 as u32,
         );
         assert!(diag.is_some());
         assert_eq!(diag.unwrap().kind, "dll_init_failed_ui_required");
@@ -468,7 +464,7 @@ mod tests {
             r"C:\tools\myapp.exe",
             &["C:\\".to_string()],
             &[],
-            STATUS_DLL_INIT_FAILED,
+            STATUS_DLL_INIT_FAILED.0 as u32,
         );
         assert!(diag.is_none());
     }

--- a/src/wxc_common/src/microvm_staging.rs
+++ b/src/wxc_common/src/microvm_staging.rs
@@ -448,8 +448,8 @@ fn check_no_reparse_points(path: &Path) -> Result<(), StagingError> {
 #[cfg(target_os = "windows")]
 fn is_reparse_point(metadata: &fs::Metadata) -> bool {
     use std::os::windows::fs::MetadataExt;
-    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    use windows::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT.0 != 0
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/src/wxc_common/src/system_drive_prep.rs
+++ b/src/wxc_common/src/system_drive_prep.rs
@@ -866,11 +866,11 @@ mod tests {
         // (FILE_GENERIC_READ = 0x00120089 — differs from ours by the
         // FILE_READ_DATA bit). This simulates a pre-existing
         // third-party ACE.
-        const FILE_GENERIC_READ: u32 = 0x0012_0089;
+        use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
         apply_explicit_ace(
             tmp.path(),
             SID_ALL_APP_PACKAGES,
-            FILE_GENERIC_READ,
+            FILE_GENERIC_READ.0,
             AceType::Allow,
             false,
         )
@@ -885,7 +885,7 @@ mod tests {
         let removed = revoke_specific_aces_for_sid(
             tmp.path(),
             SID_ALL_APP_PACKAGES,
-            FILE_GENERIC_READ,
+            FILE_GENERIC_READ.0,
             AceType::Allow,
             false,
         )
@@ -936,11 +936,11 @@ mod tests {
 
         // Pre-existing third-party ACE: FILE_GENERIC_READ (differs
         // from STAT_ACCESS_MASK by the FILE_READ_DATA bit).
-        const FILE_GENERIC_READ: u32 = 0x0012_0089;
+        use windows::Win32::Storage::FileSystem::FILE_GENERIC_READ;
         apply_explicit_ace(
             tmp.path(),
             SID_ALL_APP_PACKAGES,
-            FILE_GENERIC_READ,
+            FILE_GENERIC_READ.0,
             AceType::Allow,
             false,
         )
@@ -956,7 +956,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(sid, SID_ALL_APP_PACKAGES);
-                assert_eq!(existing_mask, FILE_GENERIC_READ);
+                assert_eq!(existing_mask, FILE_GENERIC_READ.0);
                 assert_eq!(expected_mask, STAT_ACCESS_MASK);
             }
             other => panic!("expected ConflictingAce, got {other:?}"),
@@ -966,7 +966,7 @@ mod tests {
         revoke_specific_aces_for_sid(
             tmp.path(),
             SID_ALL_APP_PACKAGES,
-            FILE_GENERIC_READ,
+            FILE_GENERIC_READ.0,
             AceType::Allow,
             false,
         )


### PR DESCRIPTION
This PR replaces locally-defined numeric Win32 constants across
wxc_common with the typed equivalents exported by the `windows` crate.
The hand-rolled definitions were correct but redundant; the typed
forms make the intent explicit (and a future windows-rs upgrade
that adjusts a value automatically propagates).

Details:
- filesystem_dacl: ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION now
  come from `windows::Win32::Foundation`. Comparison still flows
  through `raw_os_error()` (i32) via a typed `.0 as u32` view.
- fallback_detector: WRITE_DAC pulled from
  `windows::Win32::Storage::FileSystem`.
- appcontainer_runner: ERROR_ALREADY_EXISTS, SE_GROUP_ENABLED,
  CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
  EXTENDED_STARTUPINFO_PRESENT, and both PROC_THREAD_ATTRIBUTE_*
  attribute ids are now sourced from the windows crate. The
  HRESULT-form `ERROR_ALREADY_EXISTS` comparison uses
  `ERROR_ALREADY_EXISTS.to_hresult()` directly instead of a
  precomputed local constant.
- base_container_runner / launch_diagnostics / microvm_staging /
  isolation_session / system_drive_prep: same pattern — local
  numeric consts replaced with `.0` (or `as u32` / `as usize`)
  views over typed windows-rs constants.

Kept local with a doc comment naming the gap:
- `JOB_OBJECT_UILIMIT_INJECTION` (windows 0.62 doesn't export it).
- `PROCESS_CREATION_ALL_APPLICATION_PACKAGES_OPT_OUT` (it's a value
  passed via the attribute API, not a Win32 constant).
- `ERROR_NOT_FOUND_HRESULT` in isolation_session (composite
  HRESULT_FROM_WIN32 form; the regression test now derives the
  expected value from `windows::Win32::Foundation::ERROR_NOT_FOUND`).

Test:
- wxc_common cargo test: 388/388 (unchanged — pure refactor; values
  byte-identical to before).
- cargo clippy --workspace --all-targets -- -D warnings: clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/414)