### PR TITLE
build.bat: install rustup targets for pinned toolchain

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -49,11 +49,25 @@ if "%WITH_HYPERLIGHT%"=="1" set "CARGO_FLAGS=--features hyperlight %CARGO_FLAGS%
 echo.
 echo Building WXC (Rust) [%BUILD_CONFIG%]...
 pushd src
+
+:: Ensure the rustup targets are installed for the pinned toolchain
+:: (src\rust-toolchain.toml). No-op if rustup is missing or the target
+:: is already present.
+where rustup >nul 2>&1
+if not errorlevel 1 (
+    if "%BUILD_ALL%"=="1" (
+        rustup target add x86_64-pc-windows-msvc >nul 2>&1
+        rustup target add aarch64-pc-windows-msvc >nul 2>&1
+    ) else (
+        rustup target add %BUILD_ARCH% >nul 2>&1
+    )
+)
+
 if "%BUILD_ALL%"=="1" (
     echo   Target: x86_64-pc-windows-msvc
     cargo build %CARGO_FLAGS% x86_64-pc-windows-msvc || goto :error
     echo   Target: aarch64-pc-windows-msvc
-    cargo build %CARGO_FLAGS% aarch64-pc-windows-msvc || goto :error 
+    cargo build %CARGO_FLAGS% aarch64-pc-windows-msvc || goto :error
 ) else (
     echo   Target: %BUILD_ARCH%
     cargo build %CARGO_FLAGS% %BUILD_ARCH% || goto :error


### PR DESCRIPTION
## Summary

- Mirrors the `rustup target add` fix from `build-mac.sh` (lines 87-92) into `build.bat` so `build.bat --all` works for developers whose 1.93 install (pinned in #399) only includes the host target's stdlib.
- Cross-target builds (`aarch64-pc-windows-msvc` from x86_64 hosts, or vice versa) were failing because `rustup` auto-downloads the pinned channel for the host triple only — the cross-target stdlib still needs an explicit `rustup target add`.
- Guarded by `where rustup`; output silenced; errors swallowed so a missing target falls through to a real `cargo build` diagnostic rather than a vague rustup one.
- `build.sh` doesn't need the equivalent — it builds without `--target` so the host-channel auto-install is sufficient.

## Test plan

- [x] `build.bat --all` from a clean state with only the native target installed under 1.93 — both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` compile, exit 0.
- [ ] Reviewer to sanity-check on an ARM64 host if available.
- [ ] CI green.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/415)