### PR TITLE
build.bat: install rustup targets for pinned toolchain

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -49,11 +49,25 @@ if "%WITH_HYPERLIGHT%"=="1" set "CARGO_FLAGS=--features hyperlight %CARGO_FLAGS%
 echo.
 echo Building WXC (Rust) [%BUILD_CONFIG%]...
 pushd src
+
+:: Ensure the rustup targets are installed for the pinned toolchain
+:: (src\rust-toolchain.toml). No-op if rustup is missing or the target
+:: is already present.
+where rustup >nul 2>&1
+if not errorlevel 1 (
+    if "%BUILD_ALL%"=="1" (
+        rustup target add x86_64-pc-windows-msvc >nul 2>&1
+        rustup target add aarch64-pc-windows-msvc >nul 2>&1
+    ) else (
+        rustup target add %BUILD_ARCH% >nul 2>&1
+    )
+)
+
 if "%BUILD_ALL%"=="1" (
     echo   Target: x86_64-pc-windows-msvc
     cargo build %CARGO_FLAGS% x86_64-pc-windows-msvc || goto :error
     echo   Target: aarch64-pc-windows-msvc
-    cargo build %CARGO_FLAGS% aarch64-pc-windows-msvc || goto :error 
+    cargo build %CARGO_FLAGS% aarch64-pc-windows-msvc || goto :error
 ) else (
     echo   Target: %BUILD_ARCH%
     cargo build %CARGO_FLAGS% %BUILD_ARCH% || goto :error

--- a/src/nanvix_binaries/build.rs
+++ b/src/nanvix_binaries/build.rs
@@ -77,16 +77,33 @@ fn main() {
     // Generate host-local WHP snapshots at build time so even the first
     // runtime execution uses warm start. The runtime fallback in
     // nanvix_runner.rs handles the case where snapshots are missing.
-    let snapshots_dir = bin_dir.join(nanvix_common::SNAPSHOTS_SUBDIR);
-    let snapshots_present = nanvix_common::SNAPSHOT_FILES
-        .iter()
-        .all(|name| snapshots_dir.join(name).exists());
-    if !snapshots_present {
-        fs::create_dir_all(&snapshots_dir).expect("failed to create snapshots dir");
-        eprintln!("nanvix_binaries: generating host-local snapshots (cold boot)...");
-        generate_snapshots_locally(&bin_dir);
+    //
+    // Skip on non-x86_64 hosts: `nanvixd.exe` is an x86_64 Windows binary
+    // and launching it on (e.g.) ARM64 Windows fails with
+    // STATUS_INVALID_IMAGE_FORMAT (0xc000007b). Snapshot pre-generation is
+    // a warm-start cache only — the runtime fallback covers cold boot on
+    // hosts where this build step is skipped.
+    let host = std::env::var("HOST").unwrap_or_default();
+    let host_is_x86_64 = host.starts_with("x86_64-");
+    if !host_is_x86_64 {
+        eprintln!(
+            "nanvix_binaries: skipping host-local snapshot generation \
+             (host '{}' is not x86_64; nanvixd.exe cannot run here). \
+             Runtime will cold-boot on first use.",
+            host
+        );
     } else {
-        eprintln!("nanvix_binaries: host-local snapshots already present");
+        let snapshots_dir = bin_dir.join(nanvix_common::SNAPSHOTS_SUBDIR);
+        let snapshots_present = nanvix_common::SNAPSHOT_FILES
+            .iter()
+            .all(|name| snapshots_dir.join(name).exists());
+        if !snapshots_present {
+            fs::create_dir_all(&snapshots_dir).expect("failed to create snapshots dir");
+            eprintln!("nanvix_binaries: generating host-local snapshots (cold boot)...");
+            generate_snapshots_locally(&bin_dir);
+        } else {
+            eprintln!("nanvix_binaries: host-local snapshots already present");
+        }
     }
 
     println!("cargo:rustc-env=NANVIX_BIN_DIR={}", bin_dir.display());


### PR DESCRIPTION
## Summary

- Mirrors the `rustup target add` fix from `build-mac.sh` (lines 87-92) into `build.bat` so `build.bat --all` works for developers whose 1.93 install (pinned in #399) only includes the host target's stdlib.
- Cross-target builds (`aarch64-pc-windows-msvc` from x86_64 hosts, or vice versa) were failing because `rustup` auto-downloads the pinned channel for the host triple only — the cross-target stdlib still needs an explicit `rustup target add`.
- Guarded by `where rustup`; output silenced; errors swallowed so a missing target falls through to a real `cargo build` diagnostic rather than a vague rustup one.
- `build.sh` doesn't need the equivalent — it builds without `--target`, so the host-channel auto-install is sufficient.

## Test plan

- [x] `build.bat --all` from a clean state with only the native target installed under 1.93 — both `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` compile, exit 0.
- [x] Reviewer to sanity-check on an ARM64 host if available.
- [x] CI green.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/416)