### PR TITLE
deps: update hyperlight-unikraft to v0.8.0 with read-only mount enforcement

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -855,8 +855,8 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.7.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.7.0#05c4d642b445c17a4cb3f72559b15523ae5ed499"
+version = "0.8.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight-unikraft?tag=v0.8.0#b15806cc03140b139bac9375cf88739d5937151f"
 dependencies = [
  "anyhow",
  "base64",

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -28,7 +28,7 @@ getrandom = { workspace = true }
 semver = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.7.0", optional = true }
+hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.8.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 nanvix_common = { path = "../nanvix_common", optional = true }

--- a/src/wxc_common/src/hyperlight_runner.rs
+++ b/src/wxc_common/src/hyperlight_runner.rs
@@ -47,9 +47,9 @@
 //! `policy.readwritePaths` and `policy.readonlyPaths` are translated to
 //! [`Preopen`] entries — the guest sees the host directories at
 //! `/host/<basename>` and can read/write through them via `lib/hostfs`.
-//! There is currently no hostfs-level RO enforcement; `readonlyPaths` are
-//! mounted writable and policy expectations rely on the caller not
-//! writing (documented limitation until hostfs learns read-only mounts).
+//! `readonlyPaths` are mounted with `Preopen::read_only()`, which blocks
+//! all write operations (`fs_write`, `fs_mkdir`, `fs_unlink`, etc.) at
+//! the host-function level.
 //!
 //! `policy.deniedPaths` is honored: any path that appears in the denied
 //! list is rejected at preflight — including paths that also appear in
@@ -201,7 +201,7 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     let opts = pyhl::InstallOptions {
         home: &home,
         source: pyhl::InstallSource::Ghcr {
-            tag: Some("v0.7.0"),
+            tag: Some("v0.8.0"),
         },
         mounts: &[],
         network: None,
@@ -347,18 +347,16 @@ impl HyperlightScriptRunner {
     /// `/host/<basename>` — matches the `pyhl` CLI's `--mount <host>` default
     /// shape so scripts can find mounts predictably.
     ///
-    /// `readonlyPaths` are mounted writable today (hostfs has no RO
-    /// mode). Documented in the module header as a known limitation.
+    /// `readonlyPaths` are mounted with `Preopen::read_only()`, blocking
+    /// all write operations at the host-function level.
     fn preopens_from_policy(request: &CodexRequest) -> Result<Vec<Preopen>, PyhlError> {
         let mut preopens = Vec::new();
         let mut seen_guest_paths = std::collections::HashSet::new();
 
-        for host in request
-            .policy
-            .readwrite_paths
-            .iter()
-            .chain(request.policy.readonly_paths.iter())
-        {
+        let rw_iter = request.policy.readwrite_paths.iter().map(|p| (p, false));
+        let ro_iter = request.policy.readonly_paths.iter().map(|p| (p, true));
+
+        for (host, read_only) in rw_iter.chain(ro_iter) {
             let host_path = PathBuf::from(host);
 
             // Auto-create the mount dir if it doesn't exist yet.
@@ -400,11 +398,14 @@ impl HyperlightScriptRunner {
                      rename one of the host directories"
                 )));
             }
-            let pre = Preopen::new(&host_path, &guest_path).map_err(|e| {
+            let mut pre = Preopen::new(&host_path, &guest_path).map_err(|e| {
                 PyhlError::Preflight(format!(
                     "build Preopen for {host:?} -> {guest_path:?}: {e:#}"
                 ))
             })?;
+            if read_only {
+                pre = pre.read_only();
+            }
             preopens.push(pre);
         }
 

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -707,6 +707,75 @@ fn hyperlight_suite() {
         let _ = std::fs::remove_dir_all(&mount_dir);
     }
 
+    // Read-only mount enforcement test.
+    {
+        println!("--- hostfs readonly enforcement (hyperlight_fs_readonly) ---");
+        let ro_dir = std::env::temp_dir().join("hyperlight-fs-ro-e2e");
+        let rw_dir = std::env::temp_dir().join("hyperlight-fs-rw-e2e");
+        let _ = std::fs::remove_dir_all(&ro_dir);
+        let _ = std::fs::remove_dir_all(&rw_dir);
+        std::fs::create_dir_all(&ro_dir).unwrap();
+        std::fs::create_dir_all(&rw_dir).unwrap();
+        std::fs::write(ro_dir.join("input.txt"), "readonly content\n").unwrap();
+
+        let ro_basename = ro_dir.file_name().unwrap().to_string_lossy();
+        let rw_basename = rw_dir.file_name().unwrap().to_string_lossy();
+
+        let script = format!(
+            "import os\n\
+             ro = '/host/{ro_basename}'\n\
+             rw = '/host/{rw_basename}'\n\
+             with open(f'{{ro}}/input.txt') as f:\n\
+             \x20   print(f'read: {{f.read().strip()}}')\n\
+             with open(f'{{rw}}/output.txt', 'w') as f:\n\
+             \x20   f.write('rw ok')\n\
+             print('wrote to rw')\n\
+             try:\n\
+             \x20   with open(f'{{ro}}/forbidden.txt', 'w') as f:\n\
+             \x20       f.write('should fail')\n\
+             \x20   print('READONLY_BYPASSED')\n\
+             except Exception as e:\n\
+             \x20   print(f'write blocked: {{e}}')\n\
+             \x20   print('READONLY_ENFORCED')\n"
+        );
+
+        let config = serde_json::json!({
+            "process": { "commandLine": script, "timeout": 30000 },
+            "containment": "hyperlight",
+            "filesystem": {
+                "readonlyPaths": [ro_dir.to_string_lossy()],
+                "readwritePaths": [rw_dir.to_string_lossy()],
+            }
+        });
+
+        let result = run_wxc_state_aware("hyperlight-fs-readonly", &config, &["--debug", "--experimental"]);
+        let combined = result.combined_output();
+
+        if result.code != Some(0) {
+            failures.push(format!(
+                "hyperlight-fs-readonly: expected exit 0, got {:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+                result.code, result.stdout, result.stderr
+            ));
+        } else if !combined.contains("readonly content") {
+            failures.push(format!(
+                "hyperlight-fs-readonly: could not read from readonly mount\n--- combined ---\n{combined}"
+            ));
+        } else if !rw_dir.join("output.txt").exists() {
+            failures.push("hyperlight-fs-readonly: readwrite mount did not produce output.txt".to_string());
+        } else if ro_dir.join("forbidden.txt").exists() {
+            failures.push("hyperlight-fs-readonly: readonly mount was writable — forbidden.txt was created".to_string());
+        } else if !combined.contains("READONLY_ENFORCED") {
+            failures.push(format!(
+                "hyperlight-fs-readonly: guest did not confirm enforcement\n--- combined ---\n{combined}"
+            ));
+        } else {
+            println!("  PASS ({} ms)", result.wall_time_ms);
+        }
+
+        let _ = std::fs::remove_dir_all(&ro_dir);
+        let _ = std::fs::remove_dir_all(&rw_dir);
+    }
+
     if !failures.is_empty() {
         panic!("Hyperlight E2E failures:\n{}", failures.join("\n"));
     }


### PR DESCRIPTION
## Summary

- Update `hyperlight-unikraft-host` dependency from v0.7.0 to v0.8.0
- `readonlyPaths` now enforced at the host-function level via `Preopen::read_only()` — write operations (`fs_write`, `fs_mkdir`, `fs_unlink`, etc.) are blocked by Hyperlight instead of relying on caller discipline
- Remove documented-limitation comments from `hyperlight_runner.rs`
- Add Hyperlight readonly mount e2e test to `hyperlight_suite()`

Resolves #413

## Test plan

- [x] Verified locally with `lxc-exec --experimental` using Hyperlight containment — readonly mount returns `Permission denied` on write, reads succeed, readwrite mount works
- [x] E2e test added to `hyperlight_suite()` in `e2e_windows.rs`
- [x] `cargo check` and `cargo test -p wxc_common` pass (193 tests)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/417)