### PR TITLE
Fix fuzz pipeline: write feed config to CARGO_HOME for cargo install

### DIFF
--- a/.azure-pipelines/Fuzz.Build.yml
+++ b/.azure-pipelines/Fuzz.Build.yml
@@ -9,14 +9,8 @@
 #
 # Schedule: daily at 00:00 UTC on `main`. PRs do not trigger this pipeline.
 
-pr:
-  branches:
-    include:
-      - user/saulg/fuzzerFix
-trigger:
-  branches:
-    include:
-      - user/saulg/fuzzerFix
+pr: none
+trigger: none
 
 schedules:
   - cron: "0 0 * * *"

--- a/.azure-pipelines/Fuzz.Build.yml
+++ b/.azure-pipelines/Fuzz.Build.yml
@@ -9,8 +9,14 @@
 #
 # Schedule: daily at 00:00 UTC on `main`. PRs do not trigger this pipeline.
 
-pr: none
-trigger: none
+pr:
+  branches:
+    include:
+      - user/saulg/fuzzerFix
+trigger:
+  branches:
+    include:
+      - user/saulg/fuzzerFix
 
 schedules:
   - cron: "0 0 * * *"

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -33,8 +33,13 @@ jobs:
     - checkout: self
 
     # Keep all crate fetches going through the internal feed.
+    # Write to both project-level (for `cargo fuzz build`) and user-level
+    # (for `cargo install` which only reads $CARGO_HOME/config.toml).
     - powershell: |
-        Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+        $feedConfig = Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"
+        Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + $feedConfig)
+        $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+        Add-Content -Path "$cargoHome\config.toml" -Value ("`n" + $feedConfig)
       displayName: Setup Cargo Config
 
     # Install nightly Rust via rustup-init. The toolchain itself runs on the

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -39,6 +39,7 @@ jobs:
         $feedConfig = Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"
         Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + $feedConfig)
         $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+        New-Item -ItemType Directory -Force -Path $cargoHome | Out-Null
         Add-Content -Path "$cargoHome\config.toml" -Value ("`n" + $feedConfig)
       displayName: Setup Cargo Config
 


### PR DESCRIPTION
cargo install is a global command that only reads $CARGO_HOME/config.toml, not the project-level .cargo/config.toml. The existing setup only wrote the Mxc-Azure-Feed redirect to the project config, so 'cargo install cargo-fuzz' tried to reach crates.io directly and failed with a network error on the isolated agent.

Write the feed config to both locations so all cargo commands route through the internal feed.

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/418)