### PR TITLE
mxc diagnostic console: ETW parser in diagnostic console misaligns fields after struct properties

### DIFF
--- a/src/mxc_diagnostic_console/src/etw.rs
+++ b/src/mxc_diagnostic_console/src/etw.rs
@@ -549,8 +549,33 @@ fn decode_properties(
         let prop_name =
             wide_str_at(info_buf, prop_info.NameOffset).unwrap_or_else(|| format!("prop{i}"));
 
-        // PropertyStruct = PROPERTY_FLAGS(1)
+        // PropertyStruct = PROPERTY_FLAGS(1) -- the struct header itself holds no
+        // data, but its N child members do occupy space in the user data buffer.
+        // We must decode (and skip) each child member to keep `offset` in sync.
         if prop_info.Flags.0 & 1 != 0 {
+            let num_members =
+                unsafe { prop_info.Anonymous1.structType.NumOfStructMembers } as usize;
+            let start_index = unsafe { prop_info.Anonymous1.structType.StructStartIndex } as usize;
+
+            for j in 0..num_members {
+                let child_prop = unsafe {
+                    let base = std::ptr::addr_of!(info.EventPropertyInfoArray)
+                        as *const EVENT_PROPERTY_INFO;
+                    &*base.add(start_index + j)
+                };
+                let child_in_type = unsafe { child_prop.Anonymous1.nonStructType.InType };
+                let child_length = unsafe { child_prop.Anonymous3.length } as usize;
+                let remaining = user_data_len.saturating_sub(offset);
+                let data_ptr = if remaining > 0 {
+                    unsafe { user_data.add(offset) }
+                } else {
+                    std::ptr::null()
+                };
+                let (_, consumed) =
+                    format_property_value(child_in_type, child_length, data_ptr, remaining);
+                offset += consumed;
+            }
+
             results.push((prop_name, "<struct>".to_string()));
             continue;
         }


### PR DESCRIPTION
The bug: When decode_properties encountered a struct property (like wil::Activity), it pushed <struct> and continued without advancing the offset into the user data buffer. However, the struct's child members still occupy space in that buffer. Since the offset wasn't advanced past the struct's children's data, every subsequent field was read from the wrong position  causing the "off by half a field" misalignment you saw.

The fix: Before skipping a struct property, iterate through its child members (using StructStartIndex and NumOfStructMembers from the property info) and call format_property_value for each to compute how many bytes they consume, advancing offset accordingly. The child values are discarded (we still display <struct>), but the offset stays in sync for the remaining top-level fields.

Closes: #419 