### PR TITLE
[Bubblewrap] Network proxy for Bubblewrap- unprivileged proxy based network filtering

### DIFF
--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -61,6 +61,11 @@ jobs:
     - script: chmod +x $(sdkDirectory)/bin/*/lxc-exec
       displayName: Restore execute permission on lxc-exec
 
+    - script: |
+        set -euo pipefail
+        find $(sdkDirectory)/bin -name linux-test-proxy -exec chmod +x {} +
+      displayName: Restore execute permission on linux-test-proxy
+
     # Drop symbol files from the npm package — symbols ship separately.
     - script: rm -rf $(sdkDirectory)/bin/*/symbols
       displayName: Strip symbols/ from npm package

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -58,6 +58,7 @@ jobs:
         workingDirectory: $(Build.SourcesDirectory)/src/lxc
         signPattern: |
           lxc-exec
+          linux-test-proxy
 
       ${{ if eq(item.arch, 'x64') }}:
         isX64: true
@@ -121,6 +122,15 @@ jobs:
           useNextest: false
           testAllTargets: false
           buildAllTargets: false
+
+      # linux_test_proxy is a separate workspace member (not a dep of lxc), so
+      # the workspace-member-scoped build above doesn't pick it up. Build it
+      # explicitly here so it lands alongside lxc-exec in the target dir and
+      # gets copied into the artifact via signPattern.
+      - script: |
+          cargo build --release --target $(triplet) -p linux_test_proxy --manifest-path $(Build.SourcesDirectory)/src/Cargo.toml
+        displayName: Build linux-test-proxy
+        condition: eq('${{ item.os }}', 'linux')
 
       - task: EsrpCodeSigning@5
         displayName: Code Sign

--- a/build.sh
+++ b/build.sh
@@ -65,7 +65,7 @@ echo "=== Building Rust binaries ($BUILD_TYPE) ==="
 cd "$SRC_DIR"
 
 # Packages to build and lint — kept in one place so build and clippy stay in sync.
-LXC_PACKAGES=(-p lxc -p lxc_common -p wxc_common)
+LXC_PACKAGES=(-p lxc -p lxc_common -p wxc_common -p bwrap_common -p linux_test_proxy)
 
 CARGO_FEATURES=()
 if [ "$WITH_HYPERLIGHT" = true ]; then
@@ -114,10 +114,16 @@ if [ -n "$TARGET_TRIPLE" ]; then
         cp "$SRC_DIR/target/release/lxc-exec" "$BIN_DIR/" 2>/dev/null || \
         cp "$SRC_DIR/target/$TARGET_TRIPLE/release/lxc-exec" "$BIN_DIR/" 2>/dev/null || \
         echo "Warning: Could not find lxc-exec binary to copy"
+        cp "$SRC_DIR/target/release/linux-test-proxy" "$BIN_DIR/" 2>/dev/null || \
+        cp "$SRC_DIR/target/$TARGET_TRIPLE/release/linux-test-proxy" "$BIN_DIR/" 2>/dev/null || \
+        echo "Warning: Could not find linux-test-proxy binary to copy"
     else
         cp "$SRC_DIR/target/debug/lxc-exec" "$BIN_DIR/" 2>/dev/null || \
         cp "$SRC_DIR/target/$TARGET_TRIPLE/debug/lxc-exec" "$BIN_DIR/" 2>/dev/null || \
         echo "Warning: Could not find lxc-exec binary to copy"
+        cp "$SRC_DIR/target/debug/linux-test-proxy" "$BIN_DIR/" 2>/dev/null || \
+        cp "$SRC_DIR/target/$TARGET_TRIPLE/debug/linux-test-proxy" "$BIN_DIR/" 2>/dev/null || \
+        echo "Warning: Could not find linux-test-proxy binary to copy"
     fi
 fi
 

--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -143,6 +143,74 @@ Standard `process` fields work as expected:
 }
 ```
 
+## Network proxy (cooperative, unprivileged)
+
+Bubblewrap supports an **unprivileged, cooperative network proxy** that
+enforces `allowedHosts` / `blockedHosts` at the proxy layer instead of via
+iptables. This is the **recommended** way to do per-host filtering on
+Bubblewrap because it requires **no root and no `CAP_NET_ADMIN`**.
+
+### How it works
+
+1. When `network.proxy` is set, the runner launches an unprivileged HTTP
+   proxy on loopback (`127.0.0.1:N`). For tests, the bundled
+   `linux-test-proxy` binary is used (`builtinTestServer: true`); in
+   production callers supply their own proxy via `localhost: <port>`.
+2. The sandbox is then started **without** `--unshare-net` so the sandbox
+   shares the host network namespace and can reach the loopback proxy.
+3. The command builder sets `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`,
+   `https_proxy`, and `NO_PROXY=localhost,127.0.0.1` inside the sandbox
+   via `bwrap --setenv` (any caller-supplied values for these keys are
+   stripped before injection).
+4. Cooperative tools (curl, wget, Python `requests`, Node `https`, etc.)
+   honor the env vars and traffic flows through the proxy, which applies
+   the `allowedHosts` / `blockedHosts` lists.
+
+### Example: builtin test proxy with allowlist
+
+```json
+{
+  "version": "0.6.0-alpha",
+  "platform": "linux",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "curl -fsSL https://api.github.com/zen && echo OK"
+  },
+  "network": {
+    "defaultPolicy": "allow",
+    "proxy": { "builtinTestServer": true },
+    "allowedHosts": ["api.github.com"]
+  }
+}
+```
+
+### Example: external proxy on loopback
+
+```json
+{
+  "version": "0.6.0-alpha",
+  "containment": "bubblewrap",
+  "process": { "commandLine": "curl -fsSL https://example.com" },
+  "network": {
+    "proxy": { "localhost": 8080 }
+  }
+}
+```
+
+### Caveats
+
+- **Cooperative model**: only well-behaved clients that honor `HTTP_PROXY`
+  / `HTTPS_PROXY` are filtered. Tools that bypass these env vars (raw
+  sockets, custom HTTP clients) are **not enforced**. This is a deliberate
+  trade-off for zero-privilege operation.
+- **Mutually exclusive with iptables enforcement**: setting
+  `network.proxy` together with `network.enforcementMode` of `"firewall"`
+  or `"both"` is rejected at config-parse time because iptables-based
+  enforcement requires root and would defeat the proxy's privilege story.
+- **HTTPS via CONNECT**: the proxy uses HTTP `CONNECT` tunnels for TLS, so
+  certificate validation continues to work end-to-end (the proxy does not
+  see plaintext).
+
 ## Comparison with LXC
 
 | Aspect | LXC | Bubblewrap |
@@ -182,8 +250,10 @@ Test configs are in `test_configs/bubblewrap_*.json`.
 - **Linux only** — Bubblewrap requires Linux kernel namespaces
 - **Host filesystem** — the sandbox sees the host's files (read-only by
   default); there is no separate rootfs
-- **Network filtering** — per-host `allowedHosts`/`blockedHosts` requires
-  root for iptables; without host lists, only all-or-nothing isolation is
-  available
+- **Network filtering** — per-host `allowedHosts`/`blockedHosts` is best
+  done via the cooperative env-var **network proxy** (no privilege
+  required, see above). The legacy iptables path
+  (`network.enforcementMode: "firewall"` / `"both"`) still works but
+  requires root and is mutually exclusive with the proxy.
 - **No state-aware lifecycle** — Bubblewrap implements `ScriptRunner` only
   (one-shot), not `StatefulSandboxBackend`

--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -204,11 +204,15 @@ Bubblewrap because it requires **no root and no `CAP_NET_ADMIN`**.
 
 ### Caveats
 
-- **Cooperative model**: only well-behaved clients that honor `HTTP_PROXY`
-  / `HTTPS_PROXY` are filtered. Tools that bypass these env vars (raw
-  sockets, custom HTTP clients, statically-linked binaries that ignore the
-  env) are **not enforced**. This is a deliberate trade-off for
-  zero-privilege operation. For strict whole-network isolation, omit
+- **Cooperative model**: the runner enforces by injecting
+  `HTTP_PROXY` / `HTTPS_PROXY` into the sandbox environment, so only
+  well-behaved clients that honor those vars are routed through the
+  proxy. Tools that bypass them (raw sockets, custom HTTP clients,
+  statically-linked binaries that ignore the env) are **not enforced**.
+  This applies to **both** the builtin test proxy and external (BYO)
+  proxy modes — the limitation is in the env-var injection mechanism,
+  not in the proxy itself; a BYO proxy can do whatever it likes for
+  cooperating clients. For strict whole-network isolation, omit
   `network.proxy` so the runner can apply `--unshare-net` instead.
 - **Mutually exclusive with iptables enforcement**: setting
   `network.proxy` together with `network.enforcementMode` of `"firewall"`

--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -154,14 +154,19 @@ Bubblewrap because it requires **no root and no `CAP_NET_ADMIN`**.
 
 1. When `network.proxy` is set, the runner launches an unprivileged HTTP
    proxy on loopback (`127.0.0.1:N`). For tests, the bundled
-   `linux-test-proxy` binary is used (`builtinTestServer: true`); in
-   production callers supply their own proxy via `localhost: <port>`.
+   `linux-test-proxy` binary is used (`builtinTestServer: true`,
+   testing-only and gated behind `--experimental`); in production callers
+   supply their own proxy via `localhost: <port>` or `url: <url>`.
 2. The sandbox is then started **without** `--unshare-net` so the sandbox
    shares the host network namespace and can reach the loopback proxy.
-3. The command builder sets `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`,
-   `https_proxy`, and `NO_PROXY=localhost,127.0.0.1` inside the sandbox
-   via `bwrap --setenv` (any caller-supplied values for these keys are
-   stripped before injection).
+3. The command builder sets `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, and
+   `https_proxy` inside the sandbox via `bwrap --setenv` (any
+   caller-supplied values for these keys, including `NO_PROXY` /
+   `no_proxy`, are stripped before injection). The runner deliberately
+   does **not** set `NO_PROXY`: since the sandbox shares the host netns,
+   a `NO_PROXY=localhost,127.0.0.1` entry would let cooperating clients
+   bypass the proxy for host-loopback destinations, defeating
+   `allowedHosts` / `blockedHosts` enforcement for those targets.
 4. Cooperative tools (curl, wget, Python `requests`, Node `https`, etc.)
    honor the env vars and traffic flows through the proxy, which applies
    the `allowedHosts` / `blockedHosts` lists.
@@ -201,15 +206,43 @@ Bubblewrap because it requires **no root and no `CAP_NET_ADMIN`**.
 
 - **Cooperative model**: only well-behaved clients that honor `HTTP_PROXY`
   / `HTTPS_PROXY` are filtered. Tools that bypass these env vars (raw
-  sockets, custom HTTP clients) are **not enforced**. This is a deliberate
-  trade-off for zero-privilege operation.
+  sockets, custom HTTP clients, statically-linked binaries that ignore the
+  env) are **not enforced**. This is a deliberate trade-off for
+  zero-privilege operation. For strict whole-network isolation, omit
+  `network.proxy` so the runner can apply `--unshare-net` instead.
 - **Mutually exclusive with iptables enforcement**: setting
   `network.proxy` together with `network.enforcementMode` of `"firewall"`
   or `"both"` is rejected at config-parse time because iptables-based
   enforcement requires root and would defeat the proxy's privilege story.
+- **External proxy delegates policy**: when `network.proxy` uses
+  `localhost: <port>` or `url: <url>` (not `builtinTestServer`), the
+  external proxy is responsible for any host filtering. The runner does
+  **not** forward `allowedHosts` / `blockedHosts` / `defaultPolicy: "block"`
+  to it, and config combinations that would silently weaken enforcement
+  are rejected at parse time.
+- **`builtinTestServer` is testing-only**: gated behind `--experimental`
+  and never to be used as a real production proxy. It has no auth, no
+  body-size limits, and minimal hop-by-hop header handling. Use a real
+  HTTP proxy for production deployments.
 - **HTTPS via CONNECT**: the proxy uses HTTP `CONNECT` tunnels for TLS, so
   certificate validation continues to work end-to-end (the proxy does not
   see plaintext).
+
+### Common pitfalls when configuring `allowedHosts`
+
+The proxy applies `allowedHosts` and `blockedHosts` by **case-insensitive
+exact host match** — there is no subdomain wildcard and no IP-vs-hostname
+resolution.
+
+- `allowedHosts: ["github.com"]` does **not** match `api.github.com`. List
+  each subdomain explicitly (e.g. `["api.github.com", "objects.githubusercontent.com"]`).
+- `allowedHosts: ["api.github.com"]` does **not** match a CONNECT to a raw
+  IP literal such as `140.82.114.6:443`. If your workload bypasses DNS,
+  include the IPs.
+- `allowedHosts: ["localhost"]` does **not** match `127.0.0.1`; if you
+  need both, list both.
+- IPv6 literals are normalised: an allowlist entry of `"::1"` matches a
+  CONNECT to `[::1]:443`, but not the unrelated `[fe80::1]:443`.
 
 ## Comparison with LXC
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -52,7 +52,7 @@ production configs and the dev schema when working on experimental features:
     "network": {
         "defaultPolicy": "block",          // "allow" or "block"
         "enforcementMode": "firewall",     // "capabilities", "firewall", or "both"
-        "proxy": { "localhost": 8080 }     // Localhost proxy port (processcontainer only)
+        "proxy": { "localhost": 8080 }     // Loopback proxy port (processcontainer; bubblewrap)
     },
 
     "processContainer": {                  // Process-based container-specific

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -143,7 +143,7 @@
         },
         "proxy": {
           "type": "object",
-          "description": "Proxy configuration. Only supported with processcontainer backend.",
+          "description": "Proxy configuration. Supported with the 'processcontainer' (Windows) and 'bubblewrap' (Linux) backends. On Bubblewrap the proxy URL is exposed inside the sandbox as HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment variables (cooperative env-var proxying), and is mutually exclusive with network.enforcementMode=='firewall'/'both'.",
           "oneOf": [
             {
               "properties": {

--- a/schemas/dev/mxc-config.schema.0.6.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.6.0-dev.json
@@ -143,7 +143,7 @@
         },
         "proxy": {
           "type": "object",
-          "description": "Proxy configuration. Supported with the 'processcontainer' (Windows) and 'bubblewrap' (Linux) backends. On Bubblewrap the proxy URL is exposed inside the sandbox as HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment variables (cooperative env-var proxying), and is mutually exclusive with network.enforcementMode=='firewall'/'both'.",
+          "description": "Proxy configuration. Supported with the 'processcontainer' (Windows) and 'bubblewrap' (Linux) backends.",
           "oneOf": [
             {
               "properties": {

--- a/sdk/src/helper.ts
+++ b/sdk/src/helper.ts
@@ -62,6 +62,58 @@ export function makeLogFilePath(dir: string): string {
 }
 
 /**
+ * Apply Linux network-policy defaults to a `ContainerConfig`.
+ *
+ * Linux enforces per-host filtering in one of two ways:
+ *   1. **iptables firewall** (`enforcementMode: 'firewall'`) — LXC's
+ *      privileged enforcement path. Requires root / CAP_NET_ADMIN.
+ *   2. **Cooperative HTTP proxy** (`network.proxy` set) — Bubblewrap's
+ *      unprivileged enforcement path. The proxy applies the host policy
+ *      for cooperating HTTP clients; raw-socket clients bypass it.
+ *
+ * This helper auto-promotes `enforcementMode` to `'firewall'` when host
+ * lists are present without a proxy — without it, the parser would leave
+ * the mode unset and the runtime would silently ignore `allowedHosts` /
+ * `blockedHosts`.
+ *
+ * If the caller explicitly passes `enforcementMode: 'capabilities'` we
+ * warn: `'capabilities'` is a Windows/AppContainer concept (a token
+ * capability mask) and has no Linux equivalent — the Linux runner will
+ * not enforce anything and the field is silently dropped.
+ *
+ * Shared between the explicit `'bubblewrap'` / `'lxc'` builders and the
+ * abstract `'process'` branch on Linux (which resolves to Bubblewrap
+ * server-side).
+ *
+ * NOTE: when `network.proxy` is configured on Bubblewrap, host filtering
+ * is enforced at the proxy layer (unprivileged, no CAP_NET_ADMIN). The
+ * Rust config parser explicitly rejects `bubblewrap + proxy + firewall`
+ * since the iptables path requires privilege the bwrap backend
+ * deliberately avoids. Callers in that mode must leave enforcementMode
+ * at its default.
+ */
+export function applyLinuxNetworkPolicy(config: ContainerConfig): void {
+  if (!config.network) {
+    return;
+  }
+  if (config.network.enforcementMode === 'capabilities') {
+    console.warn(
+      "mxc-sdk: network.enforcementMode='capabilities' has no effect on Linux " +
+      "(it is a Windows AppContainer / ProcessContainer concept). The Linux " +
+      "runner will not enforce host filtering via capabilities. Use the " +
+      "default mode (auto-promotes to 'firewall' for LXC, or use network.proxy " +
+      "for unprivileged Bubblewrap enforcement)."
+    );
+  }
+  const hasProxy = !!config.network.proxy;
+  const hasHostRules =
+    !!(config.network.allowedHosts?.length || config.network.blockedHosts?.length);
+  if (hasHostRules && !hasProxy) {
+    config.network.enforcementMode = 'firewall';
+  }
+}
+
+/**
  * Resolves the executor binary and builds the common CLI arguments for any
  * MXC request envelope (one-shot or state-aware). Performs platform support
  * and binary-presence checks; does not validate envelope contents — callers

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -7,7 +7,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { randomBytes } from "crypto";
 import { parse as semverParse } from 'semver';
 import { SandboxPolicy, ContainerConfig, ContainmentType, ContainmentBackend } from './types.js';
-import { prepareSpawn, diagLogVersion } from './helper.js';
+import { prepareSpawn, diagLogVersion, applyLinuxNetworkPolicy } from './helper.js';
 import { diagLog } from './diagnostic.js';
 import { MxcError, mxcErrorFromCode } from './errors.js';
 
@@ -87,36 +87,6 @@ function buildWslcContainerConfig(
 }
 
 /**
- * Apply iptables-mode network enforcement on configs that use
- * Bubblewrap or LXC and have per-host filtering.
- *
- * Without setting `enforcementMode: 'firewall'` explicitly, the Linux
- * runner falls back to `Capabilities`, silently drops `allowedHosts` /
- * `blockedHosts`, and never invokes iptables.
- *
- * Shared between the explicit `'bubblewrap'` / `'lxc'` builders and the
- * abstract `'process'` branch on Linux (which resolves to Bubblewrap
- * server-side).
- *
- * NOTE: when `network.proxy` is configured on Bubblewrap, host filtering
- * is enforced at the proxy layer (unprivileged, no CAP_NET_ADMIN). The
- * Rust config parser explicitly rejects `bubblewrap + proxy + firewall`
- * since the iptables path requires privilege the bwrap backend
- * deliberately avoids. Callers in that mode must leave enforcementMode
- * at its default.
- */
-function applyIptablesNetworkEnforcement(config: ContainerConfig): void {
-    if (config.network) {
-        const hasProxy = !!config.network.proxy;
-        const hasHostRules =
-            !!(config.network.allowedHosts?.length || config.network.blockedHosts?.length);
-        if (hasHostRules && !hasProxy) {
-            config.network.enforcementMode = 'firewall';
-        }
-    }
-}
-
-/**
  * Builds the Bubblewrap (bwrap) portion of a ContainerConfig.
  * Bubblewrap is Linux-only and uses shared cross-backend fields only —
  * no backend-specific config block. Network enforcement via iptables
@@ -126,7 +96,7 @@ function buildBubblewrapConfig(
     config: ContainerConfig,
 ): ContainerConfig {
     config.containment = 'bubblewrap';
-    applyIptablesNetworkEnforcement(config);
+    applyLinuxNetworkPolicy(config);
     return config;
 }
 
@@ -143,7 +113,7 @@ function buildLinuxProcessConfig(
         release: '3.23',
         destroyOnExit: true,
     };
-    applyIptablesNetworkEnforcement(config);
+    applyLinuxNetworkPolicy(config);
     return config;
 }
 
@@ -390,7 +360,7 @@ export function createConfigFromPolicy(
             //
             // Network enforcement still needs the same iptables firewall mode
             // as explicit `'bubblewrap'` when host filtering is in play.
-            applyIptablesNetworkEnforcement(config);
+            applyLinuxNetworkPolicy(config);
             diagLog(`createConfigFromPolicy: containment=process (linux, resolves to bubblewrap), id=${containerId}`);
             return config;
         }

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -87,21 +87,30 @@ function buildWslcContainerConfig(
 }
 
 /**
- * Applies iptables-based network enforcement to `config.network`:
- * when host filtering is requested, force `enforcementMode = 'firewall'`
- * so the Linux runner actually applies iptables rules. Without this,
- * `network_enforcement_mode` falls back to the parser default of
- * `Capabilities` and the runner silently skips iptables, dropping
- * `allowedHosts` / `blockedHosts` on the floor.
+ * Apply iptables-mode network enforcement on configs that use
+ * Bubblewrap or LXC and have per-host filtering.
+ *
+ * Without setting `enforcementMode: 'firewall'` explicitly, the Linux
+ * runner falls back to `Capabilities`, silently drops `allowedHosts` /
+ * `blockedHosts`, and never invokes iptables.
  *
  * Shared between the explicit `'bubblewrap'` / `'lxc'` builders and the
  * abstract `'process'` branch on Linux (which resolves to Bubblewrap
- * server-side) so the wire-format `network` block is identical regardless
- * of which intent the caller used.
+ * server-side).
+ *
+ * NOTE: when `network.proxy` is configured on Bubblewrap, host filtering
+ * is enforced at the proxy layer (unprivileged, no CAP_NET_ADMIN). The
+ * Rust config parser explicitly rejects `bubblewrap + proxy + firewall`
+ * since the iptables path requires privilege the bwrap backend
+ * deliberately avoids. Callers in that mode must leave enforcementMode
+ * at its default.
  */
 function applyIptablesNetworkEnforcement(config: ContainerConfig): void {
     if (config.network) {
-        if (config.network.allowedHosts?.length || config.network.blockedHosts?.length) {
+        const hasProxy = !!config.network.proxy;
+        const hasHostRules =
+            !!(config.network.allowedHosts?.length || config.network.blockedHosts?.length);
+        if (hasHostRules && !hasProxy) {
             config.network.enforcementMode = 'firewall';
         }
     }
@@ -303,8 +312,19 @@ export function createConfigFromPolicy(
 
     // Network mapping (cross-platform) — default-deny: block if not explicitly allowed
     if (policy.network) {
+        // Linux: only Bubblewrap supports network.proxy (cooperative env-var
+        // proxy, no privilege required). LXC and explicit non-bubblewrap
+        // containments do not. Abstract `'process'` on Linux resolves to
+        // Bubblewrap server-side so the proxy field is permitted there too.
         if (policy.network.proxy && platform === 'linux') {
-            throw new Error('Proxy configuration is not supported on Linux');
+            const linuxProxySupported =
+                containment === 'bubblewrap' || containment === 'process';
+            if (!linuxProxySupported) {
+                throw new Error(
+                    `Proxy configuration is not supported on Linux containment='${containment}'. ` +
+                    `Use containment 'bubblewrap' (or the abstract 'process') for proxy-based host filtering.`,
+                );
+            }
         }
         if (policy.network.proxy && platform === 'darwin') {
             throw new Error('Proxy configuration is not supported on macOS');

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -182,7 +182,7 @@ export interface NetworkConfig {
   allowedHosts?: string[];
   /** Hostnames or IP addresses to block (firewall mode only) */
   blockedHosts?: string[];
-  /** Proxy configuration (Windows only) */
+  /** Proxy configuration (supported on Windows ProcessContainer and Linux Bubblewrap) */
   proxy?: { builtinTestServer: true } | { localhost: number } | { url: string };
   /** Automatically remove firewall rules after execution (default: true). Deprecated: use lifecycle.preservePolicy. */
   removeRulesOnExit?: boolean;

--- a/sdk/tests/integration/linux-bubblewrap.test.ts
+++ b/sdk/tests/integration/linux-bubblewrap.test.ts
@@ -1,15 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { describe, it } from 'node:test';
+import { describe, it, after } from 'node:test';
 import assert from 'node:assert';
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
 import {
   sdk,
   supportedVersions,
   isLinuxRoot,
+  isLinuxBubblewrap,
   debugSpawnOptions,
   spawnFromConfigAsync,
+  startLinuxTestProxy,
 } from './test-helpers.js';
+import type { ChildProcess } from 'node:child_process';
 
 // Bwrap fingerprint: when invoked with `--unshare-pid`, bubblewrap creates a
 // new PID namespace and stays as PID 1 in that namespace, acting as init
@@ -74,3 +80,97 @@ describe(`Linux Bubblewrap (schema ${schemaVersion})`, {
   });
 });
 }
+
+// Network proxy tests use the cooperative env-var proxy, which is
+// unprivileged by design -- the entire reason the proxy path exists is to
+// avoid the root requirement of iptables-based enforcement. Gate on
+// "Linux + bwrap available" rather than "Linux + root". Pinned to schema
+// 0.6.0-alpha because Bubblewrap proxy support is only available in 0.6+.
+const PROXY_SCHEMA = '0.6.0-alpha';
+describe('Linux Bubblewrap network proxy (schema 0.6.0-alpha)', {
+  skip: !isLinuxBubblewrap
+    ? 'Linux Bubblewrap proxy tests require Linux with bwrap installed'
+    : undefined,
+}, () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mxc-sdk-bwrap-proxy-'));
+  const proxies: ChildProcess[] = [];
+
+  after(() => {
+    for (const p of proxies) {
+      try { p.kill('SIGTERM'); } catch { /* ignore */ }
+    }
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('should route HTTPS traffic through an externally launched linux-test-proxy', async () => {
+    const { port, proxyProcess } = startLinuxTestProxy(tmpDir);
+    proxies.push(proxyProcess);
+
+    const config = sdk.createConfigFromPolicy(
+      { version: PROXY_SCHEMA },
+      'bubblewrap',
+      'bwrap-external-proxy',
+    );
+    config.process!.commandLine =
+      'curl -fsSL https://api.github.com/zen > /dev/null && echo PROXY_OK';
+    config.network = {
+      ...(config.network ?? {}),
+      defaultPolicy: 'allow',
+      proxy: { localhost: port },
+    };
+
+    const result = await spawnFromConfigAsync(config, { ...debugSpawnOptions, experimental: true });
+    assert.strictEqual(result.exitCode, 0, `external-proxy run failed: ${result.stdout}`);
+    assert.ok(result.stdout.includes('PROXY_OK'), `missing PROXY_OK in: ${result.stdout}`);
+  });
+
+  it('should launch a builtinTestServer proxy and route traffic through it', async () => {
+    const config = sdk.createConfigFromPolicy(
+      { version: PROXY_SCHEMA },
+      'bubblewrap',
+      'bwrap-builtin-proxy',
+    );
+    config.process!.commandLine =
+      'curl -fsSL https://api.github.com/zen > /dev/null && echo BUILTIN_OK';
+    config.network = {
+      ...(config.network ?? {}),
+      defaultPolicy: 'allow',
+      proxy: { builtinTestServer: true },
+    };
+
+    const result = await spawnFromConfigAsync(config, { ...debugSpawnOptions, experimental: true });
+    assert.strictEqual(result.exitCode, 0, `builtin-proxy run failed: ${result.stdout}`);
+    assert.ok(result.stdout.includes('BUILTIN_OK'), `missing BUILTIN_OK in: ${result.stdout}`);
+  });
+
+  it('should enforce allowedHosts at the proxy layer', async () => {
+    const config = sdk.createConfigFromPolicy(
+      { version: PROXY_SCHEMA },
+      'bubblewrap',
+      'bwrap-allowlist-proxy',
+    );
+    // Sentinel pattern: allowed host succeeds, disallowed host fails with 403
+    // from the proxy and curl exits non-zero. The script swallows that and
+    // prints BLOCKED_OK so we can assert both signals are present.
+    config.process!.commandLine =
+      'set -e; ' +
+      'curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; ' +
+      'if curl -fsS --max-time 5 https://example.com > /dev/null 2>&1; then ' +
+      '  echo SENTINEL_BAD_LEAK; exit 1; ' +
+      'else ' +
+      '  echo BLOCKED_OK; ' +
+      'fi';
+    config.network = {
+      ...(config.network ?? {}),
+      defaultPolicy: 'allow',
+      proxy: { builtinTestServer: true },
+      allowedHosts: ['api.github.com'],
+    };
+
+    const result = await spawnFromConfigAsync(config, { ...debugSpawnOptions, experimental: true });
+    assert.strictEqual(result.exitCode, 0, `allowlist run failed: ${result.stdout}`);
+    assert.ok(result.stdout.includes('SENTINEL_OK'), `missing SENTINEL_OK in: ${result.stdout}`);
+    assert.ok(result.stdout.includes('BLOCKED_OK'), `disallowed host was not blocked: ${result.stdout}`);
+    assert.ok(!result.stdout.includes('SENTINEL_BAD_LEAK'), `allowlist leaked: ${result.stdout}`);
+  });
+});

--- a/sdk/tests/integration/test-helpers.ts
+++ b/sdk/tests/integration/test-helpers.ts
@@ -55,6 +55,7 @@ export const EXPECTED_WINDOWS_BINARIES = [
 
 export const EXPECTED_LINUX_BINARIES = [
   'lxc-exec',
+  'linux-test-proxy',
 ];
 
 export const EXPECTED_MACOS_BINARIES = [
@@ -146,6 +147,25 @@ export const sandboxSkipReason = skipOsDependentTests
   : undefined;
 
 export const isLinuxRoot = os.platform() === 'linux' && process.getuid?.() === 0;
+
+/**
+ * Linux + bubblewrap available on PATH. The cooperative-proxy backend does
+ * not require root, so proxy-focused tests use this gate instead of the
+ * stricter `isLinuxRoot` used by other Bubblewrap fingerprint tests.
+ */
+export const isLinuxBubblewrap = (() => {
+  if (os.platform() !== 'linux') return false;
+  const pathDirs = (process.env.PATH ?? '').split(path.delimiter);
+  for (const dir of pathDirs) {
+    if (!dir) continue;
+    try {
+      if (fs.existsSync(path.join(dir, 'bwrap'))) return true;
+    } catch {
+      // ignore inaccessible PATH entries
+    }
+  }
+  return false;
+})();
 
 // When MXC_DEBUG=true, integration tests pass { debug: true } to spawn options
 // so wxc-exec / lxc-exec emit verbose output. Enable via pipeline parameter or locally.
@@ -389,3 +409,58 @@ export function startTestProxy(dir: string): { port: number; proxyProcess: Child
   return { port, proxyProcess };
 }
 
+// Linux-only: linux-test-proxy helpers
+
+/** Locate linux-test-proxy in the SDK package bin directory. */
+function findLinuxTestProxyBinary(): string {
+  const binDir = getSdkBinDir();
+  const proxyPath = path.join(binDir, 'linux-test-proxy');
+  if (fs.existsSync(proxyPath)) {
+    return proxyPath;
+  }
+  throw new Error(`linux-test-proxy not found at expected SDK package location: ${proxyPath}`);
+}
+
+/**
+ * Start linux-test-proxy in a child process.
+ *
+ * Binds to an OS-assigned port on `127.0.0.1` and writes it atomically to a
+ * ready file. The proxy uses `PR_SET_PDEATHSIG` so it dies when the test
+ * process exits — no cleanup-event mechanism is needed on Linux.
+ */
+export function startLinuxTestProxy(
+  dir: string,
+  opts: { allowHosts?: string[]; blockHosts?: string[] } = {},
+): { port: number; proxyProcess: ChildProcess } {
+  const proxyPath = findLinuxTestProxyBinary();
+  const readyFile = path.join(dir, 'linux-proxy-ready.txt');
+
+  const args: string[] = ['--ready-file', readyFile, '--bind-address', '127.0.0.1'];
+  for (const host of opts.allowHosts ?? []) {
+    args.push('--allow-host', host);
+  }
+  for (const host of opts.blockHosts ?? []) {
+    args.push('--block-host', host);
+  }
+
+  const proxyProcess = spawn(proxyPath, args, { stdio: 'ignore' });
+
+  const deadline = Date.now() + 15000;
+  while (!fs.existsSync(readyFile) && Date.now() < deadline) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+  }
+
+  if (!fs.existsSync(readyFile)) {
+    proxyProcess.kill('SIGTERM');
+    throw new Error('linux-test-proxy did not write ready file within 15 seconds');
+  }
+
+  const portStr = fs.readFileSync(readyFile, 'utf-8').trim();
+  const port = parseInt(portStr, 10);
+  if (isNaN(port) || port <= 0) {
+    proxyProcess.kill('SIGTERM');
+    throw new Error(`Invalid port in ready file: ${portStr}`);
+  }
+
+  return { port, proxyProcess };
+}

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -909,7 +909,7 @@ describe('createConfigFromPolicy', () => {
       assert.deepStrictEqual(config.filesystem!.readwritePaths, ['/workspace']);
       assert.deepStrictEqual(config.filesystem!.readonlyPaths, ['/data']);
       assert.deepStrictEqual(config.filesystem!.deniedPaths, ['/secrets']);
-      // Per applyIptablesNetworkEnforcement, host filtering forces firewall mode.
+      // Per applyLinuxNetworkPolicy, host filtering forces firewall mode.
       assert.strictEqual(config.network!.enforcementMode, 'firewall');
     });
   });

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -230,7 +230,37 @@ describe('buildSandboxPayload', () => {
       }
     });
 
-    it('should reject proxy configuration on Linux', () => {
+    it('should accept proxy configuration on Linux for the default process containment (resolves to bubblewrap)', () => {
+      mockLinux();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { proxy: { builtinTestServer: true } },
+        };
+        const config = buildSandboxPayload('echo hi', policy);
+        assert.strictEqual(config.containment, 'process');
+        assert.deepStrictEqual(config.network!.proxy, { builtinTestServer: true });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should accept proxy configuration on Linux for explicit bubblewrap containment', () => {
+      mockLinux();
+      try {
+        const policy: SandboxPolicy = {
+          version: '0.4.0-alpha',
+          network: { proxy: { builtinTestServer: true } },
+        };
+        const config = buildSandboxPayload('echo hi', policy, undefined, undefined, 'bubblewrap');
+        assert.strictEqual(config.containment, 'bubblewrap');
+        assert.deepStrictEqual(config.network!.proxy, { builtinTestServer: true });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject proxy configuration on Linux for non-bubblewrap containments (e.g. lxc)', () => {
       mockLinux();
       try {
         const policy: SandboxPolicy = {
@@ -238,8 +268,8 @@ describe('buildSandboxPayload', () => {
           network: { proxy: { builtinTestServer: true } },
         };
         assert.throws(
-          () => buildSandboxPayload('echo hi', policy),
-          { message: /not supported on Linux/ },
+          () => buildSandboxPayload('echo hi', policy, undefined, undefined, 'lxc'),
+          { message: /not supported on Linux containment='lxc'/ },
         );
       } finally {
         restore();
@@ -577,15 +607,76 @@ describe('createConfigFromPolicy', () => {
       }
     });
 
-    it('should reject proxy on Linux', () => {
+    it('should accept proxy on Linux for the default process containment (resolves to bubblewrap)', () => {
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.4.0-alpha',
+          network: { proxy: { builtinTestServer: true } },
+        });
+        assert.strictEqual(config.containment, 'process');
+        assert.deepStrictEqual(config.network!.proxy, { builtinTestServer: true });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should accept proxy on Linux for explicit bubblewrap containment', () => {
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy(
+          {
+            version: '0.4.0-alpha',
+            network: { proxy: { builtinTestServer: true } },
+          },
+          'bubblewrap',
+        );
+        assert.strictEqual(config.containment, 'bubblewrap');
+        assert.deepStrictEqual(config.network!.proxy, { builtinTestServer: true });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should NOT force enforcementMode=firewall when proxy + host filtering are combined on bubblewrap', () => {
+      // The Rust config_parser explicitly rejects bubblewrap+proxy+firewall
+      // since the iptables path requires privilege the bwrap backend
+      // deliberately avoids. Host enforcement happens at the proxy layer
+      // instead, so the SDK must leave enforcementMode at its default.
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy(
+          {
+            version: '0.4.0-alpha',
+            network: {
+              allowOutbound: true,
+              allowedHosts: ['example.com'],
+              proxy: { builtinTestServer: true },
+            },
+          },
+          'bubblewrap',
+        );
+        assert.strictEqual(config.containment, 'bubblewrap');
+        assert.strictEqual(config.network!.enforcementMode, undefined);
+        assert.deepStrictEqual(config.network!.proxy, { builtinTestServer: true });
+        assert.deepStrictEqual(config.network!.allowedHosts, ['example.com']);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject proxy on Linux for explicit lxc containment', () => {
       mockLinux();
       try {
         assert.throws(
-          () => createConfigFromPolicy({
-            version: '0.4.0-alpha',
-            network: { proxy: { builtinTestServer: true } },
-          }),
-          { message: /not supported on Linux/ },
+          () => createConfigFromPolicy(
+            {
+              version: '0.4.0-alpha',
+              network: { proxy: { builtinTestServer: true } },
+            },
+            'lxc',
+          ),
+          { message: /not supported on Linux containment='lxc'/ },
         );
       } finally {
         restore();

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1162,6 +1162,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "linux_test_proxy"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "clap",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "libc",
+ "tokio",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2777,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hyperlight-unikraft-host",
  "isolation_session_bindings",
+ "libc",
  "nanvix_common",
  "sandbox_spec",
  "semver",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "lxc_common",
     "wslc_common",
     "bwrap_common",
+    "linux_test_proxy",
     "isolation_session_bindings",
     "seatbelt_common",
     "mxc_darwin",

--- a/src/bwrap_common/src/bwrap_command.rs
+++ b/src/bwrap_common/src/bwrap_command.rs
@@ -7,13 +7,35 @@
 //! arguments without spawning any processes, so it compiles and can be
 //! unit-tested on every host (Windows, macOS, Linux).
 
-use wxc_common::models::{CodexRequest, NetworkPolicy};
+use wxc_common::models::{CodexRequest, NetworkPolicy, ProxyAddress};
+
+/// Env var keys that the proxy block manages. Listed here so we can strip
+/// any conflicting entries the caller supplied via `request.env` (callers
+/// must not be able to defeat the cooperative proxy by injecting their own
+/// proxy env vars).
+const PROXY_ENV_KEYS: &[&str] = &[
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+];
 
 /// Build the complete argument list for `bwrap` from the given request.
 ///
 /// The returned vector does **not** include the `bwrap` binary name itself —
 /// callers pass it to `Command::new("bwrap").args(&args)`.
-pub fn build_args(request: &CodexRequest) -> Vec<String> {
+///
+/// `proxy_address` is the loopback address of the network proxy launched by
+/// the Bubblewrap runner (if the request has `network.proxy` configured).
+/// When `Some`, the builder:
+/// - drops `--unshare-net` (the sandbox needs to reach the loopback proxy on
+///   the host's network namespace),
+/// - strips any caller-supplied `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
+///   entries from `request.env`,
+/// - emits `--setenv` for those keys pointing at the proxy URL.
+pub fn build_args(request: &CodexRequest, proxy_address: Option<&ProxyAddress>) -> Vec<String> {
     // -- Namespace isolation (all unshared by default) ---------------------
     let mut args = vec![
         "--unshare-user",
@@ -26,13 +48,16 @@ pub fn build_args(request: &CodexRequest) -> Vec<String> {
     .collect::<Vec<_>>();
 
     // Network: use --unshare-net for full block when no per-host rules are
-    // configured. When allowedHosts / blockedHosts are present the runner
-    // leaves the network namespace shared and applies iptables rules
-    // separately (handled by the runner, not the command builder).
+    // configured AND no proxy is active. When allowedHosts / blockedHosts
+    // are present the runner leaves the network namespace shared and
+    // applies iptables rules separately. When a network proxy is active we
+    // also keep the host network namespace so the sandbox can reach the
+    // loopback proxy.
     let has_host_rules =
         !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty();
-    let full_block =
-        request.policy.default_network_policy == NetworkPolicy::Block && !has_host_rules;
+    let full_block = request.policy.default_network_policy == NetworkPolicy::Block
+        && !has_host_rules
+        && proxy_address.is_none();
     if full_block {
         args.push("--unshare-net".into());
     }
@@ -79,8 +104,38 @@ pub fn build_args(request: &CodexRequest) -> Vec<String> {
     args.push("--clearenv".into());
     for env_str in &request.env {
         if let Some((key, value)) = env_str.split_once('=') {
+            // When the proxy is active, drop any caller-supplied proxy env
+            // entries so they cannot override the values we set below.
+            if proxy_address.is_some() && PROXY_ENV_KEYS.contains(&key) {
+                continue;
+            }
             args.extend(["--setenv".into(), key.into(), value.into()]);
         }
+    }
+
+    // -- Network proxy env vars -------------------------------------------
+    // Cooperative env-var proxying: well-behaved tools (curl, requests,
+    // etc.) honor these and route through the proxy where allow / block
+    // enforcement happens. Tools that bypass these variables (raw sockets)
+    // are NOT enforced -- this is a documented limitation of the
+    // unprivileged proxy model.
+    if let Some(addr) = proxy_address {
+        let url = addr.to_url();
+        for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
+            args.extend(["--setenv".into(), key.into(), url.clone()]);
+        }
+        // Exempt loopback so the proxy itself and local-only services are
+        // reached directly.
+        args.extend([
+            "--setenv".into(),
+            "NO_PROXY".into(),
+            "localhost,127.0.0.1".into(),
+        ]);
+        args.extend([
+            "--setenv".into(),
+            "no_proxy".into(),
+            "localhost,127.0.0.1".into(),
+        ]);
     }
 
     // -- Command -----------------------------------------------------------
@@ -95,7 +150,7 @@ pub fn build_args(request: &CodexRequest) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::models::{CodexRequest, NetworkPolicy};
+    use wxc_common::models::{CodexRequest, NetworkPolicy, ProxyAddress};
 
     fn base_request() -> CodexRequest {
         CodexRequest {
@@ -107,7 +162,7 @@ mod tests {
 
     #[test]
     fn basic_args_contain_namespace_flags() {
-        let args = build_args(&base_request());
+        let args = build_args(&base_request(), None);
         assert!(args.contains(&"--unshare-user".to_string()));
         assert!(args.contains(&"--unshare-pid".to_string()));
         assert!(args.contains(&"--unshare-ipc".to_string()));
@@ -118,7 +173,7 @@ mod tests {
     fn network_block_adds_unshare_net() {
         let mut r = base_request();
         r.policy.default_network_policy = NetworkPolicy::Block;
-        let args = build_args(&r);
+        let args = build_args(&r, None);
         assert!(args.contains(&"--unshare-net".to_string()));
     }
 
@@ -126,7 +181,7 @@ mod tests {
     fn network_allow_omits_unshare_net() {
         let mut r = base_request();
         r.policy.default_network_policy = NetworkPolicy::Allow;
-        let args = build_args(&r);
+        let args = build_args(&r, None);
         assert!(!args.contains(&"--unshare-net".to_string()));
     }
 
@@ -135,7 +190,7 @@ mod tests {
         let mut r = base_request();
         r.policy.default_network_policy = NetworkPolicy::Block;
         r.policy.allowed_hosts = vec!["example.com".into()];
-        let args = build_args(&r);
+        let args = build_args(&r, None);
         assert!(
             !args.contains(&"--unshare-net".to_string()),
             "should omit --unshare-net when host rules require iptables"
@@ -148,7 +203,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["/workspace".into()];
         r.policy.readonly_paths = vec!["/data".into()];
         r.policy.denied_paths = vec!["/secrets".into()];
-        let args = build_args(&r);
+        let args = build_args(&r, None);
 
         // rw
         let rw_pos = args.iter().position(|a| a == "--bind").unwrap();
@@ -186,7 +241,7 @@ mod tests {
     fn environment_variables_are_set() {
         let mut r = base_request();
         r.env = vec!["FOO=bar".into(), "PATH=/usr/bin".into()];
-        let args = build_args(&r);
+        let args = build_args(&r, None);
         assert!(args.contains(&"--clearenv".to_string()));
         let foo_pos = args.iter().position(|a| a == "FOO").unwrap();
         assert_eq!(args[foo_pos - 1], "--setenv");
@@ -195,14 +250,14 @@ mod tests {
 
     #[test]
     fn working_directory_is_set() {
-        let args = build_args(&base_request());
+        let args = build_args(&base_request(), None);
         let chdir_pos = args.iter().position(|a| a == "--chdir").unwrap();
         assert_eq!(args[chdir_pos + 1], "/home/user");
     }
 
     #[test]
     fn command_is_last() {
-        let args = build_args(&base_request());
+        let args = build_args(&base_request(), None);
         let sep = args.iter().position(|a| a == "--").unwrap();
         assert_eq!(args[sep + 1], "sh");
         assert_eq!(args[sep + 2], "-c");
@@ -213,7 +268,7 @@ mod tests {
     fn empty_working_directory_omits_chdir() {
         let mut r = base_request();
         r.working_directory = String::new();
-        let args = build_args(&r);
+        let args = build_args(&r, None);
         assert!(!args.contains(&"--chdir".to_string()));
     }
 
@@ -229,7 +284,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["/tmp/workspace".into()];
         r.policy.readonly_paths = vec!["/tmp/data".into()];
         r.policy.denied_paths = vec!["/tmp/secrets".into()];
-        let args = build_args(&r);
+        let args = build_args(&r, None);
 
         // Locate the position of the standard --tmpfs /tmp mount.
         let tmpfs_tmp_pos = args
@@ -258,5 +313,86 @@ mod tests {
         assert_after("--bind", "/tmp/workspace");
         assert_after("--ro-bind", "/tmp/data");
         assert_after("--tmpfs", "/tmp/secrets");
+    }
+
+    // ------- Network proxy env-var injection tests ----------------------
+
+    #[test]
+    fn proxy_active_omits_unshare_net_even_when_default_blocks() {
+        let mut r = base_request();
+        r.policy.default_network_policy = NetworkPolicy::Block;
+        let addr = ProxyAddress::new("127.0.0.1".into(), 12345);
+        let args = build_args(&r, Some(&addr));
+        assert!(
+            !args.contains(&"--unshare-net".to_string()),
+            "proxy active must keep host netns so loopback proxy is reachable"
+        );
+    }
+
+    #[test]
+    fn proxy_active_injects_env_vars() {
+        let r = base_request();
+        let addr = ProxyAddress::new("127.0.0.1".into(), 7777);
+        let args = build_args(&r, Some(&addr));
+
+        // Each managed key must be set via --setenv.
+        for key in &[
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ] {
+            let pos = args
+                .iter()
+                .position(|a| a == *key)
+                .unwrap_or_else(|| panic!("missing --setenv {} in {:?}", key, args));
+            assert_eq!(args[pos - 1], "--setenv");
+        }
+
+        // Value points at the loopback proxy URL.
+        let http_pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();
+        assert_eq!(args[http_pos + 1], "http://127.0.0.1:7777");
+    }
+
+    #[test]
+    fn proxy_active_strips_caller_supplied_proxy_env() {
+        let mut r = base_request();
+        r.env = vec![
+            "FOO=bar".into(),
+            "HTTP_PROXY=http://attacker.example:9999".into(),
+            "https_proxy=http://attacker.example:9999".into(),
+            "PATH=/usr/bin".into(),
+        ];
+        let addr = ProxyAddress::new("127.0.0.1".into(), 9000);
+        let args = build_args(&r, Some(&addr));
+
+        // Caller-supplied proxy values must NOT appear.
+        assert!(
+            !args.iter().any(|a| a == "http://attacker.example:9999"),
+            "caller-supplied proxy URL must be stripped"
+        );
+
+        // The legitimate (non-proxy) env vars are preserved.
+        assert!(args.iter().any(|a| a == "FOO"));
+        assert!(args.iter().any(|a| a == "PATH"));
+
+        // The proxy URL is the one we set, not the attacker's.
+        let http_pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();
+        assert_eq!(args[http_pos + 1], "http://127.0.0.1:9000");
+    }
+
+    #[test]
+    fn proxy_inactive_leaves_caller_supplied_proxy_env_intact() {
+        // When the runner has not configured a proxy, the builder must NOT
+        // strip env vars whose keys happen to match PROXY_ENV_KEYS -- those
+        // are just regular env vars set by the caller for some other reason.
+        let mut r = base_request();
+        r.env = vec!["HTTP_PROXY=http://caller.example:8080".into()];
+        let args = build_args(&r, None);
+
+        let pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();
+        assert_eq!(args[pos + 1], "http://caller.example:8080");
     }
 }

--- a/src/bwrap_common/src/bwrap_command.rs
+++ b/src/bwrap_common/src/bwrap_command.rs
@@ -119,23 +119,19 @@ pub fn build_args(request: &CodexRequest, proxy_address: Option<&ProxyAddress>) 
     // enforcement happens. Tools that bypass these variables (raw sockets)
     // are NOT enforced -- this is a documented limitation of the
     // unprivileged proxy model.
+    //
+    // We deliberately do NOT set NO_PROXY here. Bubblewrap with a proxy
+    // keeps the host network namespace shared, so without a NO_PROXY entry
+    // a cooperating client doing `CONNECT 127.0.0.1:5432` (e.g. local
+    // Postgres) still goes via the proxy, where the configured
+    // allowed/blocked-hosts policy applies. Exempting loopback via
+    // NO_PROXY would silently bypass that filtering for host-loopback
+    // destinations.
     if let Some(addr) = proxy_address {
         let url = addr.to_url();
         for key in ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
             args.extend(["--setenv".into(), key.into(), url.clone()]);
         }
-        // Exempt loopback so the proxy itself and local-only services are
-        // reached directly.
-        args.extend([
-            "--setenv".into(),
-            "NO_PROXY".into(),
-            "localhost,127.0.0.1".into(),
-        ]);
-        args.extend([
-            "--setenv".into(),
-            "no_proxy".into(),
-            "localhost,127.0.0.1".into(),
-        ]);
     }
 
     // -- Command -----------------------------------------------------------
@@ -335,15 +331,8 @@ mod tests {
         let addr = ProxyAddress::new("127.0.0.1".into(), 7777);
         let args = build_args(&r, Some(&addr));
 
-        // Each managed key must be set via --setenv.
-        for key in &[
-            "HTTP_PROXY",
-            "HTTPS_PROXY",
-            "http_proxy",
-            "https_proxy",
-            "NO_PROXY",
-            "no_proxy",
-        ] {
+        // Each HTTP/HTTPS proxy key must be set via --setenv.
+        for key in &["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"] {
             let pos = args
                 .iter()
                 .position(|a| a == *key)
@@ -354,6 +343,23 @@ mod tests {
         // Value points at the loopback proxy URL.
         let http_pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();
         assert_eq!(args[http_pos + 1], "http://127.0.0.1:7777");
+    }
+
+    #[test]
+    fn proxy_active_does_not_exempt_loopback_via_no_proxy() {
+        // Setting NO_PROXY=localhost,127.0.0.1 would let cooperating HTTP
+        // clients bypass the proxy for host-loopback destinations.
+        // Bubblewrap+proxy keeps the host netns shared, so that bypass
+        // would silently defeat allowedHosts/blockedHosts for loopback.
+        let r = base_request();
+        let addr = ProxyAddress::new("127.0.0.1".into(), 7777);
+        let args = build_args(&r, Some(&addr));
+
+        assert!(
+            !args.iter().any(|a| a == "NO_PROXY" || a == "no_proxy"),
+            "proxy mode must not emit NO_PROXY/no_proxy --setenv pairs: {:?}",
+            args,
+        );
     }
 
     #[test]

--- a/src/bwrap_common/src/bwrap_runner.rs
+++ b/src/bwrap_common/src/bwrap_runner.rs
@@ -64,16 +64,24 @@ impl BubblewrapScriptRunner {
 
 impl ScriptRunner for BubblewrapScriptRunner {
     fn validate_runner(&self, request: &CodexRequest) -> Result<(), ScriptResponse> {
-        if !Self::is_bwrap_available() {
-            return Err(ScriptResponse::error(
-                "Bubblewrap (bwrap) is not installed or not on PATH. \
-                 Install it via your package manager (e.g., apt install bubblewrap).",
-            ));
-        }
-
+        // User-input validation runs before the environmental `bwrap`
+        // probe so config errors are reported deterministically even on
+        // hosts without bwrap installed.
         if request.script_code.is_empty() {
             return Err(ScriptResponse::error(
                 "script_code is empty — nothing to execute.",
+            ));
+        }
+
+        // The bundled `linux-test-proxy` is a testing-only HTTP proxy with
+        // a deliberately permissive feature set (no auth, no body limits,
+        // no hop-by-hop header handling). Gate it behind --experimental so
+        // it cannot be enabled from a stock production config.
+        if request.policy.network_proxy.builtin_test_server && !request.experimental_enabled {
+            return Err(ScriptResponse::error(
+                "network.proxy.builtinTestServer is a testing-only feature and requires \
+                 --experimental. For production, point network.proxy at a real HTTP \
+                 proxy via 'localhost' or 'url'.",
             ));
         }
 
@@ -83,6 +91,13 @@ impl ScriptRunner for BubblewrapScriptRunner {
                 "script_timeout {}ms is below the minimum of {}ms",
                 request.script_timeout, POLL_INTERVAL_MS
             )));
+        }
+
+        if !Self::is_bwrap_available() {
+            return Err(ScriptResponse::error(
+                "Bubblewrap (bwrap) is not installed or not on PATH. \
+                 Install it via your package manager (e.g., apt install bubblewrap).",
+            ));
         }
 
         Ok(())
@@ -300,5 +315,49 @@ fn wait_with_timeout(
             }
             Err(e) => return Err(WaitError::Io(e)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wxc_common::models::ProxyConfig;
+
+    fn base_request() -> CodexRequest {
+        CodexRequest {
+            script_code: "echo hi".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_rejects_builtin_test_server_without_experimental() {
+        let mut req = base_request();
+        req.policy.network_proxy = ProxyConfig {
+            address: None,
+            builtin_test_server: true,
+        };
+        req.experimental_enabled = false;
+
+        let runner = BubblewrapScriptRunner::new();
+        let err = runner.validate_runner(&req).unwrap_err();
+        assert!(
+            err.error_message.contains("builtinTestServer")
+                && err.error_message.contains("--experimental"),
+            "expected experimental-gate error, got: {}",
+            err.error_message
+        );
+    }
+
+    #[test]
+    fn validate_rejects_empty_script_before_environment_probe() {
+        // Empty script_code is a user-input error and must be surfaced
+        // even on hosts without bwrap installed (independent of CI image).
+        let mut req = base_request();
+        req.script_code = String::new();
+
+        let runner = BubblewrapScriptRunner::new();
+        let err = runner.validate_runner(&req).unwrap_err();
+        assert!(err.error_message.contains("script_code is empty"));
     }
 }

--- a/src/bwrap_common/src/bwrap_runner.rs
+++ b/src/bwrap_common/src/bwrap_runner.rs
@@ -92,6 +92,12 @@ impl ScriptRunner for BubblewrapScriptRunner {
         // 1. Start the network proxy if configured. Must happen before
         //    arg-building so the proxy's loopback address can be injected as
         //    HTTP_PROXY / HTTPS_PROXY into the sandbox environment.
+        //
+        //    Pass the request's `default_network_policy` through so that a
+        //    config of `{ defaultPolicy: "block", proxy: {...}, allowedHosts:
+        //    [] }` actually denies-by-default at the proxy layer (otherwise
+        //    the empty allow list + no iptables + no --unshare-net would let
+        //    everything through).
         let mut proxy = LinuxProxyCoordinator::new();
         if request.policy.network_proxy.is_enabled() {
             if let Err(err) = proxy.start(
@@ -99,6 +105,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
                 "127.0.0.1",
                 &request.policy.allowed_hosts,
                 &request.policy.blocked_hosts,
+                request.policy.default_network_policy.clone(),
                 logger,
             ) {
                 return ScriptResponse::error(&format!(

--- a/src/bwrap_common/src/bwrap_runner.rs
+++ b/src/bwrap_common/src/bwrap_runner.rs
@@ -10,16 +10,27 @@
 //! with stdout/stderr capture and optional timeout enforcement.
 //!
 //! For per-host network filtering (`allowedHosts`/`blockedHosts`) the runner
-//! reuses [`lxc_common::network_iptables::NetworkIptablesManager`] from the
-//! LXC backend — this requires root but is consistent with the LXC approach.
-//! When only `defaultPolicy: "block"` is set (no host lists), the runner uses
-//! `--unshare-net` for zero-overhead full isolation without root.
+//! supports two paths:
+//! - **Cooperative env-var proxy** (default, no privilege required): when
+//!   `network.proxy` is configured the runner launches an unprivileged HTTP
+//!   proxy via [`wxc_common::linux_proxy_coordinator::LinuxProxyCoordinator`]
+//!   and the command builder injects `HTTP_PROXY` / `HTTPS_PROXY` /
+//!   `NO_PROXY` env vars into the sandbox.
+//! - **iptables firewall** (requires `CAP_NET_ADMIN` / root): when
+//!   `network.enforcementMode` is `firewall` or `both`, the runner reuses
+//!   [`lxc_common::network_iptables::NetworkIptablesManager`] from the LXC
+//!   backend.
+//!
+//! When only `defaultPolicy: "block"` is set (no host lists and no proxy),
+//! the runner uses `--unshare-net` for zero-overhead full isolation
+//! without root.
 
 use std::fmt::Write as FmtWrite;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use lxc_common::network_iptables::NetworkIptablesManager;
+use wxc_common::linux_proxy_coordinator::LinuxProxyCoordinator;
 use wxc_common::logger::Logger;
 use wxc_common::models::{CodexRequest, NetworkEnforcementMode, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
@@ -78,16 +89,37 @@ impl ScriptRunner for BubblewrapScriptRunner {
     }
 
     fn execute(&mut self, request: &CodexRequest, logger: &mut Logger) -> ScriptResponse {
-        // 1. Build the bwrap argument vector.
-        let args = bwrap_command::build_args(request);
+        // 1. Start the network proxy if configured. Must happen before
+        //    arg-building so the proxy's loopback address can be injected as
+        //    HTTP_PROXY / HTTPS_PROXY into the sandbox environment.
+        let mut proxy = LinuxProxyCoordinator::new();
+        if request.policy.network_proxy.is_enabled() {
+            if let Err(err) = proxy.start(
+                &request.policy.network_proxy,
+                "127.0.0.1",
+                &request.policy.allowed_hosts,
+                &request.policy.blocked_hosts,
+                logger,
+            ) {
+                return ScriptResponse::error(&format!(
+                    "Bubblewrap: failed to start network proxy: {}",
+                    err
+                ));
+            }
+        }
+
+        // 2. Build the bwrap argument vector.
+        let args = bwrap_command::build_args(request, proxy.address());
         let _ = writeln!(
             logger,
             "Bubblewrap: spawning bwrap with {} args",
             args.len()
         );
 
-        // 2. Determine whether iptables network rules are needed.
-        let needs_iptables = needs_iptables_rules(request);
+        // 3. Determine whether iptables network rules are needed. When the
+        //    cooperative proxy is active we skip iptables entirely (host
+        //    enforcement happens at the proxy layer).
+        let needs_iptables = needs_iptables_rules(request) && !proxy.is_active();
         let container_name = if request.container_id.is_empty() {
             format!("bwrap-{:08x}", std::process::id())
         } else {
@@ -103,11 +135,13 @@ impl ScriptRunner for BubblewrapScriptRunner {
             match mgr.apply_firewall_rules(&request.policy, logger) {
                 Ok(true) => {}
                 Ok(false) => {
+                    proxy.stop(logger);
                     return ScriptResponse::error(
                         "Bubblewrap: failed to apply iptables firewall rules.",
                     );
                 }
                 Err(e) => {
+                    proxy.stop(logger);
                     return ScriptResponse::error(&format!(
                         "Bubblewrap: network policy error: {}",
                         e
@@ -119,7 +153,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
             None
         };
 
-        // 3. Spawn `bwrap`.
+        // 4. Spawn `bwrap`.
         let mut command = Command::new("bwrap");
         command.args(&args);
         command
@@ -131,6 +165,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
             Ok(process) => process,
             Err(error) => {
                 cleanup_iptables(&mut fw_manager, logger);
+                proxy.stop(logger);
                 return ScriptResponse::error(&format!(
                     "Bubblewrap: failed to spawn bwrap: {}",
                     error
@@ -138,7 +173,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
             }
         };
 
-        // 4. Drain stdout/stderr in background threads to avoid pipe-buffer
+        // 5. Drain stdout/stderr in background threads to avoid pipe-buffer
         //    deadlock.
         let stdout_handle = child
             .stdout
@@ -149,7 +184,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
             .take()
             .map(|r| std::thread::spawn(move || read_to_string(r)));
 
-        // 5. Wait with optional timeout.
+        // 6. Wait with optional timeout.
         let timeout = if request.script_timeout == 0 {
             None
         } else {
@@ -162,6 +197,7 @@ impl ScriptRunner for BubblewrapScriptRunner {
                 let _ = child.kill();
                 let _ = child.wait();
                 cleanup_iptables(&mut fw_manager, logger);
+                proxy.stop(logger);
                 return ScriptResponse {
                     exit_code: -1,
                     standard_out: join_reader(stdout_handle),
@@ -175,12 +211,14 @@ impl ScriptRunner for BubblewrapScriptRunner {
             }
             Err(WaitError::Io(error)) => {
                 cleanup_iptables(&mut fw_manager, logger);
+                proxy.stop(logger);
                 return ScriptResponse::error(&format!("Bubblewrap: wait failed: {}", error));
             }
         };
 
-        // 6. Collect output and clean up.
+        // 7. Collect output and clean up.
         cleanup_iptables(&mut fw_manager, logger);
+        proxy.stop(logger);
 
         ScriptResponse {
             exit_code: exit_status.code().unwrap_or(-1),

--- a/src/linux_test_proxy/Cargo.toml
+++ b/src/linux_test_proxy/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "linux_test_proxy"
+version = "0.1.0"
+edition.workspace = true
+
+[[bin]]
+name = "linux-test-proxy"
+path = "src/main.rs"
+
+[dependencies]
+tokio.workspace = true
+hyper = { version = "1", features = ["server", "client", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+http-body-util = "0.1"
+bytes = "1"
+clap.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true

--- a/src/linux_test_proxy/src/main.rs
+++ b/src/linux_test_proxy/src/main.rs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Standalone binary for the Linux builtin test proxy.
+//!
+//! **Testing-only tool.** Launches a minimal HTTP CONNECT proxy on an
+//! OS-assigned port, atomically writes the port to a ready file, then waits
+//! for SIGTERM or parent death before shutting down.
+//!
+//! Designed to be spawned by `wxc_common::linux_proxy_coordinator` to provide
+//! cooperative, unprivileged proxy-based enforcement of `allowedHosts` /
+//! `blockedHosts` for the Bubblewrap backend.
+
+#[cfg(target_os = "linux")]
+mod proxy;
+
+#[cfg(target_os = "linux")]
+mod linux_main {
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use clap::Parser;
+
+    use crate::proxy;
+
+    #[derive(Parser)]
+    #[command(
+        name = "linux-test-proxy",
+        about = "Builtin test proxy for MXC Bubblewrap integration testing (NOT for production use)"
+    )]
+    pub struct Cli {
+        /// Path where the proxy atomically writes its port number once ready.
+        #[arg(long = "ready-file")]
+        pub ready_file: PathBuf,
+
+        /// Address to bind on. Defaults to loopback. Future LXC/Seatbelt
+        /// callers can pass the bridge gateway IP so the proxy is reachable
+        /// from inside a separate netns.
+        #[arg(long = "bind-address", default_value = "127.0.0.1")]
+        pub bind_address: String,
+
+        /// Hosts permitted by the proxy. May be repeated. When empty, all
+        /// hosts are permitted (subject to `--block-host`).
+        #[arg(long = "allow-host")]
+        pub allow_host: Vec<String>,
+
+        /// Hosts denied by the proxy. May be repeated. Block takes precedence
+        /// over allow.
+        #[arg(long = "block-host")]
+        pub block_host: Vec<String>,
+    }
+
+    pub async fn run() -> std::process::ExitCode {
+        // 1. Tie our lifetime to the parent so a crash of `lxc-exec` cannot
+        //    leave us behind. Must happen before any work — and we must check
+        //    for the parent-already-dead race immediately after.
+        unsafe {
+            libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0);
+            if libc::getppid() == 1 {
+                // Parent died before prctl took effect. Bail before binding
+                // anything to avoid leaking a listening socket.
+                return std::process::ExitCode::from(0);
+            }
+        }
+
+        eprintln!(
+            "[linux-test-proxy] *** SECURITY WARNING ***: testing-only proxy. Do NOT use in production."
+        );
+
+        let cli = Cli::parse();
+
+        let filter = Arc::new(proxy::HostFilter::new(
+            cli.allow_host.clone(),
+            cli.block_host.clone(),
+        ));
+
+        let port = match proxy::start(&cli.bind_address, filter).await {
+            Ok(port) => port,
+            Err(err) => {
+                eprintln!(
+                    "[linux-test-proxy] failed to bind {}: {}",
+                    cli.bind_address, err
+                );
+                return std::process::ExitCode::from(1);
+            }
+        };
+
+        eprintln!(
+            "[linux-test-proxy] Listening on {}:{}",
+            cli.bind_address, port
+        );
+
+        // 2. Atomic ready-file: write to `<file>.tmp`, then rename. This
+        //    eliminates partial-read windows when the parent polls the file.
+        let tmp_path = cli.ready_file.with_extension("tmp");
+        if let Err(err) = fs::write(&tmp_path, port.to_string()) {
+            eprintln!(
+                "[linux-test-proxy] Failed to write ready tmp file {}: {}",
+                tmp_path.display(),
+                err
+            );
+            return std::process::ExitCode::from(1);
+        }
+        if let Err(err) = fs::rename(&tmp_path, &cli.ready_file) {
+            eprintln!(
+                "[linux-test-proxy] Failed to rename ready file to {}: {}",
+                cli.ready_file.display(),
+                err
+            );
+            let _ = fs::remove_file(&tmp_path);
+            return std::process::ExitCode::from(1);
+        }
+
+        // 3. Wait for SIGTERM (parent's explicit stop signal) or SIGINT
+        //    (ctrl-C during manual testing). PR_SET_PDEATHSIG above also
+        //    delivers SIGTERM if the parent dies.
+        let mut term =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(s) => s,
+                Err(err) => {
+                    eprintln!(
+                        "[linux-test-proxy] failed to install SIGTERM handler: {}",
+                        err
+                    );
+                    return std::process::ExitCode::from(1);
+                }
+            };
+        let mut interrupt =
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()) {
+                Ok(s) => s,
+                Err(err) => {
+                    eprintln!(
+                        "[linux-test-proxy] failed to install SIGINT handler: {}",
+                        err
+                    );
+                    return std::process::ExitCode::from(1);
+                }
+            };
+
+        tokio::select! {
+            _ = term.recv() => eprintln!("[linux-test-proxy] received SIGTERM, shutting down"),
+            _ = interrupt.recv() => eprintln!("[linux-test-proxy] received SIGINT, shutting down"),
+        }
+
+        std::process::ExitCode::from(0)
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    linux_main::run().await
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!(
+        "linux-test-proxy: this binary is only supported on Linux. Use wxc-test-proxy on Windows."
+    );
+    std::process::exit(1);
+}

--- a/src/linux_test_proxy/src/main.rs
+++ b/src/linux_test_proxy/src/main.rs
@@ -20,9 +20,24 @@ mod linux_main {
     use std::path::PathBuf;
     use std::sync::Arc;
 
-    use clap::Parser;
+    use clap::{Parser, ValueEnum};
 
     use crate::proxy;
+
+    #[derive(Copy, Clone, Debug, ValueEnum)]
+    pub enum DefaultPolicyArg {
+        Allow,
+        Block,
+    }
+
+    impl From<DefaultPolicyArg> for proxy::DefaultPolicy {
+        fn from(value: DefaultPolicyArg) -> Self {
+            match value {
+                DefaultPolicyArg::Allow => proxy::DefaultPolicy::Allow,
+                DefaultPolicyArg::Block => proxy::DefaultPolicy::Block,
+            }
+        }
+    }
 
     #[derive(Parser)]
     #[command(
@@ -40,8 +55,8 @@ mod linux_main {
         #[arg(long = "bind-address", default_value = "127.0.0.1")]
         pub bind_address: String,
 
-        /// Hosts permitted by the proxy. May be repeated. When empty, all
-        /// hosts are permitted (subject to `--block-host`).
+        /// Hosts permitted by the proxy. May be repeated. When empty, the
+        /// default policy (see `--default-policy`) decides.
         #[arg(long = "allow-host")]
         pub allow_host: Vec<String>,
 
@@ -49,6 +64,15 @@ mod linux_main {
         /// over allow.
         #[arg(long = "block-host")]
         pub block_host: Vec<String>,
+
+        /// Policy applied when the allow list is empty.
+        ///
+        /// - `allow` — permit any host that isn't explicitly blocked.
+        /// - `block` — deny any host that isn't explicitly allowed.
+        ///
+        /// Ignored when `--allow-host` is non-empty (only listed hosts pass).
+        #[arg(long = "default-policy", value_enum, default_value_t = DefaultPolicyArg::Allow)]
+        pub default_policy: DefaultPolicyArg,
     }
 
     pub async fn run() -> std::process::ExitCode {
@@ -73,6 +97,7 @@ mod linux_main {
         let filter = Arc::new(proxy::HostFilter::new(
             cli.allow_host.clone(),
             cli.block_host.clone(),
+            cli.default_policy.into(),
         ));
 
         let port = match proxy::start(&cli.bind_address, filter).await {

--- a/src/linux_test_proxy/src/main.rs
+++ b/src/linux_test_proxy/src/main.rs
@@ -79,6 +79,13 @@ mod linux_main {
         // 1. Tie our lifetime to the parent so a crash of `lxc-exec` cannot
         //    leave us behind. Must happen before any work — and we must check
         //    for the parent-already-dead race immediately after.
+        //
+        //    NOTE: `PR_SET_PDEATHSIG` is a per-thread setting and applies to
+        //    the thread that invokes `prctl`. We rely on `#[tokio::main]`
+        //    keeping THIS thread (the runtime's driver) alive for the whole
+        //    process lifetime. Do NOT move this prctl call into a spawned
+        //    tokio task; that would silently break the parent-death guarantee
+        //    when the spawning thread parks or migrates.
         unsafe {
             libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM, 0, 0, 0);
             if libc::getppid() == 1 {

--- a/src/linux_test_proxy/src/proxy.rs
+++ b/src/linux_test_proxy/src/proxy.rs
@@ -1,0 +1,293 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Minimal HTTP proxy for testing — supports CONNECT tunnels and HTTP
+//! forwarding, with optional allow / block host filtering enforced at the
+//! proxy.
+//!
+//! Adapted from `wxc_test_proxy::proxy` and extended with host filtering so
+//! the Bubblewrap backend can enforce `allowedHosts` / `blockedHosts` at the
+//! proxy layer instead of via privileged iptables rules.
+
+use std::sync::Arc;
+
+use http_body_util::{BodyExt, Full};
+use hyper::body::{Bytes, Incoming};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, TcpStream};
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Host-name filter applied at the proxy layer.
+///
+/// Matching is case-insensitive and uses exact host comparison (no suffix
+/// matching). The port portion of `host:port` is stripped before lookup.
+///
+/// Behavior:
+/// - If `block` contains the host, the request is denied.
+/// - If `allow` is non-empty and the host is not in `allow`, the request is
+///   denied.
+/// - Otherwise the request is allowed.
+#[derive(Debug, Default)]
+pub struct HostFilter {
+    allow: Vec<String>,
+    block: Vec<String>,
+}
+
+impl HostFilter {
+    pub fn new(allow: Vec<String>, block: Vec<String>) -> Self {
+        Self {
+            allow: allow.into_iter().map(|h| h.to_lowercase()).collect(),
+            block: block.into_iter().map(|h| h.to_lowercase()).collect(),
+        }
+    }
+
+    /// Returns `true` if traffic to `host` is permitted.
+    pub fn permits(&self, host: &str) -> bool {
+        let host = strip_port(host).to_lowercase();
+        if self.block.iter().any(|h| h == &host) {
+            return false;
+        }
+        if !self.allow.is_empty() && !self.allow.iter().any(|h| h == &host) {
+            return false;
+        }
+        true
+    }
+}
+
+fn strip_port(host_port: &str) -> &str {
+    // For IPv6 literals (e.g. "[::1]:443") drop the bracketed prefix's port.
+    // For plain "host:port" or bare "host" forms, split on the last ':'.
+    if let Some(idx) = host_port.rfind(':') {
+        // Avoid stripping a colon that's part of an IPv6 literal without
+        // a closing bracket — extremely rare for HTTP CONNECT authorities
+        // but defensive nonetheless.
+        if !host_port[..idx].contains(']') && host_port[..idx].contains(':') {
+            return host_port; // looks like raw IPv6, leave intact
+        }
+        return &host_port[..idx];
+    }
+    host_port
+}
+
+fn empty_response(status: StatusCode) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+/// Start the test proxy. Binds to `bind_addr:0` (OS-assigned port) and
+/// returns the actual port the listener is bound to. The accept loop runs
+/// in a background tokio task and applies `filter` to every request.
+pub async fn start(bind_addr: &str, filter: Arc<HostFilter>) -> std::io::Result<u16> {
+    let listener = TcpListener::bind((bind_addr, 0)).await?;
+    let port = listener.local_addr()?.port();
+
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let filter = filter.clone();
+                    tokio::spawn(async move {
+                        let io = TokioIo::new(stream);
+                        let svc = service_fn(move |req| handle_request(req, filter.clone()));
+                        let _ = http1::Builder::new()
+                            .preserve_header_case(true)
+                            .title_case_headers(true)
+                            .serve_connection(io, svc)
+                            .with_upgrades()
+                            .await;
+                    });
+                }
+                Err(err) => {
+                    eprintln!("[linux-test-proxy] accept error: {}", err);
+                }
+            }
+        }
+    });
+
+    Ok(port)
+}
+
+async fn handle_request(
+    req: Request<Incoming>,
+    filter: Arc<HostFilter>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
+    if req.method() == Method::CONNECT {
+        return handle_connect(req, filter).await;
+    }
+    handle_forward(req, filter).await
+}
+
+async fn handle_connect(
+    req: Request<Incoming>,
+    filter: Arc<HostFilter>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
+    let authority = req
+        .uri()
+        .authority()
+        .ok_or("CONNECT missing authority")?
+        .to_string();
+
+    let host = strip_port(&authority);
+    if !filter.permits(host) {
+        eprintln!("[linux-test-proxy] BLOCK CONNECT {}", authority);
+        return Ok(empty_response(StatusCode::FORBIDDEN));
+    }
+
+    eprintln!("[linux-test-proxy] CONNECT {}", authority);
+
+    let server = TcpStream::connect(&authority).await.map_err(|err| {
+        eprintln!(
+            "[linux-test-proxy] connect error for {}: {}",
+            authority, err
+        );
+        err
+    })?;
+
+    let target = authority.clone();
+    tokio::spawn(async move {
+        let upgraded = match hyper::upgrade::on(req).await {
+            Ok(upgraded) => upgraded,
+            Err(err) => {
+                eprintln!("[linux-test-proxy] upgrade failed for {}: {}", target, err);
+                return;
+            }
+        };
+
+        let mut client = TokioIo::new(upgraded);
+        let mut server = server;
+        if let Ok((from_client, from_server)) =
+            tokio::io::copy_bidirectional(&mut client, &mut server).await
+        {
+            eprintln!(
+                "[linux-test-proxy] tunnel closed {} (client: {} bytes, server: {} bytes)",
+                target, from_client, from_server
+            );
+        }
+    });
+
+    Ok(empty_response(StatusCode::OK))
+}
+
+async fn handle_forward(
+    req: Request<Incoming>,
+    filter: Arc<HostFilter>,
+) -> Result<Response<Full<Bytes>>, BoxError> {
+    let uri = req.uri().clone();
+    let method = req.method().clone();
+
+    let host = uri.host().ok_or("missing host in URI")?;
+    if !filter.permits(host) {
+        eprintln!("[linux-test-proxy] BLOCK {} {}", method, uri);
+        return Ok(empty_response(StatusCode::FORBIDDEN));
+    }
+
+    let port = uri.port_u16().unwrap_or(80);
+    let addr = format!("{}:{}", host, port);
+
+    eprintln!("[linux-test-proxy] {} {}", method, uri);
+
+    let stream = TcpStream::connect(&addr).await.map_err(|err| {
+        eprintln!(
+            "[linux-test-proxy] forward connect error for {}: {}",
+            addr, err
+        );
+        err
+    })?;
+
+    let io = TokioIo::new(stream);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            eprintln!("[linux-test-proxy] forward connection error: {}", err);
+        }
+    });
+
+    let path = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("/");
+
+    let mut forward_req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header("Host", format!("{}:{}", host, port));
+
+    for (key, value) in req.headers() {
+        if key != "host" {
+            forward_req = forward_req.header(key, value);
+        }
+    }
+
+    let body = req.collect().await?.to_bytes();
+    let forward_req = forward_req.body(Full::new(body))?;
+
+    let resp = sender.send_request(forward_req).await?;
+
+    let status = resp.status();
+    let headers = resp.headers().clone();
+    let resp_body = resp.collect().await?.to_bytes();
+
+    let mut response = Response::builder().status(status);
+    for (key, value) in headers.iter() {
+        response = response.header(key, value);
+    }
+
+    Ok(response.body(Full::new(resp_body))?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_list_empty_permits_everything() {
+        let f = HostFilter::new(vec![], vec![]);
+        assert!(f.permits("example.com"));
+        assert!(f.permits("api.github.com"));
+    }
+
+    #[test]
+    fn allow_list_permits_only_listed_hosts() {
+        let f = HostFilter::new(vec!["api.github.com".into()], vec![]);
+        assert!(f.permits("api.github.com"));
+        assert!(!f.permits("example.com"));
+    }
+
+    #[test]
+    fn block_list_denies_listed_hosts() {
+        let f = HostFilter::new(vec![], vec!["evil.example.com".into()]);
+        assert!(!f.permits("evil.example.com"));
+        assert!(f.permits("api.github.com"));
+    }
+
+    #[test]
+    fn block_list_takes_precedence_over_allow_list() {
+        let f = HostFilter::new(vec!["api.github.com".into()], vec!["api.github.com".into()]);
+        assert!(!f.permits("api.github.com"));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        let f = HostFilter::new(vec!["API.GitHub.com".into()], vec![]);
+        assert!(f.permits("api.github.com"));
+        assert!(f.permits("API.GITHUB.COM"));
+    }
+
+    #[test]
+    fn host_with_port_is_handled() {
+        let f = HostFilter::new(vec!["api.github.com".into()], vec![]);
+        assert!(f.permits("api.github.com:443"));
+        assert!(!f.permits("example.com:80"));
+    }
+
+    #[test]
+    fn strip_port_handles_ipv6_literal() {
+        assert_eq!(strip_port("[::1]:443"), "[::1]");
+        assert_eq!(strip_port("api.github.com:443"), "api.github.com");
+        assert_eq!(strip_port("api.github.com"), "api.github.com");
+    }
+}

--- a/src/linux_test_proxy/src/proxy.rs
+++ b/src/linux_test_proxy/src/proxy.rs
@@ -21,6 +21,20 @@ use tokio::net::{TcpListener, TcpStream};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
+/// Default policy applied when the `allow` list is empty.
+///
+/// - `Allow` — permit any host that isn't explicitly blocked.
+/// - `Block` — deny any host that isn't explicitly allowed.
+///
+/// When the `allow` list is non-empty, the default policy is irrelevant: only
+/// listed hosts are permitted (subject to `block` taking precedence).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DefaultPolicy {
+    #[default]
+    Allow,
+    Block,
+}
+
 /// Host-name filter applied at the proxy layer.
 ///
 /// Matching is case-insensitive and uses exact host comparison (no suffix
@@ -28,20 +42,22 @@ type BoxError = Box<dyn std::error::Error + Send + Sync>;
 ///
 /// Behavior:
 /// - If `block` contains the host, the request is denied.
-/// - If `allow` is non-empty and the host is not in `allow`, the request is
-///   denied.
-/// - Otherwise the request is allowed.
+/// - Otherwise, if `allow` is non-empty: the host must be in `allow`.
+/// - Otherwise (empty `allow`): the request is permitted iff `default` is
+///   [`DefaultPolicy::Allow`].
 #[derive(Debug, Default)]
 pub struct HostFilter {
     allow: Vec<String>,
     block: Vec<String>,
+    default: DefaultPolicy,
 }
 
 impl HostFilter {
-    pub fn new(allow: Vec<String>, block: Vec<String>) -> Self {
+    pub fn new(allow: Vec<String>, block: Vec<String>, default: DefaultPolicy) -> Self {
         Self {
             allow: allow.into_iter().map(|h| h.to_lowercase()).collect(),
             block: block.into_iter().map(|h| h.to_lowercase()).collect(),
+            default,
         }
     }
 
@@ -51,10 +67,11 @@ impl HostFilter {
         if self.block.iter().any(|h| h == &host) {
             return false;
         }
-        if !self.allow.is_empty() && !self.allow.iter().any(|h| h == &host) {
-            return false;
+        if !self.allow.is_empty() {
+            return self.allow.iter().any(|h| h == &host);
         }
-        true
+        // Empty allow list: the default policy decides.
+        self.default == DefaultPolicy::Allow
     }
 }
 
@@ -244,42 +261,76 @@ mod tests {
     use super::*;
 
     #[test]
-    fn allow_list_empty_permits_everything() {
-        let f = HostFilter::new(vec![], vec![]);
+    fn allow_list_empty_permits_everything_when_default_allow() {
+        let f = HostFilter::new(vec![], vec![], DefaultPolicy::Allow);
         assert!(f.permits("example.com"));
         assert!(f.permits("api.github.com"));
     }
 
     #[test]
+    fn allow_list_empty_denies_everything_when_default_block() {
+        let f = HostFilter::new(vec![], vec![], DefaultPolicy::Block);
+        assert!(!f.permits("example.com"));
+        assert!(!f.permits("api.github.com"));
+    }
+
+    #[test]
     fn allow_list_permits_only_listed_hosts() {
-        let f = HostFilter::new(vec!["api.github.com".into()], vec![]);
+        let f = HostFilter::new(vec!["api.github.com".into()], vec![], DefaultPolicy::Allow);
+        assert!(f.permits("api.github.com"));
+        assert!(!f.permits("example.com"));
+    }
+
+    #[test]
+    fn allow_list_permits_only_listed_hosts_under_default_block() {
+        // Non-empty allow list with default=block behaves the same as with
+        // default=allow: only listed hosts are permitted.
+        let f = HostFilter::new(vec!["api.github.com".into()], vec![], DefaultPolicy::Block);
         assert!(f.permits("api.github.com"));
         assert!(!f.permits("example.com"));
     }
 
     #[test]
     fn block_list_denies_listed_hosts() {
-        let f = HostFilter::new(vec![], vec!["evil.example.com".into()]);
+        let f = HostFilter::new(
+            vec![],
+            vec!["evil.example.com".into()],
+            DefaultPolicy::Allow,
+        );
         assert!(!f.permits("evil.example.com"));
         assert!(f.permits("api.github.com"));
     }
 
     #[test]
     fn block_list_takes_precedence_over_allow_list() {
-        let f = HostFilter::new(vec!["api.github.com".into()], vec!["api.github.com".into()]);
+        let f = HostFilter::new(
+            vec!["api.github.com".into()],
+            vec!["api.github.com".into()],
+            DefaultPolicy::Allow,
+        );
         assert!(!f.permits("api.github.com"));
     }
 
     #[test]
+    fn block_list_takes_precedence_over_default_allow() {
+        let f = HostFilter::new(
+            vec![],
+            vec!["evil.example.com".into()],
+            DefaultPolicy::Allow,
+        );
+        assert!(!f.permits("evil.example.com"));
+    }
+
+    #[test]
     fn matching_is_case_insensitive() {
-        let f = HostFilter::new(vec!["API.GitHub.com".into()], vec![]);
+        let f = HostFilter::new(vec!["API.GitHub.com".into()], vec![], DefaultPolicy::Allow);
         assert!(f.permits("api.github.com"));
         assert!(f.permits("API.GITHUB.COM"));
     }
 
     #[test]
     fn host_with_port_is_handled() {
-        let f = HostFilter::new(vec!["api.github.com".into()], vec![]);
+        let f = HostFilter::new(vec!["api.github.com".into()], vec![], DefaultPolicy::Allow);
         assert!(f.permits("api.github.com:443"));
         assert!(!f.permits("example.com:80"));
     }

--- a/src/linux_test_proxy/src/proxy.rs
+++ b/src/linux_test_proxy/src/proxy.rs
@@ -76,14 +76,20 @@ impl HostFilter {
 }
 
 fn strip_port(host_port: &str) -> &str {
-    // For IPv6 literals (e.g. "[::1]:443") drop the bracketed prefix's port.
-    // For plain "host:port" or bare "host" forms, split on the last ':'.
+    // Bracketed IPv6 form: "[::1]" or "[::1]:443" -> "::1". Always return the
+    // inner address so it can be matched against an allowlist entry stored
+    // without brackets (e.g. `allowedHosts: ["::1"]`).
+    if let Some(stripped) = host_port.strip_prefix('[') {
+        if let Some(end) = stripped.find(']') {
+            return &stripped[..end];
+        }
+    }
+    // Plain "host:port" or unbracketed IPv6 (which has multiple colons).
     if let Some(idx) = host_port.rfind(':') {
-        // Avoid stripping a colon that's part of an IPv6 literal without
-        // a closing bracket — extremely rare for HTTP CONNECT authorities
-        // but defensive nonetheless.
-        if !host_port[..idx].contains(']') && host_port[..idx].contains(':') {
-            return host_port; // looks like raw IPv6, leave intact
+        // If the prefix before the rightmost colon already contains a colon,
+        // this is an unbracketed IPv6 literal with no port — leave intact.
+        if host_port[..idx].contains(':') {
+            return host_port;
         }
         return &host_port[..idx];
     }
@@ -337,8 +343,25 @@ mod tests {
 
     #[test]
     fn strip_port_handles_ipv6_literal() {
-        assert_eq!(strip_port("[::1]:443"), "[::1]");
+        // Bracketed IPv6 with port -> bare address (matches an allowlist
+        // entry of "::1" or "fe80::1").
+        assert_eq!(strip_port("[::1]:443"), "::1");
+        assert_eq!(strip_port("[::1]"), "::1");
+        assert_eq!(strip_port("[fe80::1]:8080"), "fe80::1");
+        // Unbracketed IPv6 has no port and must be preserved verbatim.
+        assert_eq!(strip_port("::1"), "::1");
+        // Plain hostname:port and bare hostname.
         assert_eq!(strip_port("api.github.com:443"), "api.github.com");
         assert_eq!(strip_port("api.github.com"), "api.github.com");
+    }
+
+    #[test]
+    fn ipv6_literal_allowlist_matches_bracketed_form() {
+        // A user-supplied allowlist entry of "::1" should permit a CONNECT
+        // to the bracketed form "[::1]:443" emitted by HTTP clients.
+        let f = HostFilter::new(vec!["::1".into()], vec![], DefaultPolicy::Allow);
+        assert!(f.permits("[::1]:443"));
+        assert!(f.permits("[::1]"));
+        assert!(!f.permits("[fe80::1]:443"));
     }
 }

--- a/src/wxc_common/Cargo.toml
+++ b/src/wxc_common/Cargo.toml
@@ -43,5 +43,8 @@ windows-future = { version = "0.3", optional = true }
 uuid = { workspace = true }
 windows-collections = { version = "0.3", optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -848,6 +848,54 @@ fn convert_raw_config_inner(
             logger.log_line(msg);
             return Err(WxcError::ConfigParse(msg.to_string()));
         }
+
+        // External proxy (`network.proxy.url` / `network.proxy.localhost`)
+        // enforces its own policy — the runner does NOT forward
+        // `allowedHosts` / `blockedHosts` / `defaultPolicy` to it. Reject
+        // configs that combine an external proxy with host lists or a
+        // restrictive default, otherwise users get a silently weaker
+        // enforcement than a no-proxy `defaultPolicy: "block"` config
+        // would have produced.
+        if containment == ContainmentBackend::Bubblewrap
+            && policy.network_proxy.is_enabled()
+            && !policy.network_proxy.builtin_test_server
+            && (!policy.allowed_hosts.is_empty()
+                || !policy.blocked_hosts.is_empty()
+                || policy.default_network_policy == NetworkPolicy::Block)
+        {
+            let msg = "Bubblewrap: an external network.proxy (url/localhost) cannot be \
+                       combined with allowedHosts, blockedHosts, or defaultPolicy='block'. \
+                       The external proxy is expected to enforce its own host policy; \
+                       MXC does not forward host lists to it. Use \
+                       'network.proxy.builtinTestServer: true' (testing only) for \
+                       MXC-enforced host filtering, or remove the host policy.";
+            logger.log_line(msg);
+            return Err(WxcError::ConfigParse(msg.to_string()));
+        }
+
+        // Cooperative-model warning: when the builtin test proxy is paired
+        // with `defaultPolicy: "block"` and no allowlist, well-behaved
+        // HTTP clients are denied at the proxy, but raw-socket clients
+        // (anything that ignores HTTP_PROXY/HTTPS_PROXY) still reach the
+        // host network because the sandbox shares the host netns in proxy
+        // mode. Surface this at config-validation time so users porting a
+        // working hard-block config don't silently lose enforcement when
+        // they add a proxy block.
+        if containment == ContainmentBackend::Bubblewrap
+            && policy.network_proxy.is_enabled()
+            && policy.default_network_policy == NetworkPolicy::Block
+            && policy.allowed_hosts.is_empty()
+            && policy.blocked_hosts.is_empty()
+        {
+            logger.log_line(
+                "WARNING: Bubblewrap network.proxy with defaultPolicy='block' is \
+                 cooperative. HTTP_PROXY-aware clients (curl, requests, etc.) are \
+                 denied at the proxy, but raw-socket clients that ignore HTTP_PROXY \
+                 bypass the proxy and reach the host network. For strict isolation \
+                 of all clients, remove network.proxy so --unshare-net applies; for \
+                 host-list enforcement, add allowedHosts (cooperative tools only).",
+            );
+        }
     }
 
     // Lifecycle section
@@ -2088,6 +2136,143 @@ mod tests {
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert!(req.policy.network_proxy.is_enabled());
         assert_eq!(req.policy.allowed_hosts, vec!["example.com".to_string()]);
+    }
+
+    #[test]
+    fn external_proxy_url_with_bubblewrap_and_allowed_hosts_is_rejected() {
+        // The external proxy enforces its own policy; the runner does not
+        // forward host lists to it. Combining the two is a silent
+        // policy-weakening trap and must be rejected at parse time.
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"url": "http://127.0.0.1:8080"},
+                "allowedHosts": ["api.github.com"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("external network.proxy") && msg.contains("allowedHosts"),
+            "unexpected error message: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn external_proxy_localhost_with_bubblewrap_and_blocked_hosts_is_rejected() {
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"localhost": 8080},
+                "blockedHosts": ["evil.example.com"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        assert!(format!("{}", err).contains("external network.proxy"));
+    }
+
+    #[test]
+    fn external_proxy_with_bubblewrap_and_default_block_is_rejected() {
+        // defaultPolicy=block is a hard-block intent; pairing it with an
+        // external proxy whose policy we don't control silently weakens
+        // enforcement.
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"url": "http://127.0.0.1:8080"},
+                "defaultPolicy": "block"
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        assert!(format!("{}", err).contains("defaultPolicy"));
+    }
+
+    #[test]
+    fn external_proxy_with_bubblewrap_and_no_host_policy_is_accepted() {
+        // Pure delegate-to-external-proxy with no MXC-side host policy is
+        // the supported external-proxy use case.
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"url": "http://127.0.0.1:8080"}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.is_enabled());
+        assert!(!req.policy.network_proxy.builtin_test_server);
+    }
+
+    #[test]
+    fn builtin_proxy_with_bubblewrap_and_host_policy_is_accepted() {
+        // The builtin proxy DOES enforce host lists at the proxy layer, so
+        // combining it with allowedHosts is fine.
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"builtinTestServer": true},
+                "allowedHosts": ["api.github.com"],
+                "defaultPolicy": "block"
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.builtin_test_server);
+        assert_eq!(req.policy.allowed_hosts, vec!["api.github.com".to_string()]);
+    }
+
+    #[test]
+    fn bubblewrap_proxy_with_default_block_and_empty_allowlist_warns() {
+        // Cooperative mode with no allowlist denies HTTP_PROXY-aware clients
+        // but raw-socket clients still reach the host network. Parser must
+        // surface a warning (does not reject).
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"builtinTestServer": true},
+                "defaultPolicy": "block"
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.is_enabled());
+        assert_eq!(req.policy.default_network_policy, NetworkPolicy::Block);
+        // Warning is best-effort surfaced via the logger; the request still
+        // succeeds.
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -780,9 +780,12 @@ fn convert_raw_config_inner(
     if let Some(net) = raw.network {
         if let Some(proxy_value) = net.proxy {
             let proxy_config = parse_proxy_config(&proxy_value)?;
-            if proxy_config.is_enabled() && containment != ContainmentBackend::ProcessContainer {
-                let msg =
-                    "Network proxy is only supported with the 'processcontainer' containment backend";
+            if proxy_config.is_enabled()
+                && containment != ContainmentBackend::ProcessContainer
+                && containment != ContainmentBackend::Bubblewrap
+            {
+                let msg = "Network proxy is only supported with the 'processcontainer' \
+                           or 'bubblewrap' containment backends";
                 logger.log_line(msg);
                 return Err(WxcError::ConfigParse(msg.to_string()));
             }
@@ -825,6 +828,25 @@ fn convert_raw_config_inner(
         }
         if let Some(v) = net.blocked_hosts {
             policy.blocked_hosts = v;
+        }
+
+        // Bubblewrap is unprivileged by design; iptables-based enforcement
+        // (firewall / both) requires CAP_NET_ADMIN, which defeats the
+        // backend's privilege story. Reject the combination explicitly so
+        // users get a clear error instead of an opaque runtime failure.
+        if containment == ContainmentBackend::Bubblewrap
+            && policy.network_proxy.is_enabled()
+            && matches!(
+                policy.network_enforcement_mode,
+                NetworkEnforcementMode::Firewall | NetworkEnforcementMode::Both
+            )
+        {
+            let msg = "Bubblewrap: network.proxy cannot be combined with \
+                       network.enforcementMode='firewall' or 'both'. The cooperative \
+                       env-var proxy enforces hosts at the proxy layer; iptables-based \
+                       enforcement requires privilege and is mutually exclusive.";
+            logger.log_line(msg);
+            return Err(WxcError::ConfigParse(msg.to_string()));
         }
     }
 
@@ -1975,12 +1997,97 @@ mod tests {
 
     #[test]
     fn proxy_builtin_test_server_rejected_with_non_processcontainer() {
+        // lxc is not allowed -- proxy is gated to processcontainer + bubblewrap.
         let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"builtinTestServer":true}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let result = load_request(&encoded, &mut logger, true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn proxy_accepted_with_bubblewrap() {
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {"proxy": {"builtinTestServer": true}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.is_enabled());
+        assert!(req.policy.network_proxy.builtin_test_server);
+    }
+
+    #[test]
+    fn proxy_with_bubblewrap_and_firewall_enforcement_is_rejected() {
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"builtinTestServer": true},
+                "enforcementMode": "firewall",
+                "allowedHosts": ["example.com"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(
+            msg.contains("network.proxy cannot be combined with"),
+            "unexpected error message: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn proxy_with_bubblewrap_and_both_enforcement_is_rejected() {
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"builtinTestServer": true},
+                "enforcementMode": "both",
+                "blockedHosts": ["evil.example"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        assert!(load_request(&encoded, &mut logger, true).is_err());
+    }
+
+    #[test]
+    fn proxy_with_bubblewrap_and_capabilities_enforcement_is_accepted() {
+        // Capabilities mode never invokes iptables, so combining it with a
+        // proxy is fine and must NOT trigger the conflict guard.
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "platform": "linux",
+            "containment": "bubblewrap",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "proxy": {"builtinTestServer": true},
+                "enforcementMode": "capabilities",
+                "allowedHosts": ["example.com"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.network_proxy.is_enabled());
+        assert_eq!(req.policy.allowed_hosts, vec!["example.com".to_string()]);
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -2209,14 +2209,17 @@ mod tests {
     #[test]
     fn external_proxy_with_bubblewrap_and_no_host_policy_is_accepted() {
         // Pure delegate-to-external-proxy with no MXC-side host policy is
-        // the supported external-proxy use case.
+        // the supported external-proxy use case. Under deny-by-default,
+        // callers must explicitly set `defaultPolicy: "allow"` to opt
+        // into trusting the external proxy with full policy delegation.
         let json = r#"{
             "version": "0.6.0-alpha",
             "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
-                "proxy": {"url": "http://127.0.0.1:8080"}
+                "proxy": {"url": "http://127.0.0.1:8080"},
+                "defaultPolicy": "allow"
             }
         }"#;
         let encoded = base64_encode(json.as_bytes());

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -71,10 +71,18 @@ pub mod sandbox_tracking;
 #[cfg(all(target_os = "windows", feature = "isolation_session"))]
 pub mod isolation_session;
 
+// Linux-specific modules
+#[cfg(target_os = "linux")]
+pub mod linux_proxy_coordinator;
+
 /// Test-only helpers shared across unit-test modules.
 ///
 /// Gated by `#[cfg(test)]` so this module compiles in only when
 /// building the crate's own test binary (under any profile, including
 /// CI's `--profile release`). Production binaries never link this.
-#[cfg(test)]
+/// All current consumers (`dispatcher`, `fallback_detector`, `probe`,
+/// `filesystem_dacl`) are Windows-only, so the module is additionally
+/// gated on `target_os = "windows"` to avoid dead-code warnings under
+/// `-D warnings` when running `cargo clippy --all-targets` on Linux.
+#[cfg(all(test, target_os = "windows"))]
 pub(crate) mod test_env;

--- a/src/wxc_common/src/linux_proxy_coordinator.rs
+++ b/src/wxc_common/src/linux_proxy_coordinator.rs
@@ -1,0 +1,625 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Coordinator for the Linux network proxy used by the Bubblewrap backend.
+//!
+//! # Why this exists
+//!
+//! The Bubblewrap backend wants to enforce `allowedHosts` / `blockedHosts`
+//! **without** root or `CAP_NET_ADMIN`. The Windows AppContainer proxy
+//! coordinator achieves enforcement through WinHTTP policy (set by an
+//! elevated shim). On Linux, the equivalent without privilege is a
+//! **cooperative env-var proxy**:
+//!
+//! 1. The coordinator launches an unprivileged HTTP proxy process (either a
+//!    user-supplied address, or the bundled `linux-test-proxy` binary).
+//! 2. The Bubblewrap command builder sets `HTTP_PROXY` / `HTTPS_PROXY` /
+//!    `NO_PROXY` env vars inside the sandbox.
+//! 3. Cooperative apps (curl, requests, etc.) honor the env vars and the
+//!    proxy applies allow/block filtering; non-cooperative apps reaching
+//!    out via raw sockets bypass enforcement (documented limitation).
+//!
+//! # Design notes
+//!
+//! - **Privilege-free**: no iptables, no namespaces, no setuid binaries.
+//! - **Bind address is configurable** to allow future LXC reuse (LXC has
+//!   its own netns, so the proxy needs to bind on the bridge gateway IP).
+//!   Bubblewrap shares the host netns and passes `"127.0.0.1"`.
+//! - **Atomic ready-file**: `linux-test-proxy` writes `<file>.tmp` and
+//!   renames into place to eliminate partial-read races.
+//! - **PR_SET_PDEATHSIG** in the child ensures the proxy dies if
+//!   `lxc-exec` crashes (orphan reaping safety net).
+//! - **`Drop` is silent**: never writes to stderr or `Logger`, because
+//!   destructors can run at unpredictable times (e.g. during panic
+//!   propagation) and noisy drops would corrupt the JSON envelope on
+//!   `lxc-exec`'s stderr.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::error::WxcError;
+use crate::logger::Logger;
+use crate::models::{ProxyAddress, ProxyConfig};
+
+/// Maximum time to wait for the test proxy to write its ready file.
+const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Polling interval while waiting for the ready file to appear.
+const READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Maximum time to wait for the test proxy to exit after SIGTERM.
+const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Process counter used (alongside pid + timestamp) to make ready-file
+/// names collision-resistant when multiple coordinators run concurrently
+/// inside the same process.
+static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique identifier for ready-file / temp-dir names.
+fn generate_unique_id() -> String {
+    let pid = std::process::id();
+    let counter = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    format!("{}-{}-{}", pid, counter, nanos)
+}
+
+/// Create a private 0700 temp directory under `/tmp` and return its path.
+fn create_private_temp_dir(unique_id: &str) -> Result<PathBuf, WxcError> {
+    let dir = std::env::temp_dir().join(format!("mxc-proxy-{}", unique_id));
+    fs::create_dir(&dir).map_err(|err| {
+        WxcError::NetworkProxy(format!(
+            "Failed to create proxy temp dir {}: {}",
+            dir.display(),
+            err
+        ))
+    })?;
+
+    // Best-effort 0700 chmod so other users cannot snoop the ready file.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
+    }
+
+    Ok(dir)
+}
+
+/// Best-effort cleanup of a temp directory created by
+/// [`create_private_temp_dir`]. Never panics; ignores errors.
+fn remove_temp_dir(dir: &Path) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+/// Resolve a sibling binary next to the currently running executable.
+fn resolve_sibling_binary(name: &str) -> Result<PathBuf, WxcError> {
+    let exe = std::env::current_exe().map_err(|err| {
+        WxcError::NetworkProxy(format!("cannot determine current exe path: {}", err))
+    })?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| WxcError::NetworkProxy("current exe has no parent directory".into()))?;
+    let path = dir.join(name);
+    if path.exists() {
+        Ok(path)
+    } else {
+        Err(WxcError::NetworkProxy(format!(
+            "{} not found at {}",
+            name,
+            path.display()
+        )))
+    }
+}
+
+/// Bookkeeping for a running `linux-test-proxy` child process.
+struct TestProxyChild {
+    child: Child,
+    ready_file: PathBuf,
+    temp_dir: PathBuf,
+}
+
+/// Send SIGTERM to a process group/PID (best-effort).
+fn send_sigterm(pid: u32) {
+    // SAFETY: `kill(2)` with SIGTERM is always defined; we ignore the
+    // return value because the process may already be gone.
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGTERM);
+    }
+}
+
+/// Send SIGKILL to a PID (best-effort).
+fn send_sigkill(pid: u32) {
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+/// Wait up to `timeout` for the child to exit, polling `try_wait`.
+/// Returns `true` if the child exited cleanly within the window.
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => return false,
+        }
+    }
+}
+
+/// Coordinator for the network proxy used by the Bubblewrap backend.
+///
+/// Cooperative model: launches an unprivileged HTTP proxy (either external
+/// or the bundled `linux-test-proxy`), and the caller is responsible for
+/// setting `HTTP_PROXY` / `HTTPS_PROXY` env vars inside the sandbox.
+///
+/// The coordinator is **not** active until [`start`](Self::start) succeeds,
+/// and is automatically cleaned up by [`stop`](Self::stop) or `Drop`.
+pub struct LinuxProxyCoordinator {
+    proxy_address: Option<ProxyAddress>,
+    test_proxy: Option<TestProxyChild>,
+}
+
+impl LinuxProxyCoordinator {
+    /// Create an inactive coordinator. Call [`start`](Self::start) to launch.
+    pub fn new() -> Self {
+        Self {
+            proxy_address: None,
+            test_proxy: None,
+        }
+    }
+
+    /// Returns `true` once a proxy has been started.
+    pub fn is_active(&self) -> bool {
+        self.proxy_address.is_some()
+    }
+
+    /// Returns the resolved proxy address (if any).
+    pub fn address(&self) -> Option<&ProxyAddress> {
+        self.proxy_address.as_ref()
+    }
+
+    /// Activate the proxy.
+    ///
+    /// - If `proxy_config.builtin_test_server` is `true`, launches the
+    ///   bundled `linux-test-proxy` binary on `bind_address:0` and reads
+    ///   the assigned port from the proxy's ready file. `allowed_hosts`
+    ///   and `blocked_hosts` are passed to the test proxy as
+    ///   `--allow-host` / `--block-host` flags.
+    /// - Otherwise, uses the externally provided `proxy_config.address`.
+    ///   `allowed_hosts` / `blocked_hosts` are ignored in this case: the
+    ///   external proxy is assumed to apply its own policy.
+    /// - If the proxy config is disabled (`is_enabled()` returns `false`),
+    ///   this is a no-op and the coordinator remains inactive.
+    ///
+    /// `bind_address` is the IP the test proxy listens on. For Bubblewrap
+    /// pass `"127.0.0.1"`; future LXC reuse can pass a bridge gateway IP.
+    pub fn start(
+        &mut self,
+        proxy_config: &ProxyConfig,
+        bind_address: &str,
+        allowed_hosts: &[String],
+        blocked_hosts: &[String],
+        logger: &mut Logger,
+    ) -> Result<(), WxcError> {
+        if self.is_active() {
+            return Err(WxcError::NetworkProxy(
+                "Linux network proxy is already active".into(),
+            ));
+        }
+
+        if !proxy_config.is_enabled() {
+            return Ok(());
+        }
+
+        let address = if proxy_config.builtin_test_server {
+            let port =
+                self.launch_test_proxy(bind_address, allowed_hosts, blocked_hosts, logger)?;
+            ProxyAddress::new(bind_address.to_string(), port)
+        } else if let Some(ref addr) = proxy_config.address {
+            addr.clone()
+        } else {
+            // is_enabled() was true but neither variant is set -- defensive
+            // guard, should be unreachable.
+            return Err(WxcError::NetworkProxy(
+                "Network proxy enabled but no address or builtin server configured".into(),
+            ));
+        };
+
+        self.proxy_address = Some(address);
+
+        logger.log_line(&format!(
+            "Linux network proxy active: {}",
+            self.proxy_address.as_ref().unwrap().to_url(),
+        ));
+
+        Ok(())
+    }
+
+    /// Spawn `linux-test-proxy` and read its port from the ready file.
+    ///
+    /// On any post-spawn error this method kills the child, waits briefly,
+    /// and removes the temp directory before returning -- callers must
+    /// **not** rely on `Drop` for cleanup of failed launches.
+    fn launch_test_proxy(
+        &mut self,
+        bind_address: &str,
+        allow_hosts: &[String],
+        block_hosts: &[String],
+        logger: &mut Logger,
+    ) -> Result<u16, WxcError> {
+        logger.log_line(
+            "WARNING: Starting builtin linux-test-proxy -- this is for integration \
+             testing only, NOT for production use.",
+        );
+
+        let unique_id = generate_unique_id();
+        let temp_dir = create_private_temp_dir(&unique_id)?;
+        let ready_file = temp_dir.join("ready.port");
+
+        let proxy_exe = match resolve_sibling_binary("linux-test-proxy") {
+            Ok(path) => path,
+            Err(err) => {
+                remove_temp_dir(&temp_dir);
+                return Err(err);
+            }
+        };
+
+        let mut cmd = Command::new(&proxy_exe);
+        cmd.arg("--ready-file")
+            .arg(&ready_file)
+            .arg("--bind-address")
+            .arg(bind_address);
+        for host in allow_hosts {
+            cmd.arg("--allow-host").arg(host);
+        }
+        for host in block_hosts {
+            cmd.arg("--block-host").arg(host);
+        }
+        // Use a null stderr to avoid corrupting the JSON envelope that
+        // lxc-exec writes on its own stderr stream (the proxy may emit
+        // diagnostic lines).
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(err) => {
+                remove_temp_dir(&temp_dir);
+                return Err(WxcError::NetworkProxy(format!(
+                    "Failed to launch linux-test-proxy: {}",
+                    err
+                )));
+            }
+        };
+
+        let port = match poll_for_port(&ready_file, &mut child) {
+            Ok(p) => p,
+            Err(err) => {
+                let pid = child.id();
+                send_sigterm(pid);
+                if !wait_with_timeout(&mut child, STOP_TIMEOUT) {
+                    send_sigkill(pid);
+                    let _ = child.wait();
+                }
+                remove_temp_dir(&temp_dir);
+                return Err(err);
+            }
+        };
+
+        self.test_proxy = Some(TestProxyChild {
+            child,
+            ready_file,
+            temp_dir,
+        });
+
+        logger.log_line(&format!(
+            "linux-test-proxy listening on {}:{}",
+            bind_address, port
+        ));
+
+        Ok(port)
+    }
+
+    /// Stop the proxy if active. Idempotent and best-effort. Errors during
+    /// shutdown are logged but never returned.
+    pub fn stop(&mut self, logger: &mut Logger) {
+        if let Some(mut tp) = self.test_proxy.take() {
+            let pid = tp.child.id();
+            logger.log_line("Stopping linux-test-proxy...");
+            send_sigterm(pid);
+            if wait_with_timeout(&mut tp.child, STOP_TIMEOUT) {
+                logger.log_line("linux-test-proxy exited.");
+            } else {
+                logger
+                    .log_line("Warning: linux-test-proxy did not exit within 5s; sending SIGKILL.");
+                send_sigkill(pid);
+                let _ = tp.child.wait();
+            }
+            let _ = fs::remove_file(&tp.ready_file);
+            remove_temp_dir(&tp.temp_dir);
+        }
+        self.proxy_address = None;
+    }
+}
+
+impl Default for LinuxProxyCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for LinuxProxyCoordinator {
+    /// Silent best-effort cleanup if the coordinator is still active at
+    /// drop time. **Never** writes to stderr or `Logger` because the drop
+    /// may run during panic unwinding and we must not corrupt the JSON
+    /// envelope on `lxc-exec`'s stderr.
+    fn drop(&mut self) {
+        if let Some(mut tp) = self.test_proxy.take() {
+            let pid = tp.child.id();
+            send_sigterm(pid);
+            if !wait_with_timeout(&mut tp.child, STOP_TIMEOUT) {
+                send_sigkill(pid);
+                let _ = tp.child.wait();
+            }
+            let _ = fs::remove_file(&tp.ready_file);
+            remove_temp_dir(&tp.temp_dir);
+        }
+        self.proxy_address = None;
+    }
+}
+
+/// Wait for the ready file to appear, parse the port, then re-check that
+/// the child is still alive. Returns an error if the file does not appear
+/// in time, the contents are not a valid port, or the child exited before
+/// or after publishing the port.
+fn poll_for_port(ready_file: &Path, child: &mut Child) -> Result<u16, WxcError> {
+    let deadline = Instant::now() + READY_TIMEOUT;
+    loop {
+        // 1. Has the child exited prematurely?
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(WxcError::NetworkProxy(format!(
+                    "linux-test-proxy exited before becoming ready (status: {:?})",
+                    status
+                )));
+            }
+            Ok(None) => {}
+            Err(err) => {
+                return Err(WxcError::NetworkProxy(format!(
+                    "Failed to query linux-test-proxy status: {}",
+                    err
+                )));
+            }
+        }
+
+        // 2. Has the ready file appeared?
+        if ready_file.exists() {
+            break;
+        }
+
+        if Instant::now() >= deadline {
+            return Err(WxcError::NetworkProxy(format!(
+                "Timed out waiting for linux-test-proxy ready file ({:?})",
+                READY_TIMEOUT
+            )));
+        }
+        std::thread::sleep(READY_POLL_INTERVAL);
+    }
+
+    let content = fs::read_to_string(ready_file)
+        .map_err(|err| WxcError::NetworkProxy(format!("Failed to read ready file: {}", err)))?;
+    let port: u16 = content.trim().parse().map_err(|err| {
+        WxcError::NetworkProxy(format!(
+            "Invalid port in ready file '{}': {}",
+            content.trim(),
+            err
+        ))
+    })?;
+
+    // 3. Re-check liveness AFTER parsing port. A dead proxy with a valid
+    //    port is useless to the caller and must surface as an error.
+    match child.try_wait() {
+        Ok(Some(status)) => Err(WxcError::NetworkProxy(format!(
+            "linux-test-proxy exited immediately after publishing port (status: {:?})",
+            status
+        ))),
+        Ok(None) => Ok(port),
+        Err(err) => Err(WxcError::NetworkProxy(format!(
+            "Failed to re-check linux-test-proxy status: {}",
+            err
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_logger() -> Logger {
+        Logger::new(crate::logger::Mode::Buffer)
+    }
+
+    #[test]
+    fn new_coordinator_is_inactive() {
+        let c = LinuxProxyCoordinator::new();
+        assert!(!c.is_active());
+        assert!(c.address().is_none());
+    }
+
+    #[test]
+    fn default_coordinator_is_inactive() {
+        let c = LinuxProxyCoordinator::default();
+        assert!(!c.is_active());
+    }
+
+    #[test]
+    fn start_with_disabled_proxy_is_noop() {
+        let mut c = LinuxProxyCoordinator::new();
+        let mut logger = make_logger();
+        let cfg = ProxyConfig::default();
+        assert!(!cfg.is_enabled());
+        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        assert!(!c.is_active());
+    }
+
+    #[test]
+    fn start_with_external_address_activates() {
+        let mut c = LinuxProxyCoordinator::new();
+        let mut logger = make_logger();
+        let cfg = ProxyConfig {
+            address: Some(ProxyAddress::new("127.0.0.1".into(), 8888)),
+            ..Default::default()
+        };
+        assert!(cfg.is_enabled());
+
+        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        assert!(c.is_active());
+        let addr = c.address().unwrap();
+        assert_eq!(addr.port(), 8888);
+
+        c.stop(&mut logger);
+        assert!(!c.is_active());
+    }
+
+    #[test]
+    fn start_is_rejected_if_already_active() {
+        let mut c = LinuxProxyCoordinator::new();
+        let mut logger = make_logger();
+        let cfg = ProxyConfig {
+            address: Some(ProxyAddress::new("127.0.0.1".into(), 9001)),
+            ..Default::default()
+        };
+
+        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        let err = c
+            .start(&cfg, "127.0.0.1", &[], &[], &mut logger)
+            .unwrap_err();
+        match err {
+            WxcError::NetworkProxy(msg) => assert!(msg.contains("already active")),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn stop_is_idempotent() {
+        let mut c = LinuxProxyCoordinator::new();
+        let mut logger = make_logger();
+        c.stop(&mut logger);
+        c.stop(&mut logger);
+        assert!(!c.is_active());
+    }
+
+    #[test]
+    fn generate_unique_id_produces_distinct_ids() {
+        let a = generate_unique_id();
+        let b = generate_unique_id();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn create_and_remove_private_temp_dir() {
+        let id = generate_unique_id();
+        let dir = create_private_temp_dir(&id).unwrap();
+        assert!(dir.exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let meta = fs::metadata(&dir).unwrap();
+            assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+        }
+
+        remove_temp_dir(&dir);
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn poll_for_port_times_out_when_file_never_appears() {
+        let id = generate_unique_id();
+        let dir = create_private_temp_dir(&id).unwrap();
+        let ready_file = dir.join("ready.port");
+
+        // Spawn a sleep that lives longer than the test timeout below.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("sleep is available on Linux test hosts");
+
+        // Override the timeout: use a short window for the test by
+        // temporarily inlining the polling logic.
+        let deadline = Instant::now() + Duration::from_millis(300);
+        let result: Result<u16, WxcError> = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    break Err(WxcError::NetworkProxy(format!(
+                        "exited early: {:?}",
+                        status
+                    )));
+                }
+                Ok(None) => {}
+                Err(err) => break Err(WxcError::NetworkProxy(format!("query: {}", err))),
+            }
+            if ready_file.exists() {
+                // Shouldn't happen in this test.
+                break Ok(0);
+            }
+            if Instant::now() >= deadline {
+                break Err(WxcError::NetworkProxy("timeout".into()));
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        assert!(result.is_err());
+
+        let _ = child.kill();
+        let _ = child.wait();
+        remove_temp_dir(&dir);
+    }
+
+    #[test]
+    fn poll_for_port_detects_premature_child_exit() {
+        let id = generate_unique_id();
+        let dir = create_private_temp_dir(&id).unwrap();
+        let ready_file = dir.join("ready.port");
+
+        // `true` exits successfully immediately.
+        let mut child = Command::new("true")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("true is available on Linux test hosts");
+
+        // Give the child a moment to exit.
+        std::thread::sleep(Duration::from_millis(100));
+
+        let err = poll_for_port(&ready_file, &mut child).unwrap_err();
+        match err {
+            WxcError::NetworkProxy(msg) => {
+                assert!(
+                    msg.contains("exited before becoming ready"),
+                    "unexpected message: {}",
+                    msg
+                );
+            }
+            other => panic!("unexpected error: {:?}", other),
+        }
+
+        remove_temp_dir(&dir);
+    }
+}

--- a/src/wxc_common/src/linux_proxy_coordinator.rs
+++ b/src/wxc_common/src/linux_proxy_coordinator.rs
@@ -81,7 +81,7 @@ fn create_private_temp_dir(unique_id: &str) -> Result<PathBuf, WxcError> {
     })?;
 
     // Best-effort 0700 chmod so other users cannot snoop the ready file.
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
     {
         use std::os::unix::fs::PermissionsExt;
         let _ = fs::set_permissions(&dir, fs::Permissions::from_mode(0o700));
@@ -582,7 +582,7 @@ mod tests {
         let dir = create_private_temp_dir(&id).unwrap();
         assert!(dir.exists());
 
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
         {
             use std::os::unix::fs::PermissionsExt;
             let meta = fs::metadata(&dir).unwrap();

--- a/src/wxc_common/src/linux_proxy_coordinator.rs
+++ b/src/wxc_common/src/linux_proxy_coordinator.rs
@@ -42,7 +42,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::error::WxcError;
 use crate::logger::Logger;
-use crate::models::{ProxyAddress, ProxyConfig};
+use crate::models::{NetworkPolicy, ProxyAddress, ProxyConfig};
 
 /// Maximum time to wait for the test proxy to write its ready file.
 const READY_TIMEOUT: Duration = Duration::from_secs(15);
@@ -193,12 +193,15 @@ impl LinuxProxyCoordinator {
     ///
     /// - If `proxy_config.builtin_test_server` is `true`, launches the
     ///   bundled `linux-test-proxy` binary on `bind_address:0` and reads
-    ///   the assigned port from the proxy's ready file. `allowed_hosts`
-    ///   and `blocked_hosts` are passed to the test proxy as
-    ///   `--allow-host` / `--block-host` flags.
+    ///   the assigned port from the proxy's ready file. `allowed_hosts`,
+    ///   `blocked_hosts`, and `default_policy` are passed to the test
+    ///   proxy as `--allow-host` / `--block-host` / `--default-policy`
+    ///   flags so the cooperative env-var proxy honors the request's
+    ///   `defaultPolicy: "block"` semantics (deny-by-default).
     /// - Otherwise, uses the externally provided `proxy_config.address`.
-    ///   `allowed_hosts` / `blocked_hosts` are ignored in this case: the
-    ///   external proxy is assumed to apply its own policy.
+    ///   `allowed_hosts` / `blocked_hosts` / `default_policy` are ignored
+    ///   in this case: the external proxy is assumed to apply its own
+    ///   policy.
     /// - If the proxy config is disabled (`is_enabled()` returns `false`),
     ///   this is a no-op and the coordinator remains inactive.
     ///
@@ -210,6 +213,7 @@ impl LinuxProxyCoordinator {
         bind_address: &str,
         allowed_hosts: &[String],
         blocked_hosts: &[String],
+        default_policy: NetworkPolicy,
         logger: &mut Logger,
     ) -> Result<(), WxcError> {
         if self.is_active() {
@@ -223,8 +227,13 @@ impl LinuxProxyCoordinator {
         }
 
         let address = if proxy_config.builtin_test_server {
-            let port =
-                self.launch_test_proxy(bind_address, allowed_hosts, blocked_hosts, logger)?;
+            let port = self.launch_test_proxy(
+                bind_address,
+                allowed_hosts,
+                blocked_hosts,
+                default_policy,
+                logger,
+            )?;
             ProxyAddress::new(bind_address.to_string(), port)
         } else if let Some(ref addr) = proxy_config.address {
             addr.clone()
@@ -256,6 +265,7 @@ impl LinuxProxyCoordinator {
         bind_address: &str,
         allow_hosts: &[String],
         block_hosts: &[String],
+        default_policy: NetworkPolicy,
         logger: &mut Logger,
     ) -> Result<u16, WxcError> {
         logger.log_line(
@@ -275,11 +285,18 @@ impl LinuxProxyCoordinator {
             }
         };
 
+        let default_policy_arg = match default_policy {
+            NetworkPolicy::Allow => "allow",
+            NetworkPolicy::Block => "block",
+        };
+
         let mut cmd = Command::new(&proxy_exe);
         cmd.arg("--ready-file")
             .arg(&ready_file)
             .arg("--bind-address")
-            .arg(bind_address);
+            .arg(bind_address)
+            .arg("--default-policy")
+            .arg(default_policy_arg);
         for host in allow_hosts {
             cmd.arg("--allow-host").arg(host);
         }
@@ -470,7 +487,15 @@ mod tests {
         let mut logger = make_logger();
         let cfg = ProxyConfig::default();
         assert!(!cfg.is_enabled());
-        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        c.start(
+            &cfg,
+            "127.0.0.1",
+            &[],
+            &[],
+            NetworkPolicy::Allow,
+            &mut logger,
+        )
+        .unwrap();
         assert!(!c.is_active());
     }
 
@@ -484,7 +509,15 @@ mod tests {
         };
         assert!(cfg.is_enabled());
 
-        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        c.start(
+            &cfg,
+            "127.0.0.1",
+            &[],
+            &[],
+            NetworkPolicy::Allow,
+            &mut logger,
+        )
+        .unwrap();
         assert!(c.is_active());
         let addr = c.address().unwrap();
         assert_eq!(addr.port(), 8888);
@@ -502,9 +535,24 @@ mod tests {
             ..Default::default()
         };
 
-        c.start(&cfg, "127.0.0.1", &[], &[], &mut logger).unwrap();
+        c.start(
+            &cfg,
+            "127.0.0.1",
+            &[],
+            &[],
+            NetworkPolicy::Allow,
+            &mut logger,
+        )
+        .unwrap();
         let err = c
-            .start(&cfg, "127.0.0.1", &[], &[], &mut logger)
+            .start(
+                &cfg,
+                "127.0.0.1",
+                &[],
+                &[],
+                NetworkPolicy::Allow,
+                &mut logger,
+            )
             .unwrap_err();
         match err {
             WxcError::NetworkProxy(msg) => assert!(msg.contains("already active")),

--- a/test_configs/bubblewrap_network_proxy_allowlist.json
+++ b/test_configs/bubblewrap_network_proxy_allowlist.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "CLI-Bubblewrap-Network-Proxy-Allowlist",
+  "containment": "bubblewrap",
+  "platform": "linux",
+  "process": {
+    "commandLine": "set -e; curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; if curl -fsS --max-time 5 https://example.com > /dev/null 2>&1; then echo SENTINEL_BAD_LEAK; exit 1; else echo BLOCKED_OK; fi"
+  },
+  "network": {
+    "defaultPolicy": "allow",
+    "proxy": { "builtinTestServer": true },
+    "allowedHosts": ["api.github.com"]
+  }
+}

--- a/test_configs/bubblewrap_network_proxy_blocklist.json
+++ b/test_configs/bubblewrap_network_proxy_blocklist.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "CLI-Bubblewrap-Network-Proxy-Blocklist",
+  "containment": "bubblewrap",
+  "platform": "linux",
+  "process": {
+    "commandLine": "set -e; curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; if curl -fsS --max-time 5 https://evil.example.com > /dev/null 2>&1; then echo SENTINEL_BAD_LEAK; exit 1; else echo BLOCKED_OK; fi"
+  },
+  "network": {
+    "defaultPolicy": "allow",
+    "proxy": { "builtinTestServer": true },
+    "blockedHosts": ["evil.example.com"]
+  }
+}

--- a/test_configs/bubblewrap_network_proxy_builtin.json
+++ b/test_configs/bubblewrap_network_proxy_builtin.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "CLI-Bubblewrap-Network-Proxy-Builtin",
+  "containment": "bubblewrap",
+  "platform": "linux",
+  "process": {
+    "commandLine": "curl -fsSL https://api.github.com/zen && echo PROXY_OK"
+  },
+  "network": {
+    "defaultPolicy": "allow",
+    "proxy": { "builtinTestServer": true }
+  }
+}

--- a/test_scripts/run_bwrap_all_tests.sh
+++ b/test_scripts/run_bwrap_all_tests.sh
@@ -36,6 +36,7 @@ run_test() {
 run_test "Basic Bubblewrap" "$SCRIPT_DIR/run_bwrap_basic_test.sh"
 run_test "Bubblewrap Filesystem" "$SCRIPT_DIR/run_bwrap_filesystem_test.sh"
 run_test "Bubblewrap Network Block" "$SCRIPT_DIR/run_bwrap_network_test.sh"
+run_test "Bubblewrap Network Proxy" "$SCRIPT_DIR/run_bwrap_network_proxy_test.sh"
 run_test "Linux Process Default" "$SCRIPT_DIR/run_linux_process_default_test.sh"
 
 echo "================================"

--- a/test_scripts/run_bwrap_network_proxy_test.sh
+++ b/test_scripts/run_bwrap_network_proxy_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Bubblewrap network-proxy sandbox tests (cooperative env-var proxy).
+#
+# These tests do NOT require root: the builtin test proxy runs as the
+# current user and the sandbox reaches it via loopback.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+run_one() {
+    local label="$1"
+    local config="$2"
+    local sentinel="$3"
+    echo "Running Bubblewrap network proxy test: $label..."
+    local out
+    if ! out=$("$LXC_EXEC" --experimental "$REPO_DIR/test_configs/$config" 2>&1); then
+        echo "$out"
+        echo "FAIL: $label (lxc-exec returned non-zero)"
+        return 1
+    fi
+    if ! grep -q "$sentinel" <<<"$out"; then
+        echo "$out"
+        echo "FAIL: $label (sentinel '$sentinel' not found in output)"
+        return 1
+    fi
+    echo "PASS: $label"
+}
+
+run_one "builtin proxy"    "bubblewrap_network_proxy_builtin.json"    "PROXY_OK"
+run_one "proxy allowlist"  "bubblewrap_network_proxy_allowlist.json"  "BLOCKED_OK"
+run_one "proxy blocklist"  "bubblewrap_network_proxy_blocklist.json"  "BLOCKED_OK"
+
+echo "Bubblewrap network proxy tests complete."


### PR DESCRIPTION
## 📖 Description

Adds a userspace-proxy enforcement path to the Bubblewrap backend so per-host `allowedHosts` / `blockedHosts` can be applied **without root**, removing the iptables-only restriction that made the "unprivileged" backend require privileges for any non-trivial network policy.

When `network.proxy` is configured on `containment: "bubblewrap"`, the runner:

1. Spawns a new Linux-side `linux-test-proxy` (HTTP CONNECT + forward, host filtering) preloaded with the request's allow/block lists and default policy.
2. Injects `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` into the sandbox via `bwrap --setenv` so cooperating clients (curl, git, pip, npm, requests, gh, …) route through the proxy.
3. Skips `--unshare-net` (sandbox needs loopback to reach the proxy) and skips the iptables path entirely.

Honor-system enforcement is documented as a known limitation — a hostile binary that ignores proxy env vars can still talk to the host network. Users needing hard enforcement on Linux keep using LXC. For the agent / CI workloads bwrap targets, this is a strict improvement over the previous "either root-iptables or all-or-nothing `--unshare-net`" choice.

### What's in this PR

**New Rust crate**
- `src/linux_test_proxy/` — Linux-native HTTP CONNECT + forward proxy with pluggable `HostFilter` (allow/block/default-policy decisions). Tokio-based, exits on SIGTERM or parent death (`PR_SET_PDEATHSIG`).

**Bubblewrap runner integration**
- `bwrap_common/src/bwrap_runner.rs` — new decision tree: proxy > iptables > `--unshare-net` > shared netns.
- `bwrap_common/src/bwrap_command.rs` — accepts optional `proxy_port` and emits `--setenv` for the three env vars; suppresses `--unshare-net` when proxy is in use.

**Config / parser**
- `network.proxy` is now accepted on `containment: "bubblewrap"` (previously `processcontainer`-only); schema description updated.
- New `wxc_common/src/linux_proxy_coordinator.rs` mirrors the Windows proxy coordinator: locates `linux-test-proxy` next to `lxc-exec`, spawns it, reads the ready-file, tears down on exit.

**Tests**
- `sdk/tests/integration/linux-bubblewrap.test.ts` — three new cases:
   externally launched proxy, `builtinTestServer`, allowedHosts enforcement.
   Gated on `isLinuxBubblewrap` (no root required for the proxy path).
- `test_configs/bubblewrap_network_proxy_{builtin,allowlist,blocklist}.json`
   + `test_scripts/run_bwrap_network_proxy_test.sh` for native E2E coverage.


## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/421)