### PR TITLE
Seatbelt: Honor allowLocalNetwork to permit inbound binds

### DIFF
--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -333,6 +333,7 @@ export function createConfigFromPolicy(
 
         config.network = {
             defaultPolicy: policy.network.allowOutbound ? 'allow' : 'block',
+            allowLocalNetwork: policy.network.allowLocalNetwork,
             allowedHosts: policy.network.allowedHosts,
             blockedHosts: policy.network.blockedHosts,
             proxy: policy.network.proxy,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -178,6 +178,12 @@ export interface NetworkConfig {
   enforcementMode?: 'capabilities' | 'firewall' | 'both';
   /** Default network policy: "allow" or "block" (default: "allow") */
   defaultPolicy?: 'allow' | 'block';
+  /**
+   * Whether to allow inbound connections to local IP listeners (i.e. the
+   * sandboxed process may call `bind()` + `listen()` and accept incoming
+   * TCP/UDP). Independent of `defaultPolicy`. (default: false)
+   */
+  allowLocalNetwork?: boolean;
   /** Hostnames or IP addresses/CIDR blocks to allow (firewall mode only) */
   allowedHosts?: string[];
   /** Hostnames or IP addresses to block (firewall mode only) */

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -639,6 +639,37 @@ describe('createConfigFromPolicy', () => {
       }
     });
 
+    it('should propagate allowLocalNetwork to network.allowLocalNetwork on macOS', () => {
+      // server.listen() on macOS needs Seatbelt's `network-inbound` rule,
+      // which the runner emits when ContainerPolicy.allow_local_network is
+      // true. The SDK is responsible for forwarding allowLocalNetwork through
+      // the wire format so the Rust profile builder sees it.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.5.0-alpha',
+          network: { allowOutbound: true, allowLocalNetwork: true },
+        });
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.strictEqual(config.network!.allowLocalNetwork, true);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should omit allowLocalNetwork when not set on macOS', () => {
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.5.0-alpha',
+          network: { allowOutbound: true },
+        });
+        assert.strictEqual(config.network!.allowLocalNetwork, undefined);
+      } finally {
+        restore();
+      }
+    });
+
     it('should reject proxy configuration on macOS', () => {
       mockDarwin();
       try {

--- a/src/seatbelt_common/src/profile_builder.rs
+++ b/src/seatbelt_common/src/profile_builder.rs
@@ -188,46 +188,51 @@ fn write_filesystem_deny(out: &mut String, request: &CodexRequest) -> Result<(),
 fn write_network_rules(out: &mut String, request: &CodexRequest) {
     let policy = &request.policy;
     let allow_outbound = matches!(policy.default_network_policy, NetworkPolicy::Allow);
+    let has_allowed_hosts = !policy.allowed_hosts.is_empty();
 
-    if !allow_outbound {
-        if policy.allowed_hosts.is_empty() {
+    // blocked_hosts is rejected at the runner level before reaching the
+    // profile builder, so it isn't handled here.
+    match (allow_outbound, has_allowed_hosts) {
+        (false, false) => {
             // Pure deny — implicit from `(deny default)`.
             out.push_str(";; --- network: default-deny (no allow-network rules emitted) ---\n");
-            return;
         }
-        // defaultPolicy=block + allowedHosts = allowlist mode.
-        // Seatbelt limitation: only `*` or `localhost` are valid hosts in
-        // `(remote ...)` filters — per-hostname filtering is not supported.
-        // Fall back to allowing all outbound when allowedHosts is specified.
-        out.push_str(
-            ";; --- network: allowedHosts requested but Seatbelt cannot filter by host;\n",
-        );
-        out.push_str(";;     allowing all outbound as best-effort ---\n");
-        out.push_str("(allow network-outbound)\n");
-        out.push_str("(allow network-bind (local ip))\n");
-        out.push_str("(allow system-socket)\n");
+        (true, false) => {
+            out.push_str(";; --- network: outbound allowed (any host) ---\n");
+            write_outbound_allow_rules(out);
+        }
+        (_, true) => {
+            // Seatbelt only accepts `*` or `localhost` in `(remote ...)` filters —
+            // per-hostname filtering isn't possible, so allowedHosts degrades to
+            // allow-all outbound as a best-effort.
+            out.push_str(
+                ";; --- network: allowedHosts requested but Seatbelt cannot filter by host;\n",
+            );
+            out.push_str(";;     allowing all outbound as best-effort ---\n");
+            write_outbound_allow_rules(out);
+        }
+    }
+
+    write_local_network_rules(out, policy.allow_local_network);
+}
+
+fn write_outbound_allow_rules(out: &mut String) {
+    out.push_str("(allow network-outbound)\n");
+    out.push_str("(allow network-bind (local ip))\n");
+    out.push_str("(allow system-socket)\n");
+}
+
+/// Emit the `network-inbound` rule that lets the sandboxed process accept
+/// incoming connections on its own listeners. Required for `server.listen()`
+/// on macOS — the `network-bind` rule alone is not enough; the kernel rejects
+/// `listen()` with EPERM without `network-inbound`. Scoped to `(local ip)` so
+/// it only covers IP sockets, never UNIX-domain or Mach sockets.
+fn write_local_network_rules(out: &mut String, allow_local_network: bool) {
+    if !allow_local_network {
         return;
     }
-
-    if policy.allowed_hosts.is_empty() {
-        out.push_str(";; --- network: outbound allowed (any host) ---\n");
-        out.push_str("(allow network-outbound)\n");
-        out.push_str("(allow network-bind (local ip))\n");
-        out.push_str("(allow system-socket)\n");
-    } else {
-        // Seatbelt limitation: per-host filtering not supported.
-        // Allow all outbound as best-effort when allowedHosts is specified.
-        out.push_str(
-            ";; --- network: allowedHosts requested but Seatbelt cannot filter by host;\n",
-        );
-        out.push_str(";;     allowing all outbound as best-effort ---\n");
-        out.push_str("(allow network-outbound)\n");
-        out.push_str("(allow network-bind (local ip))\n");
-        out.push_str("(allow system-socket)\n");
-    }
-
-    // Note: blocked_hosts is rejected at the runner level before reaching
-    // the profile builder, so we don't need to handle it here.
+    out.push_str(";; --- network: allowLocalNetwork — accept inbound on local IPs ---\n");
+    out.push_str("(allow network-inbound (local ip))\n");
 }
 
 fn write_ui_rules(out: &mut String, request: &CodexRequest) {
@@ -556,6 +561,39 @@ mod tests {
         r.policy.blocked_hosts = vec!["evil.example.com".into()];
         let p = build_profile(&r).unwrap();
         assert!(!p.contains("(deny network-outbound"));
+    }
+
+    #[test]
+    fn allow_local_network_emits_inbound_rule() {
+        // server.listen() on macOS needs `network-inbound` in addition to
+        // `network-bind` — the kernel rejects listen() with EPERM otherwise.
+        let mut r = req();
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        r.policy.allow_local_network = true;
+        let p = build_profile(&r).unwrap();
+        assert!(p.contains("(allow network-inbound (local ip))"));
+        assert!(p.contains("allowLocalNetwork"));
+    }
+
+    #[test]
+    fn allow_local_network_default_omits_inbound_rule() {
+        // Default (allow_local_network=false) must not emit any inbound rule.
+        let mut r = req();
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        let p = build_profile(&r).unwrap();
+        assert!(!p.contains("network-inbound"));
+    }
+
+    #[test]
+    fn allow_local_network_works_with_default_deny_outbound() {
+        // allow_local_network is independent of outbound: a process can be
+        // a pure server (no client traffic) and still accept local inbound.
+        let mut r = req();
+        r.policy.default_network_policy = NetworkPolicy::Block;
+        r.policy.allow_local_network = true;
+        let p = build_profile(&r).unwrap();
+        assert!(p.contains("(allow network-inbound (local ip))"));
+        assert!(!p.contains("(allow network-outbound)"));
     }
 
     #[test]

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -83,6 +83,8 @@ struct RawNetwork {
     default_policy: Option<String>,
     #[serde(rename = "enforcementMode")]
     enforcement_mode: Option<String>,
+    #[serde(rename = "allowLocalNetwork")]
+    allow_local_network: Option<bool>,
     #[serde(rename = "allowedHosts")]
     allowed_hosts: Option<Vec<String>>,
     #[serde(rename = "blockedHosts")]
@@ -820,6 +822,10 @@ fn convert_raw_config_inner(
             };
         }
 
+        if let Some(v) = net.allow_local_network {
+            policy.allow_local_network = v;
+        }
+
         if let Some(v) = net.allowed_hosts {
             policy.allowed_hosts = v;
         }
@@ -1498,6 +1504,32 @@ mod tests {
         assert_eq!(req.policy.blocked_hosts.len(), 2);
         assert_eq!(req.policy.blocked_hosts[0], "malicious.com");
         assert_eq!(req.policy.blocked_hosts[1], "tracker.net");
+    }
+
+    #[test]
+    fn network_allow_local_network() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "network": {"allowLocalNetwork": true}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.allow_local_network);
+    }
+
+    #[test]
+    fn network_allow_local_network_defaults_false() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "network": {}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.policy.allow_local_network);
     }
 
     #[test]

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -386,6 +386,10 @@ pub struct ContainerPolicy {
     pub fallback: FallbackPolicy,
     pub default_network_policy: NetworkPolicy,
     pub network_enforcement_mode: NetworkEnforcementMode,
+    /// When true, the sandboxed process may bind() + listen() on local IPs
+    /// and accept incoming connections. Independent of `default_network_policy`
+    /// (which governs outbound traffic).
+    pub allow_local_network: bool,
     pub allowed_hosts: Vec<String>,
     pub blocked_hosts: Vec<String>,
     #[serde(skip)]

--- a/src/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/wxc_e2e_tests/tests/e2e_windows.rs
@@ -748,7 +748,11 @@ fn hyperlight_suite() {
             }
         });
 
-        let result = run_wxc_state_aware("hyperlight-fs-readonly", &config, &["--debug", "--experimental"]);
+        let result = run_wxc_state_aware(
+            "hyperlight-fs-readonly",
+            &config,
+            &["--debug", "--experimental"],
+        );
         let combined = result.combined_output();
 
         if result.code != Some(0) {
@@ -761,9 +765,14 @@ fn hyperlight_suite() {
                 "hyperlight-fs-readonly: could not read from readonly mount\n--- combined ---\n{combined}"
             ));
         } else if !rw_dir.join("output.txt").exists() {
-            failures.push("hyperlight-fs-readonly: readwrite mount did not produce output.txt".to_string());
+            failures.push(
+                "hyperlight-fs-readonly: readwrite mount did not produce output.txt".to_string(),
+            );
         } else if ro_dir.join("forbidden.txt").exists() {
-            failures.push("hyperlight-fs-readonly: readonly mount was writable — forbidden.txt was created".to_string());
+            failures.push(
+                "hyperlight-fs-readonly: readonly mount was writable — forbidden.txt was created"
+                    .to_string(),
+            );
         } else if !combined.contains("READONLY_ENFORCED") {
             failures.push(format!(
                 "hyperlight-fs-readonly: guest did not confirm enforcement\n--- combined ---\n{combined}"


### PR DESCRIPTION
## 📖 Description
Seatbelt is ignoring the allow network setting

## 🔗 References


## 🔍 Validation
tests

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/422)