### PR TITLE
Harden CLI command overrides

### DIFF
--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -1366,13 +1366,20 @@ mod tests {
 
     #[test]
     fn isolation_session_cli_command_quotes_shell_metacharacters() {
-        let cli = parse_cli(&["wxc-exec", "policy.json", "--", "echo", "safe&whoami"]);
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "policy.json",
+            "--",
+            "python",
+            "-c",
+            "if 5 < 10: print('hello')",
+        ]);
         let command_override =
             command_override_from_cli(&cli, CommandLineContext::WindowsCommandProcessor)
                 .unwrap()
                 .unwrap();
 
-        assert_eq!(command_override, "echo \"safe&whoami\"");
+        assert_eq!(command_override, "python -c \"if 5 < 10: print('hello')\"");
     }
 
     #[test]

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -163,18 +163,12 @@ struct Cli {
     probe: bool,
 
     /// Command to run inside the container, overriding `process.commandLine`
-    /// from the policy. Everything after the config path is captured as the
-    /// command; a leading `--` separator is optional but useful when the
-    /// command itself starts with `-`. Examples:
-    ///   wxc-exec policy.json py foo.py
+    /// from the policy. The command must follow a `--` separator so normal
+    /// CLI flags remain usable after the config path. Examples:
     ///   wxc-exec policy.json -- python --version
     /// When provided, `process.commandLine` in the policy file becomes
     /// optional and is overridden.
-    #[arg(
-        value_name = "COMMAND",
-        trailing_var_arg = true,
-        allow_hyphen_values = true
-    )]
+    #[arg(value_name = "COMMAND", last = true, allow_hyphen_values = true)]
     command: Vec<String>,
 }
 
@@ -222,7 +216,9 @@ fn has_cli_command(cli: &Cli) -> bool {
 
 fn command_line_context_for_backend(backend: &ContainmentBackend) -> CommandLineContext {
     match backend {
-        ContainmentBackend::IsolationSession => CommandLineContext::WindowsCommandProcessor,
+        ContainmentBackend::IsolationSession | ContainmentBackend::WindowsSandbox => {
+            CommandLineContext::WindowsCommandProcessor
+        }
         ContainmentBackend::Wslc
         | ContainmentBackend::Lxc
         | ContainmentBackend::Seatbelt
@@ -230,8 +226,7 @@ fn command_line_context_for_backend(backend: &ContainmentBackend) -> CommandLine
         ContainmentBackend::ProcessContainer
         | ContainmentBackend::Vm
         | ContainmentBackend::MicroVm
-        | ContainmentBackend::Hyperlight
-        | ContainmentBackend::WindowsSandbox => CommandLineContext::WindowsCreateProcess,
+        | ContainmentBackend::Hyperlight => CommandLineContext::WindowsCreateProcess,
     }
 }
 
@@ -1117,20 +1112,13 @@ mod tests {
     }
 
     #[test]
-    fn cli_captures_trailing_command_after_config_path() {
-        let cli = parse_cli(&["wxc-exec", "policy.json", "python", "--version"]);
+    fn cli_parses_flags_after_config_path_without_command_override() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--experimental", "--debug"]);
 
         assert_eq!(cli.config_path.as_deref(), Some("policy.json"));
-        assert_eq!(
-            cli.command,
-            vec!["python".to_string(), "--version".to_string()]
-        );
-        assert_eq!(
-            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
-                .unwrap()
-                .as_deref(),
-            Some("python --version")
-        );
+        assert!(cli.experimental);
+        assert!(cli.debug);
+        assert!(cli.command.is_empty());
     }
 
     #[test]
@@ -1152,24 +1140,6 @@ mod tests {
 
     #[test]
     fn cli_captures_command_after_named_config() {
-        let cli = parse_cli(&["wxc-exec", "--config", "policy.json", "python", "--version"]);
-
-        assert_eq!(cli.config.as_deref(), Some("policy.json"));
-        assert_eq!(cli.config_path.as_deref(), None);
-        assert_eq!(
-            cli.command,
-            vec!["python".to_string(), "--version".to_string()]
-        );
-        assert_eq!(
-            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
-                .unwrap()
-                .as_deref(),
-            Some("python --version")
-        );
-    }
-
-    #[test]
-    fn cli_captures_command_after_named_config_separator() {
         let cli = parse_cli(&[
             "wxc-exec",
             "--config",
@@ -1194,12 +1164,40 @@ mod tests {
     }
 
     #[test]
+    fn cli_captures_command_after_named_config_separator() {
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "--config",
+            "policy.json",
+            "--experimental",
+            "--",
+            "python",
+            "--version",
+        ]);
+
+        assert_eq!(cli.config.as_deref(), Some("policy.json"));
+        assert!(cli.experimental);
+        assert_eq!(cli.config_path.as_deref(), None);
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
     fn cli_captures_command_after_config_base64() {
         let encoded = encoded_policy(r#"{ "process": { "commandLine": "policy" } }"#);
         let cli = parse_cli(&[
             "wxc-exec",
             "--config-base64",
             &encoded,
+            "--",
             "python",
             "--version",
         ]);
@@ -1255,8 +1253,16 @@ mod tests {
     }
 
     #[test]
+    fn windows_sandbox_cli_command_uses_cmd_context() {
+        assert_eq!(
+            command_line_context_for_backend(&ContainmentBackend::WindowsSandbox),
+            CommandLineContext::WindowsCommandProcessor
+        );
+    }
+
+    #[test]
     fn cli_command_overrides_policy_command_line_in_resolved_request() {
-        let cli = parse_cli(&["wxc-exec", "policy.json", "cli-app.exe", "--from-cli"]);
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--", "cli-app.exe", "--from-cli"]);
         let command_override =
             command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess).unwrap();
         let mut logger = test_logger();
@@ -1299,6 +1305,7 @@ mod tests {
         let cli = parse_cli(&[
             "wxc-exec",
             "policy.json",
+            "--",
             "cli-app.exe",
             "--message",
             "hello world",
@@ -1359,7 +1366,7 @@ mod tests {
 
     #[test]
     fn isolation_session_cli_command_quotes_shell_metacharacters() {
-        let cli = parse_cli(&["wxc-exec", "policy.json", "echo", "safe&whoami"]);
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--", "echo", "safe&whoami"]);
         let command_override =
             command_override_from_cli(&cli, CommandLineContext::WindowsCommandProcessor)
                 .unwrap()
@@ -1370,7 +1377,7 @@ mod tests {
 
     #[test]
     fn wslc_cli_command_uses_posix_shell_quoting() {
-        let cli = parse_cli(&["wxc-exec", "policy.json", "echo", "safe&whoami"]);
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--", "echo", "safe&whoami"]);
         let command_override = command_override_from_cli(&cli, CommandLineContext::PosixShell)
             .unwrap()
             .unwrap();

--- a/src/wxc/src/main.rs
+++ b/src/wxc/src/main.rs
@@ -9,8 +9,9 @@ use std::time::Instant;
 
 use clap::Parser;
 use wxc_common::appcontainer_runner::{delete_app_container_profile, AppContainerScriptRunner};
+use wxc_common::cmdline::{cmdline_from_argv_for_context, CommandLineContext, CommandLineError};
 use wxc_common::config_parser::{
-    is_base_container_version, load_mxc_request, load_request, ParseError,
+    is_base_container_version, load_mxc_request_with_options, load_request, LoadOptions, ParseError,
 };
 use wxc_common::diagnostic::DiagnosticConfig;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
@@ -23,8 +24,8 @@ use wxc_common::mxc_error::{MxcError, ResponseEnvelope};
 #[cfg(feature = "microvm")]
 use wxc_common::nanvix_runner::NanVixScriptRunner;
 use wxc_common::script_runner::{handle_dry_run_exit, ScriptRunner};
-use wxc_common::state_aware_dispatch::{run_state_aware, DispatchOutcome};
-use wxc_common::state_aware_request::{MxcRequest, ParsedStateAwareRequest};
+use wxc_common::state_aware_dispatch::{resolve_backend, run_state_aware, DispatchOutcome};
+use wxc_common::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
 use wxc_common::windows_sandbox_runner::WindowsSandboxScriptRunner;
 
 #[derive(Parser)]
@@ -160,6 +161,32 @@ struct Cli {
     /// Run the fallback detector and emit JSON, without spawning a sandbox.
     #[arg(long)]
     probe: bool,
+
+    /// Command to run inside the container, overriding `process.commandLine`
+    /// from the policy. Everything after the config path is captured as the
+    /// command; a leading `--` separator is optional but useful when the
+    /// command itself starts with `-`. Examples:
+    ///   wxc-exec policy.json py foo.py
+    ///   wxc-exec policy.json -- python --version
+    /// When provided, `process.commandLine` in the policy file becomes
+    /// optional and is overridden.
+    #[arg(
+        value_name = "COMMAND",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
+    command: Vec<String>,
+}
+
+impl Cli {
+    fn normalize_named_config_command(mut self) -> Self {
+        if self.config.is_some() || self.config_base64.is_some() {
+            if let Some(first) = self.config_path.take() {
+                self.command.insert(0, first);
+            }
+        }
+        self
+    }
 }
 
 fn log_request(request: &CodexRequest, logger: &mut Logger) {
@@ -186,6 +213,68 @@ fn display_script_results(response: &ScriptResponse, logger: &mut Logger) {
     let _ = writeln!(logger, "Exit code: {} (0x{:08X})", code, code as u32);
     if !response.error_message.is_empty() {
         let _ = writeln!(logger, "Error: {}", response.error_message);
+    }
+}
+
+fn has_cli_command(cli: &Cli) -> bool {
+    !cli.command.is_empty()
+}
+
+fn command_line_context_for_backend(backend: &ContainmentBackend) -> CommandLineContext {
+    match backend {
+        ContainmentBackend::IsolationSession => CommandLineContext::WindowsCommandProcessor,
+        ContainmentBackend::Wslc
+        | ContainmentBackend::Lxc
+        | ContainmentBackend::Seatbelt
+        | ContainmentBackend::Bubblewrap => CommandLineContext::PosixShell,
+        ContainmentBackend::ProcessContainer
+        | ContainmentBackend::Vm
+        | ContainmentBackend::MicroVm
+        | ContainmentBackend::Hyperlight
+        | ContainmentBackend::WindowsSandbox => CommandLineContext::WindowsCreateProcess,
+    }
+}
+
+fn command_override_from_cli(
+    cli: &Cli,
+    context: CommandLineContext,
+) -> Result<Option<String>, CommandLineError> {
+    if cli.command.is_empty() {
+        Ok(None)
+    } else {
+        cmdline_from_argv_for_context(&cli.command, context).map(Some)
+    }
+}
+
+fn command_override_context_for_state_aware(
+    parsed: &ParsedStateAwareRequest,
+    has_command_override: bool,
+) -> Result<Option<CommandLineContext>, MxcError> {
+    if !has_command_override {
+        return Ok(None);
+    }
+    if parsed.phase != Phase::Exec {
+        return Err(MxcError::malformed_request(
+            "CLI command override is only supported for state-aware exec requests",
+        ));
+    }
+    resolve_backend(parsed).map(|backend| Some(command_line_context_for_backend(&backend)))
+}
+
+fn apply_command_override(
+    request: &mut CodexRequest,
+    command_override: Option<&str>,
+    logger: &mut Logger,
+) {
+    if let Some(cmd) = command_override {
+        if !request.script_code.is_empty() {
+            let _ = writeln!(
+                logger,
+                "Overriding policy process.commandLine with CLI command: {}",
+                cmd
+            );
+        }
+        request.script_code = cmd.to_string();
     }
 }
 
@@ -382,7 +471,7 @@ fn install_dacl_ctrl_handler() {
 }
 
 fn main() {
-    let cli = Cli::parse();
+    let cli = Cli::parse().normalize_named_config_command();
 
     // Best-effort: reap any orphaned DACL state files left behind by
     // crashed prior MXC runs. Runs BEFORE the `--probe` arm because
@@ -617,9 +706,41 @@ fn main() {
     // one-shot. State-aware failures emit a JSON envelope on stdout; one-shot
     // and pre-discrimination failures keep the existing diagnostic-on-stderr
     // convention.
-    let request = match load_mxc_request(&config_data, &mut logger, is_base64) {
+    let has_command_override = has_cli_command(&cli);
+    let load_opts = LoadOptions {
+        is_base64,
+        allow_missing_command: has_command_override,
+    };
+    let request = match load_mxc_request_with_options(&config_data, &mut logger, load_opts) {
         Ok(MxcRequest::OneShot(req)) => req,
-        Ok(MxcRequest::StateAware(parsed)) => {
+        Ok(MxcRequest::StateAware(mut parsed)) => {
+            let context =
+                match command_override_context_for_state_aware(&parsed, has_command_override) {
+                    Ok(context) => context,
+                    Err(e) => {
+                        print_error_envelope(&e);
+                        eprint!("{}", logger.get_buffer());
+                        process::exit(1);
+                    }
+                };
+            let command_override = match context
+                .map(|context| command_override_from_cli(&cli, context))
+                .transpose()
+            {
+                Ok(command_override) => command_override.flatten(),
+                Err(e) => {
+                    print_error_envelope(&MxcError::malformed_request(format!(
+                        "invalid CLI command override: {e}"
+                    )));
+                    eprint!("{}", logger.get_buffer());
+                    process::exit(1);
+                }
+            };
+            apply_command_override(
+                &mut parsed.request,
+                command_override.as_deref(),
+                &mut logger,
+            );
             run_state_aware_main(parsed, cli.dry_run, &mut logger)
         }
         Err(ParseError::OneShot(_)) | Err(ParseError::Decode(_)) => {
@@ -636,6 +757,31 @@ fn main() {
     let mut request = request;
     request.experimental_enabled = cli.experimental;
     request.dry_run = cli.dry_run;
+
+    // Apply the CLI command-line override to one-shot requests. State-aware
+    // exec is handled above before dispatch.
+    let command_override = match command_override_from_cli(
+        &cli,
+        command_line_context_for_backend(&request.containment),
+    ) {
+        Ok(command_override) => command_override,
+        Err(e) => {
+            eprintln!("Request error\ninvalid CLI command override: {e}");
+            eprint!("{}", logger.get_buffer());
+            process::exit(1);
+        }
+    };
+    apply_command_override(&mut request, command_override.as_deref(), &mut logger);
+
+    // Final validation: a command line must come from somewhere. If neither
+    // the policy nor the CLI supplied one we cannot proceed.
+    if request.script_code.is_empty() {
+        eprintln!(
+            "Error: no command to run. Provide `process.commandLine` in the policy or pass the command as arguments after the config path."
+        );
+        eprint!("{}", logger.get_buffer());
+        process::exit(1);
+    }
 
     // Inject learningModeLogging capability when diagnostic console is enabled.
     let learning_mode_injected = if DiagnosticConfig::force_learning_mode()
@@ -944,4 +1090,309 @@ fn main() {
     }
 
     process::exit(response.exit_code);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use clap::{CommandFactory, Parser};
+    use wxc_common::encoding::base64_encode;
+    use wxc_common::logger::Mode;
+    use wxc_common::mxc_error::MxcErrorCode;
+    use wxc_common::state_aware_request::MxcRequest;
+
+    fn parse_cli(argv: &[&str]) -> Cli {
+        Cli::try_parse_from(argv)
+            .unwrap()
+            .normalize_named_config_command()
+    }
+
+    fn encoded_policy(json: &str) -> String {
+        base64_encode(json.as_bytes())
+    }
+
+    fn test_logger() -> Logger {
+        Logger::new(Mode::Buffer)
+    }
+
+    #[test]
+    fn cli_captures_trailing_command_after_config_path() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "python", "--version"]);
+
+        assert_eq!(cli.config_path.as_deref(), Some("policy.json"));
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
+    fn cli_captures_command_after_separator() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--", "python", "--version"]);
+
+        assert_eq!(cli.config_path.as_deref(), Some("policy.json"));
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
+    fn cli_captures_command_after_named_config() {
+        let cli = parse_cli(&["wxc-exec", "--config", "policy.json", "python", "--version"]);
+
+        assert_eq!(cli.config.as_deref(), Some("policy.json"));
+        assert_eq!(cli.config_path.as_deref(), None);
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
+    fn cli_captures_command_after_named_config_separator() {
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "--config",
+            "policy.json",
+            "--",
+            "python",
+            "--version",
+        ]);
+
+        assert_eq!(cli.config.as_deref(), Some("policy.json"));
+        assert_eq!(cli.config_path.as_deref(), None);
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
+    fn cli_captures_command_after_config_base64() {
+        let encoded = encoded_policy(r#"{ "process": { "commandLine": "policy" } }"#);
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "--config-base64",
+            &encoded,
+            "python",
+            "--version",
+        ]);
+
+        assert_eq!(cli.config_base64.as_deref(), Some(encoded.as_str()));
+        assert_eq!(cli.config_path.as_deref(), None);
+        assert_eq!(
+            cli.command,
+            vec!["python".to_string(), "--version".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("python --version")
+        );
+    }
+
+    #[test]
+    fn cli_captures_hyphenated_command_after_separator() {
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "--config",
+            "policy.json",
+            "--",
+            "-command",
+            "value",
+        ]);
+
+        assert_eq!(cli.config.as_deref(), Some("policy.json"));
+        assert_eq!(cli.config_path.as_deref(), None);
+        assert_eq!(
+            cli.command,
+            vec!["-command".to_string(), "value".to_string()]
+        );
+        assert_eq!(
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .as_deref(),
+            Some("-command value")
+        );
+    }
+
+    #[test]
+    fn help_text_documents_cli_command_override() {
+        let mut command = Cli::command();
+        let help = command.render_long_help().to_string();
+
+        assert!(help.contains("Windows Container Executor"));
+        assert!(help.contains("COMMAND"));
+        assert!(help.contains("process.commandLine"));
+        assert!(help.contains("wxc-exec policy.json -- python --version"));
+    }
+
+    #[test]
+    fn cli_command_overrides_policy_command_line_in_resolved_request() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "cli-app.exe", "--from-cli"]);
+        let command_override =
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess).unwrap();
+        let mut logger = test_logger();
+        let policy = r#"{
+            "process": {
+                "commandLine": "policy-app.exe --from-policy",
+                "cwd": "C:\\workspace"
+            },
+            "filesystem": {
+                "readwritePaths": ["C:\\workspace"]
+            }
+        }"#;
+        let opts = LoadOptions {
+            is_base64: true,
+            allow_missing_command: command_override.is_some(),
+        };
+
+        let mut request = match load_mxc_request_with_options(
+            &encoded_policy(policy),
+            &mut logger,
+            opts,
+        )
+        .unwrap()
+        {
+            MxcRequest::OneShot(req) => req,
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        };
+        apply_command_override(&mut request, command_override.as_deref(), &mut logger);
+
+        assert_eq!(request.script_code, "cli-app.exe --from-cli");
+        assert_eq!(request.working_directory, "C:\\workspace");
+        assert_eq!(request.policy.readwrite_paths, vec!["C:\\workspace"]);
+        assert!(logger.get_buffer().contains(
+            "Overriding policy process.commandLine with CLI command: cli-app.exe --from-cli"
+        ));
+    }
+
+    #[test]
+    fn cli_command_matches_equivalent_policy_command_line() {
+        let cli = parse_cli(&[
+            "wxc-exec",
+            "policy.json",
+            "cli-app.exe",
+            "--message",
+            "hello world",
+        ]);
+        let command_override =
+            command_override_from_cli(&cli, CommandLineContext::WindowsCreateProcess)
+                .unwrap()
+                .unwrap();
+        let mut policy_logger = test_logger();
+        let mut cli_logger = test_logger();
+        let policy = r#"{
+            "process": {
+                "commandLine": "cli-app.exe --message \"hello world\"",
+                "cwd": "C:\\workspace"
+            }
+        }"#;
+        let cli_policy = r#"{
+            "process": {
+                "cwd": "C:\\workspace"
+            }
+        }"#;
+
+        let policy_request = match load_mxc_request_with_options(
+            &encoded_policy(policy),
+            &mut policy_logger,
+            LoadOptions {
+                is_base64: true,
+                allow_missing_command: false,
+            },
+        )
+        .unwrap()
+        {
+            MxcRequest::OneShot(req) => req,
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        };
+        let mut cli_request = match load_mxc_request_with_options(
+            &encoded_policy(cli_policy),
+            &mut cli_logger,
+            LoadOptions {
+                is_base64: true,
+                allow_missing_command: true,
+            },
+        )
+        .unwrap()
+        {
+            MxcRequest::OneShot(req) => req,
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        };
+
+        apply_command_override(&mut cli_request, Some(&command_override), &mut cli_logger);
+
+        assert_eq!(cli_request.script_code, policy_request.script_code);
+        assert_eq!(
+            cli_request.working_directory,
+            policy_request.working_directory
+        );
+    }
+
+    #[test]
+    fn isolation_session_cli_command_quotes_shell_metacharacters() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "echo", "safe&whoami"]);
+        let command_override =
+            command_override_from_cli(&cli, CommandLineContext::WindowsCommandProcessor)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(command_override, "echo \"safe&whoami\"");
+    }
+
+    #[test]
+    fn wslc_cli_command_uses_posix_shell_quoting() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "echo", "safe&whoami"]);
+        let command_override = command_override_from_cli(&cli, CommandLineContext::PosixShell)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(command_override, "echo 'safe&whoami'");
+    }
+
+    #[test]
+    fn state_aware_command_override_only_applies_to_exec_phase() {
+        let parsed = ParsedStateAwareRequest {
+            request: CodexRequest::default(),
+            phase: Phase::Start,
+            containment: None,
+            sandbox_id: Some("iso:wxc-1234".into()),
+            experimental_raw: None,
+        };
+
+        let err = command_override_context_for_state_aware(&parsed, true).unwrap_err();
+
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(err
+            .message
+            .contains("only supported for state-aware exec requests"));
+    }
 }

--- a/src/wxc_common/src/cmdline.rs
+++ b/src/wxc_common/src/cmdline.rs
@@ -101,9 +101,9 @@ fn append_windows_create_process(out: &mut String, arg: &str) {
 }
 
 fn append_windows_cmd(out: &mut String, arg: &str) -> Result<(), CommandLineError> {
-    if arg.contains('%') || arg.contains('!') {
+    if arg.contains('%') || arg.contains('!') || arg.contains('"') {
         return Err(CommandLineError::new(
-            "CLI command arguments for cmd.exe-backed sandboxes must not contain '%' or '!'",
+            "CLI command arguments for cmd.exe-backed sandboxes must not contain '%', '!', or '\"'",
         ));
     }
     append_windows_quoted(out, arg, needs_windows_cmd_quotes);
@@ -297,6 +297,17 @@ mod tests {
 
         assert!(percent_err.to_string().contains("must not contain"));
         assert!(bang_err.to_string().contains("must not contain"));
+    }
+
+    #[test]
+    fn windows_cmd_context_rejects_embedded_quotes() {
+        let err = cmdline_from_argv_for_context(
+            &s(&["echo", "\"&whoami"]),
+            CommandLineContext::WindowsCommandProcessor,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("must not contain"));
     }
 
     #[test]

--- a/src/wxc_common/src/cmdline.rs
+++ b/src/wxc_common/src/cmdline.rs
@@ -65,26 +65,11 @@ pub fn cmdline_from_argv_for_context(
             CommandLineContext::WindowsCreateProcess => {
                 append_windows_create_process(&mut out, arg)
             }
-            CommandLineContext::WindowsCommandProcessor => append_windows_cmd(&mut out, arg)?,
+            CommandLineContext::WindowsCommandProcessor => append_windows_cmd(&mut out, arg),
             CommandLineContext::PosixShell => append_posix_shell(&mut out, arg),
         }
     }
     Ok(out)
-}
-
-/// Join an argv slice into a single command-line string using the
-/// `CommandLineToArgvW` quoting rules. Tokens with no whitespace or
-/// quote characters are emitted verbatim; everything else is wrapped
-/// in double quotes with backslash/quote escaping.
-pub fn cmdline_from_argv(argv: &[String]) -> String {
-    let mut out = String::new();
-    for (i, arg) in argv.iter().enumerate() {
-        if i > 0 {
-            out.push(' ');
-        }
-        append_windows_create_process(&mut out, arg);
-    }
-    out
 }
 
 fn validate_argv(argv: &[String]) -> Result<(), CommandLineError> {
@@ -100,14 +85,8 @@ fn append_windows_create_process(out: &mut String, arg: &str) {
     append_windows_quoted(out, arg, needs_windows_create_process_quotes);
 }
 
-fn append_windows_cmd(out: &mut String, arg: &str) -> Result<(), CommandLineError> {
-    if arg.contains('%') || arg.contains('!') || arg.contains('"') {
-        return Err(CommandLineError::new(
-            "CLI command arguments for cmd.exe-backed sandboxes must not contain '%', '!', or '\"'",
-        ));
-    }
+fn append_windows_cmd(out: &mut String, arg: &str) {
     append_windows_quoted(out, arg, needs_windows_cmd_quotes);
-    Ok(())
 }
 
 fn append_windows_quoted(out: &mut String, arg: &str, needs_quoting: fn(&str) -> bool) {
@@ -211,20 +190,24 @@ mod tests {
         v.iter().map(|t| (*t).to_string()).collect()
     }
 
+    fn create_process_cmdline(v: &[&str]) -> String {
+        cmdline_from_argv_for_context(&s(v), CommandLineContext::WindowsCreateProcess).unwrap()
+    }
+
     #[test]
     fn empty_argv_produces_empty_string() {
-        assert_eq!(cmdline_from_argv(&[]), "");
+        assert_eq!(create_process_cmdline(&[]), "");
     }
 
     #[test]
     fn plain_tokens_join_with_single_space() {
-        assert_eq!(cmdline_from_argv(&s(&["py", "foo.py"])), "py foo.py");
+        assert_eq!(create_process_cmdline(&["py", "foo.py"]), "py foo.py");
     }
 
     #[test]
     fn token_with_space_is_quoted() {
         assert_eq!(
-            cmdline_from_argv(&s(&["py", "hello world.py"])),
+            create_process_cmdline(&["py", "hello world.py"]),
             "py \"hello world.py\""
         );
     }
@@ -232,14 +215,14 @@ mod tests {
     #[test]
     fn token_with_quote_escapes_the_quote() {
         assert_eq!(
-            cmdline_from_argv(&s(&["py", "-c", "print(\"hi\")"])),
+            create_process_cmdline(&["py", "-c", "print(\"hi\")"]),
             "py -c \"print(\\\"hi\\\")\""
         );
     }
 
     #[test]
     fn empty_token_is_emitted_as_empty_quoted_pair() {
-        assert_eq!(cmdline_from_argv(&s(&["py", ""])), "py \"\"");
+        assert_eq!(create_process_cmdline(&["py", ""]), "py \"\"");
     }
 
     #[test]
@@ -247,7 +230,7 @@ mod tests {
         // Path "C:\foo bar\" must serialise so the runtime parser sees
         // a single trailing backslash, not an escaped closing quote.
         assert_eq!(
-            cmdline_from_argv(&s(&["echo", "C:\\foo bar\\"])),
+            create_process_cmdline(&["echo", "C:\\foo bar\\"]),
             "echo \"C:\\foo bar\\\\\""
         );
     }
@@ -255,18 +238,16 @@ mod tests {
     #[test]
     fn backslashes_not_before_quote_are_not_doubled() {
         assert_eq!(
-            cmdline_from_argv(&s(&["echo", "a\\b c"])),
+            create_process_cmdline(&["echo", "a\\b c"]),
             "echo \"a\\b c\""
         );
     }
 
     #[test]
-    fn windows_create_process_context_matches_legacy_helper() {
-        let argv = s(&["py", "hello world.py", "safe&whoami"]);
-
+    fn windows_create_process_context_allows_shell_metacharacters_as_data() {
         assert_eq!(
-            cmdline_from_argv_for_context(&argv, CommandLineContext::WindowsCreateProcess).unwrap(),
-            cmdline_from_argv(&argv)
+            create_process_cmdline(&["py", "hello world.py", "safe&whoami"]),
+            "py \"hello world.py\" safe&whoami"
         );
     }
 
@@ -283,31 +264,74 @@ mod tests {
     }
 
     #[test]
-    fn windows_cmd_context_rejects_percent_and_bang_expansion() {
-        let percent_err = cmdline_from_argv_for_context(
-            &s(&["echo", "%PATH%"]),
-            CommandLineContext::WindowsCommandProcessor,
-        )
-        .unwrap_err();
-        let bang_err = cmdline_from_argv_for_context(
-            &s(&["echo", "!PATH!"]),
-            CommandLineContext::WindowsCommandProcessor,
-        )
-        .unwrap_err();
-
-        assert!(percent_err.to_string().contains("must not contain"));
-        assert!(bang_err.to_string().contains("must not contain"));
+    fn windows_cmd_context_preserves_less_than_as_argument_data() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["python", "-c", "if 5 < 10: print('hello')"]),
+                CommandLineContext::WindowsCommandProcessor,
+            )
+            .unwrap(),
+            "python -c \"if 5 < 10: print('hello')\""
+        );
     }
 
     #[test]
-    fn windows_cmd_context_rejects_embedded_quotes() {
+    fn windows_cmd_context_passes_expansion_chars_to_caller() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["python", "-c", "if !5: print('%hello%')"]),
+                CommandLineContext::WindowsCommandProcessor,
+            )
+            .unwrap(),
+            "python -c \"if !5: print('%hello%')\""
+        );
+    }
+
+    #[test]
+    fn windows_cmd_context_passes_embedded_quotes_to_caller() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["python", "-c", "print(\"hi\")"]),
+                CommandLineContext::WindowsCommandProcessor,
+            )
+            .unwrap(),
+            "python -c \"print(\\\"hi\\\")\""
+        );
+    }
+
+    #[test]
+    fn windows_cmd_context_passes_newlines_to_caller() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["python", "-c", "print('hello')\nprint('world')"]),
+                CommandLineContext::WindowsCommandProcessor,
+            )
+            .unwrap(),
+            "python -c \"print('hello')\nprint('world')\""
+        );
+    }
+
+    #[test]
+    fn windows_cmd_context_rejects_null_bytes() {
         let err = cmdline_from_argv_for_context(
-            &s(&["echo", "\"&whoami"]),
+            &["echo\0hidden".to_string()],
             CommandLineContext::WindowsCommandProcessor,
         )
         .unwrap_err();
 
-        assert!(err.to_string().contains("must not contain"));
+        assert!(err.to_string().contains("null bytes"));
+    }
+
+    #[test]
+    fn windows_cmd_context_quotes_whitespace_like_policy_command_line() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["python", "hello world.py"]),
+                CommandLineContext::WindowsCommandProcessor
+            )
+            .unwrap(),
+            "python \"hello world.py\""
+        );
     }
 
     #[test]

--- a/src/wxc_common/src/cmdline.rs
+++ b/src/wxc_common/src/cmdline.rs
@@ -1,0 +1,333 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Helpers for turning a CLI argv vector back into the single `commandLine`
+//! string stored on `CodexRequest`.
+//!
+//! `script_code` on `CodexRequest` is a single `String`, so when the
+//! driver collects trailing CLI args we must serialise them as if the
+//! user had written the same value in `process.commandLine`. The direct
+//! Windows path uses `CommandLineToArgvW`-compatible quoting; shell-backed
+//! paths use the target shell's quoting rules so argv data does not become
+//! shell syntax.
+
+use std::error::Error;
+use std::fmt;
+
+/// Command-line parser that will consume the rendered command string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandLineContext {
+    /// The rendered string is passed directly to a Windows process-creation API.
+    WindowsCreateProcess,
+    /// The rendered string is appended after `cmd.exe /c`.
+    WindowsCommandProcessor,
+    /// The rendered string is passed to a POSIX shell as `/bin/sh -c`.
+    PosixShell,
+}
+
+/// Error returned when argv cannot be safely represented in the requested
+/// command-line context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandLineError {
+    message: String,
+}
+
+impl CommandLineError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for CommandLineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for CommandLineError {}
+
+/// Join an argv slice into a command-line string for the parser represented by
+/// `context`.
+pub fn cmdline_from_argv_for_context(
+    argv: &[String],
+    context: CommandLineContext,
+) -> Result<String, CommandLineError> {
+    validate_argv(argv)?;
+
+    let mut out = String::new();
+    for (i, arg) in argv.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        match context {
+            CommandLineContext::WindowsCreateProcess => {
+                append_windows_create_process(&mut out, arg)
+            }
+            CommandLineContext::WindowsCommandProcessor => append_windows_cmd(&mut out, arg)?,
+            CommandLineContext::PosixShell => append_posix_shell(&mut out, arg),
+        }
+    }
+    Ok(out)
+}
+
+/// Join an argv slice into a single command-line string using the
+/// `CommandLineToArgvW` quoting rules. Tokens with no whitespace or
+/// quote characters are emitted verbatim; everything else is wrapped
+/// in double quotes with backslash/quote escaping.
+pub fn cmdline_from_argv(argv: &[String]) -> String {
+    let mut out = String::new();
+    for (i, arg) in argv.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        append_windows_create_process(&mut out, arg);
+    }
+    out
+}
+
+fn validate_argv(argv: &[String]) -> Result<(), CommandLineError> {
+    if argv.iter().any(|arg| arg.contains('\0')) {
+        return Err(CommandLineError::new(
+            "CLI command arguments must not contain null bytes",
+        ));
+    }
+    Ok(())
+}
+
+fn append_windows_create_process(out: &mut String, arg: &str) {
+    append_windows_quoted(out, arg, needs_windows_create_process_quotes);
+}
+
+fn append_windows_cmd(out: &mut String, arg: &str) -> Result<(), CommandLineError> {
+    if arg.contains('%') || arg.contains('!') {
+        return Err(CommandLineError::new(
+            "CLI command arguments for cmd.exe-backed sandboxes must not contain '%' or '!'",
+        ));
+    }
+    append_windows_quoted(out, arg, needs_windows_cmd_quotes);
+    Ok(())
+}
+
+fn append_windows_quoted(out: &mut String, arg: &str, needs_quoting: fn(&str) -> bool) {
+    if !needs_quoting(arg) {
+        out.push_str(arg);
+        return;
+    }
+
+    append_quoted_windows_arg(out, arg);
+}
+
+fn needs_windows_create_process_quotes(arg: &str) -> bool {
+    arg.is_empty()
+        || arg
+            .chars()
+            .any(|c| c == ' ' || c == '\t' || c == '\n' || c == '\x0b' || c == '"')
+}
+
+fn needs_windows_cmd_quotes(arg: &str) -> bool {
+    needs_windows_create_process_quotes(arg)
+        || arg
+            .chars()
+            .any(|c| matches!(c, '&' | '|' | '<' | '>' | '^' | '(' | ')'))
+}
+
+fn append_quoted_windows_arg(out: &mut String, arg: &str) {
+    out.push('"');
+    let mut backslashes: usize = 0;
+    for c in arg.chars() {
+        match c {
+            '\\' => backslashes += 1,
+            '"' => {
+                // Double every preceding backslash, then escape the quote.
+                for _ in 0..backslashes * 2 + 1 {
+                    out.push('\\');
+                }
+                out.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                for _ in 0..backslashes {
+                    out.push('\\');
+                }
+                backslashes = 0;
+                out.push(c);
+            }
+        }
+    }
+    // Trailing backslashes inside a quoted block must be doubled so the
+    // closing quote isn't escaped.
+    for _ in 0..backslashes * 2 {
+        out.push('\\');
+    }
+    out.push('"');
+}
+
+fn append_posix_shell(out: &mut String, arg: &str) {
+    if is_posix_shell_safe_unquoted(arg) {
+        out.push_str(arg);
+        return;
+    }
+
+    out.push('\'');
+    for c in arg.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+}
+
+fn is_posix_shell_safe_unquoted(arg: &str) -> bool {
+    !arg.is_empty()
+        && arg.bytes().all(|b| {
+            matches!(
+                b,
+                b'a'..=b'z'
+                    | b'A'..=b'Z'
+                    | b'0'..=b'9'
+                    | b'_'
+                    | b'@'
+                    | b'%'
+                    | b'+'
+                    | b'='
+                    | b':'
+                    | b','
+                    | b'.'
+                    | b'/'
+                    | b'-'
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|t| (*t).to_string()).collect()
+    }
+
+    #[test]
+    fn empty_argv_produces_empty_string() {
+        assert_eq!(cmdline_from_argv(&[]), "");
+    }
+
+    #[test]
+    fn plain_tokens_join_with_single_space() {
+        assert_eq!(cmdline_from_argv(&s(&["py", "foo.py"])), "py foo.py");
+    }
+
+    #[test]
+    fn token_with_space_is_quoted() {
+        assert_eq!(
+            cmdline_from_argv(&s(&["py", "hello world.py"])),
+            "py \"hello world.py\""
+        );
+    }
+
+    #[test]
+    fn token_with_quote_escapes_the_quote() {
+        assert_eq!(
+            cmdline_from_argv(&s(&["py", "-c", "print(\"hi\")"])),
+            "py -c \"print(\\\"hi\\\")\""
+        );
+    }
+
+    #[test]
+    fn empty_token_is_emitted_as_empty_quoted_pair() {
+        assert_eq!(cmdline_from_argv(&s(&["py", ""])), "py \"\"");
+    }
+
+    #[test]
+    fn trailing_backslashes_inside_quotes_are_doubled() {
+        // Path "C:\foo bar\" must serialise so the runtime parser sees
+        // a single trailing backslash, not an escaped closing quote.
+        assert_eq!(
+            cmdline_from_argv(&s(&["echo", "C:\\foo bar\\"])),
+            "echo \"C:\\foo bar\\\\\""
+        );
+    }
+
+    #[test]
+    fn backslashes_not_before_quote_are_not_doubled() {
+        assert_eq!(
+            cmdline_from_argv(&s(&["echo", "a\\b c"])),
+            "echo \"a\\b c\""
+        );
+    }
+
+    #[test]
+    fn windows_create_process_context_matches_legacy_helper() {
+        let argv = s(&["py", "hello world.py", "safe&whoami"]);
+
+        assert_eq!(
+            cmdline_from_argv_for_context(&argv, CommandLineContext::WindowsCreateProcess).unwrap(),
+            cmdline_from_argv(&argv)
+        );
+    }
+
+    #[test]
+    fn windows_cmd_context_quotes_metacharacters() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["echo", "safe&whoami"]),
+                CommandLineContext::WindowsCommandProcessor
+            )
+            .unwrap(),
+            "echo \"safe&whoami\""
+        );
+    }
+
+    #[test]
+    fn windows_cmd_context_rejects_percent_and_bang_expansion() {
+        let percent_err = cmdline_from_argv_for_context(
+            &s(&["echo", "%PATH%"]),
+            CommandLineContext::WindowsCommandProcessor,
+        )
+        .unwrap_err();
+        let bang_err = cmdline_from_argv_for_context(
+            &s(&["echo", "!PATH!"]),
+            CommandLineContext::WindowsCommandProcessor,
+        )
+        .unwrap_err();
+
+        assert!(percent_err.to_string().contains("must not contain"));
+        assert!(bang_err.to_string().contains("must not contain"));
+    }
+
+    #[test]
+    fn posix_shell_context_single_quotes_shell_metacharacters() {
+        assert_eq!(
+            cmdline_from_argv_for_context(
+                &s(&["echo", "safe&whoami"]),
+                CommandLineContext::PosixShell
+            )
+            .unwrap(),
+            "echo 'safe&whoami'"
+        );
+    }
+
+    #[test]
+    fn posix_shell_context_escapes_single_quotes() {
+        assert_eq!(
+            cmdline_from_argv_for_context(&s(&["echo", "can't"]), CommandLineContext::PosixShell)
+                .unwrap(),
+            "echo 'can'\\''t'"
+        );
+    }
+
+    #[test]
+    fn context_renderer_rejects_null_bytes() {
+        let err = cmdline_from_argv_for_context(
+            &["echo\0hidden".to_string()],
+            CommandLineContext::WindowsCreateProcess,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("null bytes"));
+    }
+}

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -352,6 +352,24 @@ fn parse_proxy_config(value: &serde_json::Value) -> Result<ProxyConfig, WxcError
     ))
 }
 
+/// Options for [`load_mxc_request_with_options`].
+///
+/// Kept as a struct (rather than additional positional arguments) so future
+/// loader-tuning knobs can be threaded through without re-spinning every
+/// caller.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoadOptions {
+    /// Treat `input` as a base64-encoded JSON blob rather than a file path.
+    pub is_base64: bool,
+    /// Allow `process.commandLine` to be absent or empty in the policy.
+    ///
+    /// The driver sets this when it has a CLI-provided command-line
+    /// override to splice into `script_code` after parsing. Without it,
+    /// missing/empty `commandLine` is a hard parse error in one-shot
+    /// and state-aware exec requests (matching the legacy contract).
+    pub allow_missing_command: bool,
+}
+
 /// Loads and parses a JSON-based code execution request.
 ///
 /// If `is_base64` is true, `input` is treated as a base64-encoded JSON string.
@@ -361,14 +379,31 @@ pub fn load_request(
     logger: &mut Logger,
     is_base64: bool,
 ) -> Result<CodexRequest, WxcError> {
-    let json_str = decode_request_input(input, logger, is_base64)?;
+    load_request_with_options(
+        input,
+        logger,
+        LoadOptions {
+            is_base64,
+            allow_missing_command: false,
+        },
+    )
+}
+
+/// Options-aware variant of [`load_request`] used by drivers that may
+/// override `process.commandLine` from the CLI. See [`LoadOptions`].
+pub fn load_request_with_options(
+    input: &str,
+    logger: &mut Logger,
+    opts: LoadOptions,
+) -> Result<CodexRequest, WxcError> {
+    let json_str = decode_request_input(input, logger, opts.is_base64)?;
 
     let raw: RawConfig = serde_json::from_str(&json_str).map_err(|e| {
         logger.log_line("Error parsing JSON");
         WxcError::ConfigParse(format!("JSON parse error: {}", e))
     })?;
 
-    convert_raw_config(raw, logger)
+    convert_raw_config_inner(raw, logger, true, opts.allow_missing_command)
 }
 
 /// Loads a request and routes to the one-shot or state-aware path based on
@@ -381,7 +416,27 @@ pub fn load_mxc_request(
     logger: &mut Logger,
     is_base64: bool,
 ) -> Result<MxcRequest, ParseError> {
-    let json_str = decode_request_input(input, logger, is_base64).map_err(ParseError::Decode)?;
+    load_mxc_request_with_options(
+        input,
+        logger,
+        LoadOptions {
+            is_base64,
+            allow_missing_command: false,
+        },
+    )
+}
+
+/// Options-aware variant of [`load_mxc_request`]. When
+/// `LoadOptions::allow_missing_command` is set, a missing or empty
+/// `process.commandLine` in the policy is tolerated and `script_code`
+/// is left empty for the driver to fill in from a CLI override.
+pub fn load_mxc_request_with_options(
+    input: &str,
+    logger: &mut Logger,
+    opts: LoadOptions,
+) -> Result<MxcRequest, ParseError> {
+    let json_str =
+        decode_request_input(input, logger, opts.is_base64).map_err(ParseError::Decode)?;
 
     let raw: RawMxcRequest = serde_json::from_str(&json_str).map_err(|e| {
         logger.log_line("Error parsing JSON");
@@ -389,12 +444,16 @@ pub fn load_mxc_request(
     })?;
 
     match raw {
-        RawMxcRequest::StateAware(state_aware) => convert_raw_state_aware(*state_aware, logger)
-            .map(MxcRequest::StateAware)
-            .map_err(|e| ParseError::StateAware(MxcError::malformed_request(e.to_string()))),
-        RawMxcRequest::OneShot(one_shot) => convert_raw_config(*one_shot, logger)
-            .map(MxcRequest::OneShot)
-            .map_err(ParseError::OneShot),
+        RawMxcRequest::StateAware(state_aware) => {
+            convert_raw_state_aware(*state_aware, logger, opts.allow_missing_command)
+                .map(MxcRequest::StateAware)
+                .map_err(|e| ParseError::StateAware(MxcError::malformed_request(e.to_string())))
+        }
+        RawMxcRequest::OneShot(one_shot) => {
+            convert_raw_config_inner(*one_shot, logger, true, opts.allow_missing_command)
+                .map(MxcRequest::OneShot)
+                .map_err(ParseError::OneShot)
+        }
     }
 }
 
@@ -523,17 +582,19 @@ fn validate_paths(paths: &[String], logger: &mut Logger) -> Result<(), WxcError>
 
 // ---------- Conversion from raw JSON to domain model ----------
 
-fn convert_raw_config(raw: RawConfig, logger: &mut Logger) -> Result<CodexRequest, WxcError> {
-    convert_raw_config_inner(raw, logger, true)
-}
-
 // `require_process = false` allows state-aware non-exec phases to omit the
 // `process` block entirely; those phases leave `script_code` / `working_directory`
 // / `script_timeout` / `env` at their defaults and never read them.
+//
+// `allow_missing_command` further relaxes the `require_process == true` arms
+// so that a CLI command-line override (provided by the driver after parsing)
+// can stand in for `process.commandLine`. When set, a missing or empty
+// `commandLine` is silently accepted and `script_code` is left empty.
 fn convert_raw_config_inner(
     raw: RawConfig,
     logger: &mut Logger,
     require_process: bool,
+    allow_missing_command: bool,
 ) -> Result<CodexRequest, WxcError> {
     // New top-level fields
     let schema_version = raw.version.unwrap_or_default();
@@ -541,18 +602,21 @@ fn convert_raw_config_inner(
     let platform = raw.platform.unwrap_or_else(|| "windows".to_string());
 
     // Process section: required for one-shot and for state-aware exec; absent
-    // is allowed for state-aware non-exec phases (require_process == false).
+    // is allowed for state-aware non-exec phases (require_process == false)
+    // or when the driver has signalled a CLI command-line override is
+    // present via `allow_missing_command`.
+    let command_required = require_process && !allow_missing_command;
     let (script_code, working_directory, script_timeout, env) = match raw.process {
         Some(process) => {
             let script_code = match process.command_line {
                 Some(s) if !s.is_empty() => s,
-                Some(_) if require_process => {
+                Some(_) if command_required => {
                     logger.log_line("process.commandLine cannot be empty");
                     return Err(WxcError::ConfigParse(
                         "process.commandLine cannot be empty".to_string(),
                     ));
                 }
-                None if require_process => {
+                None if command_required => {
                     logger.log_line("Missing required field: process.commandLine");
                     return Err(WxcError::ConfigParse(
                         "Missing required field: process.commandLine".to_string(),
@@ -576,7 +640,7 @@ fn convert_raw_config_inner(
                 process.env.unwrap_or_default(),
             )
         }
-        None if require_process => {
+        None if command_required => {
             return Err(WxcError::ConfigParse(
                 "'process' section is required".into(),
             ));
@@ -958,6 +1022,7 @@ fn convert_raw_config_inner(
 fn convert_raw_state_aware(
     raw: RawStateAwareRequest,
     logger: &mut Logger,
+    allow_missing_command: bool,
 ) -> Result<ParsedStateAwareRequest, WxcError> {
     let phase = Phase::from_wire(&raw.phase).map_err(|e| {
         let msg = e.message.clone();
@@ -992,7 +1057,8 @@ fn convert_raw_state_aware(
     };
 
     let require_process = phase == Phase::Exec;
-    let request = convert_raw_config_inner(surrogate, logger, require_process)?;
+    let request =
+        convert_raw_config_inner(surrogate, logger, require_process, allow_missing_command)?;
 
     Ok(ParsedStateAwareRequest {
         request,
@@ -1088,6 +1154,83 @@ mod tests {
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
         load_mxc_request(&encoded, &mut logger, true)
+    }
+
+    fn load_mxc_with_opts(json: &str, opts: LoadOptions) -> Result<MxcRequest, ParseError> {
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        load_mxc_request_with_options(
+            &encoded,
+            &mut logger,
+            LoadOptions {
+                is_base64: true,
+                ..opts
+            },
+        )
+    }
+
+    #[test]
+    fn allow_missing_command_lets_one_shot_skip_command_line() {
+        // No process.commandLine in the policy — without the flag this would
+        // be a parse error; with allow_missing_command set the parser yields
+        // an empty script_code for the driver to fill in.
+        let json = r#"{"process": {"cwd": "C:\\tmp"}}"#;
+        let opts = LoadOptions {
+            is_base64: true,
+            allow_missing_command: true,
+        };
+        match load_mxc_with_opts(json, opts).unwrap() {
+            MxcRequest::OneShot(req) => {
+                assert!(req.script_code.is_empty());
+                assert_eq!(req.working_directory, "C:\\tmp");
+            }
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        }
+    }
+
+    #[test]
+    fn allow_missing_command_lets_one_shot_skip_process_block_entirely() {
+        let json = r#"{"containment": "processcontainer"}"#;
+        let opts = LoadOptions {
+            is_base64: true,
+            allow_missing_command: true,
+        };
+        match load_mxc_with_opts(json, opts).unwrap() {
+            MxcRequest::OneShot(req) => assert!(req.script_code.is_empty()),
+            MxcRequest::StateAware(_) => panic!("expected one-shot"),
+        }
+    }
+
+    #[test]
+    fn allow_missing_command_lets_state_aware_exec_skip_command_line() {
+        let json = r#"{
+            "phase": "exec",
+            "sandboxId": "iso:abcd1234",
+            "process": {"cwd": "C:\\tmp"}
+        }"#;
+        let opts = LoadOptions {
+            is_base64: true,
+            allow_missing_command: true,
+        };
+        match load_mxc_with_opts(json, opts).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Exec);
+                assert!(p.request.script_code.is_empty());
+            }
+            MxcRequest::OneShot(_) => panic!("expected state-aware"),
+        }
+    }
+
+    #[test]
+    fn default_options_still_reject_missing_command_line() {
+        // Sanity: without the flag, the legacy contract holds — missing
+        // commandLine is a hard parse error.
+        let json = r#"{"process": {"cwd": "C:\\tmp"}}"#;
+        let opts = LoadOptions {
+            is_base64: true,
+            allow_missing_command: false,
+        };
+        assert!(load_mxc_with_opts(json, opts).is_err());
     }
 
     #[test]

--- a/src/wxc_common/src/lib.rs
+++ b/src/wxc_common/src/lib.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 // Platform-agnostic modules (shared by wxc-exec and lxc-exec)
+pub mod cmdline;
 pub mod config_parser;
 pub mod encoding;
 pub mod error;


### PR DESCRIPTION
## 📖 Description

Adds a CLI command override so callers can specify the process to run inside the container directly on the `wxc-exec` command line:

```powershell
wxc-exec policy.json -- python --version
```

Arguments after the `--` separator override `process.commandLine` from the policy file, making that policy field optional for one-shot runs and state-aware `exec` requests. Normal MXC flags before `--` continue to parse as MXC flags, so invocations like `wxc-exec policy.json --experimental --debug` are not mistaken for container commands.

This PR hardens that override path end-to-end:

- Preserve command arguments when using positional configs, `--config`, or `--config-base64`.
- Render CLI argv overrides with backend-appropriate command-line semantics for Windows CreateProcess, Windows shell-backed execution, and POSIX shell-backed execution.
- Reject unsafe/unsupported shell expansion cases for `cmd.exe` contexts instead of emitting command lines with different semantics.
- Restrict state-aware CLI command overrides to the `exec` phase.
- Add unit coverage for positional, named, base64, `--` separator, hyphenated arguments, policy-vs-CLI parity, shell escaping, and state-aware override behavior.

## 🔗 References

No linked issue.

## 🔍 Validation

- `cargo fmt --all -- --check`
- `cargo test -p wxc --bins`
- `cargo test -p wxc_common cmdline`
- `cargo test -p wxc_common allow_missing_command`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task
