### PR TITLE
User/saulg/fuzzer add cargo auth task

### DIFF
--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -32,19 +32,8 @@ jobs:
   steps:
     - checkout: self
 
-    # Keep all crate fetches going through the internal feed.
-    # Write to both project-level (for `cargo fuzz build`) and user-level
-    # (for `cargo install` which only reads $CARGO_HOME/config.toml).
-    - powershell: |
-        $feedConfig = Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"
-        Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + $feedConfig)
-        $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
-        New-Item -ItemType Directory -Force -Path $cargoHome | Out-Null
-        Add-Content -Path "$cargoHome\config.toml" -Value ("`n" + $feedConfig)
-      displayName: Setup Cargo Config
-
     # Install nightly Rust via rustup-init. The toolchain itself runs on the
-    # hosted agent only -- crates come from Mxc-Azure-Feed (see above).
+    # hosted agent only -- crates come from Mxc-Azure-Feed (see below).
     - powershell: |
         $rustupInit = "$env:TEMP\rustup-init.exe"
         Invoke-WebRequest -UseBasicParsing -Uri 'https://win.rustup.rs/x86_64' -OutFile $rustupInit
@@ -52,6 +41,18 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "rustup-init failed" }
         Write-Host "##vso[task.prependpath]$env:USERPROFILE\.cargo\bin"
       displayName: Install Rust nightly
+
+    # Keep all crate fetches going through the internal feed.
+    # Write to both project-level (for `cargo fuzz build`) and user-level
+    # (for `cargo install` which only reads $CARGO_HOME/config.toml).
+    # Runs AFTER rustup-init so the config isn't overwritten.
+    - powershell: |
+        $feedConfig = Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"
+        Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + $feedConfig)
+        $cargoHome = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { "$env:USERPROFILE\.cargo" }
+        New-Item -ItemType Directory -Force -Path $cargoHome | Out-Null
+        Add-Content -Path "$cargoHome\config.toml" -Value ("`n" + $feedConfig)
+      displayName: Setup Cargo Config
 
     - powershell: |
         rustc --version

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -45,7 +45,6 @@ jobs:
     # Keep all crate fetches going through the internal feed.
     # Write to both project-level (for `cargo fuzz build`) and user-level
     # (for `cargo install` which only reads $CARGO_HOME/config.toml).
-    # Runs AFTER rustup-init so the config isn't overwritten.
     - powershell: |
         $feedConfig = Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"
         Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + $feedConfig)
@@ -53,6 +52,10 @@ jobs:
         New-Item -ItemType Directory -Force -Path $cargoHome | Out-Null
         Add-Content -Path "$cargoHome\config.toml" -Value ("`n" + $feedConfig)
       displayName: Setup Cargo Config
+
+    - task: CargoAuthenticate@0
+      inputs:
+        configFile: '$(Build.SourcesDirectory)/.cargo/config.toml'
 
     - powershell: |
         rustc --version


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
failure at install cargo-fuzz task due to missing authentication. Before this it wasn't able to connect to the mxc-azure-feed feed and connection to index.crates.io is blocked.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/429)