### PR TITLE
Emit Detail field in LearningModeViolation ETW events

### DIFF
--- a/src/mxc_diagnostic_console/src/etw.rs
+++ b/src/mxc_diagnostic_console/src/etw.rs
@@ -481,7 +481,7 @@ fn format_learning_mode_violation(props: &[(String, String)], mode: DisplayMode)
 
     // In minified mode, show a reduced set of properties.
     let display_props = if mode == DisplayMode::Minified {
-        const MINIFIED_FIELDS: &[&str] = &["ProcessName", "Category", "Denied"];
+        const MINIFIED_FIELDS: &[&str] = &["ProcessName", "Category", "Denied", "Detail"];
         let mut filtered: Vec<(String, String)> = formatted_props
             .into_iter()
             .filter(|(k, _)| MINIFIED_FIELDS.contains(&k.as_str()))


### PR DESCRIPTION
## Summary

The `Detail` field of `LearningModeViolation` ETW events (Kernel-General, Event ID 27) was never surfaced in mxc-diagnostic-console because it was missing from the ETW manifest template.

**Root cause:** The C emitter (`sediag.c`) writes 6 descriptors including `Detail` (a UInt32 between Category and Denied), but the manifest (`SystemEvents.man`) only declared 5 fields, omitting Detail. TDH therefore never reported a Detail property to consumers.

**Changes:**
- Added `Detail` to the minified-mode field list in the diagnostic console

Closes #378
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/431)