### PR TITLE
Seatbelt: Add extraMachLookups escape hatch for additional Mach services

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -364,6 +364,14 @@ export interface SeatbeltConfig {
    * needs Keychain access.
    */
   keychainAccess?: boolean;
+  /**
+   * Additional Mach service global-names to allow `mach-lookup` for.
+   * Escape hatch for callers that need a specific system service the
+   * baseline doesn't cover (e.g. opt-in agent integrations). Each entry
+   * is rendered as `(global-name "...")` inside a single
+   * `(allow mach-lookup ...)` form.
+   */
+  extraMachLookups?: string[];
 }
 
 /**

--- a/src/seatbelt_common/src/profile_builder.rs
+++ b/src/seatbelt_common/src/profile_builder.rs
@@ -72,6 +72,7 @@ pub fn build_profile(request: &CodexRequest) -> Result<String, String> {
     write_network_rules(&mut out, request);
     write_nested_pty_rules(&mut out, request);
     write_keychain_rules(&mut out, request)?;
+    write_extra_seatbelt_rules(&mut out, request);
     write_ui_rules(&mut out, request);
 
     // Policy-derived deny rules go LAST so they win on conflict.
@@ -408,6 +409,24 @@ fn write_keychain_rules(out: &mut String, request: &CodexRequest) -> Result<(), 
     let _ = writeln!(out, "    (subpath {})", quote_scheme(&user_keychains));
     out.push_str("    (subpath \"/private/var/folders\"))\n");
     Ok(())
+}
+
+/// Emit caller-provided `extraMachLookups` rules: additional Mach service
+/// global-names the inner process may resolve. No-op when the list is empty.
+fn write_extra_seatbelt_rules(out: &mut String, request: &CodexRequest) {
+    let Some(sb) = request.experimental.seatbelt.as_ref() else {
+        return;
+    };
+    if sb.extra_mach_lookups.is_empty() {
+        return;
+    }
+
+    out.push_str(";; --- extraMachLookups: caller-provided Mach services ---\n");
+    out.push_str("(allow mach-lookup\n");
+    for name in &sb.extra_mach_lookups {
+        let _ = writeln!(out, "    (global-name {})", quote_scheme(name));
+    }
+    out.push_str(")\n");
 }
 
 /// Expand a leading `~` or `~/` to the current user's home directory.
@@ -883,5 +902,39 @@ mod tests {
             "missing user keychain subpath"
         );
         assert!(p.contains("(subpath \"/private/var/folders\")"));
+    }
+
+    #[test]
+    fn extra_mach_lookups_emits_grouped_allow_form() {
+        let mut r = req();
+        r.experimental.seatbelt = Some(SeatbeltConfig {
+            extra_mach_lookups: vec![
+                "com.apple.example.one".to_string(),
+                "com.apple.example.two".to_string(),
+            ],
+            ..Default::default()
+        });
+        let p = build_profile(&r).unwrap();
+        assert!(p.contains(";; --- extraMachLookups"));
+        assert!(p.contains("(allow mach-lookup\n    (global-name \"com.apple.example.one\")\n    (global-name \"com.apple.example.two\")\n)"));
+    }
+
+    #[test]
+    fn extra_mach_lookups_omitted_when_empty() {
+        let mut r = req();
+        r.experimental.seatbelt = Some(SeatbeltConfig::default());
+        let p = build_profile(&r).unwrap();
+        assert!(!p.contains("extraMachLookups"));
+    }
+
+    #[test]
+    fn extra_mach_lookups_escape_embedded_quotes() {
+        let mut r = req();
+        r.experimental.seatbelt = Some(SeatbeltConfig {
+            extra_mach_lookups: vec!["weird\"name".to_string()],
+            ..Default::default()
+        });
+        let p = build_profile(&r).unwrap();
+        assert!(p.contains("(global-name \"weird\\\"name\")"));
     }
 }

--- a/src/wxc_common/src/config_parser.rs
+++ b/src/wxc_common/src/config_parser.rs
@@ -185,6 +185,8 @@ struct RawSeatbelt {
     nested_pty: Option<bool>,
     #[serde(rename = "keychainAccess")]
     keychain_access: Option<bool>,
+    #[serde(rename = "extraMachLookups")]
+    extra_mach_lookups: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Default)]
@@ -916,6 +918,7 @@ fn convert_raw_config_inner(
             launch_method: raw_sb.launch_method.unwrap_or_default(),
             nested_pty: raw_sb.nested_pty.unwrap_or(true),
             keychain_access: raw_sb.keychain_access.unwrap_or(false),
+            extra_mach_lookups: raw_sb.extra_mach_lookups.unwrap_or_default(),
         });
         ExperimentalConfig {
             test,

--- a/src/wxc_common/src/models.rs
+++ b/src/wxc_common/src/models.rs
@@ -94,6 +94,18 @@ pub struct SeatbeltConfig {
     /// access.
     #[serde(rename = "keychainAccess", default)]
     pub keychain_access: bool,
+
+    /// Additional Mach service global-names to allow `mach-lookup` for.
+    /// Escape hatch for callers that need to talk to a system service
+    /// the baseline doesn't cover (e.g. opt-in agent integrations).
+    /// Each entry is rendered verbatim as a `(global-name "...")`
+    /// inside a single `(allow mach-lookup ...)` form.
+    #[serde(
+        rename = "extraMachLookups",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub extra_mach_lookups: Vec<String>,
 }
 
 fn default_true() -> bool {
@@ -108,6 +120,7 @@ impl Default for SeatbeltConfig {
             launch_method: LaunchMethod::default(),
             nested_pty: true,
             keychain_access: false,
+            extra_mach_lookups: Vec::new(),
         }
     }
 }


### PR DESCRIPTION

## 📖 Description
Lets callers grant access to specific Mach global-names without overriding the entire generated profile. Each entry is emitted as `(allow mach-lookup (global-name "…"))` and serialized as `extraMachLookups` in JSON / TS.

Useful when a sandboxed workload needs a Mach service that isn't in BASELINE_ALLOW (e.g. opendirectoryd for getpwuid, com.apple.security helpers, etc.) without granting the much broader `profileOverride` escape hatch.

Example of this would be adding:

- `com.apple.system.opendirectoryd.libinfo`
- `com.apple.system.opendirectoryd.membership`

So commands users can properly use `ssh-keygen`, `whoami`, etc.

Currently, this `whoami` says you are user id 501, but you cant use git commit, for example:

```console
$ git commit --allow-empty -m 'hi'
error: No user exists for uid 501?
fatal: failed to write commit object
```

With this we could add these 2 and then this should work.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/437)