### PR TITLE
Fix fuzz pipeline: force nightly toolchain for cargo fuzz

### DIFF
--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -39,6 +39,8 @@ jobs:
         Invoke-WebRequest -UseBasicParsing -Uri 'https://win.rustup.rs/x86_64' -OutFile $rustupInit
         & $rustupInit -y --profile minimal --default-toolchain $(rustNightly) --default-host x86_64-pc-windows-msvc
         if ($LASTEXITCODE -ne 0) { throw "rustup-init failed" }
+        # Ensure nightly is the default even if agent has a pre-existing stable toolchain.
+        rustup default $(rustNightly)
         Write-Host "##vso[task.prependpath]$env:USERPROFILE\.cargo\bin"
       displayName: Install Rust nightly
 
@@ -70,11 +72,11 @@ jobs:
         cd $(fuzzDir)
         foreach ($t in 'config_parser','base64_decode') {
           Write-Host "===== building $t ====="
-          cargo fuzz build $t --release
+          cargo +$(rustNightly) fuzz build $t --release
           if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for $t" }
         }
         Write-Host "===== building validator ====="
-        cargo fuzz build validator --release --features hyperlight,isolation_session
+        cargo +$(rustNightly) fuzz build validator --release --features hyperlight,isolation_session
         if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for validator" }
       displayName: Build fuzz targets (ASAN)
 

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -76,7 +76,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for $t" }
         }
         Write-Host "===== building validator ====="
-        cargo +$(rustNightly) fuzz build validator --release --features hyperlight,isolation_session
+        cargo +$(rustNightly) fuzz build validator --release --features hyperlight,isolation_session,microvm
         if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for validator" }
       displayName: Build fuzz targets (ASAN)
 

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -80,9 +80,15 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for validator" }
       displayName: Build fuzz targets (ASAN)
 
-    # Stage the OneFuzz drop directory: one subdir per fuzzer with the .exe,
-    # the OneFuzzConfig.json subset for that fuzzer, the ASAN runtime DLL,
-    # and the seed corpus.
+    # Stage the OneFuzz drop directory. OneFuzzConfig v3 requires a flat
+    # layout: OneFuzzConfig.json at the root, with each fuzzer's .exe / .pdb
+    # and the shared ASAN runtime DLL alongside it (referenced by simple
+    # name in `Fuzzer.FuzzingHarnessExecutableName` and `JobDependencies`).
+    # Seeds are not shipped in the drop in v3 — they must live in a OneFuzz
+    # storage container referenced via `OneFuzzJobs[].SeedCorpusContainer`.
+    # TODO: provision containers (`onefuzz containers create mxc-seeds-<target>`),
+    # upload `test_configs/*.json` (and `src/fuzz/corpus/base64_decode/*`),
+    # then add `SeedCorpusContainer` to each entry in OneFuzzConfig.json.
     - powershell: |
         $asanDir = (Get-ChildItem 'C:\Program Files\Microsoft Visual Studio' -Recurse -Filter 'clang_rt.asan_dynamic-x86_64.dll' -ErrorAction SilentlyContinue | Where-Object { $_.FullName -match 'HostX64\\x64\\clang_rt' } | Select-Object -First 1).Directory.FullName
         if (-not $asanDir) { throw "Could not locate clang_rt.asan_dynamic-x86_64.dll" }
@@ -90,16 +96,15 @@ jobs:
 
         New-Item -ItemType Directory -Force -Path '$(dropDir)' | Out-Null
         Copy-Item '$(fuzzDir)/OneFuzzConfig.json' '$(dropDir)/OneFuzzConfig.json'
+        Copy-Item "$asanDir/clang_rt.asan_dynamic-x86_64.dll" '$(dropDir)/'
 
         foreach ($t in 'config_parser','base64_decode','validator') {
-          $sub = "$(dropDir)/$t"
-          New-Item -ItemType Directory -Force -Path $sub, "$sub/corpus" | Out-Null
-          Copy-Item "$(fuzzTargetDir)/$t.exe" $sub
-          Copy-Item "$asanDir/clang_rt.asan_dynamic-x86_64.dll" $sub
-          if ($t -eq 'base64_decode') {
-            Copy-Item "$(fuzzDir)/corpus/$t/*" "$sub/corpus/" -Recurse
+          Copy-Item "$(fuzzTargetDir)/$t.exe" '$(dropDir)/'
+          $pdb = "$(fuzzTargetDir)/$t.pdb"
+          if (Test-Path $pdb) {
+            Copy-Item $pdb '$(dropDir)/'
           } else {
-            Copy-Item "$(Build.SourcesDirectory)/test_configs/*.json" "$sub/corpus/"
+            Write-Warning "PDB not found for $t at $pdb"
           }
         }
         Get-ChildItem -Recurse '$(dropDir)' | Select-Object FullName, Length

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -76,8 +76,15 @@ template (`.azure-pipelines/templates/Fuzz.Build.Job.yml`):
    `Mxc-Azure-Feed`, so all crate sources still come from the internal feed).
 2. Installs `cargo-fuzz`.
 3. Builds the three fuzz targets with `-Z sanitizer=address`.
-4. Stages an OneFuzz drop directory: one subdir per fuzzer with the `.exe`,
-   the ASAN runtime DLL, and the seed corpus.
+4. Stages an OneFuzz drop directory. The OneFuzzConfig v3 schema requires
+   a **flat layout**: `OneFuzzConfig.json` at the drop root with each
+   fuzzer's `.exe` / `.pdb` and the shared ASAN runtime DLL alongside it
+   (referenced by simple name in each entry's `Fuzzer.FuzzingHarnessExecutableName`
+   and `JobDependencies`). Seeds are **not** shipped in the drop in v3 —
+   they must live in an Azure storage container referenced via
+   `OneFuzzJobs[].SeedCorpusContainer` (`onefuzz containers create
+   mxc-seeds-<target>` + SAS upload). Until those containers are
+   provisioned, fuzzers bootstrap their corpus from scratch.
 5. Publishes the drop dir as a pipeline artifact (for debugging).
 6. Submits via `onefuzz-task@0` (skipped on PR builds).
 

--- a/src/fuzz/Cargo.toml
+++ b/src/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ cargo-fuzz = true
 # These pull in heavier deps so they're opt-in for local dev.
 hyperlight = ["wxc_common/hyperlight"]
 isolation_session = ["wxc_common/isolation_session"]
+microvm = ["wxc_common/microvm"]
 
 [dependencies]
 libfuzzer-sys = "0.4"

--- a/src/fuzz/OneFuzzConfig.json
+++ b/src/fuzz/OneFuzzConfig.json
@@ -3,25 +3,19 @@
   "Entries": [
     {
       "JobNotificationEmail": "anisk@microsoft.com",
-      "FuzzerProperties": {
-        "Fuzzer": {
-          "$type": "libfuzzer"
-        },
-        "FuzzerExe": "config_parser\\config_parser.exe",
-        "JobDependencies": [
-          "config_parser\\clang_rt.asan_dynamic-x86_64.dll"
-        ],
-        "Seeds": [
-          {
-            "Path": "config_parser\\corpus"
-          }
-        ]
+      "Fuzzer": {
+        "$type": "libfuzzer",
+        "FuzzingHarnessExecutableName": "config_parser.exe"
       },
+      "JobDependencies": [
+        "config_parser.exe",
+        "config_parser.pdb",
+        "clang_rt.asan_dynamic-x86_64.dll"
+      ],
       "OneFuzzJobs": [
         {
           "ProjectName": "MXC",
-          "TargetName": "config_parser",
-          "EnableMicrosoftTelemetry": true
+          "TargetName": "config_parser"
         }
       ],
       "AdoTemplate": {
@@ -30,35 +24,25 @@
         "AreaPath": "OS\\Windows Client and Services\\WinPD\\AgOS-Agentic Platform\\Agent Runtime\\Tessera",
         "IterationPath": "OS\\Future",
         "AssignedTo": "anisk@microsoft.com",
-        "TemplateName": "Bug"
+        "Type": "Bug"
       },
-      "CodeReviewers": {
-        "Required": ["anisk@microsoft.com"],
-        "Optional": []
-      },
-      "SdlTaskId": 62294501
+      "SdlWorkItemId": 62294501
     },
     {
       "JobNotificationEmail": "anisk@microsoft.com",
-      "FuzzerProperties": {
-        "Fuzzer": {
-          "$type": "libfuzzer"
-        },
-        "FuzzerExe": "base64_decode\\base64_decode.exe",
-        "JobDependencies": [
-          "base64_decode\\clang_rt.asan_dynamic-x86_64.dll"
-        ],
-        "Seeds": [
-          {
-            "Path": "base64_decode\\corpus"
-          }
-        ]
+      "Fuzzer": {
+        "$type": "libfuzzer",
+        "FuzzingHarnessExecutableName": "base64_decode.exe"
       },
+      "JobDependencies": [
+        "base64_decode.exe",
+        "base64_decode.pdb",
+        "clang_rt.asan_dynamic-x86_64.dll"
+      ],
       "OneFuzzJobs": [
         {
           "ProjectName": "MXC",
-          "TargetName": "base64_decode",
-          "EnableMicrosoftTelemetry": true
+          "TargetName": "base64_decode"
         }
       ],
       "AdoTemplate": {
@@ -67,35 +51,25 @@
         "AreaPath": "OS\\Windows Client and Services\\WinPD\\AgOS-Agentic Platform\\Agent Runtime\\Tessera",
         "IterationPath": "OS\\Future",
         "AssignedTo": "anisk@microsoft.com",
-        "TemplateName": "Bug"
+        "Type": "Bug"
       },
-      "CodeReviewers": {
-        "Required": ["anisk@microsoft.com"],
-        "Optional": []
-      },
-      "SdlTaskId": 62294501
+      "SdlWorkItemId": 62294501
     },
     {
       "JobNotificationEmail": "anisk@microsoft.com",
-      "FuzzerProperties": {
-        "Fuzzer": {
-          "$type": "libfuzzer"
-        },
-        "FuzzerExe": "validator\\validator.exe",
-        "JobDependencies": [
-          "validator\\clang_rt.asan_dynamic-x86_64.dll"
-        ],
-        "Seeds": [
-          {
-            "Path": "validator\\corpus"
-          }
-        ]
+      "Fuzzer": {
+        "$type": "libfuzzer",
+        "FuzzingHarnessExecutableName": "validator.exe"
       },
+      "JobDependencies": [
+        "validator.exe",
+        "validator.pdb",
+        "clang_rt.asan_dynamic-x86_64.dll"
+      ],
       "OneFuzzJobs": [
         {
           "ProjectName": "MXC",
-          "TargetName": "validator",
-          "EnableMicrosoftTelemetry": true
+          "TargetName": "validator"
         }
       ],
       "AdoTemplate": {
@@ -104,13 +78,9 @@
         "AreaPath": "OS\\Windows Client and Services\\WinPD\\AgOS-Agentic Platform\\Agent Runtime\\Tessera",
         "IterationPath": "OS\\Future",
         "AssignedTo": "anisk@microsoft.com",
-        "TemplateName": "Bug"
+        "Type": "Bug"
       },
-      "CodeReviewers": {
-        "Required": ["anisk@microsoft.com"],
-        "Optional": []
-      },
-      "SdlTaskId": 62294501
+      "SdlWorkItemId": 62294501
     }
   ]
 }

--- a/src/fuzz/OneFuzzConfig.json
+++ b/src/fuzz/OneFuzzConfig.json
@@ -1,5 +1,4 @@
 {
-  "$comment": "OneFuzz job manifest for the mxc_fuzz crate. Validated by the OIP tool in the Fuzz pipeline. SDL work item: 62294501.",
   "ConfigVersion": 3,
   "Entries": [
     {

--- a/src/fuzz/fuzz_targets/validator.rs
+++ b/src/fuzz/fuzz_targets/validator.rs
@@ -34,6 +34,7 @@ fuzz_target!(|data: &[u8]| {
         // Dispatch to runner-specific validation based on backend.
         #[cfg(target_os = "windows")]
         match req.containment {
+            #[cfg(feature = "microvm")]
             ContainmentBackend::MicroVm => {
                 let runner = wxc_common::nanvix_runner::NanVixScriptRunner::new();
                 let _ = runner.validate_runner(&req);
@@ -46,7 +47,7 @@ fuzz_target!(|data: &[u8]| {
             #[cfg(feature = "isolation_session")]
             ContainmentBackend::IsolationSession => {
                 let runner =
-                    wxc_common::isolation_session_runner::IsolationSessionRunner::new();
+                    wxc_common::isolation_session::IsolationSessionRunner::new();
                 let _ = runner.validate_runner(&req);
             }
             _ => {}


### PR DESCRIPTION
The hosted agent has a pre-existing stable Rust (1.93) set as default. rustup-init detects the existing settings.toml and preserves the old default instead of switching to nightly. This causes cargo fuzz build to fail with '-Z is only accepted on the nightly compiler'.

Fix by:
1. Running 'rustup default nightly' after init to override agent default
2. Using 'cargo +nightly fuzz build' for explicit toolchain selection

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/438)