### PR TITLE
ci: stop shipping `tier2_bfs` in ADO-built release binaries

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -132,11 +132,7 @@ jobs:
           # binary still carries every runtime backend except `tier2_bfs`.
           # Schema reference: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust-virtual-task
           allFeatures: false
-          activatedFeatures:
-            - hyperlight
-            - isolation_session
-            - microvm
-            - wslc
+          activatedFeatures: 'hyperlight isolation_session microvm wslc'
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -130,18 +130,13 @@ jobs:
           # and `test_scripts/Win25H2Safe-Tests.ps1` for the safety model.
           # Enumerate the production feature set explicitly so the shipped
           # binary still carries every runtime backend except `tier2_bfs`.
-          #
-          # Shotgun across candidate input names while we identify which one
-          # the 1ES Rust task actually consumes (the task's source is internal
-          # and not browsable). Unknown inputs are silently ignored by the
-          # 1ES PT task layer, so listing several candidates is safe; once we
-          # know the canonical name we'll collapse this to a single key.
+          # Schema reference: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust-virtual-task
           allFeatures: false
-          features: 'hyperlight isolation_session microvm wslc'
-          cargoFeatures: 'hyperlight isolation_session microvm wslc'
-          featureList: 'hyperlight isolation_session microvm wslc'
-          enabledFeatures: 'hyperlight isolation_session microvm wslc'
-          extraArgs: '--features "hyperlight isolation_session microvm wslc"'
+          activatedFeatures:
+            - hyperlight
+            - isolation_session
+            - microvm
+            - wslc
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -130,8 +130,18 @@ jobs:
           # and `test_scripts/Win25H2Safe-Tests.ps1` for the safety model.
           # Enumerate the production feature set explicitly so the shipped
           # binary still carries every runtime backend except `tier2_bfs`.
+          #
+          # Shotgun across candidate input names while we identify which one
+          # the 1ES Rust task actually consumes (the task's source is internal
+          # and not browsable). Unknown inputs are silently ignored by the
+          # 1ES PT task layer, so listing several candidates is safe; once we
+          # know the canonical name we'll collapse this to a single key.
           allFeatures: false
           features: 'hyperlight isolation_session microvm wslc'
+          cargoFeatures: 'hyperlight isolation_session microvm wslc'
+          featureList: 'hyperlight isolation_session microvm wslc'
+          enabledFeatures: 'hyperlight isolation_session microvm wslc'
+          extraArgs: '--features "hyperlight isolation_session microvm wslc"'
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -132,7 +132,10 @@ jobs:
           # binary still carries every runtime backend except `tier2_bfs`.
           # Schema reference: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust-virtual-task
           allFeatures: false
-          activatedFeatures: 'hyperlight isolation_session microvm wslc'
+          ${{ if eq(item.os, 'windows') }}:
+            activatedFeatures: 'hyperlight isolation_session microvm wslc'
+          ${{ if eq(item.os, 'linux') }}:
+            activatedFeatures: 'hyperlight'
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -122,6 +122,16 @@ jobs:
           useNextest: false
           testAllTargets: false
           buildAllTargets: false
+          # IMPORTANT: do not let the 1ES task default to `--all-features`. The
+          # `tier2_bfs` Cargo feature gates Tier 2 (BFS) and must NOT be
+          # compiled into production binaries on Win 11 25H2 (the embedded
+          # `bfscfg.exe` invocation risks an OS hang). See
+          # `.github/workflows/build.yml`, `test_scripts/T3-Workloads.ps1`,
+          # and `test_scripts/Win25H2Safe-Tests.ps1` for the safety model.
+          # Enumerate the production feature set explicitly so the shipped
+          # binary still carries every runtime backend except `tier2_bfs`.
+          allFeatures: false
+          features: 'hyperlight isolation_session microvm wslc'
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it


### PR DESCRIPTION
## Summary

The ADO build was implicitly passing `--all-features` to `1ES.Build.Rust.Run@1`, which has been the default behaviour of that task ever since we adopted it (commit 8875d40, 2026-03-25). That stayed harmless until commit 8c57211 (2026-05-25, merged via #410) introduced a new Cargo feature called `tier2_bfs`, which gates an OS-hang risk on Win 11 25H2 via `bfscfg.exe` and explicitly must not ship in production. Since then, every ADO-built release binary has shipped with `tier2_bfs` compiled in — exactly the configuration that the preflight scripts in `test_scripts/T3-Workloads.ps1` and `test_scripts/Win25H2Safe-Tests.ps1` are designed to refuse to run.

This PR pins the feature set explicitly on the `1ES.Build.Rust.Run@1` build task in `.azure-pipelines/templates/Rust.Build.Job.yml` so the task no longer falls through to its `--all-features` default. The feature lists are scoped by OS to match the actual feature definitions in each crate;

* Windows (WXC): `hyperlight isolation_session microvm wslc`
* Linux (LXC): `hyperlight`

The Cargo task input names took some iteration to nail down. The 1ES Rust virtual task documents `features.allFeatures` and `features.activatedFeatures` in `features.X` notation, but at the actual task `inputs:` level they are flat keys `allFeatures` and `activatedFeatures`, and `activatedFeatures` is a scalar string at the YAML schema layer (despite being documented `string[]`) — the 1ES task splits it internally. Reference; https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust-virtual-task

## Testing

Verified on ADO build 148042154 (PR check run on this branch): all 16 jobs green, total pipeline 28.7 min. The four cargo build invocations now report exactly the expected feature sets;

* Build (x64 WXC) — `cargo build ... --features hyperlight isolation_session microvm wslc`
* Build (arm64 WXC) — `cargo build ... --features hyperlight isolation_session microvm wslc`
* Build (x64 LXC) — `cargo build ... --features hyperlight`
* Build (arm64 LXC) — `cargo build ... --features hyperlight`

No `--all-features` and no `tier2_bfs` in any of them. Critical-path job `Build (x64 WXC)` ran in 13.4 min.

Closes #442