### PR TITLE
BaseContainer: retry without environment on ERROR_NOT_SUPPORTED (0x32)

### DIFF
--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -22,7 +22,10 @@ use windows::Win32::System::Threading::{
 };
 use windows_core::PCWSTR;
 
-use crate::launch_diagnostics::{diagnose_create_process_failure, diagnose_process_exit};
+use crate::launch_diagnostics::{
+    diagnose_create_process_failure, diagnose_environment_not_supported, diagnose_process_exit,
+    is_environment_not_supported,
+};
 use crate::log_symbols::{
     EMOJI_ALLOWED, EMOJI_BLOCKED, EMOJI_NEUTRAL, EMOJI_SECTION, EMOJI_WARNING,
 };
@@ -560,6 +563,7 @@ impl ScriptRunner for BaseContainerRunner {
             cb: std::mem::size_of::<STARTUPINFOW>() as u32,
             ..unsafe { std::mem::zeroed() }
         };
+        #[allow(unused_assignments)]
         let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
 
         // Environment block for the sandboxed child.
@@ -612,22 +616,72 @@ impl ScriptRunner for BaseContainerRunner {
         }
 
         // 4. Call Experimental_CreateProcessInSandbox.
-        let success = unsafe {
-            create_process_in_sandbox(
-                ptr::null(),             // applicationName (resolved from commandLine)
-                cmd_wide.as_mut_ptr(),   // commandLine
-                ptr::null(),             // processAttributes (must be NULL)
-                ptr::null(),             // threadAttributes  (must be NULL)
-                0,                       // inheritHandles    (must be FALSE)
-                creation_flags,          // creationFlags
-                env_ptr,                 // environment
-                cwd_ptr,                 // currentDirectory
-                &si,                     // startupInfo
-                identity_wide.as_ptr(),  // identity
-                spec_bytes.as_ptr(),     // sandboxSpecification
-                spec_bytes.len() as u32, // sandboxSpecificationSize
-                &mut pi,                 // processInformation
-            )
+        //    If the OS returns ERROR_NOT_SUPPORTED (0x32) and we passed a non-null
+        //    environment block, this is a downlevel build that doesn't support the
+        //    `environment` parameter. Retry once without it.
+        let mut current_env_ptr = env_ptr;
+        let mut current_creation_flags = creation_flags;
+        let mut retries_remaining: u32 = 1;
+
+        // The loop yields (api_return_code, last_win32_error_on_failure).
+        let (success, last_error) = loop {
+            pi = unsafe { std::mem::zeroed() };
+
+            let result = unsafe {
+                create_process_in_sandbox(
+                    ptr::null(),             // applicationName (resolved from commandLine)
+                    cmd_wide.as_mut_ptr(),   // commandLine
+                    ptr::null(),             // processAttributes (must be NULL)
+                    ptr::null(),             // threadAttributes  (must be NULL)
+                    0,                       // inheritHandles    (must be FALSE)
+                    current_creation_flags,  // creationFlags
+                    current_env_ptr,         // environment
+                    cwd_ptr,                 // currentDirectory
+                    &si,                     // startupInfo
+                    identity_wide.as_ptr(),  // identity
+                    spec_bytes.as_ptr(),     // sandboxSpecification
+                    spec_bytes.len() as u32, // sandboxSpecificationSize
+                    &mut pi,                 // processInformation
+                )
+            };
+
+            if result != 0 {
+                break (result, None);
+            }
+
+            // Call failed -- capture the error before any handle cleanup.
+            let err = unsafe { GetLastError() };
+
+            if retries_remaining > 0
+                && is_environment_not_supported(err.0, !current_env_ptr.is_null())
+            {
+                retries_remaining -= 1;
+
+                // Clean up handles from the failed attempt.
+                unsafe {
+                    if !pi.hProcess.is_invalid() {
+                        let _ = CloseHandle(pi.hProcess);
+                    }
+                    if !pi.hThread.is_invalid() {
+                        let _ = CloseHandle(pi.hThread);
+                    }
+                }
+
+                let diag = diagnose_environment_not_supported();
+                let _ = writeln!(
+                    logger,
+                    "{EMOJI_WARNING} Launch diagnostic [{}]: {}",
+                    diag.kind, diag.message
+                );
+
+                // Retry without the environment block.
+                current_env_ptr = ptr::null();
+                current_creation_flags = 0;
+                continue;
+            }
+
+            // Non-retryable failure.
+            break (result, Some(err));
         };
 
         if success == 0 {
@@ -654,7 +708,7 @@ impl ScriptRunner for BaseContainerRunner {
             //
             // Diagnose the launch failure (FailurePhase::LaunchFailed).
             //
-            let err = unsafe { GetLastError() };
+            let err = last_error.unwrap_or_else(|| unsafe { GetLastError() });
             let diag = diagnose_create_process_failure(
                 err.0,
                 &request.script_code,

--- a/src/wxc_common/src/launch_diagnostics.rs
+++ b/src/wxc_common/src/launch_diagnostics.rs
@@ -61,6 +61,24 @@ pub fn diagnose_create_process_failure(
     }
 }
 
+/// Returns `true` when the Win32 error is `ERROR_NOT_SUPPORTED` (0x32) and
+/// the caller passed a non-null environment block. Downlevel OS builds that
+/// predate environment-parameter support in `Experimental_CreateProcessInSandbox`
+/// surface this error; the caller should retry without the environment block.
+pub fn is_environment_not_supported(win32_error: u32, has_environment: bool) -> bool {
+    win32_error == ERROR_NOT_SUPPORTED.0 && has_environment
+}
+
+/// Produce a [`LaunchDiagnostic`] for the environment-not-supported case.
+pub fn diagnose_environment_not_supported() -> LaunchDiagnostic {
+    LaunchDiagnostic {
+        kind: "environment_not_supported_downlevel",
+        message: "WARNING: The `environment` parameter is not supported on this OS build. \
+                  Retrying without explicit environment variables."
+            .to_string(),
+    }
+}
+
 /// Diagnose a process that launched successfully but exited with a non-zero
 /// code. Returns `None` when no recognized condition matches.
 pub fn diagnose_process_exit(
@@ -89,7 +107,9 @@ const REQUIRED_VELOCITY_KEYS: &[(u32, &str)] = &[
 // are re-exported from the `windows` crate. Comparisons against them
 // flow through `u32`, which matches the existing public surface of
 // this module (`diagnose_create_process_failure` takes `u32`).
-use windows::Win32::Foundation::{ERROR_CALL_NOT_IMPLEMENTED, E_NOTIMPL, STATUS_DLL_INIT_FAILED};
+use windows::Win32::Foundation::{
+    ERROR_CALL_NOT_IMPLEMENTED, ERROR_NOT_SUPPORTED, E_NOTIMPL, STATUS_DLL_INIT_FAILED,
+};
 
 // -- Internal heuristics -----------------------------------------------------
 


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [\.github/copilot-instructions.md\](.github/copilot-instructions.md).

-----

## Summary

Downlevel OS builds that predate environment-parameter support in `Experimental_CreateProcessInSandbox` return `ERROR_NOT_SUPPORTED` (50 / 0x32) when a non-null environment block is passed.

This PR:
1. Adds a new diagnostic kind (`environment_not_supported_downlevel`) in `launch_diagnostics.rs` that detects error 0x32 with a non-null environment pointer.
2. Wraps the `Experimental_CreateProcessInSandbox` call in `base_container_runner.rs` with a retry loop that, on detecting this condition, logs a WARNING diagnostic and retries once without the environment block.
3. Limits retries to 1 to prevent infinite loops.
4. Preserves `GetLastError()` before any handle cleanup to avoid losing the original error code on non-retryable failures.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/444)