### PR TITLE
Add PR doc to explain what Microsoft employees need to do to run PR builds

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,8 @@
 - [ ] Bug fix
 - [ ] Feature
 - [ ] Task
+
+---
+
+Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
+to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,8 @@ PowerShell and shell helper scripts that drive the executor end-to-end live unde
 
 When the change is ready, mark the Draft PR as **Ready for Review**. The PR template asks you to confirm CLA acceptance and to update [`.github/copilot-instructions.md`](./.github/copilot-instructions.md) if your change affects build commands, project architecture, or key conventions.
 
+PR builds don't run automatically — Microsoft ADO policy requires a Microsoft employee to comment `/azp run` to start the `MXC-PR-Build` pipeline. See [`docs/pull-requests.md`](./docs/pull-requests.md) for details.
+
 Reviewers will look for:
 
 * Correctness and security — MXC is a sandboxing system, so containment policy changes get extra scrutiny.

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,0 +1,10 @@
+To start the pull request build pipeline on any PR into main, a Microsoft employee must comment
+on the pull request. The comment must only contain `/azp run`. This will signal to the azure-pipelines
+bot to start the PR build pipeline.
+
+Name of the PR build pipeline:
+
+- `MXC-PR-Build`
+
+To check the status of this pipeline in Azure DevOps you can navigate to 
+[MXC-PR-Build](https://microsoft.visualstudio.com/Dart/_build?definitionId=192146).

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -1,6 +1,9 @@
-To start the pull request build pipeline on any PR into main, a Microsoft employee must comment
-on the pull request. The comment must only contain `/azp run`. This will signal to the azure-pipelines
-bot to start the PR build pipeline.
+Microsoft ADO policy disables automatic PR-build runs to prevent unreviewed
+code (e.g. from external forks) from executing on internal pipeline agents.
+To start the pull request build pipeline on any PR into `main`, a Microsoft
+employee must comment on the pull request. The comment must only contain
+`/azp run`. This will signal to the azure-pipelines bot to start the PR build
+pipeline.
 
 Name of the PR build pipeline:
 


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Due to Microsoft ADO policy auto running PR pipelines is not allowed. A Microsoft employee is required to comment and run the build. This prevents forks from non-Microsoft folks from auto running PR builds with malicious content. 

This PR adds a pull request doc to explain how Microsoft employees can start PR builds. This is the same as other repositories that use ADO pipelines like WinAppSDK: E.g https://github.com/microsoft/WindowsAppSDK/pull/6474 for example.

TLDR: Microsoft employees only need to comment on a PR with `/azp run` and the azure pipeline bot will start the PR pipeline.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/452)