### PR TITLE
Drop Tessera codename from user-facing surfaces

### DIFF
--- a/docs/base-process-container/UIPolicy_Schema.md
+++ b/docs/base-process-container/UIPolicy_Schema.md
@@ -13,7 +13,7 @@ The `"ui"` section of the MXC container configuration controls how a contained p
 - **Job Object UI Restrictions**
 - **Process Mitigation: Win32k System Call Disable** (`PROCESS_MITIGATION_SYSTEM_CALL_DISABLE_POLICY`)
 
-Developers declare *what the process is allowed to do* — Tessera translates that into the correct kernel flags and mitigations.
+Developers declare *what the process is allowed to do* — the OS-side sandbox layer translates that into the correct kernel flags and mitigations.
 
 ### Design Principles
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -6,7 +6,7 @@ A unified diagnostic view across every layer of the MXC stack:
 |-------|--------|--------------|
 | **SDK** | `mxc-sdk` (TypeScript) | SDK version, policy construction |
 | **Runtime** | `wxc-exec.exe` (Rust) | Input config, parsed request, sandbox spec, process lifecycle, timing |
-| **OS** | Tessera ETW provider | Kernel-side sandbox creation and validation events |
+| **OS** | MXC OS-side ETW provider | Kernel-side sandbox creation and validation events |
 | **Internals** | Kernel-General ETW (learning mode) | Access checks that would have been denied, logged instead of blocked |
 
 All layers stream into a single `mxc-diagnostic-console.exe` window in real time.
@@ -81,7 +81,7 @@ mxc-diagnostic-console.exe | Tee-Object -Encoding ascii -FilePath out.log
 
 ### ETW Tracing
 
-The console captures ETW events from the Tessera provider and Kernel-General
+The console captures ETW events from the MXC OS-side provider and Kernel-General
 learning-mode access check events. **Admin privileges required** for ETW; pipe
 messages work without elevation.
 

--- a/src/mxc_diagnostic_console/src/etw.rs
+++ b/src/mxc_diagnostic_console/src/etw.rs
@@ -4,7 +4,7 @@
 //! Real-time ETW consumer for MXC diagnostic providers.
 //!
 //! Listens for events from:
-//! - **Tessera** TraceLogging provider (all events)
+//! - **MXC OS-side** TraceLogging provider (all events)
 //! - **Microsoft-Windows-Kernel-General** (all events -- AccessCheckLog, AppContainerTokenCheckLog,
 //!   TokenSidManagementLog, learning-mode violations, etc.)
 //!
@@ -31,8 +31,8 @@ use super::{collect_mode, display_mode, DisplayEvent, DisplayMode};
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Tessera TraceLogging provider GUID: {f6ec123e-314e-400b-9e0a-151365e23083}
-const TESSERA_PROVIDER: GUID = GUID {
+/// MXC OS-side TraceLogging provider GUID: {f6ec123e-314e-400b-9e0a-151365e23083}
+const MXC_OS_PROVIDER: GUID = GUID {
     data1: 0xf6ec123e,
     data2: 0x314e,
     data3: 0x400b,
@@ -85,7 +85,7 @@ unsafe impl Send for SendPtr {}
 
 /// Start the ETW listener for diagnostic providers.
 ///
-/// Enables the Tessera TraceLogging provider and the Kernel-General provider
+/// Enables the MXC OS-side TraceLogging provider and the Kernel-General provider
 /// (all events for learning-mode diagnostics).
 /// Spawns a background thread that calls `ProcessTrace` (blocking). Returns
 /// immediately on success. Events are delivered via `tx`.
@@ -175,11 +175,11 @@ fn enable_provider(session_handle: u64) -> Result<(), String> {
         Value: session_handle,
     };
 
-    // Enable the Tessera TraceLogging provider (all keywords, Verbose).
+    // Enable the MXC OS-side TraceLogging provider (all keywords, Verbose).
     let status = unsafe {
         EnableTraceEx2(
             h,
-            &TESSERA_PROVIDER,
+            &MXC_OS_PROVIDER,
             1, // EVENT_CONTROL_CODE_ENABLE_PROVIDER
             TRACE_LEVEL_VERBOSE as u8,
             0xFFFF_FFFF_FFFF_FFFF, // all keywords
@@ -191,7 +191,7 @@ fn enable_provider(session_handle: u64) -> Result<(), String> {
 
     if status != WIN32_ERROR(0) {
         return Err(format!(
-            "EnableTraceEx2 (Tessera) failed: error {}",
+            "EnableTraceEx2 (MXC OS provider) failed: error {}",
             status.0
         ));
     }
@@ -211,7 +211,7 @@ fn enable_provider(session_handle: u64) -> Result<(), String> {
     };
 
     if status != WIN32_ERROR(0) {
-        // Non-fatal: warn but continue (Tessera provider is already enabled).
+        // Non-fatal: warn but continue (MXC OS-side provider is already enabled).
         eprintln!(
             "[ETW] Warning: EnableTraceEx2 (Kernel-General) failed: error {}",
             status.0
@@ -296,8 +296,8 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
     let event = unsafe { &*event_record };
     let provider = event.EventHeader.ProviderId;
 
-    if provider == TESSERA_PROVIDER {
-        // Tessera: accept all events.
+    if provider == MXC_OS_PROVIDER {
+        // MXC OS-side: accept all events.
     } else if provider == KERNEL_GENERAL_PROVIDER {
         // Kernel-General: accept all events (AccessCheckLog, AppContainerTokenCheckLog,
         // TokenSidManagementLog, learning-mode violations, etc.).

--- a/src/mxc_diagnostic_console/src/main.rs
+++ b/src/mxc_diagnostic_console/src/main.rs
@@ -92,7 +92,7 @@ enum DisplayEvent {
     Message { pid: u32, text: String },
     /// A client disconnected.
     Disconnected { pid: u32 },
-    /// An ETW event from the Tessera provider.
+    /// An ETW event from the MXC OS-side provider.
     EtwEvent {
         pid: u32,
         text: String,
@@ -254,7 +254,7 @@ fn main() {
             w = W - 39
         );
         println!("{blank}");
-        line("  ETW event capture (Tessera + learning mode events) requires administrator privileges.");
+        line("  ETW event capture (MXC OS provider + learning mode events) requires administrator privileges.");
         line("  Pipe-based log messages from wxc-exec will still work without elevation.");
         println!("{blank}");
         println!("{y}╚{bar}╝{r}");

--- a/src/wxc_common/src/sandbox_tracking.rs
+++ b/src/wxc_common/src/sandbox_tracking.rs
@@ -40,7 +40,7 @@ const TRACKING_BASE: &str = "Software\\Classes\\Local Settings\\Software\\Micros
 /// Generate a unique sandbox identity string: `sandbox-{16 lowercase hex chars}`.
 ///
 /// Uses 8 bytes of CSPRNG randomness (64 bits), matching the format specified
-/// in the Tessera sandbox lifecycle design.
+/// in the MXC sandbox lifecycle design.
 pub fn generate_sandbox_identity() -> String {
     let mut buf = [0u8; 8];
     getrandom::getrandom(&mut buf).expect("OS getrandom call failed");

--- a/src/wxc_host_prep/src/null_device/mod.rs
+++ b/src/wxc_host_prep/src/null_device/mod.rs
@@ -3,7 +3,7 @@
 
 //! Reapply the documented security descriptor on `\Device\Null`.
 //!
-//! See `set-null-acl-plan.md` (Tessera) for full background. Briefly:
+//! See `set-null-acl-plan.md` (internal design doc) for full background. Briefly:
 //! on downlevel Windows builds that pre-date the
 //! `Feature_AgenticAppContainerBfsSupport` ship, AppContainer / LPAC
 //! processes cannot open `\Device\Null` — every tool that writes to


### PR DESCRIPTION
Tessera is the Microsoft-internal Windows OS-team codename for the kernel-side sandbox layer that MXC drives. It should not appear in the public microsoft/mxc repo's user-facing surfaces.

This change scrubs the codename from: (1) two public docs (docs/diagnostics.md and docs/base-process-container/UIPolicy_Schema.md), (2) two user-visible strings printed by mxc-diagnostic-console.exe (the help line and the EnableTraceEx2 error message), and (3) source-code comments and a constant identifier (TESSERA_PROVIDER -> MXC_OS_PROVIDER) across mxc_diagnostic_console, wxc_host_prep, and wxc_common. The ETW provider GUID is unchanged; the OS still emits events under the same identity. Only prose / symbol names on the MXC side change.

Pipeline-internal references in .azure-pipelines/templates/Vpack.Package.Job.yml (vpack owner alias) and src/fuzz/OneFuzzConfig.json (ADO AreaPath for bug routing) are intentionally kept, matching the convention used by other microsoft/* OSS repos (PowerToys, winget-cli).

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/453)