### PR TITLE
Probe: report Tier 3 (not Tier 2) when BFS is compiled out, with host-prep warnings

### DIFF
--- a/docs/host-prep.md
+++ b/docs/host-prep.md
@@ -33,6 +33,27 @@ All subcommands require elevation. The binary aborts with exit code
 `65` and a clear message if launched without an elevated token (e.g.
 running a debug build directly without `Run as Administrator`).
 
+### When does MXC need these?
+
+The system-drive and null-device preparations matter for the
+**AppContainer + DACL** isolation tier (Tier 3), which MXC selects on
+hosts without the in-process BaseContainer API (and, for builds that
+ship without the `tier2_bfs` Cargo feature, without AppContainer + BFS
+either). To make the requirement discoverable, `wxc-exec --probe` (the
+detection-only path the SDK's `getPlatformSupport()` uses) emits an
+operator-visible warning recommending the relevant `wxc-host-prep`
+subcommand **whenever Tier 3 is selected and the corresponding prep is
+not already in effect**:
+
+- If the system-drive root is missing the metadata ACEs, the probe
+  recommends `wxc-host-prep prepare-system-drive`.
+- If `\Device\Null` does not grant the AppContainer package SIDs (it
+  resets to an AppContainer-hostile default at every boot), the probe
+  recommends `wxc-host-prep prepare-null-device`.
+
+The probe performs these checks read-only (no elevation, no writes); it
+suppresses a recommendation once the matching prep is detected.
+
 ### `prepare-system-drive`
 
 Adds two persistent, non-inheriting allow ACEs to the system-drive

--- a/src/wxc_common/src/fallback_detector.rs
+++ b/src/wxc_common/src/fallback_detector.rs
@@ -105,9 +105,17 @@ pub enum FallbackError {
 /// 1. If `MXC_FORCE_TIER` is set in a test build, honor it (test seam).
 /// 2. Try Tier 1 (BaseContainer) when `prefer_base_container` is true and the
 ///    API surface is detected.
-/// 3. Otherwise try Tier 2 (AppContainer + BFS) when there's no filesystem
-///    policy at all, or `bfscfg.exe` is on disk.
-/// 4. Otherwise fall back to Tier 3 (AppContainer + DACL).
+/// 3. Otherwise try Tier 2 (AppContainer + BFS), but **only when this binary
+///    was compiled with the `tier2_bfs` Cargo feature**. With the feature on,
+///    Tier 2 is selected when there's no filesystem policy at all, or
+///    `bfscfg.exe` is on disk. With the feature off, `bfscfg.exe` can never be
+///    resolved, so Tier 2 is skipped entirely (rather than mis-reporting
+///    `appcontainer-bfs` for the no-policy case) and we fall through to Tier 3.
+/// 4. Otherwise fall back to Tier 3 (AppContainer + DACL). When Tier 3 is
+///    selected we append `wxc-host-prep` recommendations to the decision's
+///    warnings for any host-side preparation (system-drive metadata ACEs;
+///    `\Device\Null` descriptor) that is read-only-detected as not already in
+///    effect on this machine.
 ///
 /// Any tier that needs to modify host DACLs (T3 always; T1/T2 when
 /// `denied_paths` is non-empty) requires `fallback.allow_dacl_mutation = true`
@@ -164,35 +172,51 @@ pub fn detect(
             warnings,
         });
     }
-    warnings.push(
-        "BaseContainer API not present or not preferred; falling back to AppContainer + BFS"
-            .to_string(),
-    );
-
     // Tier 2 — AppContainer + BFS
     //
-    // When the policy has no filesystem rules at all there is nothing for
-    // BFS to enforce, so we can stay on T2 without resolving bfscfg.exe.
-    // Otherwise we need a real path: probe-time resolution doubles as the
-    // execution path (see `TierDecision::bfscfg_path`).
-    let bfscfg_path = if has_fs_policy {
-        find_bfscfg_exe()?
-    } else {
-        None
-    };
-    if !has_fs_policy || bfscfg_path.is_some() {
-        if denied {
-            ensure_dacl_augmentation_allowed(policy)?;
-            verify_write_dac_all(&policy.denied_paths)?;
+    // Reachable only when this binary was compiled with the `tier2_bfs`
+    // feature. Without it, `find_bfscfg_exe` returns `Ok(None)`
+    // unconditionally, so BFS could never enforce a filesystem policy.
+    // Critically, the no-filesystem-policy short-circuit below would
+    // otherwise return `appcontainer-bfs` on a binary that physically
+    // cannot run BFS — so when the feature is absent we skip Tier 2
+    // entirely and fall through to Tier 3 (AppContainer + DACL).
+    if cfg!(feature = "tier2_bfs") {
+        warnings.push(
+            "BaseContainer API not present or not preferred; falling back to AppContainer + BFS"
+                .to_string(),
+        );
+
+        // When the policy has no filesystem rules at all there is
+        // nothing for BFS to enforce, so we can stay on T2 without
+        // resolving bfscfg.exe. Otherwise we need a real path: probe-
+        // time resolution doubles as the execution path (see
+        // `TierDecision::bfscfg_path`).
+        let bfscfg_path = if has_fs_policy {
+            find_bfscfg_exe()?
+        } else {
+            None
+        };
+        if !has_fs_policy || bfscfg_path.is_some() {
+            if denied {
+                ensure_dacl_augmentation_allowed(policy)?;
+                verify_write_dac_all(&policy.denied_paths)?;
+            }
+            return Ok(TierDecision {
+                tier: IsolationTier::AppContainerBfs,
+                needs_dacl_augmentation: denied,
+                bfscfg_path,
+                warnings,
+            });
         }
-        return Ok(TierDecision {
-            tier: IsolationTier::AppContainerBfs,
-            needs_dacl_augmentation: denied,
-            bfscfg_path,
-            warnings,
-        });
+        warnings.push("bfscfg.exe not present; falling back to AppContainer + DACL".to_string());
+    } else {
+        warnings.push(
+            "BaseContainer API not present or not preferred, and AppContainer + BFS is not \
+             compiled into this binary; falling back to AppContainer + DACL"
+                .to_string(),
+        );
     }
-    warnings.push("bfscfg.exe not present; falling back to AppContainer + DACL".to_string());
 
     // Tier 3 — AppContainer + DACL
     ensure_dacl_augmentation_allowed(policy)?;
@@ -211,12 +235,106 @@ pub fn detect(
         ensure_path_grantable_for_ac(Path::new(p), crate::filesystem_dacl::RO_MASK)?;
     }
     verify_write_dac_all(&policy.denied_paths)?;
+
+    // Tier 3 leans on host-side preparation the kernel does not provide
+    // by default (the system-drive metadata ACEs) or resets at every
+    // boot (the `\Device\Null` descriptor). Surface actionable
+    // `wxc-host-prep` recommendations, but only for the preparations
+    // that are not already in effect on this machine.
+    push_host_prep_warnings(&mut warnings);
+
     Ok(TierDecision {
         tier: IsolationTier::AppContainerDacl,
         needs_dacl_augmentation: true,
         bfscfg_path: None,
         warnings,
     })
+}
+
+/// Append `wxc-host-prep` recommendations to `warnings` for any
+/// host-side preparation the AppContainer + DACL tier relies on that is
+/// not currently in effect on this machine.
+///
+/// Each check is read-only and best-effort: if the machine state cannot
+/// be determined we err on the side of surfacing the recommendation
+/// rather than silently swallowing it.
+fn push_host_prep_warnings(warnings: &mut Vec<String>) {
+    if !system_drive_prepared() {
+        warnings.push(
+            "AppContainer + DACL tier selected: AppContainer processes may be unable to read \
+             metadata of the system-drive root (e.g. `cmd.exe`, `pwsh.exe`, `node.exe` startup \
+             stats of `C:\\`). Run `wxc-host-prep prepare-system-drive` (elevated) to grant the \
+             minimal metadata ACEs."
+                .to_string(),
+        );
+    }
+    if !null_device_prepared() {
+        warnings.push(
+            "AppContainer + DACL tier selected: AppContainer processes may be unable to open the \
+             NUL device (`\\Device\\Null`), which the kernel resets to an AppContainer-hostile \
+             default at every boot. Run `wxc-host-prep prepare-null-device` (elevated) to reapply \
+             the documented security descriptor."
+                .to_string(),
+        );
+    }
+}
+
+/// Well-known AppContainer package SIDs that `wxc-host-prep` grants
+/// access to. `Everyone` (`S-1-1-0`) is deliberately excluded — these
+/// checks care specifically about the AppContainer package identities.
+const HOST_PREP_AC_SIDS: &[&str] = &["S-1-15-2-1", "S-1-15-2-2"];
+
+/// Metadata-read mask `wxc-host-prep prepare-system-drive` stamps on the
+/// system-drive root (`FILE_READ_ATTRIBUTES | FILE_READ_EA |
+/// READ_CONTROL | SYNCHRONIZE`). Must stay in sync with the
+/// `STAT_ACCESS_MASK` constant in `wxc_host_prep`'s `system_drive`
+/// module.
+const SYSTEM_DRIVE_STAT_MASK: u32 = 0x0012_0088;
+
+/// Resolve the system-drive root (e.g. `C:\`) for the read-only
+/// host-prep state probe.
+///
+/// Unlike the elevated `prepare-system-drive` write path — which must
+/// not trust `%SystemDrive%` from a potentially attacker-controlled
+/// environment — this is a read-only DACL *read*, so deriving the root
+/// from `%SystemDrive%` is acceptable. Falls back to `C:\`.
+fn system_drive_root() -> std::path::PathBuf {
+    let mut root = std::env::var("SystemDrive").unwrap_or_else(|_| "C:".to_string());
+    if !root.ends_with('\\') {
+        root.push('\\');
+    }
+    std::path::PathBuf::from(root)
+}
+
+/// Returns `true` when the `prepare-system-drive` ACEs are already
+/// present for BOTH well-known AppContainer package SIDs on the
+/// system-drive root.
+///
+/// Read-only and best-effort: a failed DACL read for any SID yields
+/// `false`, so the caller surfaces the recommendation rather than
+/// suppressing it on incomplete information.
+fn system_drive_prepared() -> bool {
+    let root = system_drive_root();
+    HOST_PREP_AC_SIDS.iter().all(|sid| {
+        match crate::filesystem_dacl::scan_explicit_aces_for_sid(&root, sid) {
+            Ok(priors) => priors.iter().any(|p| {
+                p.ace_type == crate::filesystem_dacl::AceType::Allow
+                    && p.access_mask == SYSTEM_DRIVE_STAT_MASK
+                    && p.inherit_flags == 0
+            }),
+            Err(_) => false,
+        }
+    })
+}
+
+/// Returns `true` when `\Device\Null` already grants both well-known
+/// AppContainer package SIDs access — i.e. `prepare-null-device` has
+/// been applied since the last boot.
+///
+/// Read-only and best-effort: an unreadable DACL yields `false`, so the
+/// caller surfaces the recommendation.
+fn null_device_prepared() -> bool {
+    crate::filesystem_dacl::null_device_appcontainer_grants().unwrap_or(false)
 }
 
 /// Returns `Ok(true)` if a per-run ACE on `path` is unnecessary because
@@ -762,5 +880,103 @@ mod tests {
             "after explicit grant on ALL APPLICATION PACKAGES, AC should be covered"
         );
         // mgr.Drop restores, returning the path to its original state.
+    }
+
+    #[test]
+    fn system_drive_root_ends_with_backslash() {
+        let root = system_drive_root();
+        let s = root.to_string_lossy();
+        assert!(
+            s.ends_with('\\'),
+            "system-drive root should end with a backslash, got {s}"
+        );
+    }
+
+    /// The host-prep state is machine-dependent, so we assert only the
+    /// contract: at most the two known recommendations, and each names
+    /// the corresponding `wxc-host-prep` verb.
+    #[test]
+    fn push_host_prep_warnings_are_actionable_and_bounded() {
+        let mut warnings = Vec::new();
+        push_host_prep_warnings(&mut warnings);
+        assert!(
+            warnings.len() <= 2,
+            "expected at most two host-prep warnings, got {warnings:?}"
+        );
+        for w in &warnings {
+            assert!(
+                w.contains("wxc-host-prep prepare-system-drive")
+                    || w.contains("wxc-host-prep prepare-null-device"),
+                "host-prep warning should name a wxc-host-prep verb, got: {w}"
+            );
+        }
+    }
+
+    /// Read-only `\Device\Null` probe must not panic; the result is
+    /// host-dependent so we only assert it returns.
+    #[test]
+    fn null_device_grants_probe_smoke() {
+        let _ = crate::filesystem_dacl::null_device_appcontainer_grants();
+    }
+
+    /// With `tier2_bfs` compiled out, an empty policy on a host where
+    /// Tier 1 is skipped must resolve to Tier 3 (AppContainer + DACL) —
+    /// never `appcontainer-bfs` — and carry the BFS-not-compiled
+    /// fall-through warning.
+    #[cfg(not(feature = "tier2_bfs"))]
+    #[test]
+    fn no_bfs_feature_falls_through_to_dacl_for_empty_policy() {
+        // Clear MXC_FORCE_TIER under ENV_LOCK so the test-only force
+        // seam in `detect` doesn't observe a sibling test's value.
+        let _lock = {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
+            unsafe {
+                std::env::remove_var("MXC_FORCE_TIER");
+            }
+            lock
+        };
+        let mut policy = empty_policy();
+        policy.fallback.allow_dacl_mutation = true;
+        // `prefer_base_container = false` skips Tier 1 deterministically;
+        // with `tier2_bfs` off, Tier 2 is skipped too.
+        let d = detect(&policy, false).expect("empty policy must resolve");
+        assert!(
+            matches!(d.tier, IsolationTier::AppContainerDacl),
+            "tier2_bfs off must select AppContainerDacl, got {:?}",
+            d.tier
+        );
+        assert!(d.needs_dacl_augmentation);
+        assert!(
+            d.warnings
+                .iter()
+                .any(|w| w.contains("not compiled into this binary")),
+            "expected BFS-not-compiled fall-through warning, got: {:?}",
+            d.warnings
+        );
+    }
+
+    /// With `tier2_bfs` compiled in, an empty policy on a host where
+    /// Tier 1 is skipped stays on Tier 2 (AppContainer + BFS) via the
+    /// no-filesystem-policy short-circuit.
+    #[cfg(feature = "tier2_bfs")]
+    #[test]
+    fn bfs_feature_selects_bfs_for_empty_policy_when_bc_skipped() {
+        let _lock = {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: env-var mutation in tests; serialized by ENV_LOCK.
+            unsafe {
+                std::env::remove_var("MXC_FORCE_TIER");
+            }
+            lock
+        };
+        let policy = empty_policy();
+        let d = detect(&policy, false).expect("empty policy must resolve");
+        assert!(
+            matches!(d.tier, IsolationTier::AppContainerBfs),
+            "tier2_bfs on with empty policy must select AppContainerBfs, got {:?}",
+            d.tier
+        );
+        assert!(!d.needs_dacl_augmentation);
     }
 }

--- a/src/wxc_common/src/filesystem_dacl.rs
+++ b/src/wxc_common/src/filesystem_dacl.rs
@@ -1405,6 +1405,153 @@ pub(crate) fn compute_appcontainer_effective_access(path: &Path) -> Result<u32, 
     Ok(allowed)
 }
 
+/// Read-only probe used by the fallback detector's Tier-3 host-prep
+/// advice: returns `Some(true)` when BOTH well-known AppContainer
+/// package SIDs (`S-1-15-2-1`, `S-1-15-2-2`) have a non-zero explicit
+/// Allow ACE on `\Device\Null`, `Some(false)` when at least one is
+/// missing, and `None` when the device's DACL could not be read (the
+/// open or the security query failed).
+///
+/// This mirrors the symptom that `wxc-host-prep prepare-null-device`
+/// fixes — AppContainer processes being unable to open `NUL` — without
+/// requiring `SeSecurityPrivilege` (the SACL is never read) and without
+/// taking a dependency on the `wxc_host_prep` crate. `Everyone`
+/// (`S-1-1-0`) is deliberately NOT accepted as satisfying the check:
+/// the kernel-default `\Device\Null` descriptor can grant `Everyone`
+/// while still failing AppContainer access, so only the package SIDs
+/// are probative. A NULL DACL (grants everyone everything) is treated
+/// as "accessible".
+pub(crate) fn null_device_appcontainer_grants() -> Option<bool> {
+    use windows::Win32::Foundation::GENERIC_READ;
+    use windows::Win32::Security::Authorization::{GetSecurityInfo, SE_KERNEL_OBJECT};
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
+    };
+
+    // `READ_CONTROL` is the only security-class right needed to read a
+    // DACL; `GENERIC_READ` keeps the open symmetric with how the device
+    // is normally opened (some drivers reject a security-class-only
+    // open). We deliberately do NOT request WRITE_DAC / WRITE_OWNER /
+    // ACCESS_SYSTEM_SECURITY — a normal, unprivileged token can read
+    // the DACL, and asking for more could fail the open spuriously.
+    const READ_CONTROL: u32 = 0x0002_0000;
+
+    // `\\.\NUL` resolves through the I/O manager to `\Device\Null`.
+    let path: Vec<u16> = "\\\\.\\NUL\0".encode_utf16().collect();
+    let share = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+
+    // SAFETY: standard CreateFileW invocation; every pointer references
+    // local data or is NULL.
+    let handle = unsafe {
+        CreateFileW(
+            PCWSTR(path.as_ptr()),
+            GENERIC_READ.0 | READ_CONTROL,
+            share,
+            None,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            None,
+        )
+    };
+    let handle = match handle {
+        Ok(h) if !h.is_invalid() => h,
+        _ => return None,
+    };
+
+    let mut dacl: *mut ACL = ptr::null_mut();
+    let mut sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    // SAFETY: `handle` is a valid kernel-object handle opened with
+    // READ_CONTROL; the out-params are owned locals.
+    let rc = unsafe {
+        GetSecurityInfo(
+            handle,
+            SE_KERNEL_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(&mut dacl),
+            None,
+            Some(&mut sd),
+        )
+    };
+    // We have everything we need from the handle; close it regardless.
+    // SAFETY: `handle` came from a successful CreateFileW above.
+    unsafe {
+        let _ = CloseHandle(handle);
+    }
+    if rc != ERROR_SUCCESS {
+        return None;
+    }
+    if dacl.is_null() {
+        // A NULL DACL grants everyone full access — the device is
+        // reachable by AppContainer, so no prep is needed.
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        return Some(true);
+    }
+
+    let sids = match (OwnedSid::parse("S-1-15-2-1"), OwnedSid::parse("S-1-15-2-2")) {
+        (Ok(a), Ok(b)) => [a, b],
+        _ => {
+            unsafe {
+                let _ = LocalFree(Some(HLOCAL(sd.0)));
+            }
+            return None;
+        }
+    };
+
+    let mut info = ACL_SIZE_INFORMATION::default();
+    let info_sz = std::mem::size_of::<ACL_SIZE_INFORMATION>() as u32;
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            &mut info as *mut _ as *mut c_void,
+            info_sz,
+            AclSizeInformation,
+        )
+    }
+    .is_err()
+    {
+        unsafe {
+            let _ = LocalFree(Some(HLOCAL(sd.0)));
+        }
+        return None;
+    }
+
+    // Per package SID, whether it has a non-zero Allow grant.
+    let mut granted = [false; 2];
+    for i in 0..info.AceCount {
+        let mut ace_ptr: *mut c_void = ptr::null_mut();
+        if unsafe { GetAce(dacl, i, &mut ace_ptr) }.is_err() {
+            continue;
+        }
+        let header = unsafe { &*(ace_ptr as *const ACE_HEADER) };
+        // ACCESS_ALLOWED_ACE_TYPE only; deny / audit / object ACEs are
+        // not "grants" and are ignored.
+        if header.AceType != 0x00 {
+            continue;
+        }
+        let allowed = ace_ptr as *const ACCESS_ALLOWED_ACE;
+        let mask = unsafe { (*allowed).Mask };
+        if mask == 0 {
+            continue;
+        }
+        let ace_sid = PSID(unsafe { &(*allowed).SidStart } as *const _ as *mut c_void);
+        for (idx, want) in sids.iter().enumerate() {
+            if unsafe { EqualSid(ace_sid, want.as_psid()).is_ok() } {
+                granted[idx] = true;
+            }
+        }
+    }
+
+    unsafe {
+        let _ = LocalFree(Some(HLOCAL(sd.0)));
+    }
+    Some(granted[0] && granted[1])
+}
+
 /// Rebuild `path`'s DACL by dropping every explicit ACE whose trustee
 /// is `sid_str`, then re-appending `replay` ACEs (also for `sid_str`)
 /// in canonical order. Inherited ACEs and explicit ACEs for other


### PR DESCRIPTION
## Summary

Changes how `wxc-exec --probe` (the detection-only path the SDK's `getPlatformSupport()` uses) reports the AppContainer fallback tier, and adds actionable `wxc-host-prep` recommendations for the Tier 3 path.

## Details

* `fallback_detector::detect` now gates the entire Tier 2 (AppContainer + BFS) block behind `cfg!(feature = "tier2_bfs")`. Without the feature, `bfscfg.exe` can never be resolved, so the no-filesystem-policy short-circuit previously mis-reported `appcontainer-bfs` on a binary physically unable to run BFS. It now skips Tier 2 and falls through to Tier 3 (AppContainer + DACL).
* When Tier 3 is selected, `detect` appends `wxc-host-prep` recommendations (`prepare-system-drive`, `prepare-null-device`) to the decision warnings, but only for preparations not already in effect — detected read-only with no elevation or host mutation.
* Added read-only `filesystem_dacl::null_device_appcontainer_grants()`: opens `\\.\NUL`, reads its DACL, and reports whether both AppContainer package SIDs (S-1-15-2-1/-2) hold a non-zero Allow ACE. Everyone (S-1-1-0) is excluded because the kernel default can grant Everyone while still failing AppContainer. The system-drive check reuses `scan_explicit_aces_for_sid`, matching `wxc_host_prep`'s `STAT_ACCESS_MASK` (0x00120088) tuple.
* Documented the probe-driven recommendations in `docs/host-prep.md`.

## Tests

* `cargo test -p wxc_common`: all tests pass (default and `--features tier2_bfs`). Added unit tests for the no-BFS fall-through, the BFS-feature path, warning actionability/bounds, system-drive-root formatting, and a null-device grants smoke test.
* `cargo fmt --all -- --check` clean; `cargo clippy -p wxc_common --all-targets -- -D warnings` clean in both feature configs; `cargo check --workspace --all-targets` clean.
* End-to-end (prep present): `--probe` with no config reports `appcontainer-dacl` with the BFS fall-through warning and no host-prep warnings when both preps are in effect.
* End-to-end (prep removed): after removing the AppContainer ACEs from `C:\`, `--probe` emits the `Run wxc-host-prep prepare-system-drive (elevated)` warning while suppressing the null-device warning (null device still prepared), confirming the read-only state check flips as expected.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/456)