### PR TITLE
Pass STDIO handles directly to child in non-PTY mode

### DIFF
--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::io::IsTerminal;
 use std::ptr;
 
 use windows::Win32::Foundation::{
-    GetLastError, LocalFree, ERROR_ALREADY_EXISTS, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    GetLastError, LocalFree, SetHandleInformation, ERROR_ALREADY_EXISTS, HANDLE,
+    HANDLE_FLAG_INHERIT, HLOCAL, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
 use windows::Win32::Security::{FreeSid, PSID};
+use windows::Win32::System::Console::{
+    GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
 use windows::Win32::System::SystemServices::SE_GROUP_ENABLED;
 use windows::Win32::System::Threading::{
     CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
@@ -18,8 +23,9 @@ use windows::Win32::System::Threading::{
     WaitForSingleObject, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
     EXTENDED_STARTUPINFO_PRESENT, LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_CREATION_FLAGS,
     PROCESS_INFORMATION, PROC_THREAD_ATTRIBUTE_ALL_APPLICATION_PACKAGES_POLICY,
-    PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES,
-    STARTUPINFOEXW, STARTUPINFOW,
+    PROC_THREAD_ATTRIBUTE_HANDLE_LIST, PROC_THREAD_ATTRIBUTE_MITIGATION_POLICY,
+    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, STARTF_USESTDHANDLES, STARTUPINFOEXW,
+    STARTUPINFOW,
 };
 use windows_core::{PCWSTR, PWSTR};
 
@@ -128,13 +134,16 @@ struct SecurityCapabilities {
 /// Always at least 1 (`SECURITY_CAPABILITIES`). LPAC adds one
 /// (`ALL_APPLICATION_PACKAGES_POLICY`); UI-disable adds one
 /// (`MITIGATION_POLICY` for Win32k disable).
-fn compute_attr_count(least_privilege_mode: bool, ui_disable: bool) -> u32 {
-    let mut n = 1;
+fn compute_attr_count(least_privilege_mode: bool, ui_disable: bool, pipe_mode: bool) -> u32 {
+    let mut n = 1; // SECURITY_CAPABILITIES always present
     if least_privilege_mode {
         n += 1;
     }
     if ui_disable {
         n += 1;
+    }
+    if pipe_mode {
+        n += 1; // HANDLE_LIST for inheritable pipe handles
     }
     n
 }
@@ -415,10 +424,22 @@ impl AppContainerScriptRunner {
             reserved: 0,
         };
 
+        // --- Determine STDIO mode ---
+        // If wxc-exec's stdout or stderr is not a terminal (i.e., piped by the SDK),
+        // we forward our own std handles to the child via STARTF_USESTDHANDLES so the
+        // child's output streams directly to the SDK in real time. Otherwise we use
+        // console sharing (the ConPTY path).
+        let pipe_mode = !std::io::stdout().is_terminal() || !std::io::stderr().is_terminal();
+
+        if pipe_mode {
+            logger.log_line("STDIO mode: passthrough (forwarding parent handles to child)");
+        }
+
         // --- Allocate and initialize attribute list ---
         let attr_count = compute_attr_count(
             request.policy.least_privilege_mode,
             request.policy.ui.disable,
+            pipe_mode,
         );
 
         // Lifetime spans the attribute list and CreateProcessW:
@@ -499,7 +520,7 @@ impl AppContainerScriptRunner {
             }
         }
 
-        // 3. MITIGATION_POLICY (Win32k syscall disable) — applied by the kernel
+        // 3. MITIGATION_POLICY (Win32k syscall disable) -- applied by the kernel
         // before the child runs any user-mode code, so there is no race window.
         if request.policy.ui.disable {
             unsafe {
@@ -522,14 +543,71 @@ impl AppContainerScriptRunner {
             logger.log_line("Win32k mitigation applied to child process");
         }
 
+        // --- Setup handle passthrough (pipe mode only) ---
+        // Forward wxc-exec's own stdin/stdout/stderr handles to the child so the
+        // child's output streams directly to the SDK caller in real time.
+        // Handle list for PROC_THREAD_ATTRIBUTE_HANDLE_LIST. Must outlive CreateProcessW.
+        let mut handle_list: Vec<HANDLE> = Vec::new();
+
+        let h_stdin;
+        let h_stdout;
+        let h_stderr;
+
+        if pipe_mode {
+            h_stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) }
+                .map_err(|e| WxcError::Process(format!("GetStdHandle(STDIN): {e}")))?;
+            h_stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }
+                .map_err(|e| WxcError::Process(format!("GetStdHandle(STDOUT): {e}")))?;
+            h_stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) }
+                .map_err(|e| WxcError::Process(format!("GetStdHandle(STDERR): {e}")))?;
+
+            // Ensure the handles are inheritable.
+            unsafe {
+                let _ = SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                let _ = SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                let _ = SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+            }
+
+            handle_list.push(h_stdin);
+            handle_list.push(h_stdout);
+            handle_list.push(h_stderr);
+
+            // 4. HANDLE_LIST -- restrict which handles the child inherits.
+            unsafe {
+                UpdateProcThreadAttribute(
+                    attr_list,
+                    0,
+                    PROC_THREAD_ATTRIBUTE_HANDLE_LIST as usize,
+                    Some(handle_list.as_ptr() as *const core::ffi::c_void),
+                    handle_list.len() * std::mem::size_of::<HANDLE>(),
+                    None,
+                    None,
+                )
+                .map_err(|e| {
+                    WxcError::Process(format!("UpdateProcThreadAttribute(HANDLE_LIST): {}", e))
+                })?;
+            }
+        } else {
+            h_stdin = HANDLE::default();
+            h_stdout = HANDLE::default();
+            h_stderr = HANDLE::default();
+        }
+
         // --- Setup STARTUPINFOEXW ---
         let mut desktop_wide = string_util::to_wide("winsta0\\default");
 
-        // No STARTF_USESTDHANDLES — child inherits parent's console.
         let si_ex = STARTUPINFOEXW {
             StartupInfo: STARTUPINFOW {
                 cb: std::mem::size_of::<STARTUPINFOEXW>() as u32,
                 lpDesktop: PWSTR(desktop_wide.as_mut_ptr()),
+                dwFlags: if pipe_mode {
+                    STARTF_USESTDHANDLES
+                } else {
+                    Default::default()
+                },
+                hStdInput: h_stdin,
+                hStdOutput: h_stdout,
+                hStdError: h_stderr,
                 ..Default::default()
             },
             lpAttributeList: attr_list,
@@ -576,41 +654,18 @@ impl AppContainerScriptRunner {
             PROCESS_CREATION_FLAGS(flags)
         };
 
-        // --- Create process (console inheritance) ---
+        // --- Create process ---
         //
-        // Console I/O path — no pipes, no relay threads:
+        // In console-sharing mode (pipe_mode == false):
+        //   stdin:  node-pty -> ConPTY -> wxc-exec -> child (AppContainer)
+        //   stdout: node-pty <- ConPTY <----------- child (shares parent's console)
+        //   bInheritHandles = false, no STARTF_USESTDHANDLES.
         //
-        //   stdin:  node-pty → ConPTY → wxc-exec → PowerShell (AppContainer)
-        //   stdout: node-pty ← ConPTY ←─────────── PowerShell (shares parent's console)
-        //                    ↑
-        //                 onData()
-        //
-        // The child attaches to wxc-exec's console (the ConPTY created by node-pty)
-        // so PowerShell sees a real terminal — PSReadLine, ANSI, UTF-8 all work.
-        //
-        // Why this works for AppContainer:
-        //
-        //   1. Kernel (PspSetupUserProcessAddressSpace):
-        //      ObDuplicateObject copies the parent's ConsoleHandle
-        //      (\Device\ConDrv\Reference) into the child using the parent's
-        //      security context — before the AppContainer token takes effect.
-        //
-        //   2. condrv:
-        //      FILE_DEVICE_ALLOW_APPCONTAINER_TRAVERSAL is set, so the I/O
-        //      Manager permits the AppContainer to open \Device\ConDrv\Connect.
-        //
-        //   3. condrv (CdCreateConnection):
-        //      Inheritance path skips CdAccessCheck. Having the Reference
-        //      handle is proof of authorization.
-        //
-        //   4. conhost (ConsoleHandleConnectionRequest):
-        //      No token check — allocates I/O handles unconditionally.
-        //
-        // bInheritHandles = false: we have no explicit handles to inherit.
-        // Console attachment is a separate mechanism — the child automatically
-        // attaches to the parent's console session via \Device\ConDrv during
-        // process initialization, regardless of bInheritHandles. Since we don't
-        // pass CREATE_NEW_CONSOLE or DETACH_PROCESS, the child shares our console.
+        // In pipe-passthrough mode (pipe_mode == true):
+        //   The child receives wxc-exec's own stdin/stdout/stderr handles directly.
+        //   Child output streams to the SDK in real time (no intermediate buffering).
+        //   bInheritHandles = true, with PROC_THREAD_ATTRIBUTE_HANDLE_LIST restricting
+        //   which handles the child can access.
         let mut pi = PROCESS_INFORMATION::default();
 
         // Pre-launch check: abort if policy paths are on ReFS (Dev Drive) volumes
@@ -632,7 +687,7 @@ impl AppContainerScriptRunner {
                 Some(PWSTR(cmd_line_wide.as_mut_ptr())),
                 None,
                 None,
-                false, // bInheritHandles = false — no explicit handles to inherit
+                pipe_mode, // bInheritHandles: true only in pipe mode (restricted by HANDLE_LIST)
                 creation_flags,
                 env_ptr,
                 working_dir_pcwstr,
@@ -687,7 +742,6 @@ impl AppContainerScriptRunner {
         }
 
         // --- Wait for child process to exit ---
-        // No relay threads needed — child shares our console directly.
         let timeout_ms = get_timeout_milliseconds(request.script_timeout);
 
         let wait_result = unsafe { WaitForSingleObject(process_handle.get(), timeout_ms) };
@@ -921,22 +975,28 @@ impl Drop for AppContainerScriptRunner {
 mod tests {
     #[test]
     fn attr_count_neither() {
-        assert_eq!(super::compute_attr_count(false, false), 1);
+        assert_eq!(super::compute_attr_count(false, false, false), 1);
     }
 
     #[test]
     fn attr_count_lpac_only() {
-        assert_eq!(super::compute_attr_count(true, false), 2);
+        assert_eq!(super::compute_attr_count(true, false, false), 2);
     }
 
     #[test]
     fn attr_count_ui_disable_only() {
-        assert_eq!(super::compute_attr_count(false, true), 2);
+        assert_eq!(super::compute_attr_count(false, true, false), 2);
     }
 
     #[test]
     fn attr_count_both() {
-        assert_eq!(super::compute_attr_count(true, true), 3);
+        assert_eq!(super::compute_attr_count(true, true, false), 3);
+    }
+
+    #[test]
+    fn attr_count_pipe_mode() {
+        assert_eq!(super::compute_attr_count(false, false, true), 2);
+        assert_eq!(super::compute_attr_count(true, true, true), 4);
     }
 
     #[test]

--- a/src/wxc_common/src/appcontainer_runner.rs
+++ b/src/wxc_common/src/appcontainer_runner.rs
@@ -143,7 +143,7 @@ fn compute_attr_count(least_privilege_mode: bool, ui_disable: bool, pipe_mode: b
         n += 1;
     }
     if pipe_mode {
-        n += 1; // HANDLE_LIST for inheritable pipe handles
+        n += 1; // one attribute slot for HANDLE_LIST (the list itself can hold 1..N handles)
     }
     n
 }
@@ -561,11 +561,30 @@ impl AppContainerScriptRunner {
             h_stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) }
                 .map_err(|e| WxcError::Process(format!("GetStdHandle(STDERR): {e}")))?;
 
+            if h_stdin.is_invalid() || h_stdin == HANDLE::default() {
+                return Err(WxcError::Process(
+                    "GetStdHandle(STDIN) returned null/invalid handle".to_string(),
+                ));
+            }
+            if h_stdout.is_invalid() || h_stdout == HANDLE::default() {
+                return Err(WxcError::Process(
+                    "GetStdHandle(STDOUT) returned null/invalid handle".to_string(),
+                ));
+            }
+            if h_stderr.is_invalid() || h_stderr == HANDLE::default() {
+                return Err(WxcError::Process(
+                    "GetStdHandle(STDERR) returned null/invalid handle".to_string(),
+                ));
+            }
+
             // Ensure the handles are inheritable.
             unsafe {
-                let _ = SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
-                let _ = SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
-                let _ = SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                    .map_err(|e| WxcError::Process(format!("SetHandleInformation(STDIN): {e}")))?;
+                SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                    .map_err(|e| WxcError::Process(format!("SetHandleInformation(STDOUT): {e}")))?;
+                SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                    .map_err(|e| WxcError::Process(format!("SetHandleInformation(STDERR): {e}")))?;
             }
 
             handle_list.push(h_stdin);

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -11,14 +11,22 @@
 
 use std::ffi::c_void;
 use std::fmt::Write;
+use std::io::IsTerminal;
 use std::ptr;
 
-use windows::Win32::Foundation::{CloseHandle, GetLastError, WAIT_FAILED, WAIT_TIMEOUT};
+use windows::Win32::Foundation::{
+    CloseHandle, GetLastError, SetHandleInformation, HANDLE, HANDLE_FLAG_INHERIT, WAIT_FAILED,
+    WAIT_TIMEOUT,
+};
+use windows::Win32::System::Console::{
+    GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+};
 use windows::Win32::System::LibraryLoader::{
     GetProcAddress, LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32,
 };
 use windows::Win32::System::Threading::{
-    GetExitCodeProcess, TerminateProcess, WaitForSingleObject, PROCESS_INFORMATION, STARTUPINFOW,
+    GetExitCodeProcess, TerminateProcess, WaitForSingleObject, PROCESS_INFORMATION,
+    STARTF_USESTDHANDLES, STARTUPINFOW,
 };
 use windows_core::PCWSTR;
 
@@ -559,9 +567,62 @@ impl ScriptRunner for BaseContainerRunner {
             );
         }
 
-        // STARTUPINFOW -- minimal, no handle inheritance (not yet supported by the API).
+        // --- Determine STDIO mode ---
+        // If wxc-exec's stdout or stderr is not a terminal (i.e., piped by the SDK),
+        // we forward our own std handles to the child via STARTF_USESTDHANDLES so the
+        // child's output streams directly to the SDK in real time.
+        let pipe_mode = !std::io::stdout().is_terminal() || !std::io::stderr().is_terminal();
+
+        if pipe_mode {
+            let _ = writeln!(
+                logger,
+                "STDIO mode: passthrough (forwarding parent handles to child)"
+            );
+        }
+
+        // --- Retrieve parent std handles for passthrough (pipe mode only) ---
+        let h_stdin;
+        let h_stdout;
+        let h_stderr;
+
+        if pipe_mode {
+            h_stdin = match unsafe { GetStdHandle(STD_INPUT_HANDLE) } {
+                Ok(h) => h,
+                Err(e) => return ScriptResponse::error(&format!("GetStdHandle(STDIN): {e}")),
+            };
+            h_stdout = match unsafe { GetStdHandle(STD_OUTPUT_HANDLE) } {
+                Ok(h) => h,
+                Err(e) => return ScriptResponse::error(&format!("GetStdHandle(STDOUT): {e}")),
+            };
+            h_stderr = match unsafe { GetStdHandle(STD_ERROR_HANDLE) } {
+                Ok(h) => h,
+                Err(e) => return ScriptResponse::error(&format!("GetStdHandle(STDERR): {e}")),
+            };
+
+            // Ensure the handles are inheritable.
+            unsafe {
+                let _ = SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                let _ = SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                let _ = SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+            }
+        } else {
+            h_stdin = HANDLE::default();
+            h_stdout = HANDLE::default();
+            h_stderr = HANDLE::default();
+        }
+
+        // STARTUPINFOW -- in pipe mode, pass parent handles via STARTF_USESTDHANDLES
+        // so child output streams directly to the SDK caller.
         let si = STARTUPINFOW {
             cb: std::mem::size_of::<STARTUPINFOW>() as u32,
+            dwFlags: if pipe_mode {
+                STARTF_USESTDHANDLES
+            } else {
+                Default::default()
+            },
+            hStdInput: h_stdin,
+            hStdOutput: h_stdout,
+            hStdError: h_stderr,
             ..unsafe { std::mem::zeroed() }
         };
         #[allow(unused_assignments)]
@@ -634,7 +695,7 @@ impl ScriptRunner for BaseContainerRunner {
                     cmd_wide.as_mut_ptr(),   // commandLine
                     ptr::null(),             // processAttributes (must be NULL)
                     ptr::null(),             // threadAttributes  (must be NULL)
-                    0,                       // inheritHandles    (must be FALSE)
+                    i32::from(false),        // inheritHandles (must be FALSE)
                     current_creation_flags,  // creationFlags
                     current_env_ptr,         // environment
                     cwd_ptr,                 // currentDirectory
@@ -809,10 +870,19 @@ impl ScriptRunner for BaseContainerRunner {
             (String::new(), FailurePhase::None)
         };
 
+        // Merge diagnostic error into stderr field if present.
+        // In passthrough mode, stdout/stderr already went directly to the SDK caller,
+        // so standard_out/standard_err in ScriptResponse will be empty.
+        let final_stderr = if error_message.is_empty() {
+            String::new()
+        } else {
+            error_message.clone()
+        };
+
         ScriptResponse {
             exit_code: exit_code as i32,
             standard_out: String::new(),
-            standard_err: error_message.clone(),
+            standard_err: final_stderr,
             error_message,
             failure_phase,
             ..Default::default()

--- a/src/wxc_common/src/base_container_runner.rs
+++ b/src/wxc_common/src/base_container_runner.rs
@@ -581,9 +581,9 @@ impl ScriptRunner for BaseContainerRunner {
         }
 
         // --- Retrieve parent std handles for passthrough (pipe mode only) ---
-        let h_stdin;
-        let h_stdout;
-        let h_stderr;
+        let mut h_stdin = HANDLE::default();
+        let mut h_stdout = HANDLE::default();
+        let mut h_stderr = HANDLE::default();
 
         if pipe_mode {
             h_stdin = match unsafe { GetStdHandle(STD_INPUT_HANDLE) } {
@@ -599,16 +599,34 @@ impl ScriptRunner for BaseContainerRunner {
                 Err(e) => return ScriptResponse::error(&format!("GetStdHandle(STDERR): {e}")),
             };
 
+            if h_stdin.is_invalid() || h_stdin == HANDLE::default() {
+                return ScriptResponse::error("GetStdHandle(STDIN) returned null/invalid handle");
+            }
+            if h_stdout.is_invalid() || h_stdout == HANDLE::default() {
+                return ScriptResponse::error("GetStdHandle(STDOUT) returned null/invalid handle");
+            }
+            if h_stderr.is_invalid() || h_stderr == HANDLE::default() {
+                return ScriptResponse::error("GetStdHandle(STDERR) returned null/invalid handle");
+            }
+
             // Ensure the handles are inheritable.
             unsafe {
-                let _ = SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
-                let _ = SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
-                let _ = SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT);
+                if let Err(e) =
+                    SetHandleInformation(h_stdin, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                {
+                    return ScriptResponse::error(&format!("SetHandleInformation(STDIN): {e}"));
+                }
+                if let Err(e) =
+                    SetHandleInformation(h_stdout, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                {
+                    return ScriptResponse::error(&format!("SetHandleInformation(STDOUT): {e}"));
+                }
+                if let Err(e) =
+                    SetHandleInformation(h_stderr, HANDLE_FLAG_INHERIT.0, HANDLE_FLAG_INHERIT)
+                {
+                    return ScriptResponse::error(&format!("SetHandleInformation(STDERR): {e}"));
+                }
             }
-        } else {
-            h_stdin = HANDLE::default();
-            h_stdout = HANDLE::default();
-            h_stderr = HANDLE::default();
         }
 
         // STARTUPINFOW -- in pipe mode, pass parent handles via STARTF_USESTDHANDLES
@@ -691,11 +709,16 @@ impl ScriptRunner for BaseContainerRunner {
 
             let result = unsafe {
                 create_process_in_sandbox(
-                    ptr::null(),             // applicationName (resolved from commandLine)
-                    cmd_wide.as_mut_ptr(),   // commandLine
-                    ptr::null(),             // processAttributes (must be NULL)
-                    ptr::null(),             // threadAttributes  (must be NULL)
-                    i32::from(false),        // inheritHandles (must be FALSE)
+                    ptr::null(),           // applicationName (resolved from commandLine)
+                    cmd_wide.as_mut_ptr(), // commandLine
+                    ptr::null(),           // processAttributes (must be NULL)
+                    ptr::null(),           // threadAttributes  (must be NULL)
+                    // inheritHandles: must be FALSE per the OS sandbox API contract.
+                    // Unlike regular CreateProcess, CreateProcessInSandbox treats the
+                    // explicit STDIO handles in STARTUPINFO (hStdInput/hStdOutput/hStdError)
+                    // as inheritable when STARTF_USESTDHANDLES is set, but does not support
+                    // general handle inheritance.
+                    i32::from(false),        // inheritHandles
                     current_creation_flags,  // creationFlags
                     current_env_ptr,         // environment
                     cwd_ptr,                 // currentDirectory


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

In pipe mode (SDK non-PTY), forward wxc-exec's own stdin/stdout/stderr to the child process via STARTF_USESTDHANDLES instead of creating intermediate anonymous pipes. Child output now streams to the SDK caller in real time rather than being buffered until exit.

Changes:
- **appcontainer_runner.rs**: Use GetStdHandle + SetHandleInformation + PROC_THREAD_ATTRIBUTE_HANDLE_LIST for direct passthrough in pipe mode
- **base_container_runner.rs**: Same passthrough approach via STARTUPINFOW (inheritHandles stays FALSE per OS API contract - this deviates from regular CreateProcess semantics for explicit STD handle passing)

Closes: #70 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/457)