### PR TITLE
Gate build-dependent JOB_OBJECT_UILIMIT_* flags via a capability model

### DIFF
--- a/src/backends/appcontainer/common/src/job_object.rs
+++ b/src/backends/appcontainer/common/src/job_object.rs
@@ -14,6 +14,7 @@
 
 use core::ffi::c_void;
 use std::mem::size_of;
+use std::sync::OnceLock;
 
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::System::JobObjects::{
@@ -29,10 +30,124 @@ use windows_core::PCWSTR;
 use wxc_common::error::WxcError;
 use wxc_common::ui_policy::EffectiveUiRestrictions;
 
+/// Helper for loading `RtlGetVersion` from `ntdll.dll` to get the true
+/// (unshimmed) OS version. `GetVersionExW` lies on post-8.1 builds due
+/// to the compatibility shim.
+mod version_detect {
+    use std::mem::size_of;
+
+    use windows::Win32::Foundation::NTSTATUS;
+    use windows::Win32::System::SystemInformation::OSVERSIONINFOW;
+
+    type RtlGetVersionFn = unsafe extern "system" fn(version_info: *mut OSVERSIONINFOW) -> NTSTATUS;
+
+    /// Returns the real OS build number by calling `RtlGetVersion` from
+    /// `ntdll.dll`. Falls back to `u32::MAX` if the symbol cannot be
+    /// resolved or the call fails. `u32::MAX` is deliberately treated as
+    /// "modern" by capability gating so an indeterminate probe fails secure
+    /// (the more restrictive flag is kept rather than silently dropped).
+    pub(super) fn get_os_build_number() -> u32 {
+        // SAFETY: ntdll.dll is always loaded in every Windows process.
+        // `GetModuleHandleW` with "ntdll.dll" returns the existing module
+        // handle without incrementing a reference count.
+        unsafe {
+            let module = windows::Win32::System::LibraryLoader::GetModuleHandleW(
+                windows::core::w!("ntdll.dll"),
+            );
+            let module = match module {
+                Ok(h) => h,
+                Err(_) => return u32::MAX,
+            };
+            let proc = windows::Win32::System::LibraryLoader::GetProcAddress(
+                module,
+                windows::core::s!("RtlGetVersion"),
+            );
+            let proc = match proc {
+                Some(p) => p,
+                None => return u32::MAX,
+            };
+            let rtl_get_version: RtlGetVersionFn = std::mem::transmute(proc);
+            let mut info = OSVERSIONINFOW {
+                dwOSVersionInfoSize: size_of::<OSVERSIONINFOW>() as u32,
+                ..Default::default()
+            };
+            let status = rtl_get_version(&mut info);
+            if status.is_ok() {
+                info.dwBuildNumber
+            } else {
+                u32::MAX
+            }
+        }
+    }
+}
+
 /// `JOB_OBJECT_UILIMIT_INJECTION` from `winnt.h`. The `windows` crate
 /// does not emit this constant; if a future release adds it, the local
 /// definition can be removed and the import above extended.
 const JOB_OBJECT_UILIMIT_INJECTION: u32 = 0x0000_0200;
+
+/// Every `JOB_OBJECT_UILIMIT_*` bit this module's encoder
+/// ([`to_job_object_uilimit_mask`]) can emit. Acts as the universe for the
+/// capability intersection performed by [`supported_ui_limit_mask`]. Must
+/// stay in sync with the encoder — the `encoder_known_bit_positions` test
+/// pins the all-restrictions mask to this value.
+const ALL_DEFINED_UI_LIMITS: u32 = 0x0000_03FF;
+
+/// Minimum OS build that supports `JOB_OBJECT_UILIMIT_IME` (0x100).
+/// This flag is empirically accepted on Windows 11 22H2 (22621) and later
+/// — confirmed on 22631 (23H2) — but rejected with `ERROR_INVALID_PARAMETER`
+/// on Windows Server 2022 (20348). Its exact introduction build between 20348
+/// and 22631 is unconfirmed, so it is gated at the 22H2 boundary: builds below
+/// it conservatively omit the flag (UI-limit support is monotonic — once a
+/// build accepts the flag, every later build does too — so this never hands
+/// the kernel a flag it would reject).
+const MIN_BUILD_FOR_IME_LIMIT: u32 = 22621;
+
+/// Minimum OS build that supports `JOB_OBJECT_UILIMIT_INJECTION` (0x200).
+/// Windows 11 26100 (24H2) introduced this flag; earlier builds reject it
+/// with `ERROR_INVALID_PARAMETER`, so it is excluded from the supported
+/// UI-limit set on those builds.
+const MIN_BUILD_FOR_INJECTION_LIMIT: u32 = 26100;
+
+/// Cached OS build number (queried once via `RtlGetVersion`).
+static OS_BUILD_NUMBER: OnceLock<u32> = OnceLock::new();
+
+/// Returns the current OS build number, caching the result for the process
+/// lifetime. Returns `u32::MAX` when the build cannot be determined, which
+/// capability gating treats as "modern" so detection failures fail secure.
+pub fn os_build_number() -> u32 {
+    *OS_BUILD_NUMBER.get_or_init(version_detect::get_os_build_number)
+}
+
+/// Returns `true` when the current OS build can enforce
+/// `JOB_OBJECT_UILIMIT_INJECTION` (input-injection blocking). Introduced in
+/// build 26100; an unknown build is reported as supported (fail secure).
+pub fn input_injection_blocking_supported() -> bool {
+    os_build_number() >= MIN_BUILD_FOR_INJECTION_LIMIT
+}
+
+/// Pure capability map: given an OS build number, returns the subset of
+/// encoder-defined `JOB_OBJECT_UILIMIT_*` flags the kernel can enforce on
+/// that build. `JOB_OBJECT_UILIMIT_IME` and `JOB_OBJECT_UILIMIT_INJECTION`
+/// are build-gated; all other flags are universally supported.
+fn supported_ui_limit_mask_for_build(build: u32) -> u32 {
+    let mut supported = ALL_DEFINED_UI_LIMITS;
+    if build < MIN_BUILD_FOR_IME_LIMIT {
+        supported &= !JOB_OBJECT_UILIMIT_IME;
+    }
+    if build < MIN_BUILD_FOR_INJECTION_LIMIT {
+        supported &= !JOB_OBJECT_UILIMIT_INJECTION;
+    }
+    supported
+}
+
+/// Returns the subset of encoder-defined `JOB_OBJECT_UILIMIT_*` flags the
+/// current OS build can enforce. The effective restriction mask applied to a
+/// job is always `requested & supported`, so the kernel is never handed a
+/// flag it would reject. Reported to callers via `wxc-exec --probe`.
+pub fn supported_ui_limit_mask() -> u32 {
+    supported_ui_limit_mask_for_build(os_build_number())
+}
 
 /// Encode platform-agnostic UI restrictions as the `JOB_OBJECT_UILIMIT_*`
 /// bitmask consumed by `SetInformationJobObject(JobObjectBasicUIRestrictions)`
@@ -91,9 +206,17 @@ impl UiJobObject {
     /// Applies the given UI restrictions via `JobObjectBasicUIRestrictions`.
     /// Passing `EffectiveUiRestrictions::default()` clears all UI restrictions
     /// and is a valid no-op call.
+    ///
+    /// The mask actually applied is `requested & supported_ui_limit_mask()`:
+    /// flags the current OS build cannot enforce (e.g.
+    /// `JOB_OBJECT_UILIMIT_INJECTION` on builds older than 26100) are dropped
+    /// so the call never fails with `ERROR_INVALID_PARAMETER`. Which flags a
+    /// host can enforce is reported by `wxc-exec --probe`.
     pub fn set_ui_limits(&self, restrictions: &EffectiveUiRestrictions) -> Result<(), WxcError> {
+        let mask = to_job_object_uilimit_mask(restrictions) & supported_ui_limit_mask();
+
         let info = JOBOBJECT_BASIC_UI_RESTRICTIONS {
-            UIRestrictionsClass: JOB_OBJECT_UILIMIT(to_job_object_uilimit_mask(restrictions)),
+            UIRestrictionsClass: JOB_OBJECT_UILIMIT(mask),
         };
         // SAFETY: `info` is a valid, fully-initialized struct living on the
         // stack for the duration of the call. The size matches the struct
@@ -201,5 +324,102 @@ mod tests {
             }),
             0x0100
         );
+    }
+
+    #[test]
+    fn set_ui_limits_with_injection_succeeds_on_any_build() {
+        // Regardless of OS build, set_ui_limits must never fail due to the
+        // injection flag — the capability intersection drops it on downlevel.
+        let job = UiJobObject::new().expect("create");
+        job.set_ui_limits(&EffectiveUiRestrictions {
+            block_input_injection: true,
+            ..Default::default()
+        })
+        .expect("should succeed on any build");
+    }
+
+    #[test]
+    fn set_ui_limits_all_flags_succeeds_on_any_build() {
+        // The full ui.disable=true mask must succeed on any OS build.
+        let job = UiJobObject::new().expect("create");
+        let restrictions = EffectiveUiRestrictions {
+            block_external_ui_objects: true,
+            block_clipboard_read: true,
+            block_clipboard_write: true,
+            block_system_parameter_changes: true,
+            block_display_settings_changes: true,
+            block_global_ui_namespace: true,
+            block_desktop_switching: true,
+            block_logoff_or_shutdown: true,
+            block_input_method_changes: true,
+            block_input_injection: true,
+        };
+        job.set_ui_limits(&restrictions).expect("should succeed");
+    }
+
+    #[test]
+    fn supported_mask_strips_injection_on_downlevel() {
+        // Pre-26100 builds cannot enforce input-injection blocking, so it is
+        // excluded from the supported set; all other flags remain.
+        let mask = supported_ui_limit_mask_for_build(22631);
+        assert_eq!(mask & JOB_OBJECT_UILIMIT_INJECTION, 0);
+        assert_eq!(mask, ALL_DEFINED_UI_LIMITS & !JOB_OBJECT_UILIMIT_INJECTION);
+        assert_eq!(mask, 0x01FF);
+    }
+
+    #[test]
+    fn supported_mask_strips_ime_on_pre_22h2() {
+        // Builds older than 22621 (e.g. Server 2022 = 20348) reject the IME
+        // flag, so it is excluded along with injection; the classic
+        // JOB_OBJECT_UILIMIT_ALL (0xFF) set remains.
+        let mask = supported_ui_limit_mask_for_build(20348);
+        assert_eq!(mask & JOB_OBJECT_UILIMIT_IME, 0);
+        assert_eq!(mask & JOB_OBJECT_UILIMIT_INJECTION, 0);
+        assert_eq!(
+            mask,
+            ALL_DEFINED_UI_LIMITS & !JOB_OBJECT_UILIMIT_IME & !JOB_OBJECT_UILIMIT_INJECTION
+        );
+        assert_eq!(mask, 0x00FF);
+    }
+
+    #[test]
+    fn supported_mask_keeps_ime_on_22h2() {
+        // Build 22621 (22H2) and later support the IME flag.
+        let mask = supported_ui_limit_mask_for_build(22621);
+        assert_eq!(mask & JOB_OBJECT_UILIMIT_IME, JOB_OBJECT_UILIMIT_IME);
+    }
+
+    #[test]
+    fn supported_mask_keeps_injection_on_uplevel() {
+        // Build 26100 (24H2) and later support the injection flag.
+        let mask = supported_ui_limit_mask_for_build(26100);
+        assert_eq!(
+            mask & JOB_OBJECT_UILIMIT_INJECTION,
+            JOB_OBJECT_UILIMIT_INJECTION
+        );
+        assert_eq!(mask, ALL_DEFINED_UI_LIMITS);
+        assert_eq!(mask, 0x03FF);
+    }
+
+    #[test]
+    fn supported_mask_fails_secure_on_unknown_build() {
+        // An undetermined build (u32::MAX sentinel) keeps the more restrictive
+        // flag rather than silently dropping it.
+        let mask = supported_ui_limit_mask_for_build(u32::MAX);
+        assert_eq!(
+            mask & JOB_OBJECT_UILIMIT_INJECTION,
+            JOB_OBJECT_UILIMIT_INJECTION
+        );
+        assert!(
+            input_injection_blocking_supported()
+                || os_build_number() < MIN_BUILD_FOR_INJECTION_LIMIT
+        );
+    }
+
+    #[test]
+    fn os_build_number_is_reasonable() {
+        let build = os_build_number();
+        // Any Windows 10+ build number should be >= 10240.
+        assert!(build >= 10240, "unexpected build number: {build}");
     }
 }


### PR DESCRIPTION
This PR reshapes the UI-restriction handling so the set of enforceable
JOB_OBJECT_UILIMIT_* flags is treated as a host capability that varies by
OS build, rather than a per-exec degradation event. Two flags are
build-gated: JOB_OBJECT_UILIMIT_IME (0x100), accepted on Windows 11 22H2
(22621) and later but rejected on earlier builds (e.g. Server 2022,
20348); and JOB_OBJECT_UILIMIT_INJECTION (0x200), which requires Windows
build 26100 (24H2). On builds below each threshold the corresponding flag
is excluded from the enforceable mask while every other requested UI
restriction still applies. The effective mask is always
requested & supported(build).

Details

* job_object.rs: add ALL_DEFINED_UI_LIMITS (0x03FF); expose pub
  os_build_number(), input_injection_blocking_supported(), and
  supported_ui_limit_mask(); add supported_ui_limit_mask_for_build().
  set_ui_limits() returns Result<(), WxcError> and applies
  requested & supported_ui_limit_mask() instead of stripping-and-warning.
* Build-gate both extended flags: MIN_BUILD_FOR_IME_LIMIT (22621) drops
  IME below 22H2; MIN_BUILD_FOR_INJECTION_LIMIT (26100) drops injection
  below 24H2. UI-limit support is monotonic, so gating at these
  boundaries never hands the kernel a flag it would reject. This fixes
  the all-flags set_ui_limits failure on pre-22H2 CI runners.
* Fail secure on an undetermined build: os_build_number() returns
  u32::MAX when RtlGetVersion can't be resolved, which keeps the more
  restrictive flags rather than silently dropping them.

Tests

* cargo test -p appcontainer_common (release, x86_64-pc-windows-msvc):
  117 passed, including new supported_mask_strips_ime_on_pre_22h2
  (20348 -> 0x00FF), supported_mask_keeps_ime_on_22h2 (22621),
  supported_mask_strips_injection_on_downlevel (22631 -> 0x01FF),
  supported_mask_keeps_injection_on_uplevel (26100 -> 0x03FF), and
  supported_mask_fails_secure_on_unknown_build. set_ui_limits all-flags
  test verified passing on 23H2 (22631) and 25H2 machines.
* cargo fmt --all --check, clippy -p appcontainer_common
  --all-targets -D warnings, and cargo check -p wxc
  --features "hyperlight isolation_session microvm wslc" all clean.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/468)
