### PR TITLE
fix: route schema 0.4.0 through the tier dispatcher

### DIFF
--- a/src/backends/appcontainer/common/src/dispatcher.rs
+++ b/src/backends/appcontainer/common/src/dispatcher.rs
@@ -267,16 +267,24 @@ fn build_t3_dacl(
     Ok(mgr)
 }
 
-/// Build a runner with appropriate DACL augmentation for the
-/// BaseContainer-preferred path. The caller is responsible for the explicit
-/// (no-fallback) AppContainer path.
+/// Build a runner with appropriate DACL augmentation for the given
+/// base-container preference.
+///
+/// When `allow_base_container` is `true`, the detector may select Tier 1
+/// (BaseContainer) if the OS API is present. When `false`, Tier 1 is
+/// excluded and the fallback chain selects T2 (BFS, if compiled) or T3
+/// (DACL) -- use this for legacy schema versions (< 0.5.0) that must stay
+/// on AppContainer-based backends.
 ///
 /// On success the returned [`Dispatched`] contains a runner ready to
 /// execute and (when applicable) a [`DaclManager`] that has already
 /// applied its ACEs. Use [`Dispatched::into_runner_and_guard`] to
 /// extract both; the manager MUST stay alive through the run.
-pub fn dispatch_with_fallback(request: &ExecutionRequest) -> Result<Dispatched, DispatchError> {
-    let decision = fallback_detector::detect(&request.policy, /*prefer_bc=*/ true)?;
+pub fn dispatch_with_fallback(
+    request: &ExecutionRequest,
+    allow_base_container: bool,
+) -> Result<Dispatched, DispatchError> {
+    let decision = fallback_detector::detect(&request.policy, allow_base_container)?;
 
     let (runner, dacl_manager): (Box<dyn ScriptRunner>, Option<DaclManager>) = match decision.tier {
         IsolationTier::BaseContainer => {
@@ -400,7 +408,7 @@ mod tests {
     fn dispatch_t1_no_denied_paths_no_dacl() {
         let _g = ForceTierGuard::set("base-container");
         let req = test_request(empty_policy());
-        let d = dispatch_with_fallback(&req).expect("T1 dispatch should succeed");
+        let d = dispatch_with_fallback(&req, true).expect("T1 dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));
         assert!(
             !d.has_dacl_guard(),
@@ -418,7 +426,7 @@ mod tests {
         let _g = ForceTierGuard::set("base-container");
         let (policy, _tmp) = policy_with_denied_temp();
         let req = test_request(policy);
-        let d = dispatch_with_fallback(&req).expect("T1+deny dispatch should succeed");
+        let d = dispatch_with_fallback(&req, true).expect("T1+deny dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));
         assert!(
             !d.has_dacl_guard(),
@@ -430,7 +438,7 @@ mod tests {
         let _g = ForceTierGuard::set("appcontainer-bfs");
         let (policy, _tmp) = policy_with_denied_temp();
         let req = test_request(policy);
-        let d = dispatch_with_fallback(&req).expect("T2+deny dispatch should succeed");
+        let d = dispatch_with_fallback(&req, true).expect("T2+deny dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
         assert!(d.has_dacl_guard());
     }
@@ -439,7 +447,7 @@ mod tests {
         let _g = ForceTierGuard::set("appcontainer-dacl");
         let (policy, _tmp) = policy_with_rw_temp();
         let req = test_request(policy);
-        let d = dispatch_with_fallback(&req).expect("T3 dispatch should succeed");
+        let d = dispatch_with_fallback(&req, true).expect("T3 dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerDacl));
         assert!(
             d.has_dacl_guard(),
@@ -452,7 +460,7 @@ mod tests {
         let (mut policy, _tmp) = policy_with_rw_temp();
         policy.fallback.allow_dacl_mutation = false;
         let req = test_request(policy);
-        let res = dispatch_with_fallback(&req);
+        let res = dispatch_with_fallback(&req, true);
         assert!(matches!(
             res,
             Err(DispatchError::Fallback(FallbackError::DaclFallbackDisabled))
@@ -595,7 +603,40 @@ mod tests {
             return;
         }
         let req = test_request(empty_policy());
-        let d = dispatch_with_fallback(&req).expect("dispatch should succeed");
+        let d = dispatch_with_fallback(&req, true).expect("dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::BaseContainer));
+    }
+
+    #[test]
+    fn dispatch_appcontainer_only_never_selects_base_container() {
+        // Even on a host where BaseContainer is available, the
+        // appcontainer-only dispatcher must never select Tier 1.
+        let req = test_request(empty_policy());
+        let d =
+            dispatch_with_fallback(&req, false).expect("appcontainer-only dispatch should succeed");
+        assert!(
+            !matches!(d.tier, IsolationTier::BaseContainer),
+            "dispatch_appcontainer_only must not select BaseContainer, got {:?}",
+            d.tier.as_str()
+        );
+    }
+
+    #[test]
+    fn dispatch_appcontainer_only_with_fs_policy_selects_dacl_without_tier2_bfs() {
+        // Without `tier2_bfs`, the dispatcher skips T2 and lands on T3
+        // (AppContainerDacl). This is the fix path for schema 0.4.0 configs.
+        if cfg!(feature = "tier2_bfs") {
+            eprintln!("skipping: tier2_bfs is compiled in; test targets the no-BFS path");
+            return;
+        }
+        let (policy, _tmp) = policy_with_rw_temp();
+        let req = test_request(policy);
+        let d = dispatch_with_fallback(&req, false)
+            .expect("appcontainer-only+fs dispatch should succeed");
+        assert!(
+            matches!(d.tier, IsolationTier::AppContainerDacl),
+            "expected AppContainerDacl without tier2_bfs, got {:?}",
+            d.tier.as_str()
+        );
     }
 }

--- a/src/backends/appcontainer/common/src/fallback_detector.rs
+++ b/src/backends/appcontainer/common/src/fallback_detector.rs
@@ -103,7 +103,7 @@ pub enum FallbackError {
 /// The algorithm matches the design doc:
 ///
 /// 1. If `MXC_FORCE_TIER` is set in a test build, honor it (test seam).
-/// 2. Try Tier 1 (BaseContainer) when `prefer_base_container` is true and the
+/// 2. Try Tier 1 (BaseContainer) when `allow_base_container` is true and the
 ///    API surface is detected.
 /// 3. Otherwise try Tier 2 (AppContainer + BFS), but **only when this binary
 ///    was compiled with the `tier2_bfs` Cargo feature**. With the feature on,
@@ -130,7 +130,7 @@ pub enum FallbackError {
 /// fails, which on a healthy Windows host should never happen.
 pub fn detect(
     policy: &ContainerPolicy,
-    prefer_base_container: bool,
+    allow_base_container: bool,
 ) -> Result<TierDecision, FallbackError> {
     let denied = !policy.denied_paths.is_empty();
     let has_fs_policy =
@@ -160,7 +160,7 @@ pub fn detect(
     let mut warnings: Vec<String> = Vec::new();
 
     // Tier 1 — BaseContainer
-    if prefer_base_container && is_base_container_api_present() {
+    if allow_base_container && is_base_container_api_present() {
         if denied {
             ensure_dacl_augmentation_allowed(policy)?;
             verify_write_dac_all(&policy.denied_paths)?;
@@ -938,7 +938,7 @@ mod tests {
         };
         let mut policy = empty_policy();
         policy.fallback.allow_dacl_mutation = true;
-        // `prefer_base_container = false` skips Tier 1 deterministically;
+        // `allow_base_container = false` skips Tier 1 deterministically;
         // with `tier2_bfs` off, Tier 2 is skipped too.
         let d = detect(&policy, false).expect("empty policy must resolve");
         assert!(

--- a/src/backends/appcontainer/common/src/probe.rs
+++ b/src/backends/appcontainer/common/src/probe.rs
@@ -70,7 +70,7 @@ pub fn run_probe(policy: &ContainerPolicy) -> ProbeOutput {
             .is_some(),
         bfs_compiled_in: cfg!(feature = "tier2_bfs"),
     };
-    match fallback_detector::detect(policy, /* prefer_base_container */ true) {
+    match fallback_detector::detect(policy, /* allow_base_container */ true) {
         Ok(decision) => ProbeOutput {
             tier: Some(decision.tier.as_str()),
             needs_dacl_augmentation: Some(decision.needs_dacl_augmentation),

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -7,9 +7,7 @@ use std::process;
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
 
-use appcontainer_common::appcontainer_runner::{
-    delete_app_container_profile, AppContainerScriptRunner,
-};
+use appcontainer_common::appcontainer_runner::delete_app_container_profile;
 use clap::Parser;
 #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
 use hyperlight_common::HyperlightScriptRunner;
@@ -806,54 +804,61 @@ fn main() {
     let mut runner: Box<dyn ScriptRunner> = match request.containment {
         ContainmentBackend::ProcessContainer => {
             // Compute fallback eligibility on the ProcessContainer arm
-            // only — every other `ContainmentBackend` variant is
-            // unaffected by `use_base_container` and does not need to
+            // only -- every other `ContainmentBackend` variant is
+            // unaffected by `allow_base_container` and does not need to
             // pay the (trivial) semver parse cost.
             let version_implies_base_container = is_base_container_version(&request.schema_version);
-            let use_base_container = request.experimental_enabled || version_implies_base_container;
+            let allow_base_container =
+                request.experimental_enabled || version_implies_base_container;
 
-            if use_base_container {
+            if allow_base_container {
                 let reason = if version_implies_base_container {
                     format!("schema version {}", request.schema_version)
                 } else {
                     "--experimental".to_string()
                 };
                 let _ = writeln!(logger, "Using BaseContainer-fallback dispatcher ({reason})");
-
-                match appcontainer_common::dispatcher::dispatch_with_fallback(&request) {
-                    Ok(dispatched) => {
-                        for w in &dispatched.warnings {
-                            let _ = writeln!(logger, "warning: {w}");
-                        }
-                        let _ = writeln!(
-                            logger,
-                            "selected isolation tier: {}",
-                            dispatched.tier.as_str()
-                        );
-
-                        let (dispatched_runner, dacl_manager) = dispatched.into_runner_and_guard();
-                        if let Some(mgr) = dacl_manager {
-                            park_dacl_for_cleanup(mgr);
-                        }
-                        dispatched_runner
-                    }
-                    Err(e) => {
-                        eprintln!("error: {e}");
-                        if let appcontainer_common::dispatcher::DispatchError::Dacl {
-                            warnings,
-                            ..
-                        } = &e
-                        {
-                            for w in warnings {
-                                eprintln!("  dacl warning: {w}");
-                            }
-                        }
-                        eprint!("{}", logger.get_buffer());
-                        process::exit(1);
-                    }
-                }
             } else {
-                Box::new(AppContainerScriptRunner::new())
+                let _ = writeln!(
+                    logger,
+                    "Using AppContainer-only dispatcher (schema {})",
+                    request.schema_version
+                );
+            }
+
+            match appcontainer_common::dispatcher::dispatch_with_fallback(
+                &request,
+                allow_base_container,
+            ) {
+                Ok(dispatched) => {
+                    for w in &dispatched.warnings {
+                        let _ = writeln!(logger, "warning: {w}");
+                    }
+                    let _ = writeln!(
+                        logger,
+                        "selected isolation tier: {}",
+                        dispatched.tier.as_str()
+                    );
+
+                    let (dispatched_runner, dacl_manager) = dispatched.into_runner_and_guard();
+                    if let Some(mgr) = dacl_manager {
+                        park_dacl_for_cleanup(mgr);
+                    }
+                    dispatched_runner
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    if let appcontainer_common::dispatcher::DispatchError::Dacl {
+                        warnings, ..
+                    } = &e
+                    {
+                        for w in warnings {
+                            eprintln!("  dacl warning: {w}");
+                        }
+                    }
+                    eprint!("{}", logger.get_buffer());
+                    process::exit(1);
+                }
             }
         }
         ContainmentBackend::Wslc => {


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----
## Issue
0.4.0 schemas always choose Tier 2 - even when it's not compiled in.

## Summary

Schema versions below 0.5.0 previously bypassed the fallback dispatcher and constructed a bare `AppContainerScriptRunner` with the default `FilesystemMode::Bfs`. Without the `tier2_bfs` feature compiled in, `bfscfg.exe` could never be resolved, causing a hard error on any config that declared filesystem policy paths.

Now all `ProcessContainer` requests go through `dispatch_with_fallback` with an `allow_base_container` flag derived from schema version / `--experimental`. Legacy schemas pass `false` so the dispatcher skips Tier 1 (BaseContainer) and correctly falls through to T2 (BFS, if compiled) or T3 (DACL).

Also refactors the dispatcher API: `dispatch_with_fallback` now takes an explicit `allow_base_container: bool` parameter instead of hardcoding `true`, eliminating the need for a separate `dispatch_appcontainer_only` function.