### PR TITLE
Improve error message when bfscfg.exe is unavailable on schema 0.4.0

### DIFF
--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -967,7 +967,21 @@ impl ScriptRunner for AppContainerScriptRunner {
             FileSystemBfsManager::new(self.app_container_name.clone(), bfscfg_path);
         if self.filesystem_mode == FilesystemMode::Bfs {
             if let Err(e) = bfs_manager.configure(&request.policy, logger) {
-                return ScriptResponse::error(&e.to_string());
+                let msg = if matches!(&e, WxcError::BfsNotAvailable)
+                    && request.schema_version.starts_with("0.4.0")
+                {
+                    format!(
+                        "Filesystem policy error: bfscfg.exe is not available on this Windows build. \
+                         Your config uses schema version '{}', which requires BFS support. \
+                         Either update your Windows build to one that includes bfscfg.exe, \
+                         or update your config to schema version '0.6.0-alpha' or later \
+                         (which uses the BaseContainer backend and does not require bfscfg.exe).",
+                        request.schema_version
+                    )
+                } else {
+                    e.to_string()
+                };
+                return ScriptResponse::error(&msg);
             }
         }
 

--- a/src/backends/appcontainer/common/src/filesystem_bfs.rs
+++ b/src/backends/appcontainer/common/src/filesystem_bfs.rs
@@ -72,10 +72,7 @@ impl FileSystemBfsManager {
         }
 
         if self.bfscfg_path.is_none() {
-            return Err(WxcError::FilesystemPolicy(
-                "Cannot configure BFS policy: bfscfg.exe was not resolved at probe time"
-                    .to_string(),
-            ));
+            return Err(WxcError::BfsNotAvailable);
         }
 
         for path in &policy.readwrite_paths {

--- a/src/core/wxc_common/src/error.rs
+++ b/src/core/wxc_common/src/error.rs
@@ -23,6 +23,9 @@ pub enum WxcError {
     #[error("Filesystem policy error: {0}")]
     FilesystemPolicy(String),
 
+    #[error("Filesystem policy error: bfscfg.exe is not available on this host")]
+    BfsNotAvailable,
+
     #[error("Initialization error: {0}")]
     Initialization(String),
 


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [\\.github/copilot-instructions.md\\](.github/copilot-instructions.md).

-----

## Summary

When users pass a config with schema \
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/471)
 
 
<img width="1100" height="124" alt="image" src="https://github.com/user-attachments/assets/57bb11fc-9155-4d64-a707-4a27a6e75855" />
