### PR TITLE
Bump SDK and Rust workspace to 0.6.1 for build

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for MXC (Microsoft eXecution Containers)",
   "type": "module",
   "types": "dist/index.d.ts",

--- a/sdk/tests/integration/package-lock.json
+++ b/sdk/tests/integration/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "appcontainer_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "flatbuffers",
  "getrandom 0.2.17",
@@ -213,7 +213,7 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bwrap_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "lxc_common",
  "nix",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "hyperlight-unikraft-host",
  "wxc_common",
@@ -1067,7 +1067,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isolation_session_bindings"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "semver",
  "windows",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "isolation_session_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "isolation_session_bindings",
  "serde",
@@ -1242,7 +1242,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lxc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bwrap_common",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "lxc_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "mxc_pty",
@@ -1371,14 +1371,14 @@ dependencies = [
 
 [[package]]
 name = "mxc_build_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "winresource",
 ]
 
 [[package]]
 name = "mxc_darwin"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "mxc_build_common",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_diagnostic_console"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "mxc_build_common",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_pty"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "nix",
@@ -1409,14 +1409,14 @@ dependencies = [
 
 [[package]]
 name = "nanvix_binaries"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "nanvix_common",
 ]
 
 [[package]]
 name = "nanvix_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix_runner"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "nanvix_common",
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox_spec"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "flatbuffers",
 ]
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "seatbelt_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libc",
  "mxc_pty",
@@ -2691,7 +2691,7 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_sandbox_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2831,7 +2831,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wslc_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "libloading",
  "tar",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "wxc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "appcontainer_common",
@@ -2864,7 +2864,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_common"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "getrandom 0.2.17",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_e2e_tests"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "serde",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_host_prep"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "embed-manifest",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_test_driver"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_test_proxy"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bytes",
  "clap",
@@ -2936,7 +2936,7 @@ version = "0.1.0"
 
 [[package]]
 name = "wxc_windows_sandbox_daemon"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_windows_sandbox_guest"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_winhttp_proxy_shim"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "clap",
  "mxc_build_common",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -44,7 +44,7 @@ split-debuginfo = "packed"
 strip = "debuginfo"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/tests/playground/package-lock.json
+++ b/tests/playground/package-lock.json
@@ -24,7 +24,7 @@
     },
     "../../sdk": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Updates SDK, its dependents and the rust workspace to version 0.6.1 for MS build. This new release will have some fixes for down-level OSes.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/472)