### PR TITLE
Update Linux backend list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MXC ships a native container wrapper plus a TypeScript SDK — see the [SDK READ
 | Platform | Default backend | Other backends | Minimum build |
 | --- | --- | --- | --- |
 | Windows 11 24H2+ (verified on 25H2) | `processcontainer` | `windows_sandbox`, `wslc`, `microvm`, `hyperlight`, `isolation_session` | `processcontainer`: 26100 (24H2)<br>`isolation_session`: 26300.8553 ([Insider Preview](https://learn.microsoft.com/en-us/windows-insider/release-notes/experimental/preview-build-26300-8553)) |
-| Linux x64 / ARM64 | `bubblewrap` | `lxc` | — |
+| Linux x64 / ARM64 | `bubblewrap` | `lxc`, `microvm`, `hyperlight` | — |
 | macOS ARM64 / x64 (schema `0.6.0-alpha`+) | `seatbelt` | — | — |
 
 


### PR DESCRIPTION
Add `microvm` and `hyperlight` to the Linux row in the Platforms table — both are available through `lxc-exec` behind feature flags but were missing from the README.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/477)