### PR TITLE
Fix fork-PR CI: split Rust build steps into Official / Public templates

### DIFF
--- a/.azure-pipelines/.cargo/config.public.toml
+++ b/.azure-pipelines/.cargo/config.public.toml
@@ -1,0 +1,14 @@
+
+# Public, anonymous-read mirror of crates.io for fork-PR / Unofficial builds
+# that can't authenticate to the internal Mxc-Azure-Feed.
+# Feed: https://dev.azure.com/shine-oss/mxc/_artifacts/feed/MxcDependencies
+
+[registries]
+MxcDependencies = { index = "sparse+https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/Cargo/index/" }
+
+[source.crates-io]
+replace-with = "MxcDependencies"
+
+# Cross-compile linker for arm64 linux (mirrors config.toml).
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.azure-pipelines/templates/Cargo.Setup.Public.yml
+++ b/.azure-pipelines/templates/Cargo.Setup.Public.yml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Appends the public MxcDependencies cargo feed (config.public.toml) to the
+# workspace .cargo/config.toml. Used by Unofficial / fork-PR Rust steps so
+# crate downloads work under 1ES pool network isolation (crates.io is not on
+# the allowlist). Mirrors the Official setup step in Rust.Build.Steps.Official.yml.
+
+steps:
+  - pwsh: |
+      $cfg = "$(Build.SourcesDirectory)/.cargo/config.toml"
+      New-Item -ItemType Directory -Force -Path (Split-Path $cfg) | Out-Null
+      Add-Content -Path $cfg -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.public.toml"))
+    displayName: Setup Cargo Config (public feed)

--- a/.azure-pipelines/templates/Lint.Job.yml
+++ b/.azure-pipelines/templates/Lint.Job.yml
@@ -1,21 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# Standalone Lint stage that runs `cargo fmt --check` and `cargo clippy`
-# (with --all-features) in parallel with the Build_Binaries stage.
-#
-# Why this exists: clippy was previously a step inside Rust.Build.Job.yml
-# that ran AFTER the release build of the workspace finished. Because clippy
-# uses `--all-features` while the build uses default features, the cargo
-# fingerprint cache misses and clippy ends up recompiling the entire
-# workspace from scratch — adding ~10+ minutes to the critical path of the
-# x64 WXC build. Moving clippy into its own job lets it run in parallel
-# with the build, so wall-clock time on the pipeline becomes
-# max(build, clippy) instead of build + clippy.
-#
-# Linting is scoped to the two x64 targets because the existing inline step
-# was already gated on `isX64`. arm64 lint coverage is identical to x64 for
-# the rust source we control.
+# Standalone Lint stage (`cargo fmt --check` + `cargo clippy --all-features`)
+# that runs in parallel with Build_Binaries so clippy's full-feature recompile
+# doesn't extend the critical path.
 
 parameters:
 - name: matrix
@@ -25,10 +13,20 @@ parameters:
       os: windows
       triplet: x86_64-pc-windows-msvc
       component: WXC
+      clippyArgs: --locked --all-targets --all-features --release
     - name: linux_x64
       os: linux
       triplet: x86_64-unknown-linux-gnu
       component: LXC
+      clippyArgs: --locked --all-targets --all-features --release
+    - name: macos_arm64
+      os: macos
+      triplet: aarch64-apple-darwin
+      component: MAC
+      # macOS-only crates (mxc_darwin, seatbelt_common) — the workspace
+      # has Windows-only crates that do not compile on macOS, so we can't
+      # use --all-features here.
+      clippyArgs: --locked --release -p mxc_darwin -p seatbelt_common
 
 jobs:
 - ${{ each item in parameters.matrix }}:
@@ -36,13 +34,18 @@ jobs:
     displayName: 'Lint (${{ item.component }} ${{ item.os }})'
 
     pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      ${{ if eq(item.os, 'windows') }}:
-        image: windows-latest
-        os: windows
-      ${{ if eq(item.os, 'linux') }}:
-        image: ubuntu-latest
-        os: linux
+      ${{ if eq(item.os, 'macos') }}:
+        name: Azure Pipelines
+        vmImage: macOS-14-arm64
+        os: macOS
+      ${{ if ne(item.os, 'macos') }}:
+        name: Azure-Pipelines-1ESPT-ExDShared
+        ${{ if eq(item.os, 'windows') }}:
+          image: windows-latest
+          os: windows
+        ${{ if eq(item.os, 'linux') }}:
+          image: ubuntu-latest
+          os: linux
 
     variables:
       ${{ if eq(item.os, 'windows') }}:
@@ -53,42 +56,22 @@ jobs:
         # LXC build job uses src/core/lxc as cwd; mirror it so the cargo
         # target-dir cache key matches and we benefit from any shared cache.
         workingDirectory: $(Build.SourcesDirectory)/src/core/lxc
+      ${{ if eq(item.os, 'macos') }}:
+        CARGO_TARGET_DIR: $(Agent.TempDirectory)/target
+        workingDirectory: $(Build.SourcesDirectory)/src
       targetTriple: ${{ item.triplet }}
-
-    templateContext:
-      rust:
-        rustToolchain:
-          toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
-          version: 'ms-prod-1.93'
-          additionalTargets: $(targetTriple)
-        workingDirectory: $(workingDirectory)
-        cacheOptions:
-          enabled: true
-          enableTargetCache: true
 
     steps:
       - checkout: self
 
-      # Append pipeline-specific Cargo settings (registry, cross-compile linker)
-      # to the workspace config so crate downloads go through the centralized
-      # Azure Artifacts feed. Mirrors the setup in Rust.Build.Job.yml.
-      - powershell: |
-          Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
-        displayName: Setup Cargo Config
-
-      - task: 1ES.Build.Rust.Setup@1
-      - task: 1ES.Build.Rust.Restore@1
+      - template: Rust.Toolchain.Public.yml@self
+        parameters:
+          targetTriple: $(targetTriple)
 
       - script: cargo fmt --all -- --check
         displayName: cargo fmt --check
         workingDirectory: $(workingDirectory)
 
-      # Run clippy via plain cargo. Note the deliberate lack of `--workspace`:
-      # on Linux this job runs from `src/core/lxc` which scopes clippy to the lxc
-      # package and its deps (matching the existing build's scope); the
-      # Windows job runs from `src/` (the workspace root with no `[package]`),
-      # so cargo's default expands to all workspace members. This avoids
-      # dragging Windows-only crates (e.g. wxc) into the Linux clippy graph.
-      - script: cargo clippy --locked --all-targets --all-features --target $(targetTriple) --release -- -D warnings
-        displayName: cargo clippy --all-features
+      - script: cargo clippy --target $(targetTriple) ${{ item.clippyArgs }} -- -D warnings
+        displayName: cargo clippy
         workingDirectory: $(workingDirectory)

--- a/.azure-pipelines/templates/Lint.Job.yml
+++ b/.azure-pipelines/templates/Lint.Job.yml
@@ -68,6 +68,10 @@ jobs:
         parameters:
           targetTriple: $(targetTriple)
 
+      # Redirect crates.io to the public MxcDependencies feed (1ES network
+      # isolation blocks crates.io).
+      - template: Cargo.Setup.Public.yml@self
+
       - script: cargo fmt --all -- --check
         displayName: cargo fmt --check
         workingDirectory: $(workingDirectory)

--- a/.azure-pipelines/templates/Mac.Build.Job.yml
+++ b/.azure-pipelines/templates/Mac.Build.Job.yml
@@ -2,14 +2,7 @@
 # Licensed under the MIT License.
 #
 # Builds mxc-exec-mac (the macOS sandbox executor) on an ARM64 macOS
-# Microsoft-hosted agent and publishes the binary as a pipeline artifact
-# so the Package.NpmSdk and SDK.Integration.Test stages can consume it.
-#
-# This template uses the Microsoft Rust toolchain installer (msrustup) from
-# the Azure Artifacts NuGet feed instead of the 1ES.Build.Rust.* tasks, which
-# are not available on the Microsoft-hosted macOS pool. Crate downloads still
-# go through the centralized Azure Artifacts feed (appended via
-# .azure-pipelines/.cargo/config.toml) to satisfy supply-chain security requirements.
+# Microsoft-hosted agent and publishes the binary as a pipeline artifact.
 
 parameters:
 - name: triplet
@@ -45,48 +38,21 @@ jobs:
   steps:
     - checkout: self
 
-    # Append pipeline-specific Cargo settings (centralized registry) to
-    # the workspace config so crates are pulled from the Azure Artifacts
-    # feed (supply-chain security). Authentication is provided via env var on
-    # each cargo step since 1ES.Build.Rust.Setup is not available on macOS.
-    # The append is guarded: skip if the registry block is already present
-    # (e.g., if the workspace config gains these settings in the future).
-    - script: |
-        echo "" >> "$(Build.SourcesDirectory)/.cargo/config.toml"
-        cat "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml" >> "$(Build.SourcesDirectory)/.cargo/config.toml"
-      displayName: Setup Cargo Config
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - template: Rust.Build.Steps.Official.yml@self
+        parameters:
+          targetTriple: $(targetTriple)
+          workingDirectory: $(workingDirectory)
+          # macOS-only crate set; the rest of the workspace has Windows-only
+          # crates that do not compile on macOS.
+          cargoPackages: mxc_darwin,seatbelt_common,wxc_common
 
-    # Install the Microsoft Rust toolchain from the NuGet feed instead of
-    # plain rustup. This satisfies 1ES supply-chain requirements by using
-    # the same centralized feed (Mxc-Azure-Feed) as Windows/Linux builds.
-    - task: RustInstaller@1
-      inputs:
-        toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
-        rustVersion: 'ms-prod-1.93'
-        cratesIoFeedOverride: sparse+https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/Cargo/index/
-      displayName: Install Rust toolchain
-
-    - task: CargoAuthenticate@0
-      inputs:
-        configFile: '$(Build.SourcesDirectory)/.cargo/config.toml'
-
-    - script: cargo fmt --all -- --check
-      displayName: Check formatting
-      workingDirectory: $(workingDirectory)
-
-    # Clippy is scoped to the macOS-specific crates because the full
-    # workspace includes Windows-only crates that do not compile on macOS.
-    - script: cargo clippy -p mxc_darwin -p seatbelt_common --target $(targetTriple) -- -D warnings
-      displayName: Clippy
-      workingDirectory: $(workingDirectory)
-
-    - script: cargo build --release --target $(targetTriple) -p mxc_darwin
-      displayName: Build release
-      workingDirectory: $(workingDirectory)
-
-    - script: cargo test --release --target $(targetTriple) -p mxc_darwin -p seatbelt_common -p wxc_common
-      displayName: Run tests
-      workingDirectory: $(workingDirectory)
+    - ${{ else }}:
+      - template: Rust.Build.Steps.Unofficial.yml@self
+        parameters:
+          targetTriple: $(targetTriple)
+          workingDirectory: $(workingDirectory)
+          cargoArgs: -p mxc_darwin -p seatbelt_common -p wxc_common
 
     # --- macOS Code Signing + Notarization (official builds only) ---
     # ESRP handles the full signing flow using Microsoft's Developer ID

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -65,12 +65,6 @@ jobs:
           lxc-exec
           linux-test-proxy
 
-      ${{ if eq(item.arch, 'x64') }}:
-        isX64: true
-        
-      ${{ if eq(item.arch, 'arm64') }}:
-        isX64: false
-      
       # Paths
       targetTriple: $(triplet)
       targetTripleDir: $(CARGO_TARGET_DIR)/$(targetTriple)/release
@@ -94,7 +88,10 @@ jobs:
             targetTriple: $(triplet)
             workingDirectory: $(workingDirectory)
             cargoFeatures: $(cargoFeatures)
-            enableTest: $(isX64)
+            ${{ if eq(item.arch, 'x64') }}:
+              enableTest: 'true'
+            ${{ else }}:
+              enableTest: 'false'
 
       - ${{ else }}:
         # Fork-PR / Unofficial: plain rustup + crates.io, no auth tasks.
@@ -103,7 +100,10 @@ jobs:
             targetTriple: $(triplet)
             workingDirectory: $(workingDirectory)
             cargoArgs: --no-default-features --features "$(cargoFeatures)"
-            enableTest: $(isX64)
+            ${{ if eq(item.arch, 'x64') }}:
+              enableTest: 'true'
+            ${{ else }}:
+              enableTest: 'false'
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -43,6 +43,9 @@ jobs:
         CARGO_TARGET_DIR: c:/t/target
         artifactPrefix: wxc-binaries
         workingDirectory: $(Build.SourcesDirectory)/src
+        # Explicit feature set (no --all-features): tier2_bfs must NOT ship
+        # on Win 11 25H2 (bfscfg.exe risks an OS hang).
+        cargoFeatures: hyperlight isolation_session microvm wslc
         signPattern: |
             wxc-exec.exe
             wxc-host-prep.exe
@@ -57,6 +60,7 @@ jobs:
         CARGO_TARGET_DIR: /tmp/target
         artifactPrefix: lxc-binaries
         workingDirectory: $(Build.SourcesDirectory)/src/core/lxc
+        cargoFeatures: hyperlight
         signPattern: |
           lxc-exec
           linux-test-proxy
@@ -74,21 +78,6 @@ jobs:
       artifactBaseName: $(artifactPrefix)-$(targetTriple)
       configTomlPath: $(Build.SourcesDirectory)/.cargo/config.toml
 
-    templateContext:
-      rust:
-        rustToolchain:
-          toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
-          version: 'ms-prod-1.93'
-          additionalTargets: $(triplet)
-        workingDirectory: $(workingDirectory)
-        authenticateOptions:
-          configFile: $(configTomlPath)
-        installOptions:
-          configFile: $(configTomlPath)
-        cacheOptions:
-          enabled: true
-          enableTargetCache: true
-
     steps:
       - checkout: self
 
@@ -99,44 +88,22 @@ jobs:
         displayName: Install ARM64 toolchain
         condition: and(eq('${{ item.os }}','linux'), eq('${{ item.arch }}','arm64'))
 
-      # Append pipeline-specific Cargo settings (registry, cross-compile linker) to the workspace config
-      - powershell: |
-          Add-Content -Path "$(configTomlPath)" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
-        displayName: Setup Cargo Config
+      - ${{ if eq(parameters.isOfficialBuild, true) }}:
+        - template: Rust.Build.Steps.Official.yml@self
+          parameters:
+            targetTriple: $(triplet)
+            workingDirectory: $(workingDirectory)
+            cargoFeatures: $(cargoFeatures)
+            enableTest: $(isX64)
 
-      - task: 1ES.Build.Rust.Setup@1
-      - task: 1ES.Build.Rust.Restore@1
-
-      - task: 1ES.Build.Rust.Run@1
-        displayName: Build
-        inputs:
-          command: build
-          profile: release
-          target: $(triplet)
-          testCondition: "eq(variables['isX64'], 'true')" # 1ES nested template takes this as a string
-          enableTest: $(isX64)
-          publishTestResults: false
-          # Clippy + fmt run in the parallel Lint stage (Lint.Job.yml).
-          enableClippy: false
-          enableCodeStyleCheck: false
-          checkAllCodeStyle: false
-          useNextest: false
-          testAllTargets: false
-          buildAllTargets: false
-          # IMPORTANT: do not let the 1ES task default to `--all-features`. The
-          # `tier2_bfs` Cargo feature gates Tier 2 (BFS) and must NOT be
-          # compiled into production binaries on Win 11 25H2 (the embedded
-          # `bfscfg.exe` invocation risks an OS hang). See
-          # `.github/workflows/build.yml`, `tests/scripts/T3-Workloads.ps1`,
-          # and `tests/scripts/Win25H2Safe-Tests.ps1` for the safety model.
-          # Enumerate the production feature set explicitly so the shipped
-          # binary still carries every runtime backend except `tier2_bfs`.
-          # Schema reference: https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/buildworkflows/rust-virtual-task
-          allFeatures: false
-          ${{ if eq(item.os, 'windows') }}:
-            activatedFeatures: 'hyperlight isolation_session microvm wslc'
-          ${{ if eq(item.os, 'linux') }}:
-            activatedFeatures: 'hyperlight'
+      - ${{ else }}:
+        # Fork-PR / Unofficial: plain rustup + crates.io, no auth tasks.
+        - template: Rust.Build.Steps.Unofficial.yml@self
+          parameters:
+            targetTriple: $(triplet)
+            workingDirectory: $(workingDirectory)
+            cargoArgs: --no-default-features --features "$(cargoFeatures)"
+            enableTest: $(isX64)
 
       # linux_test_proxy is a separate workspace member (not a dep of lxc), so
       # the workspace-member-scoped build above doesn't pick it up. Build it

--- a/.azure-pipelines/templates/Rust.Build.Steps.Official.yml
+++ b/.azure-pipelines/templates/Rust.Build.Steps.Official.yml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Official-build Rust toolchain + build/test. Uses the internal
+# Mxc-Azure-Feed (requires System.AccessToken) and the 1ES.Build.Rust.Run
+# virtual task, which emits the SBOM into RustBuildEvidence_<triplet>_release.
+# Use Rust.Build.Steps.Unofficial.yml for fork/PR builds.
+
+parameters:
+- name: targetTriple
+  type: string
+- name: workingDirectory
+  type: string
+- name: cargoFeatures
+  type: string
+  default: ''
+- name: cargoPackages
+  type: string
+  default: ''
+- name: enableTest
+  type: string
+  default: 'true'
+- name: rustVersion
+  type: string
+  default: 'ms-prod-1.93'
+
+steps:
+  # Append pipeline-specific Cargo settings (centralized registry) to the
+  # workspace config so crates are pulled from the Azure Artifacts feed
+  # (supply-chain security).
+  - pwsh: |
+      Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+    displayName: Setup Cargo Config (Mxc-Azure-Feed)
+
+  - task: RustInstaller@1
+    displayName: Install Rust toolchain (Mxc-Azure-Feed)
+    inputs:
+      toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
+      rustVersion: ${{ parameters.rustVersion }}
+      additionalTargets: ${{ parameters.targetTriple }}
+      cratesIoFeedOverride: sparse+https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/Cargo/index/
+
+  - task: CargoAuthenticate@0
+    displayName: Cargo Authenticate
+    inputs:
+      configFile: '$(Build.SourcesDirectory)/.cargo/config.toml'
+
+  - task: 1ES.Build.Rust.Run@1
+    displayName: Build + Test (1ES)
+    inputs:
+      command: build
+      profile: release
+      target: ${{ parameters.targetTriple }}
+      enableTest: ${{ parameters.enableTest }}
+      testCondition: ${{ parameters.enableTest }}
+      publishTestResults: false
+      enableClippy: false
+      enableCodeStyleCheck: false
+      checkAllCodeStyle: false
+      useNextest: false
+      testAllTargets: false
+      buildAllTargets: false
+      allFeatures: false
+      activatedFeatures: ${{ parameters.cargoFeatures }}
+      packages: ${{ parameters.cargoPackages }}
+      workingDirectory: ${{ parameters.workingDirectory }}

--- a/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
+++ b/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
@@ -29,6 +29,10 @@ steps:
       targetTriple: ${{ parameters.targetTriple }}
       rustVersion: ${{ parameters.rustVersion }}
 
+  # Redirect crates.io to the public MxcDependencies feed (1ES network isolation
+  # blocks crates.io).
+  - template: Cargo.Setup.Public.yml@self
+
   - script: cargo build --locked --release --target ${{ parameters.targetTriple }} ${{ parameters.cargoArgs }}
     displayName: Build
     workingDirectory: ${{ parameters.workingDirectory }}

--- a/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
+++ b/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Unofficial / fork-PR Rust toolchain + cargo build/test. Public crates.io,
+# no auth tasks. (Fork PRs against a public upstream lose System.AccessToken,
+# so any task that defaults its authenticationToken to $(System.AccessToken)
+# fails at prep time — that rules out 1ES.Build.Rust.* and CargoAuthenticate.)
+
+parameters:
+- name: targetTriple
+  type: string
+- name: workingDirectory
+  type: string
+- name: cargoArgs
+  type: string
+  default: ''
+- name: enableTest
+  type: string
+  default: 'true'
+- name: rustVersion
+  type: string
+  # Public rustup channel matching the `1.93` pin in src/rust-toolchain.toml.
+  # (Official builds use the internal 'ms-prod-1.93' from Mxc-Azure-Feed.)
+  default: '1.93.0'
+
+steps:
+  - template: Rust.Toolchain.Public.yml@self
+    parameters:
+      targetTriple: ${{ parameters.targetTriple }}
+      rustVersion: ${{ parameters.rustVersion }}
+
+  - script: cargo build --locked --release --target ${{ parameters.targetTriple }} ${{ parameters.cargoArgs }}
+    displayName: Build
+    workingDirectory: ${{ parameters.workingDirectory }}
+
+  - script: cargo test --locked --release --target ${{ parameters.targetTriple }} ${{ parameters.cargoArgs }}
+    displayName: Test
+    workingDirectory: ${{ parameters.workingDirectory }}
+    condition: eq('${{ parameters.enableTest }}', 'true')

--- a/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
+++ b/.azure-pipelines/templates/Rust.Build.Steps.Unofficial.yml
@@ -21,7 +21,7 @@ parameters:
   type: string
   # Public rustup channel matching the `1.93` pin in src/rust-toolchain.toml.
   # (Official builds use the internal 'ms-prod-1.93' from Mxc-Azure-Feed.)
-  default: '1.93.0'
+  default: '1.93'
 
 steps:
   - template: Rust.Toolchain.Public.yml@self

--- a/.azure-pipelines/templates/Rust.Toolchain.Public.yml
+++ b/.azure-pipelines/templates/Rust.Toolchain.Public.yml
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Public rustup toolchain install (no auth tasks). Used by fork-PR builds,
+# the macOS build, and the Lint job. Single source of truth for the public
+# Rust version pin — keep in sync with src/rust-toolchain.toml.
+
+parameters:
+- name: targetTriple
+  type: string
+- name: rustVersion
+  type: string
+  default: '1.93.0'
+
+steps:
+  - task: RustInstaller@1
+    displayName: Install Rust toolchain (public)
+    inputs:
+      rustVersion: ${{ parameters.rustVersion }}
+      additionalTargets: ${{ parameters.targetTriple }}

--- a/.azure-pipelines/templates/Rust.Toolchain.Public.yml
+++ b/.azure-pipelines/templates/Rust.Toolchain.Public.yml
@@ -1,20 +1,29 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# Public rustup toolchain install (no auth tasks). Used by fork-PR builds,
-# the macOS build, and the Lint job. Single source of truth for the public
-# Rust version pin — keep in sync with src/rust-toolchain.toml.
+# Public rustup toolchain install (no 1ES tasks, no auth). Used by fork-PR
+# builds, the macOS build, and the Lint job. Single source of truth for the
+# public Rust version pin — keep in sync with src/rust-toolchain.toml.
 
 parameters:
 - name: targetTriple
   type: string
 - name: rustVersion
   type: string
-  default: '1.93.0'
+  default: '1.93'
 
 steps:
-  - task: RustInstaller@1
-    displayName: Install Rust toolchain (public)
-    inputs:
-      rustVersion: ${{ parameters.rustVersion }}
-      additionalTargets: ${{ parameters.targetTriple }}
+  - pwsh: |
+      $ver = '${{ parameters.rustVersion }}'
+      $triple = '${{ parameters.targetTriple }}'
+      if ($IsWindows) {
+        Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+        .\rustup-init.exe -y --default-toolchain $ver --target $triple --profile minimal --component clippy --component rustfmt --no-modify-path
+        Write-Host "##vso[task.prependpath]$env:USERPROFILE\.cargo\bin"
+      } else {
+        Invoke-WebRequest -Uri https://sh.rustup.rs -OutFile rustup-init.sh
+        chmod +x rustup-init.sh
+        ./rustup-init.sh -y --default-toolchain $ver --target $triple --profile minimal --component clippy --component rustfmt --no-modify-path
+        Write-Host "##vso[task.prependpath]$env:HOME/.cargo/bin"
+      }
+    displayName: Install Rust toolchain (rustup)


### PR DESCRIPTION
## 📖 Description

After microsoft/mxc went public, fork PRs (e.g. #465) lose `System.AccessToken`, which breaks every PR-Build step that authenticates against the internal Mxc-Azure-Feed: `1ES.Build.Rust.*`, `CargoAuthenticate@0`, `EsrpCodeSigning@5`. The pipeline fails before it can validate anything.

This PR splits the shared Rust steps and dispatches on `isOfficialBuild`:

- `Rust.Build.Steps.Official.yml` — internal feed flow (`1ES.Build.Rust.Run@1` + `CargoAuthenticate@0`). Used by the official build.
- `Rust.Build.Steps.Unofficial.yml` — public rustup install + plain `cargo build/test`. Used by PR builds (including forks), no auth needed.
- `Rust.Toolchain.Public.yml` — single source of truth for the public Rust version pin; shared by the Unofficial steps and the Lint job.

Drive-bys aligned at the same time:

- `Mac.Build.Job.yml` now dispatches on `isOfficialBuild` instead of inlining cargo. Official Mac uses the new `cargoPackages` param (→ `Run@1.packages`) to scope to `mxc_darwin,seatbelt_common,wxc_common` (the macOS-buildable subset of the workspace).
- `Lint.Job.yml` gains a `macos_arm64` leg so Mac-only clippy lives there instead of in the Mac build job.

## 🔗 References

Related to #465 (first PR to surface the fork-PR failure).

## 🔍 Validation

Pending CI on this branch (`/azp run MXC-PR-Build`). No functional code changes — pipeline YAML only.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (CI-internals only; no user-facing change)
- [ ] Updated Copilot instructions (no build commands or conventions changed for contributors)

## 📋 Issue Type

- [x] Bug fix

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/481)