### PR TITLE
Fix stale crate paths in .fbs code gen

### DIFF
--- a/src/core/generated/base_container_specification/README.md
+++ b/src/core/generated/base_container_specification/README.md
@@ -13,7 +13,7 @@ From the repo root, run in PowerShell:
 
 ```powershell
 # Clean old generated output
-Remove-Item src\generated\base_container_specification\src\ -Recurse
+Remove-Item src\core\generated\base_container_specification\src\ -Recurse
 
 # Run flatc
 & "flatc.exe" `
@@ -22,15 +22,15 @@ Remove-Item src\generated\base_container_specification\src\ -Recurse
     external/windows-sdk/BaseContainerSpecification.fbs
 
 # Move output into the crate's src/ directory and rename to match our module names
-mkdir src\generated\base_container_specification\src
-mv src\generated\base_container_specification\mod.rs src\generated\base_container_specification\src\lib.rs
-mv src\generated\base_container_specification\sandbox_tech_spec_layout src\generated\base_container_specification\src\base_container_layout
+mkdir src\core\generated\base_container_specification\src
+mv src\core\generated\base_container_specification\mod.rs src\core\generated\base_container_specification\src\lib.rs
+mv src\core\generated\base_container_specification\sandbox_tech_spec_layout src\core\generated\base_container_specification\src\base_container_layout
 
 # Patch lib.rs: rename modules and suppress warnings on generated code
-(Get-Content src\generated\base_container_specification\src\lib.rs) `
+(Get-Content src\core\generated\base_container_specification\src\lib.rs) `
     -replace 'pub mod sandbox_tech_spec_layout', 'pub mod base_container_layout' `
     -replace '// @generated', "// @generated`n#![allow(unused_imports, non_snake_case, non_camel_case_types, clippy::all)]" |
-    Set-Content src\generated\base_container_specification\src\lib.rs
+    Set-Content src\core\generated\base_container_specification\src\lib.rs
 
 # Format the generated code to pass CI checks
 cd src

--- a/src/core/generated/base_container_specification/regenerate.ps1
+++ b/src/core/generated/base_container_specification/regenerate.ps1
@@ -11,7 +11,7 @@
     Path to flatc.exe. Defaults to "flatc.exe" (must be on PATH).
 
 .EXAMPLE
-    pwsh -File src/generated/base_container_specification/regenerate.ps1
+    pwsh -File src/core/generated/base_container_specification/regenerate.ps1
 #>
 [CmdletBinding()]
 param(
@@ -27,7 +27,7 @@ if (-not $repoRoot) {
 }
 Set-Location $repoRoot
 
-$crateDir = "src\generated\base_container_specification"
+$crateDir = "src\core\generated\base_container_specification"
 $srcDir   = Join-Path $crateDir "src"
 $fbs      = "external\windows-sdk\BaseContainerSpecification.fbs"
 


### PR DESCRIPTION
The regenerate.ps1 script and README referenced src\generated\... but the crate lives at src\core\generated\base_container_specification. Update both to the correct path.

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/485)