### PR TITLE
Make .fbs regen script path-robust and simplify README

### DIFF
--- a/src/core/generated/base_container_specification/README.md
+++ b/src/core/generated/base_container_specification/README.md
@@ -9,30 +9,12 @@ The `base_container_specification` crate contains Rust bindings auto-generated f
 
 ## Steps
 
-From the repo root, run in PowerShell:
+From the repo root, run the regeneration script in PowerShell:
 
 ```powershell
-# Clean old generated output
-Remove-Item src\core\generated\base_container_specification\src\ -Recurse
-
-# Run flatc
-& "flatc.exe" `
-    --rust --gen-object-api --force-empty --no-prefix --rust-module-root-file --gen-all `
-    -o src/core/generated/base_container_specification `
-    external/windows-sdk/BaseContainerSpecification.fbs
-
-# Move output into the crate's src/ directory and rename to match our module names
-mkdir src\core\generated\base_container_specification\src
-mv src\core\generated\base_container_specification\mod.rs src\core\generated\base_container_specification\src\lib.rs
-mv src\core\generated\base_container_specification\sandbox_tech_spec_layout src\core\generated\base_container_specification\src\base_container_layout
-
-# Patch lib.rs: rename modules and suppress warnings on generated code
-(Get-Content src\core\generated\base_container_specification\src\lib.rs) `
-    -replace 'pub mod sandbox_tech_spec_layout', 'pub mod base_container_layout' `
-    -replace '// @generated', "// @generated`n#![allow(unused_imports, non_snake_case, non_camel_case_types, clippy::all)]" |
-    Set-Content src\core\generated\base_container_specification\src\lib.rs
-
-# Format the generated code to pass CI checks
-cd src
-cargo fmt -p sandbox_spec
+pwsh -File src/core/generated/base_container_specification/regenerate.ps1
 ```
+
+The script runs `flatc`, reorganizes the output into the crate's module layout,
+patches `lib.rs` (module rename + lint suppression), and formats the result with
+`cargo fmt`. Pass `-Flatc <path>` if `flatc.exe` is not on your `PATH`.

--- a/src/core/generated/base_container_specification/regenerate.ps1
+++ b/src/core/generated/base_container_specification/regenerate.ps1
@@ -20,14 +20,15 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-# Resolve repo root (two levels up from this script's directory's parents)
+# Resolve repo root (this script lives at <repoRoot>/src/core/generated/base_container_specification).
 $repoRoot = (& git rev-parse --show-toplevel) 2>$null
 if (-not $repoRoot) {
-    throw "Not inside a git repository. Run from the repo root."
+    throw "Not inside a git repository."
 }
 Set-Location $repoRoot
 
-$crateDir = "src\core\generated\base_container_specification"
+# Derive the crate dir from the script's own location so it never goes stale if the crate moves.
+$crateDir = $PSScriptRoot
 $srcDir   = Join-Path $crateDir "src"
 $fbs      = "external\windows-sdk\BaseContainerSpecification.fbs"
 


### PR DESCRIPTION
## Summary

Follow-up to #485 addressing review feedback on the FlatBuffers regeneration tooling.

This PR changes the `.fbs` regeneration script to be path-robust and simplifies the README so the manual steps are no longer duplicated.

Details

* `regenerate.ps1`: derive the crate dir from `$PSScriptRoot` instead of a hardcoded repo-relative string, so the path can never go stale if the crate moves (the class of bug #485 fixed).
* `README.md`: replace the duplicated manual flatc/reorg/patch/fmt steps with a single call to `regenerate.ps1`, which already performs all of them.

Tests

* Ran `regenerate.ps1` (flatc 25.12.19) from both the repo root and `src/`; the regenerated output is byte-identical to the committed bindings (LF/CRLF only) and `cargo check -p sandbox_spec` passes.

## Related Issues

- #485

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/487)