### PR TITLE
Enforce deniedPaths natively in BaseContainer via fs_deny

### DIFF
--- a/external/windows-sdk/BaseContainerSpecification.fbs
+++ b/external/windows-sdk/BaseContainerSpecification.fbs
@@ -26,6 +26,12 @@
 // --conform verifies that every field/enum/table in the old schema still exists
 // at the same vtable slot, type, and default in the new schema. Any incompatible
 // change produces an error. Add this as a build step or PR gate to catch regressions.
+//
+//  Steps:
+//      cp SandboxSpec.fbs SandboxSpec.previous.fbs
+//      <make changes>
+//      & "$($env:OBJECT_ROOT)\onecore\base\appmodel\execmodel\vcpkg\$($env:_BuildAlt)\vcpkg_packages\flatbuffers_x64-host-windows\tools\flatbuffers\flatc.exe" --conform SandboxSpec.previous.fbs SandboxSpec.fbs
+//
 
 namespace SandboxTechSpecLayout;
 
@@ -68,6 +74,9 @@ table SandboxSpec {
 
     // Integrity behavior
     integrity:IntegrityLevel = system_default;
+
+    // File Paths that have been denied access
+    fs_deny:[string];
 }
 
 table proxy_info {

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -329,6 +329,15 @@ pub struct AppContainerScriptRunner {
     /// [`DeriveAppContainerSidFromAppContainerName`] / `FreeSid`; that
     /// duplicate Win32 call is documented and left as a follow-up.
     preset_sid_string: Option<String>,
+    /// Set when the dispatcher enforces `denied_paths` out-of-band via a
+    /// host DACL (the Tier 2 `Bfs`-mode + deny-ACE path). BFS itself only
+    /// configures allow rules (readwrite/readonly); the dispatcher parks a
+    /// deny-only [`DaclManager`] for the denied paths. Without this flag,
+    /// [`validate_runner`](ScriptRunner::validate_runner) would reject a
+    /// non-empty `denied_paths` in any non-`Dacl` mode and abort the run
+    /// before `execute`. The flag tells validation that deny enforcement is
+    /// handled externally, so the request is legal in `Bfs` mode.
+    denied_via_external_dacl: bool,
 }
 
 impl AppContainerScriptRunner {
@@ -339,6 +348,7 @@ impl AppContainerScriptRunner {
             proxy_address: None,
             filesystem_mode: FilesystemMode::Bfs,
             preset_sid_string: None,
+            denied_via_external_dacl: false,
         }
     }
 
@@ -353,6 +363,7 @@ impl AppContainerScriptRunner {
             proxy_address: None,
             filesystem_mode: mode,
             preset_sid_string: None,
+            denied_via_external_dacl: false,
         }
     }
 
@@ -371,7 +382,27 @@ impl AppContainerScriptRunner {
             proxy_address: None,
             filesystem_mode: mode,
             preset_sid_string: Some(sid_string),
+            denied_via_external_dacl: false,
         }
+    }
+
+    /// Mark that the dispatcher enforces `denied_paths` out-of-band via a
+    /// host DACL, so [`validate_runner`](ScriptRunner::validate_runner)
+    /// accepts a non-empty `denied_paths` even though this runner is not in
+    /// [`FilesystemMode::Dacl`]. Used by the Tier 2 (`Bfs` + deny-ACE) path
+    /// where BFS configures the allow rules and a dispatcher-parked
+    /// `DaclManager` configures the deny ACEs. See
+    /// [`Self::denied_via_external_dacl`].
+    ///
+    /// `pub(crate)` by design: the **caller must have already applied (and
+    /// must keep alive) an external deny DACL** for the request's denied
+    /// paths. Only the dispatcher satisfies that invariant — it builds the
+    /// deny-only `DaclManager` and returns it alongside the runner — so this
+    /// builder is confined to the crate to keep the invariant locally
+    /// auditable. Do not expose it across crate boundaries.
+    pub(crate) fn with_external_denied_dacl(mut self) -> Self {
+        self.denied_via_external_dacl = true;
+        self
     }
 
     /// Create or derive an AppContainer SID for the given container name.
@@ -913,7 +944,10 @@ impl Default for AppContainerScriptRunner {
 
 impl ScriptRunner for AppContainerScriptRunner {
     fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        if !request.policy.denied_paths.is_empty() && self.filesystem_mode != FilesystemMode::Dacl {
+        if !request.policy.denied_paths.is_empty()
+            && self.filesystem_mode != FilesystemMode::Dacl
+            && !self.denied_via_external_dacl
+        {
             return Err(ScriptResponse::error(
                 wxc_common::error::DENIED_PATHS_NOT_SUPPORTED_MSG,
             ));
@@ -1299,6 +1333,26 @@ mod tests {
         assert!(
             runner.validate_runner(&request).is_ok(),
             "DACL mode supports deniedPaths and should not error"
+        );
+    }
+
+    #[test]
+    fn validate_runner_accepts_denied_paths_in_bfs_mode_with_external_dacl() {
+        // The Tier 2 dispatcher path runs the runner in `Bfs` mode (BFS
+        // configures the allow rules) while a dispatcher-parked
+        // `DaclManager` enforces the deny ACEs. `with_external_denied_dacl`
+        // tells validation the deny is handled out-of-band, so a non-empty
+        // `denied_paths` must NOT be rejected — otherwise `run()` aborts in
+        // `validate_runner` before `execute` and the selected fallback tier
+        // can never run.
+        let runner = AppContainerScriptRunner::with_filesystem_mode(FilesystemMode::Bfs)
+            .with_external_denied_dacl();
+        let mut request = ExecutionRequest::default();
+        request.policy.denied_paths = vec!["C:\\secret".into()];
+
+        assert!(
+            runner.validate_runner(&request).is_ok(),
+            "Bfs mode with external deny DACL should accept deniedPaths"
         );
     }
 

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -143,6 +143,7 @@ impl BaseContainerRunner {
     /// - `capabilities` from `policy.capabilities` (comma-joined)
     /// - `fs_read_write` from `policy.readwrite_paths`
     /// - `fs_read_only` from `policy.readonly_paths`
+    /// - `fs_deny` from `policy.denied_paths`
     /// - `disallow_win32k_system_calls` from `ui.disable`
     /// - `ui_restrictions` bitmask from `ui.to_ui_restrictions_bitmask()`
     /// - `network_policy.proxy.url` from proxy config
@@ -190,6 +191,18 @@ impl BaseContainerRunner {
             let offsets: Vec<_> = request
                 .policy
                 .readonly_paths
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            Some(builder.create_vector(&offsets))
+        };
+
+        let fs_deny = if request.policy.denied_paths.is_empty() {
+            None
+        } else {
+            let offsets: Vec<_> = request
+                .policy
+                .denied_paths
                 .iter()
                 .map(|s| builder.create_string(s))
                 .collect();
@@ -244,6 +257,7 @@ impl BaseContainerRunner {
                 capabilities,
                 fs_read_write,
                 fs_read_only,
+                fs_deny,
                 network_policy,
                 ..Default::default()
             },
@@ -410,14 +424,25 @@ impl BaseContainerRunner {
 
 impl ScriptRunner for BaseContainerRunner {
     fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        if !request.policy.denied_paths.is_empty() {
-            return Err(ScriptResponse::error(
-                wxc_common::error::DENIED_PATHS_NOT_SUPPORTED_MSG,
-            ));
-        }
         if !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty() {
             return Err(ScriptResponse::error(
                 wxc_common::error::HOST_LISTS_NOT_SUPPORTED_MSG,
+            ));
+        }
+        // Defense in depth for direct callers. `denied_paths` is serialized
+        // into the SandboxSpec `fs_deny` field, but the OS only honors it
+        // when `Feature_BfsPolicyDeny` is enabled (see
+        // `fallback_detector::native_fs_deny_supported`). The
+        // BaseContainer-fallback dispatcher only routes a denied-paths policy
+        // to this runner when that feature is live; a caller that constructs
+        // `BaseContainerRunner` directly bypasses that gate. Reject rather
+        // than silently run with unenforced deny — this runner has no DACL
+        // fallback of its own, so fail closed.
+        if !request.policy.denied_paths.is_empty()
+            && !crate::fallback_detector::native_fs_deny_supported()
+        {
+            return Err(ScriptResponse::error(
+                wxc_common::error::DENIED_PATHS_FEATURE_DISABLED_MSG,
             ));
         }
         Self::is_base_container_api_present().map_err(|e| {
@@ -970,6 +995,7 @@ mod tests {
         request.policy.capabilities = vec!["internetClient".into(), "registryRead".into()];
         request.policy.readwrite_paths = vec!["C:\\temp".into()];
         request.policy.readonly_paths = vec!["C:\\Windows".into()];
+        request.policy.denied_paths = vec!["C:\\secret".into()];
 
         let bytes = BaseContainerRunner::build_sandbox_spec(&request);
 
@@ -1011,6 +1037,10 @@ mod tests {
         assert_eq!(ro.len(), 1);
         assert_eq!(ro.get(0), "C:\\Windows");
 
+        let deny = spec.fs_deny().unwrap();
+        assert_eq!(deny.len(), 1);
+        assert_eq!(deny.get(0), "C:\\secret");
+
         assert!(spec.network_policy().is_none());
     }
 
@@ -1031,6 +1061,7 @@ mod tests {
         assert!(spec.capabilities().is_none());
         assert!(spec.fs_read_write().is_none());
         assert!(spec.fs_read_only().is_none());
+        assert!(spec.fs_deny().is_none());
         assert!(spec.disallow_win32k_system_calls());
         assert!(spec.network_policy().is_none());
     }
@@ -1168,17 +1199,47 @@ mod tests {
     use wxc_common::script_runner::ScriptRunner;
 
     #[test]
-    fn validate_runner_rejects_denied_paths() {
+    fn validate_runner_accepts_denied_paths() {
+        // Hold ENV_LOCK so a concurrent `FsDenyFeatureGuard::disabled()`
+        // test can't flip `MXC_FAKE_FS_DENY_FEATURE` underneath this one.
+        // With the var unset the gate reports the feature enabled (the test
+        // default), so deniedPaths must be accepted.
+        let _lock = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let runner = BaseContainerRunner::new();
+        let mut request = ExecutionRequest::default();
+        request.policy.denied_paths = vec!["C:\\secret".into()];
+
+        // denied_paths is now honored via the SandboxSpec `fs_deny` field, so it
+        // must not be rejected. validate_runner may still fail later if the
+        // BaseContainer API is unavailable on this host, but never for deniedPaths.
+        if let Err(err) = runner.validate_runner(&request) {
+            assert!(
+                !err.error_message.contains("deniedPaths"),
+                "deniedPaths should no longer be rejected, got: {}",
+                err.error_message
+            );
+        }
+    }
+
+    #[test]
+    fn validate_runner_rejects_denied_paths_when_feature_disabled() {
+        // Defense in depth: a direct caller (bypassing the dispatcher's
+        // feature gate) must not silently run with unenforced `fs_deny` when
+        // `Feature_BfsPolicyDeny` is off. The guard forces the gate to report
+        // the feature disabled for this test's duration.
+        let _guard = crate::test_env::FsDenyFeatureGuard::disabled();
         let runner = BaseContainerRunner::new();
         let mut request = ExecutionRequest::default();
         request.policy.denied_paths = vec!["C:\\secret".into()];
 
         let err = runner
             .validate_runner(&request)
-            .expect_err("BaseContainer does not yet support deniedPaths");
+            .expect_err("deniedPaths must be rejected when the fs_deny feature is disabled");
         assert!(
-            err.error_message.contains("deniedPaths"),
-            "expected message to mention deniedPaths, got: {}",
+            err.error_message.contains("Feature_BfsPolicyDeny"),
+            "expected the feature-gate message, got: {}",
             err.error_message
         );
     }

--- a/src/backends/appcontainer/common/src/dispatcher.rs
+++ b/src/backends/appcontainer/common/src/dispatcher.rs
@@ -281,12 +281,17 @@ pub fn dispatch_with_fallback(request: &ExecutionRequest) -> Result<Dispatched, 
     let (runner, dacl_manager): (Box<dyn ScriptRunner>, Option<DaclManager>) = match decision.tier {
         IsolationTier::BaseContainer => {
             // Tier 1 delegates filesystem-policy enforcement to
-            // BaseContainer's native API. We do NOT stamp host-DACL
-            // deny ACEs here because the AppContainer SID derived from
+            // BaseContainer's native API, including `deniedPaths` via the
+            // SandboxSpec `fs_deny` field. We do NOT stamp host-DACL deny
+            // ACEs here because the AppContainer SID derived from
             // `container_name(request)` is not guaranteed to match the
             // opaque principal `Experimental_CreateProcessInSandbox`
-            // actually runs the child under; a mismatch would render
-            // the ACEs inert and silently un-enforce `deniedPaths`.
+            // actually runs the child under; a mismatch would render the
+            // ACEs inert and silently un-enforce `deniedPaths`. The
+            // detector only routes a denied-paths policy here when the OS
+            // `Feature_BfsPolicyDeny` gate is enabled (otherwise it falls
+            // through to a DACL-enforcing tier), so native enforcement is
+            // guaranteed for anything that reaches this arm.
             let runner: Box<dyn ScriptRunner> = Box::new(BaseContainerRunner::new());
             (runner, None)
         }
@@ -307,12 +312,16 @@ pub fn dispatch_with_fallback(request: &ExecutionRequest) -> Result<Dispatched, 
                 let mgr = build_deny_only_dacl(&sid, &denied)?;
                 // Hand the derived SID string to the runner so it does
                 // not re-run `ConvertSidToStringSidW` for the firewall
-                // principal-id lookup.
+                // principal-id lookup. Mark the deny as externally enforced
+                // (this `mgr`) so the runner's `validate_runner` accepts the
+                // non-empty `denied_paths` in `Bfs` mode instead of aborting
+                // the run before `execute`.
                 let runner: Box<dyn ScriptRunner> = Box::new(
                     AppContainerScriptRunner::with_filesystem_mode_and_sid_string(
                         FilesystemMode::Bfs,
                         sid,
-                    ),
+                    )
+                    .with_external_denied_dacl(),
                 );
                 (runner, mgr)
             }
@@ -433,6 +442,27 @@ mod tests {
         let d = dispatch_with_fallback(&req).expect("T2+deny dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
         assert!(d.has_dacl_guard());
+    }
+
+    /// Regression: the Tier 2 (`Bfs` + deny-ACE) runner the dispatcher
+    /// returns must pass the *same* `validate_runner` gate that
+    /// `ScriptRunner::run` invokes before `execute`. Previously the runner
+    /// was built in `Bfs` mode without flagging the external deny DACL, so
+    /// `validate_runner` rejected the non-empty `denied_paths` and the run
+    /// aborted before the selected fallback tier could execute. Asserting
+    /// only `has_dacl_guard()` (as the test above does) missed this because
+    /// it never drove the returned runner through validation.
+    #[test]
+    fn dispatch_t2_denied_runner_passes_validation() {
+        let _g = ForceTierGuard::set("appcontainer-bfs");
+        let (policy, _tmp) = policy_with_denied_temp();
+        let req = test_request(policy);
+        let d = dispatch_with_fallback(&req).expect("T2+deny dispatch should succeed");
+        assert!(matches!(d.tier, IsolationTier::AppContainerBfs));
+        let (runner, _guard) = d.into_runner_and_guard();
+        runner
+            .validate_runner(&req)
+            .expect("T2 deny runner must pass validate_runner (the run() path)");
     }
     #[test]
     fn dispatch_t3_always_has_dacl() {

--- a/src/backends/appcontainer/common/src/fallback_detector.rs
+++ b/src/backends/appcontainer/common/src/fallback_detector.rs
@@ -49,9 +49,12 @@ pub struct TierDecision {
     /// The selected isolation tier.
     pub tier: IsolationTier,
     /// `true` if this tier needs DACL augmentation on host paths to enforce
-    /// the policy. T3 always sets this; T1/T2 set it when `denied_paths` is
-    /// non-empty (since neither BaseContainer nor BFS currently models a
-    /// "deny" semantic and we have to fall back to host DACLs for those).
+    /// the policy. T3 always sets this; T2 sets it when `denied_paths` is
+    /// non-empty (BFS models no "deny" semantic, so deny falls back to host
+    /// DACLs). T1 (BaseContainer) never sets it: it enforces deny natively
+    /// via the SandboxSpec `fs_deny` field, and is only selected for a
+    /// denied-paths policy when the OS gate (`Feature_BfsPolicyDeny`) is
+    /// enabled — otherwise selection falls through to T2/T3.
     pub needs_dacl_augmentation: bool,
     /// Absolute path to `bfscfg.exe` as resolved at probe time.
     ///
@@ -117,10 +120,19 @@ pub enum FallbackError {
 ///    `\Device\Null` descriptor) that is read-only-detected as not already in
 ///    effect on this machine.
 ///
-/// Any tier that needs to modify host DACLs (T3 always; T1/T2 when
+/// Any tier that needs to modify host DACLs (T3 always; T2 when
 /// `denied_paths` is non-empty) requires `fallback.allow_dacl_mutation = true`
 /// and `WRITE_DAC` on every target path. If either check fails the function
 /// returns the corresponding [`FallbackError`].
+///
+/// Tier 1 (BaseContainer) enforces `denied_paths` natively via the SandboxSpec
+/// `fs_deny` field rather than host DACLs, but the OS only honors that field
+/// when the `Feature_BfsPolicyDeny` feature is enabled in the runtime
+/// feature-configuration store. The OS *build number* is not a sound signal —
+/// the enabling change ships per-branch independently of build label — so
+/// Tier 1 is selected for a denied-paths policy only when
+/// [`native_fs_deny_supported`] confirms the feature is enabled; otherwise
+/// selection falls through to a DACL-enforcing tier (fail secure).
 ///
 /// Probing for Tier 2 resolves `%SystemRoot%` exclusively via the
 /// `GetWindowsDirectoryW` Win32 API — the `SystemRoot` environment
@@ -161,16 +173,27 @@ pub fn detect(
 
     // Tier 1 — BaseContainer
     if prefer_base_container && is_base_container_api_present() {
-        if denied {
-            ensure_dacl_augmentation_allowed(policy)?;
-            verify_write_dac_all(&policy.denied_paths)?;
+        // BaseContainer enforces denied paths natively through the SandboxSpec
+        // `fs_deny` field — the dispatcher attaches no host DACL at T1 (the
+        // sandbox principal is opaque, so a host ACE would be inert). The OS
+        // only honors `fs_deny` when `Feature_BfsPolicyDeny` is enabled, so a
+        // denied-paths policy can stay on T1 only when that feature is live.
+        // When it isn't, we cannot enforce deny here and must fall through to
+        // a DACL-enforcing tier.
+        if !denied || native_fs_deny_supported() {
+            return Ok(TierDecision {
+                tier: IsolationTier::BaseContainer,
+                needs_dacl_augmentation: false,
+                bfscfg_path: None,
+                warnings,
+            });
         }
-        return Ok(TierDecision {
-            tier: IsolationTier::BaseContainer,
-            needs_dacl_augmentation: denied,
-            bfscfg_path: None,
-            warnings,
-        });
+        warnings.push(
+            "BaseContainer API present but Feature_BfsPolicyDeny is not enabled on this OS; \
+             deniedPaths cannot be enforced natively (fs_deny) — falling back to AppContainer \
+             for deniedPaths enforcement"
+                .to_string(),
+        );
     }
     // Tier 2 — AppContainer + BFS
     //
@@ -425,10 +448,13 @@ fn forced_decision(
 ) -> Result<TierDecision, FallbackError> {
     // Forced tiers honor the same DACL-fallback guard the real algorithm
     // does: if the operator forbade host DACL changes we must still refuse
-    // any tier that would touch them.
+    // any tier that would touch them. BaseContainer (Tier 1) never touches
+    // host DACLs — it enforces deny natively via `fs_deny` — so it never
+    // needs augmentation regardless of `denied`.
     let needs_dacl = match tier {
         IsolationTier::AppContainerDacl => true,
-        IsolationTier::BaseContainer | IsolationTier::AppContainerBfs => denied,
+        IsolationTier::AppContainerBfs => denied,
+        IsolationTier::BaseContainer => false,
     };
     if needs_dacl && !policy.fallback.allow_dacl_mutation {
         return Err(FallbackError::DaclFallbackDisabled);
@@ -623,6 +649,161 @@ pub(crate) fn has_write_dac(path: &Path) -> Result<bool, std::io::Error> {
 }
 
 // ---------------------------------------------------------------------------
+// Native fs_deny capability gate (Feature_BfsPolicyDeny)
+// ---------------------------------------------------------------------------
+
+/// Windows Feature-Staging feature ID for `Feature_BfsPolicyDeny` — the OS
+/// gate that makes `Experimental_CreateProcessInSandbox` honor the SandboxSpec
+/// `fs_deny` (deniedPaths) field. Enablement ships per-branch via the runtime
+/// feature-configuration store independently of the OS build number, so
+/// build/UBR is not a sound capability signal; we query the effective feature
+/// state instead.
+#[cfg_attr(test, allow(dead_code))]
+const FEATURE_BFS_POLICY_DENY: u32 = 62_259_005;
+
+/// Returns `true` when the OS will actually honor the SandboxSpec `fs_deny`
+/// field — i.e. when `Feature_BfsPolicyDeny` resolves to *enabled* in the
+/// runtime feature-configuration store.
+///
+/// Fails secure: a `disabled`/`default` state, a down-level OS that lacks the
+/// feature-staging export, or any probe failure all yield `false`, so
+/// deniedPaths fall through to a DACL-enforcing tier rather than being
+/// silently dropped.
+#[cfg(not(test))]
+pub(crate) fn native_fs_deny_supported() -> bool {
+    feature_staging::is_feature_enabled(FEATURE_BFS_POLICY_DENY)
+}
+
+/// Test build: avoid a machine-dependent feature probe so tier-selection tests
+/// are deterministic. Defaults to "supported" (so tests that reach the real
+/// Tier 1 branch with denied paths behave predictably); the
+/// `MXC_FAKE_FS_DENY_FEATURE` seam — set via `test_env::FsDenyFeatureGuard` —
+/// forces the disabled path.
+#[cfg(test)]
+pub(crate) fn native_fs_deny_supported() -> bool {
+    match std::env::var("MXC_FAKE_FS_DENY_FEATURE") {
+        Ok(v) => v == "1",
+        Err(_) => true,
+    }
+}
+
+/// Thin binding over the documented Windows Feature-Staging API
+/// (`GetFeatureEnabledState`, `featurestagingapi.h`). It reads the same
+/// runtime feature-configuration store that Velocity populates as a feature
+/// rolls out, which is exactly how `Feature_BfsPolicyDeny` is being delivered.
+///
+/// The export is resolved from the feature-staging **API set contract**
+/// (`api-ms-win-core-featurestaging-l1-1-0.dll`), not `kernelbase.dll`:
+/// on current builds `GetProcAddress(kernelbase, "GetFeatureEnabledState")`
+/// returns null even though the API is present, and `wxc-exec` does not
+/// statically import the API set, so it must be `LoadLibrary`-loaded rather
+/// than found via `GetModuleHandle`. `kernelbase.dll` is kept only as a
+/// defensive secondary fallback.
+mod feature_staging {
+    /// `FEATURE_ENABLED_STATE_ENABLED` from `featurestagingapi.h`. The other
+    /// states (`DEFAULT = 0`, `DISABLED = 1`) both fail secure here: `DEFAULT`
+    /// means "no runtime-store override", leaving the value to the OS
+    /// component's compiled-in default, which an external process cannot
+    /// observe — so we treat anything but an explicit `ENABLED` as "off".
+    const FEATURE_ENABLED_STATE_ENABLED: i32 = 2;
+
+    /// `FEATURE_CHANGE_TIME_READ` from `featurestagingapi.h` — read the
+    /// current effective state without pinning to a change boundary.
+    #[cfg_attr(test, allow(dead_code))]
+    const FEATURE_CHANGE_TIME_READ: i32 = 0;
+
+    /// Maps a raw `FEATURE_ENABLED_STATE` value to "the feature is on". Only
+    /// the explicit `ENABLED` state counts; every other (or unexpected) value
+    /// fails secure to `false`. Pure, so it is unit-tested directly.
+    pub(super) fn enabled_state_means_on(state: i32) -> bool {
+        state == FEATURE_ENABLED_STATE_ENABLED
+    }
+
+    #[cfg(target_os = "windows")]
+    type GetFeatureEnabledStateFn =
+        unsafe extern "system" fn(feature_id: u32, change_time: i32) -> i32;
+
+    /// DLLs to try, in order, when resolving `GetFeatureEnabledState`. The
+    /// feature-staging API set contract is the documented home of the export
+    /// on current builds; `kernelbase.dll` is a defensive fallback only.
+    #[cfg(target_os = "windows")]
+    #[cfg_attr(test, allow(dead_code))]
+    const FEATURE_STAGING_DLLS: [windows::core::PCWSTR; 2] = [
+        windows::core::w!("api-ms-win-core-featurestaging-l1-1-0.dll"),
+        windows::core::w!("kernelbase.dll"),
+    ];
+
+    /// Resolve `GetFeatureEnabledState` from the first DLL in
+    /// [`FEATURE_STAGING_DLLS`] that both loads and exports it. Returns `None`
+    /// on down-level builds that lack the API entirely (fail secure).
+    ///
+    /// Uses `LoadLibraryExW` with `LOAD_LIBRARY_SEARCH_SYSTEM32` rather than
+    /// `GetModuleHandleW`/`LoadLibraryW`: `wxc-exec` does not statically import
+    /// the feature-staging API set, so the backing module may not already be
+    /// loaded, and a bare-name `LoadLibraryW` would honor the default search
+    /// order (executable dir, CWD, `PATH`) — a DLL-planting vector in the host
+    /// process before sandbox launch. `LOAD_LIBRARY_SEARCH_SYSTEM32` restricts
+    /// the load to `System32`, where both candidates live (the API-set
+    /// contract resolves to its System32 host module; `kernelbase.dll` is in
+    /// System32). This mirrors the hardened `processmodel.dll` loader in
+    /// `base_container_runner`. If the export cannot be resolved from a trusted
+    /// system module we fail closed (`None`), so a denied-paths policy falls
+    /// through to the DACL-enforcing tier rather than trusting an
+    /// unverifiable load. The loaded modules are core, process-lifetime system
+    /// DLLs; the handle is intentionally leaked (no `FreeLibrary`) so the
+    /// returned function pointer stays valid.
+    #[cfg(target_os = "windows")]
+    #[cfg_attr(test, allow(dead_code))]
+    pub(super) fn resolve_get_feature_enabled_state() -> Option<GetFeatureEnabledStateFn> {
+        use windows::Win32::System::LibraryLoader::{
+            GetProcAddress, LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32,
+        };
+        for dll in FEATURE_STAGING_DLLS {
+            // SAFETY: `dll` is a static NUL-terminated wide string. A failed
+            // load or missing export simply moves on to the next candidate.
+            unsafe {
+                let Ok(module) = LoadLibraryExW(dll, None, LOAD_LIBRARY_SEARCH_SYSTEM32) else {
+                    continue;
+                };
+                if let Some(proc) =
+                    GetProcAddress(module, windows::core::s!("GetFeatureEnabledState"))
+                {
+                    // The transmuted signature matches the documented
+                    // `featurestagingapi.h` prototype (`FEATURE_ENABLED_STATE
+                    // GetFeatureEnabledState(UINT32, FEATURE_CHANGE_TIME)`),
+                    // both enum parameter/return being C `int`.
+                    return Some(std::mem::transmute::<
+                        unsafe extern "system" fn() -> isize,
+                        GetFeatureEnabledStateFn,
+                    >(proc));
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(target_os = "windows")]
+    #[cfg_attr(test, allow(dead_code))]
+    pub(super) fn is_feature_enabled(feature_id: u32) -> bool {
+        match resolve_get_feature_enabled_state() {
+            // SAFETY: `get_state` is the resolved `GetFeatureEnabledState`
+            // export; calling it with a feature id and `FEATURE_CHANGE_TIME`
+            // is the documented usage.
+            Some(get_state) => {
+                enabled_state_means_on(unsafe { get_state(feature_id, FEATURE_CHANGE_TIME_READ) })
+            }
+            None => false,
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[cfg_attr(test, allow(dead_code))]
+    pub(super) fn is_feature_enabled(_feature_id: u32) -> bool {
+        false
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -634,7 +815,7 @@ mod tests {
     // honored uniformly across the dispatcher and fallback_detector
     // test modules. A per-module lock would let cross-module test
     // threads race on `MXC_FORCE_TIER` / `MXC_BFSCFG_PATH`.
-    use crate::test_env::{ForceTierGuard, ENV_LOCK};
+    use crate::test_env::{ForceTierGuard, FsDenyFeatureGuard, ENV_LOCK};
     // `BfscfgPathGuard` is only meaningful when the `tier2_bfs` feature
     // is compiled in; without it, `find_bfscfg_exe` ignores the env var.
     #[cfg(feature = "tier2_bfs")]
@@ -666,14 +847,73 @@ mod tests {
         assert!(!d.needs_dacl_augmentation);
     }
     #[test]
-    fn denied_paths_disabled_blocks_t1() {
+    fn forced_base_container_with_denied_enforces_natively() {
+        // BaseContainer (Tier 1) enforces deniedPaths natively via the
+        // SandboxSpec `fs_deny` field, so it needs no host DACL augmentation
+        // and is unaffected by `allow_dacl_mutation = false`.
         let _g = ForceTierGuard::set("base-container");
         let mut policy = policy_with_denied();
         policy.fallback.allow_dacl_mutation = false;
-        assert!(matches!(
-            detect(&policy, true),
-            Err(FallbackError::DaclFallbackDisabled)
-        ));
+        let d = detect(&policy, true).expect("base-container honors deny natively");
+        assert!(matches!(d.tier, IsolationTier::BaseContainer));
+        assert!(!d.needs_dacl_augmentation);
+    }
+    #[test]
+    fn denied_does_not_select_base_container_when_feature_disabled() {
+        // When `Feature_BfsPolicyDeny` is off, a denied-paths policy must not
+        // land on Tier 1 (which would silently drop deny enforcement); it
+        // falls through to a DACL-enforcing tier. Only meaningful where the
+        // BaseContainer API is actually present — otherwise T1 is unreachable
+        // regardless and the pure-function / forced tests provide coverage.
+        // BaseContainer API presence is a pure probe (no env vars), so it
+        // needs no lock; acquire the env guard only once we're going to use
+        // the feature seam.
+        if !is_base_container_api_present() {
+            return;
+        }
+        let _g = FsDenyFeatureGuard::disabled();
+        let policy = policy_with_denied();
+        // The fall-through tier may either succeed (e.g. AppContainer + DACL)
+        // or fail a downstream WRITE_DAC probe on the denied system path; the
+        // load-bearing assertion is simply that we did NOT stay on T1.
+        let result = detect(&policy, true);
+        assert!(
+            !matches!(
+                result,
+                Ok(TierDecision {
+                    tier: IsolationTier::BaseContainer,
+                    ..
+                })
+            ),
+            "deny must not select BaseContainer when the feature is disabled"
+        );
+    }
+    #[test]
+    fn feature_enabled_state_mapping_is_fail_secure() {
+        use super::feature_staging::enabled_state_means_on;
+        assert!(enabled_state_means_on(2)); // FEATURE_ENABLED_STATE_ENABLED
+        assert!(!enabled_state_means_on(0)); // FEATURE_ENABLED_STATE_DEFAULT
+        assert!(!enabled_state_means_on(1)); // FEATURE_ENABLED_STATE_DISABLED
+        assert!(!enabled_state_means_on(3)); // unexpected
+        assert!(!enabled_state_means_on(-1)); // garbage
+    }
+
+    /// The real export-resolution path is normally hidden behind the
+    /// `MXC_FAKE_FS_DENY_FEATURE` test seam (`native_fs_deny_supported`), so a
+    /// wrong-DLL regression would not surface in tier-selection tests. This
+    /// smoke test exercises the production resolver directly: every supported
+    /// Windows host (and CI) ships the feature-staging API set, so the export
+    /// MUST resolve. Resolving from `kernelbase.dll` (the prior behavior)
+    /// returns null on current builds and would fail this assertion. Calling
+    /// the resolved function must also not panic.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn feature_staging_export_resolves_on_windows() {
+        let f = super::feature_staging::resolve_get_feature_enabled_state()
+            .expect("GetFeatureEnabledState must resolve from the feature-staging API set");
+        // Exercise the call path; the concrete tri-state value is host- and
+        // rollout-dependent, so we only assert it executes without UB/panic.
+        let _state = unsafe { f(super::FEATURE_BFS_POLICY_DENY, 0) };
     }
     #[test]
     fn denied_paths_disabled_blocks_t2() {

--- a/src/backends/appcontainer/common/src/probe.rs
+++ b/src/backends/appcontainer/common/src/probe.rs
@@ -57,6 +57,14 @@ pub struct ProbeFacts {
     /// 11 25H2 where `bfscfg.exe` locks `bfs.sys`) should refuse to
     /// run a binary that reports `true` here.
     pub bfs_compiled_in: bool,
+    /// Whether the OS will honor the BaseContainer SandboxSpec `fs_deny`
+    /// field — i.e. `Feature_BfsPolicyDeny` resolves to *enabled* in the
+    /// runtime feature-configuration store. When `false`, a denied-paths
+    /// policy cannot stay on Tier 1 (BaseContainer): the detector falls
+    /// through to a DACL-enforcing tier. E2E harnesses that assert Tier 1
+    /// for `deniedPaths` must skip unless this is `true` *and*
+    /// [`Self::base_container_api_present`] is `true`.
+    pub native_fs_deny_supported: bool,
 }
 
 /// Run the fallback detector against `policy` and return a JSON-shaped
@@ -69,6 +77,7 @@ pub fn run_probe(policy: &ContainerPolicy) -> ProbeOutput {
             .flatten()
             .is_some(),
         bfs_compiled_in: cfg!(feature = "tier2_bfs"),
+        native_fs_deny_supported: fallback_detector::native_fs_deny_supported(),
     };
     match fallback_detector::detect(policy, /* prefer_base_container */ true) {
         Ok(decision) => ProbeOutput {
@@ -127,6 +136,7 @@ mod tests {
                 base_container_api_present: true,
                 bfscfg_present: false,
                 bfs_compiled_in: false,
+                native_fs_deny_supported: true,
             },
             error: None,
         };
@@ -138,6 +148,7 @@ mod tests {
         assert_eq!(v["probes"]["baseContainerApiPresent"], true);
         assert_eq!(v["probes"]["bfscfgPresent"], false);
         assert_eq!(v["probes"]["bfsCompiledIn"], false);
+        assert_eq!(v["probes"]["nativeFsDenySupported"], true);
         assert!(v.get("error").is_none());
     }
 

--- a/src/backends/appcontainer/common/src/test_env.rs
+++ b/src/backends/appcontainer/common/src/test_env.rs
@@ -99,6 +99,37 @@ impl Drop for BfscfgPathGuard {
     }
 }
 
+/// RAII guard for the `MXC_FAKE_FS_DENY_FEATURE` test seam, mirroring
+/// [`ForceTierGuard`]. The `fallback_detector`'s `native_fs_deny_supported`
+/// reads this var (only under `#[cfg(test)]`) to simulate the
+/// `Feature_BfsPolicyDeny` state without a machine-dependent probe: `"1"`
+/// forces "feature enabled", any other value forces "disabled". Defaults
+/// (unset) to "enabled" so tests that don't care get the native path.
+pub(crate) struct FsDenyFeatureGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl FsDenyFeatureGuard {
+    /// Force the gate to report the feature as **disabled**.
+    pub(crate) fn disabled() -> Self {
+        let guard = lock();
+        // SAFETY: env-var mutation is gated by ENV_LOCK; see ForceTierGuard::set.
+        unsafe {
+            std::env::set_var("MXC_FAKE_FS_DENY_FEATURE", "0");
+        }
+        FsDenyFeatureGuard { _lock: guard }
+    }
+}
+
+impl Drop for FsDenyFeatureGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialized by ENV_LOCK still held in `_lock`.
+        unsafe {
+            std::env::remove_var("MXC_FAKE_FS_DENY_FEATURE");
+        }
+    }
+}
+
 /// RAII helper that points `MXC_DACL_STATE_DIR` at a freshly created
 /// tempdir for the duration of a test, then restores the previous
 /// value on drop. Holds [`ENV_LOCK`] for its lifetime via [`lock`],

--- a/src/core/generated/base_container_specification/src/base_container_layout/sandbox_spec_generated.rs
+++ b/src/core/generated/base_container_specification/src/base_container_layout/sandbox_spec_generated.rs
@@ -30,6 +30,7 @@ impl<'a> SandboxSpec<'a> {
     pub const VT_FS_READ_ONLY: ::flatbuffers::VOffsetT = 20;
     pub const VT_NETWORK_POLICY: ::flatbuffers::VOffsetT = 22;
     pub const VT_INTEGRITY: ::flatbuffers::VOffsetT = 24;
+    pub const VT_FS_DENY: ::flatbuffers::VOffsetT = 26;
 
     #[inline]
     pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -47,6 +48,9 @@ impl<'a> SandboxSpec<'a> {
     ) -> ::flatbuffers::WIPOffset<SandboxSpec<'bldr>> {
         let mut builder = SandboxSpecBuilder::new(_fbb);
         builder.add_ui_restrictions(args.ui_restrictions);
+        if let Some(x) = args.fs_deny {
+            builder.add_fs_deny(x);
+        }
         if let Some(x) = args.network_policy {
             builder.add_network_policy(x);
         }
@@ -95,6 +99,11 @@ impl<'a> SandboxSpec<'a> {
             .network_policy()
             .map(|x| alloc::boxed::Box::new(x.unpack()));
         let integrity = self.integrity();
+        let fs_deny = self.fs_deny().map(|x| {
+            x.iter()
+                .map(|s| alloc::string::ToString::to_string(s))
+                .collect()
+        });
         SandboxSpecT {
             version,
             app_container,
@@ -106,6 +115,7 @@ impl<'a> SandboxSpec<'a> {
             fs_read_only,
             network_policy,
             integrity,
+            fs_deny,
         }
     }
 
@@ -227,6 +237,19 @@ impl<'a> SandboxSpec<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn fs_deny(
+        &self,
+    ) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<::flatbuffers::ForwardsUOffset<
+                ::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>,
+            >>(SandboxSpec::VT_FS_DENY, None)
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for SandboxSpec<'_> {
@@ -262,6 +285,9 @@ impl ::flatbuffers::Verifiable for SandboxSpec<'_> {
                 false,
             )?
             .visit_field::<IntegrityLevel>("integrity", Self::VT_INTEGRITY, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<
+                ::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>,
+            >>("fs_deny", Self::VT_FS_DENY, false)?
             .finish();
         Ok(())
     }
@@ -285,6 +311,11 @@ pub struct SandboxSpecArgs<'a> {
     >,
     pub network_policy: Option<::flatbuffers::WIPOffset<NetworkPolicy<'a>>>,
     pub integrity: IntegrityLevel,
+    pub fs_deny: Option<
+        ::flatbuffers::WIPOffset<
+            ::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>,
+        >,
+    >,
 }
 impl<'a> Default for SandboxSpecArgs<'a> {
     #[inline]
@@ -300,6 +331,7 @@ impl<'a> Default for SandboxSpecArgs<'a> {
             fs_read_only: None,
             network_policy: None,
             integrity: IntegrityLevel::system_default,
+            fs_deny: None,
         }
     }
 }
@@ -388,6 +420,16 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> SandboxSpecBuilder<'a, 'b, A>
         );
     }
     #[inline]
+    pub fn add_fs_deny(
+        &mut self,
+        fs_deny: ::flatbuffers::WIPOffset<
+            ::flatbuffers::Vector<'b, ::flatbuffers::ForwardsUOffset<&'b str>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<::flatbuffers::WIPOffset<_>>(SandboxSpec::VT_FS_DENY, fs_deny);
+    }
+    #[inline]
     pub fn new(
         _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
     ) -> SandboxSpecBuilder<'a, 'b, A> {
@@ -421,6 +463,7 @@ impl ::core::fmt::Debug for SandboxSpec<'_> {
         ds.field("fs_read_only", &self.fs_read_only());
         ds.field("network_policy", &self.network_policy());
         ds.field("integrity", &self.integrity());
+        ds.field("fs_deny", &self.fs_deny());
         ds.finish()
     }
 }
@@ -437,6 +480,7 @@ pub struct SandboxSpecT {
     pub fs_read_only: Option<alloc::vec::Vec<alloc::string::String>>,
     pub network_policy: Option<alloc::boxed::Box<NetworkPolicyT>>,
     pub integrity: IntegrityLevel,
+    pub fs_deny: Option<alloc::vec::Vec<alloc::string::String>>,
 }
 impl Default for SandboxSpecT {
     fn default() -> Self {
@@ -451,6 +495,7 @@ impl Default for SandboxSpecT {
             fs_read_only: None,
             network_policy: None,
             integrity: IntegrityLevel::system_default,
+            fs_deny: None,
         }
     }
 }
@@ -478,6 +523,10 @@ impl SandboxSpecT {
         });
         let network_policy = self.network_policy.as_ref().map(|x| x.pack(_fbb));
         let integrity = self.integrity;
+        let fs_deny = self.fs_deny.as_ref().map(|x| {
+            let w: alloc::vec::Vec<_> = x.iter().map(|s| _fbb.create_string(s)).collect();
+            _fbb.create_vector(&w)
+        });
         SandboxSpec::create(
             _fbb,
             &SandboxSpecArgs {
@@ -491,6 +540,7 @@ impl SandboxSpecT {
                 fs_read_only,
                 network_policy,
                 integrity,
+                fs_deny,
             },
         )
     }

--- a/src/core/wxc_common/src/error.rs
+++ b/src/core/wxc_common/src/error.rs
@@ -50,9 +50,17 @@ impl From<std::io::Error> for WxcError {
 
 #[cfg(target_os = "windows")]
 pub const DENIED_PATHS_NOT_SUPPORTED_MSG: &str =
-    "filesystem.deniedPaths is not yet supported on Windows. Paths are denied by \
-     default unless granted via readwritePaths or readonlyPaths. Remove deniedPaths, \
-     or narrow readwritePaths/readonlyPaths to exclude the path you wanted to deny.";
+    "filesystem.deniedPaths cannot be enforced by the AppContainer runner in BFS mode \
+     without an external deny DACL. Route the request through the BaseContainer-fallback \
+     dispatcher so deniedPaths are enforced natively (BaseContainer fs_deny) or via a \
+     DACL-backed tier, or remove deniedPaths.";
+
+#[cfg(target_os = "windows")]
+pub const DENIED_PATHS_FEATURE_DISABLED_MSG: &str =
+    "filesystem.deniedPaths cannot be enforced natively: the BaseContainer fs_deny capability \
+     (Feature_BfsPolicyDeny) is not enabled on this OS. Route the request through the \
+     BaseContainer-fallback dispatcher so deniedPaths can be enforced via a DACL-backed tier, \
+     or remove deniedPaths.";
 
 #[cfg(target_os = "windows")]
 pub const HOST_LISTS_NOT_SUPPORTED_MSG: &str =

--- a/tests/scripts/Win25H2Safe-Tests.ps1
+++ b/tests/scripts/Win25H2Safe-Tests.ps1
@@ -15,10 +15,12 @@
 #     returns `Ok(None)` unconditionally and the spawn site itself is
 #     gated. The dispatcher's natural T2→T3 fallback fires for any
 #     policy with rw/ro/denied paths.
-#   * Empty-policy runs still label the selected tier "appcontainer-bfs"
-#     because `detect()` short-circuits to T2 when there is nothing to
-#     configure. At runtime that path is a no-op — `configure()`
-#     short-circuits before any bfscfg invocation.
+#   * With `tier2_bfs` off, the entire Tier 2 block is compiled out
+#     (`detect()` guards it behind `cfg!(feature = "tier2_bfs")`), so
+#     even an empty policy never selects "appcontainer-bfs". It resolves
+#     to "base-container" when the BaseContainer API is present, and
+#     otherwise falls through to "appcontainer-dacl". On this BC-absent
+#     lane the empty-policy tier is therefore "appcontainer-dacl".
 #   * Every run is post-checked: if the captured log contains the
 #     substring "bfscfg" (proof of an actual spawn), the run is
 #     reported as failed and the harness aborts before the next test.
@@ -246,12 +248,7 @@ function Assert-NoBfscfg {
     param(
         [string]$LogContent,
         [string]$Phase,
-        [string]$Name,
-        # Phases that intentionally exercise the T2-selected, no-invocation
-        # path (P2 empty policy, P3 denied-only) pass this switch. The
-        # `bfscfg` substring check still fires either way — that one
-        # signals actual invocation, which is fatal everywhere.
-        [switch]$AllowBfsTierSelection
+        [string]$Name
     )
     # The unique signature of an actual bfscfg.exe invocation is
     # `Output from bfscfg.exe:` emitted by
@@ -264,14 +261,16 @@ function Assert-NoBfscfg {
     if ($LogContent -match '(?im)Output from bfscfg\.exe') {
         throw "[$Phase :: $Name] FATAL: log contains 'Output from bfscfg.exe' (real invocation). Aborting to avoid 25H2 deadlock."
     }
-    if (-not $AllowBfsTierSelection) {
-        # Logger interleaves a `[timestamp] ` token between every
-        # write fragment, so a single `writeln!(logger, "x: {}", y)`
-        # serializes as `x: [ts] y`. Use `.*?` instead of `\s*` to
-        # bridge that token.
-        if ($LogContent -match '(?im)selected isolation tier:.*?appcontainer-bfs') {
-            throw "[$Phase :: $Name] FATAL: log shows 'selected isolation tier: appcontainer-bfs'. Aborting."
-        }
+    # With tier2_bfs off, no run on this lane may select the BFS tier
+    # (empty policy resolves to base-container or appcontainer-dacl; any
+    # rw/ro/denied policy drops to appcontainer-dacl). Selecting BFS here
+    # signals a mis-built binary, so this check is fatal everywhere.
+    #
+    # Logger interleaves a `[timestamp] ` token between every write
+    # fragment, so a single `writeln!(logger, "x: {}", y)` serializes as
+    # `x: [ts] y`. Use `.*?` instead of `\s*` to bridge that token.
+    if ($LogContent -match '(?im)selected isolation tier:.*?appcontainer-bfs') {
+        throw "[$Phase :: $Name] FATAL: log shows 'selected isolation tier: appcontainer-bfs'. Aborting."
     }
 }
 
@@ -408,12 +407,13 @@ function Invoke-Wxc {
 # Phase 1 — probes (read-only, never touches bfscfg)
 #
 # Expectations assume the `tier2_bfs` Cargo feature is OFF (Test-Preflight
-# enforces this). With the feature off, `find_bfscfg_exe` returns
-# `Ok(None)` unconditionally, so the detector drops to T3
-# (`appcontainer-dacl`) for any policy with rw/ro/denied paths. The
-# empty-policy probe still labels T2 because `detect()` short-circuits
-# to T2 when there is nothing to configure — the runtime behavior is
-# nonetheless the no-op T2 path, never spawning bfscfg.
+# enforces this). With the feature off, the entire Tier 2 block is
+# compiled out of `detect()`, so the detector never selects
+# `appcontainer-bfs` — not even for an empty policy. The probe prefers
+# BaseContainer (`detect(policy, prefer_base_container = true)`), so the
+# empty-policy tier is `base-container` when the BaseContainer API is
+# present and `appcontainer-dacl` otherwise. Any policy with rw/ro/denied
+# paths drops to T3 (`appcontainer-dacl`) on a BC-absent host.
 # -----------------------------------------------------------------------
 function Phase-Probes {
     Section 'Phase 1: --probe (read-only)'
@@ -426,8 +426,18 @@ function Phase-Probes {
         Record-Result -Phase 'P1' -Name 'BC API absent on this host' -Pass (-not $probeEmpty.probes.baseContainerApiPresent) -Detail "baseContainerApiPresent=$($probeEmpty.probes.baseContainerApiPresent)"
         Record-Result -Phase 'P1' -Name 'bfsCompiledIn=false (safety gate)' -Pass (-not $probeEmpty.probes.bfsCompiledIn) -Detail "bfsCompiledIn=$($probeEmpty.probes.bfsCompiledIn)"
         Record-Result -Phase 'P1' -Name 'bfscfgPresent=false when feature off' -Pass (-not $probeEmpty.probes.bfscfgPresent) -Detail "bfscfgPresent=$($probeEmpty.probes.bfscfgPresent)"
-        Record-Result -Phase 'P1' -Name 'empty policy probe -> tier=appcontainer-bfs (cosmetic: detect() short-circuits)' -Pass ($probeEmpty.tier -eq 'appcontainer-bfs') -Detail "tier=$($probeEmpty.tier)"
-        Record-Result -Phase 'P1' -Name 'empty policy probe -> needsDaclAugmentation=false' -Pass ($probeEmpty.needsDaclAugmentation -eq $false) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
+        # With tier2_bfs off, an empty policy resolves to base-container
+        # (BC API present) or appcontainer-dacl (BC API absent) — never
+        # appcontainer-bfs. Branch on the probed API presence so the lane
+        # is correct on both this host and a BC-capable VM.
+        if ($probeEmpty.probes.baseContainerApiPresent) {
+            Record-Result -Phase 'P1' -Name 'empty policy probe -> tier=base-container (BC API present)' -Pass ($probeEmpty.tier -eq 'base-container') -Detail "tier=$($probeEmpty.tier)"
+            Record-Result -Phase 'P1' -Name 'empty policy probe -> needsDaclAugmentation=false (T1 native)' -Pass ($probeEmpty.needsDaclAugmentation -eq $false) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
+        }
+        else {
+            Record-Result -Phase 'P1' -Name 'empty policy probe -> tier=appcontainer-dacl (T2 gated out, BC absent)' -Pass ($probeEmpty.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeEmpty.tier)"
+            Record-Result -Phase 'P1' -Name 'empty policy probe -> needsDaclAugmentation=true' -Pass ($probeEmpty.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
+        }
     }
 
     $cfgRw = New-Config -Name 'probe-rw' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw)
@@ -462,7 +472,8 @@ function Phase-Probes {
 }
 
 # -----------------------------------------------------------------------
-# Phase 2 — release-build empty-policy run (safe lane, T2 path but no bfscfg)
+# Phase 2 — release-build empty-policy run (safe lane; resolves to T1
+# base-container when the BC API is present, else T3 appcontainer-dacl)
 # -----------------------------------------------------------------------
 function Phase-EmptyRelease {
     if ($SkipReleaseLane) {
@@ -480,13 +491,16 @@ function Phase-EmptyRelease {
     $log = Join-Path $ScratchRoot 'logs\empty-release.log'
     $r = Invoke-Wxc -Wxc $WxcRelease -ConfigPath $cfg -LogPath $log
     $logContent = Read-Log $log
-    # Empty-policy run naturally selects T2; the assertion is that
-    # bfscfg.exe was NOT actually invoked (configure() short-circuits).
-    Assert-NoBfscfg -LogContent $logContent -Phase 'P2' -Name 'empty-release' -AllowBfsTierSelection
+    # Empty-policy run resolves to base-container (BC API present) or
+    # appcontainer-dacl (BC absent) — never appcontainer-bfs with
+    # tier2_bfs off. Assert-NoBfscfg's fatal "selected isolation tier:
+    # appcontainer-bfs" safety net therefore applies here too: this run
+    # must never select BFS, and bfscfg.exe must never spawn.
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P2' -Name 'empty-release'
 
     Record-Result -Phase 'P2' -Name 'release exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode); stdout=$($r.Stdout.Trim())"
     Record-Result -Phase 'P2' -Name 'AppContainer ran the child (stdout round-trip)' -Pass ($r.Stdout -match 'P2-empty-release-ok')
-    Record-Result -Phase 'P2' -Name 'selected isolation tier: appcontainer-bfs (expected, no invocation)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-bfs'))
+    Record-Result -Phase 'P2' -Name 'selected isolation tier: appcontainer-dacl or base-container (never bfs)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?(appcontainer-dacl|base-container)')) -Detail 'empty policy must not select appcontainer-bfs with tier2_bfs off'
     Record-Result -Phase 'P2' -Name 'no bfscfg invocation in log' -Pass (-not ($logContent -match '(?im)Output from bfscfg\.exe'))
     Record-Result -Phase 'P2' -Name 'UI Job Object assigned telemetry' -Pass ([bool]($logContent -match 'UI Job Object assigned'))
 }
@@ -716,24 +730,28 @@ function Phase-T3Forced {
 }
 
 # -----------------------------------------------------------------------
-# Phase 4c — Tier 1 (BaseContainer) deny-ACE empirical test
+# Phase 4c — Tier 1 (BaseContainer) native fs_deny empirical test
 #
-# Asserts that the deny ACE the dispatcher applies on the T1 path
-# actually denies the BaseContainer-spawned child access to the path.
-# This is the empirical answer to phase-4 review #4 ("BaseContainer
-# might not run under the AppContainer SID, in which case the deny ACE
-# targets a principal the child does not run as → silent no-op").
+# Asserts that the BaseContainer's native fs_deny enforcement on the T1
+# path actually denies the BaseContainer-spawned child access to the path.
+# Unlike the DACL tiers, this does not rely on a deny ACE targeting the
+# AppContainer SID — enforcement is performed by the OS sandbox itself via
+# the fs_deny SandboxSpec field, so it is principal-independent.
 #
 # Strategy:
 #   1. Skip the phase entirely if the BaseContainer API is not present on
-#      this host (most current 25H2 hosts). T1 force without the API
-#      backing it cannot exercise the deny.
+#      this host (most current 25H2 hosts), OR if the native `fs_deny`
+#      capability (Feature_BfsPolicyDeny) is not enabled. The detector only
+#      keeps a denied-paths policy on Tier 1 when BOTH hold; otherwise it
+#      falls back to a DACL-enforcing tier, so asserting tier=base-container
+#      would fail the correct implementation. T1 force without the API (or
+#      the feature) backing it cannot exercise the native deny.
 #   2. Create a marker file under a denied directory. Force T1. Have the
 #      child try to `type` the marker. The child must exit non-zero AND
 #      not echo the marker contents.
 # -----------------------------------------------------------------------
 function Phase-T1DenyForced {
-    Section 'Phase 4c: T1 deny-ACE empirical test (skipped if BC API absent)'
+    Section 'Phase 4c: T1 native fs_deny empirical test (skipped if BC API or fs_deny feature absent)'
     Clear-StateFiles
 
     # Use the release-build probe to discover BC API presence — same JSON
@@ -747,12 +765,21 @@ function Phase-T1DenyForced {
         Record-Result -Phase 'P4c' -Name 'BC API present (required for T1 test)' -Pass $true -Detail 'SKIPPED: baseContainerApiPresent=false on this host'
         return
     }
+    # Post Feature_BfsPolicyDeny gate: BaseContainer only enforces deniedPaths
+    # natively (via fs_deny) when the feature is enabled. When it isn't, the
+    # detector correctly falls back to a DACL-enforcing tier, so the
+    # tier=base-container assertion below would fail a *correct* build. Skip
+    # unless the probe reports the native capability as available.
+    if (-not $probe.probes.nativeFsDenySupported) {
+        Record-Result -Phase 'P4c' -Name 'native fs_deny supported (required for T1 deny test)' -Pass $true -Detail 'SKIPPED: nativeFsDenySupported=false (Feature_BfsPolicyDeny not enabled) on this host'
+        return
+    }
 
     $denied = Join-Path $ScratchRoot 'deniedT1'
     New-Item -ItemType Directory -Force -Path $denied | Out-Null
     $marker = Join-Path $denied 'secret.txt'
     # Use a sentinel string the test can grep for. If the child ever
-    # echoes it, the deny ACE failed silently.
+    # echoes it, the native fs_deny failed silently.
     $sentinel = 'T1_DENY_SENTINEL_e54a23'
     Set-Content -LiteralPath $marker -Value $sentinel -Encoding utf8 -Force
 
@@ -771,7 +798,7 @@ function Phase-T1DenyForced {
     $stateAfter = @(Get-StateFiles)
 
     Record-Result -Phase 'P4c' -Name 'selected isolation tier: base-container' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?base-container')) -Detail "log saw tier=base-container"
-    Record-Result -Phase 'P4c' -Name 'child did not echo denied-file contents (deny ACE worked)' -Pass (-not ($r.Stdout -match $sentinel)) -Detail "stdout-saw-sentinel=$([bool]($r.Stdout -match $sentinel))"
+    Record-Result -Phase 'P4c' -Name 'child did not echo denied-file contents (native fs_deny worked)' -Pass (-not ($r.Stdout -match $sentinel)) -Detail "stdout-saw-sentinel=$([bool]($r.Stdout -match $sentinel))"
     Record-Result -Phase 'P4c' -Name 'child exited non-zero (access denied)' -Pass ($r.ExitCode -ne 0) -Detail "exit=$($r.ExitCode)"
     Record-Result -Phase 'P4c' -Name 'denied ACL restored after run' -Pass ($aclBefore -eq $aclAfter)
     Record-Result -Phase 'P4c' -Name 'no orphan state files' -Pass ($stateAfter.Count -eq 0) -Detail "files=$($stateAfter.Count)"


### PR DESCRIPTION
This PR plumbs `deniedPaths` into the BaseContainer SandboxSpec `fs_deny`
FlatBuffer field so denied paths reach `Experimental_CreateProcessInSandbox`,
gating native enforcement on the `Feature_BfsPolicyDeny` Velocity feature.

Details

* `base_container_runner.rs`: emit `fs_deny` from `denied_paths`;
  `validate_runner` accepts them only when `Feature_BfsPolicyDeny` is available
  and otherwise fails closed (no DACL fallback in this runner). Regenerated
  `sandbox_spec_generated.rs` for the additive `fs_deny` field.
* `fallback_detector.rs`: Tier 1 selects BaseContainer for a denied-paths
  policy only when `Feature_BfsPolicyDeny` is ENABLED (via `GetFeatureEnabledState`);
  any other state falls through to a DACL tier (fail secure). The export is
  resolved with `LoadLibraryExW(..., LOAD_LIBRARY_SEARCH_SYSTEM32)` to avoid
  DLL planting. The probe is shared as `pub(crate) native_fs_deny_supported()`.
* `dispatcher.rs` / `appcontainer_runner.rs`: when the feature is off, a
  denied-paths policy falls back to the AppContainer+BFS tier with a deny-only
  DACL, and the runner is flagged so `validate_runner` accepts it.
* `probe.rs`: add a `nativeFsDenySupported` fact for E2E harnesses.
* `Win25H2Safe-Tests.ps1`: gate the Tier 1 deny test on BC API + native
  `fs_deny` support; empty policy resolves to base-container/appcontainer-dacl,
  never appcontainer-bfs with `tier2_bfs` off.

Tests

* `cargo test -p appcontainer_common --lib`: 123 passed (default), 131 with
  `--features tier2_bfs`; `cargo test -p wxc_common`: 329 passed.
* `cargo fmt --all -- --check`, `cargo clippy ... -- -D warnings` (default and
  `tier2_bfs`), and `cargo check -p wxc --all-targets` all clean.
* Verified end-to-end on a Tier 1 (Deny) capable VM: `--probe` reports
  `nativeFsDenySupported: true`; a `deniedPaths` run selects `base-container`
  and is blocked (`Access is denied.`, exit 1) while an identical
  `readonlyPaths` control reads the same file (exit 0).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/489)