### PR TITLE
Fix fuzz pipeline: pass --fuzz-dir to cargo-fuzz after crate move

### DIFF
--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -68,10 +68,6 @@ jobs:
       displayName: Install cargo-fuzz
 
     # Build all three fuzz targets with ASAN.
-    # `--fuzz-dir .` overrides cargo-fuzz's workspace-root auto-discovery,
-    # which still expects the legacy `src/fuzz/` layout. The crate now lives
-    # at `src/testing/fuzz/`, so we tell cargo-fuzz to use the current dir
-    # (= $(fuzzDir)) directly.
     - powershell: |
         cd $(fuzzDir)
         foreach ($t in 'config_parser','base64_decode') {

--- a/.azure-pipelines/templates/Fuzz.Build.Job.yml
+++ b/.azure-pipelines/templates/Fuzz.Build.Job.yml
@@ -68,15 +68,19 @@ jobs:
       displayName: Install cargo-fuzz
 
     # Build all three fuzz targets with ASAN.
+    # `--fuzz-dir .` overrides cargo-fuzz's workspace-root auto-discovery,
+    # which still expects the legacy `src/fuzz/` layout. The crate now lives
+    # at `src/testing/fuzz/`, so we tell cargo-fuzz to use the current dir
+    # (= $(fuzzDir)) directly.
     - powershell: |
         cd $(fuzzDir)
         foreach ($t in 'config_parser','base64_decode') {
           Write-Host "===== building $t ====="
-          cargo +$(rustNightly) fuzz build $t --release
+          cargo +$(rustNightly) fuzz build --fuzz-dir . $t --release
           if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for $t" }
         }
         Write-Host "===== building validator ====="
-        cargo +$(rustNightly) fuzz build validator --release --features hyperlight,isolation_session,microvm
+        cargo +$(rustNightly) fuzz build --fuzz-dir . validator --release --features hyperlight,isolation_session,microvm
         if ($LASTEXITCODE -ne 0) { throw "fuzz build failed for validator" }
       displayName: Build fuzz targets (ASAN)
 

--- a/src/testing/fuzz/Cargo.toml
+++ b/src/testing/fuzz/Cargo.toml
@@ -15,13 +15,16 @@ cargo-fuzz = true
 [features]
 # Enable runner-specific validation in the `validator` fuzz target.
 # These pull in heavier deps so they're opt-in for local dev.
-hyperlight = ["wxc_common/hyperlight"]
-isolation_session = ["wxc_common/isolation_session"]
-microvm = ["wxc_common/microvm"]
+hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight"]
+isolation_session = ["dep:isolation_session_common"]
+microvm = ["dep:nanvix_runner", "wxc_common/microvm"]
 
 [dependencies]
 libfuzzer-sys = "0.4"
 wxc_common = { path = "../../core/wxc_common" }
+nanvix_runner = { path = "../../backends/nanvix/runner", optional = true }
+hyperlight_common = { path = "../../backends/hyperlight/common", optional = true }
+isolation_session_common = { path = "../../backends/isolation_session/common", optional = true }
 
 [[bin]]
 name = "config_parser"

--- a/src/testing/fuzz/fuzz_targets/validator.rs
+++ b/src/testing/fuzz/fuzz_targets/validator.rs
@@ -36,18 +36,17 @@ fuzz_target!(|data: &[u8]| {
         match req.containment {
             #[cfg(feature = "microvm")]
             ContainmentBackend::MicroVm => {
-                let runner = wxc_common::nanvix_runner::NanVixScriptRunner::new();
+                let runner = nanvix_runner::NanVixScriptRunner::new();
                 let _ = runner.validate_runner(&req);
             }
             #[cfg(feature = "hyperlight")]
             ContainmentBackend::Hyperlight => {
-                let runner = wxc_common::hyperlight_runner::HyperlightScriptRunner::new();
+                let runner = hyperlight_common::HyperlightScriptRunner::new();
                 let _ = runner.validate_runner(&req);
             }
             #[cfg(feature = "isolation_session")]
             ContainmentBackend::IsolationSession => {
-                let runner =
-                    wxc_common::isolation_session::IsolationSessionRunner::new();
+                let runner = isolation_session_common::IsolationSessionRunner::new();
                 let _ = runner.validate_runner(&req);
             }
             _ => {}


### PR DESCRIPTION
The Public release commit (161598f) relocated the fuzz crate from src/fuzz/ to src/testing/fuzz/ and updated the pipeline's fuzzDir variable. However cargo-fuzz ignores CWD and runs its own discovery: it walks up to the workspace root (src/Cargo.toml) and then expects <workspace_root>/fuzz/Cargo.toml. Since src/fuzz/ no longer exists, the build failed with "could not read the manifest file: src\fuzz\Cargo.toml".

Pass "--fuzz-dir ." (relative to the cd'd fuzzDir) so cargo-fuzz uses the current crate directly instead of re-discovering the legacy path.

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/491)