### PR TITLE
Remove stale CLI references from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # MXC Linux Build Script
-# Builds the lxc-exec binary and TypeScript SDK/CLI
+# Builds the lxc-exec binary and TypeScript SDK
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SRC_DIR="$SCRIPT_DIR/src"
 SDK_DIR="$SCRIPT_DIR/sdk"
-CLI_DIR="$SCRIPT_DIR/cli"
 
 # Parse arguments
 BUILD_TYPE="release"
@@ -39,7 +38,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --debug             Build in debug mode (default: release)"
-            echo "  --rust-only         Only build Rust binaries, skip SDK/CLI"
+            echo "  --rust-only         Only build Rust binaries, skip SDK"
             echo "  --with-hyperlight   Build with Hyperlight (micro-VM) backend (x86_64 only)"
             echo "  --with-microvm      Build with NanVix MicroVM backend (KVM required at runtime)"
             echo "  -h, --help          Show this help message"
@@ -140,18 +139,12 @@ if [ -n "$TARGET_TRIPLE" ]; then
     fi
 fi
 
-# Build SDK and CLI
+# Build SDK
 if [ "$BUILD_SDK" = true ]; then
     echo ""
     echo "=== Building TypeScript SDK ==="
     cd "$SDK_DIR"
     npm install --ignore-scripts 2>/dev/null || true
-    npm run build
-
-    echo ""
-    echo "=== Building TypeScript CLI ==="
-    cd "$CLI_DIR"
-    npm install 2>/dev/null || true
     npm run build
 fi
 


### PR DESCRIPTION
## 📖 Description
Remove stale CLI references from build.sh
Fixes #486 

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/496)