### PR TITLE
ci: add 1ES inventory metadata and TSA options for OS VPack

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,6 @@
+{
+    "codebaseName": "VSTS_Microsoft_OSGS_mxc",
+    "instanceUrl": "https://microsoft.visualstudio.com",
+    "projectName": "OS",
+    "areaPath": "OS\\Windows Client and Services\\WinPD\\AgOS-Agentic Platform\\Agent Runtime\\Tessera\\Process Sandbox"
+}

--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: febda914-cb97-4200-899e-7dc3077438a7
+    routing:
+      defaultAreaPath:
+        org: microsoft
+        path: OS\Windows Client and Services\WinPD\AgOS-Agentic Platform\Runtime


### PR DESCRIPTION
## 📖 Description

Adds two metadata files required by Microsoft policy for bug routing and
security-scan compliance:

- **`es-metadata.yml`** — 1ES Inventory-As-Code repo ownership metadata.
- **`.config/tsaoptions.json`** — TSA config so the daily OS VPack pipeline
  can file Guardian scan results (code + binary scans) into the right AzDO
  area path.

## 🔗 References

- 1ES Inventory-As-Code: <https://aka.ms/inventory-as-code>
- 1ES Trust Services Automation (TSA): <https://aka.ms/gdn-tsa>

## 🔍 Validation

- `es-metadata.yml` schema validated server-side on merge.
- `tsaoptions.json` mirrors the structure used by other Microsoft repos
  (e.g. `microsoft/cppwinrt`); will be exercised by the next OS VPack run.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/497)