### PR TITLE
[build] Fix build failure on non-English Windows

### DIFF
--- a/src/backends/nanvix/binaries/Cargo.toml
+++ b/src/backends/nanvix/binaries/Cargo.toml
@@ -8,6 +8,14 @@ links = "nanvix_binaries"
 [lib]
 path = "src/lib.rs"
 
+[features]
+# Gates the build script's expensive work (downloading NanVix release assets
+# and verifying their checksums). OFF by default so a plain `cargo build` —
+# which still compiles this crate as a workspace member — performs no network
+# or hashing work. Enabled transitively via the `microvm` feature of `wxc` and
+# `lxc`.
+microvm = []
+
 [dependencies]
 nanvix_common = { path = "../common" }
 

--- a/src/backends/nanvix/binaries/build.rs
+++ b/src/backends/nanvix/binaries/build.rs
@@ -34,6 +34,23 @@ use std::process::Command;
 use nanvix_common::{github_download_url, load_checksums, load_json, ReleaseConfig, RepoConfig};
 
 fn main() {
+    // The expensive work in this build script — downloading NanVix release
+    // assets and verifying their checksums via `certutil` — is only needed
+    // when the micro-VM backend is actually being built. Gate it behind this
+    // crate's `microvm` feature so that a default `cargo build` (which still
+    // compiles this crate as a workspace member) performs no network or hashing
+    // work. `wxc` and `lxc` enable `nanvix_binaries/microvm` through their own
+    // `microvm` features.
+    //
+    // `NANVIX_BIN_DIR` must still be emitted in every configuration because
+    // `lib.rs` references it via `env!`.
+    if std::env::var_os("CARGO_FEATURE_MICROVM").is_none() {
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        println!("cargo:rustc-env=NANVIX_BIN_DIR={}", out_dir);
+        println!("cargo:rerun-if-changed=build.rs");
+        return;
+    }
+
     // Check the TARGET platform (not host). NanVix binaries are only needed when
     // the output binary will run on Windows or Linux with KVM.
     let target = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();

--- a/src/backends/nanvix/binaries/build.rs
+++ b/src/backends/nanvix/binaries/build.rs
@@ -34,6 +34,13 @@ use std::process::Command;
 use nanvix_common::{github_download_url, load_checksums, load_json, ReleaseConfig, RepoConfig};
 
 fn main() {
+    // The build script's output (`NANVIX_BIN_DIR` and whether the download /
+    // verify path runs) depends on the `microvm` feature, surfaced here as the
+    // `CARGO_FEATURE_MICROVM` env var. Declare it as a rerun trigger so toggling
+    // the feature between builds re-runs this script instead of reusing stale
+    // output.
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MICROVM");
+
     // The expensive work in this build script — downloading NanVix release
     // assets and verifying their checksums via `certutil` — is only needed
     // when the micro-VM backend is actually being built. Gate it behind this

--- a/src/backends/nanvix/binaries/build.rs
+++ b/src/backends/nanvix/binaries/build.rs
@@ -436,14 +436,19 @@ fn certutil_sha256(path: &Path) -> String {
     //   SHA256 hash of <file>:
     //   <hex hash>
     //   CertUtil: -hashfile command completed successfully.
-    let stdout = String::from_utf8(output.stdout).expect("certutil output not UTF-8");
+    //
+    // Use a lossy conversion because the localized header/footer lines are
+    // emitted in the console's OEM code page (e.g. CP850 on French Windows),
+    // not UTF-8 -- a strict `from_utf8` would panic on those bytes. The hash
+    // line itself is pure ASCII hex, so it survives the lossy conversion. We
+    // locate the hash by scanning for a 64-character hex line rather than
+    // relying on a fixed line index, which keeps this locale-independent.
+    let stdout = String::from_utf8_lossy(&output.stdout);
     stdout
         .lines()
-        .nth(1)
+        .map(|line| line.trim().replace(' ', "").to_lowercase())
+        .find(|line| line.len() == 64 && line.bytes().all(|b| b.is_ascii_hexdigit()))
         .unwrap_or_else(|| panic!("nanvix_binaries: unexpected certutil output: {}", stdout))
-        .trim()
-        .replace(' ', "")
-        .to_lowercase()
 }
 
 fn verify_checksums(binaries: &[&str], bin_dir: &Path, checksums: &HashMap<String, String>) {

--- a/src/core/lxc/Cargo.toml
+++ b/src/core/lxc/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [features]
 hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight"]
-microvm = ["dep:nanvix_binaries", "dep:nanvix_runner"]
+microvm = ["nanvix_binaries/microvm", "dep:nanvix_runner"]
 
 [build-dependencies]
 mxc_build_common.workspace = true

--- a/src/core/lxc/Cargo.toml
+++ b/src/core/lxc/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/main.rs"
 
 [features]
 hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight"]
-microvm = ["nanvix_binaries/microvm", "dep:nanvix_runner"]
+microvm = ["dep:nanvix_binaries", "nanvix_binaries/microvm", "dep:nanvix_runner"]
 
 [build-dependencies]
 mxc_build_common.workspace = true

--- a/src/core/wxc/Cargo.toml
+++ b/src/core/wxc/Cargo.toml
@@ -34,7 +34,7 @@ nanvix_common = { path = "../../backends/nanvix/common" }
 
 [features]
 default = []
-microvm = ["nanvix_binaries", "dep:nanvix_runner"]
+microvm = ["nanvix_binaries/microvm", "dep:nanvix_runner"]
 wslc = ["dep:wslc_common", "wslc_common/link-wslcsdk"]
 hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight"]
 isolation_session = [

--- a/src/core/wxc/Cargo.toml
+++ b/src/core/wxc/Cargo.toml
@@ -34,7 +34,7 @@ nanvix_common = { path = "../../backends/nanvix/common" }
 
 [features]
 default = []
-microvm = ["nanvix_binaries/microvm", "dep:nanvix_runner"]
+microvm = ["dep:nanvix_binaries", "nanvix_binaries/microvm", "dep:nanvix_runner"]
 wslc = ["dep:wslc_common", "wslc_common/link-wslcsdk"]
 hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight"]
 isolation_session = [


### PR DESCRIPTION
## 📖 Description

On a non-English Windows (reported on French), running `build.bat` panicked
in the `nanvix_binaries` build script with `certutil output not UTF-8`, even
without the `--with-microvm` flag. This PR fixes both the immediate crash and
the underlying reason the NanVix download ran at all on a default build.

Two changes:

1. **Locale-robust checksum parsing** (`src/backends/nanvix/binaries/build.rs`).
   `certutil_sha256()` read `certutil`'s stdout via
   `String::from_utf8(...).expect(...)`. On localized Windows, `certutil` emits
   its header/footer lines (e.g. *"Hachage SHA256 de …"*, *"… s'est terminée
   correctement."*) in the console's OEM code page (CP850), not UTF-8 — bytes
   like `0xA0`, `0x92`, `0xE9` are invalid UTF-8 and the strict conversion
   panicked. Switched to `String::from_utf8_lossy` (the SHA256 line is pure
   ASCII and survives lossy conversion) and made hash extraction
   locale-independent by scanning for the 64-char hex line instead of relying
   on a fixed line index.

2. **Gate the NanVix download behind the `microvm` feature.** `nanvix_binaries`
   is an unconditional workspace member, so a plain `cargo build` compiled it
   and ran its build script — which gated only on the target OS, never on
   whether the micro-VM backend was requested. `--with-microvm` only added
   `--features microvm` (gating the `nanvix_runner` link and the SDK copy step)
   and never reached the download path. The crate now has a `microvm` feature;
   its `build.rs` early-returns (emitting only `NANVIX_BIN_DIR`, still required
   by `lib.rs`'s `env!`) when `CARGO_FEATURE_MICROVM` is unset — no download, no
   `certutil`, no snapshot generation. `wxc` and `lxc` enable
   `nanvix_binaries/microvm` through their own `microvm` features, so the
   download path runs exactly when `--with-microvm` is requested. `build.bat`
   needs no change.

Net effect: a default `build.bat` on any locale no longer triggers the NanVix
download/`certutil` step; the crate still compiles (cheap lib + early-returning
build script), only the network/hashing work is skipped.

## 🔗 References

Closes #498

## 🔍 Validation

- `cargo build -p nanvix_binaries` (no feature): compiles, performs no
  download/`certutil`.
- `cargo build -p wxc --features microvm`: build script runs its full path
  (binaries verified, snapshots checked), confirming `CARGO_FEATURE_MICROVM`
  propagates via `nanvix_binaries/microvm`.
- `cargo tree`: `nanvix_binaries` absent on a default build, present with
  `--features microvm`.
- Reproduced the original parse failure against the exact non-UTF-8 byte
  sequence from the issue; the new parser extracts the correct hash instead of
  panicking.
- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` clean on the
  touched crates.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/499)