### PR TITLE
Promote seatbelt from experimental to stable

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -153,7 +153,7 @@ Per-backend guides:
 - `docs/base-process-container/guide.md` — process container (Windows AppContainer / BaseContainer)
 - `docs/base-process-container/UIPolicy_Schema.md` — UI policy schema (JOB_OBJECT_UILIMIT_* mappings)
 - `docs/lxc-support/lxc-backend.md` — LXC container backend (Linux)
-- `docs/macos-support/seatbelt-backend.md` — macOS Seatbelt backend (experimental)
+- `docs/macos-support/seatbelt-backend.md` — macOS Seatbelt backend
 - `docs/windows-sandbox/windows-sandbox.md` / `docs/windows-sandbox/windows-sandbox-reference.md` — Windows Sandbox backend
 - `docs/wsl/wsl-container-getting-started.md` / `docs/wsl/wsl-container-support-plan.md` — WSL Container (WSLC SDK)
 - `docs/nanvix-microvm/nanvix.md` / `docs/nanvix-microvm/nanvix-integration-plan.md` — MicroVM via NanVix

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -132,8 +132,7 @@ You should see sandbox profile generation output followed by
 
 The macOS sandbox backend uses the same JSON configuration schema as the
 other backends, with `containment` set to `"seatbelt"`. Backend-specific
-settings live under `experimental.seatbelt`, and the `--experimental`
-flag is required to enable the backend at runtime:
+settings live under `experimental.seatbelt`:
 
 ```json
 {
@@ -214,22 +213,18 @@ SDK rejects it with a clear error, mirroring the Linux behavior.
 
 ### Command line
 
-The `seatbelt` backend is currently experimental, so every invocation
-must include the `--experimental` flag. Without it, the binary refuses to
-run with a clear error.
-
 ```bash
 # Run with config file
-./mxc-exec-mac --experimental config.json
+./mxc-exec-mac config.json
 
 # Run with base64-encoded config
-./mxc-exec-mac --experimental --config-base64 <base64-string>
+./mxc-exec-mac --config-base64 <base64-string>
 
 # Validate the config and exit without executing
-./mxc-exec-mac --experimental --dry-run config.json
+./mxc-exec-mac --dry-run config.json
 
 # Diagnostic output to console + file
-./mxc-exec-mac --experimental --debug --log-file mxc.log config.json
+./mxc-exec-mac --debug --log-file mxc.log config.json
 ```
 
 ### SDK
@@ -248,9 +243,8 @@ const policy: SandboxPolicy = {
 };
 
 // On macOS, spawnSandbox automatically resolves to mxc-exec-mac and
-// builds a seatbelt config. The backend is experimental, so the
-// caller must opt in via SandboxSpawnOptions.experimental.
-const pty = spawnSandbox('echo hello', policy, { experimental: true });
+// builds a seatbelt config.
+const pty = spawnSandbox('echo hello', policy);
 pty.onData((data) => console.log(data));
 pty.onExit((e) => console.log('Exit:', e.exitCode));
 ```

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -132,7 +132,9 @@ You should see sandbox profile generation output followed by
 
 The macOS sandbox backend uses the same JSON configuration schema as the
 other backends, with `containment` set to `"seatbelt"`. Backend-specific
-settings live under `experimental.seatbelt`:
+settings live under a top-level `seatbelt` key (preferred) or under
+`experimental.seatbelt` (deprecated, still accepted for backward
+compatibility):
 
 ```json
 {
@@ -151,10 +153,8 @@ settings live under `experimental.seatbelt`:
         "defaultPolicy": "block",
         "allowedHosts":  ["api.github.com"]
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "nestedPty": true
     }
 }
 ```
@@ -163,11 +163,11 @@ settings live under `experimental.seatbelt`:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `experimental.seatbelt.profileOverride` | string | unset | Optional override of the generated TinyScheme sandbox profile. When set, the SDK-generated profile is replaced with this raw TinyScheme string verbatim — all `filesystem`/`network`/`ui` policy fields are ignored for profile generation (they are still type-checked). Use this only when the auto-generated profile is insufficient. |
-| `experimental.seatbelt.guiAccess` | boolean | `false` | When `true`, adds wildcard Mach service and IOKit rules so GUI applications can create windows and render via WindowServer. Requires `ui.disable: false`. Native AppKit apps (e.g. Terminal.app) work well; Electron-based apps may escape the sandbox via re-launch patterns. |
-| `experimental.seatbelt.launchMethod` | `"exec"` \| `"open"` | `"exec"` | How to launch the sandboxed process. `"exec"` (default) uses the `sandbox_init()` API in `pre_exec` then execs the command directly — works for third-party GUI apps (Alacritty, etc.) and all CLI commands. `"open"` launches Terminal.app via LaunchServices (`open -n -W -a Terminal`) then applies the sandbox to the inner shell via the `sandbox-exec` CLI tool. This is required because Terminal.app enforces Apple Launch Constraints that kill it when exec'd by unauthorized parents. Currently only Terminal.app is supported with the `"open"` method — other Apple system apps (Calculator, TextEdit) cannot be sandboxed due to Launch Constraints and lack of an inner shell to constrain. |
-| `experimental.seatbelt.nestedPty` | boolean | `true` | When `true`, the inner process can allocate its own pseudo-terminals via `posix_openpt`. Required by anything that spawns a shell (test runners, `git`, `gh`, REPLs, agent tools that wrap commands in a pty). Adds `(allow pseudo-tty)` and read/write/ioctl on `/dev/ptmx` to the generated profile. Set to `false` for a tighter sandbox when the inner command does not need to allocate new ttys. |
-| `experimental.seatbelt.keychainAccess` | boolean | `false` | When `true`, opens the sandbox enough for `keytar` / `Security.framework` to reach the macOS Keychain end-to-end. Adds Mach lookup for `com.apple.SecurityServer`, `com.apple.securityd`, `com.apple.trustd`, `com.apple.ocspd`, `com.apple.cfprefsd.daemon`, `com.apple.xpcd`, and the `com.apple.lsd.*` family (regex); read access to `/private/var/db/mds` (Spotlight/MDS metadata) and `/private/var/protected/trustd` (trustd protected store); and read+write access to `~/Library/Keychains` (user keychain DB) and `/private/var/folders` (XPC cache and per-user containers). The system keychain stores under `/Library/Keychains` and `/System/Library/Keychains` are already covered by the baseline `/Library` and `/System` read-only allows. Off by default — opt in only when the inner workload genuinely needs Keychain access. |
+| `seatbelt.profileOverride` | string | unset | Optional override of the generated TinyScheme sandbox profile. When set, the SDK-generated profile is replaced with this raw TinyScheme string verbatim — all `filesystem`/`network`/`ui` policy fields are ignored for profile generation (they are still type-checked). Use this only when the auto-generated profile is insufficient. |
+| `seatbelt.guiAccess` | boolean | `false` | When `true`, adds wildcard Mach service and IOKit rules so GUI applications can create windows and render via WindowServer. Requires `ui.disable: false`. Native AppKit apps (e.g. Terminal.app) work well; Electron-based apps may escape the sandbox via re-launch patterns. |
+| `seatbelt.launchMethod` | `"exec"` \| `"open"` | `"exec"` | How to launch the sandboxed process. `"exec"` (default) uses the `sandbox_init()` API in `pre_exec` then execs the command directly — works for third-party GUI apps (Alacritty, etc.) and all CLI commands. `"open"` launches Terminal.app via LaunchServices (`open -n -W -a Terminal`) then applies the sandbox to the inner shell via the `sandbox-exec` CLI tool. This is required because Terminal.app enforces Apple Launch Constraints that kill it when exec'd by unauthorized parents. Currently only Terminal.app is supported with the `"open"` method — other Apple system apps (Calculator, TextEdit) cannot be sandboxed due to Launch Constraints and lack of an inner shell to constrain. |
+| `seatbelt.nestedPty` | boolean | `true` | When `true`, the inner process can allocate its own pseudo-terminals via `posix_openpt`. Required by anything that spawns a shell (test runners, `git`, `gh`, REPLs, agent tools that wrap commands in a pty). Adds `(allow pseudo-tty)` and read/write/ioctl on `/dev/ptmx` to the generated profile. Set to `false` for a tighter sandbox when the inner command does not need to allocate new ttys. |
+| `seatbelt.keychainAccess` | boolean | `false` | When `true`, opens the sandbox enough for `keytar` / `Security.framework` to reach the macOS Keychain end-to-end. Adds Mach lookup for `com.apple.SecurityServer`, `com.apple.securityd`, `com.apple.trustd`, `com.apple.ocspd`, `com.apple.cfprefsd.daemon`, `com.apple.xpcd`, and the `com.apple.lsd.*` family (regex); read access to `/private/var/db/mds` (Spotlight/MDS metadata) and `/private/var/protected/trustd` (trustd protected store); and read+write access to `~/Library/Keychains` (user keychain DB) and `/private/var/folders` (XPC cache and per-user containers). The system keychain stores under `/Library/Keychains` and `/System/Library/Keychains` are already covered by the baseline `/Library` and `/System` read-only allows. Off by default — opt in only when the inner workload genuinely needs Keychain access. |
 
 ### Filesystem policy
 

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -132,9 +132,7 @@ You should see sandbox profile generation output followed by
 
 The macOS sandbox backend uses the same JSON configuration schema as the
 other backends, with `containment` set to `"seatbelt"`. Backend-specific
-settings live under a top-level `seatbelt` key (preferred) or under
-`experimental.seatbelt` (deprecated, still accepted for backward
-compatibility):
+settings live under a top-level `seatbelt` key:
 
 ```json
 {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -127,7 +127,7 @@ force a particular backend.
 | `"wslc"` | Linux containers via the WSL Container SDK |
 | `"lxc"` | Native LXC container isolation |
 | `"microvm"` | MicroVM isolation via Windows HyperV Platform (NanVix microkernel) |
-| `"seatbelt"` | macOS sandbox isolation (Seatbelt; experimental) |
+| `"seatbelt"` | macOS sandbox isolation (Seatbelt) |
 | `"bubblewrap"` | Unprivileged Linux sandboxing via Bubblewrap/user namespaces (experimental) |
 
 Only the backend section matching the selected `containment` value is used;

--- a/schemas/dev/mxc-config.schema.0.7.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.7.0-dev.json
@@ -4,12 +4,14 @@
   "title": "MXC Configuration",
   "description": "Configuration schema for MXC container execution engine. Defines the recommended config format for both one-shot and state-aware sandbox lifecycle requests. The parser also accepts legacy fields not listed here during the migration period.",
   "type": "object",
-
   "properties": {
     "version": {
       "type": "string",
       "description": "MXC config schema version (semver). Current stable: '0.6.0-alpha'. Configs targeting this in-progress 0.7.0-dev schema should declare 'version: 0.7.0-alpha'.",
-      "examples": ["0.6.0-alpha", "0.7.0-alpha"]
+      "examples": [
+        "0.6.0-alpha",
+        "0.7.0-alpha"
+      ]
     },
     "containerId": {
       "type": "string",
@@ -33,17 +35,21 @@
       "default": "process",
       "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'vm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session', 'bubblewrap'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities (e.g., 'process' resolves to ProcessContainer on Windows, Bubblewrap on Linux, Seatbelt on macOS; 'vm' resolves to Windows Sandbox on Windows). 'lxc' is treated as a full Linux container and is only selected when explicitly requested. Note: 'microvm', 'windows_sandbox', 'wslc', 'isolation_session', and 'hyperlight' are experimental and require the --experimental CLI flag. 'hyperlight' and 'bubblewrap' have no per-backend configuration block; they share the common filesystem/network policy fields. The legacy aliases 'appcontainer' and 'macos_sandbox' are still accepted by the parser (with a deprecation log line) but are intentionally omitted from this enum so editors steer authors toward the canonical names."
     },
-
     "phase": {
       "type": "string",
-      "enum": ["provision", "start", "exec", "stop", "deprovision"],
+      "enum": [
+        "provision",
+        "start",
+        "exec",
+        "stop",
+        "deprovision"
+      ],
       "description": "State-aware lifecycle phase. When present, the request is a state-aware request: 'sandboxId' is required for non-provision phases, and 'process' is required only for the 'exec' phase. When absent, the request is a one-shot request and 'process' is required."
     },
     "sandboxId": {
       "type": "string",
       "description": "Sandbox identifier returned by a prior provision request. Required for non-provision state-aware phases ('start', 'exec', 'stop', 'deprovision')."
     },
-
     "lifecycle": {
       "type": "object",
       "description": "Container lifecycle settings shared across all backends.",
@@ -60,11 +66,12 @@
         }
       }
     },
-
     "process": {
       "type": "object",
       "description": "Process execution settings. Required for one-shot requests and for the state-aware 'exec' phase; omitted for non-exec state-aware phases.",
-      "required": ["commandLine"],
+      "required": [
+        "commandLine"
+      ],
       "properties": {
         "commandLine": {
           "type": "string",
@@ -77,9 +84,16 @@
         },
         "env": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Environment variables as KEY=VALUE strings.",
-          "examples": [["MY_VAR=value", "PATH=/usr/bin"]]
+          "examples": [
+            [
+              "MY_VAR=value",
+              "PATH=/usr/bin"
+            ]
+          ]
         },
         "timeout": {
           "type": "integer",
@@ -89,32 +103,36 @@
         }
       }
     },
-
     "filesystem": {
       "type": "object",
       "description": "Filesystem access policy. Shared across all backends.",
       "properties": {
         "readwritePaths": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Paths the process can read and write."
         },
         "readonlyPaths": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Paths the process can read but not write."
         },
         "deniedPaths": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Paths the process cannot access at all."
         }
       }
     },
-
     "fallback": {
       "type": "object",
       "description": "Operator consent for host-impacting containment fallbacks. Each flag gates a specific fallback mechanism the runner may otherwise pick when the preferred primitive is unavailable. Defaults preserve the pre-fallback-section behavior (all permitted).",
@@ -122,35 +140,45 @@
         "allowDaclMutation": {
           "type": "boolean",
           "default": true,
-          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS — original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3)."
+          "description": "When the BaseContainer API is absent and bfscfg.exe is unavailable, allow MXC to apply DACL ACEs on policy paths (Tier 3 fallback). MODIFIES HOST FILESYSTEM SECURITY DESCRIPTORS \u2014 original DACLs are restored on exit. Set to false to refuse this fallback (the run will fail on machines that need Tier 3)."
         }
       }
     },
-
     "network": {
       "type": "object",
       "description": "Network access policy. Shared across all backends.",
       "properties": {
         "defaultPolicy": {
           "type": "string",
-          "enum": ["allow", "block"],
+          "enum": [
+            "allow",
+            "block"
+          ],
           "default": "block",
           "description": "Default network posture. Deny-by-default."
         },
         "enforcementMode": {
           "type": "string",
-          "enum": ["capabilities", "firewall", "both"],
+          "enum": [
+            "capabilities",
+            "firewall",
+            "both"
+          ],
           "default": "capabilities",
           "description": "How network policy is enforced."
         },
         "allowedHosts": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', and 'hyperlight' containment backends."
         },
         "blockedHosts": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', and 'hyperlight' containment backends."
         },
         "allowLocalNetwork": {
@@ -171,7 +199,9 @@
                   "description": "Port of an external already running proxy on localhost."
                 }
               },
-              "required": ["localhost"],
+              "required": [
+                "localhost"
+              ],
               "additionalProperties": false
             },
             {
@@ -182,7 +212,9 @@
                   "description": "Use WXC's built-in test proxy server. Mutually exclusive with localhost."
                 }
               },
-              "required": ["builtinTestServer"],
+              "required": [
+                "builtinTestServer"
+              ],
               "additionalProperties": false
             },
             {
@@ -192,14 +224,15 @@
                   "description": "Full proxy URL including port (e.g., http://proxy.example.com:8080). Host and port are extracted from the URL."
                 }
               },
-              "required": ["url"],
+              "required": [
+                "url"
+              ],
               "additionalProperties": false
             }
           ]
         }
       }
     },
-
     "ui": {
       "type": "object",
       "description": "Cross-platform UI policy. Mapped from SandboxPolicy.ui by createConfigFromPolicy.",
@@ -211,7 +244,12 @@
         },
         "clipboard": {
           "type": "string",
-          "enum": ["none", "read", "write", "all"],
+          "enum": [
+            "none",
+            "read",
+            "write",
+            "all"
+          ],
           "default": "none",
           "description": "Clipboard access level."
         },
@@ -222,7 +260,6 @@
         }
       }
     },
-
     "processContainer": {
       "type": "object",
       "description": "ProcessContainer-specific settings. Used when containment is 'processcontainer'. The runner picks the legacy AppContainer implementation (which honors `capabilities` and `leastPrivilege`) or the newer BaseContainer implementation (which honors `ui`) at run time based on the host OS and the --experimental flag.",
@@ -234,7 +271,9 @@
         },
         "capabilities": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "AppContainer capabilities (e.g., 'internetClient', 'registryRead')."
         },
@@ -244,7 +283,12 @@
           "properties": {
             "isolation": {
               "type": "string",
-              "enum": ["desktop", "handles", "atoms", "container"],
+              "enum": [
+                "desktop",
+                "handles",
+                "atoms",
+                "container"
+              ],
               "default": "container",
               "description": "UI isolation level for the desktop."
             },
@@ -267,11 +311,13 @@
         }
       }
     },
-
     "lxc": {
       "type": "object",
       "description": "LXC-specific settings. Used when containment is 'lxc'.",
-      "required": ["distribution", "release"],
+      "required": [
+        "distribution",
+        "release"
+      ],
       "properties": {
         "distribution": {
           "type": "string",
@@ -283,7 +329,6 @@
         }
       }
     },
-
     "experimental": {
       "type": "object",
       "description": "Experimental features. Only active when --experimental is passed.",
@@ -328,12 +373,19 @@
               "type": "string",
               "default": "alpine:latest",
               "description": "Container image name (e.g., 'alpine:latest', 'python:3.12').",
-              "examples": ["alpine:latest", "python:3.12", "ubuntu:24.04"]
+              "examples": [
+                "alpine:latest",
+                "python:3.12",
+                "ubuntu:24.04"
+              ]
             },
             "imageTarPath": {
               "type": "string",
               "description": "Path to a local tar file to import as the container image. Supports both rootfs tars (from `docker export`) and Docker image archives (from `docker save`). When set, the image is imported from this file instead of pulling from a registry. The format is auto-detected: archives containing `manifest.json` are treated as Docker image format, archives with Linux root directories (bin/, etc/, usr/) are treated as rootfs tars, and unrecognized formats are rejected.",
-              "examples": ["C:\\images\\alpine.tar", "/home/user/images/alpine.tar"]
+              "examples": [
+                "C:\\images\\alpine.tar",
+                "/home/user/images/alpine.tar"
+              ]
             },
             "cpuCount": {
               "type": "integer",
@@ -374,51 +426,20 @@
                   },
                   "protocol": {
                     "type": "string",
-                    "enum": ["tcp", "udp"],
+                    "enum": [
+                      "tcp",
+                      "udp"
+                    ],
                     "default": "tcp",
                     "description": "Transport protocol for the mapping."
                   }
                 },
-                "required": ["windowsPort", "containerPort"],
+                "required": [
+                  "windowsPort",
+                  "containerPort"
+                ],
                 "additionalProperties": false
               }
-            }
-          }
-        },
-        "seatbelt": {
-          "type": "object",
-          "description": "macOS sandbox backend configuration. Used when containment is 'seatbelt'.",
-          "properties": {
-            "profileOverride": {
-              "type": "string",
-              "description": "Optional override of the generated TinyScheme sandbox profile."
-            },
-            "guiAccess": {
-              "type": "boolean",
-              "default": false,
-              "description": "Allow the Mach IPC services that GUI applications need to draw windows, composite frames, resolve fonts, and register with the Dock. Without this, GUI apps are killed on launch."
-            },
-            "launchMethod": {
-              "type": "string",
-              "enum": ["exec", "open"],
-              "default": "exec",
-              "description": "How to launch the sandboxed process. 'exec' (default) uses sandbox_init + exec and works for third-party GUI apps (e.g. Alacritty). 'open' uses LaunchServices ('open -n -W -a Terminal') to satisfy Apple Launch Constraints, then applies the sandbox to the inner shell via sandbox-exec. Required for system apps like Terminal.app that enforce launch constraints."
-            },
-            "nestedPty": {
-              "type": "boolean",
-              "default": true,
-              "description": "Allow the inner process to allocate its own pseudo-terminals via posix_openpt (needed by tests, git, gh, REPLs and other tools that spawn a shell). Adds (allow pseudo-tty) and read/write/ioctl on /dev/ptmx. Defaults to true; set to false for the tightest possible sandbox when the inner command does not need to allocate new ttys."
-            },
-            "keychainAccess": {
-              "type": "boolean",
-              "default": false,
-              "description": "Allow the inner process to use the macOS Keychain (e.g. via keytar or Security.framework) end-to-end. Adds Mach lookup for com.apple.SecurityServer, com.apple.securityd, com.apple.trustd, com.apple.ocspd, com.apple.cfprefsd.daemon, com.apple.xpcd and the com.apple.lsd.* family; read access to /private/var/db/mds and /private/var/protected/trustd; and read+write access to ~/Library/Keychains and /private/var/folders (XPC cache). System keychain stores under /Library and /System/Library are already covered by the baseline read-only allows. Defaults to false; opt in only when the inner workload genuinely needs Keychain access."
-            },
-            "extraMachLookups": {
-              "type": "array",
-              "items": { "type": "string" },
-              "default": [],
-              "description": "Caller-provided Mach service global-names the inner process may resolve. Each entry is emitted into the generated TinyScheme profile as `(allow mach-lookup (global-name \"...\"))`. Use this as a targeted escape hatch when a workload needs a Mach service the baseline profile does not already grant, without resorting to 'profileOverride' to replace the whole profile."
             }
           }
         },
@@ -428,7 +449,12 @@
           "properties": {
             "configurationId": {
               "type": "string",
-              "enum": ["small", "medium", "large", "composable"],
+              "enum": [
+                "small",
+                "medium",
+                "large",
+                "composable"
+              ],
               "default": "composable",
               "description": "IsoSession configuration ID for one-shot requests. For state-aware requests, place this under 'start.configurationId' instead. The schema enforces this enum; the runtime additionally accepts unknown values and downgrades them to 'composable' with a warning, for back-compat."
             },
@@ -439,7 +465,10 @@
                 "user": {
                   "type": "object",
                   "description": "Optional Entra credentials. When supplied, provisioning uses the Entra identity for the sandbox; the same 'user' must be supplied at start.",
-                  "required": ["upn", "wamToken"],
+                  "required": [
+                    "upn",
+                    "wamToken"
+                  ],
                   "properties": {
                     "upn": {
                       "type": "string",
@@ -459,14 +488,22 @@
               "properties": {
                 "configurationId": {
                   "type": "string",
-                  "enum": ["small", "medium", "large", "composable"],
+                  "enum": [
+                    "small",
+                    "medium",
+                    "large",
+                    "composable"
+                  ],
                   "default": "composable",
                   "description": "IsoSession configuration ID. The schema enforces this enum; the runtime additionally accepts unknown values and downgrades them to 'composable' with a warning, for back-compat."
                 },
                 "user": {
                   "type": "object",
                   "description": "Required when the sandbox was provisioned with a 'user' bundle; rejected otherwise. When required, 'upn' must match the UPN supplied at provision (case-insensitive).",
-                  "required": ["upn", "wamToken"],
+                  "required": [
+                    "upn",
+                    "wamToken"
+                  ],
                   "properties": {
                     "upn": {
                       "type": "string",
@@ -491,75 +528,244 @@
           }
         }
       }
+    },
+    "seatbelt": {
+      "type": "object",
+      "description": "macOS Seatbelt sandbox backend configuration (top-level). Used when containment is 'seatbelt'.",
+      "properties": {
+        "profileOverride": {
+          "type": "string",
+          "description": "Optional override of the generated TinyScheme sandbox profile."
+        },
+        "guiAccess": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow the Mach IPC services that GUI applications need to draw windows, composite frames, resolve fonts, and register with the Dock. Without this, GUI apps are killed on launch."
+        },
+        "launchMethod": {
+          "type": "string",
+          "enum": [
+            "exec",
+            "open"
+          ],
+          "default": "exec",
+          "description": "How to launch the sandboxed process. 'exec' (default) uses sandbox_init + exec and works for third-party GUI apps (e.g. Alacritty). 'open' uses LaunchServices ('open -n -W -a Terminal') to satisfy Apple Launch Constraints, then applies the sandbox to the inner shell via sandbox-exec. Required for system apps like Terminal.app that enforce launch constraints."
+        },
+        "nestedPty": {
+          "type": "boolean",
+          "default": true,
+          "description": "Allow the inner process to allocate its own pseudo-terminals via posix_openpt (needed by tests, git, gh, REPLs and other tools that spawn a shell). Adds (allow pseudo-tty) and read/write/ioctl on /dev/ptmx. Defaults to true; set to false for the tightest possible sandbox when the inner command does not need to allocate new ttys."
+        },
+        "keychainAccess": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow the inner process to use the macOS Keychain (e.g. via keytar or Security.framework) end-to-end. Adds Mach lookup for com.apple.SecurityServer, com.apple.securityd, com.apple.trustd, com.apple.ocspd, com.apple.cfprefsd.daemon, com.apple.xpcd and the com.apple.lsd.* family; read access to /private/var/db/mds and /private/var/protected/trustd; and read+write access to ~/Library/Keychains and /private/var/folders (XPC cache). System keychain stores under /Library and /System/Library are already covered by the baseline read-only allows. Defaults to false; opt in only when the inner workload genuinely needs Keychain access."
+        },
+        "extraMachLookups": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Caller-provided Mach service global-names the inner process may resolve. Each entry is emitted into the generated TinyScheme profile as `(allow mach-lookup (global-name \"...\"))`. Use this as a targeted escape hatch when a workload needs a Mach service the baseline profile does not already grant, without resorting to 'profileOverride' to replace the whole profile."
+        }
+      }
     }
   },
-
   "allOf": [
     {
       "$comment": "Enforce single backend section: each per-backend section requires the matching `containment` value (concrete backend or matching abstract intent). Requiring `containment` to be present when a backend section is provided also rules out the ambiguous case where two backend sections appear with no `containment` set.",
-      "if": { "required": ["processContainer"], "not": { "required": ["phase"] } },
+      "if": {
+        "required": [
+          "processContainer"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        }
+      },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["processcontainer", "process"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "processcontainer",
+              "process"
+            ]
+          }
+        }
       }
     },
     {
       "$comment": "`appContainer` is the deprecated alias for `processContainer`; same containment values are valid.",
-      "if": { "required": ["appContainer"], "not": { "required": ["phase"] } },
+      "if": {
+        "required": [
+          "appContainer"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        }
+      },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["processcontainer", "process"] } }
-      }
-    },
-    {
-      "if": { "required": ["lxc"], "not": { "required": ["phase"] } },
-      "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["lxc"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "processcontainer",
+              "process"
+            ]
+          }
+        }
       }
     },
     {
       "if": {
-        "required": ["experimental"],
-        "not": { "required": ["phase"] },
-        "properties": { "experimental": { "required": ["windows_sandbox"] } }
+        "required": [
+          "lxc"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        }
       },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["windows_sandbox", "vm"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "lxc"
+            ]
+          }
+        }
       }
     },
     {
       "if": {
-        "required": ["experimental"],
-        "not": { "required": ["phase"] },
-        "properties": { "experimental": { "required": ["wslc"] } }
+        "required": [
+          "seatbelt"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        }
       },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["wslc"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "seatbelt",
+              "process"
+            ]
+          }
+        }
       }
     },
     {
       "if": {
-        "required": ["experimental"],
-        "not": { "required": ["phase"] },
-        "properties": { "experimental": { "required": ["seatbelt"] } }
+        "required": [
+          "experimental"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        },
+        "properties": {
+          "experimental": {
+            "required": [
+              "windows_sandbox"
+            ]
+          }
+        }
       },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["seatbelt", "process"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "windows_sandbox",
+              "vm"
+            ]
+          }
+        }
       }
     },
     {
       "if": {
-        "required": ["experimental"],
-        "not": { "required": ["phase"] },
-        "properties": { "experimental": { "required": ["isolation_session"] } }
+        "required": [
+          "experimental"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        },
+        "properties": {
+          "experimental": {
+            "required": [
+              "wslc"
+            ]
+          }
+        }
       },
       "then": {
-        "required": ["containment"],
-        "properties": { "containment": { "enum": ["isolation_session"] } }
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "wslc"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": [
+          "experimental"
+        ],
+        "not": {
+          "required": [
+            "phase"
+          ]
+        },
+        "properties": {
+          "experimental": {
+            "required": [
+              "isolation_session"
+            ]
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "containment"
+        ],
+        "properties": {
+          "containment": {
+            "enum": [
+              "isolation_session"
+            ]
+          }
+        }
       }
     }
   ]

--- a/schemas/dev/mxc-config.schema.0.7.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.7.0-dev.json
@@ -31,7 +31,7 @@
         "bubblewrap"
       ],
       "default": "process",
-      "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'vm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session', 'bubblewrap'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities (e.g., 'process' resolves to ProcessContainer on Windows, Bubblewrap on Linux, Seatbelt on macOS; 'vm' resolves to Windows Sandbox on Windows). 'lxc' is treated as a full Linux container and is only selected when explicitly requested. Note: 'microvm', 'windows_sandbox', 'wslc', 'seatbelt', 'isolation_session', and 'hyperlight' are experimental and require the --experimental CLI flag. 'hyperlight' and 'bubblewrap' have no per-backend configuration block; they share the common filesystem/network policy fields. The legacy aliases 'appcontainer' and 'macos_sandbox' are still accepted by the parser (with a deprecation log line) but are intentionally omitted from this enum so editors steer authors toward the canonical names."
+      "description": "Containment value to use for execution. Accepts both abstract intents ('process', 'vm') and concrete backends ('processcontainer', 'windows_sandbox', 'lxc', 'microvm', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session', 'bubblewrap'). The native binary resolves abstract intents to a concrete backend at run time based on host capabilities (e.g., 'process' resolves to ProcessContainer on Windows, Bubblewrap on Linux, Seatbelt on macOS; 'vm' resolves to Windows Sandbox on Windows). 'lxc' is treated as a full Linux container and is only selected when explicitly requested. Note: 'microvm', 'windows_sandbox', 'wslc', 'isolation_session', and 'hyperlight' are experimental and require the --experimental CLI flag. 'hyperlight' and 'bubblewrap' have no per-backend configuration block; they share the common filesystem/network policy fields. The legacy aliases 'appcontainer' and 'macos_sandbox' are still accepted by the parser (with a deprecation log line) but are intentionally omitted from this enum so editors steer authors toward the canonical names."
     },
 
     "phase": {
@@ -387,7 +387,7 @@
         },
         "seatbelt": {
           "type": "object",
-          "description": "macOS sandbox backend (experimental). Used when containment is 'seatbelt'.",
+          "description": "macOS sandbox backend configuration. Used when containment is 'seatbelt'.",
           "properties": {
             "profileOverride": {
               "type": "string",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -63,7 +63,7 @@ child.on('close', (code) => console.log('exit:', code));
 
 Pick `0.6.0-alpha` for new code on any supported platform.
 
-> **Stable schemas document only the non-experimental surface.** Experimental backends (`windows_sandbox`, `wslc`, `microvm`, `hyperlight`, `seatbelt`, `isolation_session`), the `experimental.*` block, and state-aware lifecycle live in `0.7.0-dev`. The parser still accepts them when paired with `--experimental` regardless of which schema your config validates against — schema choice affects editor validation, not runtime behavior.
+> **Stable schemas document only the non-experimental surface.** Experimental backends (`windows_sandbox`, `wslc`, `microvm`, `hyperlight`, `isolation_session`), the `experimental.*` block, and state-aware lifecycle live in `0.7.0-dev`. The parser still accepts them when paired with `--experimental` regardless of which schema your config validates against — schema choice affects editor validation, not runtime behavior.
 
 > **Network host allow/block lists are not implemented on Windows.** `network.allowedHosts` / `network.blockedHosts` have no enforcement on this platform — use `network.defaultPolicy` (`allow` / `block`) or `network.proxy` to constrain network access.
 
@@ -75,7 +75,7 @@ Pick `0.6.0-alpha` for new code on any supported platform.
 | Linux x64 / ARM64 | `bubblewrap` | `lxc` | — |
 | macOS ARM64 (schema `0.6.0-alpha`+) | `seatbelt` | — | — |
 
-The default `processcontainer`, `bubblewrap`, and `lxc` backends work out of the box. **Experimental backends** (`windows_sandbox`, `wslc`, `microvm`, `seatbelt`, `isolation_session`, `hyperlight`) require `{ experimental: true }` in `SandboxSpawnOptions` when you spawn — see [Choosing a Backend](#choosing-a-backend).
+The default `processcontainer`, `bubblewrap`, `lxc`, and `seatbelt` backends work out of the box. **Experimental backends** (`windows_sandbox`, `wslc`, `microvm`, `isolation_session`, `hyperlight`) require `{ experimental: true }` in `SandboxSpawnOptions` when you spawn — see [Choosing a Backend](#choosing-a-backend).
 
 > **Hyperlight** is an opt-in build flavor (Linux x64 and Windows x64) gated by the `--with-hyperlight` cargo feature. Default shipped binaries do not include it; build from source with `build.bat --with-hyperlight` (Windows) or the equivalent cargo invocation on Linux.
 
@@ -196,7 +196,7 @@ console.log(result.stdout);
 | `processcontainer` | `process` | Windows | ✅ | [`docs/base-process-container/guide.md`](https://github.com/microsoft/mxc/blob/main/docs/base-process-container/guide.md) |
 | `bubblewrap` | `process` | Linux | ✅ | [`docs/bwrap-support/bubblewrap-backend.md`](https://github.com/microsoft/mxc/blob/main/docs/bwrap-support/bubblewrap-backend.md) |
 | `lxc` | (concrete only) | Linux | ✅ | [`docs/lxc-support/lxc-backend.md`](https://github.com/microsoft/mxc/blob/main/docs/lxc-support/lxc-backend.md) |
-| `seatbelt` | `process` | macOS | Experimental (schema `0.6.0-alpha`+) | [`docs/macos-support/seatbelt-backend.md`](https://github.com/microsoft/mxc/blob/main/docs/macos-support/seatbelt-backend.md) |
+| `seatbelt` | `process` | macOS | ✅ (schema `0.7.0-alpha`+) | [`docs/macos-support/seatbelt-backend.md`](https://github.com/microsoft/mxc/blob/main/docs/macos-support/seatbelt-backend.md) |
 | `windows_sandbox` | `vm` | Windows | Experimental | [`docs/windows-sandbox/windows-sandbox.md`](https://github.com/microsoft/mxc/blob/main/docs/windows-sandbox/windows-sandbox.md) |
 | `microvm` | `microvm` | Windows | Experimental | [`docs/nanvix-microvm/nanvix.md`](https://github.com/microsoft/mxc/blob/main/docs/nanvix-microvm/nanvix.md) — MicroVM via NanVix on Windows Hypervisor Platform |
 | `wslc` | (concrete only) | Windows | Experimental | [`docs/wsl/wsl-container-getting-started.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wsl-container-getting-started.md) |
@@ -326,7 +326,7 @@ Setting `cwd` (or the `workingDirectory` argument) does **not** add that path to
 | `MXC is not supported on this platform` | `getPlatformSupport()` returned `isSupported: false`. On Linux: neither LXC nor Bubblewrap on PATH. On macOS: schema version < `0.6.0-alpha`. | Install LXC/Bubblewrap, or switch to schema `0.6.0-alpha` (or `0.7.0-alpha` if you need state-aware lifecycle). |
 | `wxc-exec.exe not found` / `lxc-exec not found` | The SDK couldn't locate the native binary. | Set `MXC_BIN_DIR=<dir>` so `<dir>/<arch>/wxc-exec.exe` (or `lxc-exec`) exists, or pass `options.executablePath` explicitly. |
 | `Invalid containment value '<x>'` | `containment` field doesn't match the parser's accepted values. | Use one of the abstract intents (`process`, `vm`, `microvm`) or a concrete backend listed in [Choosing a Backend](#choosing-a-backend). |
-| `'<x>' containment requires experimental mode` | A `windows_sandbox` / `wslc` / `microvm` / `seatbelt` / `isolation_session` / `hyperlight` backend was selected without the flag. | Pass `{ experimental: true }` in `SandboxSpawnOptions`. |
+| `'<x>' containment requires experimental mode` | A `windows_sandbox` / `wslc` / `microvm` / `isolation_session` / `hyperlight` backend was selected without the flag. | Pass `{ experimental: true }` in `SandboxSpawnOptions`. |
 | `process.commandLine starts with an unquoted Windows path containing a space` | `wxc-exec` rejects unquoted paths with spaces at parse time. | Quote the executable: `'"C:\\Program Files\\…\\foo.exe" args'`. |
 | `Experimental_CreateProcessInSandbox failed: WIN32_ERROR(...)` | Native sandbox API returned an OS-level error. Codes vary: `120` = call not implemented (BaseContainer disabled — use schema `0.4.0-alpha`), `448` = device feature not supported (Windows build / WIP feature not enabled). | Check the Windows build / WIP requirements, or fall back to schema `0.4.0-alpha`. |
 | Process exits `-1` / `4294967295` with no stdout | Native binary terminated abnormally. | Re-run with `options.debug: true` (or `options.logDir: '<dir>'`) to capture diagnostic logs. |

--- a/sdk/src/sandbox.ts
+++ b/sdk/src/sandbox.ts
@@ -122,18 +122,15 @@ function buildLinuxProcessConfig(
  *
  * The seatbelt backend's `sandbox-exec` reads a TinyScheme profile
  * generated server-side by `seatbelt_common::profile_builder`, so the SDK
- * only needs to set the containment type and the mode selector under the
- * experimental block — the policy fields on `ContainerConfig` (filesystem /
+ * only needs to set the containment type and ensure the top-level `seatbelt`
+ * config block exists — the policy fields on `ContainerConfig` (filesystem /
  * network / ui) drive the actual rules.
  */
 function buildDarwinProcessConfig(
     config: ContainerConfig,
 ): ContainerConfig {
     config.containment = 'seatbelt';
-    config.experimental = {
-        ...(config.experimental ?? {}),
-        seatbelt: {},
-    };
+    config.seatbelt = config.seatbelt ?? {};
     return config;
 }
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -276,9 +276,16 @@ export interface ContainerConfig {
   experimental?: {
     /** WSLC SDK configuration for Linux containers from Windows */
     wslc?: WslcConfig;
-    /** macOS sandbox configuration (macOS only) */
+    /**
+     * macOS sandbox configuration (macOS only).
+     * @deprecated Use the top-level {@link seatbelt} field instead. This
+     * location is retained for backward compatibility and will be removed
+     * in a future schema version.
+     */
     seatbelt?: SeatbeltConfig;
   };
+  /** macOS Seatbelt sandbox configuration (macOS only) */
+  seatbelt?: SeatbeltConfig;
   /** Cross-platform UI configuration */
   ui?: UiConfig;
 }
@@ -348,8 +355,8 @@ export interface LxcConfig {
 }
 
 /**
- * macOS Seatbelt sandbox configuration. Used under
- * `experimental.seatbelt` when containment is `'seatbelt'`.
+ * macOS Seatbelt sandbox configuration. Used under the top-level
+ * `seatbelt` key (preferred) or `experimental.seatbelt` (deprecated).
  */
 export interface SeatbeltConfig {
   /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -107,7 +107,7 @@ export type ContainmentBackend =
  * Containment values (abstract intent or concrete backend) that require
  * the `--experimental` flag.
  */
-export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'windows_sandbox', 'hyperlight', 'wslc', 'seatbelt', 'isolation_session'];
+export const ExperimentalBackends: readonly (ContainmentType | ContainmentBackend)[] = ['microvm', 'windows_sandbox', 'hyperlight', 'wslc', 'isolation_session'];
 
 /**
  * Clipboard access policy levels
@@ -348,7 +348,7 @@ export interface LxcConfig {
 }
 
 /**
- * macOS Seatbelt sandbox configuration (experimental). Used under
+ * macOS Seatbelt sandbox configuration. Used under
  * `experimental.seatbelt` when containment is `'seatbelt'`.
  */
 export interface SeatbeltConfig {

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -276,13 +276,6 @@ export interface ContainerConfig {
   experimental?: {
     /** WSLC SDK configuration for Linux containers from Windows */
     wslc?: WslcConfig;
-    /**
-     * macOS sandbox configuration (macOS only).
-     * @deprecated Use the top-level {@link seatbelt} field instead. This
-     * location is retained for backward compatibility and will be removed
-     * in a future schema version.
-     */
-    seatbelt?: SeatbeltConfig;
   };
   /** macOS Seatbelt sandbox configuration (macOS only) */
   seatbelt?: SeatbeltConfig;
@@ -356,7 +349,7 @@ export interface LxcConfig {
 
 /**
  * macOS Seatbelt sandbox configuration. Used under the top-level
- * `seatbelt` key (preferred) or `experimental.seatbelt` (deprecated).
+ * `seatbelt` key when `containment == "seatbelt"`.
  */
 export interface SeatbeltConfig {
   /**

--- a/sdk/tests/integration/macos-seatbelt.test.ts
+++ b/sdk/tests/integration/macos-seatbelt.test.ts
@@ -217,13 +217,11 @@ describe('macOS Seatbelt Container', {
     assert.notStrictEqual(result.exitCode, 0, 'Expected non-zero exit for timed-out script');
   });
 
-  it('should apply profile override from experimental config', { timeout: 30_000 }, async () => {
+  it('should apply profile override from seatbelt config', { timeout: 30_000 }, async () => {
     // Build a config with a custom seatbelt profile that allows everything
     const config = sdk.createConfigFromPolicy({ version: schemaVersion });
     config.process = { commandLine: "echo 'profile override works'" };
-    config.experimental = {
-      seatbelt: { profileOverride: '(version 1)\n(allow default)' },
-    };
+    config.seatbelt = { profileOverride: '(version 1)\n(allow default)' };
     config.containerId = 'seatbelt-profile-override';
 
     const result = await new Promise<{ exitCode: number; stdout: string }>((resolve, reject) => {

--- a/sdk/tests/unit/sandbox.test.ts
+++ b/sdk/tests/unit/sandbox.test.ts
@@ -1111,26 +1111,13 @@ describe('resolveExecutableAndArgs (containment validation)', { skip: platformSk
       );
     });
 
-    it('should require experimental mode for "macos_sandbox" (mirrors seatbelt gating)', () => {
-      // Regression: pre-fix, ExperimentalBackends.includes('macos_sandbox') was
-      // false, so the legacy alias bypassed the experimental gate entirely.
-      // The gate must look at the resolved backend, not the raw wire value.
-      assert.throws(
-        () => resolveExecutableAndArgs(makeConfig('macos_sandbox'), { executablePath: fakeExe }),
-        { message: /experimental mode/ },
-      );
-    });
-
-    it('should accept "macos_sandbox" on macOS with the experimental flag set', function (this: { skip: (reason?: string) => void }) {
+    it('should accept "macos_sandbox" on macOS', function (this: { skip: (reason?: string) => void }) {
       if (process.platform !== 'darwin') {
         this.skip('seatbelt is macOS-only');
         return;
       }
       assert.doesNotThrow(() =>
-        resolveExecutableAndArgs(makeConfig('macos_sandbox'), {
-          executablePath: fakeExe,
-          experimental: true,
-        }),
+        resolveExecutableAndArgs(makeConfig('macos_sandbox'), { executablePath: fakeExe }),
       );
     });
 

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -31,13 +31,12 @@ use wxc_common::models::{ClipboardPolicy, ExecutionRequest, NetworkPolicy};
 
 /// Build a complete sandbox profile string from the given request.
 ///
-/// If `request.experimental.seatbelt.profile_override` is set, that
+/// If `request.seatbelt.profile_override` is set, that
 /// string is returned verbatim and policy fields are ignored. This is the
 /// escape hatch for advanced/testing scenarios that need to hand-author a
 /// profile.
 pub fn build_profile(request: &ExecutionRequest) -> Result<String, String> {
     if let Some(override_profile) = request
-        .experimental
         .seatbelt
         .as_ref()
         .and_then(|c| c.profile_override.as_ref())
@@ -238,11 +237,7 @@ fn write_local_network_rules(out: &mut String, allow_local_network: bool) {
 
 fn write_ui_rules(out: &mut String, request: &ExecutionRequest) {
     let ui = &request.policy.ui;
-    let gui_access = request
-        .experimental
-        .seatbelt
-        .as_ref()
-        .is_some_and(|c| c.gui_access);
+    let gui_access = request.seatbelt.as_ref().is_some_and(|c| c.gui_access);
 
     // The baseline profile uses `(deny default)`, so services are blocked
     // unless explicitly allowed. When UI is enabled, we allow the mach
@@ -321,7 +316,7 @@ fn write_ui_rules(out: &mut String, request: &ExecutionRequest) {
 /// its own pty. Skipped when `gui_access` (with UI enabled) already emits
 /// a strict superset.
 fn write_nested_pty_rules(out: &mut String, request: &ExecutionRequest) {
-    let sb = request.experimental.seatbelt.as_ref();
+    let sb = request.seatbelt.as_ref();
     let enabled = sb.is_none_or(|c| c.nested_pty);
     let gui_block_emitted = sb.is_some_and(|c| c.gui_access) && !request.policy.ui.disable;
     if !enabled || gui_block_emitted {
@@ -338,7 +333,7 @@ fn write_nested_pty_rules(out: &mut String, request: &ExecutionRequest) {
 
 /// Emit rules so `Security.framework` / `keytar` can reach `securityd`
 /// and read/write the user's Keychain. Off by default — opt in via
-/// `experimental.seatbelt.keychainAccess: true`.
+/// `seatbelt.keychainAccess: true`.
 ///
 /// Real-world Keychain access fans out across several daemons. At
 /// minimum we need:
@@ -360,11 +355,7 @@ fn write_nested_pty_rules(out: &mut String, request: &ExecutionRequest) {
 /// are already covered by the baseline `/Library` and `/System`
 /// read-only allows, so we don't re-add them here.
 fn write_keychain_rules(out: &mut String, request: &ExecutionRequest) -> Result<(), String> {
-    let enabled = request
-        .experimental
-        .seatbelt
-        .as_ref()
-        .is_some_and(|c| c.keychain_access);
+    let enabled = request.seatbelt.as_ref().is_some_and(|c| c.keychain_access);
     if !enabled {
         return Ok(());
     }
@@ -414,7 +405,7 @@ fn write_keychain_rules(out: &mut String, request: &ExecutionRequest) -> Result<
 /// Emit caller-provided `extraMachLookups` rules: additional Mach service
 /// global-names the inner process may resolve. No-op when the list is empty.
 fn write_extra_seatbelt_rules(out: &mut String, request: &ExecutionRequest) {
-    let Some(sb) = request.experimental.seatbelt.as_ref() else {
+    let Some(sb) = request.seatbelt.as_ref() else {
         return;
     };
     if sb.extra_mach_lookups.is_empty() {
@@ -661,7 +652,7 @@ mod tests {
     fn profile_override_takes_precedence() {
         let mut r = req();
         r.policy.readonly_paths = vec!["/should/be/ignored".into()];
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             profile_override: Some("(version 1)(allow default)".into()),
             gui_access: false,
             ..Default::default()
@@ -699,7 +690,7 @@ mod tests {
             clipboard: ClipboardPolicy::None,
             injection: true,
         };
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             profile_override: None,
             gui_access: true,
             ..Default::default()
@@ -729,7 +720,7 @@ mod tests {
             clipboard: ClipboardPolicy::None,
             injection: true,
         };
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             profile_override: None,
             gui_access: false,
             // Pin nested_pty off so this test stays focused on
@@ -749,7 +740,7 @@ mod tests {
     fn gui_access_requires_ui_enabled() {
         let mut r = req();
         // ui.disable = true (default) but gui_access = true
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             profile_override: None,
             gui_access: true,
             // Pin nested_pty off so this test isolates the
@@ -767,10 +758,10 @@ mod tests {
 
     #[test]
     fn nested_pty_default_on_emits_pty_rules() {
-        // When experimental.seatbelt is absent the builder should still
+        // When seatbelt is absent the builder should still
         // emit nested_pty rules — that's the documented default behavior.
         let r = req();
-        assert!(r.experimental.seatbelt.is_none());
+        assert!(r.seatbelt.is_none());
         let p = build_profile(&r).unwrap();
         assert!(p.contains("nestedPty"), "nestedPty comment missing");
         assert!(p.contains("(allow pseudo-tty)"));
@@ -780,7 +771,7 @@ mod tests {
     #[test]
     fn nested_pty_explicit_true_emits_pty_rules() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             nested_pty: true,
             ..Default::default()
         });
@@ -792,7 +783,7 @@ mod tests {
     #[test]
     fn nested_pty_false_omits_pty_rules() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             nested_pty: false,
             ..Default::default()
         });
@@ -813,7 +804,7 @@ mod tests {
             clipboard: ClipboardPolicy::None,
             injection: true,
         };
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             gui_access: true,
             nested_pty: true,
             ..Default::default()
@@ -835,7 +826,7 @@ mod tests {
             r.policy.ui.disable,
             "default ui.disable expected to be true"
         );
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             gui_access: true,
             nested_pty: true,
             ..Default::default()
@@ -867,7 +858,7 @@ mod tests {
     #[test]
     fn keychain_access_true_allows_securityd_mach_services() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             keychain_access: true,
             ..Default::default()
         });
@@ -885,7 +876,7 @@ mod tests {
     #[test]
     fn keychain_access_true_allows_filesystem_paths() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             keychain_access: true,
             ..Default::default()
         });
@@ -907,7 +898,7 @@ mod tests {
     #[test]
     fn extra_mach_lookups_emits_grouped_allow_form() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             extra_mach_lookups: vec![
                 "com.apple.example.one".to_string(),
                 "com.apple.example.two".to_string(),
@@ -922,7 +913,7 @@ mod tests {
     #[test]
     fn extra_mach_lookups_omitted_when_empty() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig::default());
+        r.seatbelt = Some(SeatbeltConfig::default());
         let p = build_profile(&r).unwrap();
         assert!(!p.contains("extraMachLookups"));
     }
@@ -930,7 +921,7 @@ mod tests {
     #[test]
     fn extra_mach_lookups_escape_embedded_quotes() {
         let mut r = req();
-        r.experimental.seatbelt = Some(SeatbeltConfig {
+        r.seatbelt = Some(SeatbeltConfig {
             extra_mach_lookups: vec!["weird\"name".to_string()],
             ..Default::default()
         });

--- a/src/backends/seatbelt/common/src/seatbelt_runner.rs
+++ b/src/backends/seatbelt/common/src/seatbelt_runner.rs
@@ -109,14 +109,12 @@ impl ScriptRunner for SeatbeltScriptRunner {
 
         // Determine launch method from seatbelt config.
         let launch_method = request
-            .experimental
             .seatbelt
             .as_ref()
             .map(|s| s.launch_method.clone())
             .unwrap_or_default();
 
         let gui_access = request
-            .experimental
             .seatbelt
             .as_ref()
             .map(|s| s.gui_access)
@@ -522,7 +520,7 @@ mod tests {
     fn base_request() -> ExecutionRequest {
         let mut request = ExecutionRequest::default();
         request.experimental_enabled = true;
-        request.experimental.seatbelt = Some(SeatbeltConfig::default());
+        request.seatbelt = Some(SeatbeltConfig::default());
         request
     }
 

--- a/src/core/mxc_darwin/src/main.rs
+++ b/src/core/mxc_darwin/src/main.rs
@@ -113,15 +113,6 @@ fn main() {
 
     log_request(&request, &mut logger);
 
-    // The macOS sandbox backend is experimental — require the flag.
-    if !request.experimental_enabled {
-        eprintln!(
-            "Error: the macOS sandbox backend is experimental. \
-             Pass --experimental to enable it."
-        );
-        process::exit(1);
-    }
-
     // The SDK should always select Seatbelt on darwin. Be lenient and
     // log a note instead of failing — same behaviour as `lxc-exec`.
     if request.containment != ContainmentBackend::Seatbelt {

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -228,7 +228,7 @@ struct RawConfig {
     network: Option<RawNetwork>,
     ui: Option<RawUi>,
     experimental: Option<RawExperimental>,
-    /// Top-level seatbelt config (preferred over experimental.seatbelt).
+    /// Top-level seatbelt config.
     #[serde(alias = "macos_sandbox")]
     seatbelt: Option<RawSeatbelt>,
 }
@@ -614,6 +614,9 @@ fn present_backend_sections(raw: &RawConfig) -> Vec<&'static str> {
     if raw.lxc.is_some() {
         push(ContainmentBackend::Lxc);
     }
+    if raw.seatbelt.is_some() {
+        push(ContainmentBackend::Seatbelt);
+    }
     if let Some(experimental) = raw.experimental.as_ref() {
         if experimental.windows_sandbox.is_some() {
             push(ContainmentBackend::WindowsSandbox);
@@ -621,15 +624,9 @@ fn present_backend_sections(raw: &RawConfig) -> Vec<&'static str> {
         if experimental.wslc.is_some() {
             push(ContainmentBackend::Wslc);
         }
-        if experimental.seatbelt.is_some() && raw.seatbelt.is_none() {
-            push(ContainmentBackend::Seatbelt);
-        }
         if experimental.isolation_session.is_some() {
             push(ContainmentBackend::IsolationSession);
         }
-    }
-    if raw.seatbelt.is_some() {
-        push(ContainmentBackend::Seatbelt);
     }
     sections
 }
@@ -721,6 +718,18 @@ fn validate_experimental_backend_keys(
 // `process` block entirely; those phases leave `script_code` / `working_directory`
 // / `script_timeout` / `env` at their defaults and never read them.
 //
+/// Convert a raw seatbelt JSON block into the validated domain struct.
+fn make_seatbelt_config(raw_sb: RawSeatbelt) -> SeatbeltConfig {
+    SeatbeltConfig {
+        profile_override: raw_sb.profile_override,
+        gui_access: raw_sb.gui_access.unwrap_or(false),
+        launch_method: raw_sb.launch_method.unwrap_or_default(),
+        nested_pty: raw_sb.nested_pty.unwrap_or(true),
+        keychain_access: raw_sb.keychain_access.unwrap_or(false),
+        extra_mach_lookups: raw_sb.extra_mach_lookups.unwrap_or_default(),
+    }
+}
+
 // `allow_missing_command` further relaxes the `require_process == true` arms
 // so that a CLI command-line override (provided by the driver after parsing)
 // can stand in for `process.commandLine`. When set, a missing or empty
@@ -1198,44 +1207,27 @@ fn convert_raw_config_inner(
             config.user = as_cfg.user;
             config
         });
-        let seatbelt = raw_exp.seatbelt.map(|raw_sb| SeatbeltConfig {
-            profile_override: raw_sb.profile_override,
-            gui_access: raw_sb.gui_access.unwrap_or(false),
-            launch_method: raw_sb.launch_method.unwrap_or_default(),
-            nested_pty: raw_sb.nested_pty.unwrap_or(true),
-            keychain_access: raw_sb.keychain_access.unwrap_or(false),
-            extra_mach_lookups: raw_sb.extra_mach_lookups.unwrap_or_default(),
-        });
+        let seatbelt = raw_exp.seatbelt;
+        if seatbelt.is_some() {
+            let msg = "'experimental.seatbelt' has moved to the stable section; \
+                       use top-level 'seatbelt' instead."
+                .to_string();
+            logger.log_line(&msg);
+            return Err(WxcError::ConfigParse(msg));
+        }
         ExperimentalConfig {
             test,
             windows_sandbox,
             wslc,
             isolation_session,
-            seatbelt,
         }
     } else {
         ExperimentalConfig::default()
     };
 
-    // Top-level `seatbelt` takes precedence over `experimental.seatbelt`.
-    // This supports the two-phase migration: new configs use the top-level key,
-    // old configs still work via the experimental path.
-    let experimental = if let Some(raw_sb) = raw.seatbelt {
-        let sb = SeatbeltConfig {
-            profile_override: raw_sb.profile_override,
-            gui_access: raw_sb.gui_access.unwrap_or(false),
-            launch_method: raw_sb.launch_method.unwrap_or_default(),
-            nested_pty: raw_sb.nested_pty.unwrap_or(true),
-            keychain_access: raw_sb.keychain_access.unwrap_or(false),
-            extra_mach_lookups: raw_sb.extra_mach_lookups.unwrap_or_default(),
-        };
-        ExperimentalConfig {
-            seatbelt: Some(sb),
-            ..experimental
-        }
-    } else {
-        experimental
-    };
+    // Top-level `seatbelt` config. Configs using `experimental.seatbelt` are
+    // rejected above.
+    let seatbelt = raw.seatbelt.map(make_seatbelt_config);
 
     // UI section
     if let Some(raw_ui) = raw.ui {
@@ -1264,6 +1256,7 @@ fn convert_raw_config_inner(
         lifecycle,
         policy,
         lxc_config,
+        seatbelt,
         experimental_enabled: false,
         experimental,
         dry_run: false,
@@ -3280,27 +3273,23 @@ mod tests {
 
     #[test]
     fn seatbelt_config_defaults() {
-        // When no experimental.seatbelt block is provided the parser
-        // leaves it unset (None) — runners should fall back to defaults.
+        // When no seatbelt block is provided the parser leaves it unset.
         let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt"}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.experimental.seatbelt.is_none());
+        assert!(req.seatbelt.is_none());
     }
 
     #[test]
     fn seatbelt_profile_override_passed_through() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"profileOverride": "(version 1)(deny default)"}}}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {"profileOverride": "(version 1)(deny default)"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("experimental.seatbelt should be populated");
+        let cfg = req.seatbelt.expect("seatbelt should be populated");
         assert_eq!(
             cfg.profile_override.as_deref(),
             Some("(version 1)(deny default)")
@@ -3309,32 +3298,27 @@ mod tests {
 
     #[test]
     fn seatbelt_nested_pty_defaults_to_true_when_block_present_but_field_absent() {
-        // experimental.seatbelt is present but nestedPty is not specified;
+        // seatbelt block is present but nestedPty is not specified;
         // the parser should fill in true to match the schema default.
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {}}}"#;
+        let json =
+            r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("experimental.seatbelt should be populated");
+        let cfg = req.seatbelt.expect("seatbelt should be populated");
         assert!(cfg.nested_pty);
         assert!(!cfg.keychain_access);
     }
 
     #[test]
     fn seatbelt_nested_pty_and_keychain_access_pass_through() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"nestedPty": false, "keychainAccess": true}}}"#;
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {"nestedPty": false, "keychainAccess": true}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("experimental.seatbelt should be populated");
+        let cfg = req.seatbelt.expect("seatbelt should be populated");
         assert!(!cfg.nested_pty);
         assert!(cfg.keychain_access);
     }
@@ -3346,27 +3330,25 @@ mod tests {
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("top-level seatbelt should populate experimental.seatbelt internally");
+        let cfg = req.seatbelt.expect("seatbelt should be populated");
         assert!(!cfg.nested_pty);
         assert!(cfg.keychain_access);
     }
 
     #[test]
-    fn top_level_seatbelt_takes_precedence_over_experimental() {
-        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {"nestedPty": false}, "experimental": {"seatbelt": {"nestedPty": true}}}"#;
+    fn experimental_seatbelt_errors_with_migration_message() {
+        // After promotion, configs using experimental.seatbelt must error.
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "experimental": {"seatbelt": {"nestedPty": true}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("seatbelt config should be set");
-        // Top-level wins over experimental.seatbelt
-        assert!(!cfg.nested_pty);
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("has moved to the stable section"),
+            "expected migration error, got: {}",
+            msg
+        );
     }
 
     // Legacy wire-name aliases. The parser accepts the pre-0.6 wire vocabulary
@@ -3418,9 +3400,9 @@ mod tests {
     }
 
     #[test]
-    fn legacy_experimental_macos_sandbox_subblock_alias_accepted() {
-        // `experimental.macos_sandbox` is the pre-rename key; serde's alias
-        // routes it to the same `seatbelt` parsing path.
+    fn legacy_experimental_macos_sandbox_subblock_alias_rejected() {
+        // `experimental.macos_sandbox` is the pre-rename key; after promotion
+        // it should be rejected with a migration error.
         let json = r#"{
             "process": {"commandLine": "echo hi"},
             "containment": "macos_sandbox",
@@ -3429,14 +3411,12 @@ mod tests {
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        let cfg = req
-            .experimental
-            .seatbelt
-            .expect("experimental.seatbelt should be populated (via macos_sandbox alias)");
-        assert_eq!(
-            cfg.profile_override.as_deref(),
-            Some("(version 1)(allow default)")
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("has moved to the stable section"),
+            "expected migration error, got: {}",
+            msg
         );
     }
 
@@ -3504,9 +3484,10 @@ mod tests {
     // check as top-level blocks.
     #[test]
     fn experimental_backend_section_for_other_containment_rejected() {
+        // seatbelt is now top-level, so use it to test cross-backend rejection
         assert_multi_backend_rejected(
             "processcontainer",
-            r#""experimental": {"seatbelt": {"guiAccess": true}}"#,
+            r#""seatbelt": {"guiAccess": true}"#,
             "seatbelt",
         );
     }
@@ -3601,7 +3582,7 @@ mod tests {
         let json = r#"{
             "process": {"commandLine": "echo hi"},
             "containment": "process",
-            "experimental": {"seatbelt": {}}
+            "seatbelt": {}
         }"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -228,6 +228,9 @@ struct RawConfig {
     network: Option<RawNetwork>,
     ui: Option<RawUi>,
     experimental: Option<RawExperimental>,
+    /// Top-level seatbelt config (preferred over experimental.seatbelt).
+    #[serde(alias = "macos_sandbox")]
+    seatbelt: Option<RawSeatbelt>,
 }
 
 // State-aware request shape. `phase` is required (no `#[serde(default)]` on
@@ -618,12 +621,15 @@ fn present_backend_sections(raw: &RawConfig) -> Vec<&'static str> {
         if experimental.wslc.is_some() {
             push(ContainmentBackend::Wslc);
         }
-        if experimental.seatbelt.is_some() {
+        if experimental.seatbelt.is_some() && raw.seatbelt.is_none() {
             push(ContainmentBackend::Seatbelt);
         }
         if experimental.isolation_session.is_some() {
             push(ContainmentBackend::IsolationSession);
         }
+    }
+    if raw.seatbelt.is_some() {
+        push(ContainmentBackend::Seatbelt);
     }
     sections
 }
@@ -1211,6 +1217,26 @@ fn convert_raw_config_inner(
         ExperimentalConfig::default()
     };
 
+    // Top-level `seatbelt` takes precedence over `experimental.seatbelt`.
+    // This supports the two-phase migration: new configs use the top-level key,
+    // old configs still work via the experimental path.
+    let experimental = if let Some(raw_sb) = raw.seatbelt {
+        let sb = SeatbeltConfig {
+            profile_override: raw_sb.profile_override,
+            gui_access: raw_sb.gui_access.unwrap_or(false),
+            launch_method: raw_sb.launch_method.unwrap_or_default(),
+            nested_pty: raw_sb.nested_pty.unwrap_or(true),
+            keychain_access: raw_sb.keychain_access.unwrap_or(false),
+            extra_mach_lookups: raw_sb.extra_mach_lookups.unwrap_or_default(),
+        };
+        ExperimentalConfig {
+            seatbelt: Some(sb),
+            ..experimental
+        }
+    } else {
+        experimental
+    };
+
     // UI section
     if let Some(raw_ui) = raw.ui {
         let clipboard = match raw_ui.clipboard.as_deref() {
@@ -1281,6 +1307,7 @@ fn convert_raw_state_aware(
         // one-shot RawExperimental; it is preserved separately on
         // ParsedStateAwareRequest as raw JSON.
         experimental: None,
+        seatbelt: None,
     };
 
     let require_process = phase == Phase::Exec;
@@ -3312,6 +3339,36 @@ mod tests {
         assert!(cfg.keychain_access);
     }
 
+    #[test]
+    fn top_level_seatbelt_config_accepted() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {"nestedPty": false, "keychainAccess": true}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cfg = req
+            .experimental
+            .seatbelt
+            .expect("top-level seatbelt should populate experimental.seatbelt internally");
+        assert!(!cfg.nested_pty);
+        assert!(cfg.keychain_access);
+    }
+
+    #[test]
+    fn top_level_seatbelt_takes_precedence_over_experimental() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "seatbelt", "seatbelt": {"nestedPty": false}, "experimental": {"seatbelt": {"nestedPty": true}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cfg = req
+            .experimental
+            .seatbelt
+            .expect("seatbelt config should be set");
+        // Top-level wins over experimental.seatbelt
+        assert!(!cfg.nested_pty);
+    }
+
     // Legacy wire-name aliases. The parser accepts the pre-0.6 wire vocabulary
     // (`appcontainer`, `macos_sandbox`, and the `appContainer` /
     // `experimental.macos_sandbox` sub-block keys) so that configs declaring
@@ -3450,7 +3507,7 @@ mod tests {
         assert_multi_backend_rejected(
             "processcontainer",
             r#""experimental": {"seatbelt": {"guiAccess": true}}"#,
-            "experimental.seatbelt",
+            "seatbelt",
         );
     }
 

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -71,7 +71,7 @@ impl ContainmentBackend {
             ContainmentBackend::Lxc => Some("lxc"),
             ContainmentBackend::WindowsSandbox => Some("experimental.windows_sandbox"),
             ContainmentBackend::Wslc => Some("experimental.wslc"),
-            ContainmentBackend::Seatbelt => Some("experimental.seatbelt"),
+            ContainmentBackend::Seatbelt => Some("seatbelt"),
             ContainmentBackend::IsolationSession => Some("experimental.isolation_session"),
             ContainmentBackend::Bubblewrap
             | ContainmentBackend::Hyperlight
@@ -81,8 +81,9 @@ impl ContainmentBackend {
     }
 }
 
-/// Configuration specific to the Seatbelt backend (experimental).
-/// Used under `experimental.seatbelt` when `containment == Seatbelt`.
+/// Configuration specific to the Seatbelt backend.
+/// Used under `seatbelt` (preferred) or `experimental.seatbelt` (deprecated)
+/// when `containment == Seatbelt`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SeatbeltConfig {
@@ -548,7 +549,7 @@ pub struct ExperimentalConfig {
     /// Isolation Session backend (experimental).
     #[serde(rename = "isolation_session")]
     pub isolation_session: Option<IsolationSessionConfig>,
-    /// Seatbelt (macOS) backend (experimental).
+    /// Seatbelt (macOS) backend. Deprecated location — prefer top-level `seatbelt`.
     pub seatbelt: Option<SeatbeltConfig>,
 }
 

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -33,7 +33,7 @@ pub enum ContainmentBackend {
     /// Isolation Session — process isolation via IsoEnvBroker Session API (experimental).
     #[serde(rename = "isolation_session")]
     IsolationSession,
-    /// macOS Seatbelt — experimental sandbox backend (requires --experimental).
+    /// macOS Seatbelt sandbox backend.
     /// Implemented on top of the OS-bundled sandbox facility (Apple's
     /// internal codename for the App Sandbox / `sandbox-exec` machinery
     /// is "Seatbelt"); selected on the wire as `"seatbelt"`.
@@ -82,8 +82,7 @@ impl ContainmentBackend {
 }
 
 /// Configuration specific to the Seatbelt backend.
-/// Used under `seatbelt` (preferred) or `experimental.seatbelt` (deprecated)
-/// when `containment == Seatbelt`.
+/// Used under the top-level `seatbelt` key when `containment == Seatbelt`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct SeatbeltConfig {
@@ -549,8 +548,6 @@ pub struct ExperimentalConfig {
     /// Isolation Session backend (experimental).
     #[serde(rename = "isolation_session")]
     pub isolation_session: Option<IsolationSessionConfig>,
-    /// Seatbelt (macOS) backend. Deprecated location — prefer top-level `seatbelt`.
-    pub seatbelt: Option<SeatbeltConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -575,6 +572,8 @@ pub struct ExecutionRequest {
     pub policy: ContainerPolicy,
     /// LXC-specific configuration (used when containment == Lxc).
     pub lxc_config: LxcConfig,
+    /// Seatbelt (macOS) backend configuration (used when containment == Seatbelt).
+    pub seatbelt: Option<SeatbeltConfig>,
     /// Whether the --experimental flag was passed.
     pub experimental_enabled: bool,
     /// Experimental feature configs (only applied when experimental_enabled is true).
@@ -598,6 +597,7 @@ impl Default for ExecutionRequest {
             lifecycle: LifecycleConfig::default(),
             policy: ContainerPolicy::default(),
             lxc_config: LxcConfig::default(),
+            seatbelt: None,
             experimental_enabled: false,
             experimental: ExperimentalConfig::default(),
             dry_run: false,

--- a/tests/examples/15_mac_hello_world.json
+++ b/tests/examples/15_mac_hello_world.json
@@ -7,14 +7,14 @@
         "timeout": 10000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"]
+        "readwritePaths": [
+            "/tmp"
+        ]
     },
     "network": {
         "defaultPolicy": "block"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/16_mac_deny_network.json
+++ b/tests/examples/16_mac_deny_network.json
@@ -7,14 +7,14 @@
         "timeout": 10000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"]
+        "readwritePaths": [
+            "/tmp"
+        ]
     },
     "network": {
         "defaultPolicy": "block"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/17_mac_deny_filesystem.json
+++ b/tests/examples/17_mac_deny_filesystem.json
@@ -7,15 +7,17 @@
         "timeout": 10000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"],
-        "deniedPaths": ["/Users"]
+        "readwritePaths": [
+            "/tmp"
+        ],
+        "deniedPaths": [
+            "/Users"
+        ]
     },
     "network": {
         "defaultPolicy": "block"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/18_mac_filesystem_access.json
+++ b/tests/examples/18_mac_filesystem_access.json
@@ -7,15 +7,17 @@
         "timeout": 15000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"],
-        "deniedPaths": ["/Users"]
+        "readwritePaths": [
+            "/tmp"
+        ],
+        "deniedPaths": [
+            "/Users"
+        ]
     },
     "network": {
         "defaultPolicy": "block"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/19_mac_network_restricted.json
+++ b/tests/examples/19_mac_network_restricted.json
@@ -7,15 +7,17 @@
         "timeout": 30000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"]
+        "readwritePaths": [
+            "/tmp"
+        ]
     },
     "network": {
         "defaultPolicy": "block",
-        "allowedHosts": ["api.github.com"]
+        "allowedHosts": [
+            "api.github.com"
+        ]
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/20_mac_combined_restrictions.json
+++ b/tests/examples/20_mac_combined_restrictions.json
@@ -7,16 +7,20 @@
         "timeout": 45000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"],
-        "deniedPaths": ["/Users"]
+        "readwritePaths": [
+            "/tmp"
+        ],
+        "deniedPaths": [
+            "/Users"
+        ]
     },
     "network": {
         "defaultPolicy": "block",
-        "allowedHosts": ["api.github.com"]
+        "allowedHosts": [
+            "api.github.com"
+        ]
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/21_mac_python_info.json
+++ b/tests/examples/21_mac_python_info.json
@@ -8,15 +8,17 @@
         "timeout": 10000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"],
-        "readonlyPaths": ["/opt/homebrew"]
+        "readwritePaths": [
+            "/tmp"
+        ],
+        "readonlyPaths": [
+            "/opt/homebrew"
+        ]
     },
     "network": {
         "defaultPolicy": "block"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/22_mac_network_allow_all.json
+++ b/tests/examples/22_mac_network_allow_all.json
@@ -7,14 +7,14 @@
         "timeout": 30000
     },
     "filesystem": {
-        "readwritePaths": ["/tmp"]
+        "readwritePaths": [
+            "/tmp"
+        ]
     },
     "network": {
         "defaultPolicy": "allow"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/23_mac_blocked_hosts_unsupported.json
+++ b/tests/examples/23_mac_blocked_hosts_unsupported.json
@@ -8,11 +8,11 @@
     },
     "network": {
         "defaultPolicy": "allow",
-        "blockedHosts": ["evil.example.com"]
+        "blockedHosts": [
+            "evil.example.com"
+        ]
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/24_mac_ui_disabled.json
+++ b/tests/examples/24_mac_ui_disabled.json
@@ -12,9 +12,7 @@
     "ui": {
         "disable": true
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/25_mac_ui_clipboard_enabled.json
+++ b/tests/examples/25_mac_ui_clipboard_enabled.json
@@ -13,9 +13,7 @@
         "disable": false,
         "clipboard": "all"
     },
-    "experimental": {
-        "seatbelt": {
-            "mode": "exec"
-        }
+    "seatbelt": {
+        "mode": "exec"
     }
 }

--- a/tests/examples/26_mac_gui_access.json
+++ b/tests/examples/26_mac_gui_access.json
@@ -1,17 +1,15 @@
 {
-  "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
-  "version": "0.7.0-alpha",
-  "containment": "seatbelt",
-  "process": {
-    "commandLine": "echo 'GUI access enabled — custom GUI apps can create windows under this profile'"
-  },
-  "ui": {
-    "disable": false,
-    "clipboard": "all"
-  },
-  "experimental": {
+    "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
+    "version": "0.7.0-alpha",
+    "containment": "seatbelt",
+    "process": {
+        "commandLine": "echo 'GUI access enabled \u2014 custom GUI apps can create windows under this profile'"
+    },
+    "ui": {
+        "disable": false,
+        "clipboard": "all"
+    },
     "seatbelt": {
-      "guiAccess": true
+        "guiAccess": true
     }
-  }
 }

--- a/tests/examples/27_mac_terminal_sandboxed.json
+++ b/tests/examples/27_mac_terminal_sandboxed.json
@@ -1,26 +1,33 @@
 {
-  "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
-  "version": "0.7.0-alpha",
-  "containment": "seatbelt",
-  "process": {
-    "commandLine": "/bin/zsh -i",
-    "env": ["ZDOTDIR=/tmp/.mxc_zsh_empty", "HISTFILE=/tmp/.mxc_zsh_history", "SHELL_SESSIONS_DISABLE=1"]
-  },
-  "ui": {
-    "disable": false,
-    "clipboard": "all"
-  },
-  "filesystem": {
-    "readwritePaths": ["/tmp", "~/.zsh_history"],
-    "readonlyPaths": ["~"]
-  },
-  "network": {
-    "defaultPolicy": "block"
-  },
-  "experimental": {
+    "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
+    "version": "0.7.0-alpha",
+    "containment": "seatbelt",
+    "process": {
+        "commandLine": "/bin/zsh -i",
+        "env": [
+            "ZDOTDIR=/tmp/.mxc_zsh_empty",
+            "HISTFILE=/tmp/.mxc_zsh_history",
+            "SHELL_SESSIONS_DISABLE=1"
+        ]
+    },
+    "ui": {
+        "disable": false,
+        "clipboard": "all"
+    },
+    "filesystem": {
+        "readwritePaths": [
+            "/tmp",
+            "~/.zsh_history"
+        ],
+        "readonlyPaths": [
+            "~"
+        ]
+    },
+    "network": {
+        "defaultPolicy": "block"
+    },
     "seatbelt": {
-      "guiAccess": true,
-      "launchMethod": "open"
+        "guiAccess": true,
+        "launchMethod": "open"
     }
-  }
 }


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Promoting Seatbelt to stable, for backwards compatibility if the --experimental flag is passed it will no-op and continue the execution.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
ran test locally, all passed.

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/500)