### PR TITLE
Stop npm junctioning the integration-test SDK dependency

### DIFF
--- a/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
+++ b/.azure-pipelines/templates/SDK.Integration.Test.Job.yml
@@ -75,6 +75,10 @@ jobs:
           SourceFolder: '$(Build.SourcesDirectory)/.azure-pipelines/.npm'
           Contents: '.npmrc'
           TargetFolder: '$(integrationDirectory)'
+          # Overwrite the repo's committed .npmrc (install-links=true) with the
+          # Azure feed/auth .npmrc. The integration job installs the SDK from a
+          # packed tarball, so it does not need install-links.
+          overWrite: true
 
       - task: NpmAuthenticate@0
         displayName: NPM Authenticate

--- a/sdk/tests/integration/.gitignore
+++ b/sdk/tests/integration/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 dist/
-.npmrc

--- a/sdk/tests/integration/.npmrc
+++ b/sdk/tests/integration/.npmrc
@@ -1,0 +1,7 @@
+; Install the file:../../ @microsoft/mxc-sdk dependency as a packed copy instead
+; of a symlink/junction. Without this, npm creates a junction at
+; node_modules/@microsoft/mxc-sdk pointing back at the sdk root, which breaks
+; `git clean` on Windows and self-references the repo tree. install-links makes
+; every install in this directory (including a bare `npm install`) produce a
+; real directory and replace any pre-existing junction.
+install-links=true

--- a/sdk/tests/integration/package-lock.json
+++ b/sdk/tests/integration/package-lock.json
@@ -18,28 +18,17 @@
         "typescript": "^5.3.3"
       }
     },
-    "../..": {
-      "name": "@microsoft/mxc-sdk",
+    "node_modules/@microsoft/mxc-sdk": {
       "version": "0.6.1",
+      "resolved": "file:../..",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",
         "semver": "^7.7.4"
       },
-      "devDependencies": {
-        "@types/node": "^20.10.0",
-        "@types/semver": "^7.7.1",
-        "node-gyp": "^12.2.0",
-        "rimraf": "^6.1.3",
-        "typescript": "^5.3.3"
-      },
       "engines": {
         "node": ">=18.0.0"
       }
-    },
-    "node_modules/@microsoft/mxc-sdk": {
-      "resolved": "../..",
-      "link": true
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -135,6 +124,22 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.2.0-beta.13",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
+      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -183,7 +188,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
## 📖 Description

npm was creating a junction (Windows) / symlink at
`sdk/tests/integration/node_modules/@microsoft/mxc-sdk` because the integration
tests declare `"@microsoft/mxc-sdk": "file:../../"`. The junction points back at
the repo's `sdk` root, which breaks `git clean` on Windows (it follows the
reparse point into the live tree) and self-references the repo.

This PR makes the integration tests install the SDK as a **packed copy** instead
of a symlink, on every install path, and ensures existing junctions are replaced
in place so dev machines self-heal and fresh clones never create one.

* Add `sdk/tests/integration/.npmrc` with `install-links=true` so the `file:`
  dependency installs as a real directory on every install in that directory —
  including a bare `npm install` — and replaces any pre-existing junction. This
  `.npmrc` is the single source of truth for the behavior.
* Track that `.npmrc` by dropping it from the integration `.gitignore`.
* Regenerate `sdk/tests/integration/package-lock.json`: the SDK is now a resolved
  copy (no `link: true`) with its runtime closure (`node-pty`, `node-addon-api`)
  materialized; `semver` is no longer dev-only.
* Set `overWrite: true` on the CopyFiles task in `SDK.Integration.Test.Job.yml`
  so the agent's Azure-feed auth `.npmrc` replaces the committed one. The
  integration job installs the SDK from a packed tarball and does not need
  install-links.

The `file:` protocol and `../..` path are unchanged and cross-platform; this only
changes the materialization mode (copy vs symlink), so macOS/Linux builds are
unaffected.

## 🔗 References

None.

## 🔍 Validation

On Windows, verified that each of these produces a real directory with zero
reparse points under `sdk/`:

* fresh clone (no `node_modules`) + bare `npm install`
* dev machine with a pre-existing junction + bare `npm install` (self-heals)
* explicit `npm install --install-links`

Also confirmed `git clean -fdx sdk/tests/integration` removes `node_modules`
cleanly (exit 0) without following into the repo tree, that the committed
lockfile is in sync (a re-install produces no drift), and that the integration
tests still build against the copied SDK (`npm run build` / tsc, exit 0).
