### PR TITLE
[Bubblewrap/Lxc] Filter resolve_host to IPv4-only addresses

### DIFF
--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -114,6 +114,12 @@ network namespace and applies iptables rules via `NetworkIptablesManager`
 (the same approach used by the LXC backend). **Requires root** for
 iptables.
 
+> **IPv4 only.** Host names are resolved to IPv4 addresses only; AAAA
+> records and IPv6 literals are silently dropped because `iptables` (the
+> IPv4 tool) cannot accept IPv6 destinations. A host with only AAAA
+> records is effectively unreachable under firewall mode. For dual-stack
+> hosts, use proxy mode (below) instead.
+
 ```json
 {
   "network": {

--- a/docs/lxc-support/lxc-backend.md
+++ b/docs/lxc-support/lxc-backend.md
@@ -101,6 +101,8 @@ Network policies are enforced via iptables/nftables rules applied to the contain
 
 Rules are automatically cleaned up when the container exits (if `removeRulesOnExit` is `true`).
 
+**IPv4 only.** Firewall mode resolves `allowedHosts` / `blockedHosts` to IPv4 addresses only; AAAA (IPv6) records and IPv6 literals are silently dropped. A host that has only AAAA records is effectively unreachable from the sandbox under firewall mode.
+
 ## Usage
 
 ### Command Line

--- a/src/backends/lxc/common/src/network_iptables.rs
+++ b/src/backends/lxc/common/src/network_iptables.rs
@@ -81,16 +81,33 @@ impl NetworkIptablesManager {
         self.veth_interface = Some(iface.to_string());
     }
 
-    /// Resolve a hostname to IP addresses.
+    /// Resolve a hostname to IPv4 addresses.
+    ///
+    /// IPv6 records (AAAA from DNS, or IPv6 literals like `"::1"` /
+    /// IPv4-mapped IPv6 like `"::ffff:127.0.0.1"`) are silently dropped
+    /// because `apply_firewall_rules` only invokes `iptables` (the IPv4
+    /// tool), which rejects IPv6 destinations. Full dual-stack support
+    /// via parallel `ip6tables` rules would require a separate change.
+    /// A host that resolves only to AAAA records will return an empty
+    /// vec, meaning no allow/deny rule is emitted and the host is
+    /// effectively unreachable from the sandbox under firewall mode.
     fn resolve_host(host: &str) -> Vec<String> {
         // Try as IP address first
-        if host.parse::<std::net::IpAddr>().is_ok() {
-            return vec![host.to_string()];
+        if let Ok(addr) = host.parse::<std::net::IpAddr>() {
+            return if addr.is_ipv4() {
+                vec![host.to_string()]
+            } else {
+                Vec::new()
+            };
         }
 
         // Try DNS resolution
         match format!("{}:0", host).to_socket_addrs() {
-            Ok(addrs) => addrs.map(|a| a.ip().to_string()).collect(),
+            Ok(addrs) => addrs
+                .map(|a| a.ip())
+                .filter(|ip| ip.is_ipv4())
+                .map(|ip| ip.to_string())
+                .collect(),
             Err(_) => Vec::new(),
         }
     }
@@ -307,5 +324,38 @@ mod tests {
     fn resolve_ip_address() {
         let ips = NetworkIptablesManager::resolve_host("127.0.0.1");
         assert_eq!(ips, vec!["127.0.0.1"]);
+    }
+
+    #[test]
+    fn resolve_host_drops_ipv6_literal() {
+        // IPv6 literals must be silently dropped — `iptables` (v4) would
+        // reject them and fail the whole `apply_firewall_rules` call.
+        let ips = NetworkIptablesManager::resolve_host("::1");
+        assert!(
+            ips.is_empty(),
+            "expected empty vec for IPv6 literal, got {:?}",
+            ips
+        );
+    }
+
+    #[test]
+    fn resolve_host_drops_ipv4_mapped_ipv6_literal() {
+        // `::ffff:127.0.0.1` parses as `IpAddr::V6` and is the v6
+        // wire-format encoding of an v4 address — `iptables` would
+        // still reject it as a v6 destination, so we drop it.
+        let ips = NetworkIptablesManager::resolve_host("::ffff:127.0.0.1");
+        assert!(
+            ips.is_empty(),
+            "expected empty vec for v4-mapped-v6 literal, got {:?}",
+            ips
+        );
+    }
+
+    #[test]
+    fn resolve_host_keeps_ipv4_literal_unchanged() {
+        // Round-trip: v4 literals must pass through verbatim — the
+        // IPv4-only filter must not regress the happy path.
+        let ips = NetworkIptablesManager::resolve_host("10.0.0.1");
+        assert_eq!(ips, vec!["10.0.0.1"]);
     }
 }


### PR DESCRIPTION
## 📖 Description
`NetworkIptablesManager::resolve_host` was returning every address `to_socket_addrs` produced, including AAAA records. The result was then fed verbatim to `iptables`, which is IPv4-only and rejects IPv6 literals, so any `allowedHosts` entry whose DNS lookup happened to return an IPv6 address (or an IPv6 literal) caused the sandbox to fail to start with a host-side `iptables` error.

This change filters `resolve_host` to keep only IPv4 addresses.
Fixes #479 

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/505)