### PR TITLE
versioning phase 0: schema-version sync + config validation CI gates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -130,10 +130,11 @@ The SDK auto-discovers native binaries by checking `sdk/bin/<target-triple>/` (n
 
 ### Schema system
 
-- **Stable schemas**: `schemas/stable/mxc-config.schema.0.4.0-alpha.json` and `schemas/stable/mxc-config.schema.0.5.0-alpha.json` — immutable after release
-- **Dev schema**: `schemas/dev/mxc-config.schema.0.7.0-dev.json`
-- Current schema version: `0.5.0-alpha`
-- Config files can reference schemas via `"$schema"` for editor validation
+- **Stable schemas**: `schemas/stable/mxc-config.schema.0.4.0-alpha.json`, `0.5.0-alpha.json`, and `0.6.0-alpha.json` — immutable after release (plus a `0.5.0-alpha-strict` view)
+- **Dev schema**: `schemas/dev/mxc-config.schema.0.7.0-dev.json` (configs targeting it declare `version: 0.7.0-alpha`)
+- **Canonical schema-version source**: `schemas/schema-version.json` — the single source of truth for the schema-version constants (min/maxSupported/state-aware/stable/dev). `scripts/versioning/check-schema-versions.js` enforces that the Rust parser, SDK, and schema filenames all agree with it; do not hand-edit a schema-version constant without updating the canonical file.
+- Current schema version: `0.7.0-alpha` (latest stable: `0.6.0-alpha`)
+- Config files can reference schemas via `"$schema"` for editor validation. `scripts/versioning/validate-configs.js` validates the `tests/examples` + `tests/configs` corpus against the dev schema in CI.
 
 ### Key documentation (`docs/`)
 
@@ -231,7 +232,7 @@ When changing behavior covered by existing documentation, update the relevant do
 
 ### Policy versioning
 
-The `SandboxPolicy.version` in the SDK must match a JSON schema version in the supported range (`0.4.0-alpha` minimum, `0.6.0-alpha` maximum). The SDK validates this in `sandbox.ts` — if the policy version is older than `MIN_VERSION` or newer than `SUPPORTED_VERSION` it throws. State-aware lifecycle requests use `0.6.0-alpha`. See `docs/versioning.md` for the full design.
+The `SandboxPolicy.version` in the SDK must match a JSON schema version in the supported range (`0.4.0-alpha` minimum, `0.7.0-alpha` maximum). The SDK validates this in `sandbox.ts` — if the policy version is older than `MIN_VERSION` or newer than `SUPPORTED_VERSION` it throws. State-aware lifecycle requests use `0.6.0-alpha`. These bounds are mirrored from the canonical `schemas/schema-version.json` and enforced by `scripts/versioning/check-schema-versions.js`. See `docs/versioning.md` for the full design.
 
 ## Creating Issues
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,35 @@ on:
 
 jobs:
 
+  # Validate versioning contracts: the product version (Cargo == npm) is in
+  # sync; the schema-version constants are in sync across the Rust parser, SDK,
+  # and schema filenames; and the example/test config corpus validates against
+  # the dev JSON schema.
+  versioning-checks:
+    name: Versioning Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Check product version sync (Cargo == npm)
+        run: node scripts/check-version-sync.js
+
+      - name: Install tooling deps
+        working-directory: scripts/versioning
+        run: npm ci
+
+      - name: Check schema version sync
+        run: node scripts/versioning/check-schema-versions.js
+
+      - name: Validate config corpus against dev schema
+        run: node scripts/versioning/validate-configs.js
+
+
   # Check formatting and linting for the Rust code
   wxc-exec-lint:
     name: WXC Exec Lint

--- a/schemas/dev/mxc-config.schema.0.7.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.7.0-dev.json
@@ -497,7 +497,7 @@
   "allOf": [
     {
       "$comment": "Enforce single backend section: each per-backend section requires the matching `containment` value (concrete backend or matching abstract intent). Requiring `containment` to be present when a backend section is provided also rules out the ambiguous case where two backend sections appear with no `containment` set.",
-      "if": { "required": ["processContainer"] },
+      "if": { "required": ["processContainer"], "not": { "required": ["phase"] } },
       "then": {
         "required": ["containment"],
         "properties": { "containment": { "enum": ["processcontainer", "process"] } }
@@ -505,14 +505,14 @@
     },
     {
       "$comment": "`appContainer` is the deprecated alias for `processContainer`; same containment values are valid.",
-      "if": { "required": ["appContainer"] },
+      "if": { "required": ["appContainer"], "not": { "required": ["phase"] } },
       "then": {
         "required": ["containment"],
         "properties": { "containment": { "enum": ["processcontainer", "process"] } }
       }
     },
     {
-      "if": { "required": ["lxc"] },
+      "if": { "required": ["lxc"], "not": { "required": ["phase"] } },
       "then": {
         "required": ["containment"],
         "properties": { "containment": { "enum": ["lxc"] } }
@@ -521,6 +521,7 @@
     {
       "if": {
         "required": ["experimental"],
+        "not": { "required": ["phase"] },
         "properties": { "experimental": { "required": ["windows_sandbox"] } }
       },
       "then": {
@@ -531,6 +532,7 @@
     {
       "if": {
         "required": ["experimental"],
+        "not": { "required": ["phase"] },
         "properties": { "experimental": { "required": ["wslc"] } }
       },
       "then": {
@@ -541,6 +543,7 @@
     {
       "if": {
         "required": ["experimental"],
+        "not": { "required": ["phase"] },
         "properties": { "experimental": { "required": ["seatbelt"] } }
       },
       "then": {
@@ -551,6 +554,7 @@
     {
       "if": {
         "required": ["experimental"],
+        "not": { "required": ["phase"] },
         "properties": { "experimental": { "required": ["isolation_session"] } }
       },
       "then": {

--- a/schemas/schema-version.json
+++ b/schemas/schema-version.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Canonical source of truth for MXC CONFIG SCHEMA versions. Separate from the PRODUCT version (src/Cargo.toml [workspace.package] and sdk/package.json), which tracks the binaries/npm package and is checked independently by check-version-sync.js. Fields: min = lowest schema version the parser/SDK accept; maxSupported = highest version they accept (the in-development 0.7 line; equals Rust CURRENT_SCHEMA_VERSION, the SUPPORTED_VERSION upper bound, and the SDK SUPPORTED_VERSION) \u2014 note this is NOT a released stable schema, it is the dev line; stableLatest = highest released immutable stable schema file; stateAware = schema version state-aware lifecycle requests use; devSchemaFile = filename suffix of the in-progress dev schema. Every matching constant in the Rust parser, the SDK, and the schema filenames must agree with these values; check-schema-versions.js enforces it in CI. When you bump a schema version, change it HERE and run `node scripts/versioning/check-schema-versions.js` to find every place that must follow.",
+  "min": "0.4.0-alpha",
+  "maxSupported": "0.7.0-alpha",
+  "stateAware": "0.6.0-alpha",
+  "stableLatest": "0.6.0-alpha",
+  "devSchemaFile": "0.7.0-dev"
+}
+

--- a/scripts/versioning/.gitignore
+++ b/scripts/versioning/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/versioning/check-schema-versions.js
+++ b/scripts/versioning/check-schema-versions.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Validates the SCHEMA version constants — the Rust parser, the SDK, and the
+// schema filenames must all agree with the canonical source of truth at
+// schemas/schema-version.json. This tracks the config wire format and is
+// deliberately separate from the PRODUCT version (Cargo / npm package), which
+// is checked by scripts/check-version-sync.js.
+//
+// Run from anywhere (paths are resolved relative to the repo root):
+//
+//   node scripts/versioning/check-schema-versions.js
+
+const { readFileSync, existsSync } = require("fs");
+const { join } = require("path");
+
+const repoRoot = join(__dirname, "..", "..");
+const errors = [];
+
+function read(...parts) {
+  return readFileSync(join(repoRoot, ...parts), "utf8");
+}
+
+// ---------------------------------------------------------------------------
+// Schema version constants vs canonical source
+// ---------------------------------------------------------------------------
+const schemaVer = JSON.parse(read("schemas", "schema-version.json"));
+const { min, maxSupported, stateAware, stableLatest, devSchemaFile } = schemaVer;
+
+// major.minor of a semver-ish "X.Y.Z[-pre]" string.
+function majorMinor(v) {
+  const m = /^(\d+)\.(\d+)\./.exec(v);
+  return m ? `${m[1]}.${m[2]}` : null;
+}
+
+// Assert a regex captures exactly `expected` in `text`.
+function expectConst(file, text, label, regex, expected) {
+  const m = regex.exec(text);
+  if (!m) {
+    errors.push(`${file}: could not find ${label} (pattern ${regex})`);
+    return;
+  }
+  if (m[1] !== expected) {
+    errors.push(
+      `${file}: ${label} is "${m[1]}" but canonical schema-version expects "${expected}"`
+    );
+  }
+}
+
+// -- Rust parser (src/core/wxc_common/src/config_parser.rs) --
+const parser = read("src", "core", "wxc_common", "src", "config_parser.rs");
+expectConst(
+  "config_parser.rs",
+  parser,
+  "CURRENT_SCHEMA_VERSION",
+  /const CURRENT_SCHEMA_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+  maxSupported
+);
+// SUPPORTED_VERSION is a semver range like ">=0.4, <=0.7"; its bounds must
+// match the canonical min/maxSupported major.minor.
+const supMatch = /const SUPPORTED_VERSION:\s*&str\s*=\s*">=([^,]+),\s*<=([^"]+)"/.exec(
+  parser
+);
+if (!supMatch) {
+  errors.push("config_parser.rs: could not find SUPPORTED_VERSION range");
+} else {
+  if (supMatch[1].trim() !== majorMinor(min)) {
+    errors.push(
+      `config_parser.rs: SUPPORTED_VERSION lower bound ">=${supMatch[1].trim()}" but canonical min is ${min} (${majorMinor(min)})`
+    );
+  }
+  if (supMatch[2].trim() !== majorMinor(maxSupported)) {
+    errors.push(
+      `config_parser.rs: SUPPORTED_VERSION upper bound "<=${supMatch[2].trim()}" but canonical maxSupported is ${maxSupported} (${majorMinor(maxSupported)})`
+    );
+  }
+}
+
+// -- SDK (sdk/src/sandbox.ts, sdk/src/state-aware-helper.ts) --
+const sandboxTs = read("sdk", "src", "sandbox.ts");
+expectConst(
+  "sandbox.ts",
+  sandboxTs,
+  "SUPPORTED_VERSION",
+  /const SUPPORTED_VERSION\s*=\s*'([^']+)'/,
+  maxSupported
+);
+expectConst(
+  "sandbox.ts",
+  sandboxTs,
+  "MIN_VERSION",
+  /const MIN_VERSION\s*=\s*'([^']+)'/,
+  min
+);
+const stateAwareTs = read("sdk", "src", "state-aware-helper.ts");
+expectConst(
+  "state-aware-helper.ts",
+  stateAwareTs,
+  "STATE_AWARE_VERSION",
+  /const STATE_AWARE_VERSION\s*=\s*'([^']+)'/,
+  stateAware
+);
+
+// -- Schema files exist for the declared stable + dev versions --
+const stablePath = join(
+  "schemas",
+  "stable",
+  `mxc-config.schema.${stableLatest}.json`
+);
+if (!existsSync(join(repoRoot, stablePath))) {
+  errors.push(`Missing stable schema file for stableLatest "${stableLatest}": ${stablePath}`);
+}
+const devPath = join("schemas", "dev", `mxc-config.schema.${devSchemaFile}.json`);
+if (!existsSync(join(repoRoot, devPath))) {
+  errors.push(`Missing dev schema file for devSchemaFile "${devSchemaFile}": ${devPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+if (errors.length > 0) {
+  console.error("Schema version sync FAILED:");
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error(
+    "\nFix the offending constant, or update schemas/schema-version.json if the canonical value changed."
+  );
+  process.exit(1);
+}
+
+console.log(`Schema version sync OK: maxSupported ${maxSupported} (min ${min}, state-aware ${stateAware}, stable ${stableLatest})`);

--- a/scripts/versioning/config-validation-exemptions.json
+++ b/scripts/versioning/config-validation-exemptions.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Config files under tests/examples or tests/configs that are INTENTIONALLY invalid against the dev schema (e.g. negative parser tests). validate-configs.js requires each listed file to FAIL validation; if one starts passing, the gate fails so this list cannot rot. Paths are repo-root-relative with forward slashes. Keep this empty unless a config is deliberately malformed.",
+  "intentionallyInvalid": []
+}

--- a/scripts/versioning/package-lock.json
+++ b/scripts/versioning/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "@microsoft/mxc-repo-scripts",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@microsoft/mxc-repo-scripts",
+      "version": "0.0.0",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/scripts/versioning/package.json
+++ b/scripts/versioning/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@microsoft/mxc-repo-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Repository tooling: version-sync and config schema validation gates. Not published.",
+  "scripts": {
+    "check-version-sync": "node check-version-sync.js",
+    "validate-configs": "node validate-configs.js"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1"
+  }
+}

--- a/scripts/versioning/package.json
+++ b/scripts/versioning/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Repository tooling: version-sync and config schema validation gates. Not published.",
   "scripts": {
-    "check-version-sync": "node check-version-sync.js",
+    "check-schema-versions": "node check-schema-versions.js",
     "validate-configs": "node validate-configs.js"
   },
   "dependencies": {

--- a/scripts/versioning/validate-configs.js
+++ b/scripts/versioning/validate-configs.js
@@ -14,7 +14,7 @@
 //   node scripts/versioning/validate-configs.js
 
 const { readFileSync, readdirSync, existsSync } = require("fs");
-const { join, relative, resolve } = require("path");
+const { join, resolve } = require("path");
 const Ajv = require("ajv");
 
 const repoRoot = resolve(__dirname, "..", "..");
@@ -31,7 +31,7 @@ const devSchemaPath = join(
 );
 const schema = readJson(devSchemaPath);
 
-// Directories whose *.json files are configs we expect to validate.
+// Directories whose *.json files (recursively) are configs we expect to validate.
 const CONFIG_DIRS = [join("tests", "examples"), join("tests", "configs")];
 
 // Files that are intentionally invalid (negative tests) and must NOT validate.
@@ -43,19 +43,43 @@ const exemptions = existsSync(exemptionsPath)
 const ajv = new Ajv({ allErrors: true, strict: false });
 const validate = ajv.compile(schema);
 
+// Recursively collect repo-root-relative paths of *.json files under `dir`, so
+// configs in nested directories are not silently skipped.
 function listJson(dir) {
   const abs = join(repoRoot, dir);
   if (!existsSync(abs)) return [];
-  return readdirSync(abs)
-    .filter((f) => f.endsWith(".json"))
-    .map((f) => join(dir, f));
+  const out = [];
+  for (const entry of readdirSync(abs, { withFileTypes: true })) {
+    const childRel = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listJson(childRel));
+    } else if (entry.name.endsWith(".json")) {
+      out.push(childRel);
+    }
+  }
+  return out;
 }
 
 const files = CONFIG_DIRS.flatMap(listJson).sort();
 
 let unexpectedInvalid = 0;
 let unexpectedValid = 0;
+let staleExemptions = 0;
 const unexpectedInvalidDetails = [];
+
+// Keep the exemption list from rotting: every listed file must still exist.
+const knownFiles = new Set(files.map((f) => f.split("\\").join("/")));
+for (const ex of exemptions) {
+  if (!knownFiles.has(ex)) {
+    staleExemptions++;
+    const reason = existsSync(join(repoRoot, ex))
+      ? "exists but is not under a scanned config dir"
+      : "does not exist";
+    unexpectedInvalidDetails.push(
+      `${ex}: listed as intentionallyInvalid but ${reason} — fix or remove the exemption`
+    );
+  }
+}
 
 for (const rel of files) {
   const relNorm = rel.split("\\").join("/");
@@ -91,11 +115,11 @@ console.log(
     `(${exemptions.size} exempt as intentionally-invalid).`
 );
 
-if (unexpectedInvalid > 0 || unexpectedValid > 0) {
+if (unexpectedInvalid > 0 || unexpectedValid > 0 || staleExemptions > 0) {
   console.error("\nConfig schema validation FAILED:");
   for (const d of unexpectedInvalidDetails) console.error(`  - ${d}`);
   console.error(
-    `\n${unexpectedInvalid} unexpected invalid, ${unexpectedValid} exemptions that now pass.`
+    `\n${unexpectedInvalid} unexpected invalid, ${unexpectedValid} exemptions that now pass, ${staleExemptions} stale exemption(s).`
   );
   process.exit(1);
 }

--- a/scripts/versioning/validate-configs.js
+++ b/scripts/versioning/validate-configs.js
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Validates the repository's example and test config corpus against the dev
+// JSON schema, so the schema and the configs cannot silently drift apart.
+//
+// The dev schema version is read from the canonical schemas/schema-version.json
+// (devSchemaFile). Files known to be intentionally invalid (negative parser
+// tests, etc.) are listed in config-validation-exemptions.json and are required
+// to FAIL validation — if an exempt file starts passing, that is also flagged
+// so the exemption list cannot rot.
+//
+// Run from anywhere (paths are resolved relative to the repo root):
+//   node scripts/versioning/validate-configs.js
+
+const { readFileSync, readdirSync, existsSync } = require("fs");
+const { join, relative, resolve } = require("path");
+const Ajv = require("ajv");
+
+const repoRoot = resolve(__dirname, "..", "..");
+
+function readJson(...parts) {
+  return JSON.parse(readFileSync(join(repoRoot, ...parts), "utf8"));
+}
+
+const schemaVer = readJson("schemas", "schema-version.json");
+const devSchemaPath = join(
+  "schemas",
+  "dev",
+  `mxc-config.schema.${schemaVer.devSchemaFile}.json`
+);
+const schema = readJson(devSchemaPath);
+
+// Directories whose *.json files are configs we expect to validate.
+const CONFIG_DIRS = [join("tests", "examples"), join("tests", "configs")];
+
+// Files that are intentionally invalid (negative tests) and must NOT validate.
+const exemptionsPath = join(repoRoot, "scripts", "versioning", "config-validation-exemptions.json");
+const exemptions = existsSync(exemptionsPath)
+  ? new Set(JSON.parse(readFileSync(exemptionsPath, "utf8")).intentionallyInvalid)
+  : new Set();
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+const validate = ajv.compile(schema);
+
+function listJson(dir) {
+  const abs = join(repoRoot, dir);
+  if (!existsSync(abs)) return [];
+  return readdirSync(abs)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => join(dir, f));
+}
+
+const files = CONFIG_DIRS.flatMap(listJson).sort();
+
+let unexpectedInvalid = 0;
+let unexpectedValid = 0;
+const unexpectedInvalidDetails = [];
+
+for (const rel of files) {
+  const relNorm = rel.split("\\").join("/");
+  const isExempt = exemptions.has(relNorm);
+  let data;
+  try {
+    data = JSON.parse(readFileSync(join(repoRoot, rel), "utf8"));
+  } catch (e) {
+    if (!isExempt) {
+      unexpectedInvalid++;
+      unexpectedInvalidDetails.push(`${relNorm}: not valid JSON (${e.message})`);
+    }
+    continue;
+  }
+
+  const ok = validate(data);
+  if (ok && isExempt) {
+    unexpectedValid++;
+    unexpectedInvalidDetails.push(
+      `${relNorm}: listed as intentionallyInvalid but now PASSES — remove it from the exemption list`
+    );
+  } else if (!ok && !isExempt) {
+    unexpectedInvalid++;
+    const msgs = (validate.errors || [])
+      .map((e) => `      ${e.instancePath || "/"} ${e.message}`)
+      .join("\n");
+    unexpectedInvalidDetails.push(`${relNorm}:\n${msgs}`);
+  }
+}
+
+console.log(
+  `Validated ${files.length} config(s) against ${devSchemaPath.split("\\").join("/")} ` +
+    `(${exemptions.size} exempt as intentionally-invalid).`
+);
+
+if (unexpectedInvalid > 0 || unexpectedValid > 0) {
+  console.error("\nConfig schema validation FAILED:");
+  for (const d of unexpectedInvalidDetails) console.error(`  - ${d}`);
+  console.error(
+    `\n${unexpectedInvalid} unexpected invalid, ${unexpectedValid} exemptions that now pass.`
+  );
+  process.exit(1);
+}
+
+console.log("Config schema validation OK.");


### PR DESCRIPTION
## 📖 Description

**Phase 0 of the versioning remediation** (first in a stacked series). This change is a pure-additive **safety net** for the config versioning scheme — **no runtime behavior changes**. It establishes ground truth and CI enforcement before the later phases tighten the parser.

What it does:

- Adds **`schemas/schema-version.json`** as the single canonical source of truth for the **schema**-version constants (`min` / `maxSupported` / `stateAware` / `stableLatest` / `devSchemaFile`), kept explicitly separate from the **product** version (Cargo / npm).
- Adds **`scripts/versioning/check-schema-versions.js`**, which asserts the Rust parser (`CURRENT_SCHEMA_VERSION`, `SUPPORTED_VERSION` bounds), the SDK (`SUPPORTED_VERSION`, `MIN_VERSION`, `STATE_AWARE_VERSION`), and the stable/dev schema filenames all agree with the canonical source. The existing `scripts/check-version-sync.js` (product Cargo == npm) is unchanged.
- Adds **`scripts/versioning/validate-configs.js`** (ajv), validating the `tests/examples` + `tests/configs` corpus against the dev JSON schema, with an exemption list for intentionally-invalid negative tests.
- Wires all three checks into a new **`Versioning Checks`** CI job in `build.yml` (none of them ran in CI before).
- **Triage fix**: scopes the single-backend-section `allOf` clauses in the dev schema to one-shot requests (`not: { required: ["phase"] }`) so state-aware per-phase configs — which carry `containment` only at `provision` — validate correctly. Schema-only change, no runtime impact.
- Fixes stale schema-version numbers in `copilot-instructions.md`.

## 🔗 References

Part of a stacked versioning-remediation series (Phase 0 of 6). No issue to auto-close.

## 🔍 Validation

- All three gates pass locally: product `0.6.1`; schema `maxSupported 0.7.0-alpha (min 0.4.0-alpha, state-aware 0.6.0-alpha, stable 0.6.0-alpha)`; 150/150 configs validate.
- **Negative-tested** both checkers: drifting a canonical constant makes `check-schema-versions.js` fail with precise messages; an invalid-enum config makes `validate-configs.js` fail. Restored after.
- Triage outcome: only 3 of 150 configs initially failed — all the same legitimate state-aware schema gap, fixed in the schema; no configs were wrong.
- `scripts/check-version-sync.js` is byte-identical to `main` (product check untouched).

## ✅ Checklist

- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/508)