### PR TITLE
versioning phase 1: reject unknown top-level config fields

### DIFF
--- a/schemas/dev/mxc-config.schema.0.7.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.7.0-dev.json
@@ -20,10 +20,6 @@
     "_comment": {
       "description": "Optional human-readable annotation. Accepted but ignored by the parser."
     },
-    "platform": {
-      "type": "string",
-      "description": "Target platform hint (e.g. 'windows', 'linux'). Defaults to 'windows' when omitted."
-    },
     "appContainer": {
       "$ref": "#/properties/processContainer"
     },

--- a/schemas/dev/mxc-config.schema.0.7.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.7.0-dev.json
@@ -13,6 +13,20 @@
         "0.7.0-alpha"
       ]
     },
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor validation. Accepted but ignored by the parser."
+    },
+    "_comment": {
+      "description": "Optional human-readable annotation. Accepted but ignored by the parser."
+    },
+    "platform": {
+      "type": "string",
+      "description": "Target platform hint (e.g. 'windows', 'linux'). Defaults to 'windows' when omitted."
+    },
+    "appContainer": {
+      "$ref": "#/properties/processContainer"
+    },
     "containerId": {
       "type": "string",
       "description": "Externally assigned container identifier."
@@ -572,6 +586,9 @@
       }
     }
   },
+
+  "additionalProperties": false,
+
   "allOf": [
     {
       "$comment": "Enforce single backend section: each per-backend section requires the matching `containment` value (concrete backend or matching abstract intent). Requiring `containment` to be present when a backend section is provided also rules out the ambiguous case where two backend sections appear with no `containment` set.",

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -134,7 +134,6 @@ fn log_request(request: &ExecutionRequest, logger: &mut Logger) {
     if !request.container_id.is_empty() {
         let _ = writeln!(logger, "Container ID: {}", request.container_id);
     }
-    let _ = writeln!(logger, "Platform: {}", request.platform);
     let _ = writeln!(logger, "Script code length: {}", request.script_code.len());
     let _ = writeln!(logger, "Working directory: {}", request.working_directory);
     let _ = writeln!(logger, "Script timeout: {}", request.script_timeout);

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
 
@@ -231,6 +232,12 @@ struct RawConfig {
     /// Top-level seatbelt config.
     #[serde(alias = "macos_sandbox")]
     seatbelt: Option<RawSeatbelt>,
+    // Captures any top-level key not matched above so unrecognised fields can
+    // be rejected at the trust boundary instead of being silently dropped.
+    // Allowed annotation keys ($schema, _comment) are filtered out in
+    // `reject_unknown_top_level_fields`.
+    #[serde(flatten)]
+    unknown: HashMap<String, serde_json::Value>,
 }
 
 // State-aware request shape. `phase` is required (no `#[serde(default)]` on
@@ -260,6 +267,10 @@ struct RawStateAwareRequest {
     ui: Option<RawUi>,
     #[serde(default)]
     experimental: Option<serde_json::Value>,
+    // See `RawConfig::unknown`. Mirrored here so unrecognised top-level keys are
+    // rejected on the state-aware path too.
+    #[serde(flatten)]
+    unknown: HashMap<String, serde_json::Value>,
 }
 
 // Untagged enum: serde tries `StateAware` first (requires `phase`), falls
@@ -600,6 +611,40 @@ fn validate_paths(paths: &[String], logger: &mut Logger) -> Result<(), WxcError>
 
 // ---------- Conversion from raw JSON to domain model ----------
 
+/// Top-level keys that are permitted but carry no semantic meaning: `$schema`
+/// (editor hint) and `_comment` (human annotation). They are accepted at the
+/// trust boundary but ignored by the model.
+const ALLOWED_TOP_LEVEL_ANNOTATIONS: &[&str] = &["$schema", "_comment"];
+
+/// Rejects unrecognised top-level fields captured by a `#[serde(flatten)]` map.
+///
+/// This is the structural half of schema enforcement at the trust boundary:
+/// typos and silently-dropped fields (for example `fileSystem` instead of
+/// `filesystem`, or a stray `policy` block) now fail loudly with a precise
+/// error instead of being ignored, which previously meant the associated
+/// policy was never applied.
+fn reject_unknown_top_level_fields(
+    unknown: &HashMap<String, serde_json::Value>,
+    logger: &mut Logger,
+) -> Result<(), WxcError> {
+    let mut keys: Vec<&str> = unknown
+        .keys()
+        .map(String::as_str)
+        .filter(|k| !ALLOWED_TOP_LEVEL_ANNOTATIONS.contains(k))
+        .collect();
+    if keys.is_empty() {
+        return Ok(());
+    }
+    keys.sort_unstable();
+    let msg = format!(
+        "Unknown top-level field(s) in config: {}. Remove them or check for typos \
+         (field names are case-sensitive, e.g. 'filesystem' not 'fileSystem').",
+        keys.join(", ")
+    );
+    logger.log_line(&msg);
+    Err(WxcError::ConfigParse(msg))
+}
+
 fn present_backend_sections(raw: &RawConfig) -> Vec<&'static str> {
     let mut sections: Vec<&'static str> = Vec::new();
     let mut push = |backend: ContainmentBackend| {
@@ -739,11 +784,20 @@ fn convert_raw_config_inner(
     require_process: bool,
     allow_missing_command: bool,
 ) -> Result<ExecutionRequest, WxcError> {
+    // Reject unrecognised top-level fields before anything else, so typos and
+    // stray sections fail loudly instead of being silently ignored.
+    reject_unknown_top_level_fields(&raw.unknown, logger)?;
+
     // Captured before `raw` fields are moved out below.
     let present_backend_sections = present_backend_sections(&raw);
 
     // New top-level fields
     let schema_version = raw.version.unwrap_or_default();
+
+    // Validate the schema version up front so an unsupported version fails fast,
+    // before any of the per-section conversion work below.
+    validate_schema_version(&schema_version, logger)?;
+
     let container_id = raw.container_id.unwrap_or_default();
     let platform = raw.platform.unwrap_or_else(|| "windows".to_string());
 
@@ -1126,9 +1180,6 @@ fn convert_raw_config_inner(
         }
     };
 
-    // Schema version check
-    validate_schema_version(&schema_version, logger)?;
-
     // Experimental section (parsed but only applied when --experimental flag is set)
     let experimental = if let Some(raw_exp) = raw.experimental {
         let test = raw_exp.test.map(|t| TestFeatureConfig::from_raw(t.message));
@@ -1267,6 +1318,10 @@ fn convert_raw_state_aware(
     logger: &mut Logger,
     allow_missing_command: bool,
 ) -> Result<ParsedStateAwareRequest, WxcError> {
+    // Reject unrecognised top-level fields on the state-aware envelope before
+    // building the one-shot surrogate (whose `unknown` map is always empty).
+    reject_unknown_top_level_fields(&raw.unknown, logger)?;
+
     let phase = Phase::from_wire(&raw.phase).map_err(|e| {
         let msg = e.message.clone();
         logger.log_line(&msg);
@@ -1300,6 +1355,7 @@ fn convert_raw_state_aware(
         // ParsedStateAwareRequest as raw JSON.
         experimental: None,
         seatbelt: None,
+        unknown: HashMap::new(),
     };
 
     let require_process = phase == Phase::Exec;
@@ -2744,6 +2800,74 @@ mod tests {
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.schema_version, "0.7.0-alpha");
+    }
+
+    #[test]
+    fn unknown_top_level_field_rejected() {
+        let json = r#"{"process": {"commandLine": "echo hi"}, "bogusField": true}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(
+            result.is_err(),
+            "unknown top-level field should be rejected"
+        );
+    }
+
+    #[test]
+    fn filesystem_typo_rejected() {
+        // `fileSystem` (capital S) used to be silently dropped, so the policy
+        // never applied. It must now be rejected as an unknown field.
+        let json = r#"{"process": {"commandLine": "echo hi"}, "fileSystem": {"readwritePaths": ["C:\\x"]}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let result = load_request(&encoded, &mut logger, true);
+        assert!(result.is_err(), "fileSystem typo should be rejected");
+    }
+
+    #[test]
+    fn top_level_annotations_allowed() {
+        // `$schema` and `_comment` are permitted but ignored.
+        let json = r#"{
+            "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
+            "_comment": "annotation that the parser ignores",
+            "version": "0.7.0-alpha",
+            "process": {"commandLine": "echo hi"}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert_eq!(req.script_code, "echo hi");
+    }
+
+    #[test]
+    fn state_aware_unknown_top_level_field_rejected() {
+        let json = r#"{
+            "phase": "provision",
+            "containment": "isolation_session",
+            "bogusField": true
+        }"#;
+        let result = load_mxc(json);
+        assert!(
+            result.is_err(),
+            "unknown top-level field on a state-aware request should be rejected"
+        );
+    }
+
+    #[test]
+    fn state_aware_top_level_annotation_allowed() {
+        let json = r#"{
+            "$schema": "../schemas/dev/mxc-config.schema.0.7.0-dev.json",
+            "phase": "provision",
+            "containment": "isolation_session"
+        }"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => assert_eq!(p.phase, Phase::Provision),
+            _ => panic!("expected state-aware request"),
+        }
     }
 
     #[test]

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::fmt::Write;
 use std::fs;
 
+use serde::de::IgnoredAny;
 use serde::Deserialize;
 
 use crate::encoding::base64_decode;
@@ -217,7 +218,6 @@ struct RawConfig {
     version: Option<String>,
     #[serde(rename = "containerId")]
     container_id: Option<String>,
-    platform: Option<String>,
     process: Option<RawProcess>,
     lifecycle: Option<RawLifecycle>,
     containment: Option<String>,
@@ -234,10 +234,12 @@ struct RawConfig {
     seatbelt: Option<RawSeatbelt>,
     // Captures any top-level key not matched above so unrecognised fields can
     // be rejected at the trust boundary instead of being silently dropped.
-    // Allowed annotation keys ($schema, _comment) are filtered out in
+    // `IgnoredAny` discards each value during deserialisation, so a large or
+    // complex unknown section costs nothing beyond its key. Allowed annotation
+    // keys ($schema, _comment) are filtered out in
     // `reject_unknown_top_level_fields`.
     #[serde(flatten)]
-    unknown: HashMap<String, serde_json::Value>,
+    unknown: HashMap<String, IgnoredAny>,
 }
 
 // State-aware request shape. `phase` is required (no `#[serde(default)]` on
@@ -250,6 +252,8 @@ struct RawConfig {
 struct RawStateAwareRequest {
     #[serde(default)]
     version: Option<String>,
+    #[serde(rename = "containerId", default)]
+    container_id: Option<String>,
     #[serde(default)]
     containment: Option<String>,
     phase: String,
@@ -270,7 +274,7 @@ struct RawStateAwareRequest {
     // See `RawConfig::unknown`. Mirrored here so unrecognised top-level keys are
     // rejected on the state-aware path too.
     #[serde(flatten)]
-    unknown: HashMap<String, serde_json::Value>,
+    unknown: HashMap<String, IgnoredAny>,
 }
 
 // Untagged enum: serde tries `StateAware` first (requires `phase`), falls
@@ -623,8 +627,8 @@ const ALLOWED_TOP_LEVEL_ANNOTATIONS: &[&str] = &["$schema", "_comment"];
 /// `filesystem`, or a stray `policy` block) now fail loudly with a precise
 /// error instead of being ignored, which previously meant the associated
 /// policy was never applied.
-fn reject_unknown_top_level_fields(
-    unknown: &HashMap<String, serde_json::Value>,
+fn reject_unknown_top_level_fields<V>(
+    unknown: &HashMap<String, V>,
     logger: &mut Logger,
 ) -> Result<(), WxcError> {
     let mut keys: Vec<&str> = unknown
@@ -799,7 +803,6 @@ fn convert_raw_config_inner(
     validate_schema_version(&schema_version, logger)?;
 
     let container_id = raw.container_id.unwrap_or_default();
-    let platform = raw.platform.unwrap_or_else(|| "windows".to_string());
 
     // Process section: required for one-shot and for state-aware exec; absent
     // is allowed for state-aware non-exec phases (require_process == false)
@@ -1297,7 +1300,6 @@ fn convert_raw_config_inner(
     Ok(ExecutionRequest {
         schema_version,
         container_id,
-        platform,
         env,
         script_code,
         working_directory,
@@ -1339,8 +1341,7 @@ fn convert_raw_state_aware(
     // same conversion path one-shot uses for cross-cutting wire fields.
     let surrogate = RawConfig {
         version: raw.version,
-        container_id: None,
-        platform: None,
+        container_id: raw.container_id,
         process: raw.process,
         lifecycle: None,
         containment: raw.containment,
@@ -2483,7 +2484,6 @@ mod tests {
     fn proxy_accepted_with_bubblewrap() {
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {"proxy": {"builtinTestServer": true}}
@@ -2500,7 +2500,6 @@ mod tests {
     fn proxy_with_bubblewrap_and_firewall_enforcement_is_rejected() {
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2525,7 +2524,6 @@ mod tests {
     fn proxy_with_bubblewrap_and_both_enforcement_is_rejected() {
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2546,7 +2544,6 @@ mod tests {
         // proxy is fine and must NOT trigger the conflict guard.
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2570,7 +2567,6 @@ mod tests {
         // policy-weakening trap and must be rejected at parse time.
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2594,7 +2590,6 @@ mod tests {
     fn external_proxy_localhost_with_bubblewrap_and_blocked_hosts_is_rejected() {
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2616,7 +2611,6 @@ mod tests {
         // enforcement.
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2639,7 +2633,6 @@ mod tests {
         // into trusting the external proxy with full policy delegation.
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2661,7 +2654,6 @@ mod tests {
         // combining it with allowedHosts is fine.
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2685,7 +2677,6 @@ mod tests {
         // surface a warning (does not reject).
         let json = r#"{
             "version": "0.6.0-alpha",
-            "platform": "linux",
             "containment": "bubblewrap",
             "process": {"commandLine": "echo hi"},
             "network": {
@@ -2705,14 +2696,13 @@ mod tests {
 
     #[test]
     fn new_toplevel_fields_parsed() {
-        let json = r#"{"version": "0.4.0-alpha", "containerId": "abc-123", "platform": "linux", "containment": "lxc", "process": {"commandLine": "echo hi"}}"#;
+        let json = r#"{"version": "0.4.0-alpha", "containerId": "abc-123", "containment": "lxc", "process": {"commandLine": "echo hi"}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.schema_version, "0.4.0-alpha");
         assert_eq!(req.container_id, "abc-123");
-        assert_eq!(req.platform, "linux");
     }
 
     #[test]
@@ -2724,7 +2714,6 @@ mod tests {
         let req = load_request(&encoded, &mut logger, true).unwrap();
         assert_eq!(req.schema_version, "");
         assert_eq!(req.container_id, "");
-        assert_eq!(req.platform, "windows");
     }
 
     #[test]
@@ -2866,6 +2855,24 @@ mod tests {
         }"#;
         match load_mxc(json).unwrap() {
             MxcRequest::StateAware(p) => assert_eq!(p.phase, Phase::Provision),
+            _ => panic!("expected state-aware request"),
+        }
+    }
+
+    #[test]
+    fn state_aware_forwards_container_id() {
+        // `containerId` is a documented top-level field and must be preserved
+        // into the inner ExecutionRequest for state-aware requests, not dropped.
+        let json = r#"{
+            "phase": "provision",
+            "containerId": "sa-container-1",
+            "containment": "isolation_session"
+        }"#;
+        match load_mxc(json).unwrap() {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Provision);
+                assert_eq!(p.request.container_id, "sa-container-1");
+            }
             _ => panic!("expected state-aware request"),
         }
     }

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -550,15 +550,13 @@ pub struct ExperimentalConfig {
     pub isolation_session: Option<IsolationSessionConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct ExecutionRequest {
     /// Schema version for the config format.
     pub schema_version: String,
     /// Externally assigned container identifier.
     pub container_id: String,
-    /// Target platform: "linux" or "windows". Default: "windows".
-    pub platform: String,
     /// Environment variables as "KEY=VALUE" strings (from process.env).
     pub env: Vec<String>,
     pub script_code: String,
@@ -581,28 +579,6 @@ pub struct ExecutionRequest {
     /// Dry-run mode: validate config and runner setup then return success
     /// without executing the sandboxed process.
     pub dry_run: bool,
-}
-
-impl Default for ExecutionRequest {
-    fn default() -> Self {
-        Self {
-            schema_version: String::new(),
-            container_id: String::new(),
-            platform: "windows".to_string(),
-            env: Vec::new(),
-            script_code: String::new(),
-            working_directory: String::new(),
-            script_timeout: 0,
-            containment: ContainmentBackend::default(),
-            lifecycle: LifecycleConfig::default(),
-            policy: ContainerPolicy::default(),
-            lxc_config: LxcConfig::default(),
-            seatbelt: None,
-            experimental_enabled: false,
-            experimental: ExperimentalConfig::default(),
-            dry_run: false,
-        }
-    }
 }
 
 /// Distinguishes whether an error occurred during process creation (launch)

--- a/tests/configs/basic_lxc.json
+++ b/tests/configs/basic_lxc.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "echo 'Hello from LXC' && uname -a"
   },

--- a/tests/configs/bubblewrap_basic.json
+++ b/tests/configs/bubblewrap_basic.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Hello-World",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "echo 'Hello from Bubblewrap' && id && cat /etc/os-release | head -2"
   }

--- a/tests/configs/bubblewrap_filesystem.json
+++ b/tests/configs/bubblewrap_filesystem.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Filesystem-Test",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "cat /mnt/readonly/test.txt && echo 'write test' > /mnt/readwrite/output.txt && ls /mnt/denied 2>&1 || echo 'denied path correctly masked'"
   },

--- a/tests/configs/bubblewrap_network_block.json
+++ b/tests/configs/bubblewrap_network_block.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Network-Block",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "wget -qO- --timeout=3 https://api.github.com/zen 2>&1 || echo 'Network correctly blocked'"
   },

--- a/tests/configs/bubblewrap_network_firewall.json
+++ b/tests/configs/bubblewrap_network_firewall.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Network-Firewall",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "wget -qO- https://api.github.com/zen"
   },

--- a/tests/configs/bubblewrap_network_proxy_allowlist.json
+++ b/tests/configs/bubblewrap_network_proxy_allowlist.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Network-Proxy-Allowlist",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "set -e; curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; if curl -fsS --max-time 5 https://example.com > /dev/null 2>&1; then echo SENTINEL_BAD_LEAK; exit 1; else echo BLOCKED_OK; fi"
   },

--- a/tests/configs/bubblewrap_network_proxy_blocklist.json
+++ b/tests/configs/bubblewrap_network_proxy_blocklist.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Network-Proxy-Blocklist",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "set -e; curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; if curl -fsS --max-time 5 https://evil.example.com > /dev/null 2>&1; then echo SENTINEL_BAD_LEAK; exit 1; else echo BLOCKED_OK; fi"
   },

--- a/tests/configs/bubblewrap_network_proxy_builtin.json
+++ b/tests/configs/bubblewrap_network_proxy_builtin.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Bubblewrap-Network-Proxy-Builtin",
   "containment": "bubblewrap",
-  "platform": "linux",
   "process": {
     "commandLine": "curl -fsSL https://api.github.com/zen && echo PROXY_OK"
   },

--- a/tests/configs/isolation_session_concurrent_A.json
+++ b/tests/configs/isolation_session_concurrent_A.json
@@ -6,7 +6,7 @@
     "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\A.ps1",
     "timeout": 60000
   },
-  "policy": {
+  "filesystem": {
     "readwritePaths": ["C:\\mxc_concurrent_log"]
   }
 }

--- a/tests/configs/isolation_session_concurrent_B.json
+++ b/tests/configs/isolation_session_concurrent_B.json
@@ -6,7 +6,7 @@
     "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\B.ps1",
     "timeout": 30000
   },
-  "policy": {
+  "filesystem": {
     "readwritePaths": ["C:\\mxc_concurrent_log"]
   }
 }

--- a/tests/configs/isolation_session_concurrent_C.json
+++ b/tests/configs/isolation_session_concurrent_C.json
@@ -6,7 +6,7 @@
     "commandLine": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\mxc_concurrent_log\\C.ps1",
     "timeout": 75000
   },
-  "policy": {
+  "filesystem": {
     "readwritePaths": ["C:\\mxc_concurrent_log"]
   }
 }

--- a/tests/configs/linux_process_abstract.json
+++ b/tests/configs/linux_process_abstract.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-Linux-Process-Abstract",
   "containment": "process",
-  "platform": "linux",
   "process": {
     "commandLine": "PID1=$(cat /proc/1/comm 2>/dev/null || echo unknown); MOUNTS=$(wc -l </proc/self/mountinfo); echo 'Hello from abstract process containment'; id; cat /etc/os-release | head -2; echo '--- backend probe ---'; echo \"pid1=$PID1 mountinfo_lines=$MOUNTS\"; [ \"$PID1\" = \"bwrap\" ] || { echo \"FAIL: not under bubblewrap (pid1=$PID1)\"; exit 1; }; echo 'OK: under bubblewrap (pid1=bwrap)'"
   }

--- a/tests/configs/linux_process_default.json
+++ b/tests/configs/linux_process_default.json
@@ -1,7 +1,6 @@
 {
   "version": "0.6.0-alpha",
   "containerId": "CLI-Linux-Process-Default",
-  "platform": "linux",
   "process": {
     "commandLine": "PID1=$(cat /proc/1/comm 2>/dev/null || echo unknown); MOUNTS=$(wc -l </proc/self/mountinfo); echo 'Hello from default Linux process sandbox'; id; cat /etc/os-release | head -2; echo '--- backend probe ---'; echo \"pid1=$PID1 mountinfo_lines=$MOUNTS\"; [ \"$PID1\" = \"bwrap\" ] || { echo \"FAIL: not under bubblewrap (pid1=$PID1)\"; exit 1; }; echo 'OK: under bubblewrap (pid1=bwrap)'"
   }

--- a/tests/configs/lxc_env_cwd_test.json
+++ b/tests/configs/lxc_env_cwd_test.json
@@ -2,7 +2,6 @@
   "version": "0.6.0-alpha",
   "containerId": "CLI-LXC-Env-Cwd-Test",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "set -e; ACTUAL_PWD=$(pwd); [ \"$ACTUAL_PWD\" = \"/etc\" ] || { echo \"FAIL cwd: got '$ACTUAL_PWD', want '/etc'\" >&2; exit 11; }; [ \"${MXC_TEST_FOO:-}\" = \"bar baz\" ] || { echo \"FAIL env MXC_TEST_FOO: got '${MXC_TEST_FOO:-<unset>}', want 'bar baz'\" >&2; exit 12; }; [ \"${MXC_TEST_EQ:-}\" = \"a=b=c\" ] || { echo \"FAIL env MXC_TEST_EQ: got '${MXC_TEST_EQ:-<unset>}', want 'a=b=c'\" >&2; exit 13; }; echo \"OK cwd=$ACTUAL_PWD MXC_TEST_FOO=$MXC_TEST_FOO MXC_TEST_EQ=$MXC_TEST_EQ\"",
     "cwd": "/etc",

--- a/tests/configs/lxc_filesystem_test.json
+++ b/tests/configs/lxc_filesystem_test.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Filesystem-Test",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "cat /mnt/readonly/test.txt && echo 'write test' > /mnt/readwrite/output.txt"
   },

--- a/tests/configs/lxc_network_test.json
+++ b/tests/configs/lxc_network_test.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Network-Test",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "wget -qO- https://api.github.com/zen"
   },

--- a/tests/configs/lxc_timeout.json
+++ b/tests/configs/lxc_timeout.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Timeout-Test",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "echo 'Starting long task'; sleep 120; echo 'Should not reach here'",
     "timeout": 5000

--- a/tests/examples/05_custom_python.json
+++ b/tests/examples/05_custom_python.json
@@ -9,7 +9,9 @@
   "processContainer": {
     "capabilities": [ "registryRead" ]
   },
-  "fileSystem": {
-    "executablePath": "C:\\Users\\AdminUser\\AppData\\Local\\anaconda3\\python.exe"
+  "filesystem": {
+    "readonlyPaths": [
+      "C:\\Users\\AdminUser\\AppData\\Local\\anaconda3"
+    ]
   }
 }

--- a/tests/examples/11_lxc_hello_world.json
+++ b/tests/examples/11_lxc_hello_world.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-Hello-World",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "echo 'Hello from LXC container!'"
   },

--- a/tests/examples/12_lxc_filesystem_access.json
+++ b/tests/examples/12_lxc_filesystem_access.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-FilesystemAccess",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "ls -la /mnt/shared && echo 'test' > /mnt/output/result.txt && cat /mnt/output/result.txt"
   },

--- a/tests/examples/13_lxc_network_restricted.json
+++ b/tests/examples/13_lxc_network_restricted.json
@@ -2,7 +2,6 @@
   "version": "0.4.0-alpha",
   "containerId": "CLI-LXC-NetworkRestricted",
   "containment": "lxc",
-  "platform": "linux",
   "process": {
     "commandLine": "wget -qO- https://api.github.com/zen || echo 'Network blocked as expected'"
   },


### PR DESCRIPTION
## 📖 Description

**Phase 1 of the versioning remediation** (stacked on #508, now merged). This adds **structural enforcement at the trust boundary**: the parser previously dropped unrecognised top-level config fields silently, so typos (e.g. `fileSystem` vs `filesystem`) and stray sections meant the associated policy was *never applied*.

What it does:

- **Parser** (`config_parser.rs`): captures unrecognised top-level keys via a `#[serde(flatten)]` map on both `RawConfig` (one-shot) and `RawStateAwareRequest` (state-aware) and rejects them with a precise error. `$schema` and `_comment` are allowed as ignored annotations. Schema-version validation is moved to the front of conversion so an unsupported version fails fast.
- **Dev schema**: sets root `additionalProperties: false` and adds the previously-undocumented `$schema`, `_comment`, `platform`, and `appContainer` (alias) top-level properties so editor/CI validation matches the parser exactly.
- **Latent bugs fixed** (surfaced by the new enforcement):
  - `05_custom_python.json`: the bogus `fileSystem.executablePath` block (no such field; silently ignored) is converted to a valid `filesystem.readonlyPaths` grant for the anaconda install dir, preserving the author's intent (mirrors the `readonlyPaths: ["/opt/homebrew"]` pattern in `21_mac_python_info.json`).
  - The three `isolation_session_concurrent_*` configs: top-level `policy` renamed to `filesystem` (the readwrite path was never applied).
- **+6 parser unit tests**.

## 🔗 References

Part of the stacked versioning-remediation series (Phase 1 of 6). Follows #508.

## 🔍 Validation

- `cargo test -p wxc_common`: **334 pass**; new parser tests: **158 pass** (+6). `cargo test --workspace --exclude wxc_e2e_tests` passes (the single `wxc_host_prep` failure is a pre-existing `requireAdministrator`-manifest elevation requirement, confirmed identical on the base branch).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --all -- --check`: clean.
- Both Phase 0 CI gates stay green; **162/162** configs validate against the tightened dev schema (root `additionalProperties:false`).

## Deferred (intentional)

Version-introduced (back-dating) enforcement — rejecting a config that declares an older schema version while using newer fields — is **not** in this PR. The config corpus itself back-dates (e.g. `processContainer` declared at `0.4`), and normalizing config versions to enforce the gate would silently change backends while `is_base_container_version` couples backend selection to the version string. So that gate depends on Phase 3 (backend decoupling) and is tracked separately.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/509)