### PR TITLE
Remove seatbelt from KNOWN_EXPERIMENTAL_BACKENDS

### DIFF
--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -515,8 +515,7 @@ const BASE_CONTAINER_MIN_VERSION: &str = "0.5.0";
 /// experimental backend sections that don't match the selected
 /// `containment`. Add a new entry when promoting a backend to a top-level
 /// section or graduating one from experimental.
-const KNOWN_EXPERIMENTAL_BACKENDS: &[&str] =
-    &["windows_sandbox", "wslc", "seatbelt", "isolation_session"];
+const KNOWN_EXPERIMENTAL_BACKENDS: &[&str] = &["windows_sandbox", "wslc", "isolation_session"];
 
 /// Returns `true` if `version` is a BaseContainer-era schema version (>= 0.5.0).
 ///


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Follow-up to #500: removes `seatbelt` from `KNOWN_EXPERIMENTAL_BACKENDS` in `config_parser.rs` since seatbelt has been promoted to a top-level stable backend.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/514)