### PR TITLE
Centralize the tempfile dev-dependency in workspace deps

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -109,5 +109,5 @@ sandbox_spec = { path = "core/generated/base_container_specification" }
 widestring = "1"
 url = "2"
 winreg = "0.55"
-mxc_build_common = { path = "core/mxc_build_common" }
 tempfile = "3"
+mxc_build_common = { path = "core/mxc_build_common" }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -110,3 +110,4 @@ widestring = "1"
 url = "2"
 winreg = "0.55"
 mxc_build_common = { path = "core/mxc_build_common" }
+tempfile = "3"

--- a/src/backends/appcontainer/common/Cargo.toml
+++ b/src/backends/appcontainer/common/Cargo.toml
@@ -28,4 +28,4 @@ widestring = { workspace = true }
 winreg = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/src/backends/windows_sandbox/daemon/Cargo.toml
+++ b/src/backends/windows_sandbox/daemon/Cargo.toml
@@ -18,7 +18,7 @@ anyhow.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
 mxc_build_common.workspace = true

--- a/src/backends/wslc/common/Cargo.toml
+++ b/src/backends/wslc/common/Cargo.toml
@@ -15,7 +15,7 @@ tar = "0.4"
 libloading = "0.8"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
 zip = "2"

--- a/src/core/wxc_common/Cargo.toml
+++ b/src/core/wxc_common/Cargo.toml
@@ -28,4 +28,4 @@ winreg = { workspace = true }
 libc = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true

--- a/src/host/wxc_host_prep/Cargo.toml
+++ b/src/host/wxc_host_prep/Cargo.toml
@@ -28,4 +28,4 @@ mxc_build_common = { workspace = true }
 embed-manifest = "1.4"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true


### PR DESCRIPTION
This PR lifts the duplicated tempfile dev-dependency into the workspace so crates inherit a single pinned version instead of each pinning `tempfile = "3"` independently.

## Details

* Add `tempfile` to `[workspace.dependencies]` in `src/Cargo.toml`.
* Switch `appcontainer/common`, `wslc/common`, and `wxc_host_prep` from `tempfile = "3"` to `tempfile.workspace = true`.

## Tests

* `cargo metadata` resolves the workspace cleanly.
