### PR TITLE
[WSLC] Add enforcement assertions for WSLC cpuCount/memoryMb; smoke tests for destroyOnExit

### DIFF
--- a/tests/configs/wslc_destroy_on_exit_false.json
+++ b/tests/configs/wslc_destroy_on_exit_false.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Smoke test: asserts config parses and payload runs. The destroyOnExit semantics are NOT externally verified -- WSLC's session teardown reaps session-scoped containers regardless of the AutoRemove flag, so `wslc list --all` shows the container as absent in both true/false cases. True verification requires a runner-side log assertion (follow-up).",
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "containerId": "wslc-destroy-on-exit-false",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_destroy_on_exit_false.json
+++ b/tests/configs/wslc_destroy_on_exit_false.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Smoke test: asserts config parses and payload runs. The destroyOnExit semantics are NOT externally verified -- WSLC's session teardown reaps session-scoped containers regardless of the AutoRemove flag, so `wslc list --all` shows the container as absent in both true/false cases. True verification requires a runner-side log assertion (follow-up).",
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-destroy-on-exit-false",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "echo 'PASS: container ran (destroyOnExit=false)'"
+  },
+  "lifecycle": {
+    "destroyOnExit": false
+  },
+  "network": {
+    "defaultPolicy": "block"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "alpine:latest"
+    }
+  }
+}

--- a/tests/configs/wslc_destroy_on_exit_true.json
+++ b/tests/configs/wslc_destroy_on_exit_true.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Smoke test: asserts config parses and payload runs. The destroyOnExit semantics are NOT externally verified -- WSLC's session teardown reaps session-scoped containers regardless of the AutoRemove flag, so `wslc list --all` shows the container as absent in both true/false cases. True verification requires a runner-side log assertion (follow-up).",
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-destroy-on-exit-true",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "echo 'PASS: container ran (destroyOnExit=true)'"
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "network": {
+    "defaultPolicy": "block"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "alpine:latest"
+    }
+  }
+}

--- a/tests/configs/wslc_destroy_on_exit_true.json
+++ b/tests/configs/wslc_destroy_on_exit_true.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Smoke test: asserts config parses and payload runs. The destroyOnExit semantics are NOT externally verified -- WSLC's session teardown reaps session-scoped containers regardless of the AutoRemove flag, so `wslc list --all` shows the container as absent in both true/false cases. True verification requires a runner-side log assertion (follow-up).",
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "containerId": "wslc-destroy-on-exit-true",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_filesystem.json
+++ b/tests/configs/wslc_filesystem.json
@@ -3,7 +3,7 @@
   "containerId": "wslc-filesystem-test",
   "containment": "wslc",
   "process": {
-    "commandLine": "ls -la /mnt/c/workspace && echo 'Filesystem test passed'",
+    "commandLine": "set -e; ls -la /mnt/c/workspace >/dev/null && echo 'PASS: filesystem mount visible' || { echo 'FAIL: /mnt/c/workspace not visible'; exit 1; }; cpus=$(nproc); echo \"CPU_COUNT=$cpus\"; [ \"$cpus\" = \"2\" ] && echo 'PASS: cpuCount enforced (nproc=2)' || { echo \"FAIL: expected nproc=2, got $cpus\"; exit 1; }; mem_kb=$(awk '/MemTotal:/ {print $2}' /proc/meminfo); mem_mb=$((mem_kb/1024)); echo \"MEM_TOTAL_MB=$mem_mb\"; [ $mem_mb -ge 820 ] && [ $mem_mb -le 1075 ] && echo 'PASS: memoryMb enforced (~1024MB, kernel-visible 80-105%)' || { echo \"FAIL: expected 820-1075MB, got ${mem_mb}MB\"; exit 1; }",
     "cwd": "C:\\workspace"
   },
   "filesystem": {

--- a/tests/scripts/run_wslc_all_tests.ps1
+++ b/tests/scripts/run_wslc_all_tests.ps1
@@ -97,7 +97,9 @@ function Run-WslcTest {
     param(
         [string]$ConfigFile,
         [int]$ExpectedExit = 0,
-        [string]$OutputContains = ""
+        [string]$OutputContains = "",
+        [string]$OutputMatches = "",
+        [scriptblock]$PostExitCheck = $null
     )
 
     $configPath = Join-Path $TestConfigs $ConfigFile
@@ -153,6 +155,28 @@ function Run-WslcTest {
         $reason = "Output missing '$OutputContains'"
     }
 
+    # OutputMatches is a regex pattern (no escaping).
+    if ($pass -and $OutputMatches -and $output -notmatch $OutputMatches) {
+        $pass = $false
+        $reason = "Output did not match regex '$OutputMatches'"
+    }
+
+    # PostExitCheck runs after exit/output gates pass. Receives ($id, $output)
+    # and must return truthy. Use for externally-observable state assertions.
+    if ($pass -and $PostExitCheck) {
+        $containerId = $configJson.containerId
+        try {
+            $checkResult = & $PostExitCheck $containerId $output
+            if (-not $checkResult) {
+                $pass = $false
+                $reason = "PostExitCheck returned false"
+            }
+        } catch {
+            $pass = $false
+            $reason = "PostExitCheck threw: $_"
+        }
+    }
+
     if ($pass) {
         Write-Host "PASS" -ForegroundColor Green
     } else {
@@ -186,7 +210,9 @@ $null = $results.Add((Run-WslcTest "wslc_stderr.json" -OutputContains "stdout me
 $null = $results.Add((Run-WslcTest "wslc_large_output.json"))
 
 Write-Host "`n--- Filesystem Tests ---" -ForegroundColor Cyan
-$null = $results.Add((Run-WslcTest "wslc_filesystem.json" -OutputContains "Filesystem test passed"))
+# wslc_filesystem.json also asserts cpuCount + memoryMb enforcement via nproc and /proc/meminfo.
+$null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
+    -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))
 $null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "Read succeeded"))
 
 Write-Host "`n--- Network Tests ---" -ForegroundColor Cyan
@@ -203,6 +229,16 @@ $null = $results.Add((Run-WslcTest "wslc_tar_import_docker_save.json" -OutputCon
 
 Write-Host "`n--- Timeout Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_timeout.json" -ExpectedExit -1 -OutputContains "Starting long task"))
+
+Write-Host "`n--- Lifecycle Tests ---" -ForegroundColor Cyan
+# Smoke tests only: assert config parses and payload runs. WSLC's session
+# teardown reaps session-scoped containers regardless of AutoRemove, so
+# destroyOnExit has no externally observable effect via `wslc list`.
+# True semantic verification requires a runner-side log assertion (TODO).
+$null = $results.Add((Run-WslcTest "wslc_destroy_on_exit_true.json" `
+    -OutputContains "PASS: container ran (destroyOnExit=true)"))
+$null = $results.Add((Run-WslcTest "wslc_destroy_on_exit_false.json" `
+    -OutputContains "PASS: container ran (destroyOnExit=false)"))
 
 # Summary
 $passed = @($results | Where-Object { $_.Pass -and -not $_.Skipped }).Count


### PR DESCRIPTION
## 📖 Description
Closes two of three "surface-touched but no enforcement assertion" gaps in the WSLC test suite:
 - `cpuCount` — fully verified (payload reads `nproc` inside the container, asserts `== 2`)
 - `memoryMb` — fully verified (payload reads `/proc/meminfo` MemTotal, asserts within 820-1075 MB window for `memoryMb: 1024`)
 - `destroyOnExit` — smoke tests only; runtime effect not externally verifiable on WSLC (see "Known limitation" below)

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

Microsoft reviewers: PR builds don't auto-run (ADO policy). Comment `/azp run`
to start `MXC-PR-Build`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/518)