### PR TITLE
fix: downgrade hyperlight-unikraft to v0.8.0 to fix KVM overlap (#525)

### DIFF
--- a/src/backends/hyperlight/common/Cargo.toml
+++ b/src/backends/hyperlight/common/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 wxc_common = { workspace = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.9.0", optional = true }
+hyperlight-unikraft-host = { git = "https://github.com/hyperlight-dev/hyperlight-unikraft", tag = "v0.8.0", optional = true }
 
 [features]
 default = []

--- a/src/backends/hyperlight/common/src/lib.rs
+++ b/src/backends/hyperlight/common/src/lib.rs
@@ -211,7 +211,7 @@ pub fn setup(force: bool, logger: &mut Logger) -> Result<PathBuf, String> {
     let opts = pyhl::InstallOptions {
         home: &home,
         source: pyhl::InstallSource::Ghcr {
-            tag: Some("v0.9.0"),
+            tag: Some("v0.8.0"),
         },
         mounts: &[],
         network: None,


### PR DESCRIPTION
Description
-----------
Resolves an `EEXIST` (os error 17) during KVM initialization when running `lxc-exec --setup-hyperlight`. 

The `v0.9.0` release of `hyperlight-unikraft` increased the size of the `python-agent-driver-initrd` image to over 1 GB. Because the `initrd` is mapped at physical address `0xc0000000` (3 GB mark), this new size causes the memory region to cross the 4 GB boundary, overlapping directly with KVM's reserved Local APIC region at `0xfee00000`. 

This PR downgrades the `hyperlight-unikraft-host` dependency and the GHCR image tag to `v0.8.0`, where the `initrd` was smaller and safely avoided the APIC memory hole.

References
----------
Fixes #525 

Validation
----------
- Verified compilation with `v0.8.0` via `cargo check --features hyperlight`.
- Confirmed `lxc-exec --setup-hyperlight` completes successfully without the KVM memory map overlap error.
