### PR TITLE
ci: fix versioning Rust toolchain sync check for new template layout

### DIFF
--- a/scripts/versioning/check-rust-toolchain-sync.js
+++ b/scripts/versioning/check-rust-toolchain-sync.js
@@ -2,11 +2,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-// Validates that the Rust toolchain pin in src/rust-toolchain.toml matches
-// the `ms-prod-1.<N>` version pinned in each ADO job that drives the 1ES
-// Rust virtual tasks (Rust.Build.Job.yml and Mac.Build.Job.yml). The rustup
-// file pins `channel = "1.<N>"`; the ADO templates pin the matching
-// internal toolchain from Mxc-Azure-Feed. All three must move together.
+// Validates that src/rust-toolchain.toml (`channel = "1.<N>"`) matches the
+// `ms-prod-1.<N>` pin in every ADO job template that uses templateContext.rust.
 //
 //   node scripts/versioning/check-rust-toolchain-sync.js
 
@@ -14,52 +11,39 @@ const { readFileSync } = require("fs");
 const { join } = require("path");
 
 const repoRoot = join(__dirname, "..", "..");
-const errors = [];
-
-function read(...parts) {
-  return readFileSync(join(repoRoot, ...parts), "utf8");
-}
-
-const toolchainToml = read("src", "rust-toolchain.toml");
-const channelMatch = toolchainToml.match(/^\s*channel\s*=\s*"([^"]+)"/m);
-if (!channelMatch) {
-  errors.push("Could not find `channel = \"...\"` in src/rust-toolchain.toml");
-}
-const rustupChannel = channelMatch ? channelMatch[1] : null;
-
 const adoTemplates = [
-  [".azure-pipelines", "templates", "Rust.Build.Job.yml"],
-  [".azure-pipelines", "templates", "Mac.Build.Job.yml"],
+  ".azure-pipelines/templates/Rust.Build.Job.yml",
+  ".azure-pipelines/templates/Mac.Build.Job.yml",
 ];
 
-const adoPins = [];
-for (const parts of adoTemplates) {
-  const relPath = parts.join("/");
-  const content = read(...parts);
-  const match = content.match(/version:\s*'ms-prod-(\d+\.\d+(?:\.\d+)?)'/);
-  if (!match) {
-    errors.push(`Could not find \`version: 'ms-prod-<version>'\` in ${relPath}`);
-    continue;
-  }
-  adoPins.push({ relPath, version: match[1] });
-}
+const read = (relPath) => readFileSync(join(repoRoot, relPath), "utf8");
+const errors = [];
 
-if (rustupChannel) {
-  for (const { relPath, version } of adoPins) {
-    if (version !== rustupChannel) {
+const channel = read("src/rust-toolchain.toml").match(/^\s*channel\s*=\s*"([^"]+)"/m)?.[1];
+if (!channel) errors.push("Missing `channel = \"...\"` in src/rust-toolchain.toml");
+
+const adoPins = adoTemplates.map((path) => {
+  const version = read(path).match(/version:\s*'ms-prod-(\d+\.\d+(?:\.\d+)?)'/)?.[1];
+  if (!version) errors.push(`Missing \`version: 'ms-prod-<version>'\` in ${path}`);
+  return { path, version };
+});
+
+if (channel) {
+  for (const { path, version } of adoPins) {
+    if (version && version !== channel) {
       errors.push(
-        `Rust toolchain drift: src/rust-toolchain.toml channel="${rustupChannel}" ` +
-        `but ${relPath} pins "ms-prod-${version}". Bump both in the same commit.`
+        `Drift: src/rust-toolchain.toml channel="${channel}" but ${path} pins ` +
+        `"ms-prod-${version}". Bump both in the same commit.`
       );
     }
   }
 }
 
-if (errors.length > 0) {
+if (errors.length) {
   console.error("Rust toolchain sync check FAILED:");
   for (const e of errors) console.error("  - " + e);
   process.exit(1);
 }
 
-const summary = adoPins.map(p => `${p.relPath}=ms-prod-${p.version}`).join(", ");
-console.log(`Rust toolchain sync OK (rustup channel ${rustupChannel}; ${summary})`);
+const pinSummary = adoPins.map((p) => `${p.path}=ms-prod-${p.version}`).join(", ");
+console.log(`Rust toolchain sync OK (channel ${channel}; ${pinSummary})`);

--- a/scripts/versioning/check-rust-toolchain-sync.js
+++ b/scripts/versioning/check-rust-toolchain-sync.js
@@ -4,6 +4,10 @@
 
 // Validates that src/rust-toolchain.toml (`channel = "1.<N>"`) matches the
 // `ms-prod-1.<N>` pin in every ADO job template that uses templateContext.rust.
+// The ADO official build installs Microsoft's internal Rust toolchain from
+// Mxc-Azure-Feed; keeping it in sync with the public rustup channel used by
+// the repo (and all other CI) prevents the official build from compiling
+// against a different Rust version than dev / GitHub Actions.
 //
 //   node scripts/versioning/check-rust-toolchain-sync.js
 

--- a/scripts/versioning/check-rust-toolchain-sync.js
+++ b/scripts/versioning/check-rust-toolchain-sync.js
@@ -3,9 +3,10 @@
 // Licensed under the MIT License.
 
 // Validates that the Rust toolchain pin in src/rust-toolchain.toml matches
-// the `rustVersion` default in .azure-pipelines/templates/Rust.Build.Steps.Official.yml.
-// The ADO official build installs `ms-prod-1.<N>` from the Mxc-Azure-Feed;
-// the rustup file pins `channel = "1.<N>"`. They must move together.
+// the `ms-prod-1.<N>` version pinned in each ADO job that drives the 1ES
+// Rust virtual tasks (Rust.Build.Job.yml and Mac.Build.Job.yml). The rustup
+// file pins `channel = "1.<N>"`; the ADO templates pin the matching
+// internal toolchain from Mxc-Azure-Feed. All three must move together.
 //
 //   node scripts/versioning/check-rust-toolchain-sync.js
 
@@ -26,19 +27,32 @@ if (!channelMatch) {
 }
 const rustupChannel = channelMatch ? channelMatch[1] : null;
 
-const adoTemplate = read(".azure-pipelines", "templates", "Rust.Build.Steps.Official.yml");
-const adoMatch = adoTemplate.match(/default:\s*'ms-prod-(\d+\.\d+(?:\.\d+)?)'/);
-if (!adoMatch) {
-  errors.push("Could not find `default: 'ms-prod-<version>'` in .azure-pipelines/templates/Rust.Build.Steps.Official.yml");
-}
-const adoVersion = adoMatch ? adoMatch[1] : null;
+const adoTemplates = [
+  [".azure-pipelines", "templates", "Rust.Build.Job.yml"],
+  [".azure-pipelines", "templates", "Mac.Build.Job.yml"],
+];
 
-if (rustupChannel && adoVersion && rustupChannel !== adoVersion) {
-  errors.push(
-    `Rust toolchain drift: src/rust-toolchain.toml channel="${rustupChannel}" ` +
-    `but .azure-pipelines/templates/Rust.Build.Steps.Official.yml pins "ms-prod-${adoVersion}". ` +
-    `Bump both in the same commit.`
-  );
+const adoPins = [];
+for (const parts of adoTemplates) {
+  const relPath = parts.join("/");
+  const content = read(...parts);
+  const match = content.match(/version:\s*'ms-prod-(\d+\.\d+(?:\.\d+)?)'/);
+  if (!match) {
+    errors.push(`Could not find \`version: 'ms-prod-<version>'\` in ${relPath}`);
+    continue;
+  }
+  adoPins.push({ relPath, version: match[1] });
+}
+
+if (rustupChannel) {
+  for (const { relPath, version } of adoPins) {
+    if (version !== rustupChannel) {
+      errors.push(
+        `Rust toolchain drift: src/rust-toolchain.toml channel="${rustupChannel}" ` +
+        `but ${relPath} pins "ms-prod-${version}". Bump both in the same commit.`
+      );
+    }
+  }
 }
 
 if (errors.length > 0) {
@@ -47,4 +61,5 @@ if (errors.length > 0) {
   process.exit(1);
 }
 
-console.log(`Rust toolchain sync OK (${rustupChannel} == ms-prod-${adoVersion})`);
+const summary = adoPins.map(p => `${p.relPath}=ms-prod-${p.version}`).join(", ");
+console.log(`Rust toolchain sync OK (rustup channel ${rustupChannel}; ${summary})`);

--- a/scripts/versioning/check-rust-toolchain-sync.js
+++ b/scripts/versioning/check-rust-toolchain-sync.js
@@ -27,7 +27,7 @@ const channel = read("src/rust-toolchain.toml").match(/^\s*channel\s*=\s*"([^"]+
 if (!channel) errors.push("Missing `channel = \"...\"` in src/rust-toolchain.toml");
 
 const adoPins = adoTemplates.map((path) => {
-  const version = read(path).match(/version:\s*'ms-prod-(\d+\.\d+(?:\.\d+)?)'/)?.[1];
+  const version = read(path).match(/^\s*version:\s*['"]?ms-prod-(\d+\.\d+(?:\.\d+)?)['"]?\s*$/m)?.[1];
   if (!version) errors.push(`Missing \`version: 'ms-prod-<version>'\` in ${path}`);
   return { path, version };
 });


### PR DESCRIPTION
## 📖 Description

The Rust toolchain sync check (`scripts/versioning/check-rust-toolchain-sync.js`) was looking for `default: 'ms-prod-<version>'` in `.azure-pipelines/templates/Rust.Build.Steps.Official.yml`. PR #481 moved that pin into `templateContext.rust.rustToolchain.version` on the per-platform job templates (`Rust.Build.Job.yml` and `Mac.Build.Job.yml`), so the check broke.

Updates the script to read both job templates with the new `version: 'ms-prod-X.Y'` shape and validate each agrees with `src/rust-toolchain.toml`.

## 🔗 References

Follow-up to #481.

## 🔍 Validation

`node scripts/versioning/check-rust-toolchain-sync.js` →
`Rust toolchain sync OK (channel 1.93; ...Rust.Build.Job.yml=ms-prod-1.93, ...Mac.Build.Job.yml=ms-prod-1.93)`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/529)