### PR TITLE
NanVix backend: host networking support

### DIFF
--- a/docs/nanvix-microvm/nanvix.md
+++ b/docs/nanvix-microvm/nanvix.md
@@ -152,11 +152,64 @@ Not supported for MicroVM. If `deniedPaths` is specified, the config is rejected
 | Symlinks/reparse points in source paths | Not supported (rejected at preflight)       |
 | Junctions for staging                   | Not used                                    |
 | `workingDirectory`                      | Not supported (guest CWD is `/`)            |
-| Network policy                          | Not supported (Nanvix has no network stack) |
+| Network policy                          | Host networking + per-host egress filtering |
+
+## Networking
+
+Host networking is **opt-in**. Set `network.defaultPolicy` to `"allow"` to
+enable unrestricted egress; the runner then passes `-allow-host-networking` to
+`nanvixd`. The default (`"block"`) leaves networking disabled, and a guest
+socket call fails with `OSError: [Errno 134]`.
+
+### Per-host egress filtering
+
+`allowedHosts` and `blockedHosts` are supported and forwarded to the guest's
+host-side socket proxy, which enforces egress at `connect()`. The guest filter
+is **allow-XOR-block**, so the two lists are mutually exclusive (specifying both
+is rejected at preflight). Presence of either list implies host networking, so
+`defaultPolicy` is ignored when a list is set:
+
+| `allowedHosts` | `blockedHosts` | Effect |
+| -------------- | -------------- | ------ |
+| _(empty)_      | _(empty)_      | follows `defaultPolicy` (`block` = no egress, `allow` = unrestricted) |
+| `[A, ...]`     | _(empty)_      | **allowlist** — only the listed destinations are reachable |
+| _(empty)_      | `[B, ...]`     | **blocklist** — everything except the listed destinations is reachable |
+| `[A, ...]`     | `[B, ...]`     | rejected at preflight (mutually exclusive) |
+
+Entries may be IPv4 literals (`93.184.216.34`), IPv4 CIDR blocks
+(`10.0.0.0/8`), or hostnames. Hostnames are resolved to their IPv4 (A-record)
+addresses at preflight; IPv6 (AAAA) results are dropped because the guest filter
+is IPv4-only. If a non-empty list resolves to **no** IPv4 address, the run is
+rejected at preflight rather than silently allowing all traffic — an allowlist
+never fails open.
+
+**DNS:** in allowlist mode the guest daemon automatically exempts the DNS port
+(53), so name resolution works without adding the resolver to `allowedHosts`.
+
+Network proxies (`network.proxy`) are not supported and are rejected at
+preflight.
+
+```jsonc
+{
+  "containment": "microvm",
+  "process": { "commandLine": "import urllib.request; ..." },
+  // Unrestricted egress:
+  "network": { "defaultPolicy": "allow" }
+}
+```
+
+```jsonc
+{
+  "containment": "microvm",
+  "process": { "commandLine": "import urllib.request; ..." },
+  // Allowlist: only example.com and the 10.0.0.0/8 block are reachable.
+  "network": { "allowedHosts": ["example.com", "10.0.0.0/8"] }
+}
+```
 
 ## Not Supported
 
 | Workload                        | Error                               |
 | ------------------------------- | ----------------------------------- |
-| Network I/O                     | `OSError: Function not implemented` |
+| Both `allowedHosts` + `blockedHosts` | Rejected at preflight (mutually exclusive) |
 | File writing outside `/mnt/rw/` | `OSError: Read-only file system`    |

--- a/docs/nanvix-microvm/nanvix.md
+++ b/docs/nanvix-microvm/nanvix.md
@@ -179,9 +179,18 @@ is rejected at preflight). Presence of either list implies host networking, so
 Entries may be IPv4 literals (`93.184.216.34`), IPv4 CIDR blocks
 (`10.0.0.0/8`), or hostnames. Hostnames are resolved to their IPv4 (A-record)
 addresses at preflight; IPv6 (AAAA) results are dropped because the guest filter
-is IPv4-only. If a non-empty list resolves to **no** IPv4 address, the run is
-rejected at preflight rather than silently allowing all traffic — an allowlist
-never fails open.
+is IPv4-only. Resolution failures are handled per direction so neither list ever
+fails open:
+
+- **allowlist** (deny-by-default): each dropped entry is logged as a warning and
+  the run continues, since dropping an entry only *narrows* access. If the list
+  resolves to **no** IPv4 address at all, the run is rejected at preflight rather
+  than silently allowing all traffic.
+- **blocklist** (allow-by-default): **any** entry that resolves to no IPv4
+  address rejects the run at preflight. Silently dropping a blocked host would
+  let traffic the policy explicitly blocks flow freely, and the static preflight
+  filter cannot enforce a name that does not resolve — so the blocklist
+  fails closed.
 
 **DNS:** in allowlist mode the guest daemon automatically exempts the DNS port
 (53), so name resolution works without adding the resolver to `allowedHosts`.

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -165,7 +165,7 @@
             "block"
           ],
           "default": "block",
-          "description": "Default network posture. Deny-by-default."
+          "description": "Default network posture. Deny-by-default. For the 'microvm' (NanVix) backend this enables host networking when set to 'allow' (nanvixd '-allow-host-networking'); 'block' disables it. When 'allowedHosts' or 'blockedHosts' is set on the 'microvm' backend, host networking is implied and this field is ignored."
         },
         "enforcementMode": {
           "type": "string",
@@ -182,14 +182,14 @@
           "items": {
             "type": "string"
           },
-          "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', and 'hyperlight' containment backends."
+          "description": "Hostnames or IP/CIDR blocks to allow (when defaultPolicy is 'block'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', 'hyperlight', and 'microvm' containment backends. On 'microvm' this is mutually exclusive with 'blockedHosts'; hostnames are resolved to IPv4 (A records) at preflight and the guest auto-exempts DNS."
         },
         "blockedHosts": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', and 'hyperlight' containment backends."
+          "description": "Hostnames or IP addresses to block (when defaultPolicy is 'allow'). Enforced by 'lxc', 'processcontainer', 'bubblewrap', 'wslc', 'hyperlight', and 'microvm' containment backends. On 'microvm' this is mutually exclusive with 'allowedHosts'; hostnames are resolved to IPv4 (A records) at preflight."
         },
         "allowLocalNetwork": {
           "type": "boolean",

--- a/src/backends/nanvix/binaries/checksums.json
+++ b/src/backends/nanvix/binaries/checksums.json
@@ -1,14 +1,14 @@
 {
   "windows": {
-    "nanvixd.exe": "9172542c250c7cc3eb1bba00fb027543f2a309e5b0152f5f9dee9e6484ed21ec",
-    "nanvix_rootfs.img": "0d45a1f0a29e0d6fc9f297016c02a798738d5288acacb46e770eb9103e1ca0b9",
-    "python3.initrd": "9e20583c70b2b6feb43ccbd477657d78f5cd1a061e962bacb7b13079fbdede92",
-    "kernel.elf": "4e75f32192b63c034846f7f802e3e3cfe7d6df57b3a0c8d6bd5927fc4ead0b2d"
+    "nanvixd.exe": "1c6f985da5f7bd914e737a7bff01d3589bdf23912258a5d27284c2ccf36bbe89",
+    "nanvix_rootfs.img": "a1e34f4658c4740351fca0147d6061d75ff67e29a586be1accf3bde96753b036",
+    "python3.initrd": "b5f545510e3a5f94b39632f38493e20fa938a7a649a8d9d18b62eabc16386686",
+    "kernel.elf": "49c9a1a184b1fec4a437488b3e8145ed1247fa5692799c8eb8499531d6f98c7a"
   },
   "linux": {
-    "nanvixd.elf": "4c4368c523784808bcb21471e2377341b7920f4f3c9e255a6287e5dac5a54b3c",
-    "nanvix_rootfs.img": "0d45a1f0a29e0d6fc9f297016c02a798738d5288acacb46e770eb9103e1ca0b9",
-    "python3.initrd": "9e20583c70b2b6feb43ccbd477657d78f5cd1a061e962bacb7b13079fbdede92",
-    "kernel.elf": "207b50dc44db4c2f513da5ce2d8223a21ec01a135343ff56b773ebf391b5dec4"
+    "nanvixd.elf": "49de37a6002fd88acf890eaef1b7a5fc8259ff1469a635261948e386b4012a8e",
+    "nanvix_rootfs.img": "a1e34f4658c4740351fca0147d6061d75ff67e29a586be1accf3bde96753b036",
+    "python3.initrd": "b5f545510e3a5f94b39632f38493e20fa938a7a649a8d9d18b62eabc16386686",
+    "kernel.elf": "dff28c4668083e7b0148d8d66b8e2a72ba6d9d2515562931bb062f0a74c32882"
   }
 }

--- a/src/backends/nanvix/binaries/versions.json
+++ b/src/backends/nanvix/binaries/versions.json
@@ -1,6 +1,6 @@
 {
     "nanvix_python": {
-        "tag": "3.12.3-nanvix-0.15.4-ac76d40",
+        "tag": "3.12.3-nanvix-0.16.65-fce3620",
         "asset": "microvm-standalone-256mb.zip",
         "asset_linux": "microvm-standalone-256mb.tar.gz",
         "binaries": [

--- a/src/backends/nanvix/runner/src/lib.rs
+++ b/src/backends/nanvix/runner/src/lib.rs
@@ -519,8 +519,8 @@ impl NanVixScriptRunner {
     ///   dropped because the guest filter is IPv4-only.
     /// - Entries that fail to parse or resolve contribute nothing.
     ///
-    /// Mirrors `lxc::network_iptables::resolve_host` so the two backends agree
-    /// on resolution semantics.
+    /// Mirrors `lxc::network_iptables::resolve_host` for hostname-to-IPv4 mapping,
+    /// and additionally preserves IPv4/CIDR literals for nanvixd.
     fn resolve_hosts(hosts: &[String]) -> Vec<String> {
         let mut out: Vec<String> = Vec::new();
         for host in hosts {

--- a/src/backends/nanvix/runner/src/lib.rs
+++ b/src/backends/nanvix/runner/src/lib.rs
@@ -107,8 +107,28 @@ const ERR_HOSTS_UNRESOLVED: &str = concat!(
     "none of the specified allowedHosts/blockedHosts resolved to an IPv4 address -- ",
     "the NanVix guest filter is IPv4-only; use IPv4 literals/CIDR or hosts with A records",
 );
+const ERR_BLOCKED_HOST_UNRESOLVED: &str = concat!(
+    "a blockedHosts entry did not resolve to any IPv4 address -- ",
+    "the NanVix guest egress filter is static (resolved once at preflight) and IPv4-only, ",
+    "so an unresolvable blocked host cannot be enforced. Silently dropping it would let ",
+    "traffic the policy explicitly blocks flow freely, so the run is rejected (fail-closed). ",
+    "Use an IPv4 literal/CIDR or a host with A records",
+);
 const ERR_PROXY_POLICY: &str = "network proxy is not supported by the NanVix backend";
 const ERR_WORKDIR: &str = "workingDirectory is not supported by the NanVix backend -- guest has its own filesystem namespace";
+
+/// Outcome of resolving a request's egress host lists.
+///
+/// `allow`/`block` are the IPv4/CIDR literals handed to nanvixd; at most one is
+/// non-empty. `warnings` carries human-readable notices for allowlist entries
+/// that were dropped during resolution (blocklist drops are a hard error and
+/// never reach here).
+#[derive(Debug)]
+struct ResolvedHostLists {
+    allow: Vec<String>,
+    block: Vec<String>,
+    warnings: Vec<String>,
+}
 
 /// Maps a finished child's [`ExitStatus`] to a host-visible exit code.
 ///
@@ -512,22 +532,30 @@ impl NanVixScriptRunner {
     }
 
     /// Resolves a host entry list into IPv4/CIDR literals for nanvixd's
-    /// `-allow-host`/`-block-host` flags.
+    /// `-allow-host`/`-block-host` flags, alongside the entries that resolved
+    /// to nothing.
     ///
     /// - `a.b.c.d` and `a.b.c.d/n` literals pass through unchanged.
     /// - Hostnames resolve to their IPv4 (A-record) addresses; AAAA results are
     ///   dropped because the guest filter is IPv4-only.
-    /// - Entries that fail to parse or resolve contribute nothing.
+    /// - Entries that fail to parse or resolve to any IPv4 address contribute
+    ///   nothing to the resolved list and are collected into the second return
+    ///   value so callers can warn (allowlist) or reject (blocklist).
     ///
-    /// Mirrors `lxc::network_iptables::resolve_host` for hostname-to-IPv4 mapping,
-    /// and additionally preserves IPv4/CIDR literals for nanvixd.
-    fn resolve_hosts(hosts: &[String]) -> Vec<String> {
+    /// Mirrors `lxc::network_iptables::resolve_host` for the hostname-to-IPv4
+    /// mapping; unlike that helper this also preserves IPv4/CIDR literals.
+    ///
+    /// Returns `(resolved_ips, unresolved_entries)`. Empty/whitespace entries
+    /// are ignored entirely and appear in neither list.
+    fn resolve_hosts_detailed(hosts: &[String]) -> (Vec<String>, Vec<String>) {
         let mut out: Vec<String> = Vec::new();
+        let mut unresolved: Vec<String> = Vec::new();
         for host in hosts {
             let entry = host.trim();
             if entry.is_empty() {
                 continue;
             }
+            let before = out.len();
             // CIDR literal: pass through only when the address is IPv4 and the
             // prefix is in range. nanvixd parses CIDR directly.
             if let Some((addr, prefix)) = entry.split_once('/') {
@@ -540,45 +568,70 @@ impl NanVixScriptRunner {
                 if addr_ok && prefix_ok {
                     out.push(entry.to_string());
                 }
-                continue;
-            }
-            // Bare IP literal: keep IPv4, drop IPv6.
-            if let Ok(addr) = entry.parse::<std::net::IpAddr>() {
+            } else if let Ok(addr) = entry.parse::<std::net::IpAddr>() {
+                // Bare IP literal: keep IPv4, drop IPv6.
                 if addr.is_ipv4() {
                     out.push(entry.to_string());
                 }
-                continue;
-            }
-            // Hostname: resolve to IPv4 A records.
-            if let Ok(addrs) = format!("{}:0", entry).to_socket_addrs() {
+            } else if let Ok(addrs) = format!("{}:0", entry).to_socket_addrs() {
+                // Hostname: resolve to IPv4 A records.
                 for ip in addrs.map(|a| a.ip()).filter(|ip| ip.is_ipv4()) {
                     out.push(ip.to_string());
                 }
             }
+            if out.len() == before {
+                unresolved.push(entry.to_string());
+            }
         }
-        out
+        (out, unresolved)
     }
 
     /// Resolves the request's allow/block host lists, failing closed.
     ///
-    /// Returns `(resolved_allow, resolved_block)`. At most one list is non-empty
-    /// (the mutual-exclusion check in [`Self::validate_policies`] runs first). If
-    /// a user-supplied list resolves to nothing — e.g. an allowlist of names
-    /// that have no A records — this returns an error rather than silently
-    /// emitting `-allow-host-networking` with no filter (which nanvixd would
-    /// treat as allow-all), so an allowlist never fails open.
-    fn resolve_host_lists(
-        request: &ExecutionRequest,
-    ) -> Result<(Vec<String>, Vec<String>), NanVixError> {
-        let allow = Self::resolve_hosts(&request.policy.allowed_hosts);
+    /// Returns the resolved allow/block IPv4 lists plus human-readable
+    /// warnings for any allowlist entries that were dropped. At most one list
+    /// is non-empty (the mutual-exclusion check in [`Self::validate_policies`]
+    /// runs first).
+    ///
+    /// Fail-closed semantics differ by list direction:
+    /// - **Allowlist** (deny-by-default): a fully unresolvable allowlist is an
+    ///   error, because emitting `-allow-host-networking` with no filter would
+    ///   fail open (nanvixd treats no list as allow-all). Partially dropped
+    ///   entries only narrow access, so they are reported as warnings and the
+    ///   run continues.
+    /// - **Blocklist** (allow-by-default): *any* unresolvable entry is an
+    ///   error. Silently dropping a blocked host would let traffic the policy
+    ///   explicitly blocks flow freely (fail-open), and the static preflight
+    ///   filter cannot enforce a name that does not resolve.
+    fn resolve_host_lists(request: &ExecutionRequest) -> Result<ResolvedHostLists, NanVixError> {
+        let (allow, allow_unresolved) = Self::resolve_hosts_detailed(&request.policy.allowed_hosts);
         if !request.policy.allowed_hosts.is_empty() && allow.is_empty() {
             return Err(NanVixError::Preflight(ERR_HOSTS_UNRESOLVED.to_string()));
         }
-        let block = Self::resolve_hosts(&request.policy.blocked_hosts);
-        if !request.policy.blocked_hosts.is_empty() && block.is_empty() {
-            return Err(NanVixError::Preflight(ERR_HOSTS_UNRESOLVED.to_string()));
+
+        let (block, block_unresolved) = Self::resolve_hosts_detailed(&request.policy.blocked_hosts);
+        if let Some(first) = block_unresolved.first() {
+            return Err(NanVixError::Preflight(format!(
+                "{} (entry: '{}')",
+                ERR_BLOCKED_HOST_UNRESOLVED, first
+            )));
         }
-        Ok((allow, block))
+
+        let warnings = allow_unresolved
+            .iter()
+            .map(|h| {
+                format!(
+                    "Warning: could not resolve allowedHosts entry '{}' to an IPv4 address; skipping",
+                    h
+                )
+            })
+            .collect();
+
+        Ok(ResolvedHostLists {
+            allow,
+            block,
+            warnings,
+        })
     }
 
     fn validate_policies(request: &ExecutionRequest) -> Result<(), NanVixError> {
@@ -920,7 +973,12 @@ impl ScriptRunner for NanVixScriptRunner {
             let _ = writeln!(logger, "NanVix: host networking enabled");
         }
         let (allow_hosts, block_hosts) = match Self::resolve_host_lists(request) {
-            Ok(v) => v,
+            Ok(resolved) => {
+                for warning in &resolved.warnings {
+                    let _ = writeln!(logger, "NanVix: {}", warning);
+                }
+                (resolved.allow, resolved.block)
+            }
             Err(e) => {
                 let _ = writeln!(logger, "{}", e);
                 return e.to_response();
@@ -1125,8 +1183,9 @@ mod tests {
             "10.0.0.0/8".to_string(),
             "192.168.1.1/32".to_string(),
         ];
-        let resolved = NanVixScriptRunner::resolve_hosts(&hosts);
+        let (resolved, unresolved) = NanVixScriptRunner::resolve_hosts_detailed(&hosts);
         assert_eq!(resolved, vec!["1.2.3.4", "10.0.0.0/8", "192.168.1.1/32"]);
+        assert!(unresolved.is_empty());
     }
 
     #[test]
@@ -1138,7 +1197,7 @@ mod tests {
             "  ".to_string(),            // blank -> skipped
             "5.6.7.8".to_string(),       // valid -> kept
         ];
-        let resolved = NanVixScriptRunner::resolve_hosts(&hosts);
+        let (resolved, _) = NanVixScriptRunner::resolve_hosts_detailed(&hosts);
         assert_eq!(resolved, vec!["5.6.7.8"]);
     }
 
@@ -1151,9 +1210,10 @@ mod tests {
             },
             ..Default::default()
         };
-        let (allow, block) = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
-        assert_eq!(allow, vec!["1.1.1.1", "8.8.8.8/32"]);
-        assert!(block.is_empty());
+        let resolved = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert_eq!(resolved.allow, vec!["1.1.1.1", "8.8.8.8/32"]);
+        assert!(resolved.block.is_empty());
+        assert!(resolved.warnings.is_empty());
     }
 
     #[test]
@@ -1177,12 +1237,98 @@ mod tests {
     }
 
     #[test]
+    fn resolve_hosts_detailed_reports_unresolved_entries() {
+        // IPv4/CIDR pass through; IPv6 + malformed entries are reported as
+        // unresolved; blanks are ignored entirely.
+        let hosts = vec![
+            "5.6.7.8".to_string(),            // valid -> kept
+            "::1".to_string(),                // IPv6 literal -> unresolved
+            "2001:db8::/32".to_string(),      // IPv6 CIDR -> unresolved
+            "1.2.3.4/33".to_string(),         // out-of-range prefix -> unresolved
+            "not_a_host.invalid".to_string(), // no A record -> unresolved
+            "  ".to_string(),                 // blank -> ignored (neither list)
+        ];
+        let (resolved, unresolved) = NanVixScriptRunner::resolve_hosts_detailed(&hosts);
+        assert_eq!(resolved, vec!["5.6.7.8"]);
+        assert_eq!(
+            unresolved,
+            vec!["::1", "2001:db8::/32", "1.2.3.4/33", "not_a_host.invalid"]
+        );
+    }
+
+    #[test]
+    fn resolve_host_lists_warns_on_dropped_allowlist_entries() {
+        // A partially-resolvable allowlist narrows access (fail-safe): the run
+        // continues and each dropped entry produces a warning.
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                allowed_hosts: vec![
+                    "9.9.9.9".to_string(),
+                    "::1".to_string(),
+                    "dropme.invalid".to_string(),
+                ],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let resolved = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert_eq!(resolved.allow, vec!["9.9.9.9"]);
+        assert!(resolved.block.is_empty());
+        assert_eq!(resolved.warnings.len(), 2, "two entries were dropped");
+        assert!(resolved.warnings.iter().any(|w| w.contains("::1")));
+        assert!(resolved
+            .warnings
+            .iter()
+            .any(|w| w.contains("dropme.invalid")));
+    }
+
+    #[test]
+    fn resolve_host_lists_fails_closed_on_unresolvable_blocklist_entry() {
+        // A blocklist (allow-by-default) must fail closed if ANY entry cannot
+        // be resolved -- silently dropping it would let blocked traffic flow.
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                blocked_hosts: vec!["10.0.0.1".to_string(), "::1".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = NanVixScriptRunner::resolve_host_lists(&request).unwrap_err();
+        assert!(
+            err.to_string().contains(ERR_BLOCKED_HOST_UNRESOLVED),
+            "unresolvable blocklist entry should fail closed, got: {}",
+            err
+        );
+        assert!(
+            err.to_string().contains("::1"),
+            "error should name the offending entry, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn resolve_host_lists_accepts_fully_resolved_blocklist() {
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                blocked_hosts: vec!["10.0.0.1".to_string(), "192.168.0.0/16".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let resolved = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert!(resolved.allow.is_empty());
+        assert_eq!(resolved.block, vec!["10.0.0.1", "192.168.0.0/16"]);
+        assert!(resolved.warnings.is_empty());
+    }
+
+    #[test]
     fn default_block_no_lists_disables_host_networking() {
         // The default posture (block, no lists) keeps networking off.
         let request = ExecutionRequest::default();
         assert!(!NanVixScriptRunner::host_networking_enabled(&request));
-        let (allow, block) = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
-        assert!(allow.is_empty() && block.is_empty());
+        let resolved = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert!(resolved.allow.is_empty() && resolved.block.is_empty());
+        assert!(resolved.warnings.is_empty());
     }
 
     #[test]

--- a/src/backends/nanvix/runner/src/lib.rs
+++ b/src/backends/nanvix/runner/src/lib.rs
@@ -37,9 +37,9 @@
 //!
 //! Host networking is **off by default** and is enabled per-run by passing
 //! `-allow-host-networking` to `nanvixd`. The runner adds that flag when the
-//! request sets `network.defaultPolicy = "allow"`. NanVix host networking is
-//! all-or-nothing: per-host filtering (`allowedHosts` / `blockedHosts`) and
-//! proxies are not supported and are rejected at validation time.
+//! request sets `network.defaultPolicy = "allow"`, or when `allowedHosts` /
+//! `blockedHosts` is present (forwarded as `-allow-host` / `-block-host`).
+//! Network proxies are not supported and are rejected at validation time.
 //!
 //! Auto-discovery
 //!

--- a/src/backends/nanvix/runner/src/lib.rs
+++ b/src/backends/nanvix/runner/src/lib.rs
@@ -33,12 +33,21 @@
 //!
 //! `nanvixd` propagates the guest process exit code directly.
 //!
+//! ## Networking
+//!
+//! Host networking is **off by default** and is enabled per-run by passing
+//! `-allow-host-networking` to `nanvixd`. The runner adds that flag when the
+//! request sets `network.defaultPolicy = "allow"`. NanVix host networking is
+//! all-or-nothing: per-host filtering (`allowedHosts` / `blockedHosts`) and
+//! proxies are not supported and are rejected at validation time.
+//!
 //! Auto-discovery
 //!
 //! All required binaries (`nanvixd.exe`, `python3.initrd`, `nanvix_rootfs.img`)
 //! are discovered next to the running executable. No configuration is needed.
 
 use std::fmt::Write;
+use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -89,10 +98,16 @@ const ERR_DENIED_PATHS: &str = concat!(
     "-- the guest has no host filesystem visibility. ",
     "Only readwrite_paths and readonly_paths are supported",
 );
-const ERR_NETWORK_POLICY: &str =
-    "network policy is not supported by the NanVix backend -- NanVix has no network stack";
-const ERR_PROXY_POLICY: &str =
-    "network proxy is not supported by the NanVix backend -- NanVix has no network stack";
+const ERR_NETWORK_HOSTS: &str = concat!(
+    "allowedHosts and blockedHosts are mutually exclusive for the NanVix backend -- ",
+    "the guest egress filter is allow-XOR-block. Specify an allowlist (allowedHosts) ",
+    "or a blocklist (blockedHosts), not both",
+);
+const ERR_HOSTS_UNRESOLVED: &str = concat!(
+    "none of the specified allowedHosts/blockedHosts resolved to an IPv4 address -- ",
+    "the NanVix guest filter is IPv4-only; use IPv4 literals/CIDR or hosts with A records",
+);
+const ERR_PROXY_POLICY: &str = "network proxy is not supported by the NanVix backend";
 const ERR_WORKDIR: &str = "workingDirectory is not supported by the NanVix backend -- guest has its own filesystem namespace";
 
 /// Maps a finished child's [`ExitStatus`] to a host-visible exit code.
@@ -483,16 +498,100 @@ impl NanVixScriptRunner {
         }
     }
 
+    /// Returns whether the request opts in to host networking.
+    ///
+    /// Host networking is enabled when `network.defaultPolicy = "allow"` OR when
+    /// a per-host allow/block list is present (a list always implies networking,
+    /// regardless of `defaultPolicy`). When enabled, the runner passes
+    /// `-allow-host-networking` to nanvixd; per-host lists are additionally
+    /// forwarded as `-allow-host`/`-block-host` (see [`Self::spawn_nanvixd`]).
+    fn host_networking_enabled(request: &ExecutionRequest) -> bool {
+        request.policy.default_network_policy == NetworkPolicy::Allow
+            || !request.policy.allowed_hosts.is_empty()
+            || !request.policy.blocked_hosts.is_empty()
+    }
+
+    /// Resolves a host entry list into IPv4/CIDR literals for nanvixd's
+    /// `-allow-host`/`-block-host` flags.
+    ///
+    /// - `a.b.c.d` and `a.b.c.d/n` literals pass through unchanged.
+    /// - Hostnames resolve to their IPv4 (A-record) addresses; AAAA results are
+    ///   dropped because the guest filter is IPv4-only.
+    /// - Entries that fail to parse or resolve contribute nothing.
+    ///
+    /// Mirrors `lxc::network_iptables::resolve_host` so the two backends agree
+    /// on resolution semantics.
+    fn resolve_hosts(hosts: &[String]) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for host in hosts {
+            let entry = host.trim();
+            if entry.is_empty() {
+                continue;
+            }
+            // CIDR literal: pass through only when the address is IPv4 and the
+            // prefix is in range. nanvixd parses CIDR directly.
+            if let Some((addr, prefix)) = entry.split_once('/') {
+                let addr_ok = addr.trim().parse::<std::net::Ipv4Addr>().is_ok();
+                let prefix_ok = prefix
+                    .trim()
+                    .parse::<u8>()
+                    .map(|p| p <= 32)
+                    .unwrap_or(false);
+                if addr_ok && prefix_ok {
+                    out.push(entry.to_string());
+                }
+                continue;
+            }
+            // Bare IP literal: keep IPv4, drop IPv6.
+            if let Ok(addr) = entry.parse::<std::net::IpAddr>() {
+                if addr.is_ipv4() {
+                    out.push(entry.to_string());
+                }
+                continue;
+            }
+            // Hostname: resolve to IPv4 A records.
+            if let Ok(addrs) = format!("{}:0", entry).to_socket_addrs() {
+                for ip in addrs.map(|a| a.ip()).filter(|ip| ip.is_ipv4()) {
+                    out.push(ip.to_string());
+                }
+            }
+        }
+        out
+    }
+
+    /// Resolves the request's allow/block host lists, failing closed.
+    ///
+    /// Returns `(resolved_allow, resolved_block)`. At most one list is non-empty
+    /// (the mutual-exclusion check in [`Self::validate_policies`] runs first). If
+    /// a user-supplied list resolves to nothing — e.g. an allowlist of names
+    /// that have no A records — this returns an error rather than silently
+    /// emitting `-allow-host-networking` with no filter (which nanvixd would
+    /// treat as allow-all), so an allowlist never fails open.
+    fn resolve_host_lists(
+        request: &ExecutionRequest,
+    ) -> Result<(Vec<String>, Vec<String>), NanVixError> {
+        let allow = Self::resolve_hosts(&request.policy.allowed_hosts);
+        if !request.policy.allowed_hosts.is_empty() && allow.is_empty() {
+            return Err(NanVixError::Preflight(ERR_HOSTS_UNRESOLVED.to_string()));
+        }
+        let block = Self::resolve_hosts(&request.policy.blocked_hosts);
+        if !request.policy.blocked_hosts.is_empty() && block.is_empty() {
+            return Err(NanVixError::Preflight(ERR_HOSTS_UNRESOLVED.to_string()));
+        }
+        Ok((allow, block))
+    }
+
     fn validate_policies(request: &ExecutionRequest) -> Result<(), NanVixError> {
         // denied_paths is explicitly rejected — microvm has no host visibility.
         if !request.policy.denied_paths.is_empty() {
             return Err(NanVixError::Preflight(ERR_DENIED_PATHS.to_string()));
         }
-        if !request.policy.allowed_hosts.is_empty()
-            || !request.policy.blocked_hosts.is_empty()
-            || request.policy.default_network_policy != NetworkPolicy::Block
-        {
-            return Err(NanVixError::Preflight(ERR_NETWORK_POLICY.to_string()));
+        // Per-host filtering is supported (forwarded to nanvixd as
+        // -allow-host/-block-host). The guest egress filter is allow-XOR-block,
+        // so the two lists are mutually exclusive; defaultPolicy is ignored when
+        // either list is present.
+        if !request.policy.allowed_hosts.is_empty() && !request.policy.blocked_hosts.is_empty() {
+            return Err(NanVixError::Preflight(ERR_NETWORK_HOSTS.to_string()));
         }
         if request.policy.network_proxy.is_enabled() {
             return Err(NanVixError::Preflight(ERR_PROXY_POLICY.to_string()));
@@ -507,6 +606,9 @@ impl NanVixScriptRunner {
     fn spawn_nanvixd(
         paths: &ResolvedPaths,
         staging_dir: &Path,
+        host_networking: bool,
+        allow_hosts: &[String],
+        block_hosts: &[String],
     ) -> Result<std::process::Child, NanVixError> {
         let trace = nanvix_trace_enabled();
         // Default: silence nanvixd and inherit stderr so kernel traces (if
@@ -521,11 +623,33 @@ impl NanVixScriptRunner {
 
         let mut cmd = Command::new(&paths.nanvixd);
 
+        // Host networking is opt-in. When enabled, attach the host network
+        // backend; nanvixd parses this flag regardless of argument order, so
+        // it is added up front for both the Windows (snapshot) and Linux
+        // (cold-boot) invocations below. Verified to work on warm-start
+        // snapshot restore as well as cold boot.
+        if host_networking {
+            cmd.arg("-allow-host-networking");
+        }
+
+        // Per-host egress filtering. The two lists are mutually exclusive
+        // (validated upstream), so at most one of these loops emits flags.
+        // nanvixd requires `-allow-host-networking` for these to take effect,
+        // which is guaranteed because a non-empty list forces host_networking
+        // on (see `host_networking_enabled`). The guest daemon auto-exempts the
+        // DNS port in allowlist mode, so no resolver IPs are added here.
+        for host in allow_hosts {
+            cmd.arg("-allow-host").arg(host);
+        }
+        for host in block_hosts {
+            cmd.arg("-block-host").arg(host);
+        }
+
         #[cfg(target_os = "windows")]
         {
             // nanvixd loads kernel.vmem from <cwd>/snapshots/ so cwd must be
             // the snapshot home. All other paths are passed as absolute.
-            //   nanvixd.exe -snapshot snapshots/kernel.whp.cbor
+            //   nanvixd.exe [-allow-host-networking] -snapshot snapshots/kernel.whp.cbor
             //              -bin-dir <exe>/bin -ramfs <img> -mount <staging> -- python3.initrd
             let snapshot_rel = Path::new(SNAPSHOTS_DIR).join(SNAPSHOT_CBOR);
             cmd.current_dir(&paths.snapshot_home)
@@ -544,7 +668,7 @@ impl NanVixScriptRunner {
         #[cfg(target_os = "linux")]
         {
             // Linux invocation (cold boot via KVM):
-            //   nanvixd.elf -ramfs <rootfs.img> -mount <staging_dir> -- python3.initrd
+            //   nanvixd.elf [-allow-host-networking] -ramfs <rootfs.img> -mount <staging_dir> -- python3.initrd
             cmd.current_dir(&paths.exe_dir)
                 .arg("-ramfs")
                 .arg(&paths.ramfs)
@@ -791,7 +915,30 @@ impl ScriptRunner for NanVixScriptRunner {
         Self::log_resolved_paths(logger, &paths);
         let _ = writeln!(logger, "NanVix: staging_dir={:?}", staging.path());
 
-        let mut child = match Self::spawn_nanvixd(&paths, staging.path()) {
+        let host_networking = Self::host_networking_enabled(request);
+        if host_networking {
+            let _ = writeln!(logger, "NanVix: host networking enabled");
+        }
+        let (allow_hosts, block_hosts) = match Self::resolve_host_lists(request) {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = writeln!(logger, "{}", e);
+                return e.to_response();
+            }
+        };
+        if !allow_hosts.is_empty() {
+            let _ = writeln!(logger, "NanVix: egress allowlist={:?}", allow_hosts);
+        }
+        if !block_hosts.is_empty() {
+            let _ = writeln!(logger, "NanVix: egress blocklist={:?}", block_hosts);
+        }
+        let mut child = match Self::spawn_nanvixd(
+            &paths,
+            staging.path(),
+            host_networking,
+            &allow_hosts,
+            &block_hosts,
+        ) {
             Ok(c) => c,
             Err(e) => {
                 let _ = writeln!(logger, "{}", e);
@@ -913,42 +1060,136 @@ mod tests {
     }
 
     #[test]
-    fn policy_rejects_network_hosts() {
-        let mut runner = NanVixScriptRunner::new();
+    fn policy_accepts_allowlist_only() {
+        // A bare allowlist is now supported (forwarded as -allow-host).
         let request = ExecutionRequest {
             script_code: "echo test".to_string(),
             policy: ContainerPolicy {
-                allowed_hosts: vec!["example.com".to_string()],
+                allowed_hosts: vec!["93.184.216.34".to_string()],
                 ..Default::default()
             },
             ..Default::default()
         };
-        let mut logger = Logger::new(Mode::Buffer);
-        let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
+        assert!(
+            NanVixScriptRunner::validate_policies(&request).is_ok(),
+            "a bare allowlist should pass validation"
+        );
+        // A list implies host networking regardless of defaultPolicy (Block).
+        assert!(NanVixScriptRunner::host_networking_enabled(&request));
     }
 
     #[test]
-    fn policy_rejects_blocked_network_hosts() {
-        let mut runner = NanVixScriptRunner::new();
+    fn policy_accepts_blocklist_only() {
+        // A bare blocklist is now supported (forwarded as -block-host).
         let request = ExecutionRequest {
             script_code: "echo test".to_string(),
             policy: ContainerPolicy {
-                blocked_hosts: vec!["evil.com".to_string()],
+                blocked_hosts: vec!["93.184.216.34".to_string()],
                 ..Default::default()
             },
             ..Default::default()
         };
-        let mut logger = Logger::new(Mode::Buffer);
-        let resp = runner.run(&request, &mut logger);
-        assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
+        assert!(
+            NanVixScriptRunner::validate_policies(&request).is_ok(),
+            "a bare blocklist should pass validation"
+        );
+        assert!(NanVixScriptRunner::host_networking_enabled(&request));
     }
 
     #[test]
-    fn policy_rejects_network_allow_policy() {
-        let mut runner = NanVixScriptRunner::new();
+    fn policy_rejects_both_host_lists() {
+        // allow + block are mutually exclusive (the guest filter is allow-XOR-block).
+        let request = ExecutionRequest {
+            script_code: "echo test".to_string(),
+            policy: ContainerPolicy {
+                allowed_hosts: vec!["10.0.0.1".to_string()],
+                blocked_hosts: vec!["10.0.0.2".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = NanVixScriptRunner::validate_policies(&request).unwrap_err();
+        assert!(
+            err.to_string().contains(ERR_NETWORK_HOSTS),
+            "both lists should be rejected, got: {}",
+            err
+        );
+    }
+
+    // -- Host resolution / decision-matrix tests --------------------------------
+
+    #[test]
+    fn resolve_hosts_passes_ipv4_and_cidr_literals() {
+        let hosts = vec![
+            "1.2.3.4".to_string(),
+            "10.0.0.0/8".to_string(),
+            "192.168.1.1/32".to_string(),
+        ];
+        let resolved = NanVixScriptRunner::resolve_hosts(&hosts);
+        assert_eq!(resolved, vec!["1.2.3.4", "10.0.0.0/8", "192.168.1.1/32"]);
+    }
+
+    #[test]
+    fn resolve_hosts_drops_ipv6_and_bad_entries() {
+        let hosts = vec![
+            "::1".to_string(),           // IPv6 literal -> dropped
+            "2001:db8::/32".to_string(), // IPv6 CIDR -> dropped (addr not IPv4)
+            "1.2.3.4/33".to_string(),    // out-of-range prefix -> dropped
+            "  ".to_string(),            // blank -> skipped
+            "5.6.7.8".to_string(),       // valid -> kept
+        ];
+        let resolved = NanVixScriptRunner::resolve_hosts(&hosts);
+        assert_eq!(resolved, vec!["5.6.7.8"]);
+    }
+
+    #[test]
+    fn resolve_host_lists_returns_resolved_allow() {
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                allowed_hosts: vec!["1.1.1.1".to_string(), "8.8.8.8/32".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let (allow, block) = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert_eq!(allow, vec!["1.1.1.1", "8.8.8.8/32"]);
+        assert!(block.is_empty());
+    }
+
+    #[test]
+    fn resolve_host_lists_fails_closed_when_allowlist_unresolvable() {
+        // A non-empty allowlist that resolves to nothing must error rather than
+        // silently fall through to allow-all.
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                // IPv6-only literal resolves to no IPv4 entry.
+                allowed_hosts: vec!["::1".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = NanVixScriptRunner::resolve_host_lists(&request).unwrap_err();
+        assert!(
+            err.to_string().contains(ERR_HOSTS_UNRESOLVED),
+            "unresolvable allowlist should fail closed, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn default_block_no_lists_disables_host_networking() {
+        // The default posture (block, no lists) keeps networking off.
+        let request = ExecutionRequest::default();
+        assert!(!NanVixScriptRunner::host_networking_enabled(&request));
+        let (allow, block) = NanVixScriptRunner::resolve_host_lists(&request).unwrap();
+        assert!(allow.is_empty() && block.is_empty());
+    }
+
+    #[test]
+    fn allow_policy_enables_host_networking() {
+        // `network.defaultPolicy = "allow"` maps to host networking and must
+        // pass validation (the run later fails on missing nanvixd binaries,
+        // not on policy). Per-host filtering is absent, so it is accepted.
         let request = ExecutionRequest {
             script_code: "echo test".to_string(),
             policy: ContainerPolicy {
@@ -957,10 +1198,21 @@ mod tests {
             },
             ..Default::default()
         };
+        assert!(NanVixScriptRunner::host_networking_enabled(&request));
+        assert!(
+            NanVixScriptRunner::validate_policies(&request).is_ok(),
+            "allow posture without per-host filtering should pass validation"
+        );
+
+        let mut runner = NanVixScriptRunner::new();
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
-        assert!(resp.error_message.contains(ERR_NETWORK_POLICY));
+        assert!(
+            !resp.error_message.contains(ERR_NETWORK_HOSTS),
+            "allow posture must not trigger a network policy rejection, got: {}",
+            resp.error_message
+        );
     }
 
     #[test]
@@ -979,19 +1231,20 @@ mod tests {
 
     #[test]
     fn policy_allows_defaults() {
-        // NanVix accepts a default (deny-by-default) policy because it has
-        // no network stack -- Block is naturally enforced. The run then
-        // fails later on missing nanvixd binaries, not on policy.
+        // NanVix accepts a default (deny-by-default) policy. With no host
+        // networking requested, the run later fails on missing nanvixd
+        // binaries, not on policy.
         let mut runner = NanVixScriptRunner::new();
         let request = ExecutionRequest {
             script_code: "echo test".to_string(),
             ..Default::default()
         };
+        assert!(!NanVixScriptRunner::host_networking_enabled(&request));
         let mut logger = Logger::new(Mode::Buffer);
         let resp = runner.run(&request, &mut logger);
         assert_eq!(resp.exit_code, ERROR_EXIT_CODE);
         assert!(
-            !resp.error_message.contains(ERR_NETWORK_POLICY),
+            !resp.error_message.contains(ERR_NETWORK_HOSTS),
             "default request should not trigger network policy rejection"
         );
         assert!(

--- a/src/testing/wxc_e2e_tests/src/lib.rs
+++ b/src/testing/wxc_e2e_tests/src/lib.rs
@@ -463,6 +463,25 @@ pub fn run_wxc_state_aware(
     run_executable(label, &exe, args)
 }
 
+/// Run `wxc-exec.exe` with a one-shot config supplied as an in-memory JSON
+/// value. The value is serialised, base64-encoded, and passed via
+/// `--config-base64`, so callers can build configs with values only known at
+/// test time (e.g. a dynamically discovered host IP or port).
+pub fn run_wxc_config_value(
+    label: &str,
+    config: &serde_json::Value,
+    extra_args: &[&str],
+) -> CommandResult {
+    let exe = find_binary("wxc-exec.exe").expect("wxc-exec.exe should be available");
+    let encoded = STANDARD.encode(config.to_string().as_bytes());
+
+    let mut args: Vec<String> = extra_args.iter().map(|s| (*s).to_string()).collect();
+    args.push("--config-base64".to_string());
+    args.push(encoded);
+
+    run_executable(label, &exe, args)
+}
+
 /// Run `wxc-test-driver.exe` against a directory or a single config file.
 pub fn run_test_driver(target: &Path, extra_args: &[&str]) -> CommandResult {
     let exe = find_binary("wxc-test-driver.exe").expect("wxc-test-driver.exe should be available");

--- a/src/testing/wxc_e2e_tests/tests/e2e_linux_microvm.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_linux_microvm.rs
@@ -72,6 +72,34 @@ fn test_microvm_hello() {
     );
 }
 
+#[test]
+fn test_microvm_network() {
+    if !skip_unless_ready() {
+        return;
+    }
+    // Exercises the `-allow-host-networking` path on Linux/KVM: the guest runs
+    // a loopback TCP ping/pong round-trip and prints NET_OK. Without host
+    // networking the guest socket() fails (errno 134), so a clean exit plus
+    // the marker confirms the flag is wired through for the cold-boot path.
+    let result = run_lxc_config("microvm_network_linux.json", &["--debug", "--experimental"]);
+    assert_eq!(
+        result.code,
+        Some(0),
+        "expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        result.code,
+        result.stdout,
+        result.stderr
+    );
+    assert!(
+        result
+            .combined_output_with_decoded_base64()
+            .contains("NET_OK"),
+        "guest network round-trip marker missing\nstdout: {}\nstderr: {}",
+        result.stdout,
+        result.stderr
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Full microvm suite (mirrors test_microvm_suite on Windows)
 // ---------------------------------------------------------------------------

--- a/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
@@ -128,6 +128,28 @@ fn microvm_basic() {
     assert_wxc_success("microvm_hello.json", &["--debug", "--experimental"]);
 }
 
+fn microvm_network() {
+    // Drives the `-allow-host-networking` path: the guest opens a loopback TCP
+    // socket, completes a ping/pong round-trip, and prints NET_OK. Without host
+    // networking enabled the guest's socket() call fails (errno 134) and the
+    // process exits non-zero, so a clean exit + marker proves the flag wiring.
+    let result = run_wxc_config("microvm_network.json", &["--debug", "--experimental"]);
+    assert_eq!(
+        result.code,
+        Some(0),
+        "expected exit 0, got {:?}\nstdout: {}\nstderr: {}",
+        result.code,
+        result.stdout,
+        result.stderr
+    );
+    let combined = result.combined_output_with_decoded_base64();
+    assert!(
+        combined.contains("NET_OK"),
+        "guest network round-trip marker missing\ncombined: {}",
+        combined
+    );
+}
+
 fn processcontainer_proxy() {
     let config = test_configs_dir().join("proxy_builtin_test.json");
     if !config.exists() {
@@ -230,6 +252,17 @@ fn test_microvm_basic() {
         return;
     }
     with_test_lock(microvm_basic);
+}
+
+#[test]
+fn test_microvm_network() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+    if !cached_has_nanvix_binaries() {
+        return;
+    }
+    with_test_lock(microvm_network);
 }
 
 #[test]

--- a/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
@@ -18,8 +18,8 @@ use wxc_e2e_tests::{
     assert_exit, assert_pwsh, assert_python, assert_success,
     assert_success_or_skip_missing_prerequisite, examples_dir, find_binary, has_daemon,
     has_hyperlight_snapshot, has_nanvix_binaries, has_test_driver, has_windows_sandbox_feature,
-    has_wxc_exe, repo_root, run_test_driver, run_wxc_config, run_wxc_state_aware, test_configs_dir,
-    TempDirs,
+    has_wxc_exe, repo_root, run_test_driver, run_wxc_config, run_wxc_config_value,
+    run_wxc_state_aware, test_configs_dir, TempDirs,
 };
 
 static HAS_WXC_EXE: OnceLock<bool> = OnceLock::new();
@@ -150,6 +150,119 @@ fn microvm_network() {
     );
 }
 
+/// Discovers a non-loopback IPv4 address of the host. nanvixd proxies guest
+/// `connect()` calls through the host network stack, so a host-routable IP
+/// gives a deterministic, internet-independent target for egress-filter tests.
+fn host_lan_ipv4() -> Option<std::net::Ipv4Addr> {
+    let sock = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    // Connecting a UDP socket sends no packets; it just selects the outbound
+    // interface so `local_addr` reports this host's routable address.
+    sock.connect("10.255.255.255:9").ok()?;
+    match sock.local_addr().ok()?.ip() {
+        std::net::IpAddr::V4(v4) if !v4.is_loopback() && !v4.is_unspecified() => Some(v4),
+        _ => None,
+    }
+}
+
+/// Returns a TCP port that is very likely closed: bind an ephemeral port, read
+/// it, then drop the listener. A guest connecting there while egress is
+/// permitted gets `ECONNREFUSED`, distinguishing "allowed but unreachable"
+/// from "blocked by the filter" (`EACCES`).
+fn likely_closed_tcp_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("read ephemeral port").port();
+    drop(listener);
+    port
+}
+
+/// Builds the guest Python that connects to `host:port` and prints the result
+/// as `RESULT CONNECT_OK` or `RESULT ERRNO <n>`. A blocked egress surfaces as
+/// `PermissionError`/`EACCES` (errno 13); an allowed-but-closed target as
+/// `ECONNREFUSED` (errno 111).
+fn egress_probe_source(host: std::net::Ipv4Addr, port: u16) -> String {
+    format!(
+        "import _socket\n\
+         s = _socket.socket(2, 1, 0)\n\
+         try:\n\
+         \x20   s.connect(('{host}', {port}))\n\
+         \x20   print('RESULT CONNECT_OK', flush=True)\n\
+         except OSError as e:\n\
+         \x20   print('RESULT ERRNO %d' % (e.errno,), flush=True)\n",
+        host = host,
+        port = port
+    )
+}
+
+/// Negative egress test: a blocklisted host must be rejected by the guest
+/// filter (Part B `-block-host`). Drives the host-networking path, asks the
+/// guest to connect to a blocked host IP, and asserts the connection is denied
+/// with `EACCES` (errno 13). A positive control connects to the same target
+/// under an allow-all policy and asserts it is *not* denied, proving the
+/// `EACCES` in the negative case comes from the filter rather than the network.
+fn microvm_network_blocked() {
+    let Some(host_ip) = host_lan_ipv4() else {
+        println!("SKIPPED: microvm_network_blocked needs a non-loopback host IPv4");
+        return;
+    };
+    let port = likely_closed_tcp_port();
+    let source = egress_probe_source(host_ip, port);
+
+    // Negative case: host is on the blocklist -> guest egress denied (EACCES).
+    let blocked = serde_json::json!({
+        "process": { "commandLine": source, "timeout": 30000 },
+        "containment": "microvm",
+        "network": { "blockedHosts": [host_ip.to_string()] }
+    });
+    let blocked_result = run_wxc_config_value(
+        "microvm_network_blocked",
+        &blocked,
+        &["--debug", "--experimental"],
+    );
+    let blocked_out = blocked_result.combined_output_with_decoded_base64();
+    assert_eq!(
+        blocked_result.code,
+        Some(0),
+        "blocked-egress run should exit cleanly (the guest catches the error)\ncombined: {}",
+        blocked_out
+    );
+    assert!(
+        blocked_out.contains("RESULT ERRNO 13"),
+        "blocklisted host should be denied with EACCES (errno 13)\ncombined: {}",
+        blocked_out
+    );
+
+    // Positive control: allow-all policy -> egress permitted, so the same
+    // closed target yields a connection error other than EACCES (typically
+    // ECONNREFUSED / errno 111), never the filter's EACCES.
+    let allowed = serde_json::json!({
+        "process": { "commandLine": source, "timeout": 30000 },
+        "containment": "microvm",
+        "network": { "defaultPolicy": "allow" }
+    });
+    let allowed_result = run_wxc_config_value(
+        "microvm_network_allowed_control",
+        &allowed,
+        &["--debug", "--experimental"],
+    );
+    let allowed_out = allowed_result.combined_output_with_decoded_base64();
+    assert_eq!(
+        allowed_result.code,
+        Some(0),
+        "allow-all control run should exit cleanly\ncombined: {}",
+        allowed_out
+    );
+    assert!(
+        allowed_out.contains("RESULT "),
+        "allow-all control should produce a connect result\ncombined: {}",
+        allowed_out
+    );
+    assert!(
+        !allowed_out.contains("RESULT ERRNO 13"),
+        "allow-all egress must not be denied with EACCES (proves filter, not network, blocks)\ncombined: {}",
+        allowed_out
+    );
+}
+
 fn processcontainer_proxy() {
     let config = test_configs_dir().join("proxy_builtin_test.json");
     if !config.exists() {
@@ -263,6 +376,17 @@ fn test_microvm_network() {
         return;
     }
     with_test_lock(microvm_network);
+}
+
+#[test]
+fn test_microvm_network_blocked() {
+    if !cached_has_wxc_exe() {
+        return;
+    }
+    if !cached_has_nanvix_binaries() {
+        return;
+    }
+    with_test_lock(microvm_network_blocked);
 }
 
 #[test]

--- a/tests/configs/microvm_network.json
+++ b/tests/configs/microvm_network.json
@@ -1,0 +1,10 @@
+{
+    "process": {
+        "commandLine": "import _socket\nsrv = _socket.socket(2, 1, 0)\nsrv.bind(('127.0.0.1', 8080))\nsrv.listen(1)\ncli = _socket.socket(2, 1, 0)\ncli.connect(('127.0.0.1', 8080))\nfd, addr = srv._accept()\nconn = _socket.socket(2, 1, 0, fd)\ncli.send(b'ping')\nassert conn.recv(64) == b'ping'\nconn.send(b'pong')\nassert cli.recv(64) == b'pong'\nprint('NET_OK loopback roundtrip', flush=True)",
+        "timeout": 30000
+    },
+    "containment": "microvm",
+    "network": {
+        "defaultPolicy": "allow"
+    }
+}

--- a/tests/configs/microvm_network_linux.json
+++ b/tests/configs/microvm_network_linux.json
@@ -1,0 +1,10 @@
+{
+    "process": {
+        "commandLine": "import _socket\nsrv = _socket.socket(2, 1, 0)\nsrv.bind(('127.0.0.1', 8080))\nsrv.listen(1)\ncli = _socket.socket(2, 1, 0)\ncli.connect(('127.0.0.1', 8080))\nfd, addr = srv._accept()\nconn = _socket.socket(2, 1, 0, fd)\ncli.send(b'ping')\nassert conn.recv(64) == b'ping'\nconn.send(b'pong')\nassert cli.recv(64) == b'pong'\nprint('NET_OK loopback roundtrip', flush=True)",
+        "timeout": 30000
+    },
+    "containment": "microvm",
+    "network": {
+        "defaultPolicy": "allow"
+    }
+}


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [x] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Adds host networking support to the NanVix (microvm) backend, wiring the MXC runner to the per-host egress filtering that nanvixd now implements.

The NanVix runner emits `-allow-host-networking` to nanvixd when `network.defaultPolicy` is `"allow"`, and forwards per-host allow/block lists as `-allow-host` / `-block-host`. Egress filtering is allow-XOR-block (an allowlist is deny-by-default; a blocklist is allow-by-default), and host resolution mirrors the `lxc` backend so the two agree on hostname-to-IPv4 mapping at preflight.

The pinned `nanvix-python` build is bumped to `3.12.3-nanvix-0.16.65-fce3620`, which bundles the nanvixd that implements per-host egress filtering, and `checksums.json` is updated to match. The schema gains `microvm` in the `allowedHosts` / `blockedHosts` backend lists, with the microvm-specific mutual-exclusivity and DNS-exemption notes.

Windows and Linux microvm networking e2e tests (`test_microvm_network`) plus their configs are added. The Windows test was run locally against the bumped nanvixd and passes (guest completes a loopback TCP round-trip and prints `NET_OK`).

### Related Issues

None.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/531)