### PR TITLE
[LXC] Enable LXC integration tests on GHA Linux runners

### DIFF
--- a/.github/workflows/SDK.Integration.Test.Job.yml
+++ b/.github/workflows/SDK.Integration.Test.Job.yml
@@ -22,10 +22,16 @@ jobs:
         working-directory: sdk/tests/integration
     env:
       MXC_SKIP_OS_BUILD_DEPENDENT_TESTS: '1'
+      # Skip network-dependent LXC tests on GHA. Capability probe
+      # 27576588204 confirmed lxc-net.service + lxcbr0 + dnsmasq come up
+      # cleanly on every supported runner, but the alpine download
+      # template's eth0 stays IPv4-less inside the test window (only an
+      # IPv6 link-local address is configured), so DHCP-dependent DNS
+      # lookups fail. The non-network LXC paths (create/start/attach/
+      # mount/exit-code/multi-command) all pass and ship LXC backend
+      # coverage on GHA. ADO sets the same env var in
+      # `.azure-pipelines/templates/SDK.Integration.Test.Job.yml`.
       MXC_SKIP_LXC_NETWORK_TESTS: '1'
-      # Classic LXC is unreliable on the GHA ubuntu-latest (24.04) runner; full
-      # LXC coverage runs in the ADO pipeline on merge to main and nightly.
-      MXC_SKIP_LXC_TESTS: '1'
     steps:
       - uses: actions/checkout@v4
 
@@ -52,12 +58,41 @@ jobs:
       - name: npm run build
         run: npm run build
 
-      - name: Install bubblewrap (Linux only, cached)
+      - name: Install bubblewrap + LXC stack (Linux only, cached)
         if: matrix.os_label == 'linux'
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: bubblewrap
-          version: 1.2
+          # Installs the LXC + Bubblewrap substrate the SDK integration
+          # tests need. Capability probe 27576588204 confirmed these
+          # packages install cleanly on ubuntu-latest, ubuntu-22.04, and
+          # ubuntu-24.04-arm and that lxc-net.service brings up the
+          # lxcbr0 bridge with dnsmasq serving DHCP on 10.0.3.0/24, so
+          # the long-standing "classic LXC is unreliable on GHA
+          # ubuntu-latest" assumption no longer holds for the non-network
+          # LXC paths (create/start/attach/mount/exit-code).
+          # The network-dependent LXC tests stay gated by
+          # MXC_SKIP_LXC_NETWORK_TESTS=1 (see the job-level env block)
+          # because the alpine download template's eth0 doesn't pick up
+          # a DHCP lease within the test window on these runners.
+          # The ADO equivalent
+          # (.azure-pipelines/templates/SDK.Integration.Test.Job.yml)
+          # installs a similar but narrower set and sets the same skip
+          # env var for the same reason (compounded by 1ES Hosted Pool
+          # egress filtering).
+          packages: bubblewrap lxc lxc-utils dnsmasq-base iptables bridge-utils
+          version: 1.3
+
+      - name: Start LXC services (cache restore skips postinst hooks)
+        if: matrix.os_label == 'linux'
+        shell: bash
+        run: |
+          # cache-apt-pkgs-action restores package files but does not
+          # re-run postinst hooks on cache hit, so AppArmor profiles
+          # (lxc-container-default) and the lxc-net bridge service may
+          # not be active. Load/start them explicitly so lxc-start
+          # doesn't abort with an AppArmor denial.
+          sudo apparmor_parser -rT /etc/apparmor.d/lxc* 2>/dev/null || true
+          sudo systemctl start lxc-net 2>/dev/null || true
 
       - name: Restore execute permission on mxc-exec-mac
         if: matrix.os_label == 'macos'

--- a/sdk/tests/integration/linux-process-container.test.ts
+++ b/sdk/tests/integration/linux-process-container.test.ts
@@ -18,10 +18,13 @@ import {
   spawnFromConfigAsync,
 } from './test-helpers.js';
 
-// MXC_SKIP_LXC_TESTS=1 skips the entire LXC describe block. Used by the GHA
-// PR pipeline because classic LXC is unreliable on the ubuntu-latest (24.04)
-// runner image; full LXC coverage runs in the ADO pipeline on merge to main
-// and nightly.
+// MXC_SKIP_LXC_TESTS=1 skips the entire LXC describe block. Provided as
+// an escape hatch for local dev or for CI hosts that genuinely lack the
+// LXC substrate. Both GHA and ADO Linux jobs install LXC, so the
+// non-network LXC cases run on both CI surfaces; the network-dependent
+// LXC cases are gated separately on both surfaces via
+// MXC_SKIP_LXC_NETWORK_TESTS=1 (see lxcNetworkSkipReason in
+// test-helpers.ts for the per-CI rationale).
 const skipLxcTests = process.env.MXC_SKIP_LXC_TESTS === '1';
 const lxcSkipReason = !isLinuxRoot
   ? 'Linux LXC Container tests require Linux with root privileges (sudo npm test)'

--- a/sdk/tests/integration/test-helpers.ts
+++ b/sdk/tests/integration/test-helpers.ts
@@ -145,10 +145,17 @@ export const debugSpawnOptions = {
 export const NETWORK_TEST_URL =
   'https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/npm/registry/@types/json-schema';
 
-// TODO: Investigate LXC container networking on CI agents. Containers lack
-// network bridge/NAT config on hosted Ubuntu runners, causing outbound
-// requests to fail. Needs lxcbr0 bridge + IP forwarding + DNS setup.
-// Set MXC_SKIP_LXC_NETWORK_TESTS=1 to skip network-dependent LXC tests.
+// Set MXC_SKIP_LXC_NETWORK_TESTS=1 to skip network-dependent LXC tests
+// (e.g. environments without an `lxcbr0` bridge / IP forwarding /
+// outbound network access). Both CI lanes currently set this env var:
+// GHA sets it in `.github/workflows/SDK.Integration.Test.Job.yml`
+// because the alpine download template doesn't acquire a DHCP-issued
+// IPv4 lease within the test window on the runner images, so
+// container-side DNS lookups fail; ADO sets it in
+// `.azure-pipelines/templates/SDK.Integration.Test.Job.yml` because
+// the 1ES Hosted Pool's egress firewall blocks lxcbr0-NAT'd traffic.
+// Both CIs still run the non-network LXC paths
+// (create/start/attach/mount/exit-code/multi-command) end-to-end.
 const skipLxcNetworkTests = process.env.MXC_SKIP_LXC_NETWORK_TESTS === '1';
 export const lxcNetworkSkipReason = skipLxcNetworkTests
   ? 'Skipped: LXC network not available in this environment (MXC_SKIP_LXC_NETWORK_TESTS)'


### PR DESCRIPTION
## 📖 Description
Flips the GHA SDK.Integration.Test.Job.yml Linux job to run the LXC integration tests instead of skipping the entire LXC suite. The non-network LXC paths (container create / start / lxc-attach / readwrite + readonly mounts / exit-code propagation / multi-command pipeline / backend-selection probe) now run end-to-end on the GHA ubuntu-latest runner. Network-dependent LXC tests stay gated by MXC_SKIP_LXC_NETWORK_TESTS=1 on GHA, matching ADO, because the alpine LXC download template's eth0 doesn't acquire a DHCP-issued IPv4 lease inside the test window on the GHA runner images (only an IPv6 link-local address is configured), so container-side DNS lookups fail.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/532)