### PR TITLE
chore: declare MIT license metadata for all crates

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -47,6 +47,7 @@ strip = "debuginfo"
 [workspace.package]
 version = "0.7.0"
 edition = "2021"
+license = "MIT"
 
 [workspace.dependencies]
 windows = { version = "0.62", features = [

--- a/src/backends/appcontainer/common/Cargo.toml
+++ b/src/backends/appcontainer/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "appcontainer_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 # Compile-time gate for Tier 2 (AppContainer + BFS via bfscfg.exe).

--- a/src/backends/bubblewrap/common/Cargo.toml
+++ b/src/backends/bubblewrap/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bwrap_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true }

--- a/src/backends/hyperlight/common/Cargo.toml
+++ b/src/backends/hyperlight/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hyperlight_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true }

--- a/src/backends/isolation_session/bindings/Cargo.toml
+++ b/src/backends/isolation_session/bindings/Cargo.toml
@@ -2,6 +2,7 @@
 name = "isolation_session_bindings"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]

--- a/src/backends/isolation_session/common/Cargo.toml
+++ b/src/backends/isolation_session/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "isolation_session_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true }

--- a/src/backends/lxc/common/Cargo.toml
+++ b/src/backends/lxc/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lxc_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true }

--- a/src/backends/nanvix/binaries/Cargo.toml
+++ b/src/backends/nanvix/binaries/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nanvix_binaries"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description = "Build-time download of NanVix binaries from GitHub releases"
 links = "nanvix_binaries"
 

--- a/src/backends/nanvix/build_common/Cargo.toml
+++ b/src/backends/nanvix/build_common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nanvix_build_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description = "Build-time helpers for staging NanVix micro-VM binaries (build-only; never linked into runtime)"
 
 [dependencies]

--- a/src/backends/nanvix/common/Cargo.toml
+++ b/src/backends/nanvix/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nanvix_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description = "Shared constants and configuration types for NanVix micro-VM binaries"
 
 [dependencies]

--- a/src/backends/nanvix/runner/Cargo.toml
+++ b/src/backends/nanvix/runner/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nanvix_runner"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true, features = ["microvm"] }

--- a/src/backends/seatbelt/common/Cargo.toml
+++ b/src/backends/seatbelt/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "seatbelt_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 # Provides ExecutionRequest, ContainerPolicy, SeatbeltConfig, Logger, and

--- a/src/backends/windows_sandbox/common/Cargo.toml
+++ b/src/backends/windows_sandbox/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "windows_sandbox_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 wxc_common = { workspace = true }

--- a/src/backends/windows_sandbox/daemon/Cargo.toml
+++ b/src/backends/windows_sandbox/daemon/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_windows_sandbox_daemon"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-windows-sandbox-daemon"

--- a/src/backends/windows_sandbox/guest/Cargo.toml
+++ b/src/backends/windows_sandbox/guest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_windows_sandbox_guest"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-windows-sandbox-guest"

--- a/src/backends/wslc/common/Cargo.toml
+++ b/src/backends/wslc/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wslc_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 default = []

--- a/src/core/generated/base_container_specification/Cargo.toml
+++ b/src/core/generated/base_container_specification/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sandbox_spec"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 description = "Generated FlatBuffers bindings for SandboxSpec"
 

--- a/src/core/lxc/Cargo.toml
+++ b/src/core/lxc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lxc"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "lxc-exec"

--- a/src/core/mxc_build_common/Cargo.toml
+++ b/src/core/mxc_build_common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mxc_build_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 description = "Shared build-time helpers for embedding Windows VersionInfo in MXC binaries"
 
 [target.'cfg(windows)'.dependencies]

--- a/src/core/mxc_darwin/Cargo.toml
+++ b/src/core/mxc_darwin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mxc_darwin"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "mxc-exec-mac"

--- a/src/core/mxc_pty/Cargo.toml
+++ b/src/core/mxc_pty/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mxc_pty"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Unix-only at runtime: mxc_pty wraps `openpty` + `pre_exec` (TIOCSCTTY,
 # setsid) + sigwait-style helpers, none of which have a sensible Windows

--- a/src/core/wxc/Cargo.toml
+++ b/src/core/wxc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-exec"

--- a/src/core/wxc_common/Cargo.toml
+++ b/src/core/wxc_common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_common"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 microvm = ["dep:nanvix_common", "dep:uuid"]

--- a/src/host/wxc_host_prep/Cargo.toml
+++ b/src/host/wxc_host_prep/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_host_prep"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 # Binary name uses hyphens (`wxc-host-prep`) to match the rest of the MXC
 # CLI surface (`wxc-exec`, `lxc-exec`, `mxc-exec-mac`).

--- a/src/host/wxc_winhttp_proxy_shim/Cargo.toml
+++ b/src/host/wxc_winhttp_proxy_shim/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_winhttp_proxy_shim"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "winhttp-proxy-shim"

--- a/src/testing/fuzz/Cargo.toml
+++ b/src/testing/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "mxc_fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/testing/linux_test_proxy/Cargo.toml
+++ b/src/testing/linux_test_proxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "linux_test_proxy"
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "linux-test-proxy"

--- a/src/testing/wxc_e2e_tests/Cargo.toml
+++ b/src/testing/wxc_e2e_tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_e2e_tests"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 publish = false
 description = "End-to-end integration tests for MXC"
 

--- a/src/testing/wxc_test_driver/Cargo.toml
+++ b/src/testing/wxc_test_driver/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_test_driver"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-test-driver"

--- a/src/testing/wxc_test_proxy/Cargo.toml
+++ b/src/testing/wxc_test_proxy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_test_proxy"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-test-proxy"

--- a/src/testing/wxc_ui_probe/Cargo.toml
+++ b/src/testing/wxc_ui_probe/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wxc_ui_probe"
 version = "0.1.0"
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "wxc-ui-probe"

--- a/src/tools/mxc_diagnostic_console/Cargo.toml
+++ b/src/tools/mxc_diagnostic_console/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mxc_diagnostic_console"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "mxc-diagnostic-console"


### PR DESCRIPTION
## 📖 Description

Adds explicit license metadata to every crate in the Rust workspace.

- `src/Cargo.toml` — sets `license = "MIT"` on `[workspace.package]`.
- All 30 workspace member crates — add `license.workspace = true` so they inherit the workspace license.
- `src/testing/fuzz/Cargo.toml` (`mxc_fuzz`) — gets a direct `license = "MIT"` because it is `exclude`d from the workspace and cannot inherit from `[workspace.package]`.

This is a pure metadata change: `license` lines only, no functional or build-behavior changes. Each crate's existing line endings (LF, and CRLF for `wxc_common`, `base_container_specification`, and `mxc_diagnostic_console`) were preserved.

## 🔗 References

Extracts the crate-license metadata changes from #524 into a standalone PR.

## 🔍 Validation

- `cargo metadata --no-deps` resolves `license = "MIT"` for all 30 workspace members; none missing.
- All 32 `Cargo.toml` files parse as valid TOML.
- `git diff` confirms 32 insertions, 0 deletions — every added line is a `license` declaration.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/538)