### PR TITLE
[CI] Route Unofficial/fork-PR crate downloads through Mxc-Azure-Feed

### DIFF
--- a/.azure-pipelines/templates/Cargo.Setup.Public.yml
+++ b/.azure-pipelines/templates/Cargo.Setup.Public.yml
@@ -1,14 +1,12 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# Appends the public MxcDependencies cargo feed (config.public.toml) to the
+# Appends the internal Mxc-Azure-Feed cargo feed (config.toml) to the
 # workspace .cargo/config.toml. Used by Unofficial / fork-PR Rust steps so
 # crate downloads work under 1ES pool network isolation (crates.io is not on
 # the allowlist). Mirrors the Official setup step in Rust.Build.Steps.Official.yml.
 
 steps:
   - pwsh: |
-      $cfg = "$(Build.SourcesDirectory)/.cargo/config.toml"
-      New-Item -ItemType Directory -Force -Path (Split-Path $cfg) | Out-Null
-      Add-Content -Path $cfg -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.public.toml"))
-    displayName: Setup Cargo Config (public feed)
+      Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+    displayName: Setup Cargo Config (Mxc-Azure-Feed)


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
Updating azure PR builds to use the private feed instead of the public anonymous feed. 

Only way for us to see if this is a viable option is try it out. Otherwise we need to add new dependencies to https://dev.azure.com/shine-oss/mxc/_artifacts/feed/MxcDependencies for PRs that update them.
## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->
## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/541)