### PR TITLE
Fix JOB_OBJECT_UILIMIT probe assertions in Win25H2Safe-Tests

### DIFF
--- a/src/testing/wxc_ui_probe/src/main.rs
+++ b/src/testing/wxc_ui_probe/src/main.rs
@@ -15,6 +15,9 @@
 use std::env;
 use std::ffi::c_void;
 use std::iter;
+use std::path::Path;
+use std::thread;
+use std::time::{Duration, Instant};
 
 type Bool = i32;
 type Dword = u32;
@@ -26,6 +29,34 @@ type Atom = u16;
 type FarProc = *const c_void;
 type LpcWstr = *const u16;
 type LpVoid = *mut c_void;
+
+/// Optional `--key=value` parameters supplied by the test harness on the
+/// command line for probes that require host coordination (GLOBALATOMS,
+/// HANDLES). When absent (e.g. a developer running the probe by hand) those
+/// probes emit diagnostics instead of attempting the isolation checks.
+#[derive(Debug, Default, Clone)]
+struct ProbeArgs {
+    /// Name of an atom the host planted in its session-global atom table.
+    /// The contained probe must NOT be able to find it.
+    host_name: Option<String>,
+    /// Name of an atom the contained probe creates in its (private) atom
+    /// table. The host must NOT be able to find it.
+    guest_name: Option<String>,
+    /// File the probe creates once `guest_name` has been added, signalling the
+    /// host that it may check its own atom table.
+    ready_file: Option<String>,
+    /// File the host creates once it has finished checking, releasing the
+    /// probe to delete its atom and exit.
+    release_file: Option<String>,
+    /// HWND (as an integer) of a window owned by the host process — i.e. a
+    /// USER handle owned by a process *outside* the job. Under
+    /// `JOB_OBJECT_UILIMIT_HANDLES` the contained probe must NOT be able to
+    /// use it (e.g. read its text).
+    handle_hwnd: Option<usize>,
+    /// The window title the host set on `handle_hwnd`. If the probe manages to
+    /// read this back, the handle restriction failed.
+    handle_title: Option<String>,
+}
 
 #[repr(C)]
 #[derive(Default, Clone, Copy)]
@@ -66,6 +97,7 @@ extern "system" {
     fn LoadLibraryW(name: LpcWstr) -> Hmodule;
     fn GetProcAddress(module: Hmodule, name: *const u8) -> FarProc;
     fn GlobalAddAtomW(name: LpcWstr) -> Atom;
+    fn GlobalFindAtomW(name: LpcWstr) -> Atom;
     fn GlobalDeleteAtom(atom: Atom) -> Atom;
     fn GetLastError() -> Dword;
 }
@@ -132,17 +164,91 @@ fn emit_diag(tag: &str, reason: &str) {
     println!("{}=DIAG {}", tag, reason);
 }
 
-fn probe_globalatoms() {
-    let wide = to_wide("MxcUiProbeAtom");
+/// Block until `path` exists or `timeout` elapses. Returns whether the file
+/// exists at the end. Used for the GLOBALATOMS guest->host handshake so the
+/// probe never hangs indefinitely if the host fails to release it.
+fn wait_for_file(path: &str, timeout: Duration) -> bool {
+    let p = Path::new(path);
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if p.exists() {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    p.exists()
+}
+
+/// Probe the GLOBALATOMS UI restriction (`JOB_OBJECT_UILIMIT_GLOBALATOMS`).
+///
+/// Unlike most UI limits this does NOT make the atom APIs fail: the documented
+/// behavior is that each job gets its own private atom table, so
+/// `GlobalAddAtomW` still succeeds inside the container. The restriction is
+/// therefore verified as *isolation* between the host's session-global atom
+/// table and the contained job's private table, in both directions:
+///
+/// * `GLOBALATOMS_HOST_TO_GUEST` — the host plants an atom in its global table
+///   and passes the name via `--atom-host-name`. PASS means this contained
+///   process CANNOT find it (`GlobalFindAtomW` -> 0). Decided here.
+/// * `GLOBALATOMS_GUEST_TO_HOST` — this process adds an atom named by
+///   `--atom-guest-name`, signals readiness by creating `--atom-ready-file`,
+///   then blocks until the host creates `--atom-release-file`. While the atom
+///   is held alive the host checks its own global table and records the
+///   result; this function only performs the create / hold / cleanup half.
+fn probe_globalatoms(args: &ProbeArgs) {
+    // Direction 1: host -> guest. We must not see the host's global atom.
+    match args.host_name.as_deref() {
+        Some(name) => {
+            let wide = to_wide(name);
+            let found = unsafe { GlobalFindAtomW(wide.as_ptr()) };
+            if found == 0 {
+                emit_pass("GLOBALATOMS_HOST_TO_GUEST");
+            } else {
+                emit_fail("GLOBALATOMS_HOST_TO_GUEST");
+            }
+        }
+        None => emit_diag(
+            "GLOBALATOMS_HOST_TO_GUEST",
+            "no --atom-host-name provided (run via the harness)",
+        ),
+    }
+
+    // Direction 2: guest -> host. The host must not see our atom. The PASS/FAIL
+    // verdict is recorded host-side; here we create the atom and hold it alive
+    // across the handshake.
+    let guest = match args.guest_name.as_deref() {
+        Some(g) => g,
+        None => {
+            emit_diag(
+                "GLOBALATOMS_GUEST_TO_HOST",
+                "no --atom-guest-name provided (run via the harness)",
+            );
+            return;
+        }
+    };
+    let wide = to_wide(guest);
     let atom = unsafe { GlobalAddAtomW(wide.as_ptr()) };
     if atom == 0 {
-        emit_pass("GLOBALATOMS");
+        emit_diag(
+            "GLOBALATOMS_GUEST_TO_HOST",
+            "GlobalAddAtomW failed unexpectedly",
+        );
         return;
     }
+
+    // Signal the host that the atom now exists, then hold it until released.
+    if let Some(ready) = args.ready_file.as_deref() {
+        if std::fs::write(ready, b"ready").is_err() {
+            emit_diag("GLOBALATOMS_GUEST_TO_HOST", "failed to write ready file");
+        }
+    }
+    if let Some(release) = args.release_file.as_deref() {
+        let _ = wait_for_file(release, Duration::from_secs(15));
+    }
+
     unsafe {
         let _ = GlobalDeleteAtom(atom);
     }
-    emit_fail("GLOBALATOMS");
 }
 
 fn probe_readclipboard(user32: Hmodule) {
@@ -352,25 +458,51 @@ fn probe_exitwindows(user32: Hmodule) {
     }
 }
 
-fn probe_handles(user32: Hmodule) {
-    type FindWindowWFn = unsafe extern "system" fn(LpcWstr, LpcWstr) -> Hwnd;
-    let find = match get_proc(user32, "FindWindowW") {
-        Some(p) => unsafe { std::mem::transmute::<FarProc, FindWindowWFn>(p) },
+/// Probe the HANDLES UI restriction (`JOB_OBJECT_UILIMIT_HANDLES`).
+///
+/// This limit does NOT stop `FindWindow` from returning HWNDs — it blocks
+/// *using* USER handles owned by processes outside the job. So isolation is
+/// verified by attempting to read the title of a window the host created
+/// (a USER handle owned by a process outside the job): `GetWindowTextW`
+/// reaches an external window via `WM_GETTEXT`, which the limit rejects at
+/// the sender. PASS means we could NOT read it (empty / blocked); FAIL means
+/// we read back the host's sentinel title.
+fn probe_handles(user32: Hmodule, args: &ProbeArgs) {
+    let hwnd_val = match args.handle_hwnd {
+        Some(h) => h,
         None => {
-            emit_diag("HANDLES", "FindWindowW not resolvable");
+            emit_diag("HANDLES", "no --handle-hwnd provided (run via the harness)");
+            return;
+        }
+    };
+    type GetWindowTextWFn = unsafe extern "system" fn(Hwnd, *mut u16, i32) -> i32;
+    let get_text = match get_proc(user32, "GetWindowTextW") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, GetWindowTextWFn>(p) },
+        None => {
+            emit_diag("HANDLES", "GetWindowTextW not resolvable");
             emit_fail("HANDLES");
             return;
         }
     };
-    // FindWindowW(NULL, NULL) returns the top-level desktop window when
-    // the process can enumerate global window handles. With UILIMIT_HANDLES
-    // set, the call sees only handles created inside the job (none here)
-    // and returns NULL.
-    let hwnd = unsafe { find(std::ptr::null(), std::ptr::null()) };
-    if hwnd.is_null() {
+
+    let hwnd = hwnd_val as Hwnd;
+    let mut buf = [0u16; 256];
+    let len = unsafe { get_text(hwnd, buf.as_mut_ptr(), buf.len() as i32) };
+    if len <= 0 {
+        // Could not read the external window's text -> the cross-job
+        // WM_GETTEXT was blocked.
         emit_pass("HANDLES");
-    } else {
-        emit_fail("HANDLES");
+        return;
+    }
+
+    let text = String::from_utf16_lossy(&buf[..len as usize]);
+    match args.handle_title.as_deref() {
+        Some(expected) if text == expected => emit_fail("HANDLES"),
+        Some(_) => {
+            emit_diag("HANDLES", "read unexpected window text");
+            emit_fail("HANDLES");
+        }
+        None => emit_fail("HANDLES"),
     }
 }
 
@@ -392,9 +524,9 @@ fn probe_win32k(user32: Hmodule) {
     emit_fail("WIN32K");
 }
 
-fn run_probe(tag: &str, user32: Option<Hmodule>) {
+fn run_probe(tag: &str, user32: Option<Hmodule>, probe_args: &ProbeArgs) {
     match tag {
-        "GLOBALATOMS" => probe_globalatoms(),
+        "GLOBALATOMS" => probe_globalatoms(probe_args),
         "READCLIPBOARD" => match user32 {
             Some(h) => probe_readclipboard(h),
             None => {
@@ -439,7 +571,7 @@ fn run_probe(tag: &str, user32: Option<Hmodule>) {
             }
         },
         "HANDLES" => match user32 {
-            Some(h) => probe_handles(h),
+            Some(h) => probe_handles(h, probe_args),
             None => {
                 emit_diag("HANDLES", "user32.dll not loadable");
                 emit_fail("HANDLES");
@@ -449,8 +581,18 @@ fn run_probe(tag: &str, user32: Option<Hmodule>) {
             Some(h) if destructive_probe_allowed() => probe_win32k(h),
             Some(_) => refuse_destructive("WIN32K"),
             None => {
-                emit_diag("WIN32K", "user32.dll not loadable");
-                emit_fail("WIN32K");
+                // user32 failed to load. Under the Win32k syscall-disable
+                // mitigation (ui.disable=true) this is expected: user32's
+                // initialization makes win32k syscalls the mitigation blocks,
+                // so the GUI subsystem is unavailable. That is a
+                // mitigation-honored outcome, NOT a failure — emit a DIAG only
+                // and deliberately do not emit PASS or FAIL (the harness keys
+                // off the ABSENCE of WIN32K=FAIL/PASS, same as the
+                // killed-on-syscall path).
+                emit_diag(
+                    "WIN32K",
+                    "user32.dll not loadable (GUI subsystem blocked by Win32k mitigation)",
+                );
             }
         },
         other => {
@@ -462,27 +604,56 @@ fn run_probe(tag: &str, user32: Option<Hmodule>) {
     let _ = std::io::stdout().flush();
 }
 
-fn collect_tags() -> Vec<String> {
-    let mut tags: Vec<String> = env::args().skip(1).collect();
-    if tags.is_empty() {
+/// Collect raw arguments, falling back to `MXC_UI_PROBE_TAGS` when no
+/// positional arguments are supplied. Returned values include both probe tags
+/// and any `--key=value` flags; `parse_args` separates them.
+fn collect_raw_args() -> Vec<String> {
+    let mut raw: Vec<String> = env::args().skip(1).collect();
+    if raw.is_empty() {
         if let Ok(v) = env::var("MXC_UI_PROBE_TAGS") {
-            tags = v
+            raw = v
                 .split(|c: char| c == ',' || c.is_whitespace())
                 .filter(|s| !s.is_empty())
                 .map(|s| s.to_string())
                 .collect();
         }
     }
-    tags
+    raw
+}
+
+/// Split raw arguments into positional probe tags and the optional
+/// `--key=value` flags that parameterize the host-coordinated probes
+/// (GLOBALATOMS handshake, HANDLES external-window access). Unknown flags are
+/// ignored so the probe stays forward-compatible with the harness.
+fn parse_args(raw: Vec<String>) -> (Vec<String>, ProbeArgs) {
+    let mut tags = Vec::new();
+    let mut args = ProbeArgs::default();
+    for arg in raw {
+        match arg.strip_prefix("--").and_then(|rest| rest.split_once('=')) {
+            Some(("atom-host-name", value)) => args.host_name = Some(value.to_string()),
+            Some(("atom-guest-name", value)) => args.guest_name = Some(value.to_string()),
+            Some(("atom-ready-file", value)) => args.ready_file = Some(value.to_string()),
+            Some(("atom-release-file", value)) => args.release_file = Some(value.to_string()),
+            Some(("handle-hwnd", value)) => args.handle_hwnd = value.parse::<usize>().ok(),
+            Some(("handle-title", value)) => args.handle_title = Some(value.to_string()),
+            Some(_) => {} // unknown flag: ignore
+            None => tags.push(arg),
+        }
+    }
+    (tags, args)
 }
 
 fn main() {
-    let tags = collect_tags();
+    let (tags, probe_args) = parse_args(collect_raw_args());
     if tags.is_empty() {
         eprintln!(
             "usage: wxc-ui-probe <TAG>... (or MXC_UI_PROBE_TAGS=TAG,TAG); \
              valid tags: GLOBALATOMS READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS \
-             DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES WIN32K"
+             DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES WIN32K. \
+             GLOBALATOMS accepts --atom-host-name=, --atom-guest-name=, \
+             --atom-ready-file=, --atom-release-file= for the host/guest \
+             isolation handshake; HANDLES accepts --handle-hwnd=, --handle-title= \
+             for the external-window access check."
         );
         std::process::exit(2);
     }
@@ -497,9 +668,9 @@ fn main() {
     // every other probe gets a chance to report.
     let (win32k, rest): (Vec<_>, Vec<_>) = tags.into_iter().partition(|t| t == "WIN32K");
     for tag in rest {
-        run_probe(&tag, user32);
+        run_probe(&tag, user32, &probe_args);
     }
     for tag in win32k {
-        run_probe(&tag, user32);
+        run_probe(&tag, user32, &probe_args);
     }
 }

--- a/src/testing/wxc_ui_probe/src/main.rs
+++ b/src/testing/wxc_ui_probe/src/main.rs
@@ -243,7 +243,18 @@ fn probe_globalatoms(args: &ProbeArgs) {
         }
     }
     if let Some(release) = args.release_file.as_deref() {
-        let _ = wait_for_file(release, Duration::from_secs(15));
+        // Wait comfortably longer than the harness's readiness window (30s) so a
+        // loaded host can't make us delete the atom before its GlobalFindAtomW
+        // check runs — which would otherwise read as a false "isolated". On
+        // timeout, surface a DIAG so the (otherwise silent) stall is diagnosable
+        // rather than being misread as a pass.
+        let released = wait_for_file(release, Duration::from_secs(60));
+        if !released {
+            emit_diag(
+                "GLOBALATOMS_GUEST_TO_HOST",
+                "release file not seen within 60s; host check may be unreliable",
+            );
+        }
     }
 
     unsafe {

--- a/tests/scripts/Win25H2Safe-Tests.ps1
+++ b/tests/scripts/Win25H2Safe-Tests.ps1
@@ -1130,10 +1130,16 @@ function Invoke-GlobalAtomProbe {
     $sbErr = New-Object System.Text.StringBuilder
     $p = New-Object System.Diagnostics.Process
     $p.StartInfo = $psi
-    $outEvt = Register-ObjectEvent -InputObject $p -EventName OutputDataReceived -MessageData $sbOut -Action {
+    # Use explicit SourceIdentifiers so the finally block can unregister the
+    # subscriptions AND remove the backing PSEventJobs unambiguously.
+    # Unregister-Event removes only the subscription, not the job it created,
+    # so without Remove-Job the jobs accumulate across same-session re-runs.
+    $outSid = "MxcGAOut_$suffix"
+    $errSid = "MxcGAErr_$suffix"
+    $outEvt = Register-ObjectEvent -InputObject $p -EventName OutputDataReceived -SourceIdentifier $outSid -MessageData $sbOut -Action {
         if ($null -ne $EventArgs.Data) { [void]$Event.MessageData.AppendLine($EventArgs.Data) }
     }
-    $errEvt = Register-ObjectEvent -InputObject $p -EventName ErrorDataReceived -MessageData $sbErr -Action {
+    $errEvt = Register-ObjectEvent -InputObject $p -EventName ErrorDataReceived -SourceIdentifier $errSid -MessageData $sbErr -Action {
         if ($null -ne $EventArgs.Data) { [void]$Event.MessageData.AppendLine($EventArgs.Data) }
     }
 
@@ -1168,8 +1174,12 @@ function Invoke-GlobalAtomProbe {
     finally {
         # Remove the host-planted atom regardless of outcome.
         [void][Mxc.AtomNative]::GlobalDeleteAtom($hostAtom)
-        if ($outEvt) { Unregister-Event -SourceIdentifier $outEvt.Name -ErrorAction SilentlyContinue }
-        if ($errEvt) { Unregister-Event -SourceIdentifier $errEvt.Name -ErrorAction SilentlyContinue }
+        # Unregister the subscriptions, then remove the PSEventJobs they
+        # created (Unregister-Event leaves the job behind).
+        foreach ($sid in @($outSid, $errSid)) {
+            Unregister-Event -SourceIdentifier $sid -ErrorAction SilentlyContinue
+            Remove-Job -Name $sid -Force -ErrorAction SilentlyContinue
+        }
     }
 
     $stdout = $sbOut.ToString()

--- a/tests/scripts/Win25H2Safe-Tests.ps1
+++ b/tests/scripts/Win25H2Safe-Tests.ps1
@@ -51,19 +51,121 @@ param(
     [string]$CargoLog       = (Join-Path $env:TEMP 'Win25H2Safe-Tests.cargo.log'),
     [switch]$SkipBuild,
     [switch]$SkipReleaseLane,
-    [switch]$KeepArtifacts
+    [switch]$KeepArtifacts,
+    # Restrict execution to a subset of phases (build + preflight + scratch
+    # init always run). Accepts the phase keys listed in $AllPhases below, e.g.
+    # -Phases UiMitigationMatrix runs only Phase 4b. Empty = run all phases.
+    [string[]]$Phases = @()
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
-# The UI-mitigation probe binary refuses EXITWINDOWS / WIN32K by
-# default — running those operations outside a sandbox can log out
-# the interactive user. Set the explicit override here so the AC
-# child wxc_ui_probe inherits it via wxc-exec's env-passthrough.
-# Without this, Phase 4b's EXITWINDOWS / WIN32K assertions fail with
-# "DIAG: refused".
-$env:MXC_PROBE_DESTRUCTIVE_OK = '1'
+# The UI-mitigation probe binary refuses EXITWINDOWS / WIN32K by default —
+# running those operations outside a sandbox can log out the interactive
+# user. The contained child must see MXC_PROBE_DESTRUCTIVE_OK=1 to attempt
+# them. NOTE: the AppContainer (T3) runner REPLACES the child environment with
+# the config's `process.env` whenever it is non-empty (it only falls back to
+# CreateEnvironmentBlock when env is empty), so a process-level `$env:` here
+# would NOT reach the child. The override is therefore delivered per-run via
+# New-Config -Env (see Get-ProbeEnvWithDestructive). That env block must be
+# COMPLETE — CreateProcessW requires at least %SystemRoot% and fails with
+# ERROR_ENVVAR_NOT_FOUND (0x800700CB) on a one-var block — so we pass the full
+# current environment plus the override, not just the override alone.
+
+# kernel32 atom-table P/Invoke used by Phase-GlobalAtomIsolation to plant a
+# host-side global atom (direction 1) and to probe its own session-global
+# table for the contained process's atom (direction 2). Guarded so a re-run
+# in the same PowerShell session doesn't throw "type already exists".
+if (-not ([System.Management.Automation.PSTypeName]'Mxc.AtomNative').Type) {
+    Add-Type -Namespace 'Mxc' -Name 'AtomNative' -MemberDefinition @'
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern ushort GlobalAddAtomW(string lpString);
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern ushort GlobalFindAtomW(string lpString);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern ushort GlobalDeleteAtom(ushort nAtom);
+'@ | Out-Null
+}
+
+# A hidden, message-pumping top-level window owned by the harness process —
+# used by Phase 4b's HANDLES probe as a USER handle owned by a process OUTSIDE
+# the job. The window runs its message loop on a dedicated background thread so
+# a cross-job GetWindowTextW (WM_GETTEXT) is answered promptly in the (broken)
+# case where the JOB_OBJECT_UILIMIT_HANDLES limit fails to block it.
+if (-not ([System.Management.Automation.PSTypeName]'Mxc.WindowHost').Type) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Mxc {
+    public class WindowHost {
+        [StructLayout(LayoutKind.Sequential)]
+        private struct MSG { public IntPtr hwnd; public uint message; public IntPtr wParam; public IntPtr lParam; public uint time; public int ptX; public int ptY; }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateWindowExW(int dwExStyle, string lpClassName, string lpWindowName, int dwStyle, int x, int y, int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance, IntPtr lpParam);
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyWindow(IntPtr hWnd);
+        [DllImport("user32.dll")]
+        private static extern int GetMessageW(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+        [DllImport("user32.dll")]
+        private static extern bool TranslateMessage(ref MSG lpMsg);
+        [DllImport("user32.dll")]
+        private static extern IntPtr DispatchMessageW(ref MSG lpMsg);
+        [DllImport("user32.dll")]
+        private static extern bool PostThreadMessageW(uint idThread, uint Msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("kernel32.dll")]
+        private static extern uint GetCurrentThreadId();
+
+        private const uint WM_QUIT = 0x0012;
+        private const int WS_EX_TOOLWINDOW = 0x00000080;
+
+        private Thread _thread;
+        private uint _threadId;
+        private volatile IntPtr _hwnd = IntPtr.Zero;
+        private readonly ManualResetEventSlim _ready = new ManualResetEventSlim(false);
+        private string _title;
+
+        public IntPtr Hwnd { get { return _hwnd; } }
+        public string Title { get { return _title; } }
+
+        public void Start(string title) {
+            _title = title;
+            _thread = new Thread(Run);
+            _thread.IsBackground = true;
+            _thread.Start();
+            if (!_ready.Wait(5000)) { throw new Exception("WindowHost: window creation timed out"); }
+            if (_hwnd == IntPtr.Zero) { throw new Exception("WindowHost: CreateWindowExW failed"); }
+        }
+
+        private void Run() {
+            _threadId = GetCurrentThreadId();
+            // The system "STATIC" class needs no registration; omitting
+            // WS_VISIBLE keeps the window hidden. Its caption is the sentinel
+            // title that WM_GETTEXT (DefWindowProc) returns.
+            _hwnd = CreateWindowExW(WS_EX_TOOLWINDOW, "STATIC", _title, 0, 0, 0, 0, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            _ready.Set();
+            if (_hwnd == IntPtr.Zero) { return; }
+            MSG msg;
+            // GetMessageW returns 0 on WM_QUIT and -1 on error; exit on both.
+            while (GetMessageW(out msg, IntPtr.Zero, 0, 0) > 0) {
+                TranslateMessage(ref msg);
+                DispatchMessageW(ref msg);
+            }
+            DestroyWindow(_hwnd);
+        }
+
+        public void Stop() {
+            if (_thread == null) { return; }
+            if (_threadId != 0) { PostThreadMessageW(_threadId, WM_QUIT, IntPtr.Zero, IntPtr.Zero); }
+            _thread.Join(3000);
+        }
+    }
+}
+'@ | Out-Null
+}
 
 # -----------------------------------------------------------------------
 # Result accumulator
@@ -278,6 +380,25 @@ function Assert-NoBfscfg {
 # -----------------------------------------------------------------------
 # Config generation
 # -----------------------------------------------------------------------
+# Build a COMPLETE environment block (current process env + the destructive
+# override) for delivery to the contained probe via New-Config -Env. The T3
+# runner replaces the child env with process.env when it is non-empty, and
+# CreateProcessW requires a full block (notably %SystemRoot%), so passing only
+# the override would fail with ERROR_ENVVAR_NOT_FOUND (0x800700CB).
+function Get-ProbeEnvWithDestructive {
+    $list = New-Object System.Collections.Generic.List[string]
+    foreach ($e in [System.Environment]::GetEnvironmentVariables().GetEnumerator()) {
+        $k = [string]$e.Key
+        # Skip the hidden per-drive "=C:" cwd vars and any empty key; skip the
+        # override (re-added below) and the test-only tier knob.
+        if ([string]::IsNullOrEmpty($k) -or $k.StartsWith('=')) { continue }
+        if ($k -ieq 'MXC_PROBE_DESTRUCTIVE_OK' -or $k -ieq 'MXC_FORCE_TIER') { continue }
+        [void]$list.Add("$k=$($e.Value)")
+    }
+    [void]$list.Add('MXC_PROBE_DESTRUCTIVE_OK=1')
+    return $list.ToArray()
+}
+
 function New-Config {
     param(
         [Parameter(Mandatory)] [string]$Name,
@@ -293,7 +414,8 @@ function New-Config {
         [string]$BpUiSystemSettings         = $null,
         [Nullable[bool]]$BpUiIme            = $null,
         [string]$Clipboard                  = $null,
-        [Nullable[bool]]$Injection          = $null
+        [Nullable[bool]]$Injection          = $null,
+        [string[]]$Env                      = @()
     )
     $obj = [ordered]@{
         version     = '0.5.0-dev'
@@ -304,6 +426,7 @@ function New-Config {
             timeout     = $TimeoutMs
         }
     }
+    if ($Env.Count -gt 0) { $obj['process']['env'] = @($Env) }
     if ($ReadWrite.Count -gt 0 -or $ReadOnly.Count -gt 0 -or $Denied.Count -gt 0) {
         $fs = [ordered]@{}
         if ($ReadWrite.Count -gt 0) { $fs['readwritePaths'] = @($ReadWrite) }
@@ -820,50 +943,100 @@ function Phase-UiMitigationMatrix {
     # injection=false. base_process_ui: isolation=container (HANDLES +
     # GLOBALATOMS), desktopSystemControl=false (DESKTOP + EXITWINDOWS),
     # systemSettings=none (SYSTEMPARAMETERS + DISPLAYSETTINGS), ime=false.
-    $probeArgsA = 'GLOBALATOMS READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES'
-    $cmdA = "`"$UiProbeDebug`" $probeArgsA"
-    $cfgA = New-Config -Name 'ui-matrix-A-allbits' `
-        -CommandLine $cmdA `
-        -ReadWrite @($rw) `
-        -UiDisable $false `
-        -Clipboard 'none' `
-        -Injection $false `
-        -BpUiIsolation 'container' `
-        -BpUiDesktopControl $false `
-        -BpUiSystemSettings 'none' `
-        -BpUiIme $false
-    $logA = Join-Path $ScratchRoot 'logs\ui-matrix-A.log'
-    $rA = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgA -LogPath $logA
-    $logContentA = Read-Log $logA
-    Assert-NoBfscfg -LogContent $logContentA -Phase 'P4b' -Name 'ui-matrix-A'
+    # NOTE: GLOBALATOMS is NOT probed here. JOB_OBJECT_UILIMIT_GLOBALATOMS
+    # does not fail the atom APIs — it gives the job a private atom table —
+    # so it cannot be verified with the simple "API failed -> PASS" matrix.
+    # Phase-GlobalAtomIsolation covers it with a bidirectional isolation test.
+    # Create a hidden, message-pumping window owned by THIS (out-of-job)
+    # process. Its USER handle is what the HANDLES probe must NOT be able to
+    # reach: JOB_OBJECT_UILIMIT_HANDLES does not stop FindWindow from returning
+    # HWNDs — it blocks USING handles owned by processes outside the job — so
+    # the probe reads the window's title via GetWindowTextW (a cross-job
+    # WM_GETTEXT). PASS = it could not read the sentinel; FAIL = it read it.
+    # The window pumps messages on its own thread so the broken case returns
+    # the title promptly instead of hanging; the working case never delivers
+    # the message (rejected at the sender), so no pump dependency there.
+    $handleTitle = "MxcHandleProbe_$([guid]::NewGuid().ToString('N'))"
+    $winHost = New-Object Mxc.WindowHost
+    $winHost.Start($handleTitle)
+    try {
+        $hwndVal = $winHost.Hwnd.ToInt64()
+        $probeArgsA = 'READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES'
+        $cmdA = "`"$UiProbeDebug`" $probeArgsA --handle-hwnd=$hwndVal --handle-title=`"$handleTitle`""
+        $cfgA = New-Config -Name 'ui-matrix-A-allbits' `
+            -CommandLine $cmdA `
+            -ReadWrite @($rw) `
+            -UiDisable $false `
+            -Clipboard 'none' `
+            -Injection $false `
+            -BpUiIsolation 'container' `
+            -BpUiDesktopControl $false `
+            -BpUiSystemSettings 'none' `
+            -BpUiIme $false `
+            -Env (Get-ProbeEnvWithDestructive)
+        $logA = Join-Path $ScratchRoot 'logs\ui-matrix-A.log'
+        $rA = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgA -LogPath $logA
+        $logContentA = Read-Log $logA
+        Assert-NoBfscfg -LogContent $logContentA -Phase 'P4b' -Name 'ui-matrix-A'
 
-    $matrixA = @{}
-    foreach ($line in ($rA.Stdout -split "`r?`n")) {
-        if ($line -match '^(?<k>GLOBALATOMS|READCLIPBOARD|WRITECLIPBOARD|SYSTEMPARAMETERS|DISPLAYSETTINGS|DESKTOP|EXITWINDOWS|HANDLES|WIN32K)=(?<v>PASS|FAIL)\s*$') {
-            $matrixA[$matches['k']] = $matches['v']
+        $matrixA = @{}
+        foreach ($line in ($rA.Stdout -split "`r?`n")) {
+            if ($line -match '^(?<k>READCLIPBOARD|WRITECLIPBOARD|SYSTEMPARAMETERS|DISPLAYSETTINGS|DESKTOP|EXITWINDOWS|HANDLES|WIN32K)=(?<v>PASS|FAIL)\s*$') {
+                $matrixA[$matches['k']] = $matches['v']
+            }
         }
+        $summaryA = ($matrixA.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ' '
+
+        Record-Result -Phase 'P4b' -Name 'scenarioA: UI Job Object assigned telemetry' -Pass ([bool]($logContentA -match 'UI Job Object assigned'))
+        Record-Result -Phase 'P4b' -Name 'scenarioA: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentA -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+        # ui.disable=false on this run: Win32k mitigation applied must NOT appear.
+        Record-Result -Phase 'P4b' -Name 'scenarioA: no Win32k mitigation applied (ui.disable=false)' -Pass (-not ($logContentA -match 'Win32k mitigation applied'))
+
+        foreach ($tag in @('READCLIPBOARD','WRITECLIPBOARD','SYSTEMPARAMETERS','DISPLAYSETTINGS','DESKTOP','EXITWINDOWS','HANDLES')) {
+            $got = if ($matrixA.ContainsKey($tag)) { $matrixA[$tag] } else { '<missing>' }
+            Record-Result -Phase 'P4b' -Name "scenarioA: $tag blocked (probe -> PASS)" -Pass ($got -eq 'PASS') -Detail "got=$got; full=$summaryA"
+        }
+
+        # Negative control for HANDLES: same probe + host window, but
+        # isolation=desktop sets NO UILIMIT_HANDLES. The probe MUST be able to
+        # read the external window's title -> HANDLES=FAIL, proving the
+        # HANDLES=PASS above is a real isolation result and not vacuous (e.g.
+        # GetWindowTextW returning empty for an unrelated reason).
+        $cmdAneg = "`"$UiProbeDebug`" HANDLES --handle-hwnd=$hwndVal --handle-title=`"$handleTitle`""
+        $cfgAneg = New-Config -Name 'ui-matrix-A-handles-neg' `
+            -CommandLine $cmdAneg `
+            -ReadWrite @($rw) `
+            -UiDisable $false `
+            -BpUiIsolation 'desktop' `
+            -Env (Get-ProbeEnvWithDestructive)
+        $logAneg = Join-Path $ScratchRoot 'logs\ui-matrix-A-handles-neg.log'
+        $rAneg = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgAneg -LogPath $logAneg
+        Assert-NoBfscfg -LogContent (Read-Log $logAneg) -Phase 'P4b' -Name 'ui-matrix-A-handles-neg'
+        $negHandles = if ($rAneg.Stdout -match '(?m)^HANDLES=(?<v>PASS|FAIL)\s*$') { $matches['v'] } else { '<missing>' }
+        Record-Result -Phase 'P4b' -Name 'negative control: HANDLES visible without UILIMIT_HANDLES (probe -> FAIL)' -Pass ($negHandles -eq 'FAIL') -Detail "got=$negHandles; stdout=$($rAneg.Stdout.Trim())"
     }
-    $summaryA = ($matrixA.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ' '
-
-    Record-Result -Phase 'P4b' -Name 'scenarioA: UI Job Object assigned telemetry' -Pass ([bool]($logContentA -match 'UI Job Object assigned'))
-    Record-Result -Phase 'P4b' -Name 'scenarioA: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentA -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
-    # ui.disable=false on this run: Win32k mitigation applied must NOT appear.
-    Record-Result -Phase 'P4b' -Name 'scenarioA: no Win32k mitigation applied (ui.disable=false)' -Pass (-not ($logContentA -match 'Win32k mitigation applied'))
-
-    foreach ($tag in @('GLOBALATOMS','READCLIPBOARD','WRITECLIPBOARD','SYSTEMPARAMETERS','DISPLAYSETTINGS','DESKTOP','EXITWINDOWS','HANDLES')) {
-        $got = if ($matrixA.ContainsKey($tag)) { $matrixA[$tag] } else { '<missing>' }
-        Record-Result -Phase 'P4b' -Name "scenarioA: $tag blocked (probe -> PASS)" -Pass ($got -eq 'PASS') -Detail "got=$got; full=$summaryA"
+    finally {
+        $winHost.Stop()
     }
 
     # ---------------- Scenario B: ui.disable=true (Win32k mitigation) ----
-    # WIN32K probe makes a Win32k syscall (GetMessageW). With the
-    # mitigation in place the kernel terminates the process. If the
-    # mitigation is NOT honored the probe prints WIN32K=FAIL and exits 0.
+    # WIN32K probe makes a Win32k syscall (GetMessageW). The mitigation is
+    # honored in either of two ways depending on the host:
+    #   * user32.dll loads, the GetMessageW syscall is reached, and the kernel
+    #     terminates the process — the probe prints nothing; or
+    #   * user32.dll fails to load at all (its init makes blocked win32k
+    #     syscalls) — the probe prints a WIN32K=DIAG line and nothing else.
+    # Either way the child must print neither WIN32K=FAIL nor WIN32K=PASS. If
+    # the mitigation is NOT honored, user32 loads and GetMessageW returns, so
+    # the probe prints WIN32K=FAIL. WIN32K is destructive-gated, so the
+    # MXC_PROBE_DESTRUCTIVE_OK override must reach the child (via the full env
+    # block) for the GetMessageW path to be attempted.
     $cmdB = "`"$UiProbeDebug`" WIN32K"
     $cfgB = New-Config -Name 'ui-matrix-B-win32k' `
         -CommandLine $cmdB `
         -ReadWrite @($rw) `
-        -UiDisable $true
+        -UiDisable $true `
+        -Env (Get-ProbeEnvWithDestructive)
     $logB = Join-Path $ScratchRoot 'logs\ui-matrix-B.log'
     $rB = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgB -LogPath $logB
     $logContentB = Read-Log $logB
@@ -879,6 +1052,158 @@ function Phase-UiMitigationMatrix {
     # by the kernel; without it the probe completes and exits 0.
     Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=FAIL (mitigation honored)' -Pass (-not $printedFail) -Detail "exit=$($rB.ExitCode); stdout=$($rB.Stdout.Trim())"
     Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=PASS' -Pass (-not $printedPass) -Detail 'probe never returns PASS for WIN32K (process is killed before printing)'
+}
+
+# -----------------------------------------------------------------------
+# Phase 4c — GLOBALATOMS bidirectional isolation (T3 forced)
+#
+# JOB_OBJECT_UILIMIT_GLOBALATOMS does NOT make the atom APIs fail — the
+# documented behavior is that each job gets its own private atom table, so
+# GlobalAddAtomW still succeeds inside the container. The restriction is
+# therefore verified as *isolation* between the host's session-global atom
+# table and the contained job's private table, in BOTH directions:
+#
+#   * host -> guest: the host plants a global atom and passes its name to the
+#     probe. The probe must NOT be able to find it. Decided by the probe and
+#     printed as GLOBALATOMS_HOST_TO_GUEST=PASS|FAIL.
+#   * guest -> host: the probe adds its own atom, creates the ready file, and
+#     blocks until the host creates the release file. While the probe holds
+#     the atom alive the host checks its own global table and must NOT find
+#     it. Decided here (the job-private table is torn down when the container
+#     exits, so the check MUST happen while the probe is still alive — hence
+#     the handshake).
+# -----------------------------------------------------------------------
+function Invoke-GlobalAtomProbe {
+    # Runs the GLOBALATOMS bidirectional handshake once with the given
+    # isolation mode and returns the observed results so the caller can assert
+    # either the isolated (container) or non-isolated (desktop) expectation.
+    # Returns: HostToGuest (PASS|FAIL|<missing>), GuestFound (UInt16 atom, or
+    # $null if the probe never signalled ready), TierMatch (bool), Detail.
+    param(
+        [Parameter(Mandatory)] [string]$Isolation,
+        [Parameter(Mandatory)] [string]$Name
+    )
+    $rw = Join-Path $ScratchRoot 'rw'
+    New-Item -ItemType Directory -Path $rw -Force | Out-Null
+
+    $suffix      = [guid]::NewGuid().ToString('N')
+    $hostName    = "MxcWin25H2HostAtom_$suffix"
+    $guestName   = "MxcWin25H2GuestAtom_$suffix"
+    $readyFile   = Join-Path $rw "globalatom-ready-$suffix"
+    $releaseFile = Join-Path $rw "globalatom-release-$suffix"
+    Remove-Item -LiteralPath $readyFile, $releaseFile -ErrorAction SilentlyContinue
+
+    # Plant the host-side global atom (the direction-1 reference). Held alive
+    # until the finally block — PowerShell stays running, so it persists for
+    # the whole contained run.
+    $hostAtom = [Mxc.AtomNative]::GlobalAddAtomW($hostName)
+    if ($hostAtom -eq 0) {
+        return [pscustomobject]@{ HostToGuest = '<missing>'; GuestFound = $null; TierMatch = $false; Detail = 'host GlobalAddAtomW returned 0' }
+    }
+
+    $cmd = "`"$UiProbeDebug`" GLOBALATOMS " +
+        "--atom-host-name=$hostName --atom-guest-name=$guestName " +
+        "--atom-ready-file=`"$readyFile`" --atom-release-file=`"$releaseFile`""
+    $cfg = New-Config -Name $Name `
+        -CommandLine $cmd `
+        -ReadWrite @($rw) `
+        -UiDisable $false `
+        -BpUiIsolation $Isolation
+    $log = Join-Path $ScratchRoot "logs\$Name.log"
+
+    # Match Invoke-Wxc's defensive scrub of the test-only tier override.
+    Remove-Item Env:\MXC_FORCE_TIER -ErrorAction SilentlyContinue
+
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $WxcDebug
+    $psi.Arguments = "--config `"$cfg`" --experimental --log-file `"$log`""
+    $psi.RedirectStandardOutput = $true
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow  = $true
+
+    # The probe blocks mid-run waiting on the release file, so we cannot use
+    # the synchronous Invoke-Wxc (which reads stdout only after exit). Drain
+    # both streams asynchronously to avoid a pipe-buffer deadlock while the
+    # child is parked.
+    $sbOut = New-Object System.Text.StringBuilder
+    $sbErr = New-Object System.Text.StringBuilder
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $psi
+    $outEvt = Register-ObjectEvent -InputObject $p -EventName OutputDataReceived -MessageData $sbOut -Action {
+        if ($null -ne $EventArgs.Data) { [void]$Event.MessageData.AppendLine($EventArgs.Data) }
+    }
+    $errEvt = Register-ObjectEvent -InputObject $p -EventName ErrorDataReceived -MessageData $sbErr -Action {
+        if ($null -ne $EventArgs.Data) { [void]$Event.MessageData.AppendLine($EventArgs.Data) }
+    }
+
+    $guestFound = $null
+    try {
+        [void]$p.Start()
+        $p.BeginOutputReadLine()
+        $p.BeginErrorReadLine()
+
+        # Wait for the probe to signal that its atom now exists.
+        $deadline = (Get-Date).AddSeconds(30)
+        $ready = $false
+        while ((Get-Date) -lt $deadline) {
+            if (Test-Path -LiteralPath $readyFile) { $ready = $true; break }
+            if ($p.HasExited) { break }
+            Start-Sleep -Milliseconds 100
+        }
+
+        if ($ready) {
+            # Direction 2: does the host find the contained process's atom?
+            $guestFound = [Mxc.AtomNative]::GlobalFindAtomW($guestName)
+        }
+
+        # Release the probe so it deletes its atom and exits.
+        Set-Content -LiteralPath $releaseFile -Value 'go' -ErrorAction SilentlyContinue
+
+        if (-not $p.WaitForExit(30000)) {
+            try { $p.Kill() } catch {}
+        }
+        $p.WaitForExit()   # ensure async stdout/stderr handlers flush
+    }
+    finally {
+        # Remove the host-planted atom regardless of outcome.
+        [void][Mxc.AtomNative]::GlobalDeleteAtom($hostAtom)
+        if ($outEvt) { Unregister-Event -SourceIdentifier $outEvt.Name -ErrorAction SilentlyContinue }
+        if ($errEvt) { Unregister-Event -SourceIdentifier $errEvt.Name -ErrorAction SilentlyContinue }
+    }
+
+    $stdout = $sbOut.ToString()
+    $logContent = Read-Log $log
+    Assert-NoBfscfg -LogContent $logContent -Phase 'P4c' -Name $Name
+    $tierMatch = [bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl')
+    $h2g = if ($stdout -match '(?m)^GLOBALATOMS_HOST_TO_GUEST=(?<v>PASS|FAIL)\s*$') { $matches['v'] } else { '<missing>' }
+    return [pscustomobject]@{ HostToGuest = $h2g; GuestFound = $guestFound; TierMatch = $tierMatch; Detail = "stdout=$($stdout.Trim())" }
+}
+
+function Phase-GlobalAtomIsolation {
+    Section 'Phase 4c: GLOBALATOMS bidirectional isolation (T3 forced)'
+
+    # ---- Positive: isolation=container sets UILIMIT_GLOBALATOMS -> isolated.
+    $pos = Invoke-GlobalAtomProbe -Isolation 'container' -Name 'ui-globalatoms'
+    Record-Result -Phase 'P4c' -Name 'selected isolation tier: appcontainer-dacl' -Pass $pos.TierMatch
+    Record-Result -Phase 'P4c' -Name 'host atom NOT visible to contained process (host->guest)' -Pass ($pos.HostToGuest -eq 'PASS') -Detail "got=$($pos.HostToGuest); $($pos.Detail)"
+    if ($null -eq $pos.GuestFound) {
+        Record-Result -Phase 'P4c' -Name 'contained atom NOT visible to host (guest->host)' -Pass $false -Detail 'probe never signalled ready; no guest-atom check performed'
+    } else {
+        Record-Result -Phase 'P4c' -Name 'contained atom NOT visible to host (guest->host)' -Pass ($pos.GuestFound -eq 0) -Detail "GlobalFindAtomW=$($pos.GuestFound) (0 = not found = isolated)"
+    }
+
+    # ---- Negative control: isolation=desktop sets NO UILIMIT_GLOBALATOMS, so
+    # the global atom table is shared. The probe MUST see the host atom and the
+    # host MUST see the guest atom — proving the positive results above are not
+    # vacuous (e.g. an atom API silently failing would otherwise read as PASS).
+    $neg = Invoke-GlobalAtomProbe -Isolation 'desktop' -Name 'ui-globalatoms-neg'
+    Record-Result -Phase 'P4c' -Name 'negative control: host atom VISIBLE without UILIMIT_GLOBALATOMS (host->guest -> FAIL)' -Pass ($neg.HostToGuest -eq 'FAIL') -Detail "got=$($neg.HostToGuest); $($neg.Detail)"
+    if ($null -eq $neg.GuestFound) {
+        Record-Result -Phase 'P4c' -Name 'negative control: contained atom VISIBLE to host without UILIMIT_GLOBALATOMS' -Pass $false -Detail 'probe never signalled ready; no guest-atom check performed'
+    } else {
+        Record-Result -Phase 'P4c' -Name 'negative control: contained atom VISIBLE to host without UILIMIT_GLOBALATOMS' -Pass ($neg.GuestFound -ne 0) -Detail "GlobalFindAtomW=$($neg.GuestFound) (nonzero = found = NOT isolated)"
+    }
 }
 
 # -----------------------------------------------------------------------
@@ -1032,15 +1357,30 @@ try {
     Test-Preflight
     Initialize-Scratch
 
-    Phase-UnitTests
-    Phase-Probes
-    Phase-EmptyRelease
-    Phase-DeniedRelease
-    Phase-T3Forced
-    Phase-T1DenyForced
-    Phase-UiMitigationMatrix
-    Phase-DaclDisabled
-    Phase-CrashRecovery
+    # Phase registry. Build + preflight + scratch init above always run; this
+    # table is filtered by the -Phases parameter (empty = run all). Phase 4b is
+    # 'UiMitigationMatrix'; Phase 4c is 'GlobalAtomIsolation'.
+    $AllPhases = [ordered]@{
+        'UnitTests'           = { Phase-UnitTests }
+        'Probes'              = { Phase-Probes }
+        'EmptyRelease'        = { Phase-EmptyRelease }
+        'DeniedRelease'       = { Phase-DeniedRelease }
+        'T3Forced'            = { Phase-T3Forced }
+        'T1DenyForced'        = { Phase-T1DenyForced }
+        'UiMitigationMatrix'  = { Phase-UiMitigationMatrix }
+        'GlobalAtomIsolation' = { Phase-GlobalAtomIsolation }
+        'DaclDisabled'        = { Phase-DaclDisabled }
+        'CrashRecovery'       = { Phase-CrashRecovery }
+    }
+    if ($Phases.Count -gt 0) {
+        $unknown = $Phases | Where-Object { $_ -notin $AllPhases.Keys }
+        if ($unknown) { throw "Unknown -Phases value(s): $($unknown -join ', '). Valid: $($AllPhases.Keys -join ', ')" }
+    }
+    foreach ($key in $AllPhases.Keys) {
+        if ($Phases.Count -eq 0 -or $Phases -contains $key) {
+            & $AllPhases[$key]
+        }
+    }
 }
 catch {
     Write-Host ''


### PR DESCRIPTION
This PR fixes the failing Phase 4b/4c UI-mitigation assertions in Win25H2Safe-Tests.ps1 (HANDLES, GLOBALATOMS, WIN32K, EXITWINDOWS) so each verifies the documented behavior of the corresponding job-object UI limit rather than an incidental API failure, and adds negative controls plus a -Phases selector to make the suite self-validating and easier to run.

Details

* GLOBALATOMS: rewrote the wxc_ui_probe probe to verify per-job atom-table isolation bidirectionally (host->guest must not find a host-planted atom; guest->host held across a ready/release file handshake) instead of treating a non-existent API failure as PASS. Added the matching Phase 4c (Phase-GlobalAtomIsolation) plus an isolation=desktop negative control that asserts the host DOES see the guest atom.
* HANDLES: probe now verifies it cannot *use* a USER handle owned by a process outside the job (cross-job GetWindowTextW against a harness-owned hidden message-pumping window) rather than relying on FindWindow returning NULL. Added an isolation=desktop negative control asserting HANDLES=FAIL.
* WIN32K: the "user32 not loadable" arm now emits a DIAG only (no WIN32K=FAIL), so the harness correctly reads a not-loadable result as Win32k-mitigation-honored; only WIN32K's None arm changed.
* EXITWINDOWS / env delivery: deliver MXC_PROBE_DESTRUCTIVE_OK=1 to the contained child via a COMPLETE process.env block (current env minus the hidden "=C:" cwd vars and MXC_FORCE_TIER), since the AppContainer runner builds the child env with CreateEnvironmentBlock(bInherit=FALSE) and replaces the block when process.env is non-empty; a one-var block failed CreateProcessW with 0x800700CB. Probe data that can't ride env now passes via CLI flags.
* Harness ergonomics: added a -Phases parameter and phase registry so a subset of phases can be run; build, preflight, and scratch init always run and unknown phase names abort early with the valid list.

Tests

* cargo build -p wxc_ui_probe (debug + release), cargo clippy -p wxc_ui_probe --all-targets -- -D warnings, and cargo fmt -p wxc_ui_probe -- --check: clean.
* End-to-end via wxc-exec for each probe, both isolated and as a negative control: GLOBALATOMS, HANDLES, and WIN32K flip correctly between PASS (isolation=container) and FAIL (isolation=desktop); the env fix lets CreateProcessW succeed and the child run to exit 0 (READCLIPBOARD=PASS), confirming the prior one-var block failed with 0x800700CB.
* Full Win25H2Safe-Tests.ps1 re-run on the 25H2 host: Phase 4b and Phase 4c pass (confirmed by author). Script parses.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/544)