### PR TITLE
docs(lxc): replace removed `script` setting in example config

### DIFF
--- a/docs/lxc-support/lxc-backend.md
+++ b/docs/lxc-support/lxc-backend.md
@@ -39,13 +39,17 @@ The LXC backend uses the same JSON configuration schema as the Windows backends,
 
 ```json
 {
-    "script": "echo 'Hello from container'",
+    "containerId": "my-sandbox",
     "containment": "lxc",
-    "lxc": {
-        "containerName": "my-sandbox",
-        "distribution": "alpine",
-        "release": "3.20",
+    "process": {
+        "commandLine": "echo 'Hello from container'"
+    },
+    "lifecycle": {
         "destroyOnExit": true
+    },
+    "lxc": {
+        "distribution": "alpine",
+        "release": "3.20"
     },
     "filesystem": {
         "readwritePaths": ["/tmp/output"],


### PR DESCRIPTION
## 📖 Description

The LXC backend doc's example configuration used a `"script"` toplevel setting, which has been removed from the schema. It also used `lxc.containerName` and `lxc.destroyOnExit`, which are not valid `lxc` section fields.

This updates the example to the current, schema-valid shape:

- `"script": "..."` → `"process": { "commandLine": "..." }`
- `lxc.containerName` → top-level `containerId`
- `lxc.destroyOnExit` → `lifecycle.destroyOnExit`

The `lxc` section now only contains `distribution` and `release`, matching the field reference table directly below the example and the working configs in `test_configs/`.

## 🔗 References

Resolves #527

## 🔍 Validation

- Confirmed the corrected JSON example parses and that all top-level and `lxc` keys are valid against `schemas/dev/mxc-config.schema.0.6.0-dev.json`.
- Cross-checked the shape against `test_configs/basic_lxc.json` and `test_configs/lxc_filesystem_test.json`.
- Docs-only change; no build/test impact.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/545)