### PR TITLE
Make the Windows process-container test harness capability-driven

### DIFF
--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -99,6 +99,13 @@ type PfnQuerySandboxSupport = unsafe extern "system" fn(capabilities: *mut u64) 
 /// `SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX`: when clear, Tier 1 is unusable.
 const SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX: u64 = 0x0000_0000_0000_0001;
 
+/// `SANDBOX_CAP_DENY_PATHS`: when set, the BaseContainer (Tier 1) backend can
+/// enforce `filesystem.deniedPaths`. Bit 0 reports whether the create API is
+/// callable; deny support is expected to light up on a separate bit (currently
+/// assumed bit 1). When clear, `deniedPaths` is rejected at launch and callers
+/// must rely on default-deny plus explicit `readwrite`/`readonly` grants.
+const SANDBOX_CAP_DENY_PATHS: u64 = 0x0000_0000_0000_0002;
+
 /// True when a Win32 error code signals the BaseContainer feature is not
 /// enabled on this build (symbol present, capability gated off).
 pub(crate) fn is_api_not_implemented(err: u32) -> bool {
@@ -162,6 +169,34 @@ impl BaseContainerRunner {
             Some(enabled) => enabled,
             None => Self::probe_create_process_feature_enabled(),
         }
+    }
+
+    /// Whether the BaseContainer (Tier 1) backend can enforce
+    /// `filesystem.deniedPaths` on this host.
+    ///
+    /// Reads the `SANDBOX_CAP_DENY_PATHS` bit from
+    /// `Experimental_QuerySandboxSupport`. Returns `false` when the query
+    /// export is absent or the bit is clear — the behavior on builds where
+    /// BaseContainer deny support has not yet shipped, where `deniedPaths` is
+    /// rejected at launch. Tier 3 (AppContainer + DACL) enforces `deniedPaths`
+    /// via DENY ACEs independently of this bit.
+    pub fn base_container_supports_deny_paths() -> bool {
+        let Some(query) = Self::load_query_sandbox_support() else {
+            return false;
+        };
+        let mut capabilities: u64 = 0;
+        // SAFETY: `query` is the resolved export; `capabilities` is a valid
+        // out-param.
+        let succeeded = unsafe { query(&mut capabilities) };
+        Self::decode_deny_capability(succeeded, capabilities)
+    }
+
+    /// Decode a `QuerySandboxSupport` result for the deny-paths capability.
+    /// `succeeded` is the export's Win32 `BOOL` return (TRUE = nonzero = the
+    /// query call succeeded), NOT an HRESULT. The capability is present only
+    /// when the call succeeded and the bit is set.
+    fn decode_deny_capability(succeeded: i32, capabilities: u64) -> bool {
+        succeeded != 0 && (capabilities & SANDBOX_CAP_DENY_PATHS) != 0
     }
 
     /// Query `Experimental_QuerySandboxSupport` for the create-process bit.
@@ -1115,6 +1150,23 @@ mod tests {
         assert!(!BaseContainerRunner::decode_create_capability(1, 0)); // bit clear
         assert!(BaseContainerRunner::decode_create_capability(1, cap)); // enabled
         assert!(BaseContainerRunner::decode_create_capability(1, cap | 0x4)); // extra bits ok
+    }
+
+    #[test]
+    fn decode_deny_capability_table() {
+        // create bit alone does not imply deny support, and vice versa.
+        let cap = SANDBOX_CAP_DENY_PATHS;
+        assert!(!BaseContainerRunner::decode_deny_capability(0, cap)); // FALSE return
+        assert!(!BaseContainerRunner::decode_deny_capability(1, 0)); // bit clear
+        assert!(BaseContainerRunner::decode_deny_capability(1, cap)); // enabled
+        assert!(!BaseContainerRunner::decode_deny_capability(
+            1,
+            SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX
+        ));
+        assert!(BaseContainerRunner::decode_deny_capability(
+            1,
+            cap | SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX
+        ));
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/probe.rs
+++ b/src/backends/appcontainer/common/src/probe.rs
@@ -58,6 +58,13 @@ pub struct ProbeFacts {
     /// 11 25H2 where `bfscfg.exe` locks `bfs.sys`) should refuse to
     /// run a binary that reports `true` here.
     pub bfs_compiled_in: bool,
+    /// Whether the BaseContainer (Tier 1) tier can enforce
+    /// `filesystem.deniedPaths` on this host (the `SANDBOX_CAP_DENY_PATHS` bit
+    /// from `Experimental_QuerySandboxSupport`). `false` on builds where deny
+    /// support has not yet shipped, where `deniedPaths` is rejected at launch.
+    /// Tier 3 (AppContainer + DACL) enforces `deniedPaths` via DENY ACEs
+    /// regardless of this bit; it is meaningful only for the BaseContainer tier.
+    pub base_container_supports_deny_paths: bool,
     /// Platform-agnostic UI restrictions this host can enforce.
     pub ui_capabilities: UiCapabilitySupport,
 }
@@ -117,6 +124,8 @@ pub fn run_probe(policy: &ContainerPolicy) -> ProbeOutput {
             .flatten()
             .is_some(),
         bfs_compiled_in: cfg!(feature = "tier2_bfs"),
+        base_container_supports_deny_paths:
+            crate::base_container_runner::BaseContainerRunner::base_container_supports_deny_paths(),
         ui_capabilities: crate::job_object::supported_ui_restrictions().into(),
     };
     match fallback_detector::detect(policy, /* prefer_base_container */ true) {
@@ -191,6 +200,7 @@ mod tests {
                 base_container_api_present: true,
                 bfscfg_present: false,
                 bfs_compiled_in: false,
+                base_container_supports_deny_paths: false,
                 ui_capabilities: all_ui_capabilities(),
             },
             error: None,
@@ -225,6 +235,7 @@ mod tests {
                 base_container_api_present: false,
                 bfscfg_present: false,
                 bfs_compiled_in: false,
+                base_container_supports_deny_paths: false,
                 ui_capabilities: UiCapabilitySupport {
                     can_block_input_injection: false,
                     can_block_input_method_changes: false,

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -439,7 +439,7 @@ fn main() {
     // Best-effort: reap any orphaned DACL state files left behind by
     // crashed prior MXC runs. Runs BEFORE the `--probe` arm because
     // `wxc-exec --probe` is the canonical recovery trigger consumers
-    // (Win25H2Safe-Tests Phase 6, SDK warm-start) rely on. Errors here
+    // (WinProcessContainer-Tests Phase 6, SDK warm-start) rely on. Errors here
     // are non-fatal and only surface via stderr. On a healthy host
     // with zero state files this is sub-millisecond.
     match wxc_common::filesystem_dacl::recover_orphaned_state() {

--- a/src/core/wxc_common/src/filesystem_dacl.rs
+++ b/src/core/wxc_common/src/filesystem_dacl.rs
@@ -2393,7 +2393,7 @@ mod tests {
     /// order at every observable step. Guards against:
     ///   (1) `SetEntriesInAclW(REVOKE_ACCESS)` quirk on Windows 25H2
     ///       where DENY ACEs survive a REVOKE; observed in the field
-    ///       via Win25H2Safe-Tests Phase 3 / Phase 4 "denied ACL
+    ///       via WinProcessContainer-Tests Phase 3 / Phase 4 "denied ACL
     ///       restored" failures.
     ///   (2) `replace_explicit_aces_for_sid_inner` emitting ACEs in
     ///       non-canonical order, which Windows accepts but resolves

--- a/src/testing/wxc_ui_probe/src/main.rs
+++ b/src/testing/wxc_ui_probe/src/main.rs
@@ -51,11 +51,12 @@ struct ProbeArgs {
     /// HWND (as an integer) of a window owned by the host process — i.e. a
     /// USER handle owned by a process *outside* the job. Under
     /// `JOB_OBJECT_UILIMIT_HANDLES` the contained probe must NOT be able to
-    /// use it (e.g. read its text).
+    /// use it (e.g. query its owning thread/process).
     handle_hwnd: Option<usize>,
-    /// The window title the host set on `handle_hwnd`. If the probe manages to
-    /// read this back, the handle restriction failed.
-    handle_title: Option<String>,
+    /// The process id that owns `handle_hwnd` (the host process). If the probe
+    /// can read the owner back via `GetWindowThreadProcessId` and it matches,
+    /// the handle restriction failed.
+    handle_pid: Option<u32>,
 }
 
 #[repr(C)]
@@ -85,6 +86,67 @@ struct SecurityAttributes {
     b_inherit_handle: Bool,
 }
 
+/// `MOUSEINPUT` payload of `INPUT`. Retained as the largest union member so
+/// the `INPUT` struct is sized correctly (`SendInput` validates `cbSize`); the
+/// probe only ever fills the keyboard variant, so its fields are never read.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+#[allow(dead_code)]
+struct MouseInput {
+    dx: i32,
+    dy: i32,
+    mouse_data: u32,
+    dw_flags: u32,
+    time: u32,
+    dw_extra_info: usize,
+}
+
+/// `KEYBDINPUT` payload of `INPUT`.
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct KeybdInput {
+    w_vk: u16,
+    w_scan: u16,
+    dw_flags: u32,
+    time: u32,
+    dw_extra_info: usize,
+}
+
+/// Union of the `INPUT` payloads (sized by the largest member, `MOUSEINPUT`).
+#[repr(C)]
+union InputUnion {
+    mi: MouseInput,
+    ki: KeybdInput,
+}
+
+/// `INPUT` for `SendInput`.
+#[repr(C)]
+struct Input {
+    input_type: u32,
+    u: InputUnion,
+}
+
+/// `WNDCLASSEXW` for registering the probe's own transient window class. The
+/// INJECTION probe creates and foregrounds its own top-level window so the
+/// kernel's GPQ-foreground-accessible check (which precedes the injection job
+/// limit and silently skips input when the foreground belongs to another
+/// inaccessible process) passes and the injection limit is actually evaluated.
+#[repr(C)]
+struct WndClassExW {
+    cb_size: u32,
+    style: u32,
+    lpfn_wnd_proc: *const c_void,
+    cb_cls_extra: i32,
+    cb_wnd_extra: i32,
+    h_instance: Hmodule,
+    h_icon: *mut c_void,
+    h_cursor: *mut c_void,
+    hbr_background: *mut c_void,
+    lpsz_menu_name: *const u16,
+    lpsz_class_name: *const u16,
+    h_icon_sm: *mut c_void,
+}
+
 const CF_TEXT: u32 = 1;
 const SPI_SETMOUSESPEED: u32 = 0x0071;
 const SPIF_SENDCHANGE: u32 = 0x0002;
@@ -92,6 +154,21 @@ const EWX_LOGOFF: u32 = 0x00000000;
 const EWX_FORCEIFHUNG: u32 = 0x00000010;
 const DESKTOP_CREATEWINDOW: u32 = 0x0002;
 const GENERIC_ALL: u32 = 0x10000000;
+const INPUT_KEYBOARD: u32 = 1;
+const KEYEVENTF_KEYUP: u32 = 0x0002;
+/// `VK_NONAME` — a reserved no-op virtual key. Injecting a lone key-up of it is
+/// a real synthetic-input event with no side effect on any focused window.
+const VK_NONAME: u16 = 0xFC;
+/// `ERROR_ACCESS_DENIED` (Win32). The kernel's injection job-limit denial path
+/// (`DoInputCheck` → `xxxSendInput`) sets this via `UserSetLastError` when it
+/// blocks an injection, so a genuine INJECTION block is distinguishable from a
+/// zero-insert caused by some unrelated condition.
+const ERROR_ACCESS_DENIED: u32 = 5;
+/// Window styles for the probe's own transient foreground window.
+const WS_VISIBLE: u32 = 0x1000_0000;
+const WS_OVERLAPPEDWINDOW: u32 = 0x00CF_0000;
+const SW_SHOW: i32 = 5;
+const PM_REMOVE: u32 = 0x0001;
 
 extern "system" {
     fn LoadLibraryW(name: LpcWstr) -> Hmodule;
@@ -100,6 +177,8 @@ extern "system" {
     fn GlobalFindAtomW(name: LpcWstr) -> Atom;
     fn GlobalDeleteAtom(atom: Atom) -> Atom;
     fn GetLastError() -> Dword;
+    fn GetModuleHandleW(name: LpcWstr) -> Hmodule;
+    fn GetCurrentProcessId() -> Dword;
 }
 
 fn to_wide(s: &str) -> Vec<u16> {
@@ -158,6 +237,15 @@ fn refuse_destructive(tag: &str) {
 
 fn emit_fail(tag: &str) {
     println!("{}=FAIL", tag);
+}
+
+/// Emitted when a probe could not actually exercise its restriction, so neither
+/// PASS nor FAIL would be truthful. The harness records this as a skip rather
+/// than a verdict. Used by INJECTION when the contained process cannot acquire
+/// the foreground (so `SendInput`'s foreground-accessible check pre-empts the
+/// injection job-limit check and the limit is never evaluated).
+fn emit_inconclusive(tag: &str) {
+    println!("{}=INCONCLUSIVE", tag);
 }
 
 fn emit_diag(tag: &str, reason: &str) {
@@ -472,12 +560,13 @@ fn probe_exitwindows(user32: Hmodule) {
 /// Probe the HANDLES UI restriction (`JOB_OBJECT_UILIMIT_HANDLES`).
 ///
 /// This limit does NOT stop `FindWindow` from returning HWNDs — it blocks
-/// *using* USER handles owned by processes outside the job. So isolation is
-/// verified by attempting to read the title of a window the host created
-/// (a USER handle owned by a process outside the job): `GetWindowTextW`
-/// reaches an external window via `WM_GETTEXT`, which the limit rejects at
-/// the sender. PASS means we could NOT read it (empty / blocked); FAIL means
-/// we read back the host's sentinel title.
+/// *using* USER handles owned by processes outside the job. Isolation is
+/// verified by calling `GetWindowThreadProcessId` on a window the host created
+/// (a USER handle owned by a process outside the job). Unlike `GetWindowTextW`
+/// it does not send `WM_GETTEXT`, so it is not confounded by UIPI / message
+/// filtering / the target pumping messages — it reads window-manager state
+/// directly. PASS means we could NOT resolve the owner (the limit blocked the
+/// handle use); FAIL means we read back the host's owning process id.
 fn probe_handles(user32: Hmodule, args: &ProbeArgs) {
     let hwnd_val = match args.handle_hwnd {
         Some(h) => h,
@@ -486,34 +575,281 @@ fn probe_handles(user32: Hmodule, args: &ProbeArgs) {
             return;
         }
     };
-    type GetWindowTextWFn = unsafe extern "system" fn(Hwnd, *mut u16, i32) -> i32;
-    let get_text = match get_proc(user32, "GetWindowTextW") {
-        Some(p) => unsafe { std::mem::transmute::<FarProc, GetWindowTextWFn>(p) },
+    type GetWindowThreadProcessIdFn = unsafe extern "system" fn(Hwnd, *mut Dword) -> Dword;
+    let get_wtpid = match get_proc(user32, "GetWindowThreadProcessId") {
+        Some(p) => unsafe { std::mem::transmute::<FarProc, GetWindowThreadProcessIdFn>(p) },
         None => {
-            emit_diag("HANDLES", "GetWindowTextW not resolvable");
+            emit_diag("HANDLES", "GetWindowThreadProcessId not resolvable");
             emit_fail("HANDLES");
             return;
         }
     };
 
     let hwnd = hwnd_val as Hwnd;
-    let mut buf = [0u16; 256];
-    let len = unsafe { get_text(hwnd, buf.as_mut_ptr(), buf.len() as i32) };
-    if len <= 0 {
-        // Could not read the external window's text -> the cross-job
-        // WM_GETTEXT was blocked.
+    let mut pid: Dword = 0;
+    let tid = unsafe { get_wtpid(hwnd, &mut pid as *mut Dword) };
+    if tid == 0 {
+        // Could not access the external window handle -> the limit blocked it.
         emit_pass("HANDLES");
         return;
     }
 
-    let text = String::from_utf16_lossy(&buf[..len as usize]);
-    match args.handle_title.as_deref() {
-        Some(expected) if text == expected => emit_fail("HANDLES"),
-        Some(_) => {
-            emit_diag("HANDLES", "read unexpected window text");
+    match args.handle_pid {
+        Some(expected) if pid == expected => emit_fail("HANDLES"),
+        Some(expected) => {
+            emit_diag(
+                "HANDLES",
+                &format!("resolved owner pid {pid} != expected {expected}"),
+            );
             emit_fail("HANDLES");
         }
-        None => emit_fail("HANDLES"),
+        // We resolved an owner but have no expected pid to compare against, so
+        // we can't make an isolation verdict. Per the tool's contract (missing
+        // harness args -> DIAG + skip), emit a diagnostic instead of a FAIL that
+        // would look like a real "handle restriction failed" result. The harness
+        // always passes --handle-pid, so this only affects ad-hoc runs.
+        None => emit_diag(
+            "HANDLES",
+            &format!("resolved owner pid {pid} but no --handle-pid provided to compare (run via the harness)"),
+        ),
+    }
+}
+
+/// Probe the INJECTION UI restriction (`JOB_OBJECT_UILIMIT_INJECTION`, build
+/// 26100+). The limit blocks a job process from injecting synthetic input via
+/// `SendInput`, enforced in the kernel against the caller.
+///
+/// Subtlety that this probe must work around: in the kernel's input check
+/// (`DoInputCheck`), the **foreground-accessible** test runs *before* the
+/// injection job-limit test, and `xxxSendInput` silently `continue`s (skips the
+/// input, returns success, leaves `GetLastError` untouched) when the foreground
+/// window belongs to another process the caller cannot access. A contained
+/// (AppContainer) process on an interactive desktop almost always sees an
+/// inaccessible foreground, so a naive `SendInput` returns `inserted=1, gle=0`
+/// *without the injection limit ever being evaluated* — which would read as a
+/// false "not enforced". The kernel deliberately allows a process to inject
+/// into its **own** foreground window, so we create and foreground our own
+/// top-level window first; only then does `SendInput` reach the injection
+/// limit.
+///
+/// Outcomes:
+/// * `PASS`  — we owned the foreground and `SendInput` injected 0 of 1 with
+///   `gle=ERROR_ACCESS_DENIED`: the injection limit blocked it (enforced).
+/// * `FAIL`  — we owned the foreground but the event went through
+///   (`inserted=1, gle=0`): the limit did not block (genuinely not enforced).
+/// * `INCONCLUSIVE` — either we could not create/own a foreground window (so the
+///   foreground-accessible check would pre-empt the limit), or the injection was
+///   dropped with a `gle` other than `ERROR_ACCESS_DENIED` (blocked for some
+///   unrelated reason, not the job limit). Both are ambiguous, so the harness
+///   records a skip rather than a verdict.
+///
+/// A DIAG line always reports `inserted`/expected and `GetLastError`.
+fn probe_injection(user32: Hmodule) {
+    type RegisterClassExWFn = unsafe extern "system" fn(*const WndClassExW) -> u16;
+    #[allow(clippy::type_complexity)]
+    type CreateWindowExWFn = unsafe extern "system" fn(
+        u32,
+        *const u16,
+        *const u16,
+        u32,
+        i32,
+        i32,
+        i32,
+        i32,
+        Hwnd,
+        *mut c_void,
+        Hmodule,
+        *mut c_void,
+    ) -> Hwnd;
+    type ShowWindowFn = unsafe extern "system" fn(Hwnd, i32) -> Bool;
+    type SetForegroundWindowFn = unsafe extern "system" fn(Hwnd) -> Bool;
+    type BringWindowToTopFn = unsafe extern "system" fn(Hwnd) -> Bool;
+    type GetForegroundWindowFn = unsafe extern "system" fn() -> Hwnd;
+    type GetWindowThreadProcessIdFn = unsafe extern "system" fn(Hwnd, *mut Dword) -> Dword;
+    type DestroyWindowFn = unsafe extern "system" fn(Hwnd) -> Bool;
+    type UnregisterClassWFn = unsafe extern "system" fn(*const u16, Hmodule) -> Bool;
+    type PeekMessageWFn = unsafe extern "system" fn(*mut Msg, Hwnd, u32, u32, u32) -> Bool;
+    type TranslateMessageFn = unsafe extern "system" fn(*const Msg) -> Bool;
+    type DispatchMessageWFn = unsafe extern "system" fn(*const Msg) -> isize;
+    type SendInputFn = unsafe extern "system" fn(u32, *const Input, i32) -> u32;
+
+    macro_rules! resolve {
+        ($name:literal, $ty:ty) => {
+            match get_proc(user32, $name) {
+                Some(p) => unsafe { std::mem::transmute::<FarProc, $ty>(p) },
+                None => {
+                    emit_diag("INJECTION", concat!($name, " not resolvable"));
+                    emit_inconclusive("INJECTION");
+                    return;
+                }
+            }
+        };
+    }
+
+    let register_class = resolve!("RegisterClassExW", RegisterClassExWFn);
+    let create_window = resolve!("CreateWindowExW", CreateWindowExWFn);
+    let show_window = resolve!("ShowWindow", ShowWindowFn);
+    let set_foreground = resolve!("SetForegroundWindow", SetForegroundWindowFn);
+    let bring_to_top = resolve!("BringWindowToTop", BringWindowToTopFn);
+    let get_foreground = resolve!("GetForegroundWindow", GetForegroundWindowFn);
+    let get_wtpid = resolve!("GetWindowThreadProcessId", GetWindowThreadProcessIdFn);
+    let destroy_window = resolve!("DestroyWindow", DestroyWindowFn);
+    let unregister_class = resolve!("UnregisterClassW", UnregisterClassWFn);
+    let peek_message = resolve!("PeekMessageW", PeekMessageWFn);
+    let translate_message = resolve!("TranslateMessage", TranslateMessageFn);
+    let dispatch_message = resolve!("DispatchMessageW", DispatchMessageWFn);
+    let send_input = resolve!("SendInput", SendInputFn);
+    // DefWindowProcW is used directly as the class window procedure.
+    let def_window_proc: FarProc = match get_proc(user32, "DefWindowProcW") {
+        Some(p) => p,
+        None => {
+            emit_diag("INJECTION", "DefWindowProcW not resolvable");
+            emit_inconclusive("INJECTION");
+            return;
+        }
+    };
+
+    let class_name = to_wide("MxcInjectionProbeWindow");
+    let title = to_wide("MxcInjectionProbe");
+    let hinstance = unsafe { GetModuleHandleW(std::ptr::null()) };
+    let wc = WndClassExW {
+        cb_size: std::mem::size_of::<WndClassExW>() as u32,
+        style: 0,
+        lpfn_wnd_proc: def_window_proc,
+        cb_cls_extra: 0,
+        cb_wnd_extra: 0,
+        h_instance: hinstance,
+        h_icon: std::ptr::null_mut(),
+        h_cursor: std::ptr::null_mut(),
+        hbr_background: std::ptr::null_mut(),
+        lpsz_menu_name: std::ptr::null(),
+        lpsz_class_name: class_name.as_ptr(),
+        h_icon_sm: std::ptr::null_mut(),
+    };
+    let class_atom = unsafe { register_class(&wc as *const WndClassExW) };
+    if class_atom == 0 {
+        emit_diag(
+            "INJECTION",
+            &format!("RegisterClassExW failed gle={}", unsafe { GetLastError() }),
+        );
+        emit_inconclusive("INJECTION");
+        return;
+    }
+    let hwnd = unsafe {
+        create_window(
+            0,
+            class_name.as_ptr(),
+            title.as_ptr(),
+            WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+            0,
+            0,
+            200,
+            100,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            hinstance,
+            std::ptr::null_mut(),
+        )
+    };
+    if hwnd.is_null() {
+        emit_diag(
+            "INJECTION",
+            &format!("CreateWindowExW failed gle={}", unsafe { GetLastError() }),
+        );
+        unsafe { unregister_class(class_name.as_ptr(), hinstance) };
+        emit_inconclusive("INJECTION");
+        return;
+    }
+
+    // Acquire the foreground (retry: activation can require a message pump).
+    let self_pid = unsafe { GetCurrentProcessId() };
+    let mut msg = Msg::default();
+    let mut owns_foreground = false;
+    let mut fg_pid: Dword = 0;
+    for _ in 0..20 {
+        unsafe {
+            show_window(hwnd, SW_SHOW);
+            bring_to_top(hwnd);
+            set_foreground(hwnd);
+            while peek_message(&mut msg as *mut Msg, std::ptr::null_mut(), 0, 0, PM_REMOVE) != 0 {
+                translate_message(&msg as *const Msg);
+                dispatch_message(&msg as *const Msg);
+            }
+        }
+        let fg = unsafe { get_foreground() };
+        fg_pid = 0;
+        if !fg.is_null() {
+            unsafe { get_wtpid(fg, &mut fg_pid as *mut Dword) };
+        }
+        if !fg.is_null() && fg_pid == self_pid {
+            owns_foreground = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+
+    if !owns_foreground {
+        emit_diag(
+            "INJECTION",
+            &format!(
+                "inconclusive: could not own foreground (fg owner pid {fg_pid} != self {self_pid}); \
+                 SendInput's foreground-accessible check pre-empts the injection limit"
+            ),
+        );
+        unsafe {
+            destroy_window(hwnd);
+            unregister_class(class_name.as_ptr(), hinstance);
+        }
+        emit_inconclusive("INJECTION");
+        return;
+    }
+
+    // We own the foreground -> the kernel reaches the injection job-limit check.
+    let input = Input {
+        input_type: INPUT_KEYBOARD,
+        u: InputUnion {
+            ki: KeybdInput {
+                w_vk: VK_NONAME,
+                w_scan: 0,
+                dw_flags: KEYEVENTF_KEYUP,
+                time: 0,
+                dw_extra_info: 0,
+            },
+        },
+    };
+    let inserted = unsafe {
+        send_input(
+            1,
+            &input as *const Input,
+            std::mem::size_of::<Input>() as i32,
+        )
+    };
+    let gle = if inserted < 1 {
+        unsafe { GetLastError() }
+    } else {
+        0
+    };
+
+    unsafe {
+        destroy_window(hwnd);
+        unregister_class(class_name.as_ptr(), hinstance);
+    }
+
+    emit_diag(
+        "INJECTION",
+        &format!("SendInput injected {inserted}/1 gle={gle} (owns foreground)"),
+    );
+    if inserted == 0 {
+        // Blocked. Only a denial by the injection job limit sets
+        // ERROR_ACCESS_DENIED; a zero-insert with any other gle was blocked for
+        // some unrelated reason, so the limit was not what we observed.
+        if gle == ERROR_ACCESS_DENIED {
+            emit_pass("INJECTION");
+        } else {
+            emit_inconclusive("INJECTION");
+        }
+    } else {
+        emit_fail("INJECTION");
     }
 }
 
@@ -588,6 +924,13 @@ fn run_probe(tag: &str, user32: Option<Hmodule>, probe_args: &ProbeArgs) {
                 emit_fail("HANDLES");
             }
         },
+        "INJECTION" => match user32 {
+            Some(h) => probe_injection(h),
+            None => {
+                emit_diag("INJECTION", "user32.dll not loadable");
+                emit_fail("INJECTION");
+            }
+        },
         "WIN32K" => match user32 {
             Some(h) if destructive_probe_allowed() => probe_win32k(h),
             Some(_) => refuse_destructive("WIN32K"),
@@ -646,7 +989,7 @@ fn parse_args(raw: Vec<String>) -> (Vec<String>, ProbeArgs) {
             Some(("atom-ready-file", value)) => args.ready_file = Some(value.to_string()),
             Some(("atom-release-file", value)) => args.release_file = Some(value.to_string()),
             Some(("handle-hwnd", value)) => args.handle_hwnd = value.parse::<usize>().ok(),
-            Some(("handle-title", value)) => args.handle_title = Some(value.to_string()),
+            Some(("handle-pid", value)) => args.handle_pid = value.parse::<u32>().ok(),
             Some(_) => {} // unknown flag: ignore
             None => tags.push(arg),
         }
@@ -660,10 +1003,10 @@ fn main() {
         eprintln!(
             "usage: wxc-ui-probe <TAG>... (or MXC_UI_PROBE_TAGS=TAG,TAG); \
              valid tags: GLOBALATOMS READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS \
-             DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES WIN32K. \
+             DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES INJECTION WIN32K. \
              GLOBALATOMS accepts --atom-host-name=, --atom-guest-name=, \
              --atom-ready-file=, --atom-release-file= for the host/guest \
-             isolation handshake; HANDLES accepts --handle-hwnd=, --handle-title= \
+             isolation handshake; HANDLES accepts --handle-hwnd=, --handle-pid= \
              for the external-window access check."
         );
         std::process::exit(2);

--- a/tests/scripts/T3-Workloads.ps1
+++ b/tests/scripts/T3-Workloads.ps1
@@ -4,7 +4,7 @@
 # T3-Workloads.ps1 — explore what real workloads can run inside the
 # Tier 3 (AppContainer + DACL) sandbox on a 25H2 host.
 #
-# Companion to Win25H2Safe-Tests.ps1: that script proves the T3
+# Companion to WinProcessContainer-Tests.ps1: that script proves the T3
 # *primitives* (rw / ro / denied / control matrix, crash recovery, UI
 # mitigations) work; this one asks whether useful programs — pwsh 7
 # and git in particular — can run on top of those primitives.

--- a/tests/scripts/WinProcessContainer-Tests.ps1
+++ b/tests/scripts/WinProcessContainer-Tests.ps1
@@ -1,33 +1,36 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 #
-# Win25H2Safe-Tests.ps1
+# WinProcessContainer-Tests.ps1  (formerly Win25H2Safe-Tests.ps1)
 #
-# Exercises the BaseContainer-fallback work (downlevel-phase5 branch) on a
-# Windows 11 25H2 host without ever invoking bfscfg.exe (which would
-# hard-lock the bfs.sys minifilter on 25H2).
+# Exercises the Windows process-container (AppContainer / BaseContainer) stack
+# without ever invoking bfscfg.exe (which hard-locks the bfs.sys minifilter on
+# 25H2). The harness is capability-driven and runs on any Windows host: it
+# derives the EXPECTED containment tier from the runtime --probe signals rather
+# than hardcoding it (see Get-HostCapabilities).
 #
 # Safety model (`tier2_bfs` Cargo feature OFF, the default):
 #   * Test-Preflight refuses to run if either wxc-exec binary reports
 #     `bfsCompiledIn=true` in --probe output. This is the load-bearing
-#     gate; everything else is belt-and-suspenders.
-#   * With `tier2_bfs` off, `fallback_detector::find_bfscfg_exe`
-#     returns `Ok(None)` unconditionally and the spawn site itself is
-#     gated. The dispatcher's natural T2→T3 fallback fires for any
-#     policy with rw/ro/denied paths.
-#   * Empty-policy runs still label the selected tier "appcontainer-bfs"
-#     because `detect()` short-circuits to T2 when there is nothing to
-#     configure. At runtime that path is a no-op — `configure()`
-#     short-circuits before any bfscfg invocation.
-#   * Every run is post-checked: if the captured log contains the
-#     substring "bfscfg" (proof of an actual spawn), the run is
-#     reported as failed and the harness aborts before the next test.
+#     gate; everything else is belt-and-suspenders. It applies on every
+#     build — bfscfg is never invoked regardless of OS version, so no
+#     OS-version branching is needed for safety. (bfscfg.exe only ships on
+#     Germanium+ / 24H2+25H2 anyway; 22H2/23H2 lack it entirely.)
+#   * With `tier2_bfs` off, `fallback_detector::find_bfscfg_exe` returns
+#     `Ok(None)` unconditionally, `appcontainer-bfs` is never selected, and
+#     the dispatcher falls back to BaseContainer (T1, when usable) or
+#     AppContainer + DACL (T3).
+#   * Every run is post-checked: if the captured log contains the spawn
+#     marker "Output from bfscfg.exe" the run fails and the harness aborts.
 #   * The harness relies on **natural** tier selection — there is no
 #     `-ForceTier` parameter and no `MXC_FORCE_TIER` env-var manipulation
 #     (the env var is `#[cfg(test)]`-gated and has no effect on the
-#     production wxc-exec binary). With `tier2_bfs` off, the detector
-#     drops to T3 for any policy with rw/ro/denied paths, which is
-#     exactly what the assertions below expect.
+#     production wxc-exec binary).
+#
+# Tier expectations (with tier2_bfs OFF) are identical for every policy shape:
+#   * BaseContainer usable -> `base-container`
+#   * otherwise            -> `appcontainer-dacl`
+# $Script:ExpectedTier (derived once at startup) drives every tier assertion.
 
 [CmdletBinding()]
 param(
@@ -40,15 +43,15 @@ param(
     [string]$WxcRelease     = (Join-Path $RepoRoot 'src\target\release\wxc-exec.exe'),
     [string]$UiProbeDebug   = (Join-Path $RepoRoot 'src\target\debug\wxc-ui-probe.exe'),
     [string]$UiProbeRelease = (Join-Path $RepoRoot 'src\target\release\wxc-ui-probe.exe'),
-    [string]$ScratchRoot    = (Join-Path $env:TEMP 'mxc-25h2-tests'),
+    [string]$ScratchRoot    = (Join-Path $env:TEMP 'mxc-wpc-tests'),
     # Default results/log files live in $env:TEMP but OUTSIDE $ScratchRoot
     # so `Initialize-Scratch`'s recursive nuke can't conflict with the
     # `Start-Transcript` file handle (the script starts the transcript
     # BEFORE wiping the scratch tree). The previous default landed them
     # under $ScratchRoot and tripped a "file in use" abort on every run.
-    [string]$ResultsFile    = (Join-Path $env:TEMP 'Win25H2Safe-Tests.results.txt'),
-    [string]$ResultsJson    = (Join-Path $env:TEMP 'Win25H2Safe-Tests.results.json'),
-    [string]$CargoLog       = (Join-Path $env:TEMP 'Win25H2Safe-Tests.cargo.log'),
+    [string]$ResultsFile    = (Join-Path $env:TEMP 'WinProcessContainer-Tests.results.txt'),
+    [string]$ResultsJson    = (Join-Path $env:TEMP 'WinProcessContainer-Tests.results.json'),
+    [string]$CargoLog       = (Join-Path $env:TEMP 'WinProcessContainer-Tests.cargo.log'),
     [switch]$SkipBuild,
     [switch]$SkipReleaseLane,
     [switch]$KeepArtifacts,
@@ -143,13 +146,16 @@ namespace Mxc {
         private void Run() {
             _threadId = GetCurrentThreadId();
             // The system "STATIC" class needs no registration; omitting
-            // WS_VISIBLE keeps the window hidden. Its caption is the sentinel
-            // title that WM_GETTEXT (DefWindowProc) returns.
+            // WS_VISIBLE keeps the window hidden. The window just needs to be a
+            // valid HWND owned by this (out-of-job) process for the HANDLES
+            // probe's GetWindowThreadProcessId to resolve.
             _hwnd = CreateWindowExW(WS_EX_TOOLWINDOW, "STATIC", _title, 0, 0, 0, 0, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
             _ready.Set();
             if (_hwnd == IntPtr.Zero) { return; }
             MSG msg;
-            // GetMessageW returns 0 on WM_QUIT and -1 on error; exit on both.
+            // Pump the queue to keep this thread (and thus the window) alive
+            // until Stop() posts WM_QUIT. GetMessageW returns 0 on WM_QUIT and
+            // -1 on error; exit on both.
             while (GetMessageW(out msg, IntPtr.Zero, 0, 0) > 0) {
                 TranslateMessage(ref msg);
                 DispatchMessageW(ref msg);
@@ -176,18 +182,35 @@ function Record-Result {
     param(
         [Parameter(Mandatory)] [string]$Phase,
         [Parameter(Mandatory)] [string]$Name,
-        [Parameter(Mandatory)] [bool]$Pass,
+        [bool]$Pass = $true,
+        # Visual/semantic status. When omitted, derived from -Pass for back-
+        # compat (pass/fail). 'skip' = not applicable on this host/tier/build;
+        # 'warn' = a constraint we expected to hold was NOT enforced (e.g. an
+        # OS feature gated off). Neither 'skip' nor 'warn' fails the run, but
+        # both render distinctly so a non-enforced check is never a green PASS.
+        [ValidateSet('pass', 'fail', 'skip', 'warn')] [string]$Status,
         [string]$Detail = ''
     )
+    if (-not $PSBoundParameters.ContainsKey('Status')) {
+        $Status = if ($Pass) { 'pass' } else { 'fail' }
+    } else {
+        # Keep the boolean consistent for downstream logic: only 'fail' fails.
+        $Pass = ($Status -ne 'fail')
+    }
     $entry = [pscustomobject]@{
         Phase  = $Phase
         Name   = $Name
         Pass   = $Pass
+        Status = $Status
         Detail = $Detail
     }
     $Script:Results.Add($entry) | Out-Null
-    $tag = if ($Pass) { '[PASS]' } else { '[FAIL]' }
-    $color = if ($Pass) { 'Green' } else { 'Red' }
+    switch ($Status) {
+        'pass' { $tag = '[PASS]'; $color = 'Green' }
+        'fail' { $tag = '[FAIL]'; $color = 'Red' }
+        'skip' { $tag = '[SKIP]'; $color = 'Yellow' }
+        'warn' { $tag = '[WARN]'; $color = 'Yellow' }
+    }
     Write-Host ("  {0} {1} :: {2} {3}" -f $tag, $Phase, $Name, $(if ($Detail) { "($Detail)" } else { '' })) -ForegroundColor $color
 }
 
@@ -197,6 +220,31 @@ function Section {
     Write-Host ('=' * 72) -ForegroundColor Cyan
     Write-Host $Title -ForegroundColor Cyan
     Write-Host ('=' * 72) -ForegroundColor Cyan
+}
+
+# Probe binaries report each checked operation as TAG=PASS / TAG=FAIL, where
+# PASS/FAIL describe the *probe's* notion of the outcome, not the harness
+# verdict. Surfacing those raw tokens next to the harness's own [PASS]/[FAIL]
+# reads as a contradiction (e.g. a green [PASS] line containing "got=FAIL").
+# These helpers translate the probe tokens into semantic verbs for display
+# only — the wire protocol and the parsing regexes are unchanged. Callers pass
+# the verb pair for the probe family: UI/atom probes use blocked/allowed
+# (PASS = the constraint blocked the op); the filesystem matrix uses
+# allowed/denied (PASS = the access succeeded).
+function Format-Verdict {
+    param([string]$Verdict, [string]$Pass, [string]$Fail)
+    switch ($Verdict) {
+        'PASS' { $Pass }
+        'FAIL' { $Fail }
+        default { $Verdict }
+    }
+}
+
+function Format-VerdictSummary {
+    param([string]$Summary, [string]$Pass, [string]$Fail)
+    [regex]::Replace($Summary, '=(PASS|FAIL)\b', {
+        param($m) '=' + (Format-Verdict $m.Groups[1].Value $Pass $Fail)
+    })
 }
 
 # -----------------------------------------------------------------------
@@ -210,10 +258,11 @@ function Test-Preflight {
 
     $bfsPath = Join-Path $env:SystemRoot 'System32\bfscfg.exe'
     $bfsPresent = Test-Path $bfsPath
-    Write-Host ("bfscfg.exe present in System32: {0}" -f $bfsPresent)
-    if (-not $bfsPresent) {
-        Write-Warning 'bfscfg.exe was not found in System32. The harness assumes 25H2-shaped hosts.'
-    }
+    # bfscfg.exe ships only on Germanium+ builds (24H2/25H2); 22H2/23H2 lack it
+    # entirely. Its presence is informational only — this harness never invokes
+    # it on any build (the bfsCompiledIn=false gate below is what enforces
+    # safety), so absence is not a problem.
+    Write-Host ("bfscfg.exe present in System32: {0} (Germanium+ ships it; pre-Ge builds do not)" -f $bfsPresent)
 
     if (-not $SkipBuild) {
         if (-not (Test-Path (Join-Path $CargoRoot 'Cargo.toml'))) {
@@ -399,6 +448,107 @@ function Get-ProbeEnvWithDestructive {
     return $list.ToArray()
 }
 
+# -----------------------------------------------------------------------
+# Capability model — derive the expected containment tier from runtime
+# --probe signals rather than hardcoding it, so the harness runs unchanged on
+# both T3 hosts (BaseContainer unusable) and T1 hosts (BaseContainer usable,
+# e.g. pre-Germanium builds that lack bfscfg.exe entirely).
+#
+# `tier2_bfs` is always OFF here (Test-Preflight enforces bfsCompiledIn=false),
+# so `appcontainer-bfs` is never selected and the selected tier is identical
+# for every policy shape: `base-container` when BaseContainer is usable, else
+# `appcontainer-dacl`. BaseContainer usability is detected by the empty-policy
+# probe resolving to `base-container`.
+# -----------------------------------------------------------------------
+function Get-HostCapabilities {
+    $p = Invoke-Probe -Wxc $WxcRelease -Phase 'P0' -Name 'host-capabilities'
+    if (-not $p) {
+        throw 'Get-HostCapabilities: empty-policy --probe failed; cannot determine host tier.'
+    }
+    $tier = [string]$p.tier
+    # Fail fast on an empty/absent tier. A detector error makes $p.tier null,
+    # which would collapse to "" here; Test-SelectedTier then escapes "" into a
+    # pattern that matches ANY "selected isolation tier:" line, silently turning
+    # an unknown tier into false PASS results. Surface the probe error/warnings
+    # instead of proceeding with an unknown tier.
+    if ([string]::IsNullOrEmpty($tier)) {
+        $errDetail = if ($p.PSObject.Properties['error'] -and $p.error) { [string]$p.error } else { '<none>' }
+        $warnDetail = if ($p.PSObject.Properties['warnings'] -and $p.warnings) { ($p.warnings -join '; ') } else { '<none>' }
+        throw "Get-HostCapabilities: empty-policy --probe returned no tier (error=$errDetail; warnings=$warnDetail); cannot determine host tier."
+    }
+    # Defensive: older binaries may not expose baseContainerSupportsDenyPaths.
+    $denyBit = if ($p.probes.PSObject.Properties['baseContainerSupportsDenyPaths']) {
+        [bool]$p.probes.baseContainerSupportsDenyPaths
+    } else { $false }
+    # uiCapabilities is absent on older binaries / when the detector errored.
+    $canInject = $false
+    if ($p.probes.PSObject.Properties['uiCapabilities'] -and
+        $p.probes.uiCapabilities.PSObject.Properties['canBlockInputInjection']) {
+        $canInject = [bool]$p.probes.uiCapabilities.canBlockInputInjection
+    }
+    return [pscustomobject]@{
+        BaselineTier                   = $tier
+        BaseContainerUsable            = ($tier -eq 'base-container')
+        BaseContainerApiPresent        = [bool]$p.probes.baseContainerApiPresent
+        BfsCompiledIn                  = [bool]$p.probes.bfsCompiledIn
+        BfscfgPresent                  = [bool]$p.probes.bfscfgPresent
+        BaseContainerSupportsDenyPaths = $denyBit
+        # JOB_OBJECT_UILIMIT_INJECTION is build-gated (>= 26100). The probe
+        # reports whether the OS build supports the bit; runtime enforcement may
+        # still be behind a feature flag, which the Phase 4b INJECTION check
+        # accounts for separately.
+        CanBlockInputInjection         = $canInject
+        # deniedPaths is enforced on T3 via DENY ACEs, and on BaseContainer only
+        # when the SANDBOX_CAP_DENY_PATHS bit is set (lights up when the feature
+        # ships). Detected at runtime so denied tests auto-enable then.
+        SupportsDeniedPaths            = (($tier -eq 'appcontainer-dacl') -or $denyBit)
+    }
+}
+
+# Expected needsDaclAugmentation for a policy shape: DACL tier always augments;
+# BaseContainer augments only when the policy carries denied paths.
+function Get-ExpectedDaclAug {
+    param([bool]$HasDenied)
+    switch ($Script:Caps.BaselineTier) {
+        'appcontainer-dacl' { return $true }
+        'base-container'    { return [bool]$HasDenied }
+        default             { return $true }
+    }
+}
+
+# Pass when the log shows the host's expected isolation tier. The logger
+# interleaves a `[ts] ` token between write fragments, so bridge with `.*?`.
+function Test-SelectedTier {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$LogContent)
+    $pattern = '(?im)selected isolation tier:.*?' + [regex]::Escape($Script:ExpectedTier)
+    return [bool]($LogContent -match $pattern)
+}
+
+# Pass when the log shows that UI restrictions were applied, using the tier's
+# telemetry. T3 (AppContainer + DACL) creates the job object on the OUTSIDE and
+# logs "UI Job Object assigned". BaseContainer applies the job/UI limits INSIDE
+# via Experimental_CreateProcessInSandbox and instead logs a
+# "[ui subsystem] ... uilimits blocked" line.
+function Test-UiRestrictionsApplied {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$LogContent)
+    if ($Script:ExpectedTier -eq 'appcontainer-dacl') {
+        return [bool]($LogContent -match 'UI Job Object assigned')
+    }
+    return [bool]($LogContent -match '(?im)uilimits blocked')
+}
+
+# Pass when the log shows the Win32k mitigation (win32k syscalls blocked) was
+# applied. T3 logs "Win32k mitigation applied"; BaseContainer logs a
+# "win32k_system_calls: ... blocked" line in its [ui subsystem] section (vs.
+# "... allowed" when ui.disable=false).
+function Test-Win32kMitigationApplied {
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$LogContent)
+    if ($Script:ExpectedTier -eq 'appcontainer-dacl') {
+        return [bool]($LogContent -match 'Win32k mitigation applied')
+    }
+    return [bool]($LogContent -match '(?im)win32k_system_calls:.*?blocked')
+}
+
 function New-Config {
     param(
         [Parameter(Mandatory)] [string]$Name,
@@ -419,19 +569,22 @@ function New-Config {
     )
     $obj = [ordered]@{
         version     = '0.5.0-dev'
-        containerId = "MxcWin25H2-$Name"
+        containerId = "MxcWinPC-$Name"
         containment = 'appcontainer'
         process     = [ordered]@{
             commandLine = $CommandLine
             timeout     = $TimeoutMs
         }
     }
-    if ($Env.Count -gt 0) { $obj['process']['env'] = @($Env) }
-    if ($ReadWrite.Count -gt 0 -or $ReadOnly.Count -gt 0 -or $Denied.Count -gt 0) {
+    if ($null -ne $Env -and $Env.Count -gt 0) { $obj['process']['env'] = @($Env) }
+    $hasRw     = ($null -ne $ReadWrite -and $ReadWrite.Count -gt 0)
+    $hasRo     = ($null -ne $ReadOnly  -and $ReadOnly.Count  -gt 0)
+    $hasDenied = ($null -ne $Denied    -and $Denied.Count    -gt 0)
+    if ($hasRw -or $hasRo -or $hasDenied) {
         $fs = [ordered]@{}
-        if ($ReadWrite.Count -gt 0) { $fs['readwritePaths'] = @($ReadWrite) }
-        if ($ReadOnly.Count -gt 0)  { $fs['readonlyPaths']  = @($ReadOnly) }
-        if ($Denied.Count -gt 0)    { $fs['deniedPaths']    = @($Denied) }
+        if ($hasRw)     { $fs['readwritePaths'] = @($ReadWrite) }
+        if ($hasRo)     { $fs['readonlyPaths']  = @($ReadOnly) }
+        if ($hasDenied) { $fs['deniedPaths']    = @($Denied) }
         $obj['filesystem'] = $fs
     }
     if ($null -ne $AllowDaclMutation) {
@@ -531,13 +684,13 @@ function Invoke-Wxc {
 # Phase 1 — probes (read-only, never touches bfscfg)
 #
 # Expectations assume the `tier2_bfs` Cargo feature is OFF (Test-Preflight
-# enforces this) and that BaseContainer (Tier 1) is NOT usable on this
-# host: either the processmodel.dll export is absent, or it is present
-# but the OS feature is disabled. Both cases resolve identically, so the
-# detector drops to T3 (`appcontainer-dacl`) for every policy, including
-# the empty one. The harness keys off the selected tier (a
-# capability-derived signal) rather than raw symbol presence, so it runs
-# unchanged on both host variants.
+# enforces this), so the selected tier is the same for every policy shape:
+# `base-container` when BaseContainer is usable, else `appcontainer-dacl`.
+# The phase keys off $Script:ExpectedTier (derived from the empty-policy
+# probe) rather than any OS-version assumption, so it runs unchanged on both
+# T1-capable and T3-only hosts. needsDaclAugmentation is asserted via
+# Get-ExpectedDaclAug (DACL tier always augments; BaseContainer augments only
+# for denied paths).
 # -----------------------------------------------------------------------
 function Phase-Probes {
     Section 'Phase 1: --probe (read-only)'
@@ -547,51 +700,54 @@ function Phase-Probes {
 
     $probeEmpty = Invoke-Probe -Wxc $WxcRelease -Phase 'P1' -Name 'probe-no-config'
     if ($probeEmpty) {
-        # Drive everything off the selected tier. T1 is "usable" only when
-        # the empty-policy probe resolves to base-container; on both target
-        # hosts (symbol absent, or present-but-disabled) it resolves to
-        # appcontainer-dacl. `baseContainerApiPresent` is informational only.
-        $bcUsable = ($probeEmpty.tier -eq 'base-container')
-        $bcState = if ($bcUsable) { 'usable' }
+        $bcState = if ($Script:Caps.BaseContainerUsable) { 'usable' }
                    elseif ($probeEmpty.probes.baseContainerApiPresent) { 'present-but-disabled' }
                    else { 'absent' }
-        Write-Host ("BaseContainer state on this host: {0} (apiPresent={1})" -f $bcState, $probeEmpty.probes.baseContainerApiPresent)
+        Write-Host ("BaseContainer state on this host: {0} (apiPresent={1}); expected tier={2}" -f $bcState, $probeEmpty.probes.baseContainerApiPresent, $Script:ExpectedTier)
 
-        Record-Result -Phase 'P1' -Name 'BaseContainer not usable (T3 fallback active)' -Pass (-not $bcUsable) -Detail "tier=$($probeEmpty.tier); bcState=$bcState; apiPresent=$($probeEmpty.probes.baseContainerApiPresent)"
+        Record-Result -Phase 'P1' -Name 'expected tier is a recognized value' -Pass ($Script:ExpectedTier -in @('base-container', 'appcontainer-dacl')) -Detail "expectedTier=$($Script:ExpectedTier)"
         Record-Result -Phase 'P1' -Name 'bfsCompiledIn=false (safety gate)' -Pass (-not $probeEmpty.probes.bfsCompiledIn) -Detail "bfsCompiledIn=$($probeEmpty.probes.bfsCompiledIn)"
         Record-Result -Phase 'P1' -Name 'bfscfgPresent=false when feature off' -Pass (-not $probeEmpty.probes.bfscfgPresent) -Detail "bfscfgPresent=$($probeEmpty.probes.bfscfgPresent)"
-        Record-Result -Phase 'P1' -Name 'empty policy probe -> tier=appcontainer-dacl (T1 unusable, T2 gated out)' -Pass ($probeEmpty.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeEmpty.tier)"
-        Record-Result -Phase 'P1' -Name 'empty policy probe -> needsDaclAugmentation=true' -Pass ($probeEmpty.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
+        Record-Result -Phase 'P1' -Name "empty policy probe -> tier=$($Script:ExpectedTier)" -Pass ($probeEmpty.tier -eq $Script:ExpectedTier) -Detail "tier=$($probeEmpty.tier)"
+        $expAugEmpty = Get-ExpectedDaclAug -HasDenied:$false
+        Record-Result -Phase 'P1' -Name "empty policy probe -> needsDaclAugmentation=$expAugEmpty" -Pass ($probeEmpty.needsDaclAugmentation -eq $expAugEmpty) -Detail "needsDaclAugmentation=$($probeEmpty.needsDaclAugmentation)"
     }
 
     $cfgRw = New-Config -Name 'probe-rw' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw)
     $probeRw = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgRw -Phase 'P1' -Name 'probe-rw-config'
     if ($probeRw) {
-        Record-Result -Phase 'P1' -Name 'rw-paths probe -> tier=appcontainer-dacl (T2 gated out)' -Pass ($probeRw.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeRw.tier)"
-        Record-Result -Phase 'P1' -Name 'rw-paths probe -> needsDaclAugmentation=true' -Pass ($probeRw.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeRw.needsDaclAugmentation)"
+        Record-Result -Phase 'P1' -Name "rw-paths probe -> tier=$($Script:ExpectedTier)" -Pass ($probeRw.tier -eq $Script:ExpectedTier) -Detail "tier=$($probeRw.tier)"
+        $expAugRw = Get-ExpectedDaclAug -HasDenied:$false
+        Record-Result -Phase 'P1' -Name "rw-paths probe -> needsDaclAugmentation=$expAugRw" -Pass ($probeRw.needsDaclAugmentation -eq $expAugRw) -Detail "needsDaclAugmentation=$($probeRw.needsDaclAugmentation)"
     }
 
     $cfgDenied = New-Config -Name 'probe-denied' -CommandLine 'cmd /c exit 0' -Denied @($denied)
     $probeDenied = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgDenied -Phase 'P1' -Name 'probe-denied-config'
     if ($probeDenied) {
-        Record-Result -Phase 'P1' -Name 'denied probe -> tier=appcontainer-dacl (T2 gated out)' -Pass ($probeDenied.tier -eq 'appcontainer-dacl') -Detail "tier=$($probeDenied.tier)"
-        Record-Result -Phase 'P1' -Name 'denied probe -> needsDaclAugmentation=true' -Pass ($probeDenied.needsDaclAugmentation -eq $true) -Detail "needsDaclAugmentation=$($probeDenied.needsDaclAugmentation)"
+        Record-Result -Phase 'P1' -Name "denied probe -> tier=$($Script:ExpectedTier)" -Pass ($probeDenied.tier -eq $Script:ExpectedTier) -Detail "tier=$($probeDenied.tier)"
+        $expAugDenied = Get-ExpectedDaclAug -HasDenied:$true
+        Record-Result -Phase 'P1' -Name "denied probe -> needsDaclAugmentation=$expAugDenied" -Pass ($probeDenied.needsDaclAugmentation -eq $expAugDenied) -Detail "needsDaclAugmentation=$($probeDenied.needsDaclAugmentation)"
     }
 
     $cfgRefuse = New-Config -Name 'probe-refuse' -CommandLine 'cmd /c exit 0' -ReadWrite @($rw) -AllowDaclMutation $false
     $probeRefuse = Invoke-Probe -Wxc $WxcRelease -ConfigPath $cfgRefuse -Phase 'P1' -Name 'probe-allow-dacl-false'
     if ($probeRefuse) {
-        # With T2 gated out, rw-paths probe falls through to T3, which
-        # requires DACL augmentation. allowDaclMutation=false therefore
-        # trips DaclFallbackDisabled and the detector returns an error
-        # (tier omitted).
-        #
-        # Under Set-StrictMode -Version Latest, accessing an absent
-        # property throws; check existence via PSObject.Properties
-        # instead of `$null -eq $obj.foo`.
+        # Under Set-StrictMode -Version Latest, accessing an absent property
+        # throws; check existence via PSObject.Properties instead of
+        # `$null -eq $obj.foo`.
         $tierMissing = -not [bool]$probeRefuse.PSObject.Properties['tier']
         $errorStr    = if ($probeRefuse.PSObject.Properties['error']) { [string]$probeRefuse.error } else { '' }
-        Record-Result -Phase 'P1' -Name 'allowDaclMutation=false + rw-paths probe -> error (T3 needs DACL)' -Pass ($tierMissing -and ($errorStr -match 'DACL fallback')) -Detail "tierMissing=$tierMissing; error=$errorStr"
+        if (Get-ExpectedDaclAug -HasDenied:$false) {
+            # The expected tier needs DACL augmentation for rw paths, so
+            # allowDaclMutation=false trips DaclFallbackDisabled and the
+            # detector returns an error (tier omitted).
+            Record-Result -Phase 'P1' -Name 'allowDaclMutation=false + rw-paths probe -> error (DACL augmentation refused)' -Pass ($tierMissing -and ($errorStr -match 'DACL fallback')) -Detail "tierMissing=$tierMissing; error=$errorStr"
+        } else {
+            # BaseContainer host: rw paths need no DACL augmentation, so
+            # allowDaclMutation=false is a no-op and the probe still resolves.
+            $tierVal = if ($probeRefuse.PSObject.Properties['tier']) { [string]$probeRefuse.tier } else { '<missing>' }
+            Record-Result -Phase 'P1' -Name 'allowDaclMutation=false + rw-paths probe -> still resolves (no DACL augmentation needed)' -Pass ((-not $tierMissing) -and ($tierVal -eq $Script:ExpectedTier)) -Detail "tier=$tierVal; error=$errorStr"
+        }
     }
 }
 
@@ -620,9 +776,9 @@ function Phase-EmptyRelease {
 
     Record-Result -Phase 'P2' -Name 'release exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode); stdout=$($r.Stdout.Trim())"
     Record-Result -Phase 'P2' -Name 'AppContainer ran the child (stdout round-trip)' -Pass ($r.Stdout -match 'P2-empty-release-ok')
-    Record-Result -Phase 'P2' -Name 'selected isolation tier: appcontainer-dacl (T1 unusable, T2 gated out)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P2' -Name "selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContent) -Detail "expected=$($Script:ExpectedTier)"
     Record-Result -Phase 'P2' -Name 'no bfscfg invocation in log' -Pass (-not ($logContent -match '(?im)Output from bfscfg\.exe'))
-    Record-Result -Phase 'P2' -Name 'UI Job Object assigned telemetry' -Pass ([bool]($logContent -match 'UI Job Object assigned'))
+    Record-Result -Phase 'P2' -Name 'UI restrictions applied telemetry' -Pass (Test-UiRestrictionsApplied -LogContent $logContent)
 }
 
 # -----------------------------------------------------------------------
@@ -635,6 +791,15 @@ function Phase-DeniedRelease {
     }
     Section 'Phase 3: release build, deniedPaths only (safe lane)'
     Clear-StateFiles
+
+    # deniedPaths is enforced on T3 (DENY ACEs) and on BaseContainer only once
+    # the SANDBOX_CAP_DENY_PATHS bit lights up. Where unsupported, the runner
+    # rejects deniedPaths at launch, so skip rather than assert a transient
+    # limitation (the phase auto-enables when the capability appears).
+    if (-not $Script:Caps.SupportsDeniedPaths) {
+        Record-Result -Phase 'P3' -Name 'deniedPaths run' -Status 'skip' -Detail "deniedPaths not supported on tier=$($Script:ExpectedTier) (no SANDBOX_CAP_DENY_PATHS)"
+        return
+    }
 
     $denied = Join-Path $ScratchRoot 'denied'
     $aclBefore = Get-Acl-Snapshot $denied
@@ -652,7 +817,7 @@ function Phase-DeniedRelease {
     $aclAfter = Get-Acl-Snapshot $denied
 
     Record-Result -Phase 'P3' -Name 'release exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode)"
-    Record-Result -Phase 'P3' -Name 'selected isolation tier: appcontainer-dacl (T2 gated out)' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P3' -Name "selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContent) -Detail "expected=$($Script:ExpectedTier)"
     Record-Result -Phase 'P3' -Name 'no bfscfg invocation in log' -Pass (-not ($logContent -match '(?im)Output from bfscfg\.exe'))
     Record-Result -Phase 'P3' -Name 'denied-path ACL restored after run' -Pass ($aclBefore -eq $aclAfter)
     Record-Result -Phase 'P3' -Name 'no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
@@ -674,7 +839,14 @@ function Phase-T3Forced {
     $aclDeniedBefore = Get-Acl-Snapshot $denied
 
     $cmd = "cmd /c echo hello-from-t3 > `"$rw\probe.txt`" && type `"$rw\probe.txt`""
-    $cfg = New-Config -Name 't3-forced' -CommandLine $cmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied @($denied)
+    # deniedPaths is only included where the tier can enforce it; on a
+    # BaseContainer host without deny support the runner would reject the whole
+    # request. rw/ro still exercise the grant path either way. Assign in two
+    # steps: `if/else { @() }` as an expression collapses an empty array to
+    # $null, which then trips New-Config's `.Count` under StrictMode.
+    $deniedPolicy = @()
+    if ($Script:Caps.SupportsDeniedPaths) { $deniedPolicy = @($denied) }
+    $cfg = New-Config -Name 't3-forced' -CommandLine $cmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied $deniedPolicy
     $log = Join-Path $ScratchRoot 'logs\t3-forced.log'
     $r = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfg -LogPath $log
     $logContent = Read-Log $log
@@ -686,9 +858,9 @@ function Phase-T3Forced {
     $stateAfter     = @(Get-StateFiles)
 
     Record-Result -Phase 'P4' -Name 'child exit=0' -Pass ($r.ExitCode -eq 0) -Detail "exit=$($r.ExitCode)"
-    Record-Result -Phase 'P4' -Name 'selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
-    Record-Result -Phase 'P4' -Name 'UI Job Object assigned telemetry' -Pass ([bool]($logContent -match 'UI Job Object assigned'))
-    Record-Result -Phase 'P4' -Name 'Win32k mitigation applied telemetry (ui.disable=false -> not expected)' -Pass (-not ($logContent -match 'Win32k mitigation applied')) -Detail 'this config has ui.disable=false'
+    Record-Result -Phase 'P4' -Name "selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContent) -Detail "expected=$($Script:ExpectedTier)"
+    Record-Result -Phase 'P4' -Name 'UI restrictions applied telemetry' -Pass (Test-UiRestrictionsApplied -LogContent $logContent)
+    Record-Result -Phase 'P4' -Name 'Win32k mitigation NOT applied (ui.disable=false)' -Pass (-not (Test-Win32kMitigationApplied -LogContent $logContent)) -Detail 'this config has ui.disable=false'
     Record-Result -Phase 'P4' -Name 'rw ACL restored after run'     -Pass ($aclRwBefore -eq $aclRwAfter)
     Record-Result -Phase 'P4' -Name 'ro ACL restored after run'     -Pass ($aclRoBefore -eq $aclRoAfter)
     Record-Result -Phase 'P4' -Name 'denied ACL restored after run' -Pass ($aclDeniedBefore -eq $aclDeniedAfter)
@@ -709,8 +881,8 @@ function Phase-T3Forced {
     $logContent2 = Read-Log $log2
     Assert-NoBfscfg -LogContent $logContent2 -Phase 'P4' -Name 't3-ui-disable'
 
-    Record-Result -Phase 'P4' -Name 'ui.disable=true emits Win32k mitigation applied' -Pass ([bool]($logContent2 -match 'Win32k mitigation applied')) -Detail "child exit=$($r2.ExitCode) (expected to fail; cmd.exe needs Win32k)"
-    Record-Result -Phase 'P4' -Name 'ui.disable=true emits selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContent2 -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P4' -Name 'ui.disable=true emits Win32k mitigation applied' -Pass (Test-Win32kMitigationApplied -LogContent $logContent2) -Detail "child exit=$($r2.ExitCode) (expected to fail; cmd.exe needs Win32k)"
+    Record-Result -Phase 'P4' -Name "ui.disable=true emits selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContent2) -Detail "expected=$($Script:ExpectedTier)"
     # Even though child crashed, ACEs must still be cleaned up.
     $aclRwAfterUi = Get-Acl-Snapshot $rw
     Record-Result -Phase 'P4' -Name 'ui.disable=true rw ACL still cleaned up' -Pass ($aclRwBefore -eq $aclRwAfterUi)
@@ -749,7 +921,7 @@ function Phase-T3Forced {
     # load-bearing assertions.
     $accessSignal = $combinedPing -match '(?im)access\s*is\s*denied|access\s*denied|socket|10013|ICMP|general\s*failure|unable\s*to\s*contact'
     Record-Result -Phase 'P4' -Name 'sandbox blocks ping (failure looks socket-related)' -Pass ([bool]$accessSignal) -Detail 'best-effort string match'
-    Record-Result -Phase 'P4' -Name 'sandbox blocks ping: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentPing -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P4' -Name "sandbox blocks ping: selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContentPing) -Detail "expected=$($Script:ExpectedTier)"
     Record-Result -Phase 'P4' -Name 'sandbox blocks ping: rw ACL still cleaned up' -Pass ($aclRwBefore -eq $aclRwAfterPing)
     Record-Result -Phase 'P4' -Name 'sandbox blocks ping: no orphan state files' -Pass (@(Get-StateFiles).Count -eq 0)
 
@@ -800,15 +972,21 @@ function Phase-T3Forced {
         # propagation of the ALLOW ACE to existing children).
         Probe-Read  'RO_READ'        $ro      'readme.txt'
         Probe-Write 'RO_WRITE'       $ro      'rw_marker.tmp'
-        # Denied + control: must fail both ways.
-        Probe-Read  'DENIED_READ'    $denied  'readme.txt'
-        Probe-Write 'DENIED_WRITE'   $denied  'denied_attempt.tmp'
+        # Control: a path in NO policy must fail both ways (proves the
+        # AppContainer is sandboxed at all, not just that explicit ACEs work).
         Probe-Read  'CONTROL_READ'   $control 'readme.txt'
         Probe-Write 'CONTROL_WRITE'  $control 'control_attempt.tmp'
     )
+    # Denied rows only when the tier can enforce deniedPaths (see capability).
+    if ($Script:Caps.SupportsDeniedPaths) {
+        $clauses += Probe-Read  'DENIED_READ'  $denied 'readme.txt'
+        $clauses += Probe-Write 'DENIED_WRITE' $denied 'denied_attempt.tmp'
+    }
     $matrixCmd = 'cmd /c ' + ($clauses -join ' & ')
 
-    $cfgMatrix = New-Config -Name 't3-access-matrix' -CommandLine $matrixCmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied @($denied)
+    $matrixDenied = @()
+    if ($Script:Caps.SupportsDeniedPaths) { $matrixDenied = @($denied) }
+    $cfgMatrix = New-Config -Name 't3-access-matrix' -CommandLine $matrixCmd -ReadWrite @($rw) -ReadOnly @($ro) -Denied $matrixDenied
     $logMatrix = Join-Path $ScratchRoot 'logs\t3-access-matrix.log'
     $rMatrix = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgMatrix -LogPath $logMatrix
     $logContentMatrix = Read-Log $logMatrix
@@ -827,15 +1005,22 @@ function Phase-T3Forced {
     function Assert-Matrix {
         param([string]$Key, [string]$Want, [string]$Reason)
         $got = if ($matrix.ContainsKey($Key)) { $matrix[$Key] } else { '<missing>' }
-        Record-Result -Phase 'P4' -Name "matrix $Key=$Want ($Reason)" -Pass ($got -eq $Want) -Detail "got=$got; full=$matrixSummary"
+        $wantV = Format-Verdict $Want 'allowed' 'denied'
+        $gotV  = Format-Verdict $got  'allowed' 'denied'
+        $fullV = Format-VerdictSummary $matrixSummary 'allowed' 'denied'
+        Record-Result -Phase 'P4' -Name "matrix $Key ($Reason)" -Pass ($got -eq $Want) -Detail "expected=$wantV; got=$gotV; full=$fullV"
     }
 
     Assert-Matrix 'RW_WRITE'       'PASS' 'rw grant must allow child to create files'
     Assert-Matrix 'RW_READ'        'PASS' 'rw grant must allow child to read its own file'
     Assert-Matrix 'RO_READ'        'PASS' 'ro grant must allow reads (tests ACE inheritance to existing children)'
     Assert-Matrix 'RO_WRITE'       'FAIL' 'ro grant must NOT allow writes'
-    Assert-Matrix 'DENIED_READ'    'FAIL' 'denied path must block reads'
-    Assert-Matrix 'DENIED_WRITE'   'FAIL' 'denied path must block writes'
+    if ($Script:Caps.SupportsDeniedPaths) {
+        Assert-Matrix 'DENIED_READ'    'FAIL' 'denied path must block reads'
+        Assert-Matrix 'DENIED_WRITE'   'FAIL' 'denied path must block writes'
+    } else {
+        Record-Result -Phase 'P4' -Name 'matrix DENIED_READ/DENIED_WRITE' -Status 'skip' -Detail "deniedPaths not supported on tier=$($Script:ExpectedTier)"
+    }
     Assert-Matrix 'CONTROL_READ'   'FAIL' 'control path (no policy) must be sandboxed'
     Assert-Matrix 'CONTROL_WRITE'  'FAIL' 'control path (no policy) must be sandboxed'
 
@@ -882,7 +1067,16 @@ function Phase-T1DenyForced {
         return
     }
     if ($probe.tier -ne 'base-container') {
-        Record-Result -Phase 'P4c' -Name 'BaseContainer usable (required for T1 deny test)' -Pass $true -Detail "SKIPPED: BaseContainer not usable on this host (tier=$($probe.tier), apiPresent=$($probe.probes.baseContainerApiPresent))"
+        Record-Result -Phase 'P4c' -Name 'BaseContainer usable (required for T1 deny test)' -Status 'skip' -Detail "BaseContainer not usable on this host (tier=$($probe.tier), apiPresent=$($probe.probes.baseContainerApiPresent))"
+        return
+    }
+    # The deny test is only meaningful once BaseContainer can enforce
+    # deniedPaths. Before SANDBOX_CAP_DENY_PATHS lights up the runner rejects
+    # deniedPaths outright, which would otherwise make this phase "pass"
+    # vacuously (the run aborts, so the child never echoes the secret). Skip
+    # until the capability is present; it then asserts real deny enforcement.
+    if (-not $Script:Caps.SupportsDeniedPaths) {
+        Record-Result -Phase 'P4c' -Name 'BaseContainer deny-ACE enforcement' -Status 'skip' -Detail 'BaseContainer does not yet support deniedPaths (no SANDBOX_CAP_DENY_PATHS)'
         return
     }
 
@@ -916,7 +1110,7 @@ function Phase-T1DenyForced {
 }
 
 # -----------------------------------------------------------------------
-# Phase 4b — UI mitigation behavior matrix (T3 forced, debug build)
+# Phase 4b — UI mitigation behavior matrix (host baseline tier, debug build)
 #
 # Phase 4 already asserts that Win32k mitigation applied telemetry fires
 # when ui.disable=true and that UI Job Object assigned fires unconditionally.
@@ -933,7 +1127,7 @@ function Phase-T1DenyForced {
 #   it on the GetMessageW syscall).
 # -----------------------------------------------------------------------
 function Phase-UiMitigationMatrix {
-    Section 'Phase 4b: UI mitigation behavior matrix (T3 forced)'
+    Section 'Phase 4b: UI mitigation behavior matrix (host baseline tier)'
 
     $rw = Join-Path $ScratchRoot 'rw'
 
@@ -947,22 +1141,21 @@ function Phase-UiMitigationMatrix {
     # does not fail the atom APIs — it gives the job a private atom table —
     # so it cannot be verified with the simple "API failed -> PASS" matrix.
     # Phase-GlobalAtomIsolation covers it with a bidirectional isolation test.
-    # Create a hidden, message-pumping window owned by THIS (out-of-job)
-    # process. Its USER handle is what the HANDLES probe must NOT be able to
-    # reach: JOB_OBJECT_UILIMIT_HANDLES does not stop FindWindow from returning
-    # HWNDs — it blocks USING handles owned by processes outside the job — so
-    # the probe reads the window's title via GetWindowTextW (a cross-job
-    # WM_GETTEXT). PASS = it could not read the sentinel; FAIL = it read it.
-    # The window pumps messages on its own thread so the broken case returns
-    # the title promptly instead of hanging; the working case never delivers
-    # the message (rejected at the sender), so no pump dependency there.
+    # Create a hidden window owned by THIS (out-of-job) process. Its USER handle
+    # is what the HANDLES probe must NOT be able to use: JOB_OBJECT_UILIMIT_HANDLES
+    # does not stop FindWindow from returning HWNDs — it blocks USING handles
+    # owned by processes outside the job — so the probe calls
+    # GetWindowThreadProcessId on the HWND. That reads window-manager state
+    # directly (no WM_GETTEXT / SendMessage), so it is not confounded by UIPI or
+    # the target pumping messages. PASS = it could not resolve the owner (limit
+    # blocked the handle use); FAIL = it read back our process id.
     $handleTitle = "MxcHandleProbe_$([guid]::NewGuid().ToString('N'))"
     $winHost = New-Object Mxc.WindowHost
     $winHost.Start($handleTitle)
     try {
         $hwndVal = $winHost.Hwnd.ToInt64()
-        $probeArgsA = 'READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES'
-        $cmdA = "`"$UiProbeDebug`" $probeArgsA --handle-hwnd=$hwndVal --handle-title=`"$handleTitle`""
+        $probeArgsA = 'READCLIPBOARD WRITECLIPBOARD SYSTEMPARAMETERS DISPLAYSETTINGS DESKTOP EXITWINDOWS HANDLES INJECTION'
+        $cmdA = "`"$UiProbeDebug`" $probeArgsA --handle-hwnd=$hwndVal --handle-pid=$PID"
         $cfgA = New-Config -Name 'ui-matrix-A-allbits' `
             -CommandLine $cmdA `
             -ReadWrite @($rw) `
@@ -981,28 +1174,64 @@ function Phase-UiMitigationMatrix {
 
         $matrixA = @{}
         foreach ($line in ($rA.Stdout -split "`r?`n")) {
-            if ($line -match '^(?<k>READCLIPBOARD|WRITECLIPBOARD|SYSTEMPARAMETERS|DISPLAYSETTINGS|DESKTOP|EXITWINDOWS|HANDLES|WIN32K)=(?<v>PASS|FAIL)\s*$') {
+            if ($line -match '^(?<k>READCLIPBOARD|WRITECLIPBOARD|SYSTEMPARAMETERS|DISPLAYSETTINGS|DESKTOP|EXITWINDOWS|HANDLES|INJECTION|WIN32K)=(?<v>PASS|FAIL)\s*$') {
                 $matrixA[$matches['k']] = $matches['v']
             }
         }
         $summaryA = ($matrixA.GetEnumerator() | Sort-Object Name | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ' '
 
-        Record-Result -Phase 'P4b' -Name 'scenarioA: UI Job Object assigned telemetry' -Pass ([bool]($logContentA -match 'UI Job Object assigned'))
-        Record-Result -Phase 'P4b' -Name 'scenarioA: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentA -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+        Record-Result -Phase 'P4b' -Name 'scenarioA: UI restrictions applied telemetry' -Pass (Test-UiRestrictionsApplied -LogContent $logContentA)
+        Record-Result -Phase 'P4b' -Name "scenarioA: selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContentA) -Detail "expected=$($Script:ExpectedTier)"
         # ui.disable=false on this run: Win32k mitigation applied must NOT appear.
-        Record-Result -Phase 'P4b' -Name 'scenarioA: no Win32k mitigation applied (ui.disable=false)' -Pass (-not ($logContentA -match 'Win32k mitigation applied'))
+        Record-Result -Phase 'P4b' -Name 'scenarioA: Win32k mitigation NOT applied (ui.disable=false)' -Pass (-not (Test-Win32kMitigationApplied -LogContent $logContentA))
 
         foreach ($tag in @('READCLIPBOARD','WRITECLIPBOARD','SYSTEMPARAMETERS','DISPLAYSETTINGS','DESKTOP','EXITWINDOWS','HANDLES')) {
             $got = if ($matrixA.ContainsKey($tag)) { $matrixA[$tag] } else { '<missing>' }
-            Record-Result -Phase 'P4b' -Name "scenarioA: $tag blocked (probe -> PASS)" -Pass ($got -eq 'PASS') -Detail "got=$got; full=$summaryA"
+            $gotV  = Format-Verdict $got 'blocked' 'allowed'
+            $fullV = Format-VerdictSummary $summaryA 'blocked' 'allowed'
+            Record-Result -Phase 'P4b' -Name "scenarioA: $tag" -Pass ($got -eq 'PASS') -Detail "expected=blocked; got=$gotV; full=$fullV"
+        }
+
+        # INJECTION (JOB_OBJECT_UILIMIT_INJECTION, 0x200) is handled separately
+        # from the hard-assertion loop above. The probe creates and foregrounds
+        # its OWN window before SendInput so the kernel's foreground-accessible
+        # check (which precedes the injection job-limit check and silently skips
+        # input when the foreground belongs to another inaccessible process)
+        # passes and the limit is actually evaluated. Outcomes:
+        #   * build < 26100 (canBlockInputInjection false) -> SKIP (bit dropped).
+        #   * INJECTION=INCONCLUSIVE -> the probe could not own the foreground on
+        #     this desktop, so the limit was never exercised -> SKIP (not a
+        #     verdict); the injected/gle pair would be ambiguous.
+        #   * INJECTION=PASS -> owned foreground and SendInput was blocked
+        #     (injected 0/1 gle=5): enforced -> hard PASS.
+        #   * INJECTION=FAIL -> owned foreground but the event went through
+        #     (injected 1/1 gle=0): genuinely not enforced -> WARN, not a green
+        #     PASS. Auto-promotes to PASS once enforcement is on.
+        $injDiag = if ($rA.Stdout -match '(?m)^INJECTION=DIAG\s+(?<d>.+?)\s*$') { $matches['d'] } else { '<no diag>' }
+        $injInconclusive = [bool]($rA.Stdout -match '(?m)^INJECTION=INCONCLUSIVE\s*$')
+        if (-not $Script:Caps.CanBlockInputInjection) {
+            Record-Result -Phase 'P4b' -Name 'scenarioA: INJECTION' -Status 'skip' -Detail "JOB_OBJECT_UILIMIT_INJECTION not supported on this build (< 26100); diag=$injDiag"
+        } elseif ($injInconclusive) {
+            Record-Result -Phase 'P4b' -Name 'scenarioA: INJECTION' -Status 'skip' -Detail "could not own the foreground on this desktop; injection limit not exercised; diag=$injDiag"
+        } else {
+            $injGot = if ($matrixA.ContainsKey('INJECTION')) { $matrixA['INJECTION'] } else { '<missing>' }
+            if ($injGot -eq 'PASS') {
+                Record-Result -Phase 'P4b' -Name 'scenarioA: INJECTION' -Status 'pass' -Detail "expected=blocked; got=blocked; diag=$injDiag"
+            } else {
+                # Owned the foreground but the injection still went through ->
+                # the limit was not enforced. Non-failing WARN so the suite stays
+                # green where OS enforcement is not yet active.
+                $injGotV = Format-Verdict $injGot 'blocked' 'allowed'
+                Record-Result -Phase 'P4b' -Name 'scenarioA: INJECTION enforcement' -Status 'warn' -Detail "expected=blocked; got=$injGotV; NOT ENFORCED; diag=$injDiag"
+            }
         }
 
         # Negative control for HANDLES: same probe + host window, but
         # isolation=desktop sets NO UILIMIT_HANDLES. The probe MUST be able to
-        # read the external window's title -> HANDLES=FAIL, proving the
+        # resolve the external window's owner -> HANDLES=FAIL, proving the
         # HANDLES=PASS above is a real isolation result and not vacuous (e.g.
-        # GetWindowTextW returning empty for an unrelated reason).
-        $cmdAneg = "`"$UiProbeDebug`" HANDLES --handle-hwnd=$hwndVal --handle-title=`"$handleTitle`""
+        # GetWindowThreadProcessId failing for an unrelated reason).
+        $cmdAneg = "`"$UiProbeDebug`" HANDLES --handle-hwnd=$hwndVal --handle-pid=$PID"
         $cfgAneg = New-Config -Name 'ui-matrix-A-handles-neg' `
             -CommandLine $cmdAneg `
             -ReadWrite @($rw) `
@@ -1013,7 +1242,9 @@ function Phase-UiMitigationMatrix {
         $rAneg = Invoke-Wxc -Wxc $WxcDebug -ConfigPath $cfgAneg -LogPath $logAneg
         Assert-NoBfscfg -LogContent (Read-Log $logAneg) -Phase 'P4b' -Name 'ui-matrix-A-handles-neg'
         $negHandles = if ($rAneg.Stdout -match '(?m)^HANDLES=(?<v>PASS|FAIL)\s*$') { $matches['v'] } else { '<missing>' }
-        Record-Result -Phase 'P4b' -Name 'negative control: HANDLES visible without UILIMIT_HANDLES (probe -> FAIL)' -Pass ($negHandles -eq 'FAIL') -Detail "got=$negHandles; stdout=$($rAneg.Stdout.Trim())"
+        $negHandlesV = Format-Verdict $negHandles 'blocked' 'allowed'
+        $negStdoutV  = Format-VerdictSummary ($rAneg.Stdout.Trim()) 'blocked' 'allowed'
+        Record-Result -Phase 'P4b' -Name 'negative control: HANDLES usable without UILIMIT_HANDLES' -Pass ($negHandles -eq 'FAIL') -Detail "expected=allowed; got=$negHandlesV; stdout=$negStdoutV"
     }
     finally {
         $winHost.Stop()
@@ -1045,17 +1276,17 @@ function Phase-UiMitigationMatrix {
     $printedFail = ($rB.Stdout -match '(?m)^WIN32K=FAIL\s*$')
     $printedPass = ($rB.Stdout -match '(?m)^WIN32K=PASS\s*$')
 
-    Record-Result -Phase 'P4b' -Name 'scenarioB: Win32k mitigation applied telemetry' -Pass ([bool]($logContentB -match 'Win32k mitigation applied'))
-    Record-Result -Phase 'P4b' -Name 'scenarioB: selected isolation tier: appcontainer-dacl' -Pass ([bool]($logContentB -match '(?im)selected isolation tier:.*?appcontainer-dacl'))
+    Record-Result -Phase 'P4b' -Name 'scenarioB: Win32k mitigation applied telemetry' -Pass (Test-Win32kMitigationApplied -LogContent $logContentB)
+    Record-Result -Phase 'P4b' -Name "scenarioB: selected isolation tier: $($Script:ExpectedTier)" -Pass (Test-SelectedTier -LogContent $logContentB) -Detail "expected=$($Script:ExpectedTier)"
     # Mitigation worked iff the child never reported WIN32K=FAIL. Child
     # exit code is incidental — under the mitigation the process is killed
     # by the kernel; without it the probe completes and exits 0.
-    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=FAIL (mitigation honored)' -Pass (-not $printedFail) -Detail "exit=$($rB.ExitCode); stdout=$($rB.Stdout.Trim())"
-    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=PASS' -Pass (-not $printedPass) -Detail 'probe never returns PASS for WIN32K (process is killed before printing)'
+    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=allowed (mitigation honored)' -Pass (-not $printedFail) -Detail "exit=$($rB.ExitCode); stdout=$(Format-VerdictSummary ($rB.Stdout.Trim()) 'blocked' 'allowed')"
+    Record-Result -Phase 'P4b' -Name 'scenarioB: child did NOT report WIN32K=blocked' -Pass (-not $printedPass) -Detail 'probe never reports WIN32K=blocked (process is killed before printing)'
 }
 
 # -----------------------------------------------------------------------
-# Phase 4c — GLOBALATOMS bidirectional isolation (T3 forced)
+# Phase 4c — GLOBALATOMS bidirectional isolation (host baseline tier)
 #
 # JOB_OBJECT_UILIMIT_GLOBALATOMS does NOT make the atom APIs fail — the
 # documented behavior is that each job gets its own private atom table, so
@@ -1087,8 +1318,8 @@ function Invoke-GlobalAtomProbe {
     New-Item -ItemType Directory -Path $rw -Force | Out-Null
 
     $suffix      = [guid]::NewGuid().ToString('N')
-    $hostName    = "MxcWin25H2HostAtom_$suffix"
-    $guestName   = "MxcWin25H2GuestAtom_$suffix"
+    $hostName    = "MxcWinPCHostAtom_$suffix"
+    $guestName   = "MxcWinPCGuestAtom_$suffix"
     $readyFile   = Join-Path $rw "globalatom-ready-$suffix"
     $releaseFile = Join-Path $rw "globalatom-release-$suffix"
     Remove-Item -LiteralPath $readyFile, $releaseFile -ErrorAction SilentlyContinue
@@ -1185,18 +1416,18 @@ function Invoke-GlobalAtomProbe {
     $stdout = $sbOut.ToString()
     $logContent = Read-Log $log
     Assert-NoBfscfg -LogContent $logContent -Phase 'P4c' -Name $Name
-    $tierMatch = [bool]($logContent -match '(?im)selected isolation tier:.*?appcontainer-dacl')
+    $tierMatch = Test-SelectedTier -LogContent $logContent
     $h2g = if ($stdout -match '(?m)^GLOBALATOMS_HOST_TO_GUEST=(?<v>PASS|FAIL)\s*$') { $matches['v'] } else { '<missing>' }
-    return [pscustomobject]@{ HostToGuest = $h2g; GuestFound = $guestFound; TierMatch = $tierMatch; Detail = "stdout=$($stdout.Trim())" }
+    return [pscustomobject]@{ HostToGuest = $h2g; GuestFound = $guestFound; TierMatch = $tierMatch; Detail = "stdout=$(Format-VerdictSummary ($stdout.Trim()) 'blocked' 'allowed')" }
 }
 
 function Phase-GlobalAtomIsolation {
-    Section 'Phase 4c: GLOBALATOMS bidirectional isolation (T3 forced)'
+    Section 'Phase 4c: GLOBALATOMS bidirectional isolation (host baseline tier)'
 
     # ---- Positive: isolation=container sets UILIMIT_GLOBALATOMS -> isolated.
     $pos = Invoke-GlobalAtomProbe -Isolation 'container' -Name 'ui-globalatoms'
-    Record-Result -Phase 'P4c' -Name 'selected isolation tier: appcontainer-dacl' -Pass $pos.TierMatch
-    Record-Result -Phase 'P4c' -Name 'host atom NOT visible to contained process (host->guest)' -Pass ($pos.HostToGuest -eq 'PASS') -Detail "got=$($pos.HostToGuest); $($pos.Detail)"
+    Record-Result -Phase 'P4c' -Name "selected isolation tier: $($Script:ExpectedTier)" -Pass $pos.TierMatch
+    Record-Result -Phase 'P4c' -Name 'host atom NOT visible to contained process (host->guest)' -Pass ($pos.HostToGuest -eq 'PASS') -Detail "expected=blocked; got=$(Format-Verdict $pos.HostToGuest 'blocked' 'allowed'); $($pos.Detail)"
     if ($null -eq $pos.GuestFound) {
         Record-Result -Phase 'P4c' -Name 'contained atom NOT visible to host (guest->host)' -Pass $false -Detail 'probe never signalled ready; no guest-atom check performed'
     } else {
@@ -1208,7 +1439,7 @@ function Phase-GlobalAtomIsolation {
     # host MUST see the guest atom — proving the positive results above are not
     # vacuous (e.g. an atom API silently failing would otherwise read as PASS).
     $neg = Invoke-GlobalAtomProbe -Isolation 'desktop' -Name 'ui-globalatoms-neg'
-    Record-Result -Phase 'P4c' -Name 'negative control: host atom VISIBLE without UILIMIT_GLOBALATOMS (host->guest -> FAIL)' -Pass ($neg.HostToGuest -eq 'FAIL') -Detail "got=$($neg.HostToGuest); $($neg.Detail)"
+    Record-Result -Phase 'P4c' -Name 'negative control: host atom visible without UILIMIT_GLOBALATOMS (host->guest)' -Pass ($neg.HostToGuest -eq 'FAIL') -Detail "expected=allowed; got=$(Format-Verdict $neg.HostToGuest 'blocked' 'allowed'); $($neg.Detail)"
     if ($null -eq $neg.GuestFound) {
         Record-Result -Phase 'P4c' -Name 'negative control: contained atom VISIBLE to host without UILIMIT_GLOBALATOMS' -Pass $false -Detail 'probe never signalled ready; no guest-atom check performed'
     } else {
@@ -1220,8 +1451,18 @@ function Phase-GlobalAtomIsolation {
 # Phase 5 — allowDaclMutation=false rejection under forced T3
 # -----------------------------------------------------------------------
 function Phase-DaclDisabled {
-    Section 'Phase 5: debug build, T3 forced, allowDaclMutation=false'
+    Section 'Phase 5: debug build, allowDaclMutation=false (DACL-augmentation refusal)'
     Clear-StateFiles
+
+    # This phase exercises the DACL-augmentation refusal path, which only
+    # engages when the host's expected tier augments DACLs for an rw policy
+    # (i.e. appcontainer-dacl). On a BaseContainer host, rw paths use the
+    # BaseContainer mechanism and need no DACL augmentation, so
+    # allowDaclMutation=false is a no-op and there is nothing to refuse.
+    if (-not (Get-ExpectedDaclAug -HasDenied:$false)) {
+        Record-Result -Phase 'P5' -Name 'DACL-augmentation refusal' -Status 'skip' -Detail "rw policy needs no DACL augmentation on tier=$($Script:ExpectedTier)"
+        return
+    }
 
     $rw = Join-Path $ScratchRoot 'rw'
     $aclBefore = Get-Acl-Snapshot $rw
@@ -1246,8 +1487,17 @@ function Phase-DaclDisabled {
 # Phase 6 — crash-recovery
 # -----------------------------------------------------------------------
 function Phase-CrashRecovery {
-    Section 'Phase 6: debug build, T3 forced, taskkill mid-run (crash recovery)'
+    Section 'Phase 6: debug build, taskkill mid-run (DACL state crash recovery)'
     Clear-StateFiles
+
+    # Crash recovery is about reaping orphaned DACL-augmentation state, so it
+    # only applies when an rw policy actually augments DACLs (appcontainer-dacl
+    # tier). On a BaseContainer host no ACEs/state files are written for rw
+    # paths, so there is nothing to orphan or reap.
+    if (-not (Get-ExpectedDaclAug -HasDenied:$false)) {
+        Record-Result -Phase 'P6' -Name 'DACL state crash recovery' -Status 'skip' -Detail "rw policy writes no DACL state on tier=$($Script:ExpectedTier)"
+        return
+    }
 
     $rw = Join-Path $ScratchRoot 'rw'
     $aclBefore = Get-Acl-Snapshot $rw
@@ -1340,7 +1590,7 @@ function Invoke-CargoTest {
 function Phase-UnitTests {
     Section 'Phase 7: cargo test'
     # Truncate the cargo log at the start of each run.
-    Set-Content -LiteralPath $CargoLog -Value "Win25H2Safe-Tests cargo log — $(Get-Date -Format 'o')`n" -Encoding utf8
+    Set-Content -LiteralPath $CargoLog -Value "WinProcessContainer-Tests cargo log — $(Get-Date -Format 'o')`n" -Encoding utf8
     Push-Location $CargoRoot
     try {
         $exit1 = Invoke-CargoTest -Arguments @('test', '-p', 'wxc_common', '--lib') -Label 'wxc_common --lib'
@@ -1365,6 +1615,10 @@ $null = Start-Transcript -Path $ResultsFile -Force -IncludeInvocationHeader
 
 try {
     Test-Preflight
+    $Script:Caps = Get-HostCapabilities
+    $Script:ExpectedTier = $Script:Caps.BaselineTier
+    Write-Host ("Host capabilities: expectedTier={0} baseContainerUsable={1} apiPresent={2} bfscfgPresent={3} bfsCompiledIn={4} supportsDeniedPaths={5}" -f `
+        $Script:Caps.BaselineTier, $Script:Caps.BaseContainerUsable, $Script:Caps.BaseContainerApiPresent, $Script:Caps.BfscfgPresent, $Script:Caps.BfsCompiledIn, $Script:Caps.SupportsDeniedPaths) -ForegroundColor Cyan
     Initialize-Scratch
 
     # Phase registry. Build + preflight + scratch init above always run; this
@@ -1403,11 +1657,29 @@ catch {
 finally {
     Section 'Summary'
     # Force pipeline output to an array — under StrictMode, $null.Count throws.
-    $passed = @($Script:Results | Where-Object { $_.Pass })
-    $failed = @($Script:Results | Where-Object { -not $_.Pass })
+    $passed  = @($Script:Results | Where-Object { $_.Status -eq 'pass' })
+    $failed  = @($Script:Results | Where-Object { $_.Status -eq 'fail' })
+    $skipped = @($Script:Results | Where-Object { $_.Status -eq 'skip' })
+    $warned  = @($Script:Results | Where-Object { $_.Status -eq 'warn' })
     $pass = $passed.Count
     $fail = $failed.Count
-    Write-Host ("Total: {0}    Passed: {1}    Failed: {2}" -f ($pass + $fail), $pass, $fail)
+    $skip = $skipped.Count
+    $warn = $warned.Count
+    Write-Host ("Total: {0}    Passed: {1}    Failed: {2}    Skipped: {3}    Warnings: {4}" -f ($pass + $fail + $skip + $warn), $pass, $fail, $skip, $warn)
+    if ($warn -gt 0) {
+        Write-Host ''
+        Write-Host 'Warnings (constraint not enforced on this host):' -ForegroundColor Yellow
+        foreach ($r in $warned) {
+            Write-Host ("  [{0}] {1} :: {2}" -f $r.Phase, $r.Name, $r.Detail) -ForegroundColor Yellow
+        }
+    }
+    if ($skip -gt 0) {
+        Write-Host ''
+        Write-Host 'Skipped (not applicable on this host):' -ForegroundColor Yellow
+        foreach ($r in $skipped) {
+            Write-Host ("  [{0}] {1} :: {2}" -f $r.Phase, $r.Name, $r.Detail) -ForegroundColor Yellow
+        }
+    }
     if ($fail -gt 0) {
         Write-Host ''
         Write-Host 'Failures:' -ForegroundColor Red
@@ -1422,9 +1694,11 @@ finally {
         host        = $env:COMPUTERNAME
         os          = (Get-CimInstance Win32_OperatingSystem).Caption
         osBuild     = (Get-CimInstance Win32_OperatingSystem).BuildNumber
-        total       = $pass + $fail
+        total       = $pass + $fail + $skip + $warn
         passed      = $pass
         failed      = $fail
+        skipped     = $skip
+        warnings    = $warn
         results     = $Script:Results
     }
     try {


### PR DESCRIPTION
## 📖 Description

Reworks the Windows process-container test harness to be **capability-driven**:
it runs the correct checks on any Windows build (Nickel 23H2 / Germanium
24H2+25H2) by deriving the expected isolation tier and per-limit expectations
from `wxc-exec --probe` at runtime, instead of branching on the OS version.
Renames the harness accordingly, adds a working
`JOB_OBJECT_UILIMIT_INJECTION` probe, and makes the result output unambiguous.

Highlights:

* **Capability-driven harness + rename.** Tier and per-limit expectations come
  from `--probe`; renamed `Win25H2Safe-Tests.ps1` → `WinProcessContainer-Tests.ps1`
  and updated stale references (`T3-Workloads.ps1`, `wxc` main.rs,
  `filesystem_dacl.rs`).
* **BaseContainer (Tier 1) support.** Tier-aware telemetry/assertions and a new
  `probes.baseContainerSupportsDenyPaths` fact (`SANDBOX_CAP_DENY_PATHS`) so
  `deniedPaths` tests auto-skip where the BaseContainer tier can't yet enforce
  them and auto-enable when the capability ships. Fixed a T1 `New-Config`
  `$null`-array-collapse crash under StrictMode.
* **HANDLES probe** switched from `GetWindowTextW` to `GetWindowThreadProcessId`
  so it reads window-manager state directly and isn't confounded by UIPI or the
  target pumping messages.
* **INJECTION probe** (`JOB_OBJECT_UILIMIT_INJECTION`, build 26100+) now creates
  and foregrounds its **own** top-level window before `SendInput`. The kernel's
  `DoInputCheck` evaluates the foreground-accessible check *before* the injection
  job-limit check and silently skips the input (returning success) when the
  foreground belongs to another inaccessible process, so a contained process on
  an interactive desktop would otherwise misread enforcement as "not enforced".
  Owning the foreground (the kernel permits injecting into one's own window)
  makes the limit actually evaluate. New `INJECTION=INCONCLUSIVE` outcome →
  harness SKIP when the foreground can't be owned, rather than a false verdict.
* **Result reporting.** `Record-Result` gains `skip`/`warn` statuses
  (`[SKIP]`/`[WARN]`, non-failing, yellow) so a not-applicable or not-enforced
  check is never shown as a green `[PASS]`; the summary and JSON carry
  skipped/warnings counts. Probe `PASS`/`FAIL` tokens are translated to semantic
  verbs in output (blocked/allowed for UI/atom probes, allowed/denied for the
  filesystem matrix) so a green `[PASS]` line never contains the word `FAIL`.
* Dropped stale "T3 forced" labels from the Phase 4b/4c headers (those phases run
  on the host's baseline tier).

> **Note:** This PR targets `user/gudge/job_limit_test_fixes` (the head of
> #544). It should be rebased onto `main` and retargeted once #544 merges.

## 🔗 References

- Builds on #544.

## 🔍 Validation

* `cargo fmt --all -- --check`, `cargo check --workspace --all-targets`, and
  `cargo clippy --workspace --all-targets -- -D warnings`: all clean.
* `cargo test`: `appcontainer_common` 126 passed, `wxc_common` 338 passed, 0
  failures.
* Direct verification on build 26200: a process self-assigned to a job with
  `JOB_OBJECT_UILIMIT_INJECTION` is blocked by `SendInput`
  (`gle=ERROR_ACCESS_DENIED`), confirming the OS enforces the limit; the
  reworked probe run contained via `wxc-exec` reports `INJECTION=PASS`
  ("owns foreground", injected 0/1 gle=5) where the old probe falsely reported
  not-enforced.
* Harness parse-checked via `[Parser]::ParseFile`; unit-tested the INJECTION
  verdict gate (enforced / not-enforced / inconclusive / build-gated) and the
  verdict-translation helpers (UI / filesystem / atom token sets, plus DIAG and
  `<missing>` pass-through).
* Validated end-to-end on interactive 23H2 (22631), 25H2 (26200), and 25H2+
  (26634) machines — INJECTION correctly skips when the foreground is stolen
  mid-run and passes when left alone. Full Phase 4b/4c not run on the shared dev
  host (EXITWINDOWS carries a logoff risk).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/547)