### PR TITLE
Remove GitHub build exclusions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -6,24 +6,10 @@ name: Build
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/copilot-instructions.md'
-      - '.github/instructions/**'
-      - '**/*.md'
-      - '.editorconfig'
+
   pull_request:
     branches: [main, 'feature/*', 'user/*']
-    paths-ignore:
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/copilot-instructions.md'
-      - '.github/instructions/**'
-      - '**/*.md'
-      - '.editorconfig'
+
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION

## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
We currently exclude .md files from the Build workflow here:

https://github.com/microsoft/mxc/blob/b19e8126f7c5c2562066d602ec78096f136c014d/.github/workflows/Build.yml#L19

However, in the repository settings, the GitHub Actions checks are marked as required. As a result, when a PR only changes .md files, such as #539, the Build workflow does not run because those files are excluded. Since the required check is never produced, GitHub blocks the PR from merging due to a missing required status check. This change now removes the excludes. We will now run the pipeline for all PRs so we can keep the pipelines as required.
## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/549)