### PR TITLE
Add denial channel: cross-platform captureDenials transport

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -23,7 +23,7 @@
     "watch": "tsc --watch",
     "clean": "rimraf dist",
     "test": "npm run test:unit",
-    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js dist-tests/tests/unit/platform.test.js",
+    "test:unit": "npm run build:test-unit && node --test dist-tests/tests/unit/sandbox.test.js dist-tests/tests/unit/policy.test.js dist-tests/tests/unit/logger.test.js dist-tests/tests/unit/errors.test.js dist-tests/tests/unit/state-aware-types.test.js dist-tests/tests/unit/state-aware.test.js dist-tests/tests/unit/platform.test.js dist-tests/tests/unit/denial-stream.test.js dist-tests/tests/unit/denial-side-channel.test.js",
     "test:integration": "cd tests/integration && npm install && npm run build && npm test",
     "prepublishOnly": "npm run build"
   },

--- a/sdk/src/denial-channel/index.ts
+++ b/sdk/src/denial-channel/index.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Denial channel — cross-platform captureDenials transport.
+ *
+ * Cross-platform wire transport for `DeniedResource` events:
+ *
+ * - {@link ./stream | `./stream`} — NDJSON parser + types + dedupe.
+ *   The parser is stream-agnostic (reads any `Readable`), so the
+ *   "stderr transport" is currently implicit: callers pass
+ *   `child.stderr` directly.
+ * - {@link ./transports/named-pipe | `./transports/named-pipe`} —
+ *   Windows named-pipe server, used when the workload owns the
+ *   PTY and the denial stream needs its own channel.
+ *
+ * Re-exported by the package root so external callers can write
+ * `import { parseDenialStream } from '@microsoft/mxc-sdk'`; this
+ * file exists to make the subdirectory a coherent unit for
+ * internal callers.
+ */
+
+export * from './stream.js';
+export * from './transports/named-pipe.js';

--- a/sdk/src/denial-channel/stream.ts
+++ b/sdk/src/denial-channel/stream.ts
@@ -1,0 +1,488 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * captureDenials streaming protocol — TypeScript consumer side.
+ *
+ * When `ContainerConfig.captureDenials` is true, the native binary
+ * (`wxc-exec`) captures access denials from the sandboxed process and
+ * writes one NDJSON line per captured denial to its own stderr,
+ * prefixed with the ASCII Record Separator byte (0x1E):
+ *
+ * ```text
+ * \x1e{"type":"denial","path":"...","resourceType":"...","accessType":"...","pid":N,"filetime":N}\n
+ * ...
+ * \x1e{"type":"summary","exitCode":N,"totalDenials":N,"deniedResourcesTruncated":bool}\n
+ * ```
+ *
+ * The 0x1E prefix is what makes this safely embeddable in stderr
+ * alongside the workload's own stderr writes: the byte is
+ * non-printable and effectively never appears in real workload
+ * output. Consumers split stderr on 0x1E and parse each non-empty
+ * segment as JSON.
+ *
+ * Scope: filesystem/registry denials only. Network denials have a
+ * different shape and are not yet captured; the `DeniedResource`
+ * discriminated union is designed so adding a `kind: "network"`
+ * variant later is additive.
+ */
+
+import type { Readable } from 'stream';
+
+/** ASCII Record Separator. Sentinel byte that prefixes every line in the stream. */
+export const DENIAL_STREAM_MARKER = 0x1e;
+
+/** Kind of access the sandboxed process attempted on a denied resource. */
+export type DenialAccessType = 'read' | 'write' | 'execute' | 'unknown';
+
+/**
+ * Type of resource that was denied. `file` covers both files and
+ * directories; `registry` covers Windows registry keys (which are
+ * reported by the kernel with the `\REGISTRY\...` namespace prefix).
+ * `other` is a fallback for object-manager namespaces we haven't
+ * specifically categorised yet.
+ */
+export type DenialResourceType = 'file' | 'registry' | 'network' | 'other';
+
+/**
+ * A single captured access-denial event, in the shape the SDK
+ * surfaces to callers. Discriminated union on `kind` so adding new
+ * resource families (network, IPC, …) later is additive: existing
+ * code that handles `kind === 'file'` keeps working.
+ */
+export type DeniedResource =
+  | {
+      kind: 'file';
+      /** User-visible path. May still carry `\??\` NT-DOS-namespace prefix if filters are disabled. */
+      path: string;
+      /** Whether this was a registry key (vs filesystem file/dir). */
+      resourceType: Extract<DenialResourceType, 'file' | 'registry' | 'other'>;
+      /** Access kind the workload attempted. */
+      accessType: DenialAccessType;
+      /** PID of the workload process inside the sandbox. */
+      pid: number;
+      /** Windows FILETIME (100-ns ticks since 1601) when the kernel logged the denial. */
+      filetime: number;
+    };
+// (Future: { kind: 'network'; host: string; port: number; protocol: 'tcp'|'udp'|'icmp'; direction: 'outbound'|'inbound'; ... })
+
+/**
+ * Summary terminator emitted at the end of the captureDenials
+ * stream. Receiving this is the canonical end-of-stream signal for
+ * the captureDenials protocol (independent of process exit).
+ */
+export interface DenialStreamSummary {
+  exitCode: number;
+  /**
+   * Number of *unique* `(path, accessType)` pairs the native binary
+   * streamed during the run. Matches the number of `DeniedResource`
+   * events a consumer parsed (before applying noise filters).
+   */
+  totalDenials: number;
+  /**
+   * True if the internal capture buffer hit its cap and dropped
+   * events. Indicates the resource list is incomplete.
+   */
+  deniedResourcesTruncated: boolean;
+  /**
+   * True when the runner successfully activated denial capture for
+   * this invocation. False when capture was requested
+   * (`captureDenials: true` on the config) but the runner couldn't
+   * activate it.
+   *
+   * SDK consumers should check this before treating
+   * `totalDenials: 0` as "the workload didn't trip any denials"; an
+   * inactive capture also produces 0 streamed denials, but it means
+   * something completely different (the feature isn't working).
+   */
+  captureDenialsActive: boolean;
+  /**
+   * Best-effort count of distinct child-process PIDs the runner
+   * observed under the workload during the run, via a 500-ms
+   * poll loop.
+   *
+   * When descendant tracking is active, denials from descendant PIDs
+   * flow into the same stream as the root's. `childProcessesObserved`
+   * remains a useful cross-check (it can sometimes catch descendants
+   * the primary path missed due to start/exit races, since the two
+   * mechanisms have different timing).
+   *
+   * Very short-lived children that start and exit between polls
+   * won't appear here. It is a best-effort signal, not a
+   * guarantee.
+   */
+  childProcessesObserved: number;
+  /**
+   * Authoritative count of descendant PIDs the runner successfully
+   * attached denial capture to. Each descendant that successfully
+   * joined is counted once; descendants the runner saw but failed to
+   * attach are excluded.
+   *
+   * Use this rather than `childProcessesObserved` when surfacing a
+   * "captured M denials across N descendants" message to the user.
+   */
+  descendantPidsCovered: number;
+  /**
+   * Pre-dedupe kernel event count. Only present when the workload
+   * was launched with `MXC_DENIAL_VERBOSE=1` in its environment;
+   * undefined otherwise. Useful for diagnosing chatty workloads.
+   */
+  rawEventCount?: number;
+}
+
+/**
+ * Predicate that returns true to keep a streamed denial and false
+ * to drop it. Composed with `defaultDenialFilters` to build the
+ * effective filter chain for {@link parseDenialStream}.
+ */
+export type DenialFilter = (resource: DeniedResource) => boolean;
+
+/**
+ * Default filter chain applied to streamed denials unless
+ * `filters: 'none'` is passed to {@link parseDenialStream}.
+ *
+ * These filters remove the bulk of the sandbox "background hum" —
+ * access checks the OS records for every sandboxed process regardless
+ * of what the workload is actually doing (locale/config probes,
+ * loader library searches in system directories, etc.). Callers who
+ * need the full unfiltered stream (e.g. for diagnostics or building a
+ * noise allow-list) can pass `filters: 'none'`.
+ */
+export const defaultDenialFilters: readonly DenialFilter[] = [
+  // 1. Drop AppContainer-default registry probes
+  //    (\REGISTRY\USER\.DEFAULT\Control Panel\*, Software\Classes\*, …).
+  //    These are system noise, not workload intent.
+  (r) =>
+    !(
+      r.kind === 'file' &&
+      /^\\REGISTRY\\USER\\\.DEFAULT\\/i.test(r.path)
+    ),
+
+  // 2. Drop kernel-loader DLL/MUI/MUN/CAT probes under
+  //    C:\Windows\System32. These are emitted by the OS loader for
+  //    every newly-spawned process and are never something the
+  //    workload would prompt the user about.
+  (r) =>
+    !(
+      r.kind === 'file' &&
+      /^(?:\\\?\?\\)?C:\\Windows\\System32\\.*\.(?:dll|mui|mun|cat|cdf-ms|nls)$/i.test(
+        r.path,
+      )
+    ),
+];
+
+/**
+ * Strip the `\??\` NT-DOS-device-namespace prefix that the kernel
+ * uses internally so paths surface to the user in the familiar
+ * `C:\…` form. No-op for paths that don't carry the prefix
+ * (registry keys, already-stripped paths).
+ */
+export function stripNtPrefix(path: string): string {
+  return path.startsWith('\\??\\') ? path.slice(4) : path;
+}
+
+/**
+ * Outcome of consuming a captureDenials stream end-to-end.
+ */
+export interface DenialStreamResult {
+  /**
+   * All resources that survived the filter chain, in arrival order.
+   * Already deduped by `(path, accessType)` upstream by the native
+   * binary.
+   */
+  denials: DeniedResource[];
+  /**
+   * The terminator summary line, if one was observed. Absent only
+   * when the stream ended abnormally (process killed before the
+   * summary was emitted).
+   */
+  summary?: DenialStreamSummary;
+  /**
+   * Count of streamed lines we couldn't parse as JSON. Non-zero
+   * indicates a wire-format mismatch (likely a native-binary version
+   * skew); consumers should log and continue.
+   */
+  parseErrors: number;
+}
+
+/**
+ * Options for {@link parseDenialStream}.
+ */
+export interface ParseDenialStreamOptions {
+  /**
+   * Filter chain. Defaults to {@link defaultDenialFilters}. Pass
+   * `'none'` to receive the full unfiltered stream, or an array of
+   * {@link DenialFilter} predicates to apply in order (all must
+   * return true for the resource to be kept).
+   */
+  filters?: readonly DenialFilter[] | 'none';
+  /**
+   * If true, strip the `\??\` NT-DOS-device prefix from file paths
+   * before they reach the callback / result. Defaults to true —
+   * `C:\Users\Foo` reads more naturally than `\??\C:\Users\Foo`.
+   */
+  stripNtPrefix?: boolean;
+  /**
+   * Called for every denial that passes the filter chain, in the
+   * order the native binary streamed them. Use this to drive
+   * mid-run UX (e.g. prompt the user to grant access). The same
+   * resources are also accumulated into the final result.
+   */
+  onDenial?: (resource: DeniedResource) => void;
+  /**
+   * Called when the summary terminator line is observed. Receiving
+   * this means the captureDenials stream is finished (the process
+   * may still be alive briefly afterwards).
+   */
+  onSummary?: (summary: DenialStreamSummary) => void;
+  /**
+   * Optional hook for stderr bytes that are *not* part of the
+   * captureDenials protocol (i.e. anything between 0x1E markers,
+   * including the workload's own stderr writes and wxc-exec's error
+   * envelopes). Receives raw chunks as they arrive so callers can
+   * forward them to their own stderr or to a log.
+   */
+  onPassthrough?: (chunk: Buffer) => void;
+}
+
+/**
+ * Consume a `wxc-exec` stderr stream end-to-end, demultiplexing
+ * captureDenials NDJSON lines (prefixed with 0x1E) from the
+ * workload's own stderr writes.
+ *
+ * Returns a Promise that resolves when the stream closes, with all
+ * parsed denials (already filtered + path-normalised by default)
+ * plus the terminator summary line.
+ *
+ * @example
+ * ```typescript
+ * import { spawnSandboxFromConfig } from '@microsoft/mxc-sdk';
+ * import { parseDenialStream, stripNtPrefix } from '@microsoft/mxc-sdk';
+ *
+ * const config = createConfigFromPolicy(policy, 'process');
+ * config.captureDenials = true;
+ * config.process!.commandLine = 'cat /path/to/file.txt';
+ *
+ * const child = spawnSandboxFromConfig(config, { usePty: false });
+ * const result = await parseDenialStream(child.stderr!, {
+ *   onDenial: (r) => console.log('Denied:', r.path),
+ * });
+ * console.log(`Survived filters: ${result.denials.length}`);
+ * console.log(`Exit: ${result.summary?.exitCode}`);
+ * ```
+ *
+ * @param stderr - The stderr stream from a `wxc-exec` child process
+ *   spawned with `usePty: false`. PTY mode merges stdout+stderr and
+ *   is not supported.
+ * @param options - {@link ParseDenialStreamOptions} controlling
+ *   filtering, path normalisation, and event callbacks.
+ */
+export function parseDenialStream(
+  stderr: Readable,
+  options: ParseDenialStreamOptions = {},
+): Promise<DenialStreamResult> {
+  const filterChain =
+    options.filters === 'none'
+      ? []
+      : options.filters ?? defaultDenialFilters;
+  const stripPrefix = options.stripNtPrefix !== false;
+  const result: DenialStreamResult = { denials: [], parseErrors: 0 };
+
+  return new Promise<DenialStreamResult>((resolve, reject) => {
+    // Accumulator for bytes between 0x1E and \n when a segment
+    // straddles chunks. Cleared every time we successfully flush a
+    // segment.
+    let pending: Buffer = Buffer.alloc(0);
+    let inSegment = false;
+
+    const flushSegment = (segment: Buffer) => {
+      // A segment ends at the next 0x1E (handled by caller) or at
+      // stream close. We trim the trailing newline the native side
+      // appends after the JSON.
+      let text = segment.toString('utf8');
+      if (text.endsWith('\n')) text = text.slice(0, -1);
+      if (text.length === 0) return;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        result.parseErrors += 1;
+        return;
+      }
+
+      if (!parsed || typeof parsed !== 'object') {
+        result.parseErrors += 1;
+        return;
+      }
+      const obj = parsed as Record<string, unknown>;
+
+      if (obj.type === 'denial') {
+        const resource = denialFromWire(obj);
+        if (!resource) {
+          result.parseErrors += 1;
+          return;
+        }
+        const normalized = stripPrefix
+          ? { ...resource, path: stripNtPrefix(resource.path) }
+          : resource;
+        for (const f of filterChain) {
+          if (!f(normalized)) return;
+        }
+        result.denials.push(normalized);
+        options.onDenial?.(normalized);
+        return;
+      }
+
+      if (obj.type === 'summary') {
+        const summary = summaryFromWire(obj);
+        if (!summary) {
+          result.parseErrors += 1;
+          return;
+        }
+        result.summary = summary;
+        options.onSummary?.(summary);
+        return;
+      }
+
+      // Unknown envelope type — count as a parse error so a future
+      // native-binary version that adds new envelope types is
+      // visible to callers rather than silently dropped.
+      result.parseErrors += 1;
+    };
+
+    stderr.on('data', (chunk: Buffer) => {
+      // State machine:
+      //   not-in-segment + 0x1E  -> enter segment
+      //   not-in-segment + byte  -> passthrough byte
+      //   in-segment + '\n'      -> close segment (flush), exit segment
+      //   in-segment + byte      -> accumulate
+      //
+      // We walk the chunk once, batching consecutive passthrough or
+      // segment bytes into a single slice per call to minimize copies.
+      let i = 0;
+      while (i < chunk.length) {
+        const byte = chunk[i];
+        if (!inSegment) {
+          if (byte === DENIAL_STREAM_MARKER) {
+            inSegment = true;
+            i += 1;
+            continue;
+          }
+          // Run-length scan for the next 0x1E and emit everything
+          // before it as a single passthrough chunk.
+          let j = i + 1;
+          while (j < chunk.length && chunk[j] !== DENIAL_STREAM_MARKER) j += 1;
+          if (options.onPassthrough) {
+            options.onPassthrough(chunk.subarray(i, j));
+          }
+          i = j;
+          continue;
+        }
+        // In segment: scan for terminating newline.
+        let j = i;
+        while (j < chunk.length && chunk[j] !== 0x0a) j += 1;
+        if (j < chunk.length) {
+          // Found '\n'. Combine with pending bytes from prior chunks
+          // (if any) and flush.
+          const segment =
+            pending.length > 0
+              ? Buffer.concat([pending, chunk.subarray(i, j)])
+              : chunk.subarray(i, j);
+          flushSegment(segment);
+          pending = Buffer.alloc(0);
+          inSegment = false;
+          i = j + 1; // skip the newline itself
+        } else {
+          // Segment continues into next chunk; buffer what we have.
+          pending = Buffer.concat([pending, chunk.subarray(i)]);
+          i = chunk.length;
+        }
+      }
+    });
+
+    stderr.on('end', () => {
+      // Flush any pending in-segment bytes as a final record. This
+      // handles the (legal) case where the writer didn't append a
+      // trailing newline after the summary line.
+      if (inSegment && pending.length > 0) {
+        flushSegment(pending);
+        pending = Buffer.alloc(0);
+      }
+      resolve(result);
+    });
+
+    stderr.on('error', (err) => reject(err));
+  });
+}
+
+/**
+ * Convert a wire-format `denial` JSON envelope into a typed
+ * {@link DeniedResource}. Returns null when required fields are
+ * missing or have the wrong type so the parser can count the line
+ * as a parseError rather than throwing.
+ */
+function denialFromWire(obj: Record<string, unknown>): DeniedResource | null {
+  if (typeof obj.path !== 'string') return null;
+  if (typeof obj.pid !== 'number') return null;
+  if (typeof obj.filetime !== 'number') return null;
+
+  const resourceTypeStr = typeof obj.resourceType === 'string' ? obj.resourceType : 'other';
+  const accessTypeStr = typeof obj.accessType === 'string' ? obj.accessType : 'unknown';
+
+  const resourceType: DeniedResource['resourceType'] =
+    resourceTypeStr === 'file' || resourceTypeStr === 'registry' ? resourceTypeStr : 'other';
+  const accessType: DenialAccessType =
+    accessTypeStr === 'read' || accessTypeStr === 'write' || accessTypeStr === 'execute'
+      ? accessTypeStr
+      : 'unknown';
+
+  return {
+    kind: 'file',
+    path: obj.path,
+    resourceType,
+    accessType,
+    pid: obj.pid,
+    filetime: obj.filetime,
+  };
+}
+
+/**
+ * Convert a wire-format `summary` JSON envelope into a typed
+ * {@link DenialStreamSummary}. Returns null when required fields
+ * are missing or have the wrong type.
+ */
+function summaryFromWire(obj: Record<string, unknown>): DenialStreamSummary | null {
+  if (typeof obj.exitCode !== 'number') return null;
+  if (typeof obj.totalDenials !== 'number') return null;
+  if (typeof obj.deniedResourcesTruncated !== 'boolean') return null;
+  // captureDenialsActive landed in a later native-binary version. We
+  // accept its absence (treat as true) so older binaries that don't
+  // emit the field don't trip the parser; new binaries always emit
+  // it.
+  const captureDenialsActive =
+    typeof obj.captureDenialsActive === 'boolean' ? obj.captureDenialsActive : true;
+  // Same forward-compat policy for childProcessesObserved -- older
+  // binaries that don't yet poll for children get treated as if no
+  // children were observed (the conservative answer).
+  const childProcessesObserved =
+    typeof obj.childProcessesObserved === 'number' ? obj.childProcessesObserved : 0;
+  // descendantPidsCovered landed in Phase E of the descendant-tracking
+  // work. Older `wxc-exec` builds (everything before Phase E) don't
+  // emit the field; treat its absence as 0 so a recent SDK against an
+  // older runner stays sane.
+  const descendantPidsCovered =
+    typeof obj.descendantPidsCovered === 'number' ? obj.descendantPidsCovered : 0;
+  const summary: DenialStreamSummary = {
+    exitCode: obj.exitCode,
+    totalDenials: obj.totalDenials,
+    deniedResourcesTruncated: obj.deniedResourcesTruncated,
+    captureDenialsActive,
+    childProcessesObserved,
+    descendantPidsCovered,
+  };
+  if (typeof obj.rawEventCount === 'number') {
+    summary.rawEventCount = obj.rawEventCount;
+  }
+  return summary;
+}

--- a/sdk/src/denial-channel/stream.ts
+++ b/sdk/src/denial-channel/stream.ts
@@ -61,8 +61,14 @@ export type DeniedResource =
       accessType: DenialAccessType;
       /** PID of the workload process inside the sandbox. */
       pid: number;
-      /** Windows FILETIME (100-ns ticks since 1601) when the kernel logged the denial. */
-      filetime: number;
+      /**
+       * Kernel timestamp when the denial was logged (on Windows, a
+       * `FILETIME`: 100-ns ticks since 1601). Carried on the wire as a
+       * decimal string and surfaced here as a `bigint` so the full
+       * 64-bit value round-trips without the precision loss a JS
+       * `number` would incur past 2^53-1.
+       */
+      filetime: bigint;
     };
 // (Future: { kind: 'network'; host: string; port: number; protocol: 'tcp'|'udp'|'icmp'; direction: 'outbound'|'inbound'; ... })
 
@@ -351,7 +357,13 @@ export function parseDenialStream(
       result.parseErrors += 1;
     };
 
-    stderr.on('data', (chunk: Buffer) => {
+    stderr.on('data', (chunkRaw: Buffer | string) => {
+      // A Readable with an encoding set (e.g. setEncoding('utf8'))
+      // emits string chunks; coerce to Buffer so the byte-wise scan
+      // and 0x1E comparisons below stay correct.
+      const chunk = Buffer.isBuffer(chunkRaw)
+        ? chunkRaw
+        : Buffer.from(chunkRaw);
       // State machine:
       //   not-in-segment + 0x1E  -> enter segment
       //   not-in-segment + byte  -> passthrough byte
@@ -425,7 +437,21 @@ export function parseDenialStream(
 function denialFromWire(obj: Record<string, unknown>): DeniedResource | null {
   if (typeof obj.path !== 'string') return null;
   if (typeof obj.pid !== 'number') return null;
-  if (typeof obj.filetime !== 'number') return null;
+  // filetime is carried as a decimal string (see model.rs) to preserve
+  // full 64-bit precision. Accept a number too for forward/backward
+  // tolerance, but coerce both to bigint.
+  let filetime: bigint;
+  try {
+    if (typeof obj.filetime === 'string') {
+      filetime = BigInt(obj.filetime);
+    } else if (typeof obj.filetime === 'number' && Number.isInteger(obj.filetime)) {
+      filetime = BigInt(obj.filetime);
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
 
   const resourceTypeStr = typeof obj.resourceType === 'string' ? obj.resourceType : 'other';
   const accessTypeStr = typeof obj.accessType === 'string' ? obj.accessType : 'unknown';
@@ -443,7 +469,7 @@ function denialFromWire(obj: Record<string, unknown>): DeniedResource | null {
     resourceType,
     accessType,
     pid: obj.pid,
-    filetime: obj.filetime,
+    filetime,
   };
 }
 

--- a/sdk/src/denial-channel/transports/named-pipe.ts
+++ b/sdk/src/denial-channel/transports/named-pipe.ts
@@ -48,7 +48,9 @@ import * as os from 'os';
  * The returned socket implements the Readable interface expected
  * by `parseDenialStream`. The stream emits `end` when wxc-exec
  * closes its side (typically when the workload exits and the
- * runner's writer thread sees its mpsc channel close).
+ * runner's writer thread sees its mpsc channel close). If `close()`
+ * is called before any client connects, `denialStream` rejects so
+ * the shutdown is observable rather than hanging.
  *
  * `close()` tears down the server and the accepted socket. Safe
  * to call multiple times. Idempotent.
@@ -87,9 +89,13 @@ export function createDenialPipeServer(): DenialPipeServer {
   let acceptedSocket: Socket | null = null;
   let server: Server | null = null;
   let closed = false;
+  let settled = false;
+  let rejectStream: (err: Error) => void = () => {};
 
   const denialStream = new Promise<Socket>((resolve, reject) => {
+    rejectStream = reject;
     server = createServer((socket) => {
+      settled = true;
       acceptedSocket = socket;
       // Stop listening after the first (and only expected)
       // connection -- this pipe is private to one wxc-exec run.
@@ -98,7 +104,10 @@ export function createDenialPipeServer(): DenialPipeServer {
     });
 
     server.on('error', (err) => {
-      if (!closed) reject(err);
+      if (!closed && !settled) {
+        settled = true;
+        reject(err);
+      }
     });
 
     server.listen(fullPath, () => {
@@ -112,6 +121,17 @@ export function createDenialPipeServer(): DenialPipeServer {
     close() {
       if (closed) return;
       closed = true;
+      // If no client ever connected, settle the promise so callers
+      // awaiting `denialStream` observe the shutdown instead of
+      // hanging forever.
+      if (!settled) {
+        settled = true;
+        rejectStream(
+          new Error(
+            'createDenialPipeServer: closed before a client connected',
+          ),
+        );
+      }
       try {
         acceptedSocket?.destroy();
       } catch {

--- a/sdk/src/denial-channel/transports/named-pipe.ts
+++ b/sdk/src/denial-channel/transports/named-pipe.ts
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Side-channel transport for the captureDenials NDJSON stream.
+ *
+ * The default transport is stderr (see `denial-stream.ts`), which
+ * works fine for non-PTY workloads. PTY mode is different: the
+ * point of PTY is interactive workloads (REPLs, vim, npm install
+ * with its spinning ASCII, cargo build with colors) that need a
+ * clean terminal. Splattering `\x1E{"type":"denial",...}` bytes
+ * onto a terminal the user is watching is awful UX, and the
+ * 0x1E demuxer is more likely to collide with workload-generated
+ * bytes when stdout+stderr are merged into one stream.
+ *
+ * The side channel solves both problems by routing the
+ * captureDenials stream through a private Windows named pipe:
+ *
+ *   1. SDK creates a named-pipe server with a unique random name.
+ *   2. SDK sets `MXC_DENIALS_PIPE=<name>` in the wxc-exec process
+ *      env (without the `\\.\pipe\` prefix).
+ *   3. wxc-exec on startup opens the pipe for writing and uses it
+ *      in place of stderr for both denial lines and the summary.
+ *   4. SDK reads from the pipe's accepted-connection socket and
+ *      feeds bytes into `parseDenialStream` exactly as it would
+ *      for the stderr transport.
+ *
+ * The workload itself never sees the pipe -- only wxc-exec does.
+ * The user's terminal stays clean.
+ *
+ * Named pipes are a Windows concept. The module type-checks and
+ * exports on all platforms but `createDenialPipeServer()` throws
+ * with a clear error on non-Windows hosts.
+ */
+
+import { createServer, type Server, type Socket } from 'net';
+import { randomBytes } from 'crypto';
+import * as os from 'os';
+
+/**
+ * Outcome of {@link createDenialPipeServer}.
+ *
+ * `pipeName` is the *base name* (no `\\.\pipe\` prefix) you set in
+ * the wxc-exec env as `MXC_DENIALS_PIPE`. The Rust side prepends
+ * the prefix.
+ *
+ * `denialStream` resolves when wxc-exec connects to the server.
+ * The returned socket implements the Readable interface expected
+ * by `parseDenialStream`. The stream emits `end` when wxc-exec
+ * closes its side (typically when the workload exits and the
+ * runner's writer thread sees its mpsc channel close).
+ *
+ * `close()` tears down the server and the accepted socket. Safe
+ * to call multiple times. Idempotent.
+ */
+export interface DenialPipeServer {
+  pipeName: string;
+  denialStream: Promise<Socket>;
+  close(): void;
+}
+
+/**
+ * Create a Windows named-pipe server for the captureDenials side
+ * channel.
+ *
+ * The pipe name is randomised per call so concurrent invocations
+ * never collide. Format: `mxc-denials-<8 hex bytes>`. The full
+ * path the wxc-exec side opens is `\\.\pipe\<name>`.
+ *
+ * The server is set to listen for exactly one connection (the
+ * wxc-exec process spawned for this run). It auto-closes after the
+ * client disconnects.
+ *
+ * Throws on non-Windows hosts, since named pipes are a Windows
+ * concept.
+ */
+export function createDenialPipeServer(): DenialPipeServer {
+  if (os.platform() !== 'win32') {
+    throw new Error(
+      'createDenialPipeServer: Windows named pipes only.',
+    );
+  }
+
+  const pipeName = `mxc-denials-${randomBytes(8).toString('hex')}`;
+  const fullPath = `\\\\.\\pipe\\${pipeName}`;
+
+  let acceptedSocket: Socket | null = null;
+  let server: Server | null = null;
+  let closed = false;
+
+  const denialStream = new Promise<Socket>((resolve, reject) => {
+    server = createServer((socket) => {
+      acceptedSocket = socket;
+      // Stop listening after the first (and only expected)
+      // connection -- this pipe is private to one wxc-exec run.
+      server?.close();
+      resolve(socket);
+    });
+
+    server.on('error', (err) => {
+      if (!closed) reject(err);
+    });
+
+    server.listen(fullPath, () => {
+      // listening; resolve happens on first accept above.
+    });
+  });
+
+  return {
+    pipeName,
+    denialStream,
+    close() {
+      if (closed) return;
+      closed = true;
+      try {
+        acceptedSocket?.destroy();
+      } catch {
+        /* ignore */
+      }
+      try {
+        server?.close();
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -54,6 +54,27 @@ export {
   SandboxSpawnOptions,
 } from './sandbox.js';
 
+// Export captureDenials side-channel transport
+export {
+  createDenialPipeServer,
+  DenialPipeServer,
+} from './denial-channel/transports/named-pipe.js';
+
+// Export captureDenials streaming consumer
+export {
+  DENIAL_STREAM_MARKER,
+  DenialAccessType,
+  DenialResourceType,
+  DeniedResource,
+  DenialStreamSummary,
+  DenialFilter,
+  defaultDenialFilters,
+  stripNtPrefix,
+  DenialStreamResult,
+  ParseDenialStreamOptions,
+  parseDenialStream,
+} from './denial-channel/stream.js';
+
 // Export policy discovery functions
 export {
   getAvailableToolsPolicy,

--- a/sdk/tests/unit/denial-side-channel.test.ts
+++ b/sdk/tests/unit/denial-side-channel.test.ts
@@ -17,6 +17,10 @@ describe('createDenialPipeServer', { skip: !isWindows ? 'Windows-only' : false }
   it('produces a unique randomised pipe name on each call', () => {
     const a = createDenialPipeServer();
     const b = createDenialPipeServer();
+    // Neither server gets a client; swallow the close()-before-connect
+    // rejection so it doesn't surface as an unhandled rejection.
+    void a.denialStream.catch(() => {});
+    void b.denialStream.catch(() => {});
     try {
       assert.match(a.pipeName, /^mxc-denials-[0-9a-f]{16}$/);
       assert.match(b.pipeName, /^mxc-denials-[0-9a-f]{16}$/);
@@ -56,18 +60,24 @@ describe('createDenialPipeServer', { skip: !isWindows ? 'Windows-only' : false }
 
   it('close() is idempotent', () => {
     const s = createDenialPipeServer();
+    void s.denialStream.catch(() => {});
     s.close();
     // Second close must not throw.
     s.close();
     s.close();
   });
 
-  it('close() tears down the server before any client connects', async () => {
+  it('close() before any client connects rejects denialStream and refuses connections', async () => {
     const s = createDenialPipeServer();
+    // close() before a client connects must settle denialStream
+    // (rejecting) so awaiters observe shutdown instead of hanging.
+    const rejected = assert.rejects(
+      s.denialStream,
+      /closed before a client connected/,
+    );
     s.close();
-    // After close, an attempt to connect should fail. Don't await
-    // the denialStream promise -- it stays pending forever when no
-    // one ever connects, which is the desired semantic.
+    await rejected;
+    // And an attempt to connect after close should fail.
     await new Promise<void>((resolve) => {
       const sock = createConnection(`\\\\.\\pipe\\${s.pipeName}`);
       sock.once('error', () => resolve());

--- a/sdk/tests/unit/denial-side-channel.test.ts
+++ b/sdk/tests/unit/denial-side-channel.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { createConnection } from 'node:net';
+import * as os from 'os';
+import { createDenialPipeServer } from '../../src/denial-channel/transports/named-pipe.js';
+
+// All tests in this file require Windows named-pipe semantics. The
+// module itself throws on non-Windows, and a Unix host has no
+// equivalent we can substitute for the test, so we skip the whole
+// suite when not on win32.
+const isWindows = os.platform() === 'win32';
+
+describe('createDenialPipeServer', { skip: !isWindows ? 'Windows-only' : false }, () => {
+  it('produces a unique randomised pipe name on each call', () => {
+    const a = createDenialPipeServer();
+    const b = createDenialPipeServer();
+    try {
+      assert.match(a.pipeName, /^mxc-denials-[0-9a-f]{16}$/);
+      assert.match(b.pipeName, /^mxc-denials-[0-9a-f]{16}$/);
+      assert.notStrictEqual(a.pipeName, b.pipeName);
+    } finally {
+      a.close();
+      b.close();
+    }
+  });
+
+  it('resolves denialStream when a client connects, end-to-end bytes round-trip', async () => {
+    const server = createDenialPipeServer();
+    try {
+      const fullPath = `\\\\.\\pipe\\${server.pipeName}`;
+      // Spin up a fake "wxc-exec writer" that opens the pipe and
+      // writes a single 0x1E-prefixed JSON envelope + newline,
+      // exactly like the Rust side would.
+      const writerSocket = createConnection(fullPath);
+      await new Promise<void>((resolve, reject) => {
+        writerSocket.once('connect', resolve);
+        writerSocket.once('error', reject);
+      });
+      const writePayload = Buffer.from('\x1e{"type":"denial","path":"C:\\\\a.txt"}\n', 'utf8');
+      writerSocket.write(writePayload);
+      writerSocket.end();
+
+      const reader = await server.denialStream;
+      const received: Buffer[] = [];
+      reader.on('data', (c) => received.push(c));
+      await new Promise<void>((resolve) => reader.once('end', () => resolve()));
+
+      assert.deepStrictEqual(Buffer.concat(received), writePayload);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('close() is idempotent', () => {
+    const s = createDenialPipeServer();
+    s.close();
+    // Second close must not throw.
+    s.close();
+    s.close();
+  });
+
+  it('close() tears down the server before any client connects', async () => {
+    const s = createDenialPipeServer();
+    s.close();
+    // After close, an attempt to connect should fail. Don't await
+    // the denialStream promise -- it stays pending forever when no
+    // one ever connects, which is the desired semantic.
+    await new Promise<void>((resolve) => {
+      const sock = createConnection(`\\\\.\\pipe\\${s.pipeName}`);
+      sock.once('error', () => resolve());
+      sock.once('connect', () => {
+        sock.destroy();
+        assert.fail('connection should not succeed after close()');
+      });
+    });
+  });
+});
+
+describe('createDenialPipeServer on non-Windows', { skip: isWindows ? 'Windows-only test' : false }, () => {
+  it('throws with an actionable error message', () => {
+    assert.throws(
+      () => createDenialPipeServer(),
+      /Windows named pipes only/,
+    );
+  });
+});

--- a/sdk/tests/unit/denial-stream.test.ts
+++ b/sdk/tests/unit/denial-stream.test.ts
@@ -71,7 +71,7 @@ describe('defaultDenialFilters', () => {
     resourceType: 'file',
     accessType: 'read',
     pid: 1234,
-    filetime: 0,
+    filetime: 0n,
   });
 
   it('drops \\REGISTRY\\USER\\.DEFAULT registry noise', () => {
@@ -121,7 +121,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 1234,
-          filetime: 132000000000000000,
+          filetime: '132000000000000000',
         },
       },
       {
@@ -147,7 +147,7 @@ describe('parseDenialStream', () => {
       resourceType: 'file',
       accessType: 'read',
       pid: 1234,
-      filetime: 132000000000000000,
+      filetime: 132000000000000000n,
     });
     assert.deepStrictEqual(result.summary, {
       exitCode: 0,
@@ -177,7 +177,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 7,
-          filetime: 1,
+          filetime: '1',
         },
       },
       { passthrough: 'workload progress 50%\n' },
@@ -215,7 +215,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 1,
-          filetime: 1,
+          filetime: '1',
         },
       },
       {
@@ -225,7 +225,7 @@ describe('parseDenialStream', () => {
           resourceType: 'other',
           accessType: 'unknown',
           pid: 1,
-          filetime: 2,
+          filetime: '2',
         },
       },
       {
@@ -235,7 +235,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 1,
-          filetime: 3,
+          filetime: '3',
         },
       },
       {
@@ -265,7 +265,7 @@ describe('parseDenialStream', () => {
           resourceType: 'other',
           accessType: 'unknown',
           pid: 1,
-          filetime: 1,
+          filetime: '1',
         },
       },
       {
@@ -291,7 +291,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 1,
-          filetime: 1,
+          filetime: '1',
         },
       },
       {
@@ -333,7 +333,7 @@ describe('parseDenialStream', () => {
       resourceType: 'file',
       accessType: 'read',
       pid: 1,
-      filetime: 1,
+      filetime: '1',
     });
     const summary = JSON.stringify({
       type: 'summary',
@@ -361,7 +361,7 @@ describe('parseDenialStream', () => {
   it('counts unparseable segments as parseErrors and keeps going', async () => {
     const stream = readableOf(
       `${RS}not valid json\n` +
-        `${RS}{"type":"denial","path":"C:\\\\ok.txt","resourceType":"file","accessType":"read","pid":1,"filetime":1}\n` +
+        `${RS}{"type":"denial","path":"C:\\\\ok.txt","resourceType":"file","accessType":"read","pid":1,"filetime":"1"}\n` +
         `${RS}{"type":"summary","exitCode":0,"totalDenials":1,"deniedResourcesTruncated":false}\n`,
     );
 
@@ -399,7 +399,7 @@ describe('parseDenialStream', () => {
           resourceType: 'file',
           accessType: 'read',
           pid: 1,
-          filetime: 1,
+          filetime: '1',
         },
       },
     ]);

--- a/sdk/tests/unit/denial-stream.test.ts
+++ b/sdk/tests/unit/denial-stream.test.ts
@@ -1,0 +1,507 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { Readable } from 'stream';
+import {
+  parseDenialStream,
+  stripNtPrefix,
+  defaultDenialFilters,
+  DENIAL_STREAM_MARKER,
+  DeniedResource,
+  DenialStreamSummary,
+} from '../../src/denial-channel/stream.js';
+
+// ---------- helpers ---------------------------------------------------------
+
+const RS = String.fromCharCode(DENIAL_STREAM_MARKER);
+
+/**
+ * Build a captureDenials stderr stream from a list of native-format
+ * JSON envelopes interleaved with arbitrary workload-stderr bytes.
+ * Each envelope is rendered as `\x1e<json>\n` exactly as the native
+ * writer would emit it.
+ */
+function buildStream(parts: ReadonlyArray<{ envelope?: object; passthrough?: string }>): Readable {
+  const chunks: Buffer[] = [];
+  for (const p of parts) {
+    if (p.passthrough !== undefined) {
+      chunks.push(Buffer.from(p.passthrough, 'utf8'));
+    }
+    if (p.envelope !== undefined) {
+      chunks.push(Buffer.from(`${RS}${JSON.stringify(p.envelope)}\n`, 'utf8'));
+    }
+  }
+  return Readable.from([Buffer.concat(chunks)]);
+}
+
+/** Convenience: build a single-chunk readable from a raw buffer. */
+function readableOf(buf: Buffer | string): Readable {
+  return Readable.from([typeof buf === 'string' ? Buffer.from(buf, 'utf8') : buf]);
+}
+
+// ---------- unit tests for the pure helpers --------------------------------
+
+describe('stripNtPrefix', () => {
+  it('strips a \\??\\ prefix', () => {
+    assert.strictEqual(stripNtPrefix('\\??\\C:\\Users\\Foo'), 'C:\\Users\\Foo');
+  });
+
+  it('leaves paths without a \\??\\ prefix untouched', () => {
+    assert.strictEqual(stripNtPrefix('C:\\Users\\Foo'), 'C:\\Users\\Foo');
+    assert.strictEqual(
+      stripNtPrefix('\\REGISTRY\\USER\\.DEFAULT\\Foo'),
+      '\\REGISTRY\\USER\\.DEFAULT\\Foo',
+    );
+  });
+
+  it('returns the empty string unchanged', () => {
+    assert.strictEqual(stripNtPrefix(''), '');
+  });
+});
+
+describe('defaultDenialFilters', () => {
+  const apply = (r: DeniedResource): boolean =>
+    defaultDenialFilters.every((f) => f(r));
+
+  const file = (path: string): DeniedResource => ({
+    kind: 'file',
+    path,
+    resourceType: 'file',
+    accessType: 'read',
+    pid: 1234,
+    filetime: 0,
+  });
+
+  it('drops \\REGISTRY\\USER\\.DEFAULT registry noise', () => {
+    assert.strictEqual(
+      apply(file('\\REGISTRY\\USER\\.DEFAULT\\Control Panel\\International')),
+      false,
+    );
+  });
+
+  it('drops System32 loader probes (.dll, .mui, .mun, .cat, .cdf-ms, .nls)', () => {
+    for (const ext of ['dll', 'mui', 'mun', 'cat', 'cdf-ms', 'nls']) {
+      assert.strictEqual(
+        apply(file(`C:\\Windows\\System32\\foo.${ext}`)),
+        false,
+        `expected .${ext} loader probe to be dropped`,
+      );
+    }
+  });
+
+  it('drops System32 loader probes even when carrying a \\??\\ prefix', () => {
+    assert.strictEqual(
+      apply(file('\\??\\C:\\Windows\\System32\\kernel32.dll')),
+      false,
+    );
+  });
+
+  it('keeps real workload-target paths under user profile', () => {
+    assert.strictEqual(apply(file('C:\\Users\\Alice\\Documents\\report.txt')), true);
+  });
+
+  it('keeps arbitrary registry keys that are not the default user', () => {
+    assert.strictEqual(apply(file('\\REGISTRY\\MACHINE\\Software\\MyApp')), true);
+  });
+});
+
+// ---------- end-to-end parser tests ----------------------------------------
+
+describe('parseDenialStream', () => {
+  it('parses a single denial + summary into typed shapes', async () => {
+    const denials: DeniedResource[] = [];
+    const summaries: DenialStreamSummary[] = [];
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\??\\C:\\Users\\Alice\\Documents\\report.txt',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 1234,
+          filetime: 132000000000000000,
+        },
+      },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 1,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream, {
+      onDenial: (r) => denials.push(r),
+      onSummary: (s) => summaries.push(s),
+    });
+
+    assert.strictEqual(result.parseErrors, 0);
+    assert.strictEqual(result.denials.length, 1);
+    assert.deepStrictEqual(result.denials[0], {
+      kind: 'file',
+      path: 'C:\\Users\\Alice\\Documents\\report.txt', // \\??\\ stripped by default
+      resourceType: 'file',
+      accessType: 'read',
+      pid: 1234,
+      filetime: 132000000000000000,
+    });
+    assert.deepStrictEqual(result.summary, {
+      exitCode: 0,
+      totalDenials: 1,
+      deniedResourcesTruncated: false,
+      // No captureDenialsActive in the wire fixture; parser
+      // defaults to true for forward-compat with older binaries.
+      captureDenialsActive: true,
+      // Same forward-compat policy for childProcessesObserved.
+      childProcessesObserved: 0,
+      // Same for descendantPidsCovered (Phase E of descendant
+      // tracking — landed after captureDenials shipped).
+      descendantPidsCovered: 0,
+    });
+    assert.strictEqual(denials.length, 1, 'onDenial fired exactly once');
+    assert.strictEqual(summaries.length, 1, 'onSummary fired exactly once');
+  });
+
+  it('demuxes denial lines from interleaved workload stderr writes', async () => {
+    const passthrough: Buffer[] = [];
+    const stream = buildStream([
+      { passthrough: 'workload starting...\n' },
+      {
+        envelope: {
+          type: 'denial',
+          path: 'C:\\Users\\Bob\\file.txt',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 7,
+          filetime: 1,
+        },
+      },
+      { passthrough: 'workload progress 50%\n' },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 1,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream, {
+      filters: 'none',
+      onPassthrough: (c) => passthrough.push(c),
+    });
+
+    assert.strictEqual(result.denials.length, 1);
+    assert.ok(result.summary);
+    const combined = Buffer.concat(passthrough).toString('utf8');
+    // Passthrough should contain only the workload bytes, not the JSON envelopes.
+    assert.ok(combined.includes('workload starting'));
+    assert.ok(combined.includes('workload progress'));
+    assert.ok(!combined.includes('"type":"denial"'));
+    assert.ok(!combined.includes('"type":"summary"'));
+  });
+
+  it('default filters drop System32 loader probes and DEFAULT-user registry noise', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\??\\C:\\Windows\\System32\\kernel32.dll',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 1,
+          filetime: 1,
+        },
+      },
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\REGISTRY\\USER\\.DEFAULT\\Control Panel\\International',
+          resourceType: 'other',
+          accessType: 'unknown',
+          pid: 1,
+          filetime: 2,
+        },
+      },
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\??\\C:\\Users\\Carol\\Documents\\report.txt',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 1,
+          filetime: 3,
+        },
+      },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 3,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+
+    assert.strictEqual(result.denials.length, 1, 'only the real workload target survived');
+    assert.strictEqual(result.denials[0].path, 'C:\\Users\\Carol\\Documents\\report.txt');
+    // Summary reflects the native-side total (pre-SDK-filter), not the filtered count.
+    assert.strictEqual(result.summary?.totalDenials, 3);
+  });
+
+  it('filters: "none" passes every denial through unchanged', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\REGISTRY\\USER\\.DEFAULT\\Foo',
+          resourceType: 'other',
+          accessType: 'unknown',
+          pid: 1,
+          filetime: 1,
+        },
+      },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 1,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream, { filters: 'none' });
+    assert.strictEqual(result.denials.length, 1);
+  });
+
+  it('stripNtPrefix: false preserves the raw \\??\\ form', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'denial',
+          path: '\\??\\C:\\Users\\Dan\\foo.txt',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 1,
+          filetime: 1,
+        },
+      },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 1,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream, { stripNtPrefix: false });
+    assert.strictEqual(result.denials[0].path, '\\??\\C:\\Users\\Dan\\foo.txt');
+  });
+
+  it('captures rawEventCount when present in the summary (verbose mode)', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 8,
+          deniedResourcesTruncated: false,
+          rawEventCount: 651,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.summary?.totalDenials, 8);
+    assert.strictEqual(result.summary?.rawEventCount, 651);
+  });
+
+  it('handles a chunk that splits a JSON envelope across boundaries', async () => {
+    const json = JSON.stringify({
+      type: 'denial',
+      path: 'C:\\Users\\Eve\\file.txt',
+      resourceType: 'file',
+      accessType: 'read',
+      pid: 1,
+      filetime: 1,
+    });
+    const summary = JSON.stringify({
+      type: 'summary',
+      exitCode: 0,
+      totalDenials: 1,
+      deniedResourcesTruncated: false,
+    });
+    const full = Buffer.from(`${RS}${json}\n${RS}${summary}\n`, 'utf8');
+
+    // Push the bytes one at a time to exercise mid-segment boundary
+    // handling — this is the worst case the demuxer must survive.
+    const stream = new Readable({ read() {} });
+    for (const byte of full) {
+      stream.push(Buffer.from([byte]));
+    }
+    stream.push(null);
+
+    const result = await parseDenialStream(stream, { filters: 'none' });
+    assert.strictEqual(result.parseErrors, 0);
+    assert.strictEqual(result.denials.length, 1);
+    assert.strictEqual(result.denials[0].path, 'C:\\Users\\Eve\\file.txt');
+    assert.strictEqual(result.summary?.totalDenials, 1);
+  });
+
+  it('counts unparseable segments as parseErrors and keeps going', async () => {
+    const stream = readableOf(
+      `${RS}not valid json\n` +
+        `${RS}{"type":"denial","path":"C:\\\\ok.txt","resourceType":"file","accessType":"read","pid":1,"filetime":1}\n` +
+        `${RS}{"type":"summary","exitCode":0,"totalDenials":1,"deniedResourcesTruncated":false}\n`,
+    );
+
+    const result = await parseDenialStream(stream, { filters: 'none' });
+    assert.strictEqual(result.parseErrors, 1);
+    assert.strictEqual(result.denials.length, 1);
+    assert.ok(result.summary);
+  });
+
+  it('counts unknown envelope types as parseErrors so version skew is visible', async () => {
+    const stream = buildStream([
+      { envelope: { type: 'denial-v2', path: 'foo', pid: 1, filetime: 1 } },
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 0,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.parseErrors, 1);
+    assert.strictEqual(result.denials.length, 0);
+    assert.ok(result.summary);
+  });
+
+  it('resolves with summary=undefined when the stream ends before a summary line', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'denial',
+          path: 'C:\\Users\\Fred\\foo.txt',
+          resourceType: 'file',
+          accessType: 'read',
+          pid: 1,
+          filetime: 1,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream, { filters: 'none' });
+    assert.strictEqual(result.denials.length, 1);
+    assert.strictEqual(result.summary, undefined);
+  });
+
+  it('surfaces captureDenialsActive=false when the native side could not attach the collector', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 0,
+          deniedResourcesTruncated: false,
+          captureDenialsActive: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.ok(result.summary);
+    assert.strictEqual(result.summary!.captureDenialsActive, false);
+    assert.strictEqual(result.summary!.totalDenials, 0);
+  });
+
+  it('surfaces captureDenialsActive=true when the native side attached the collector', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 3,
+          deniedResourcesTruncated: false,
+          captureDenialsActive: true,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.summary!.captureDenialsActive, true);
+  });
+
+  it('defaults captureDenialsActive to true when the field is absent (older native binaries)', async () => {
+    // Forward-compat: an older binary that doesn't yet know about
+    // the `captureDenialsActive` field shouldn't trip the parser.
+    // We optimistically assume "active" so its behavior matches
+    // what consumers saw before the field landed.
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 0,
+          deniedResourcesTruncated: false,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.summary!.captureDenialsActive, true);
+  });
+
+  it('surfaces childProcessesObserved when present in the summary', async () => {
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 2,
+          deniedResourcesTruncated: false,
+          captureDenialsActive: true,
+          childProcessesObserved: 7,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.summary!.childProcessesObserved, 7);
+  });
+
+  it('defaults childProcessesObserved to 0 when the field is absent (older native binaries)', async () => {
+    // Same forward-compat policy as captureDenialsActive: an older
+    // native binary that doesn't poll for children should not look
+    // like "definitely no children" -- it should look like "the
+    // field wasn't reported", and we surface that as 0 with the
+    // expectation that consumers treat 0 as "no observation made".
+    const stream = buildStream([
+      {
+        envelope: {
+          type: 'summary',
+          exitCode: 0,
+          totalDenials: 0,
+          deniedResourcesTruncated: false,
+          captureDenialsActive: true,
+        },
+      },
+    ]);
+
+    const result = await parseDenialStream(stream);
+    assert.strictEqual(result.summary!.childProcessesObserved, 0);
+  });
+});

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -468,6 +468,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "denial_channel"
+version = "0.7.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "core/wxc",
     "core/wxc_common",
+    "core/denial_channel",
     "core/lxc",
     "core/mxc_darwin",
     "core/mxc_pty",
@@ -90,6 +91,7 @@ anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 wxc_common = { path = "core/wxc_common" }
+denial_channel = { path = "core/denial_channel" }
 appcontainer_common = { path = "backends/appcontainer/common" }
 windows_sandbox_common = { path = "backends/windows_sandbox/common" }
 isolation_session_common = { path = "backends/isolation_session/common" }

--- a/src/core/denial_channel/Cargo.toml
+++ b/src/core/denial_channel/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "denial_channel"
+version.workspace = true
+edition.workspace = true
+
+# Cross-platform crate. Holds the public denial-channel data shapes
+# (DeniedResource, ResourceType, AccessType) that the wire format
+# carries. All OS-specific code (denial collectors, path
+# canonicalisation, side-channel transports, etc.) lives in the
+# per-OS learning-mode backend crates that depend on this one.
+#
+# Adding a new resource kind (network, IPC, etc.) is an additive
+# change here -- both the existing Windows backend and any future
+# Linux/macOS backend re-export the new variant via the same trait
+# surface they all implement.
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/src/core/denial_channel/Cargo.toml
+++ b/src/core/denial_channel/Cargo.toml
@@ -16,4 +16,6 @@ edition.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+
+[dev-dependencies]
 serde_json = { workspace = true }

--- a/src/core/denial_channel/src/lib.rs
+++ b/src/core/denial_channel/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Cross-platform data shapes for the captureDenials/learning-mode
+//! pipeline.
+//!
+//! This crate intentionally has no OS dependencies. It is consumed
+//! by:
+//!
+//! - **`learning_mode_windows`**: extracts denials from the
+//!   platform-native source, converts into the `DeniedResource`
+//!   shape declared here, and writes them to the denial channel.
+//! - **`learning_mode_linux`** / **`learning_mode_macos`** (stubs
+//!   today): will do the same with platform-native sources when
+//!   implemented.
+//! - **`learning_mode`** (the core orchestrator): re-exports these
+//!   types so consumers depend on one crate.
+//! - The SDK's TypeScript NDJSON parser, whose `DeniedResource`
+//!   type mirrors this shape field-for-field.
+
+pub mod model;
+
+pub use model::{AccessType, DeniedResource, ResourceType};

--- a/src/core/denial_channel/src/lib.rs
+++ b/src/core/denial_channel/src/lib.rs
@@ -16,7 +16,10 @@
 //! - **`learning_mode`** (the core orchestrator): re-exports these
 //!   types so consumers depend on one crate.
 //! - The SDK's TypeScript NDJSON parser, whose `DeniedResource`
-//!   type mirrors this shape field-for-field.
+//!   type is an ergonomic superset of this wire shape: it parses the
+//!   same fields, but adds a `kind` discriminator and anticipates
+//!   resource-type values (e.g. `registry`) that this minimal model
+//!   currently folds into `Other`.
 
 pub mod model;
 

--- a/src/core/denial_channel/src/model.rs
+++ b/src/core/denial_channel/src/model.rs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Public data model for the captureDenials/learning-mode pipeline.
+//!
+//! `DeniedResource` is the shape every backend emits, every transport
+//! carries, and every SDK consumer parses. New OS backends produce
+//! it from their native sources; new transports just move it across
+//! a channel. The types stay tiny and cross-platform so the wire
+//! format never accidentally encodes a Windows assumption.
+
+use serde::{Deserialize, Serialize};
+
+/// The type of resource that was denied access.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResourceType {
+    /// Filesystem path denied.
+    File,
+    /// Network endpoint denied. Reserved for future network/WFP
+    /// capture; not produced by the current Windows file-only
+    /// backend.
+    Network,
+    /// Unclassified denial (registry on Windows, COM, IPC, etc.).
+    Other,
+}
+
+/// The type of access that was requested and denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessType {
+    Read,
+    Write,
+    Execute,
+    Unknown,
+}
+
+/// Public denial shape surfaced on the wire and via
+/// `ScriptResponse.denied_resources` in the SDK.
+///
+/// One `DeniedResource` describes one (path, accessType) pair the
+/// sandboxed workload was denied access to. Per-PID dedup happens
+/// upstream in the writer thread, so callers can treat the stream
+/// as already-unique.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeniedResource {
+    /// User-visible canonicalised path. On Windows: drive-letter form
+    /// (`C:\Users\...`) with NT-device-namespace prefixes (`\??\`,
+    /// `\Device\HarddiskVolumeN\`) already stripped. On Linux/macOS:
+    /// the posix path. Network endpoints (when implemented) use a
+    /// `host:port` form.
+    pub path: String,
+
+    /// Type of resource (see [`ResourceType`]).
+    pub resource_type: ResourceType,
+
+    /// Access type the workload was attempting (see [`AccessType`]).
+    pub access_type: AccessType,
+
+    /// Process ID inside the sandbox that triggered the denial.
+    pub pid: u32,
+
+    /// Kernel timestamp of the denial. On Windows this is `FILETIME`
+    /// (100-nanosecond intervals since 1601-01-01 UTC) copied from
+    /// `EVENT_RECORD.EventHeader.TimeStamp`. Linux/macOS backends
+    /// will normalise their native clocks into the same epoch on
+    /// emit so consumers can treat the field uniformly.
+    pub filetime: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn denied_resource_serializes_camel_case() {
+        // Guards the wire-format contract: SDK consumers depend on
+        // `resourceType` / `accessType` / `filetime` keys (camelCase)
+        // and the lowercased enum strings. A future serde rename
+        // would break every downstream parser silently.
+        let r = DeniedResource {
+            path: r"C:\Users\test\file.txt".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 1234,
+            filetime: 132_847_890_123_456_789,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"resourceType\":\"file\""), "got {json}");
+        assert!(json.contains("\"accessType\":\"read\""), "got {json}");
+        assert!(
+            json.contains("\"filetime\":132847890123456789"),
+            "got {json}"
+        );
+    }
+
+    #[test]
+    fn denied_resource_round_trips_through_json() {
+        let r = DeniedResource {
+            path: r"C:\foo\bar.txt".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Write,
+            pid: 9999,
+            filetime: 42,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let parsed: DeniedResource = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, parsed);
+    }
+
+    #[test]
+    fn resource_type_serialises_each_variant_to_expected_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&ResourceType::File).unwrap(),
+            "\"file\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ResourceType::Network).unwrap(),
+            "\"network\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ResourceType::Other).unwrap(),
+            "\"other\""
+        );
+    }
+
+    #[test]
+    fn access_type_serialises_each_variant_to_expected_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&AccessType::Read).unwrap(),
+            "\"read\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AccessType::Write).unwrap(),
+            "\"write\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AccessType::Execute).unwrap(),
+            "\"execute\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AccessType::Unknown).unwrap(),
+            "\"unknown\""
+        );
+    }
+
+    #[test]
+    fn access_type_is_hashable_and_copy() {
+        // Used as part of the `(path, accessType)` dedup key in
+        // the writer thread. Removing Hash or Copy would silently
+        // break that path.
+        fn assert_hashable<T: std::hash::Hash + Copy>() {}
+        assert_hashable::<AccessType>();
+    }
+}

--- a/src/core/denial_channel/src/model.rs
+++ b/src/core/denial_channel/src/model.rs
@@ -66,7 +66,30 @@ pub struct DeniedResource {
     /// `EVENT_RECORD.EventHeader.TimeStamp`. Linux/macOS backends
     /// will normalise their native clocks into the same epoch on
     /// emit so consumers can treat the field uniformly.
+    ///
+    /// Serialised as a decimal **string** on the wire: FILETIME values
+    /// (~1.3e17 today) exceed JavaScript's safe-integer range (2^53-1),
+    /// so a JSON number would silently lose precision in JS consumers.
+    /// The string form round-trips exactly to a `bigint` in the SDK.
+    #[serde(with = "filetime_str")]
     pub filetime: u64,
+}
+
+/// Serialises [`DeniedResource::filetime`] as a decimal string and
+/// parses it back to `u64`, so cross-language consumers (notably the
+/// JS/TypeScript SDK) can round-trip the full 64-bit value without
+/// the precision loss a JSON number would incur past 2^53-1.
+mod filetime_str {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<u64>().map_err(serde::de::Error::custom)
+    }
 }
 
 #[cfg(test)]
@@ -77,8 +100,10 @@ mod tests {
     fn denied_resource_serializes_camel_case() {
         // Guards the wire-format contract: SDK consumers depend on
         // `resourceType` / `accessType` / `filetime` keys (camelCase)
-        // and the lowercased enum strings. A future serde rename
-        // would break every downstream parser silently.
+        // and the lowercased enum strings. `filetime` is a decimal
+        // string (not a JSON number) so 64-bit values round-trip
+        // without precision loss in JS. A future serde rename would
+        // break every downstream parser silently.
         let r = DeniedResource {
             path: r"C:\Users\test\file.txt".to_string(),
             resource_type: ResourceType::File,
@@ -90,7 +115,7 @@ mod tests {
         assert!(json.contains("\"resourceType\":\"file\""), "got {json}");
         assert!(json.contains("\"accessType\":\"read\""), "got {json}");
         assert!(
-            json.contains("\"filetime\":132847890123456789"),
+            json.contains("\"filetime\":\"132847890123456789\""),
             "got {json}"
         );
     }
@@ -102,7 +127,8 @@ mod tests {
             resource_type: ResourceType::File,
             access_type: AccessType::Write,
             pid: 9999,
-            filetime: 42,
+            // A value past 2^53 to exercise the decimal-string codec.
+            filetime: 132_847_890_123_456_789,
         };
         let json = serde_json::to_string(&r).unwrap();
         let parsed: DeniedResource = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
Introduces the denial_channel core crate (DeniedResource/ResourceType/AccessType wire types + serde format) and the SDK denial-channel surface (NDJSON stream parser, named-pipe side-channel transport) with unit tests. This is the shared transport contract consumed by the learning-mode orchestrator and Windows capture runners in later PRs.

## 📖 Description
 First in a stacked series that lands the `captureDenials` feature.
 This PR adds the cross-platform wire contract and transport for access-denial events, with no OS-specific capture logic and no consumers yet (those arrive in later PRs).

 **Rust** — new `denial_channel` core crate:
 - `DeniedResource` / `ResourceType` / `AccessType` data shapes plus the serde (camelCase) wire format shared by the native binaries and the SDK parser.
 - No OS dependencies; later per-OS learning-mode backend crates depend on this one.
 - Wired into the workspace (`Cargo.toml` member + `[workspace.dependencies]` entry).

 **SDK** — new `denial-channel` surface:
 - `stream.ts` — NDJSON stream parser (0x1E record-separator framing), default noise filters, path normalisation, and the `DeniedResource` / summary types mirroring the Rust shapes field-for-field.
 - `transports/named-pipe.ts` — side-channel transport (named-pipe server) used when the workload owns the PTY and the denial stream needs its own channel.
 - Exported from the package root; two unit-test files added to `test:unit`.

 **Scope / limitations:** Filesystem/registry denials only; the union is designed so a future `network` variant is additive. The crate and SDK surface are self-contained — nothing invokes capture yet, so this PR has no runtime effect on its own.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
 - `cargo fmt --all -- --check` — clean
 - `cargo clippy --workspace --all-targets -- -D warnings` — clean
 - `cargo test -p denial_channel` — 5/5 pass (serde round-trip + per-variant
   wire-format assertions)
 - `cargo test --workspace` — green
 - SDK `npm run build` (tsc) — clean
 - SDK `npm run test:unit` — 203 pass / 0 fail / 4 skip, including the new
   `denial-stream` and `denial-side-channel` suites

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [x] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/558)