### PR TITLE
refactor: idiomatic cleanups in wxc_common and the AppContainer/WSLC/LXC backends

### DIFF
--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -173,82 +173,93 @@ fn inject_proxy_vars(entries: &mut Vec<(String, String)>, addr: &wxc_common::mod
     entries.push(("HTTPS_PROXY".to_string(), proxy_url));
 }
 
-/// Owned capability SID derived from a capability name via
-/// [`get_capability_sid_from_name`]. Frees the underlying `LocalAlloc`'d SID
-/// with `LocalFree` on drop, so callers don't have to track and free the raw
-/// pointer themselves.
-struct OwnedCapabilitySid(PSID);
+/// Owned capability SID derived from a capability name. Frees the underlying
+/// `LocalAlloc`'d SID with `LocalFree` on drop, so callers don't have to track
+/// and free the raw pointer themselves.
+struct OwnedCapabilitySid {
+    sid: PSID,
+}
 
 impl OwnedCapabilitySid {
+    fn new(sid: PSID) -> Self {
+        Self { sid }
+    }
+
+    /// Derive the capability SID for a given capability name. Capability SIDs
+    /// are an AppContainer concept, so this helper lives in the AppContainer
+    /// backend rather than the shared foundation crate.
+    fn from_capability_name(name: &str) -> Result<Self, WxcError> {
+        let wide_name = string_util::to_wide(name);
+        let pcwstr = PCWSTR(wide_name.as_ptr());
+
+        let mut capability_sids: *mut PSID = std::ptr::null_mut();
+        let mut capability_sid_count: u32 = 0;
+        let mut group_sids: *mut PSID = std::ptr::null_mut();
+        let mut group_sid_count: u32 = 0;
+
+        // SAFETY: the Windows API writes LocalAlloc-compatible SID arrays and
+        // counts. We read only within those counts, free each returned pointer
+        // or array once, and transfer one capability SID into OwnedCapabilitySid.
+        unsafe {
+            DeriveCapabilitySidsFromName(
+                pcwstr,
+                &mut group_sids,
+                &mut group_sid_count,
+                &mut capability_sids,
+                &mut capability_sid_count,
+            )
+            .map_err(|e| {
+                WxcError::Process(format!("DeriveCapabilitySidsFromName({name}) failed: {e}"))
+            })?;
+
+            // Free group SIDs
+            for i in 0..group_sid_count {
+                let sid = *group_sids.add(i as usize);
+                let _ = LocalFree(Some(HLOCAL(sid.0)));
+            }
+            let _ = LocalFree(Some(HLOCAL(group_sids as *mut _)));
+
+            if capability_sid_count == 0 {
+                let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
+                return Err(WxcError::Process(format!(
+                    "No capability SID returned for {}",
+                    name
+                )));
+            }
+
+            // Take the first capability SID
+            let result_sid = *capability_sids;
+
+            // Free remaining capability SIDs (index 1+)
+            for i in 1..capability_sid_count {
+                let sid = *capability_sids.add(i as usize);
+                let _ = LocalFree(Some(HLOCAL(sid.0)));
+            }
+            let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
+
+            Ok(Self::new(result_sid))
+        }
+    }
+
     /// Borrow the raw `PSID` for building a `SID_AND_ATTRIBUTES` array. The
     /// pointer is valid only while `self` is alive — keep the owner around
     /// until the process-creation call has returned.
     fn as_psid(&self) -> PSID {
-        self.0
+        self.sid
     }
 }
 
 impl Drop for OwnedCapabilitySid {
     fn drop(&mut self) {
-        if !self.0 .0.is_null() {
+        let ptr = self.sid.0;
+
+        if !ptr.is_null() {
+            // SAFETY: `OwnedCapabilitySid` owns this SID pointer and frees it
+            // exactly once using the allocator required by the Windows API.
             unsafe {
-                let _ = LocalFree(Some(HLOCAL(self.0 .0)));
+                let _ = LocalFree(Some(HLOCAL(ptr)));
             }
         }
-    }
-}
-
-/// Derive the capability SID for a given capability name, returning an owned
-/// handle that frees the SID on drop. Capability SIDs are an AppContainer
-/// concept, so this helper lives in the AppContainer backend rather than the
-/// shared foundation crate.
-fn get_capability_sid_from_name(name: &str) -> Result<OwnedCapabilitySid, WxcError> {
-    let wide_name = string_util::to_wide(name);
-    let pcwstr = PCWSTR(wide_name.as_ptr());
-
-    let mut capability_sids: *mut PSID = std::ptr::null_mut();
-    let mut capability_sid_count: u32 = 0;
-    let mut group_sids: *mut PSID = std::ptr::null_mut();
-    let mut group_sid_count: u32 = 0;
-
-    unsafe {
-        DeriveCapabilitySidsFromName(
-            pcwstr,
-            &mut group_sids,
-            &mut group_sid_count,
-            &mut capability_sids,
-            &mut capability_sid_count,
-        )
-        .map_err(|e| {
-            WxcError::Process(format!("DeriveCapabilitySidsFromName({name}) failed: {e}"))
-        })?;
-
-        // Free group SIDs
-        for i in 0..group_sid_count {
-            let sid = *group_sids.add(i as usize);
-            let _ = LocalFree(Some(HLOCAL(sid.0)));
-        }
-        let _ = LocalFree(Some(HLOCAL(group_sids as *mut _)));
-
-        if capability_sid_count == 0 {
-            let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
-            return Err(WxcError::Process(format!(
-                "No capability SID returned for {}",
-                name
-            )));
-        }
-
-        // Take the first capability SID
-        let result_sid = *capability_sids;
-
-        // Free remaining capability SIDs (index 1+)
-        for i in 1..capability_sid_count {
-            let sid = *capability_sids.add(i as usize);
-            let _ = LocalFree(Some(HLOCAL(sid.0)));
-        }
-        let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
-
-        Ok(OwnedCapabilitySid(result_sid))
     }
 }
 
@@ -538,7 +549,7 @@ impl AppContainerScriptRunner {
         let mut sid_attrs: Vec<SidAndAttributes> = Vec::new();
 
         for cap_name in &capabilities_to_add {
-            match get_capability_sid_from_name(cap_name) {
+            match OwnedCapabilitySid::from_capability_name(cap_name) {
                 Ok(sid) => {
                     sid_attrs.push(SidAndAttributes {
                         sid: sid.as_psid(),

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -12,7 +12,7 @@ use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::Isolation::{
     CreateAppContainerProfile, DeleteAppContainerProfile, DeriveAppContainerSidFromAppContainerName,
 };
-use windows::Win32::Security::{FreeSid, PSID, TOKEN_QUERY};
+use windows::Win32::Security::{DeriveCapabilitySidsFromName, FreeSid, PSID, TOKEN_QUERY};
 use windows::Win32::System::Console::{
     GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
 };
@@ -36,8 +36,8 @@ use wxc_common::error::WxcError;
 use wxc_common::logger::Logger;
 use wxc_common::models::{ExecutionRequest, NetworkEnforcementMode, NetworkPolicy, ScriptResponse};
 use wxc_common::process_util::{
-    create_std_pipes, get_capability_sid_from_name, InterruptiblePipeReader, OwnedHandle,
-    PipeReadCanceller, PipeWriter, SendOwnedHandle, SidAndAttributes,
+    create_std_pipes, InterruptiblePipeReader, OwnedHandle, PipeReadCanceller, PipeWriter,
+    SendOwnedHandle, SidAndAttributes,
 };
 use wxc_common::sandbox_process::{
     boxed_closer, cancel_and_join_discard, spawn_discard, take_boxed_read, take_boxed_write,
@@ -173,27 +173,82 @@ fn inject_proxy_vars(entries: &mut Vec<(String, String)>, addr: &wxc_common::mod
     entries.push(("HTTPS_PROXY".to_string(), proxy_url));
 }
 
-/// RAII guard that frees capability SID pointers via `LocalFree` on drop.
-/// Ensures SIDs are freed regardless of the error return path.
-struct CapabilitySidGuard(Vec<*mut core::ffi::c_void>);
+/// Owned capability SID derived from a capability name via
+/// [`get_capability_sid_from_name`]. Frees the underlying `LocalAlloc`'d SID
+/// with `LocalFree` on drop, so callers don't have to track and free the raw
+/// pointer themselves.
+struct OwnedCapabilitySid(PSID);
 
-impl CapabilitySidGuard {
-    fn new() -> Self {
-        Self(Vec::new())
-    }
-
-    fn push(&mut self, sid: *mut core::ffi::c_void) {
-        self.0.push(sid);
+impl OwnedCapabilitySid {
+    /// Borrow the raw `PSID` for building a `SID_AND_ATTRIBUTES` array. The
+    /// pointer is valid only while `self` is alive — keep the owner around
+    /// until the process-creation call has returned.
+    fn as_psid(&self) -> PSID {
+        self.0
     }
 }
 
-impl Drop for CapabilitySidGuard {
+impl Drop for OwnedCapabilitySid {
     fn drop(&mut self) {
-        for &sid in &self.0 {
+        if !self.0 .0.is_null() {
             unsafe {
-                let _ = LocalFree(Some(HLOCAL(sid)));
+                let _ = LocalFree(Some(HLOCAL(self.0 .0)));
             }
         }
+    }
+}
+
+/// Derive the capability SID for a given capability name, returning an owned
+/// handle that frees the SID on drop. Capability SIDs are an AppContainer
+/// concept, so this helper lives in the AppContainer backend rather than the
+/// shared foundation crate.
+fn get_capability_sid_from_name(name: &str) -> Result<OwnedCapabilitySid, WxcError> {
+    let wide_name = string_util::to_wide(name);
+    let pcwstr = PCWSTR(wide_name.as_ptr());
+
+    let mut capability_sids: *mut PSID = std::ptr::null_mut();
+    let mut capability_sid_count: u32 = 0;
+    let mut group_sids: *mut PSID = std::ptr::null_mut();
+    let mut group_sid_count: u32 = 0;
+
+    unsafe {
+        DeriveCapabilitySidsFromName(
+            pcwstr,
+            &mut group_sids,
+            &mut group_sid_count,
+            &mut capability_sids,
+            &mut capability_sid_count,
+        )
+        .map_err(|e| {
+            WxcError::Process(format!("DeriveCapabilitySidsFromName({name}) failed: {e}"))
+        })?;
+
+        // Free group SIDs
+        for i in 0..group_sid_count {
+            let sid = *group_sids.add(i as usize);
+            let _ = LocalFree(Some(HLOCAL(sid.0)));
+        }
+        let _ = LocalFree(Some(HLOCAL(group_sids as *mut _)));
+
+        if capability_sid_count == 0 {
+            let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
+            return Err(WxcError::Process(format!(
+                "No capability SID returned for {}",
+                name
+            )));
+        }
+
+        // Take the first capability SID
+        let result_sid = *capability_sids;
+
+        // Free remaining capability SIDs (index 1+)
+        for i in 1..capability_sid_count {
+            let sid = *capability_sids.add(i as usize);
+            let _ = LocalFree(Some(HLOCAL(sid.0)));
+        }
+        let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
+
+        Ok(OwnedCapabilitySid(result_sid))
     }
 }
 
@@ -476,17 +531,20 @@ impl AppContainerScriptRunner {
         }
 
         // --- Derive SIDs for each capability ---
-        let mut capability_sid_guard = CapabilitySidGuard::new();
+        // `owned_capability_sids` owns the derived SIDs (freed on drop); it
+        // must outlive `sid_attrs` / `security_capabilities`, which borrow the
+        // raw pointers for the process-creation call below.
+        let mut owned_capability_sids: Vec<OwnedCapabilitySid> = Vec::new();
         let mut sid_attrs: Vec<SidAndAttributes> = Vec::new();
 
         for cap_name in &capabilities_to_add {
             match get_capability_sid_from_name(cap_name) {
-                Ok(sid_ptr) => {
+                Ok(sid) => {
                     sid_attrs.push(SidAndAttributes {
-                        sid: PSID(sid_ptr),
+                        sid: sid.as_psid(),
                         attributes: SE_GROUP_ENABLED as u32,
                     });
-                    capability_sid_guard.push(sid_ptr);
+                    owned_capability_sids.push(sid);
                 }
                 Err(e) => {
                     logger.log_line(&format!(
@@ -929,7 +987,8 @@ impl AppContainerScriptRunner {
         if self.app_container_sid.0.is_null() {
             return "unknown-sid".to_string();
         }
-        unsafe { string_util::sid_to_string(self.app_container_sid.0, "unknown-sid") }
+        unsafe { string_util::sid_to_string(self.app_container_sid.0) }
+            .unwrap_or_else(|| "unknown-sid".to_string())
     }
 }
 

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -1467,7 +1467,8 @@ fn derive_sid_string_from_name(name: &str) -> String {
 
     match unsafe { DeriveAppContainerSidFromAppContainerName(pcwstr_name) } {
         Ok(sid) => {
-            let s = unsafe { string_util::sid_to_string(sid.0, "unknown-sid") };
+            let s = unsafe { string_util::sid_to_string(sid.0) }
+                .unwrap_or_else(|| "unknown-sid".to_string());
             // SAFETY: SID returned by DeriveAppContainerSidFromAppContainerName
             // must be freed with FreeSid.
             unsafe {

--- a/src/backends/appcontainer/common/src/sandbox_tracking.rs
+++ b/src/backends/appcontainer/common/src/sandbox_tracking.rs
@@ -65,18 +65,14 @@ pub fn derive_sid_string(identity: &str) -> Result<String, String> {
     };
 
     // Reuse the shared SID-to-string helper from string_util.
-    let result = unsafe { string_util::sid_to_string(psid.0, "") };
+    let result = unsafe { string_util::sid_to_string(psid.0) };
 
     // SAFETY: SID was allocated by the OS and must be freed with FreeSid.
     unsafe {
         FreeSid(psid);
     }
 
-    if result.is_empty() {
-        return Err("ConvertSidToStringSidW failed".into());
-    }
-
-    Ok(result)
+    result.ok_or_else(|| "ConvertSidToStringSidW failed".into())
 }
 
 /// Information about a tracked sandbox entry, used for logging and cleanup.

--- a/src/backends/lxc/common/src/filesystem_mounts.rs
+++ b/src/backends/lxc/common/src/filesystem_mounts.rs
@@ -15,7 +15,8 @@ use wxc_common::models::ContainerPolicy;
 use crate::lxc_bindings::LxcContainer;
 
 /// Validate that a path does not contain characters that could inject
-/// additional LXC configuration directives (whitespace, newlines, carriage returns).
+/// additional LXC configuration directives. `char::is_whitespace` already
+/// covers spaces, tabs, newlines, and carriage returns.
 fn validate_path(path: &str) -> Result<(), String> {
     if path.is_empty() {
         return Err("Empty path is not allowed".to_string());
@@ -23,12 +24,6 @@ fn validate_path(path: &str) -> Result<(), String> {
     if path.chars().any(|c| c.is_whitespace()) {
         return Err(format!(
             "Path contains whitespace characters which could inject or break LXC config parsing: {:?}",
-            path
-        ));
-    }
-    if path.contains('\n') || path.contains('\r') {
-        return Err(format!(
-            "Path contains newline characters which could inject LXC config: {:?}",
             path
         ));
     }

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -479,15 +479,18 @@ impl WSLContainerRunner {
         let image_name = &self.config.image;
         let mut image_found = false;
         if !images.is_null() {
-            for i in 0..image_count as isize {
-                let info = &*images.offset(i);
-                let name_bytes: Vec<u8> = info
-                    .name
+            let images_slice = std::slice::from_raw_parts(images, image_count as usize);
+            for info in images_slice {
+                // `info.name` is a fixed-size, possibly-unterminated C buffer;
+                // read up to the first NUL (or the whole buffer if there is
+                // none) without allocating, matching the SDK's own truncation.
+                let name_bytes =
+                    std::slice::from_raw_parts(info.name.as_ptr().cast::<u8>(), info.name.len());
+                let end = name_bytes
                     .iter()
-                    .take_while(|&&b| b != 0)
-                    .map(|&b| b as u8)
-                    .collect();
-                if let Ok(name) = std::str::from_utf8(&name_bytes) {
+                    .position(|&b| b == 0)
+                    .unwrap_or(name_bytes.len());
+                if let Ok(name) = std::str::from_utf8(&name_bytes[..end]) {
                     if name == image_name.as_str() {
                         image_found = true;
                         break;

--- a/src/core/wxc_common/src/diagnostic.rs
+++ b/src/core/wxc_common/src/diagnostic.rs
@@ -61,17 +61,13 @@ fn get_current_user_sid() -> Option<String> {
 
     // SAFETY: GetTokenInformation succeeded with TokenUser, so buf contains a valid TOKEN_USER.
     let token_user = unsafe { &*(buf.as_ptr() as *const TOKEN_USER) };
-    let sid_str = unsafe { sid_to_string(token_user.User.Sid.0, "") };
+    let sid_str = unsafe { sid_to_string(token_user.User.Sid.0) };
 
     unsafe {
         let _ = CloseHandle(token);
     }
 
-    if sid_str.is_empty() {
-        None
-    } else {
-        Some(sid_str)
-    }
+    sid_str
 }
 
 /// Maximum number of characters to include from `script_code` in diagnostic output.

--- a/src/core/wxc_common/src/mxc_error.rs
+++ b/src/core/wxc_common/src/mxc_error.rs
@@ -86,7 +86,7 @@ impl MxcError {
 
     pub fn to_envelope(&self) -> ErrorEnvelope {
         ErrorEnvelope {
-            code: self.code.as_str().to_string(),
+            code: self.code,
             message: self.message.clone(),
             details: self.details.clone(),
         }
@@ -133,11 +133,12 @@ impl MxcError {
     }
 }
 
-/// Wire shape of the `error` arm. `code` is a snake_case string from
-/// `MxcErrorCode::as_str`; `details` is omitted from JSON when absent.
+/// Wire shape of the `error` arm. `code` is a closed `MxcErrorCode` that
+/// serialises to its snake_case wire string; `details` is omitted from JSON
+/// when absent.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ErrorEnvelope {
-    pub code: String,
+    pub code: MxcErrorCode,
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub details: Option<Value>,
@@ -265,7 +266,7 @@ mod tests {
     #[test]
     fn error_envelope_round_trips_via_json() {
         let env = ErrorEnvelope {
-            code: "stale_id".into(),
+            code: MxcErrorCode::StaleId,
             message: "session expired".into(),
             details: Some(json!({"k": "v"})),
         };
@@ -277,7 +278,7 @@ mod tests {
     #[test]
     fn error_envelope_omits_details_when_none() {
         let env = ErrorEnvelope {
-            code: "stale_id".into(),
+            code: MxcErrorCode::StaleId,
             message: "x".into(),
             details: None,
         };
@@ -295,7 +296,7 @@ mod tests {
     #[test]
     fn response_envelope_error_serialises_with_error_key() {
         let inner = ErrorEnvelope {
-            code: "stale_id".into(),
+            code: MxcErrorCode::StaleId,
             message: "x".into(),
             details: None,
         };
@@ -307,7 +308,7 @@ mod tests {
     #[test]
     fn response_envelope_round_trips_via_json() {
         let inner = ErrorEnvelope {
-            code: "backend_error".into(),
+            code: MxcErrorCode::BackendError,
             message: "boom".into(),
             details: Some(json!({"x": 1})),
         };

--- a/src/core/wxc_common/src/process_util.rs
+++ b/src/core/wxc_common/src/process_util.rs
@@ -10,16 +10,14 @@ use crate::sandbox_process::StreamCloser;
 use crate::string_util;
 
 use windows::Win32::Foundation::{
-    CloseHandle, LocalFree, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT,
-    HLOCAL, WAIT_OBJECT_0,
+    CloseHandle, SetHandleInformation, HANDLE, HANDLE_FLAGS, HANDLE_FLAG_INHERIT, WAIT_OBJECT_0,
 };
-use windows::Win32::Security::{DeriveCapabilitySidsFromName, PSID, SECURITY_ATTRIBUTES};
+use windows::Win32::Security::{PSID, SECURITY_ATTRIBUTES};
 use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
 use windows::Win32::System::Pipes::CreatePipe;
 use windows::Win32::System::Threading::WaitForSingleObject;
 use windows::Win32::System::IO::CancelIoEx;
 use windows_core::BOOL;
-use windows_core::PCWSTR;
 
 /// A readable end of an anonymous pipe (e.g. the child's stdout/stderr),
 /// owning the handle and closing it on drop. Implements [`std::io::Read`]
@@ -520,58 +518,6 @@ pub fn run_process_with_captured_output(
 pub struct SidAndAttributes {
     pub sid: PSID,
     pub attributes: u32,
-}
-
-/// Derive the capability SID for a given capability name.
-/// Returns the raw SID pointer. The caller is responsible for freeing it with `LocalFree`.
-pub fn get_capability_sid_from_name(name: &str) -> Result<*mut core::ffi::c_void, WxcError> {
-    let wide_name = string_util::to_wide(name);
-    let pcwstr = PCWSTR(wide_name.as_ptr());
-
-    let mut capability_sids: *mut PSID = std::ptr::null_mut();
-    let mut capability_sid_count: u32 = 0;
-    let mut group_sids: *mut PSID = std::ptr::null_mut();
-    let mut group_sid_count: u32 = 0;
-
-    unsafe {
-        DeriveCapabilitySidsFromName(
-            pcwstr,
-            &mut group_sids,
-            &mut group_sid_count,
-            &mut capability_sids,
-            &mut capability_sid_count,
-        )
-        .map_err(|e| {
-            WxcError::Process(format!("DeriveCapabilitySidsFromName({name}) failed: {e}"))
-        })?;
-
-        // Free group SIDs
-        for i in 0..group_sid_count {
-            let sid = *group_sids.add(i as usize);
-            let _ = LocalFree(Some(HLOCAL(sid.0)));
-        }
-        let _ = LocalFree(Some(HLOCAL(group_sids as *mut _)));
-
-        if capability_sid_count == 0 {
-            let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
-            return Err(WxcError::Process(format!(
-                "No capability SID returned for {}",
-                name
-            )));
-        }
-
-        // Take the first capability SID
-        let result_sid = (*capability_sids).0;
-
-        // Free remaining capability SIDs (index 1+)
-        for i in 1..capability_sid_count {
-            let sid = *capability_sids.add(i as usize);
-            let _ = LocalFree(Some(HLOCAL(sid.0)));
-        }
-        let _ = LocalFree(Some(HLOCAL(capability_sids as *mut _)));
-
-        Ok(result_sid)
-    }
 }
 
 // ── Sibling binary resolution ─────────────────────────────────────────────

--- a/src/core/wxc_common/src/state_aware_request.rs
+++ b/src/core/wxc_common/src/state_aware_request.rs
@@ -109,7 +109,9 @@ impl ParsedStateAwareRequest {
         let Some(phase_value) = backend_obj.get(phase_name) else {
             return Ok(None);
         };
-        serde_json::from_value::<C>(phase_value.clone())
+        // Deserialize directly from the borrowed `&Value` — no need to clone
+        // the (potentially large) backend config subtree first.
+        <C as serde::Deserialize>::deserialize(phase_value)
             .map(Some)
             .map_err(|e| {
                 MxcError::malformed_request(format!(

--- a/src/core/wxc_common/src/string_util.rs
+++ b/src/core/wxc_common/src/string_util.rs
@@ -19,24 +19,21 @@ pub fn from_wide(wide: &[u16]) -> String {
 }
 
 /// Convert a SID pointer to its string representation (e.g. "S-1-5-...").
-/// Returns `default_value` on failure.
+/// Returns `None` if the pointer is null or the conversion fails.
 ///
 /// # Safety
-/// The caller must ensure `sid` points to a valid SID structure.
-pub unsafe fn sid_to_string(sid: *mut std::ffi::c_void, default_value: &str) -> String {
+/// The caller must ensure `sid` points to a valid SID structure (or is null).
+pub unsafe fn sid_to_string(sid: *mut std::ffi::c_void) -> Option<String> {
     if sid.is_null() {
-        return default_value.to_string();
+        return None;
     }
 
     let mut string_sid = windows_core::PWSTR::null();
     let psid = PSID(sid);
 
-    let ok = unsafe { ConvertSidToStringSidW(psid, &mut string_sid) };
-    if ok.is_err() {
-        return default_value.to_string();
-    }
+    unsafe { ConvertSidToStringSidW(psid, &mut string_sid) }.ok()?;
 
-    let result = unsafe { string_sid.to_string() }.unwrap_or_else(|_| default_value.to_string());
+    let result = unsafe { string_sid.to_string() }.ok();
 
     unsafe {
         let _ = LocalFree(Some(HLOCAL(string_sid.0 as *mut std::ffi::c_void)));
@@ -379,14 +376,8 @@ mod tests {
     // ========== sid_to_string ==========
 
     #[test]
-    fn sid_to_string_null_returns_default() {
-        let result = unsafe { sid_to_string(std::ptr::null_mut(), "DEFAULT") };
-        assert_eq!(result, "DEFAULT");
-    }
-
-    #[test]
-    fn sid_to_string_null_returns_empty_default() {
-        let result = unsafe { sid_to_string(std::ptr::null_mut(), "") };
-        assert_eq!(result, "");
+    fn sid_to_string_null_returns_none() {
+        let result = unsafe { sid_to_string(std::ptr::null_mut()) };
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary

Idiomatic-Rust cleanups. No intended behavior change — only ownership,
error-signalling, and stdlib-usage improvements. This is the follow-up to the
behavior-bug PR (#570); the larger related refactors (`WxcError` typed source
errors, SDK/CLI `PathBuf` migration, `mxc_pty` typed error, the WinHTTP-shim
RAII rework) are intentionally **deferred to their own focused PRs**.

**Details**

* **Capability SID ownership.** `get_capability_sid_from_name` now returns an
  owning `OwnedCapabilitySid` (frees on drop) instead of a raw `*mut c_void`
  with a "caller must `LocalFree`" contract. The helper *and* the owner type
  were relocated out of the shared `wxc_common` foundation into the
  `appcontainer` backend (now private) — capability SIDs are an AppContainer
  concept with a single caller, so this both removes the hand-rolled
  `CapabilitySidGuard` and keeps backend-specific logic out of the foundation
  crate.
* **`string_util::sid_to_string`** returns `Option<String>` instead of taking a
  sentinel `default_value`. The `LocalAlloc`'d buffer is still read then freed
  exactly once on the success path; the four call sites map `None` to their
  prior fallback.
* **`ErrorEnvelope.code`** is now the closed `MxcErrorCode` enum rather than a
  `String`. The snake_case wire format is unchanged (serde).
* **`deserialize_config`** deserializes from the borrowed `&Value` instead of
  cloning the backend config subtree.
* **WSLC image enumeration** is allocation-free (`slice::from_raw_parts` + a
  first-NUL scan with full-buffer fallback) instead of manual `.offset(i)`
  pointer walking and a per-entry `Vec<u8>`.
* **LXC `validate_path`** drops a provably-unreachable `\n`/`\r` branch already
  covered by `char::is_whitespace`.

**Tests**

* `cargo test -p wxc_common -p appcontainer_common -p wslc_common` — 126 + 45 +
  346 pass (includes the updated `sid_to_string_null_returns_none` and the
  `ErrorEnvelope` round-trip/serialisation tests).
* `cargo clippy -p wxc_common -p appcontainer_common -p wslc_common
  --all-targets -- -D warnings` and `cargo fmt ... -- --check` clean.
* `cargo check -p wxc --all-targets` clean (full Windows backend dispatch).
* **Not built on the Windows host:** the LXC `validate_path` change
  (`lxc_common` is Linux-only). It is the removal of a provably-dead branch
  with no logic change.

## Related Issues

- (none)
