### PR TITLE
Phase 2B follow-up: use From<T> for wire->domain enum conversions

### DIFF
--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -8,7 +8,7 @@ use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
-    ClipboardPolicy, ContainerPolicy, ContainmentBackend, ExecutionRequest, ExperimentalConfig,
+    ContainerPolicy, ContainmentBackend, ExecutionRequest, ExperimentalConfig,
     IsolationSessionConfig, LifecycleConfig, LxcConfig, NetworkEnforcementMode, NetworkPolicy,
     PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig, TestFeatureConfig, UiPolicy,
     WindowsSandboxConfig, WslcConfig,
@@ -507,60 +507,15 @@ fn make_seatbelt_config(sb: wire::Seatbelt) -> SeatbeltConfig {
     }
 }
 
-/// Lowercase wire-format string for a UI isolation level (matches the schema
-/// enum values consumed downstream).
-fn wire_ui_isolation_str(iso: &wire::UiIsolation) -> &'static str {
-    match iso {
-        wire::UiIsolation::Desktop => "desktop",
-        wire::UiIsolation::Handles => "handles",
-        wire::UiIsolation::Atoms => "atoms",
-        wire::UiIsolation::Container => "container",
-    }
-}
-
-/// Resolve the `containment` wire enum to a concrete domain backend.
+/// Resolve the optional `containment` wire enum to a concrete domain backend.
 ///
-/// `None` (omitted) and the abstract intent `Process` resolve to the OS-native
-/// process sandbox per target_os; `Vm` resolves to the host's VM-class backend.
-/// Deprecated spellings (`appcontainer`, `macos_sandbox`) are accepted via
-/// `#[serde(alias)]` on the wire enum and arrive here already mapped to the
-/// canonical variant. Concrete backends map verbatim.
+/// An omitted `containment` (`None`) resolves identically to the abstract
+/// `process` intent: the OS-native process sandbox. Concrete and abstract
+/// variants are mapped by `From<wire::Containment>`.
 fn map_wire_containment(c: Option<&wire::Containment>) -> ContainmentBackend {
-    use wire::Containment as W;
     match c {
-        None | Some(W::Process) => {
-            #[cfg(target_os = "linux")]
-            {
-                ContainmentBackend::Bubblewrap
-            }
-            #[cfg(target_os = "macos")]
-            {
-                ContainmentBackend::Seatbelt
-            }
-            #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-            {
-                ContainmentBackend::ProcessContainer
-            }
-        }
-        Some(W::ProcessContainer) => ContainmentBackend::ProcessContainer,
-        Some(W::Vm) => {
-            #[cfg(target_os = "windows")]
-            {
-                ContainmentBackend::WindowsSandbox
-            }
-            #[cfg(not(target_os = "windows"))]
-            {
-                ContainmentBackend::Vm
-            }
-        }
-        Some(W::WindowsSandbox) => ContainmentBackend::WindowsSandbox,
-        Some(W::Lxc) => ContainmentBackend::Lxc,
-        Some(W::Microvm) => ContainmentBackend::MicroVm,
-        Some(W::Hyperlight) => ContainmentBackend::Hyperlight,
-        Some(W::Wslc) => ContainmentBackend::Wslc,
-        Some(W::Seatbelt) => ContainmentBackend::Seatbelt,
-        Some(W::IsolationSession) => ContainmentBackend::IsolationSession,
-        Some(W::Bubblewrap) => ContainmentBackend::Bubblewrap,
+        Some(c) => c.clone().into(),
+        None => wire::Containment::Process.into(),
     }
 }
 
@@ -708,7 +663,7 @@ fn convert_wire_config(
             policy.base_process_ui.isolation = raw_ui
                 .isolation
                 .as_ref()
-                .map(wire_ui_isolation_str)
+                .map(wire::UiIsolation::as_str)
                 .unwrap_or("container")
                 .to_string();
             policy.base_process_ui.desktop_system_control =
@@ -757,18 +712,11 @@ fn convert_wire_config(
         }
 
         if let Some(p) = net.default_policy {
-            policy.default_network_policy = match p {
-                wire::NetworkPolicy::Allow => NetworkPolicy::Allow,
-                wire::NetworkPolicy::Block => NetworkPolicy::Block,
-            };
+            policy.default_network_policy = p.into();
         }
 
         if let Some(m) = net.enforcement_mode {
-            policy.network_enforcement_mode = match m {
-                wire::NetworkEnforcement::Capabilities => NetworkEnforcementMode::Capabilities,
-                wire::NetworkEnforcement::Firewall => NetworkEnforcementMode::Firewall,
-                wire::NetworkEnforcement::Both => NetworkEnforcementMode::Both,
-            };
+            policy.network_enforcement_mode = m.into();
         }
 
         if let Some(v) = net.allow_local_network {
@@ -965,12 +913,7 @@ fn convert_wire_config(
 
     // UI section
     if let Some(raw_ui) = cfg.ui {
-        let clipboard = match raw_ui.clipboard {
-            Some(wire::ClipboardPolicy::Read) => ClipboardPolicy::Read,
-            Some(wire::ClipboardPolicy::Write) => ClipboardPolicy::Write,
-            Some(wire::ClipboardPolicy::All) => ClipboardPolicy::All,
-            _ => ClipboardPolicy::None,
-        };
+        let clipboard = raw_ui.clipboard.map(Into::into).unwrap_or_default();
         policy.ui = UiPolicy {
             disable: raw_ui.disable.unwrap_or(true),
             clipboard,
@@ -1108,6 +1051,7 @@ mod tests {
     use super::*;
     use crate::encoding::base64_encode;
     use crate::logger::Mode;
+    use crate::models::ClipboardPolicy;
 
     fn test_logger() -> Logger {
         Logger::new(Mode::Buffer)

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -81,6 +81,54 @@ impl ContainmentBackend {
     }
 }
 
+impl From<crate::wire::Containment> for ContainmentBackend {
+    /// Resolve a `containment` wire value to a concrete domain backend.
+    ///
+    /// The abstract intents resolve per host: `process` → the OS-native process
+    /// sandbox, `vm` → the host's VM-class backend. Concrete backends map
+    /// verbatim. Deprecated spellings (`appcontainer`, `macos_sandbox`) are
+    /// accepted via `#[serde(alias)]` on the wire enum and arrive here already
+    /// mapped to the canonical variant.
+    fn from(c: crate::wire::Containment) -> Self {
+        use crate::wire::Containment as W;
+        match c {
+            W::Process => {
+                #[cfg(target_os = "linux")]
+                {
+                    Self::Bubblewrap
+                }
+                #[cfg(target_os = "macos")]
+                {
+                    Self::Seatbelt
+                }
+                #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+                {
+                    Self::ProcessContainer
+                }
+            }
+            W::ProcessContainer => Self::ProcessContainer,
+            W::Vm => {
+                #[cfg(target_os = "windows")]
+                {
+                    Self::WindowsSandbox
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    Self::Vm
+                }
+            }
+            W::WindowsSandbox => Self::WindowsSandbox,
+            W::Lxc => Self::Lxc,
+            W::Microvm => Self::MicroVm,
+            W::Hyperlight => Self::Hyperlight,
+            W::Wslc => Self::Wslc,
+            W::Seatbelt => Self::Seatbelt,
+            W::IsolationSession => Self::IsolationSession,
+            W::Bubblewrap => Self::Bubblewrap,
+        }
+    }
+}
+
 /// Configuration specific to the Seatbelt backend.
 /// Used under the top-level `seatbelt` key when `containment == Seatbelt`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -299,6 +347,15 @@ pub enum NetworkPolicy {
     Block,
 }
 
+impl From<crate::wire::NetworkPolicy> for NetworkPolicy {
+    fn from(p: crate::wire::NetworkPolicy) -> Self {
+        match p {
+            crate::wire::NetworkPolicy::Allow => Self::Allow,
+            crate::wire::NetworkPolicy::Block => Self::Block,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum NetworkEnforcementMode {
@@ -306,6 +363,16 @@ pub enum NetworkEnforcementMode {
     Capabilities,
     Firewall,
     Both,
+}
+
+impl From<crate::wire::NetworkEnforcement> for NetworkEnforcementMode {
+    fn from(m: crate::wire::NetworkEnforcement) -> Self {
+        match m {
+            crate::wire::NetworkEnforcement::Capabilities => Self::Capabilities,
+            crate::wire::NetworkEnforcement::Firewall => Self::Firewall,
+            crate::wire::NetworkEnforcement::Both => Self::Both,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -375,6 +442,17 @@ pub enum ClipboardPolicy {
     Write,
     #[serde(rename = "all")]
     All,
+}
+
+impl From<crate::wire::ClipboardPolicy> for ClipboardPolicy {
+    fn from(c: crate::wire::ClipboardPolicy) -> Self {
+        match c {
+            crate::wire::ClipboardPolicy::None => Self::None,
+            crate::wire::ClipboardPolicy::Read => Self::Read,
+            crate::wire::ClipboardPolicy::Write => Self::Write,
+            crate::wire::ClipboardPolicy::All => Self::All,
+        }
+    }
 }
 
 /// Cross-platform UI policy parsed from the `ui` JSON section.

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -211,6 +211,18 @@ pub enum UiIsolation {
     Container,
 }
 
+impl UiIsolation {
+    /// Lowercase wire-format string matching the schema enum values.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            UiIsolation::Desktop => "desktop",
+            UiIsolation::Handles => "handles",
+            UiIsolation::Atoms => "atoms",
+            UiIsolation::Container => "container",
+        }
+    }
+}
+
 /// LXC container settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]


### PR DESCRIPTION
## Summary

Follow-up to the merged Phase 2B PR (#566). It addresses the one review thread bbonaby left unresolved at merge: extend the `From<T>` treatment to the remaining wire->domain enum conversions, and give `wire::UiIsolation` an `as_str()` on the enum itself.

This converts the last inline `match` mappings in the config parser to `From<T>` impls placed beside the domain types, matching the pattern already used for `wire::Phase`, `LaunchMethod`, `IsolationConfigurationId`, and `IsolationUser`. Call sites now read as a plain `.into()`.

Original review comment: https://github.com/microsoft/mxc/pull/566#discussion_r3477623235

### Details
- Add `From<wire::NetworkPolicy>`, `From<wire::NetworkEnforcement>`, and `From<wire::ClipboardPolicy>` impls next to their domain enums in `models.rs`.
- Add `From<wire::Containment> for ContainmentBackend`, moving the per-OS abstract-intent resolution (`process`/`vm`) onto the impl; `map_wire_containment` now only resolves the omitted (`None`) case to the `process` default.
- Add `wire::UiIsolation::as_str()` in `wire.rs` and drop the `wire_ui_isolation_str` free function.
- Replace the inline `match` conversions in `config_parser.rs` with `.into()` / `as_str()`; move the now test-only `ClipboardPolicy` import into the test module.
- No behavior change — purely a refactor of how the wire enums map to domain enums; the generated schema is unaffected.

### Tests
- `cargo test -p wxc_common` (359 passed).
- `cargo clippy -p wxc_common --all-targets` and `cargo fmt --all -- --check` clean.
- `cargo check --workspace` clean.
- `node scripts/versioning/check-schema-codegen.js` reports the dev schema unchanged.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/574)