### PR TITLE
Stage isolation_session test collateral into the OS vpack

### DIFF
--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -50,6 +50,13 @@ extends:
     cloudvault:
       enabled: false
 
+    globalSdl:
+      evidence:
+        enabled: false
+      # Use evidenceV2 for the new evidence format instead of deprecated v1 job.
+      evidenceV2:
+        enabled: true
+
     stages:
     - stage: vpack
       displayName: 'Create OS vpack'
@@ -118,3 +125,19 @@ extends:
                   # _manifest/spdx_2.2/ at the top of VPackContents. The
                   # per-arch SBOMs are identical source-wise, so promote x64's.
                   Copy-Item -Recurse -Force "$(ob_outputDirectory)\x64\_manifest" "$(ob_outputDirectory)\_manifest"
+
+            # Stage the current isolation_session test collateral into the vpack
+            # under isolation_session/main/, so the OS side can run these tests.
+            # Copies every *isolation_session* file from tests/scripts and
+            # tests/configs into scripts/ and configs/ subfolders.
+            - task: PowerShell@2
+              displayName: Stage isolation_session tests for vpack
+              inputs:
+                targetType: inline
+                script: |
+                  $scriptsDest = "$(ob_outputDirectory)\isolation_session\main\scripts"
+                  $configsDest = "$(ob_outputDirectory)\isolation_session\main\configs"
+                  New-Item -ItemType Directory -Force -Path $scriptsDest | Out-Null
+                  New-Item -ItemType Directory -Force -Path $configsDest | Out-Null
+                  Copy-Item -Force "$(Build.SourcesDirectory)\tests\scripts\*isolation_session*" $scriptsDest
+                  Copy-Item -Force "$(Build.SourcesDirectory)\tests\configs\*isolation_session*" $configsDest

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -135,9 +135,19 @@ extends:
               inputs:
                 targetType: inline
                 script: |
+                  $ErrorActionPreference = 'Stop'
+                  # Enumerate matches first so a stale/empty pattern fails fast
+                  # with a clear message, instead of a generic Copy-Item error or
+                  # a silently-empty folder in the vpack.
+                  $scriptsSrc = Get-ChildItem "$(Build.SourcesDirectory)\tests\scripts\*isolation_session*" -File
+                  $configsSrc = Get-ChildItem "$(Build.SourcesDirectory)\tests\configs\*isolation_session*" -File
+                  if (-not $scriptsSrc) { throw "No *isolation_session* scripts found under tests\scripts" }
+                  if (-not $configsSrc) { throw "No *isolation_session* configs found under tests\configs" }
+
                   $scriptsDest = "$(ob_outputDirectory)\isolation_session\main\scripts"
                   $configsDest = "$(ob_outputDirectory)\isolation_session\main\configs"
                   New-Item -ItemType Directory -Force -Path $scriptsDest | Out-Null
                   New-Item -ItemType Directory -Force -Path $configsDest | Out-Null
-                  Copy-Item -Force "$(Build.SourcesDirectory)\tests\scripts\*isolation_session*" $scriptsDest
-                  Copy-Item -Force "$(Build.SourcesDirectory)\tests\configs\*isolation_session*" $configsDest
+                  $scriptsSrc | Copy-Item -Destination $scriptsDest -Force
+                  $configsSrc | Copy-Item -Destination $configsDest -Force
+                  Write-Host "Staged $($scriptsSrc.Count) scripts and $($configsSrc.Count) configs into isolation_session\main"


### PR DESCRIPTION
## 📖 Description
Adds an `isolation_session/main/` tree to the OS vpack so the OS side can run the isolation_session tests from the package. The new step copies the current `*isolation_session*` PowerShell scripts (`tests/scripts/`) and configs (`tests/configs/`) into `scripts/` and `configs/` subfolders. Also disables the deprecated Guardian evidence v1 job (`globalSdl.evidence`) in favor of `evidenceV2` for the vpack pipeline.

## 🔗 References
<!-- Add "Resolves #NNNN" if there's a tracking issue. -->

## 🔍 Validation
Pipeline-only change (no shipping code). Validated locally: YAML parses; the embedded PowerShell parses; the copy globs resolve to 3 scripts and 46 configs against the current tree. Full validation on first `MXC-PR-Build` run.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/583)