### PR TITLE
Permissive Learning Mode 4/6 Capability

### DIFF
--- a/src/host/plm/readme.md
+++ b/src/host/plm/readme.md
@@ -2,7 +2,7 @@
 
 `plm.exe` is the Windows-only trace driver for permissive learning mode. Long-form, it captures the access-denied events emitted by Windows' permissive sandbox layer, decodes them into structured findings, and merges those findings back into an MXC container config so the next enforcing run succeeds.
 
-This PR introduces **config generation**: discovered file paths are written to a copy of the input config as `Adjusted_<name>.json` next to the captured trace, and the operator sees a per-path / per-mask detection summary. The summary also emits a "Detected capabilities" line, but until the capability-extraction PR wires up the `EventID=14` DACL ACE-blob decoder that populates it, it will always report zero. UI relaxation arrives in a subsequent PR as well.
+This PR introduces **capability extraction**: `EventID=14` DACL ACE blobs are decoded into AppContainer capability names via `extract_caps`, and those names are merged into the config's containment-backend `capabilities` array (when the backend supports it). UI relaxation arrives in a subsequent PR.
 
 PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mode-permissive-learning-mode); the standalone CLI documented here is for capturing traces, interactive iteration, and debugging the parser itself.
 
@@ -11,21 +11,22 @@ PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mo
 1. **Capture** — `plm start` calls `wpr -start <plm.wprp>!AccessFailureProfile -filemode`, enabling the `Microsoft-Windows-Privacy-Auditing-PermissiveLearningMode` and `Microsoft-Windows-Kernel-General` ETW providers in a secure realtime collector.
 2. **Run** — the operator runs the workload. The OS-side permissive sandbox logs `EventID=14` / `EventID=27` for every access that *would* have been denied.
 3. **Stop** — `plm stop` calls `wpr -stop <trace.etl>` and walks the `.etl` with `EvtQuery` / `EvtRender`.
-4. **Parse** — for each `EventID=14`, the parser pulls the file path / access mask. Capability ACE-blob decoding lands in a later PR; `EventID=27` UI relaxation lands in a later PR.
-5. **Merge** — file paths are added to `filesystem.readwritePaths` / `filesystem.readonlyPaths` on a copy of the input config and written as `Adjusted_<name>.json` next to the captured trace.
+4. **Parse** — for each `EventID=14`, the parser pulls the file path / access mask and decodes the DACL ACE blob into AppContainer capability names. `EventID=27` UI relaxation lands in a later PR.
+5. **Merge** — file paths are added to `filesystem.readwritePaths` / `filesystem.readonlyPaths`; capability names are added to the containment-backend's `capabilities` array; results are written as `Adjusted_<name>.json` next to the captured trace.
 
 ## Layout (this PR)
 
 | File                    | Role                                                                              |
 |-------------------------|-----------------------------------------------------------------------------------|
-| `src/main.rs`           | `clap` dispatch for `plm start` / `plm stop` / `plm log` (`extract-caps` lands later) |
+| `src/main.rs`           | `clap` dispatch for `plm start` / `plm stop` / `plm log` / `plm extract-caps`     |
 | `src/start.rs`          | `wpr -cancel` (best-effort) + `wpr -start …!AccessFailureProfile -filemode`       |
-| `src/stop.rs`           | `wpr -stop` (or skip with `--trace-file`) + parse + FS merge                      |
+| `src/stop.rs`           | `wpr -stop` (or skip with `--trace-file`) + parse + FS/capability merge           |
 | `src/log.rs`            | Interactive mode: Enter to start, Enter to stop, then diff vs a blank config      |
 | `src/event_parser.rs`   | `EvtQuery` / `EvtRender` walk; shared `ParseAccumulator` + per-event dispatcher   |
-| `src/access_failure.rs` | `EventID=14` decoder: file-path normalization, post-XPath filters                 |
+| `src/access_failure.rs` | `EventID=14` decoder: file-path normalization, post-XPath filters, ACE blob -> capabilities |
 | `src/access_event.rs`   | `LearningModeAccessEvent` plain struct                                            |
-| `src/config.rs`         | JSON load/mutate; path merge into `filesystem.{readwritePaths,readonlyPaths}`     |
+| `src/extract_caps.rs`   | DACL ACE blob decoder; resolves capability SIDs via `DeriveCapabilitySidsFromName` |
+| `src/config.rs`         | JSON load/mutate; FS + capability merge into containment-backend section          |
 | `src/coordination.rs`   | Cross-process singleton named-mutex + bypass-env-var coordination for `plm log`   |
 | `src/wpr_path.rs`       | Resolves `wpr.exe` to its absolute `%SystemRoot%\System32` path (PATH-spoof-safe) |
 | `src/profile_gen.rs`    | Inline WPR profile (`EMBEDDED_WPRP`) + run-time writer that drops `plm.wprp` next to `plm.exe` when missing |
@@ -53,7 +54,15 @@ plm.exe stop [--config-path <path>] [--log-dir <path>] [--bin-path <path>]
              [--trace-file <path>] [--verbose-logging]
 ```
 
-`--config-path` drives an in-memory filesystem merge against the input config and persists the result as `Adjusted_<name>.json` in the log directory. The adjusted config is written next to the operator's config snapshot in `--log-dir`; there is deliberately no flag to redirect it to an arbitrary path, because `plm.exe` runs elevated and an operator-named output path would be an admin-privileged arbitrary-write primitive. The write is atomic (temp file in the same directory, then rename over the destination) so a downstream enforcing run never observes a truncated policy.
+`--config-path` drives an in-memory merge of discovered file paths and capabilities against the input config and persists the result as `Adjusted_<name>.json` in the log directory. The adjusted config is written next to the operator's config snapshot in `--log-dir`; there is deliberately no flag to redirect it to an arbitrary path, because `plm.exe` runs elevated and an operator-named output path would be an admin-privileged arbitrary-write primitive. The write is atomic (temp file in the same directory, then rename over the destination) so a downstream enforcing run never observes a truncated policy.
+
+### `plm extract-caps`
+
+Decode a raw hex-encoded DACL ACE buffer into a sorted list of AppContainer capability names. Useful for debugging the ACE decoder against ETW payloads dumped by other tools.
+
+```powershell
+plm.exe extract-caps --hex-bytes <hex> [--verbose-logging]
+```
 
 ### `plm log`
 
@@ -80,7 +89,7 @@ The WPR profile is embedded into `plm.exe` itself (see `src/profile_gen.rs`); on
 
 - **Windows-only.** Uses `wpr.exe` and Job-Object UI-limit semantics that have no portable equivalent.
 - **Deny matching is enforced on literal, lexically-normalized paths only.** `config::normalize_path` strips verbatim/device prefixes, lowercases, collapses separators, and rejects ADS / `.` / `..`, but it is filesystem-free and does **not** resolve directory junctions, symlinks/reparse points, or 8.3 short names. 8.3 short-name aliases of a denied directory are detected lexically and refused promotion (fail-closed), but a junction/symlink alias (e.g. `C:\work\link` → `C:\Secrets`) is a lexically distinct path that will **not** match a deny entry and can therefore be promoted into the persisted `Adjusted_*.json`. Operators must deny the canonical target path; aliasing the target through a reparse point is a known gap. See the deny-matching code in `src/config.rs`.
-- **No capability or UI extraction yet.** `plm stop` writes `Adjusted_<name>.json` with the discovered file paths only. Capability extraction (`EventID=14` DACL ACE blobs) and UI-policy extraction (`EventID=27`) arrive in subsequent PRs.
+- **No UI extraction yet.** `plm stop` writes `Adjusted_<name>.json` with the discovered file paths and AppContainer capabilities. UI-policy extraction (`EventID=27`) arrives in a subsequent PR.
 
 ## See also
 

--- a/src/host/plm/readme.md
+++ b/src/host/plm/readme.md
@@ -2,7 +2,7 @@
 
 `plm.exe` is the Windows-only trace driver for permissive learning mode. Long-form, it captures the access-denied events emitted by Windows' permissive sandbox layer, decodes them into structured findings, and merges those findings back into an MXC container config so the next enforcing run succeeds.
 
-This PR introduces **capability extraction**: `EventID=14` DACL ACE blobs are decoded into AppContainer capability names via `extract_caps`, and those names are merged into the config's containment-backend `capabilities` array (when the backend supports it). UI relaxation arrives in a subsequent PR.
+This PR introduces **capability extraction**: `EventID=14` DACL ACE blobs are decoded into AppContainer capability names via `extract_caps`, and those names are merged into `processContainer.capabilities`. UI relaxation arrives in a subsequent PR.
 
 PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mode-permissive-learning-mode); the standalone CLI documented here is for capturing traces, interactive iteration, and debugging the parser itself.
 
@@ -12,7 +12,9 @@ PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mo
 2. **Run** — the operator runs the workload. The OS-side permissive sandbox logs `EventID=14` / `EventID=27` for every access that *would* have been denied.
 3. **Stop** — `plm stop` calls `wpr -stop <trace.etl>` and walks the `.etl` with `EvtQuery` / `EvtRender`.
 4. **Parse** — for each `EventID=14`, the parser pulls the file path / access mask and decodes the DACL ACE blob into AppContainer capability names. `EventID=27` UI relaxation lands in a later PR.
-5. **Merge** — file paths are added to `filesystem.readwritePaths` / `filesystem.readonlyPaths`; capability names are added to the containment-backend's `capabilities` array; results are written as `Adjusted_<name>.json` next to the captured trace.
+5. **Merge** — file paths are added to `filesystem.readwritePaths` / `filesystem.readonlyPaths`; capability names are added to `processContainer.capabilities` (deduplicated case-insensitively against any capabilities already authored there, then sorted); results are written as `Adjusted_<name>.json` next to the captured trace.
+
+> **Capability merge caveats.** Capabilities are only merged into a `processContainer` block — backends that cannot express AppContainer capabilities (LXC, Windows Sandbox, …) are left untouched and the discovered set is reported on stderr instead. The reserved names `learningModeLogging` and `permissiveLearningMode` are never written back, because `processContainer.capabilities` rejects them.
 
 ## Layout (this PR)
 
@@ -63,6 +65,8 @@ Decode a raw hex-encoded DACL ACE buffer into a sorted list of AppContainer capa
 ```powershell
 plm.exe extract-caps --hex-bytes <hex> [--verbose-logging]
 ```
+
+> **An empty result does not mean the blob contained no capabilities.** Only names on the module's built-in known-capability list are recognized, and only when the OS resolves them via `DeriveCapabilitySidsFromName` — names this Windows build rejects are skipped at table-build time, and any SID that is not in the resulting index is ignored. Capabilities are also only collected from *allow* ACEs that grant a non-zero access mask. Use `--verbose-logging` to see per-ACE decisions, including SIDs that resolved to nothing.
 
 ### `plm log`
 

--- a/src/host/plm/src/access_failure.rs
+++ b/src/host/plm/src/access_failure.rs
@@ -8,11 +8,8 @@
 //!     prefixes -> DOS form),
 //!   * the post-XPath filters (current-directory, drive-letter,
 //!     self-access, invalid filename chars),
-//!   * the per-event accumulator helper that pushes the resulting
-//!     access event into `ParseAccumulator`.
-//!
-//! ACE-blob → capability-name extraction lands in a later PR; this PR
-//! only collects file paths and access masks.
+//!   * the per-event accumulator helper that feeds the DACL ACE blob
+//!     through `extract_caps` and pushes the resulting access event.
 //!
 //! `ParseAccumulator` (in `event_parser`) owns the mutable state;
 //! `consume_access_failure` is the only public entry point.
@@ -28,13 +25,31 @@ pub(crate) const FILE_PATH_INDEX: usize = 2;
 const APP_PATH_INDEX: usize = 3;
 const ACCESS_MASK_INDEX: usize = 5;
 
-/// Per-event consume helper for `EventID=14`. Applies the post-XPath
-/// filters and pushes a `LearningModeAccessEvent` into
-/// `acc.valid_access_events` on success.
+/// Per-event consume helper for `EventID=14`. Walks the DACL ACE blob
+/// through `extract_caps`, applies the post-XPath filters, and pushes a
+/// `LearningModeAccessEvent` into `acc.valid_access_events` on success.
 pub(crate) fn consume_access_failure(acc: &mut ParseAccumulator, mut ev: ParsedEvent) {
+    if let Some(idx) = ev.complex_data_4_idx {
+        // Borrow rather than clone — the ACE hex blob was already pushed
+        // by `parse_event_xml`; the other EventData slots taken below
+        // (0/1/3) live at different indices so this is safe.
+        if let Some(blob) = ev.event_data.get(idx) {
+            let blob_str = blob.as_str();
+            if !blob_str.trim().is_empty() {
+                let _ = crate::extract_caps::extract_caps_with_index_into(
+                    blob_str,
+                    &acc.capability_index,
+                    acc.verbose,
+                    &mut acc.requested_capabilities,
+                );
+            }
+        }
+    }
+
     // Pull the file path. Absent paths typically mean capability-only
-    // resource accesses; the capability-extraction PR will use the
-    // DACL ACE blob for those, but this PR drops them.
+    // resource accesses whose capability has already been collected
+    // from the DACL above. Take the slot out via `mem::take` so we can
+    // normalise + trim in place without a second `String` allocation.
     let mut file_path = match ev.event_data.get_mut(FILE_PATH_INDEX) {
         Some(s) if !s.is_empty() => std::mem::take(s),
         _ => return,
@@ -226,7 +241,10 @@ pub(crate) fn is_skippable(
     current_directory: Option<&str>,
     verbose: bool,
 ) -> bool {
-    crate::event_parser::ParseAccumulator::new(current_directory, verbose).is_skippable(file_path)
+    // An empty capability table is fine: `is_skippable` only consults the
+    // cached CWD / drive-letter state, not the capability index.
+    crate::event_parser::ParseAccumulator::new(current_directory, verbose, Vec::new())
+        .is_skippable(file_path)
 }
 
 /// Shared `EventID=14` XML fixture used by tests in this module and
@@ -339,7 +357,7 @@ mod tests {
             make_event_xml("C:\\Users\\test\\foo.txt", "0x1"),
             make_event_xml("C:\\Users\\test\\bar.txt", "0x2"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 2);
         assert_eq!(
             result.valid_access_events[0].file_path,
@@ -364,7 +382,7 @@ mod tests {
             "<not-an-event/>".to_string(),
             valid_b,
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert_eq!(
             result.valid_access_events.len(),
             2,
@@ -408,7 +426,7 @@ mod tests {
     #[test]
     fn consume_drops_mount_point_manager() {
         let xmls = [make_event_xml("\\Device\\MountPointManager", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -420,7 +438,7 @@ mod tests {
             make_event_xml("C:\\repo\\src\\main.rs", "0x1"),
             make_event_xml("C:\\other\\x.txt", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), Some("C:\\repo"), false);
+        let result = parse_events_from_xml(xmls.iter(), Some("C:\\repo"), false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\other\\x.txt");
     }
@@ -433,7 +451,7 @@ mod tests {
             make_event_xml("abc", "0x1"),
             make_event_xml("\\\\server\\share\\x", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -442,7 +460,7 @@ mod tests {
     #[test]
     fn consume_drops_invalid_filename_chars() {
         let xmls = [make_event_xml("C:\\foo*bar.txt", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -456,16 +474,18 @@ mod tests {
             "\\Device\\HarddiskVolume3\\Tools\\app.exe",
             "0x1",
         )];
-        assert!(parse_events_from_xml(device.iter(), None, false)
-            .valid_access_events
-            .is_empty());
+        assert!(
+            parse_events_from_xml(device.iter(), None, false, Vec::new())
+                .valid_access_events
+                .is_empty()
+        );
 
         let dos = [make_event_xml_with_app(
             "C:\\Tools\\app.exe",
             "C:\\Tools\\app.exe",
             "0x1",
         )];
-        assert!(parse_events_from_xml(dos.iter(), None, false)
+        assert!(parse_events_from_xml(dos.iter(), None, false, Vec::new())
             .valid_access_events
             .is_empty());
 
@@ -475,7 +495,7 @@ mod tests {
             "\\Device\\HarddiskVolume3\\tools\\app.exe",
             "0x1",
         )];
-        assert!(parse_events_from_xml(cased.iter(), None, false)
+        assert!(parse_events_from_xml(cased.iter(), None, false, Vec::new())
             .valid_access_events
             .is_empty());
     }
@@ -491,7 +511,7 @@ mod tests {
             "\\Device\\HarddiskVolume3\\Tools\\app.exe",
             "0x1",
         )];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\app.exe");
     }
@@ -501,7 +521,7 @@ mod tests {
     #[test]
     fn consume_keeps_normal_valid_event() {
         let xmls = [make_event_xml("C:\\Users\\test\\doc.txt", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(
             result.valid_access_events[0].file_path,
@@ -520,7 +540,7 @@ mod tests {
             make_event_xml("C:\\USERS\\TEST\\DUP.TXT", "0x2"),
             make_event_xml("C:\\Users\\test\\dup.txt", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false);
+        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
         assert_eq!(
             result.valid_access_events.len(),
             1,

--- a/src/host/plm/src/access_failure.rs
+++ b/src/host/plm/src/access_failure.rs
@@ -36,12 +36,24 @@ pub(crate) fn consume_access_failure(acc: &mut ParseAccumulator, mut ev: ParsedE
         if let Some(blob) = ev.event_data.get(idx) {
             let blob_str = blob.as_str();
             if !blob_str.trim().is_empty() {
-                let _ = crate::extract_caps::extract_caps_with_index_into(
+                // A structurally invalid ACE blob must not vanish: the
+                // file-path half of this event still succeeds, so
+                // dropping the error here would silently lose every
+                // capability the event carried with nothing in the
+                // output to show for it. Count it like any other parse
+                // failure so the end-of-parse total stays honest.
+                if let Err(err) = crate::extract_caps::extract_caps_with_index_into(
                     blob_str,
                     &acc.capability_index,
                     acc.verbose,
+                    &mut acc.ace_scratch,
                     &mut acc.requested_capabilities,
-                );
+                ) {
+                    acc.parse_failures += 1;
+                    if acc.verbose {
+                        eprintln!("Failed to decode DACL ACE blob for an EventID=14 event: {err}");
+                    }
+                }
             }
         }
     }

--- a/src/host/plm/src/access_failure.rs
+++ b/src/host/plm/src/access_failure.rs
@@ -45,24 +45,28 @@ pub(crate) fn consume_access_failure(acc: &mut ParseAccumulator, mut ev: ParsedE
                 // them only if the entire walk succeeds; on failure the
                 // staged matches are dropped and the record is counted
                 // as data loss.
-                acc.ace_matches.clear();
-                let outcome = crate::extract_caps::extract_caps_with_index_into(
+                acc.ace_walk.matches.clear();
+                let outcome = crate::extract_caps::extract_caps_into(
                     blob_str,
                     &acc.capability_index,
                     acc.verbose,
-                    &mut acc.ace_scratch,
-                    &mut acc.ace_matches,
+                    &mut acc.ace_walk,
                 );
                 match outcome {
                     Ok(()) => {
-                        // Move the staged names across; `drain` reuses
-                        // the scratch set's capacity for the next event.
-                        for name in acc.ace_matches.drain() {
-                            acc.requested_capabilities.insert(name);
+                        // Promote the staged names. `drain` reuses the
+                        // staging set's capacity for the next event, and
+                        // the membership test means a `String` is
+                        // allocated only the first time the trace sees a
+                        // given capability.
+                        for name in acc.ace_walk.matches.drain() {
+                            if !acc.requested_capabilities.contains(name) {
+                                acc.requested_capabilities.insert(name.to_string());
+                            }
                         }
                     }
                     Err(err) => {
-                        acc.ace_matches.clear();
+                        acc.ace_walk.matches.clear();
                         acc.parse_failures += 1;
                         if acc.verbose {
                             eprintln!(
@@ -271,10 +275,14 @@ pub(crate) fn is_skippable(
     current_directory: Option<&str>,
     verbose: bool,
 ) -> bool {
-    // An empty capability table is fine: `is_skippable` only consults the
+    // An empty capability index is fine: `is_skippable` only consults the
     // cached CWD / drive-letter state, not the capability index.
-    crate::event_parser::ParseAccumulator::new(current_directory, verbose, Vec::new())
-        .is_skippable(file_path)
+    crate::event_parser::ParseAccumulator::new(
+        current_directory,
+        verbose,
+        crate::extract_caps::CapabilityIndex::for_test(&[]),
+    )
+    .is_skippable(file_path)
 }
 
 /// Shared `EventID=14` XML fixture used by tests in this module and
@@ -304,6 +312,13 @@ pub(crate) fn make_event_xml(file_path: &str, mask_hex: &str) -> String {
 mod tests {
     use super::*;
     use crate::event_parser::parse_events_from_xml;
+    use crate::extract_caps::CapabilityIndex;
+
+    /// These tests exercise path handling, not ACE matching, so they
+    /// inject an index that resolves nothing.
+    fn no_caps() -> CapabilityIndex {
+        CapabilityIndex::for_test(&[])
+    }
 
     #[test]
     fn normalize_file_path_strips_nt_object_prefix() {
@@ -387,7 +402,7 @@ mod tests {
             make_event_xml("C:\\Users\\test\\foo.txt", "0x1"),
             make_event_xml("C:\\Users\\test\\bar.txt", "0x2"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert_eq!(result.valid_access_events.len(), 2);
         assert_eq!(
             result.valid_access_events[0].file_path,
@@ -412,7 +427,7 @@ mod tests {
             "<not-an-event/>".to_string(),
             valid_b,
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert_eq!(
             result.valid_access_events.len(),
             2,
@@ -456,7 +471,7 @@ mod tests {
     #[test]
     fn consume_drops_mount_point_manager() {
         let xmls = [make_event_xml("\\Device\\MountPointManager", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -468,7 +483,7 @@ mod tests {
             make_event_xml("C:\\repo\\src\\main.rs", "0x1"),
             make_event_xml("C:\\other\\x.txt", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), Some("C:\\repo"), false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), Some("C:\\repo"), false, no_caps());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\other\\x.txt");
     }
@@ -481,7 +496,7 @@ mod tests {
             make_event_xml("abc", "0x1"),
             make_event_xml("\\\\server\\share\\x", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -490,7 +505,7 @@ mod tests {
     #[test]
     fn consume_drops_invalid_filename_chars() {
         let xmls = [make_event_xml("C:\\foo*bar.txt", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert!(result.valid_access_events.is_empty());
     }
 
@@ -504,18 +519,16 @@ mod tests {
             "\\Device\\HarddiskVolume3\\Tools\\app.exe",
             "0x1",
         )];
-        assert!(
-            parse_events_from_xml(device.iter(), None, false, Vec::new())
-                .valid_access_events
-                .is_empty()
-        );
+        assert!(parse_events_from_xml(device.iter(), None, false, no_caps())
+            .valid_access_events
+            .is_empty());
 
         let dos = [make_event_xml_with_app(
             "C:\\Tools\\app.exe",
             "C:\\Tools\\app.exe",
             "0x1",
         )];
-        assert!(parse_events_from_xml(dos.iter(), None, false, Vec::new())
+        assert!(parse_events_from_xml(dos.iter(), None, false, no_caps())
             .valid_access_events
             .is_empty());
 
@@ -525,7 +538,7 @@ mod tests {
             "\\Device\\HarddiskVolume3\\tools\\app.exe",
             "0x1",
         )];
-        assert!(parse_events_from_xml(cased.iter(), None, false, Vec::new())
+        assert!(parse_events_from_xml(cased.iter(), None, false, no_caps())
             .valid_access_events
             .is_empty());
     }
@@ -541,7 +554,7 @@ mod tests {
             "\\Device\\HarddiskVolume3\\Tools\\app.exe",
             "0x1",
         )];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\app.exe");
     }
@@ -551,7 +564,7 @@ mod tests {
     #[test]
     fn consume_keeps_normal_valid_event() {
         let xmls = [make_event_xml("C:\\Users\\test\\doc.txt", "0x1")];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(
             result.valid_access_events[0].file_path,
@@ -570,7 +583,7 @@ mod tests {
             make_event_xml("C:\\USERS\\TEST\\DUP.TXT", "0x2"),
             make_event_xml("C:\\Users\\test\\dup.txt", "0x1"),
         ];
-        let result = parse_events_from_xml(xmls.iter(), None, false, Vec::new());
+        let result = parse_events_from_xml(xmls.iter(), None, false, no_caps());
         assert_eq!(
             result.valid_access_events.len(),
             1,

--- a/src/host/plm/src/access_failure.rs
+++ b/src/host/plm/src/access_failure.rs
@@ -42,6 +42,12 @@ pub(crate) fn consume_access_failure(acc: &mut ParseAccumulator, mut ev: ParsedE
                 // capability the event carried with nothing in the
                 // output to show for it. Count it like any other parse
                 // failure so the end-of-parse total stays honest.
+                //
+                // The walk inserts as it goes, so a blob that is valid
+                // up to a corrupt tail leaves its already-matched
+                // capabilities in `requested_capabilities` and is still
+                // counted here. That is intended — see
+                // `extract_caps::invoke_ace_walk_with_index_into`.
                 if let Err(err) = crate::extract_caps::extract_caps_with_index_into(
                     blob_str,
                     &acc.capability_index,

--- a/src/host/plm/src/access_failure.rs
+++ b/src/host/plm/src/access_failure.rs
@@ -36,28 +36,40 @@ pub(crate) fn consume_access_failure(acc: &mut ParseAccumulator, mut ev: ParsedE
         if let Some(blob) = ev.event_data.get(idx) {
             let blob_str = blob.as_str();
             if !blob_str.trim().is_empty() {
-                // A structurally invalid ACE blob must not vanish: the
-                // file-path half of this event still succeeds, so
-                // dropping the error here would silently lose every
-                // capability the event carried with nothing in the
-                // output to show for it. Count it like any other parse
-                // failure so the end-of-parse total stays honest.
-                //
-                // The walk inserts as it goes, so a blob that is valid
-                // up to a corrupt tail leaves its already-matched
-                // capabilities in `requested_capabilities` and is still
-                // counted here. That is intended — see
-                // `extract_caps::invoke_ace_walk_with_index_into`.
-                if let Err(err) = crate::extract_caps::extract_caps_with_index_into(
+                // Fail closed. The walker inserts matches as it goes, so
+                // a blob that is valid up to a corrupt tail would
+                // otherwise contribute capabilities from a record we
+                // know is malformed. Since the blob is
+                // attacker-influenceable and the output is a security
+                // policy, stage matches in a scratch set and promote
+                // them only if the entire walk succeeds; on failure the
+                // staged matches are dropped and the record is counted
+                // as data loss.
+                acc.ace_matches.clear();
+                let outcome = crate::extract_caps::extract_caps_with_index_into(
                     blob_str,
                     &acc.capability_index,
                     acc.verbose,
                     &mut acc.ace_scratch,
-                    &mut acc.requested_capabilities,
-                ) {
-                    acc.parse_failures += 1;
-                    if acc.verbose {
-                        eprintln!("Failed to decode DACL ACE blob for an EventID=14 event: {err}");
+                    &mut acc.ace_matches,
+                );
+                match outcome {
+                    Ok(()) => {
+                        // Move the staged names across; `drain` reuses
+                        // the scratch set's capacity for the next event.
+                        for name in acc.ace_matches.drain() {
+                            acc.requested_capabilities.insert(name);
+                        }
+                    }
+                    Err(err) => {
+                        acc.ace_matches.clear();
+                        acc.parse_failures += 1;
+                        if acc.verbose {
+                            eprintln!(
+                                "Failed to decode DACL ACE blob for an EventID=14 event; \
+                                 discarding its capabilities: {err}"
+                            );
+                        }
                     }
                 }
             }

--- a/src/host/plm/src/config.rs
+++ b/src/host/plm/src/config.rs
@@ -1,8 +1,8 @@
 //! Port of the config-update logic from `stop_plm_logging.ps1`.
 //!
 //! Reads an MXC container config (JSON) and merges discovered
-//! file-access paths into it. Capability-merge and the Adjusted_*.json
-//! writer arrive in the config-generation PR.
+//! file-access paths and AppContainer capabilities into it, then writes
+//! the result out as `Adjusted_*.json`.
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -853,14 +853,128 @@ pub fn write_requested_capabilities_summary(requested: &HashSet<String>, verbose
     }
 }
 
+/// Capability names the schema reserves for internal use. They are
+/// injected by `--audit` / `learningMode` rather than authored, and
+/// `processContainer.capabilities` rejects them outright — so a learned
+/// set must never write them back into the adjusted config.
+const RESERVED_CAPABILITIES: &[&str] = &["learningModeLogging", "permissiveLearningMode"];
+
+/// Case-insensitive ASCII ordering, shared with the CLI so merged and
+/// printed capability lists agree. See
+/// [`crate::extract_caps::ascii_ci_cmp`].
+use crate::extract_caps::ascii_ci_cmp;
+
+/// Look up a key in a JSON object ignoring ASCII case, returning the
+/// key's actual spelling. MXC configs are normally camelCase, but the
+/// parser accepts other spellings and we must not silently create a
+/// second `processcontainer` block alongside an existing
+/// `processContainer`.
+fn object_key_ignore_ascii_case(config: &Value, wanted: &str) -> Option<String> {
+    config
+        .as_object()?
+        .keys()
+        .find(|k| k.eq_ignore_ascii_case(wanted))
+        .cloned()
+}
+
 /// Merge discovered AppContainer capability names into the config's
-/// containment-backend block. Implementation arrives in the
-/// capability-extraction PR; until then this is a no-op. Callers may
-/// pass a non-empty set (e.g. when a future stop.rs wires in the
-/// EventID=14 ACE-blob parser ahead of this merge) without triggering
-/// a spurious failure — the actual merge is landed atomically in the
-/// capability-extraction PR.
-pub fn merge_capabilities(_config: &mut Value, _requested: &HashSet<String>) -> Result<()> {
+/// containment-backend block (`processContainer.capabilities`).
+///
+/// Existing entries are preserved with their original spelling; the
+/// merged array is deduplicated case-insensitively and sorted. Reserved
+/// learning-mode capability names are dropped (see
+/// [`RESERVED_CAPABILITIES`]) because the schema rejects them.
+///
+/// Backends that have no capability array (anything that is not a
+/// process container) cannot express capabilities, so the discovered set
+/// is reported on stderr and left unmerged rather than silently dropped.
+pub fn merge_capabilities(config: &mut Value, requested: &HashSet<String>) -> Result<()> {
+    if requested.is_empty() {
+        return Ok(());
+    }
+
+    let mergeable: Vec<&str> = requested
+        .iter()
+        .map(String::as_str)
+        .filter(|name| {
+            !RESERVED_CAPABILITIES
+                .iter()
+                .any(|r| r.eq_ignore_ascii_case(name))
+        })
+        .collect();
+    if mergeable.is_empty() {
+        return Ok(());
+    }
+
+    let Some(pc_key) = object_key_ignore_ascii_case(config, "processContainer") else {
+        let mut names: Vec<&str> = mergeable.clone();
+        names.sort_by(|a, b| ascii_ci_cmp(a, b));
+        eprintln!(
+            "warning: config has no processContainer block, so this containment backend has no \
+             capabilities array; {} discovered capability/capabilities not merged: {}",
+            names.len(),
+            names.join(", ")
+        );
+        return Ok(());
+    };
+
+    let caps_slot = {
+        let pc = &mut config[&pc_key];
+        if !pc.is_object() {
+            eprintln!(
+                "warning: config's \"{pc_key}\" is not an object; {} discovered capability/\
+                 capabilities not merged",
+                mergeable.len()
+            );
+            return Ok(());
+        }
+        match object_key_ignore_ascii_case(pc, "capabilities") {
+            Some(existing) => existing,
+            None => {
+                // The block exists but has never carried capabilities.
+                // Creating the array is the whole point of learning mode,
+                // so add it rather than warning.
+                pc["capabilities"] = json!([]);
+                "capabilities".to_string()
+            }
+        }
+    };
+
+    let slot = &mut config[&pc_key][&caps_slot];
+    if slot.is_null() {
+        *slot = json!([]);
+    }
+    let Some(existing) = slot.as_array() else {
+        eprintln!(
+            "warning: \"{pc_key}.{caps_slot}\" is not an array; {} discovered capability/\
+             capabilities not merged",
+            mergeable.len()
+        );
+        return Ok(());
+    };
+
+    // Preserve existing entries verbatim (including any non-string
+    // values, which validation elsewhere owns) and append only the
+    // discovered names that are not already present under a
+    // case-insensitive comparison.
+    let mut merged: Vec<String> = existing
+        .iter()
+        .map(|v| match v.as_str() {
+            Some(s) => s.to_string(),
+            None => v.to_string(),
+        })
+        .collect();
+
+    for name in mergeable {
+        if !merged.iter().any(|e| e.eq_ignore_ascii_case(name)) {
+            merged.push(name.to_string());
+        }
+    }
+
+    merged.sort_by(|a, b| ascii_ci_cmp(a, b));
+    merged.dedup_by(|a, b| a.eq_ignore_ascii_case(b));
+
+    *slot = Value::Array(merged.into_iter().map(Value::String).collect());
     Ok(())
 }
 
@@ -1568,5 +1682,161 @@ mod tests {
         let back2: Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(back2, cfg2);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---- merge_capabilities ---------------------------------------------
+
+    fn caps_of(config: &Value) -> Vec<String> {
+        config["processContainer"]["capabilities"]
+            .as_array()
+            .expect("capabilities array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect()
+    }
+
+    fn requested(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn merge_capabilities_adds_to_existing_array_sorted() {
+        let mut cfg = json!({"processContainer": {"capabilities": ["registryRead"]}});
+        merge_capabilities(
+            &mut cfg,
+            &requested(&["internetClient", "documentsLibrary"]),
+        )
+        .unwrap();
+        assert_eq!(
+            caps_of(&cfg),
+            vec!["documentsLibrary", "internetClient", "registryRead"]
+        );
+    }
+
+    #[test]
+    fn merge_capabilities_preserves_existing_spelling_and_dedupes_case_insensitively() {
+        // An existing entry must not be duplicated by a discovered name
+        // that differs only in case, and the authored spelling wins.
+        let mut cfg = json!({"processContainer": {"capabilities": ["InternetClient"]}});
+        merge_capabilities(&mut cfg, &requested(&["internetclient"])).unwrap();
+        assert_eq!(caps_of(&cfg), vec!["InternetClient"]);
+    }
+
+    #[test]
+    fn merge_capabilities_creates_missing_array() {
+        let mut cfg = json!({"processContainer": {"learningMode": true}});
+        merge_capabilities(&mut cfg, &requested(&["internetClient"])).unwrap();
+        assert_eq!(caps_of(&cfg), vec!["internetClient"]);
+        // Sibling keys survive.
+        assert_eq!(cfg["processContainer"]["learningMode"], json!(true));
+    }
+
+    #[test]
+    fn merge_capabilities_replaces_null_array() {
+        let mut cfg = json!({"processContainer": {"capabilities": null}});
+        merge_capabilities(&mut cfg, &requested(&["internetClient"])).unwrap();
+        assert_eq!(caps_of(&cfg), vec!["internetClient"]);
+    }
+
+    #[test]
+    fn merge_capabilities_resolves_containment_key_case_insensitively() {
+        // Must merge into the existing block rather than creating a
+        // second, differently-cased one.
+        let mut cfg = json!({"ProcessContainer": {"capabilities": []}});
+        merge_capabilities(&mut cfg, &requested(&["internetClient"])).unwrap();
+        assert!(cfg.get("processContainer").is_none());
+        assert_eq!(
+            cfg["ProcessContainer"]["capabilities"],
+            json!(["internetClient"])
+        );
+    }
+
+    #[test]
+    fn merge_capabilities_is_noop_without_process_container() {
+        // Backends with no capability array (lxc, windows sandbox, …)
+        // must be left untouched rather than growing a bogus block.
+        let mut cfg = json!({"lxc": {"image": "ubuntu"}});
+        let before = cfg.clone();
+        merge_capabilities(&mut cfg, &requested(&["internetClient"])).unwrap();
+        assert_eq!(cfg, before);
+    }
+
+    #[test]
+    fn merge_capabilities_drops_reserved_names() {
+        // The schema rejects these in processContainer.capabilities, so
+        // a learned set must never write them back.
+        let mut cfg = json!({"processContainer": {"capabilities": []}});
+        merge_capabilities(
+            &mut cfg,
+            &requested(&[
+                "permissiveLearningMode",
+                "learningModeLogging",
+                "internetClient",
+            ]),
+        )
+        .unwrap();
+        assert_eq!(caps_of(&cfg), vec!["internetClient"]);
+    }
+
+    #[test]
+    fn merge_capabilities_reserved_only_leaves_config_untouched() {
+        let mut cfg = json!({"processContainer": {"learningMode": true}});
+        let before = cfg.clone();
+        merge_capabilities(&mut cfg, &requested(&["permissiveLearningMode"])).unwrap();
+        assert_eq!(cfg, before);
+    }
+
+    #[test]
+    fn merge_capabilities_empty_request_is_noop() {
+        let mut cfg = json!({"processContainer": {"learningMode": true}});
+        let before = cfg.clone();
+        merge_capabilities(&mut cfg, &HashSet::new()).unwrap();
+        assert_eq!(cfg, before);
+    }
+
+    #[test]
+    fn merge_capabilities_is_idempotent() {
+        let mut cfg = json!({"processContainer": {"capabilities": []}});
+        let req = requested(&["internetClient", "documentsLibrary"]);
+        merge_capabilities(&mut cfg, &req).unwrap();
+        let once = cfg.clone();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        assert_eq!(cfg, once, "re-merging the same set must not change output");
+    }
+
+    #[test]
+    fn merge_capabilities_leaves_non_array_capabilities_alone() {
+        let mut cfg = json!({"processContainer": {"capabilities": "internetClient"}});
+        let before = cfg.clone();
+        merge_capabilities(&mut cfg, &requested(&["documentsLibrary"])).unwrap();
+        assert_eq!(
+            cfg, before,
+            "must not clobber a malformed capabilities slot"
+        );
+    }
+
+    #[test]
+    fn ascii_ci_cmp_is_a_total_order_including_non_ascii() {
+        use std::cmp::Ordering;
+        // Case-folding must not break antisymmetry/transitivity, and
+        // non-ASCII input must still order deterministically.
+        assert_eq!(ascii_ci_cmp("abc", "ABC"), Ordering::Equal);
+        assert_eq!(ascii_ci_cmp("abc", "abcd"), Ordering::Less);
+        assert_eq!(ascii_ci_cmp("Zeta", "alpha"), Ordering::Greater);
+        let a = "café";
+        let b = "CAFÉ";
+        assert_eq!(ascii_ci_cmp(a, b), ascii_ci_cmp(a, b));
+        assert_eq!(ascii_ci_cmp(a, a), Ordering::Equal);
+    }
+
+    #[test]
+    fn merge_capabilities_sorts_case_insensitively() {
+        let mut cfg = json!({"processContainer": {"capabilities": []}});
+        merge_capabilities(
+            &mut cfg,
+            &requested(&["Zebra", "apple", "Banana", "cherry"]),
+        )
+        .unwrap();
+        assert_eq!(caps_of(&cfg), vec!["apple", "Banana", "cherry", "Zebra"]);
     }
 }

--- a/src/host/plm/src/config.rs
+++ b/src/host/plm/src/config.rs
@@ -888,6 +888,12 @@ fn object_key_ignore_ascii_case(config: &Value, wanted: &str) -> Option<String> 
 /// Backends that have no capability array (anything that is not a
 /// process container) cannot express capabilities, so the discovered set
 /// is reported on stderr and left unmerged rather than silently dropped.
+///
+/// A malformed `capabilities` value — not an array, or an array holding
+/// a non-string entry — is reported and left exactly as authored. The
+/// adjusted config is an operator-facing artifact, so rewriting invalid
+/// input into something that merely looks valid is worse than declining
+/// to merge.
 pub fn merge_capabilities(config: &mut Value, requested: &HashSet<String>) -> Result<()> {
     if requested.is_empty() {
         return Ok(());
@@ -953,17 +959,25 @@ pub fn merge_capabilities(config: &mut Value, requested: &HashSet<String>) -> Re
         return Ok(());
     };
 
-    // Preserve existing entries verbatim (including any non-string
-    // values, which validation elsewhere owns) and append only the
-    // discovered names that are not already present under a
-    // case-insensitive comparison.
-    let mut merged: Vec<String> = existing
-        .iter()
-        .map(|v| match v.as_str() {
-            Some(s) => s.to_string(),
-            None => v.to_string(),
-        })
-        .collect();
+    // Every entry must already be a string. Coercing anything else with
+    // `Value::to_string()` would rewrite the authored policy: `true`
+    // becomes the capability name "true", `null` becomes "null", and an
+    // object becomes escaped JSON text. That turns input the MXC typed
+    // parser would reject into a valid-looking array with different
+    // semantics, so decline the merge and leave the slot untouched —
+    // the same way the non-array case above is handled.
+    let mut merged: Vec<String> = Vec::with_capacity(existing.len());
+    for value in existing {
+        let Some(name) = value.as_str() else {
+            eprintln!(
+                "warning: \"{pc_key}.{caps_slot}\" contains a non-string entry ({value}); {} \
+                 discovered capability/capabilities not merged",
+                mergeable.len()
+            );
+            return Ok(());
+        };
+        merged.push(name.to_string());
+    }
 
     for name in mergeable {
         if !merged.iter().any(|e| e.eq_ignore_ascii_case(name)) {
@@ -1813,6 +1827,37 @@ mod tests {
             cfg, before,
             "must not clobber a malformed capabilities slot"
         );
+    }
+
+    #[test]
+    fn merge_capabilities_leaves_non_string_entries_alone() {
+        // Coercing these with `Value::to_string()` would rewrite the
+        // authored policy into capability names like "true" and "null",
+        // turning input the typed parser rejects into a valid-looking
+        // array with different semantics.
+        for bad in [
+            json!(["internetClient", true]),
+            json!(["internetClient", null]),
+            json!(["internetClient", 42]),
+            json!(["internetClient", {"name": "documentsLibrary"}]),
+            json!(["internetClient", ["documentsLibrary"]]),
+        ] {
+            let mut cfg = json!({ "processContainer": { "capabilities": bad } });
+            let before = cfg.clone();
+            merge_capabilities(&mut cfg, &requested(&["documentsLibrary"])).unwrap();
+            assert_eq!(
+                cfg, before,
+                "a non-string entry must leave the array exactly as authored"
+            );
+        }
+    }
+
+    #[test]
+    fn merge_capabilities_still_merges_when_every_entry_is_a_string() {
+        // The rejection above must not fire on a well-formed array.
+        let mut cfg = json!({"processContainer": {"capabilities": ["internetClient"]}});
+        merge_capabilities(&mut cfg, &requested(&["documentsLibrary"])).unwrap();
+        assert_eq!(caps_of(&cfg), vec!["documentsLibrary", "internetClient"]);
     }
 
     #[test]

--- a/src/host/plm/src/event_parser.rs
+++ b/src/host/plm/src/event_parser.rs
@@ -27,6 +27,7 @@ use windows::Win32::System::EventLog::{
 };
 
 use crate::access_event::LearningModeAccessEvent;
+use crate::extract_caps;
 
 /// EventID the PLM provider emits for a file/capability access that
 /// *would* have been denied. Decoded by `crate::access_failure`.
@@ -434,8 +435,14 @@ pub(crate) struct ParsedEvent {
     pub(crate) time_created: DateTime<Utc>,
     pub(crate) process_id: u32,
     pub(crate) thread_id: u32,
-    /// EventData/Data values in document order.
+    /// EventData/Data values in document order. May be Data or ComplexData.
     pub(crate) event_data: Vec<String>,
+    /// Index into `event_data` of the 5th `<ComplexData>` sibling (the
+    /// DACL ACE blob on `EventID=14` access events). `None` if fewer
+    /// than five `ComplexData` children were seen. Borrowed directly
+    /// rather than cloned to avoid a second `String` allocation of the
+    /// largest per-event field.
+    pub(crate) complex_data_4_idx: Option<usize>,
 }
 
 pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
@@ -484,6 +491,7 @@ pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
         process_id: acc.process_id,
         thread_id: acc.thread_id,
         event_data: acc.event_data,
+        complex_data_4_idx: acc.complex_data_4_idx,
     })
 }
 
@@ -492,7 +500,7 @@ pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
 /// never captured here.
 enum Capture {
     EventId,
-    Data,
+    Data { is_complex: bool },
 }
 
 /// Streaming replacement for the former per-event roxmltree DOM. Walks
@@ -518,6 +526,10 @@ struct StreamAcc {
     process_id: u32,
     thread_id: u32,
     event_data: Vec<String>,
+    // Position of the 5th `<ComplexData>` sibling (the DACL ACE blob),
+    // tracked instead of cloning that multi-KB text a second time.
+    complex_data_4_idx: Option<usize>,
+    complex_index: usize,
     capture: Option<(Capture, String)>,
 }
 
@@ -563,10 +575,11 @@ impl StreamAcc {
                 }
             }
             b"Data" | b"ComplexData" if self.in_event_data => {
+                let is_complex = name.local_name().as_ref() == b"ComplexData";
                 if is_empty {
-                    self.event_data.push(String::new());
+                    self.finish_data(is_complex, String::new());
                 } else {
-                    self.capture = Some((Capture::Data, String::new()));
+                    self.capture = Some((Capture::Data { is_complex }, String::new()));
                 }
             }
             _ => {}
@@ -588,7 +601,7 @@ impl StreamAcc {
         let matches = matches!(
             (&self.capture, local),
             (Some((Capture::EventId, _)), b"EventID")
-                | (Some((Capture::Data, _)), b"Data" | b"ComplexData")
+                | (Some((Capture::Data { .. }, _)), b"Data" | b"ComplexData")
         );
         if !matches {
             return;
@@ -596,7 +609,18 @@ impl StreamAcc {
         let (kind, text) = self.capture.take().unwrap();
         match kind {
             Capture::EventId => self.event_id = text.parse::<u32>().unwrap_or(0),
-            Capture::Data => self.event_data.push(text),
+            Capture::Data { is_complex } => self.finish_data(is_complex, text),
+        }
+    }
+
+    fn finish_data(&mut self, is_complex: bool, text: String) {
+        let pushed_idx = self.event_data.len();
+        self.event_data.push(text);
+        if is_complex {
+            if self.complex_index == 4 {
+                self.complex_data_4_idx = Some(pushed_idx);
+            }
+            self.complex_index += 1;
         }
     }
 }
@@ -642,10 +666,23 @@ pub(crate) struct ParseAccumulator {
     /// rather than aborting the trace, but the running total is surfaced
     /// at the end of a parse so silent data loss is observable.
     pub(crate) parse_failures: usize,
+    // Capability table is retained for tests/diagnostics that want to
+    // inspect the source; per-event resolution always goes through
+    // `capability_index` to avoid the O(table_size) HashMap rebuild
+    // that resolving from the raw `Vec<CapabilityEntry>` would pay per
+    // ACE blob.
+    #[allow(dead_code)]
+    pub(crate) capability_table: Vec<extract_caps::CapabilityEntry>,
+    pub(crate) capability_index: extract_caps::CapabilityIndex,
 }
 
 impl ParseAccumulator {
-    pub(crate) fn new(current_directory: Option<&str>, verbose: bool) -> Self {
+    pub(crate) fn new(
+        current_directory: Option<&str>,
+        verbose: bool,
+        capability_table: Vec<extract_caps::CapabilityEntry>,
+    ) -> Self {
+        let capability_index = extract_caps::CapabilityIndex::from_table(&capability_table);
         let (cwd_lc_trimmed, cwd_lc_prefix) = match current_directory {
             Some(cwd) => {
                 let trimmed = cwd.trim_end_matches('\\');
@@ -677,6 +714,8 @@ impl ParseAccumulator {
             access_event_index: HashMap::new(),
             requested_capabilities: HashSet::new(),
             parse_failures: 0,
+            capability_table,
+            capability_index,
         }
     }
 
@@ -771,7 +810,12 @@ pub fn parse_events(
     current_directory: Option<&str>,
     verbose: bool,
 ) -> Result<ParseResult> {
-    let mut acc = ParseAccumulator::new(current_directory, verbose);
+    // Build the capability table once. Each entry requires a
+    // `DeriveCapabilitySidsFromName` syscall + LocalAlloc/LocalFree
+    // pair; the table is process-static so doing this per-event would
+    // dominate wall-time on large traces.
+    let capability_table = extract_caps::build_capability_table();
+    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_table);
     for_each_event_xml(trace_file, verbose, |xml| {
         acc.consume(xml);
         Ok(())
@@ -781,17 +825,19 @@ pub fn parse_events(
 
 /// Fixture-test seam: drive the same per-event accumulator
 /// `parse_events` uses, but pull XML strings from an iterator rather
-/// than a live ETW session.
+/// than a live ETW session. Pass an empty `capability_table` when ACE
+/// matching isn't under test.
 pub fn parse_events_from_xml<I, S>(
     xmls: I,
     current_directory: Option<&str>,
     verbose: bool,
+    capability_table: Vec<extract_caps::CapabilityEntry>,
 ) -> ParseResult
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let mut acc = ParseAccumulator::new(current_directory, verbose);
+    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_table);
     for xml in xmls {
         acc.consume(xml.as_ref());
     }
@@ -842,7 +888,7 @@ mod tests {
         // Single fs-only event; ensure the dispatcher runs and the
         // event is collected.
         let xml = make_event_xml("C:\\app\\foo.txt", "0x1");
-        let result = parse_events_from_xml(vec![xml], None, false);
+        let result = parse_events_from_xml(vec![xml], None, false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\app\\foo.txt");
     }

--- a/src/host/plm/src/event_parser.rs
+++ b/src/host/plm/src/event_parser.rs
@@ -65,6 +65,11 @@ pub struct ParseResult {
     /// partial data loss on a long trace is observable rather than
     /// silent.
     pub parse_failures: usize,
+    /// Allow ACEs that named a known capability but granted nothing, so
+    /// were not treated as capability requests. Reported once per trace
+    /// and surfaced here so the condition is assertable in tests rather
+    /// than depending on process-global warning state.
+    pub zero_mask_capabilities: usize,
 }
 
 impl ParseResult {
@@ -672,29 +677,28 @@ pub(crate) struct ParseAccumulator {
     /// at the end of a parse so silent data loss is observable.
     pub(crate) parse_failures: usize,
     pub(crate) capability_index: extract_caps::CapabilityIndex,
-    /// Reusable decode buffer for `EventID=14` ACE hex blobs. Held here
-    /// so the per-event decode reuses one allocation for the whole
-    /// trace instead of allocating a multi-KB `Vec` per record.
-    pub(crate) ace_scratch: Vec<u8>,
-    /// Per-event staging set for capability matches.
+    /// Per-trace scratch and diagnostics for the ACE walk.
     ///
-    /// The ACE walk inserts as it goes, so a blob that is valid up to a
-    /// corrupt tail would otherwise contribute its already-matched
-    /// capabilities even though the record is malformed. These blobs are
-    /// attacker-influenceable, and the output is a security policy, so
-    /// the merge is fail-closed: matches land here first and are only
-    /// promoted into `requested_capabilities` once the whole blob walks
-    /// cleanly. Reused across events to keep the hot path allocation-free.
-    pub(crate) ace_matches: HashSet<String>,
+    /// Holds the reusable hex-decode buffer, the per-event staging set,
+    /// and the zero-mask counter. Staged matches are borrowed
+    /// `&'static str`, so a repeated capability costs nothing until it
+    /// is first promoted into `requested_capabilities`.
+    ///
+    /// The staging set is the fail-closed boundary: the ACE walk inserts
+    /// as it goes, so a blob that is valid up to a corrupt tail would
+    /// otherwise contribute its already-matched capabilities even though
+    /// the record is malformed. These blobs are attacker-influenceable
+    /// and the output is a security policy, so matches land here first
+    /// and are promoted only once the whole blob walks cleanly.
+    pub(crate) ace_walk: extract_caps::AceWalkState,
 }
 
 impl ParseAccumulator {
     pub(crate) fn new(
         current_directory: Option<&str>,
         verbose: bool,
-        capability_table: Vec<extract_caps::CapabilityEntry>,
+        capability_index: extract_caps::CapabilityIndex,
     ) -> Self {
-        let capability_index = extract_caps::CapabilityIndex::from_table(&capability_table);
         let (cwd_lc_trimmed, cwd_lc_prefix) = match current_directory {
             Some(cwd) => {
                 let trimmed = cwd.trim_end_matches('\\');
@@ -727,8 +731,7 @@ impl ParseAccumulator {
             requested_capabilities: HashSet::new(),
             parse_failures: 0,
             capability_index,
-            ace_scratch: Vec::new(),
-            ace_matches: HashSet::new(),
+            ace_walk: extract_caps::AceWalkState::new(),
         }
     }
 
@@ -803,17 +806,37 @@ impl ParseAccumulator {
         }
     }
 
-    fn into_result(self) -> ParseResult {
+    /// Write the end-of-parse diagnostics.
+    ///
+    /// Takes a writer rather than calling `eprintln!` directly so the
+    /// operator-visible text and its counts are assertable in a test and
+    /// cannot go silent in a later refactor.
+    fn write_parse_diagnostics(&self, out: &mut dyn std::io::Write) {
         if self.parse_failures > 0 {
-            eprintln!(
+            let _ = writeln!(
+                out,
                 "Warning: skipped {} malformed event record(s) that could not be parsed",
                 self.parse_failures
             );
         }
+        let zero_mask = self.ace_walk.zero_mask_capabilities();
+        if zero_mask > 0 {
+            let _ = writeln!(
+                out,
+                "warning: {zero_mask} allow ACE(s) named a known capability with a zero access \
+                 mask and were not treated as capability requests. If capabilities are missing \
+                 from the generated config, this filter is the first thing to check."
+            );
+        }
+    }
+
+    fn into_result(self) -> ParseResult {
+        self.write_parse_diagnostics(&mut std::io::stderr());
         ParseResult {
             valid_access_events: self.valid_access_events,
             requested_capabilities: self.requested_capabilities,
             parse_failures: self.parse_failures,
+            zero_mask_capabilities: self.ace_walk.zero_mask_capabilities(),
         }
     }
 }
@@ -823,32 +846,9 @@ pub fn parse_events(
     trace_file: &Path,
     current_directory: Option<&str>,
     verbose: bool,
+    capability_index: extract_caps::CapabilityIndex,
 ) -> Result<ParseResult> {
-    // Build the capability table once. Each entry requires a
-    // `DeriveCapabilitySidsFromName` syscall + LocalAlloc/LocalFree
-    // pair; the table is process-static so doing this per-event would
-    // dominate wall-time on large traces.
-    let built = extract_caps::build_capability_table_with_diagnostics();
-    // An empty table silently resolves every ACE to "no capability",
-    // which is indistinguishable in the output from a workload that
-    // genuinely needed none. Say so rather than emitting a quietly
-    // capability-free config.
-    if built.entries.is_empty() {
-        eprintln!(
-            "warning: no AppContainer capability SIDs could be derived on this host \
-             ({} of {} known names rejected); no capabilities will be detected.",
-            built.derive_failures,
-            extract_caps::known_capability_count()
-        );
-    } else if built.derive_failures > 0 && verbose {
-        println!(
-            "Note: {} of {} known capability names were rejected by this OS and will not be \
-             matched.",
-            built.derive_failures,
-            extract_caps::known_capability_count()
-        );
-    }
-    let mut acc = ParseAccumulator::new(current_directory, verbose, built.entries);
+    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_index);
     for_each_event_xml(trace_file, verbose, |xml| {
         acc.consume(xml);
         Ok(())
@@ -858,19 +858,19 @@ pub fn parse_events(
 
 /// Fixture-test seam: drive the same per-event accumulator
 /// `parse_events` uses, but pull XML strings from an iterator rather
-/// than a live ETW session. Pass an empty `capability_table` when ACE
-/// matching isn't under test.
+/// than a live ETW session. Pass `CapabilityIndex::for_test(&[])` when
+/// ACE matching isn't under test.
 pub fn parse_events_from_xml<I, S>(
     xmls: I,
     current_directory: Option<&str>,
     verbose: bool,
-    capability_table: Vec<extract_caps::CapabilityEntry>,
+    capability_index: extract_caps::CapabilityIndex,
 ) -> ParseResult
 where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
-    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_table);
+    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_index);
     for xml in xmls {
         acc.consume(xml.as_ref());
     }
@@ -921,7 +921,12 @@ mod tests {
         // Single fs-only event; ensure the dispatcher runs and the
         // event is collected.
         let xml = make_event_xml("C:\\app\\foo.txt", "0x1");
-        let result = parse_events_from_xml(vec![xml], None, false, Vec::new());
+        let result = parse_events_from_xml(
+            vec![xml],
+            None,
+            false,
+            extract_caps::CapabilityIndex::for_test(&[]),
+        );
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\app\\foo.txt");
     }
@@ -955,12 +960,8 @@ mod tests {
         bytes.iter().map(|b| format!("{b:02X}")).collect()
     }
 
-    fn e2e_table(name: &str, sid: &[u8]) -> Vec<extract_caps::CapabilityEntry> {
-        vec![extract_caps::CapabilityEntry {
-            name: name.into(),
-            app_package_sid: Some(sid.to_vec()),
-            group_sid: None,
-        }]
+    fn e2e_index(name: &'static str, sid: &[u8]) -> extract_caps::CapabilityIndex {
+        extract_caps::CapabilityIndex::for_test(&[(name, Some(sid), None)])
     }
 
     /// `EventID=14` XML carrying `complex_count` `<ComplexData>`
@@ -1007,7 +1008,7 @@ mod tests {
         let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, &hex);
 
         let result =
-            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
 
         assert!(
             result.requested_capabilities.contains("internetClient"),
@@ -1029,7 +1030,7 @@ mod tests {
         let xml = event_xml_with_complex_data("", "0x1", 5, &hex);
 
         let result =
-            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
 
         assert!(result.requested_capabilities.contains("internetClient"));
         assert!(result.valid_access_events.is_empty());
@@ -1045,7 +1046,7 @@ mod tests {
         let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 4, &hex);
 
         let result =
-            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
 
         assert!(
             result.requested_capabilities.is_empty(),
@@ -1064,7 +1065,7 @@ mod tests {
         let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, "ZZZZ");
 
         let result =
-            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
 
         assert!(result.requested_capabilities.is_empty());
         assert_eq!(result.valid_access_events.len(), 1);
@@ -1086,7 +1087,7 @@ mod tests {
         let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, &e2e_hex(&bytes));
 
         let result =
-            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
 
         assert!(
             result.requested_capabilities.is_empty(),
@@ -1112,7 +1113,7 @@ mod tests {
             event_xml_with_complex_data("C:\\app\\good.txt", "0x1", 5, &good),
         ];
 
-        let result = parse_events_from_xml(xmls, None, false, e2e_table("internetClient", &sid));
+        let result = parse_events_from_xml(xmls, None, false, e2e_index("internetClient", &sid));
 
         assert_eq!(result.parse_failures, 1);
         assert!(
@@ -1130,10 +1131,96 @@ mod tests {
             .map(|i| event_xml_with_complex_data(&format!("C:\\app\\f{i}.txt"), "0x1", 5, &hex))
             .collect();
 
-        let result = parse_events_from_xml(xmls, None, false, e2e_table("internetClient", &sid));
+        let result = parse_events_from_xml(xmls, None, false, e2e_index("internetClient", &sid));
 
         assert_eq!(result.requested_capabilities.len(), 1);
         assert_eq!(result.valid_access_events.len(), 3);
+    }
+
+    #[test]
+    fn every_record_malformed_yields_an_empty_result_and_no_config_output() {
+        // A trace where nothing decodes must be loudly empty, not
+        // quietly partial: `stop` keys its "skip writing Adjusted_*.json"
+        // decision off `is_empty()`, so a regression that let junk
+        // through here would emit a config derived from garbage.
+        let xmls = vec![
+            "not xml".to_string(),
+            "<not-an-event/>".to_string(),
+            // Well-formed XML, but no <System> element — the one hard
+            // requirement `parse_event_xml` enforces.
+            "<Event><EventData><Data>x</Data></EventData></Event>".to_string(),
+            String::new(),
+        ];
+        let expected_failures = xmls.len();
+
+        let result = parse_events_from_xml(
+            xmls,
+            None,
+            false,
+            extract_caps::CapabilityIndex::for_test(&[]),
+        );
+
+        assert_eq!(
+            result.parse_failures, expected_failures,
+            "every malformed record must be counted"
+        );
+        assert!(result.valid_access_events.is_empty());
+        assert!(result.requested_capabilities.is_empty());
+        assert!(
+            result.is_empty(),
+            "is_empty() gates whether stop writes an Adjusted_*.json at all"
+        );
+    }
+
+    #[test]
+    fn parse_diagnostics_report_failures_and_zero_mask_counts() {
+        // The counters are covered elsewhere; this pins the
+        // operator-visible text so a refactor cannot make parse failures
+        // silent. Written through a captured writer rather than stderr.
+        let mut acc =
+            ParseAccumulator::new(None, false, extract_caps::CapabilityIndex::for_test(&[]));
+        acc.parse_failures = 3;
+
+        let mut out = Vec::new();
+        acc.write_parse_diagnostics(&mut out);
+        let text = String::from_utf8(out).expect("diagnostics must be UTF-8");
+
+        assert!(
+            text.contains("skipped 3 malformed event record(s)"),
+            "parse-failure count must be reported verbatim: {text}"
+        );
+    }
+
+    #[test]
+    fn parse_diagnostics_are_silent_on_a_clean_trace() {
+        let acc = ParseAccumulator::new(None, false, extract_caps::CapabilityIndex::for_test(&[]));
+        let mut out = Vec::new();
+        acc.write_parse_diagnostics(&mut out);
+        assert!(
+            out.is_empty(),
+            "a clean parse must not emit warning noise: {}",
+            String::from_utf8_lossy(&out)
+        );
+    }
+
+    #[test]
+    fn zero_mask_capabilities_are_reported_and_surfaced_on_the_result() {
+        // A zero-mask allow ACE is filtered out, but silently dropping
+        // it would look identical to "this capability was never
+        // requested" — so the count reaches both the operator and the
+        // caller.
+        let sid = e2e_sid();
+        let hex = e2e_hex(&e2e_ace(0, &sid));
+        let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, &hex);
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_index("internetClient", &sid));
+
+        assert!(result.requested_capabilities.is_empty());
+        assert_eq!(
+            result.zero_mask_capabilities, 1,
+            "the filtered ACE must be counted on the result"
+        );
     }
 }
 

--- a/src/host/plm/src/event_parser.rs
+++ b/src/host/plm/src/event_parser.rs
@@ -1,12 +1,12 @@
 //! Walks a sequence of WinEvent records produced by the permissive
 //! learning-mode trace and returns the file-access events that survived
-//! filtering.
+//! filtering, plus the AppContainer capabilities the workload was
+//! observed to need.
 //!
-//! This PR introduces filesystem extraction only. Capability extraction
-//! (`EventID=14` DACL ACE blobs) lands in a later PR; UI relaxation
-//! (`EventID=27`) lands in a later PR. `requested_capabilities` is
-//! exposed today as an always-empty placeholder so call-sites in
-//! `stop`/`log` can stay stable.
+//! `EventID=14` records carry both a file path and a DACL ACE blob; the
+//! blob is decoded by `crate::extract_caps` and accumulated into
+//! `requested_capabilities`. UI relaxation (`EventID=27`) lands in a
+//! later PR.
 
 use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
@@ -56,10 +56,15 @@ impl Drop for EvtHandleOwned {
 
 pub struct ParseResult {
     pub valid_access_events: Vec<LearningModeAccessEvent>,
-    /// Placeholder for the capability-extraction PR. Always empty in
-    /// this PR; the field exists today so `stop`/`log` call-sites stay
-    /// stable across the split.
+    /// AppContainer capability names decoded from the DACL ACE blobs of
+    /// `EventID=14` records. Only capabilities in the module's known
+    /// list, granted by a non-zero allow ACE, appear here.
     pub requested_capabilities: HashSet<String>,
+    /// Records that could not be parsed: malformed event XML, or an
+    /// `EventID=14` whose DACL ACE blob failed to decode. Surfaced so
+    /// partial data loss on a long trace is observable rather than
+    /// silent.
+    pub parse_failures: usize,
 }
 
 impl ParseResult {
@@ -666,14 +671,11 @@ pub(crate) struct ParseAccumulator {
     /// rather than aborting the trace, but the running total is surfaced
     /// at the end of a parse so silent data loss is observable.
     pub(crate) parse_failures: usize,
-    // Capability table is retained for tests/diagnostics that want to
-    // inspect the source; per-event resolution always goes through
-    // `capability_index` to avoid the O(table_size) HashMap rebuild
-    // that resolving from the raw `Vec<CapabilityEntry>` would pay per
-    // ACE blob.
-    #[allow(dead_code)]
-    pub(crate) capability_table: Vec<extract_caps::CapabilityEntry>,
     pub(crate) capability_index: extract_caps::CapabilityIndex,
+    /// Reusable decode buffer for `EventID=14` ACE hex blobs. Held here
+    /// so the per-event decode reuses one allocation for the whole
+    /// trace instead of allocating a multi-KB `Vec` per record.
+    pub(crate) ace_scratch: Vec<u8>,
 }
 
 impl ParseAccumulator {
@@ -714,8 +716,8 @@ impl ParseAccumulator {
             access_event_index: HashMap::new(),
             requested_capabilities: HashSet::new(),
             parse_failures: 0,
-            capability_table,
             capability_index,
+            ace_scratch: Vec::new(),
         }
     }
 
@@ -800,6 +802,7 @@ impl ParseAccumulator {
         ParseResult {
             valid_access_events: self.valid_access_events,
             requested_capabilities: self.requested_capabilities,
+            parse_failures: self.parse_failures,
         }
     }
 }
@@ -814,8 +817,27 @@ pub fn parse_events(
     // `DeriveCapabilitySidsFromName` syscall + LocalAlloc/LocalFree
     // pair; the table is process-static so doing this per-event would
     // dominate wall-time on large traces.
-    let capability_table = extract_caps::build_capability_table();
-    let mut acc = ParseAccumulator::new(current_directory, verbose, capability_table);
+    let built = extract_caps::build_capability_table_with_diagnostics();
+    // An empty table silently resolves every ACE to "no capability",
+    // which is indistinguishable in the output from a workload that
+    // genuinely needed none. Say so rather than emitting a quietly
+    // capability-free config.
+    if built.entries.is_empty() {
+        eprintln!(
+            "warning: no AppContainer capability SIDs could be derived on this host \
+             ({} of {} known names rejected); no capabilities will be detected.",
+            built.derive_failures,
+            extract_caps::known_capability_count()
+        );
+    } else if built.derive_failures > 0 && verbose {
+        println!(
+            "Note: {} of {} known capability names were rejected by this OS and will not be \
+             matched.",
+            built.derive_failures,
+            extract_caps::known_capability_count()
+        );
+    }
+    let mut acc = ParseAccumulator::new(current_directory, verbose, built.entries);
     for_each_event_xml(trace_file, verbose, |xml| {
         acc.consume(xml);
         Ok(())
@@ -891,6 +913,168 @@ mod tests {
         let result = parse_events_from_xml(vec![xml], None, false, Vec::new());
         assert_eq!(result.valid_access_events.len(), 1);
         assert_eq!(result.valid_access_events[0].file_path, "C:\\app\\foo.txt");
+    }
+
+    // ---- end-to-end: XML -> ACE blob -> requested_capabilities ----------
+    //
+    // The positional handoff (`complex_data_4_idx` = the 5th
+    // `<ComplexData>` sibling) is the contract between the provider's
+    // schema and capability extraction, and it is the piece most likely
+    // to break silently if the provider reorders its payload. Every
+    // other test in this crate either feeds `<Data>`-only XML (so the
+    // blob is never reached) or calls the extractor directly (so the
+    // XML layer is bypassed). These drive the whole path.
+
+    /// S-1-1-0 "Everyone" — stands in for a capability SID.
+    fn e2e_sid() -> Vec<u8> {
+        vec![1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]
+    }
+
+    /// Build one ACE in the layout `extract_caps` decodes.
+    fn e2e_ace(mask: u32, sid: &[u8]) -> Vec<u8> {
+        let mut v = vec![0u8]; // ACCESS_ALLOWED
+        v.extend_from_slice(&[0, 0, 0]); // padding
+        v.extend_from_slice(&[0, 0, 0, 0]); // flags
+        v.extend_from_slice(&mask.to_le_bytes());
+        v.extend_from_slice(sid);
+        v
+    }
+
+    fn e2e_hex(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02X}")).collect()
+    }
+
+    fn e2e_table(name: &str, sid: &[u8]) -> Vec<extract_caps::CapabilityEntry> {
+        vec![extract_caps::CapabilityEntry {
+            name: name.into(),
+            app_package_sid: Some(sid.to_vec()),
+            group_sid: None,
+        }]
+    }
+
+    /// `EventID=14` XML carrying `complex_count` `<ComplexData>`
+    /// siblings, the last of which holds `blob_hex`.
+    fn event_xml_with_complex_data(
+        file_path: &str,
+        mask_hex: &str,
+        complex_count: usize,
+        blob_hex: &str,
+    ) -> String {
+        let mut complex = String::new();
+        for i in 0..complex_count {
+            let body = if i + 1 == complex_count {
+                blob_hex
+            } else {
+                "00"
+            };
+            complex.push_str(&format!("<ComplexData>{body}</ComplexData>"));
+        }
+        format!(
+            r#"<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+          <System>
+            <EventID>14</EventID>
+            <TimeCreated SystemTime="2024-01-02T03:04:05.000Z"/>
+            <Execution ProcessID="111" ThreadID="222"/>
+          </System>
+          <EventData>
+            <Data>Permissive</Data>
+            <Data>File</Data>
+            <Data>{file_path}</Data>
+            <Data>App.exe</Data>
+            <Data>0</Data>
+            <Data>{mask_hex}</Data>
+            {complex}
+          </EventData>
+        </Event>"#
+        )
+    }
+
+    #[test]
+    fn fifth_complex_data_sibling_populates_requested_capabilities() {
+        let sid = e2e_sid();
+        let hex = e2e_hex(&e2e_ace(0x0012_0089, &sid));
+        let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, &hex);
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+
+        assert!(
+            result.requested_capabilities.contains("internetClient"),
+            "the 5th <ComplexData> blob should have produced a capability, got {:?}",
+            result.requested_capabilities
+        );
+        assert_eq!(result.valid_access_events.len(), 1);
+        assert_eq!(result.parse_failures, 0);
+    }
+
+    #[test]
+    fn capability_only_event_without_file_path_still_yields_capability() {
+        // Capability-only accesses arrive with an empty path. The event
+        // produces no access-event row, but its capability must still
+        // be collected — this is why extraction runs before the
+        // path-based early return.
+        let sid = e2e_sid();
+        let hex = e2e_hex(&e2e_ace(0x0012_0089, &sid));
+        let xml = event_xml_with_complex_data("", "0x1", 5, &hex);
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+
+        assert!(result.requested_capabilities.contains("internetClient"));
+        assert!(result.valid_access_events.is_empty());
+    }
+
+    #[test]
+    fn fewer_than_five_complex_data_siblings_yields_no_capability() {
+        // The blob lives in the 5th sibling; with only four present
+        // there is nothing to decode and the event must still be
+        // processed normally rather than mis-indexing into another slot.
+        let sid = e2e_sid();
+        let hex = e2e_hex(&e2e_ace(0x0012_0089, &sid));
+        let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 4, &hex);
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+
+        assert!(
+            result.requested_capabilities.is_empty(),
+            "no 5th <ComplexData> means no capability blob"
+        );
+        assert_eq!(result.valid_access_events.len(), 1);
+        assert_eq!(result.parse_failures, 0);
+    }
+
+    #[test]
+    fn malformed_ace_blob_is_counted_as_a_parse_failure() {
+        // A corrupt blob must not vanish silently: the file-path half of
+        // the event still succeeds, so without the counter the lost
+        // capabilities would leave no trace in the output.
+        let sid = e2e_sid();
+        let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, "ZZZZ");
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+
+        assert!(result.requested_capabilities.is_empty());
+        assert_eq!(result.valid_access_events.len(), 1);
+        assert_eq!(
+            result.parse_failures, 1,
+            "a malformed ACE blob should be counted"
+        );
+    }
+
+    #[test]
+    fn capabilities_dedupe_across_multiple_events() {
+        let sid = e2e_sid();
+        let hex = e2e_hex(&e2e_ace(0x0012_0089, &sid));
+        let xmls: Vec<String> = (0..3)
+            .map(|i| event_xml_with_complex_data(&format!("C:\\app\\f{i}.txt"), "0x1", 5, &hex))
+            .collect();
+
+        let result = parse_events_from_xml(xmls, None, false, e2e_table("internetClient", &sid));
+
+        assert_eq!(result.requested_capabilities.len(), 1);
+        assert_eq!(result.valid_access_events.len(), 3);
     }
 }
 

--- a/src/host/plm/src/event_parser.rs
+++ b/src/host/plm/src/event_parser.rs
@@ -676,6 +676,16 @@ pub(crate) struct ParseAccumulator {
     /// so the per-event decode reuses one allocation for the whole
     /// trace instead of allocating a multi-KB `Vec` per record.
     pub(crate) ace_scratch: Vec<u8>,
+    /// Per-event staging set for capability matches.
+    ///
+    /// The ACE walk inserts as it goes, so a blob that is valid up to a
+    /// corrupt tail would otherwise contribute its already-matched
+    /// capabilities even though the record is malformed. These blobs are
+    /// attacker-influenceable, and the output is a security policy, so
+    /// the merge is fail-closed: matches land here first and are only
+    /// promoted into `requested_capabilities` once the whole blob walks
+    /// cleanly. Reused across events to keep the hot path allocation-free.
+    pub(crate) ace_matches: HashSet<String>,
 }
 
 impl ParseAccumulator {
@@ -718,6 +728,7 @@ impl ParseAccumulator {
             parse_failures: 0,
             capability_index,
             ace_scratch: Vec::new(),
+            ace_matches: HashSet::new(),
         }
     }
 
@@ -1061,6 +1072,54 @@ mod tests {
             result.parse_failures, 1,
             "a malformed ACE blob should be counted"
         );
+    }
+
+    #[test]
+    fn valid_ace_with_truncated_tail_contributes_no_capabilities() {
+        // Fail-closed: the blob is attacker-influenceable and the output
+        // is a security policy, so a record that walks partway and then
+        // hits a corrupt trailer must contribute nothing at all — not
+        // the capability it managed to match before failing.
+        let sid = e2e_sid();
+        let mut bytes = e2e_ace(0x0012_0089, &sid);
+        bytes.extend_from_slice(&[0u8; 6]); // truncated trailing ACE
+        let xml = event_xml_with_complex_data("C:\\app\\foo.txt", "0x1", 5, &e2e_hex(&bytes));
+
+        let result =
+            parse_events_from_xml(vec![xml], None, false, e2e_table("internetClient", &sid));
+
+        assert!(
+            result.requested_capabilities.is_empty(),
+            "a partially-valid blob must not leak capabilities into policy, got {:?}",
+            result.requested_capabilities
+        );
+        assert_eq!(result.parse_failures, 1);
+    }
+
+    #[test]
+    fn staging_set_does_not_leak_between_events() {
+        // The staging set is reused across events; a failed record must
+        // not poison the next one, and a good record after a bad one
+        // must still be collected.
+        let sid = e2e_sid();
+        let good = e2e_hex(&e2e_ace(0x0012_0089, &sid));
+        let mut bad_bytes = e2e_ace(0x0012_0089, &sid);
+        bad_bytes.extend_from_slice(&[0u8; 6]);
+        let bad = e2e_hex(&bad_bytes);
+
+        let xmls = vec![
+            event_xml_with_complex_data("C:\\app\\bad.txt", "0x1", 5, &bad),
+            event_xml_with_complex_data("C:\\app\\good.txt", "0x1", 5, &good),
+        ];
+
+        let result = parse_events_from_xml(xmls, None, false, e2e_table("internetClient", &sid));
+
+        assert_eq!(result.parse_failures, 1);
+        assert!(
+            result.requested_capabilities.contains("internetClient"),
+            "the following good event must still contribute"
+        );
+        assert_eq!(result.requested_capabilities.len(), 1);
     }
 
     #[test]

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -1,0 +1,834 @@
+//! Port of `extract_caps.ps1`.
+//!
+//! Walks a hex-encoded blob of concatenated ACEs from a permissive
+//! learning-mode event's DACL, resolves each ACE's SID to a known
+//! capability name (via `DeriveCapabilitySidsFromName`), and returns the
+//! set of matched capability names.
+//!
+//! Each ACE in the buffer is laid out as:
+//! - `[0]`     ACE type        (1 byte)
+//! - `[1..3]`  Padding          (3 bytes)
+//! - `[4..7]`  ACE flags        (4 bytes, only low byte meaningful)
+//! - `[8..11]` Access mask      (4 bytes, little-endian)
+//! - `[12..]`  SID:
+//!     - `[0]`    Revision           (1 byte)
+//!     - `[1]`    SubAuthorityCount  (1 byte)
+//!     - `[2..7]` IdentifierAuthority (6 bytes)
+//!     - `[8..]`  SubAuthorities      (4 bytes each)
+
+use anyhow::{anyhow, Result};
+use std::collections::{HashMap, HashSet};
+
+#[cfg(target_os = "windows")]
+use windows::core::PWSTR;
+#[cfg(target_os = "windows")]
+use windows::Win32::Foundation::{LocalFree, HLOCAL};
+#[cfg(target_os = "windows")]
+use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
+#[cfg(target_os = "windows")]
+use windows::Win32::Security::{DeriveCapabilitySidsFromName, GetLengthSid, IsValidSid, PSID};
+
+const ACE_HEADER_SIZE: usize = 1 + 3 + 4 + 4; // type + 3 padding + 4 flags + 4 mask
+const SID_FIXED_HEADER_SIZE: usize = 1 + 1 + 6; // revision + subauth count + id auth
+
+/// Capability names we want to recognize when their SID appears in an
+/// ACE. Mirrors the `$knownCapabilities` list from `extract_caps.ps1`
+/// (sourced from MSDN's App / restricted / device capability
+/// declarations). Names rejected by `DeriveCapabilitySidsFromName` on
+/// this OS are silently skipped at table-build time.
+const KNOWN_CAPABILITIES: &[&str] = &[
+    // General-use capabilities
+    "internetClient",
+    "internetClientServer",
+    "privateNetworkClientServer",
+    "documentsLibrary",
+    "picturesLibrary",
+    "videosLibrary",
+    "musicLibrary",
+    "removableStorage",
+    "sharedUserCertificates",
+    "appointments",
+    "contacts",
+    "chat",
+    "phoneCall",
+    "voipCall",
+    "objects3D",
+    "userAccountInformation",
+    // userPrincipalName intentionally excluded: it is read by LSASS during
+    // token/logon plumbing on behalf of arbitrary callers, so it shows up
+    // in audit traces for workloads that never asked for it.
+    "backgroundMediaPlayback",
+    "codeGeneration",
+    "allowElevation",
+    // Intentionally disabled in the source PS list -- left here as
+    // comments so changes stay aligned across the two implementations.
+    // "broadFileSystemAccess",
+    // "enterpriseAuthentication",
+    // "runFullTrust",
+    // "packageManagement",
+
+    // Device capabilities
+    "location",
+    "microphone",
+    "webcam",
+    "proximity",
+    "bluetooth",
+    "bluetooth.genericAttributeProfile",
+    "bluetooth.rfcomm",
+    "humaninterfacedevice",
+    "lowLevelDevices",
+    "pointOfService",
+    "radios",
+    "serialcommunication",
+    "usb",
+    "wiFiControl",
+    "gazeInput",
+    "optical",
+    "activity",
+    // Graphics / capture
+    "graphicsCapture",
+    "graphicsCaptureProgrammatic",
+    "graphicsCaptureWithoutBorder",
+    "screenDuplication",
+    "appCaptureServices",
+    "appCaptureSettings",
+    // Background / extended execution
+    "backgroundMediaRecording",
+    "backgroundSpatialPerception",
+    "backgroundVoIP",
+    "extendedBackgroundTaskTime",
+    "extendedExecutionBackgroundAudio",
+    "extendedExecutionCritical",
+    "extendedExecutionUnconstrained",
+    // System / app-package management
+    "accessoryManager",
+    "allAppMods",
+    "appBroadcastServices",
+    "appLicensing",
+    "audioDeviceConfiguration",
+    "cellularDeviceControl",
+    "cellularDeviceIdentity",
+    "cellularMessaging",
+    "confirmAppClose",
+    "customInstallActions",
+    "developmentModeNetwork",
+    "dualSimTiles",
+    "enterpriseCloudSSO",
+    "enterpriseDataPolicy",
+    "enterpriseDeviceLockdown",
+    "firstSignInSettings",
+    "gameBarServices",
+    "gameList",
+    "gameMonitor",
+    "globalMediaControl",
+    "inputForegroundObservation",
+    "inputInjectionBrokered",
+    "inputObservation",
+    "inputSuppression",
+    "interopServices",
+    "liveIdService",
+    "localSystemServices",
+    "locationHistory",
+    "locationSystem",
+    "modifiableApp",
+    "networkConnectionManagerProvisioning",
+    "networkDataPlanProvisioning",
+    "networkingVpnProvider",
+    "oemDeploymentInfo",
+    "oemPublicDirectory",
+    "packagePolicySystem",
+    "packageQuery",
+    "packageWriteRedirectionCompatibilityShim",
+    "previewInkWorkspace",
+    "previewPenWorkspace",
+    "previewStore",
+    "previewUiComposition",
+    "protectedApp",
+    "secondaryAuthenticationFactor",
+    "secureAssessment",
+    "shellExperience",
+    "shellExperienceComposer",
+    "slapiQueryLicenseValue",
+    "smbios",
+    "smsSend",
+    "startScreenManagement",
+    "storeLicenseManagement",
+    "systemManagement",
+    "targetedContent",
+    "teamEditionDeviceCredential",
+    "teamEditionExperience",
+    "teamEditionView",
+    "uiAccess",
+    "uiAutomation",
+    "unvirtualizedResources",
+    "walletSystem",
+    "xboxAccessoryManagement",
+    // User-data system capabilities
+    "appointmentsSystem",
+    "chatSystem",
+    "contactsSystem",
+    "email",
+    "emailSystem",
+    "phoneCallHistory",
+    "phoneCallHistorySystem",
+    "phoneLineTransportManagement",
+    "userDataAccountsProvider",
+    "userDataSystem",
+    "userSystemId",
+    "cortanaPermissions",
+    "cortanaSpeechAccessory",
+];
+
+#[derive(Debug, Clone)]
+pub struct CapabilityEntry {
+    pub name: String,
+    pub app_package_sid: Option<Vec<u8>>,
+    pub group_sid: Option<Vec<u8>>,
+}
+
+#[cfg(target_os = "windows")]
+fn to_wide_z(s: &str) -> Vec<u16> {
+    wxc_common::string_util::to_wide(s)
+}
+
+/// Copy a SID pointed to by `psid` into a managed byte vector.
+#[cfg(target_os = "windows")]
+unsafe fn sid_bytes_from_ptr(psid: PSID) -> Option<Vec<u8>> {
+    if psid.0.is_null() {
+        return None;
+    }
+    let len = GetLengthSid(psid);
+    if len == 0 {
+        return None;
+    }
+    let mut buf = vec![0u8; len as usize];
+    std::ptr::copy_nonoverlapping(psid.0 as *const u8, buf.as_mut_ptr(), len as usize);
+    Some(buf)
+}
+
+/// Free an array of SID pointers and the array itself, mirroring the
+/// LocalFree-loop cleanup from the PowerShell version.
+#[cfg(target_os = "windows")]
+unsafe fn free_sid_array(arr: *mut PSID, count: u32) {
+    if arr.is_null() {
+        return;
+    }
+    for i in 0..count as isize {
+        let p = *arr.offset(i);
+        if !p.0.is_null() {
+            let _ = LocalFree(Some(HLOCAL(p.0)));
+        }
+    }
+    let _ = LocalFree(Some(HLOCAL(arr as *mut _)));
+}
+
+/// Copy the bytes of the canonical (first) SID out of an array returned by
+/// `DeriveCapabilitySidsFromName`.
+///
+/// `arr` points to `count` contiguous `PSID` values (or is null when
+/// `count` is 0). The first element is read through a length-`count`
+/// slice so the access is provably in bounds rather than a bare pointer
+/// dereference; the individual SID is then null- and length-validated by
+/// [`sid_bytes_from_ptr`].
+#[cfg(target_os = "windows")]
+unsafe fn first_sid_bytes(arr: *const PSID, count: u32) -> Option<Vec<u8>> {
+    if arr.is_null() || count == 0 {
+        return None;
+    }
+    // SAFETY: `arr`/`count` are forwarded exactly as reported by
+    // `DeriveCapabilitySidsFromName`, which allocates `count` contiguous
+    // `PSID` entries at `arr`. `arr` is non-null and `count > 0` (checked
+    // above), so a slice of `count` elements is valid and index 0 is in
+    // bounds. The bounds check on `[0]` cannot panic given `count > 0`.
+    let first = unsafe { std::slice::from_raw_parts(arr, count as usize)[0] };
+    // SAFETY: `first` is one of the SID pointers the OS allocated;
+    // `sid_bytes_from_ptr` null-checks and length-validates it before copy.
+    unsafe { sid_bytes_from_ptr(first) }
+}
+
+/// Build the table of (capability name, AppPackage SID, Group SID) tuples
+/// by calling `DeriveCapabilitySidsFromName` for each known capability.
+/// Capabilities the OS rejects are silently skipped. Non-Windows targets
+/// get an empty table (the API has no cross-platform equivalent); pure
+/// ACE/byte-parsing tests remain meaningful regardless.
+#[cfg(target_os = "windows")]
+pub fn build_capability_table() -> Vec<CapabilityEntry> {
+    let mut out = Vec::with_capacity(KNOWN_CAPABILITIES.len());
+
+    for &name in KNOWN_CAPABILITIES {
+        let wide = to_wide_z(name);
+        let mut group_sids: *mut PSID = std::ptr::null_mut();
+        let mut group_count: u32 = 0;
+        let mut cap_sids: *mut PSID = std::ptr::null_mut();
+        let mut cap_count: u32 = 0;
+
+        let ok = unsafe {
+            DeriveCapabilitySidsFromName(
+                PWSTR(wide.as_ptr() as *mut u16),
+                &mut group_sids as *mut _,
+                &mut group_count as *mut _,
+                &mut cap_sids as *mut _,
+                &mut cap_count as *mut _,
+            )
+        };
+        if ok.is_err() {
+            continue;
+        }
+
+        // First entry of each array is the canonical SID; alternate
+        // encodings (when present) are not currently matched. Each is read
+        // through a bounded slice (see `first_sid_bytes`) so the access is
+        // tied to the count the OS reported rather than a raw dereference.
+        let app_package_sid = unsafe { first_sid_bytes(cap_sids, cap_count) };
+        let group_sid = unsafe { first_sid_bytes(group_sids, group_count) };
+
+        out.push(CapabilityEntry {
+            name: name.to_string(),
+            app_package_sid,
+            group_sid,
+        });
+
+        unsafe {
+            free_sid_array(cap_sids, cap_count);
+            free_sid_array(group_sids, group_count);
+        }
+    }
+
+    out
+}
+
+/// Non-Windows stub: there is no equivalent to
+/// `DeriveCapabilitySidsFromName` on Linux/macOS. Returning an empty
+/// table keeps the pure parts of this module (parse_hex_string, ACE
+/// byte walker, CapabilityIndex) callable in cross-platform tests.
+#[cfg(not(target_os = "windows"))]
+pub fn build_capability_table() -> Vec<CapabilityEntry> {
+    Vec::new()
+}
+
+/// Best-effort string form of a SID for diagnostics. Returns `None` if the
+/// bytes aren't a valid SID.
+#[cfg(target_os = "windows")]
+pub fn sid_to_string(sid_bytes: &[u8]) -> Option<String> {
+    let psid = PSID(sid_bytes.as_ptr() as *mut _);
+    unsafe {
+        if !IsValidSid(psid).as_bool() {
+            return None;
+        }
+        let mut out = PWSTR::null();
+        if ConvertSidToStringSidW(psid, &mut out as *mut _).is_err() {
+            return None;
+        }
+        // Walk to NUL.
+        let mut len = 0usize;
+        while *out.0.add(len) != 0 {
+            len += 1;
+        }
+        let slice = std::slice::from_raw_parts(out.0, len);
+        let s = String::from_utf16_lossy(slice);
+        let _ = LocalFree(Some(HLOCAL(out.0 as *mut _)));
+        Some(s)
+    }
+}
+
+/// Non-Windows stub.
+#[cfg(not(target_os = "windows"))]
+pub fn sid_to_string(_sid_bytes: &[u8]) -> Option<String> {
+    None
+}
+
+/// Result of resolving a SID against the capability table.
+pub enum SidResolution<'a> {
+    Capability(&'a str),
+    GroupCapability(&'a str),
+    Unknown,
+}
+
+/// Indexed view of a capability table for O(1) SID lookup. A naive
+/// `resolve_sid` doing a linear scan over ~150 entries per ACE
+/// dominates CPU time on traces with thousands of ACEs.
+///
+/// The map keys are SID byte sequences; the value pairs the matched
+/// capability name with a flag distinguishing the package-SID variant
+/// (`false`) from the group-SID variant (`true`). Owns its keys so it
+/// can be carried alongside the table inside `ParseAccumulator` without
+/// the self-referential lifetime headaches that the previous
+/// borrowing form imposed on callers.
+pub struct CapabilityIndex {
+    by_sid: HashMap<Vec<u8>, (String, bool)>,
+}
+
+impl CapabilityIndex {
+    pub fn from_table(table: &[CapabilityEntry]) -> Self {
+        let mut by_sid: HashMap<Vec<u8>, (String, bool)> = HashMap::with_capacity(table.len() * 2);
+        for entry in table {
+            if let Some(s) = &entry.app_package_sid {
+                by_sid.insert(s.clone(), (entry.name.clone(), false));
+            }
+            if let Some(s) = &entry.group_sid {
+                // App-package SID wins on conflict (it's the canonical
+                // form); only insert the group SID when no entry exists.
+                by_sid
+                    .entry(s.clone())
+                    .or_insert((entry.name.clone(), true));
+            }
+        }
+        Self { by_sid }
+    }
+
+    pub fn resolve<'a>(&'a self, sid_bytes: &[u8]) -> SidResolution<'a> {
+        if let Some((name, is_group)) = self.by_sid.get(sid_bytes) {
+            return if *is_group {
+                SidResolution::GroupCapability(name.as_str())
+            } else {
+                SidResolution::Capability(name.as_str())
+            };
+        }
+        SidResolution::Unknown
+    }
+}
+
+/// Legacy linear-scan resolver. Kept for callers that already have a
+/// `&[CapabilityEntry]` and don't want to build an index for one ACE.
+/// Prefer `CapabilityIndex::resolve` for any per-ACE hot loop.
+pub fn resolve_sid<'a>(sid_bytes: &[u8], table: &'a [CapabilityEntry]) -> SidResolution<'a> {
+    for entry in table {
+        if let Some(s) = &entry.app_package_sid {
+            if s == sid_bytes {
+                return SidResolution::Capability(&entry.name);
+            }
+        }
+        if let Some(s) = &entry.group_sid {
+            if s == sid_bytes {
+                return SidResolution::GroupCapability(&entry.name);
+            }
+        }
+    }
+    SidResolution::Unknown
+}
+
+pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
+    // Single-pass byte decoder: walk the input once, skip whitespace,
+    // accumulate nibbles into bytes. The previous 3-pass version
+    // (filter → length/charset checks → from_str_radix per pair)
+    // allocated an intermediate `String` per call; with thousands of
+    // ACE blobs per trace that added up.
+    //
+    // iterate `as_bytes()` rather than `chars()`. The
+    // input is always ASCII hex emitted by the Windows event renderer
+    // (`<ComplexData>` text nodes from EvtRender), so per-codepoint
+    // UTF-8 decoding is pure overhead. Non-hex / non-whitespace bytes
+    // still surface the same error.
+    let mut bytes: Vec<u8> = Vec::with_capacity(hex_input.len() / 2);
+    let mut nibble: Option<u8> = None;
+    for b in hex_input.as_bytes() {
+        let b = *b;
+        if b.is_ascii_whitespace() {
+            continue;
+        }
+        let v = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => return Err(anyhow!("Hex string contains non-hex characters.")),
+        };
+        match nibble.take() {
+            None => nibble = Some(v),
+            Some(hi) => bytes.push((hi << 4) | v),
+        }
+    }
+    if nibble.is_some() || bytes.is_empty() {
+        return Err(anyhow!(
+            "Hex string must be non-empty and have an even length."
+        ));
+    }
+    Ok(bytes)
+}
+
+struct AceSlice<'a> {
+    ace_type: u8,
+    ace_flags: u8,
+    access_mask: u32,
+    sub_authority_count: u8,
+    sid_bytes: &'a [u8],
+    next_cursor: usize,
+}
+
+fn read_ace_at_offset(buf: &[u8], cursor: usize) -> Result<AceSlice<'_>> {
+    let total = buf.len();
+    if total - cursor < ACE_HEADER_SIZE + SID_FIXED_HEADER_SIZE {
+        return Err(anyhow!(
+            "Truncated ACE header at byte offset {} (need at least {} more bytes).",
+            cursor,
+            ACE_HEADER_SIZE + SID_FIXED_HEADER_SIZE
+        ));
+    }
+    let ace_type = buf[cursor];
+    let ace_flags = buf[cursor + 4];
+    let access_mask = u32::from_le_bytes([
+        buf[cursor + 8],
+        buf[cursor + 9],
+        buf[cursor + 10],
+        buf[cursor + 11],
+    ]);
+
+    let sid_offset = cursor + ACE_HEADER_SIZE;
+    let sub_authority_count = buf[sid_offset + 1];
+    let sid_size = SID_FIXED_HEADER_SIZE + 4 * sub_authority_count as usize;
+    if total - sid_offset < sid_size {
+        return Err(anyhow!(
+            "Truncated SID at byte offset {} (need {} bytes, have {}).",
+            sid_offset,
+            sid_size,
+            total - sid_offset
+        ));
+    }
+
+    Ok(AceSlice {
+        ace_type,
+        ace_flags,
+        access_mask,
+        sub_authority_count,
+        sid_bytes: &buf[sid_offset..sid_offset + sid_size],
+        next_cursor: sid_offset + sid_size,
+    })
+}
+
+/// Walk every ACE in `buf` and return the case-insensitively-deduped set
+/// of capability names matched along the way. When `verbose` is true, a
+/// per-ACE diagnostic line is emitted to stdout.
+///
+/// Accepts a pre-built `CapabilityIndex`. Use this in any hot loop that
+/// walks many ACE buffers in a row — building the index is
+/// O(table_size) and you only want to do it once. Hot-loop callers
+/// should prefer `invoke_ace_walk_with_index_into` to avoid the
+/// throwaway `HashSet` allocation per blob.
+pub fn invoke_ace_walk_with_index(
+    buf: &[u8],
+    index: &CapabilityIndex,
+    verbose: bool,
+) -> Result<HashSet<String>> {
+    let mut found: HashSet<String> = HashSet::new();
+    invoke_ace_walk_with_index_into(buf, index, verbose, &mut found)?;
+    Ok(found)
+}
+
+/// R5-17: variant that writes directly into a caller-provided
+/// `&mut HashSet<String>`. Avoids allocating + draining a throwaway
+/// `HashSet` per ACE blob in the hot loop.
+pub fn invoke_ace_walk_with_index_into(
+    buf: &[u8],
+    index: &CapabilityIndex,
+    verbose: bool,
+    found: &mut HashSet<String>,
+) -> Result<()> {
+    let mut cursor = 0usize;
+    let mut ace_index = 0usize;
+
+    while cursor < buf.len() {
+        let ace = read_ace_at_offset(buf, cursor)?;
+        let is_allow_ace = matches!(ace.ace_type, 0x00 | 0x09);
+        let resolution = index.resolve(ace.sid_bytes);
+
+        if is_allow_ace {
+            match &resolution {
+                SidResolution::Capability(name) => {
+                    found.insert(name.to_string());
+                }
+                SidResolution::GroupCapability(name) => {
+                    found.insert(name.to_string());
+                }
+                SidResolution::Unknown => {}
+            }
+        }
+
+        if verbose {
+            let resolved_str = match &resolution {
+                SidResolution::Capability(name) => format!("capability \"{name}\""),
+                SidResolution::GroupCapability(name) => {
+                    format!("capability \"{name}\" (group SID)")
+                }
+                SidResolution::Unknown => {
+                    "<no known capability/account matches this SID>".to_string()
+                }
+            };
+            let sid_str =
+                sid_to_string(ace.sid_bytes).unwrap_or_else(|| "<invalid SID>".to_string());
+            println!(
+                "ACE {}: type=0x{:02X}, flags=0x{:02X}, mask=0x{:08X}, subAuthCount={}",
+                ace_index, ace.ace_type, ace.ace_flags, ace.access_mask, ace.sub_authority_count
+            );
+            println!("  SID:      {sid_str}");
+            println!("  Resolved: {resolved_str}");
+            println!();
+        }
+
+        cursor = ace.next_cursor;
+        ace_index += 1;
+    }
+
+    Ok(())
+}
+
+/// Convenience wrapper that builds a fresh capability table per call.
+/// Prefer `invoke_ace_walk_with_index` (with a reused index) in any loop.
+pub fn invoke_ace_walk(buf: &[u8], verbose: bool) -> Result<HashSet<String>> {
+    let table = build_capability_table();
+    let index = CapabilityIndex::from_table(&table);
+    invoke_ace_walk_with_index(buf, &index, verbose)
+}
+
+/// Top-level entry point matching the script's `-HexBytes` invocation.
+pub fn extract_caps(hex_bytes: &str, verbose: bool) -> Result<HashSet<String>> {
+    let bytes = parse_hex_string(hex_bytes)?;
+    invoke_ace_walk(&bytes, verbose)
+}
+
+/// Per-event variant that takes a pre-built `CapabilityIndex` so the
+/// O(table_size) build cost is paid once per parse, not per ACE blob.
+/// Prefer `extract_caps_with_index_into` (which writes into a
+/// caller-owned set) for the production hot loop; this variant is kept
+/// for tests and callers that want a fresh `HashSet` per blob.
+pub fn extract_caps_with_index(
+    hex_bytes: &str,
+    index: &CapabilityIndex,
+    verbose: bool,
+) -> Result<HashSet<String>> {
+    let bytes = parse_hex_string(hex_bytes)?;
+    invoke_ace_walk_with_index(&bytes, index, verbose)
+}
+
+/// R5-17: hot-path variant that writes directly into a caller-provided
+/// `&mut HashSet<String>` to skip the per-blob throwaway HashSet.
+pub fn extract_caps_with_index_into(
+    hex_bytes: &str,
+    index: &CapabilityIndex,
+    verbose: bool,
+    found: &mut HashSet<String>,
+) -> Result<()> {
+    let bytes = parse_hex_string(hex_bytes)?;
+    invoke_ace_walk_with_index_into(&bytes, index, verbose, found)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- parse_hex_string ------------------------------------------------
+
+    #[test]
+    fn parse_hex_string_decodes_simple_bytes() {
+        let v = parse_hex_string("DEADBEEF").unwrap();
+        assert_eq!(v, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn parse_hex_string_accepts_whitespace_and_lower() {
+        let v = parse_hex_string("de ad\nbe\tef").unwrap();
+        assert_eq!(v, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn parse_hex_string_rejects_odd_length() {
+        assert!(parse_hex_string("ABC").is_err());
+    }
+
+    #[test]
+    fn parse_hex_string_rejects_empty() {
+        assert!(parse_hex_string("").is_err());
+        assert!(parse_hex_string("   \n").is_err());
+    }
+
+    #[test]
+    fn parse_hex_string_rejects_non_hex() {
+        assert!(parse_hex_string("DEADXYZZ").is_err());
+    }
+
+    // ---- read_ace_at_offset (defensive: bounds checks on attacker bytes) -
+
+    fn well_world_sid() -> Vec<u8> {
+        // S-1-1-0 "Everyone": revision=1, subAuthCount=1, IdAuth=...,
+        // SubAuthority[0]=0.
+        vec![
+            1, 1, 0, 0, 0, 0, 0, 1, // header + identifier authority
+            0, 0, 0, 0, // sub_authority[0]
+        ]
+    }
+
+    fn build_ace(mask: u32, sid: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.push(0u8); // ace_type
+        v.extend_from_slice(&[0, 0, 0]); // padding
+        v.extend_from_slice(&[0, 0, 0, 0]); // flags (4 bytes, low byte = ace_flags)
+        v.extend_from_slice(&mask.to_le_bytes());
+        v.extend_from_slice(sid);
+        v
+    }
+
+    #[test]
+    fn read_ace_at_offset_decodes_well_known_sid() {
+        let buf = build_ace(0xDEADBEEF, &well_world_sid());
+        let ace = read_ace_at_offset(&buf, 0).expect("should decode");
+        assert_eq!(ace.access_mask, 0xDEADBEEF);
+        assert_eq!(ace.sid_bytes, well_world_sid().as_slice());
+        assert_eq!(ace.next_cursor, buf.len());
+    }
+
+    #[test]
+    fn read_ace_at_offset_rejects_truncated_header() {
+        // Less than ACE_HEADER_SIZE + SID_FIXED_HEADER_SIZE.
+        let buf = vec![0u8; 4];
+        assert!(read_ace_at_offset(&buf, 0).is_err());
+    }
+
+    #[test]
+    fn read_ace_at_offset_rejects_truncated_subauthorities() {
+        // Pretend SubAuthorityCount is 5 but only one slot is present.
+        let mut sid = vec![1u8, 5, 0, 0, 0, 0, 0, 1]; // revision=1, count=5
+        sid.extend_from_slice(&[0, 0, 0, 0]); // only one sub_authority
+        let buf = build_ace(0, &sid);
+        assert!(read_ace_at_offset(&buf, 0).is_err());
+    }
+
+    // ---- CapabilityIndex -------------------------------------------------
+
+    #[test]
+    fn capability_index_resolves_app_package_and_group_sids() {
+        let table = vec![CapabilityEntry {
+            name: "internetClient".into(),
+            app_package_sid: Some(well_world_sid()),
+            group_sid: None,
+        }];
+        let idx = CapabilityIndex::from_table(&table);
+        match idx.resolve(&well_world_sid()) {
+            SidResolution::Capability(n) => assert_eq!(n, "internetClient"),
+            _ => panic!("expected Capability"),
+        }
+    }
+
+    fn build_ace_typed(ace_type: u8, mask: u32, sid: &[u8]) -> Vec<u8> {
+        let mut v = Vec::new();
+        v.push(ace_type);
+        v.extend_from_slice(&[0, 0, 0]);
+        v.extend_from_slice(&[0, 0, 0, 0]);
+        v.extend_from_slice(&mask.to_le_bytes());
+        v.extend_from_slice(sid);
+        v
+    }
+
+    #[test]
+    fn invoke_ace_walk_with_index_collects_matched_caps() {
+        let sid = well_world_sid();
+        let table = vec![CapabilityEntry {
+            name: "internetClient".into(),
+            app_package_sid: Some(sid.clone()),
+            group_sid: None,
+        }];
+        let idx = CapabilityIndex::from_table(&table);
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&build_ace(0, &sid));
+        buf.extend_from_slice(&build_ace(0, &sid));
+
+        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        assert!(caps.contains("internetClient"));
+        assert_eq!(caps.len(), 1);
+    }
+
+    #[test]
+    fn invoke_ace_walk_skips_access_denied_ace() {
+        // R5-6: an ACCESS_DENIED ACE (type 0x01) for a capability SID
+        // does NOT grant the capability and must not be promoted.
+        let sid = well_world_sid();
+        let table = vec![CapabilityEntry {
+            name: "internetClient".into(),
+            app_package_sid: Some(sid.clone()),
+            group_sid: None,
+        }];
+        let idx = CapabilityIndex::from_table(&table);
+
+        let buf = build_ace_typed(0x01, 0, &sid);
+        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        assert!(caps.is_empty(), "deny ACE must not produce capability");
+
+        // Allow-callback ACE (0x09) should still grant.
+        let buf = build_ace_typed(0x09, 0, &sid);
+        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        assert!(caps.contains("internetClient"));
+    }
+
+    // ---- public entry points: extract_caps* ------------------------------
+    //
+    // the public surface (`extract_caps`,
+    // `extract_caps_with_index`, `extract_caps_with_index_into`) had
+    // no direct tests. Pin the hex-decode → ACE walk → resolve glue
+    // here so a regression in any of those layers fails fast rather
+    // than surfacing only via the WPR-driven integration harness.
+
+    fn hex_for_bytes(bytes: &[u8]) -> String {
+        use std::fmt::Write;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            let _ = write!(s, "{:02X}", b);
+        }
+        s
+    }
+
+    #[test]
+    fn extract_caps_with_index_decodes_hex_and_matches_capability() {
+        let sid = well_world_sid();
+        let table = vec![CapabilityEntry {
+            name: "documentsLibrary".into(),
+            app_package_sid: Some(sid.clone()),
+            group_sid: None,
+        }];
+        let idx = CapabilityIndex::from_table(&table);
+        let hex = hex_for_bytes(&build_ace(0, &sid));
+
+        let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
+        assert!(caps.contains("documentsLibrary"));
+        assert_eq!(caps.len(), 1);
+    }
+
+    #[test]
+    fn extract_caps_with_index_into_writes_into_caller_set() {
+        let sid = well_world_sid();
+        let table = vec![CapabilityEntry {
+            name: "internetClient".into(),
+            app_package_sid: Some(sid.clone()),
+            group_sid: None,
+        }];
+        let idx = CapabilityIndex::from_table(&table);
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&build_ace(0, &sid));
+        buf.extend_from_slice(&build_ace(0, &sid));
+        let hex = hex_for_bytes(&buf);
+
+        // Pre-seed with an unrelated entry — extract_caps must
+        // PRESERVE existing members, not overwrite them.
+        let mut found: HashSet<String> = HashSet::new();
+        found.insert("preexisting".into());
+        extract_caps_with_index_into(&hex, &idx, false, &mut found).unwrap();
+        assert!(found.contains("preexisting"));
+        assert!(found.contains("internetClient"));
+    }
+
+    #[test]
+    fn extract_caps_with_index_rejects_malformed_hex() {
+        let table: Vec<CapabilityEntry> = Vec::new();
+        let idx = CapabilityIndex::from_table(&table);
+        assert!(extract_caps_with_index("not-hex", &idx, false).is_err());
+        assert!(extract_caps_with_index("ABC", &idx, false).is_err());
+    }
+
+    #[test]
+    fn extract_caps_with_index_returns_empty_for_no_match() {
+        // SID doesn't match any capability entry in the table.
+        let sid = well_world_sid();
+        let table: Vec<CapabilityEntry> = Vec::new();
+        let idx = CapabilityIndex::from_table(&table);
+        let hex = hex_for_bytes(&build_ace(0, &sid));
+        let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
+        assert!(caps.is_empty());
+    }
+}

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -15,6 +15,22 @@
 //!     - `[1]`    SubAuthorityCount  (1 byte)
 //!     - `[2..7]` IdentifierAuthority (6 bytes)
 //!     - `[8..]`  SubAuthorities      (4 bytes each)
+//!
+//! # Layout provenance — read before changing the constants below
+//!
+//! This is the DWORD-padded shape the PowerShell script decoded, **not**
+//! the packed Win32 `ACCESS_ALLOWED_ACE` (`ACE_HEADER` is 4 bytes —
+//! type, flags, `AceSize` — with the mask at `[4..7]` and the SID at
+//! `[8..]`). The two disagree about where the SID begins (12 vs 8), and
+//! this walker also derives each ACE's length from its SID size rather
+//! than reading `AceSize`.
+//!
+//! Every fixture in this module's tests is *built* with the same layout
+//! it *asserts*, so the suite cannot tell the two encodings apart. Do
+//! not "correct" these offsets to the Win32 struct on inspection alone:
+//! settle it against one real captured `EventID=14` blob first, and land
+//! that blob as a golden fixture (see the `TODO` on
+//! `golden_fixture_needed` in the tests below).
 
 use anyhow::{anyhow, Result};
 use std::collections::{HashMap, HashSet};
@@ -28,8 +44,32 @@ use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 #[cfg(target_os = "windows")]
 use windows::Win32::Security::{DeriveCapabilitySidsFromName, GetLengthSid, IsValidSid, PSID};
 
+// --- ACE / SID wire layout -------------------------------------------
+//
+// Single source of truth for the offsets the walker and the test
+// fixtures both use. See the layout-provenance note in the module
+// header before changing any of these.
+
+/// Offset of the ACE type byte within an ACE.
+const ACE_TYPE_OFFSET: usize = 0;
+/// Offset of the ACE flags field (only the low byte is meaningful).
+const ACE_FLAGS_OFFSET: usize = 4;
+/// Offset of the little-endian access mask.
+const ACE_ACCESS_MASK_OFFSET: usize = 8;
+/// Bytes occupied by the ACE header before the embedded SID begins.
 const ACE_HEADER_SIZE: usize = 1 + 3 + 4 + 4; // type + 3 padding + 4 flags + 4 mask
+
+/// Offset of `SubAuthorityCount` within a SID.
+const SID_SUB_AUTHORITY_COUNT_OFFSET: usize = 1;
+/// Bytes of fixed SID header preceding the sub-authority array.
 const SID_FIXED_HEADER_SIZE: usize = 1 + 1 + 6; // revision + subauth count + id auth
+/// Width of a single sub-authority entry.
+const SID_SUB_AUTHORITY_SIZE: usize = 4;
+
+/// `ACCESS_ALLOWED_ACE_TYPE` — grants the access in the mask.
+const ACE_TYPE_ACCESS_ALLOWED: u8 = 0x00;
+/// `ACCESS_ALLOWED_CALLBACK_ACE_TYPE` — same grant, callback variant.
+const ACE_TYPE_ACCESS_ALLOWED_CALLBACK: u8 = 0x09;
 
 /// Capability names we want to recognize when their SID appears in an
 /// ACE. Mirrors the `$knownCapabilities` list from `extract_caps.ps1`
@@ -246,14 +286,63 @@ unsafe fn first_sid_bytes(arr: *const PSID, count: u32) -> Option<Vec<u8>> {
     unsafe { sid_bytes_from_ptr(first) }
 }
 
+/// Case-insensitive ASCII ordering that allocates nothing.
+///
+/// Sorting by a `to_ascii_lowercase()` key would allocate a `String` per
+/// comparison; folding each byte as it is compared avoids that. Only
+/// `A-Z` are folded, so this stays a well-defined total order for
+/// arbitrary (including non-ASCII) input: ties under the fold are broken
+/// by length, and the relation remains transitive and antisymmetric.
+///
+/// Shared by the config merge and the `plm extract-caps` CLI so both
+/// present capability names in the same order.
+pub(crate) fn ascii_ci_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    let (ab, bb) = (a.as_bytes(), b.as_bytes());
+    for i in 0..ab.len().min(bb.len()) {
+        let (x, y) = (ab[i].to_ascii_lowercase(), bb[i].to_ascii_lowercase());
+        if x != y {
+            return x.cmp(&y);
+        }
+    }
+    ab.len().cmp(&bb.len())
+}
+
+/// Capability names in stable display order.
+///
+/// Extracted from the `plm extract-caps` CLI arm so the ordering is
+/// testable without spawning the binary.
+pub fn sorted_capability_names(caps: &HashSet<String>) -> Vec<&str> {
+    let mut out: Vec<&str> = caps.iter().map(String::as_str).collect();
+    out.sort_by(|a, b| ascii_ci_cmp(a, b));
+    out
+}
+
+/// Number of capability names this module knows how to match. Used by
+/// callers reporting how many the OS rejected at table-build time.
+pub fn known_capability_count() -> usize {
+    KNOWN_CAPABILITIES.len()
+}
+
+/// Outcome of building the capability table, including how many known
+/// capability names the OS refused to resolve.
+///
+/// A silently-empty table is indistinguishable from "this workload
+/// needed no capabilities": every subsequent lookup misses and the
+/// generated config omits capabilities entirely. Callers use
+/// `derive_failures` / an empty `entries` to warn instead.
+pub struct CapabilityTable {
+    pub entries: Vec<CapabilityEntry>,
+    pub derive_failures: usize,
+}
+
 /// Build the table of (capability name, AppPackage SID, Group SID) tuples
 /// by calling `DeriveCapabilitySidsFromName` for each known capability.
-/// Capabilities the OS rejects are silently skipped. Non-Windows targets
-/// get an empty table (the API has no cross-platform equivalent); pure
-/// ACE/byte-parsing tests remain meaningful regardless.
+/// Capabilities the OS rejects are counted in `derive_failures` rather
+/// than silently dropped.
 #[cfg(target_os = "windows")]
-pub fn build_capability_table() -> Vec<CapabilityEntry> {
+pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
     let mut out = Vec::with_capacity(KNOWN_CAPABILITIES.len());
+    let mut derive_failures = 0usize;
 
     for &name in KNOWN_CAPABILITIES {
         let wide = to_wide_z(name);
@@ -272,6 +361,7 @@ pub fn build_capability_table() -> Vec<CapabilityEntry> {
             )
         };
         if ok.is_err() {
+            derive_failures += 1;
             continue;
         }
 
@@ -294,7 +384,10 @@ pub fn build_capability_table() -> Vec<CapabilityEntry> {
         }
     }
 
-    out
+    CapabilityTable {
+        entries: out,
+        derive_failures,
+    }
 }
 
 /// Non-Windows stub: there is no equivalent to
@@ -302,8 +395,16 @@ pub fn build_capability_table() -> Vec<CapabilityEntry> {
 /// table keeps the pure parts of this module (parse_hex_string, ACE
 /// byte walker, CapabilityIndex) callable in cross-platform tests.
 #[cfg(not(target_os = "windows"))]
+pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
+    CapabilityTable {
+        entries: Vec::new(),
+        derive_failures: 0,
+    }
+}
+
+/// Convenience wrapper that discards the build diagnostics.
 pub fn build_capability_table() -> Vec<CapabilityEntry> {
-    Vec::new()
+    build_capability_table_with_diagnostics().entries
 }
 
 /// Best-effort string form of a SID for diagnostics. Returns `None` if the
@@ -344,9 +445,9 @@ pub enum SidResolution<'a> {
     Unknown,
 }
 
-/// Indexed view of a capability table for O(1) SID lookup. A naive
-/// `resolve_sid` doing a linear scan over ~150 entries per ACE
-/// dominates CPU time on traces with thousands of ACEs.
+/// Indexed view of a capability table for O(1) SID lookup. A linear
+/// scan over ~150 entries per ACE dominates CPU time on traces with
+/// thousands of ACEs.
 ///
 /// The map keys are SID byte sequences; the value pairs the matched
 /// capability name with a flag distinguishing the package-SID variant
@@ -388,26 +489,22 @@ impl CapabilityIndex {
     }
 }
 
-/// Legacy linear-scan resolver. Kept for callers that already have a
-/// `&[CapabilityEntry]` and don't want to build an index for one ACE.
-/// Prefer `CapabilityIndex::resolve` for any per-ACE hot loop.
-pub fn resolve_sid<'a>(sid_bytes: &[u8], table: &'a [CapabilityEntry]) -> SidResolution<'a> {
-    for entry in table {
-        if let Some(s) = &entry.app_package_sid {
-            if s == sid_bytes {
-                return SidResolution::Capability(&entry.name);
-            }
-        }
-        if let Some(s) = &entry.group_sid {
-            if s == sid_bytes {
-                return SidResolution::GroupCapability(&entry.name);
-            }
-        }
-    }
-    SidResolution::Unknown
+pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    parse_hex_string_into(hex_input, &mut out)?;
+    Ok(out)
 }
 
-pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
+/// Decode `hex_input` into a caller-owned buffer, reusing its existing
+/// capacity.
+///
+/// The per-event hot path decodes one multi-KB ACE blob per
+/// `EventID=14` record; allocating and freeing a fresh `Vec` for each
+/// one is pure overhead on a long trace. Callers hold a single scratch
+/// buffer and pass it here, so steady-state decoding allocates nothing.
+/// The buffer is cleared on entry, and is left empty on error so a
+/// failed decode cannot leak bytes into the next event.
+pub(crate) fn parse_hex_string_into(hex_input: &str, out: &mut Vec<u8>) -> Result<()> {
     // Single-pass byte decoder: walk the input once, skip whitespace,
     // accumulate nibbles into bytes. The previous 3-pass version
     // (filter → length/charset checks → from_str_radix per pair)
@@ -419,7 +516,8 @@ pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
     // (`<ComplexData>` text nodes from EvtRender), so per-codepoint
     // UTF-8 decoding is pure overhead. Non-hex / non-whitespace bytes
     // still surface the same error.
-    let mut bytes: Vec<u8> = Vec::with_capacity(hex_input.len() / 2);
+    out.clear();
+    out.reserve(hex_input.len() / 2);
     let mut nibble: Option<u8> = None;
     for b in hex_input.as_bytes() {
         let b = *b;
@@ -430,19 +528,23 @@ pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
             b'0'..=b'9' => b - b'0',
             b'a'..=b'f' => b - b'a' + 10,
             b'A'..=b'F' => b - b'A' + 10,
-            _ => return Err(anyhow!("Hex string contains non-hex characters.")),
+            _ => {
+                out.clear();
+                return Err(anyhow!("Hex string contains non-hex characters."));
+            }
         };
         match nibble.take() {
             None => nibble = Some(v),
-            Some(hi) => bytes.push((hi << 4) | v),
+            Some(hi) => out.push((hi << 4) | v),
         }
     }
-    if nibble.is_some() || bytes.is_empty() {
+    if nibble.is_some() || out.is_empty() {
+        out.clear();
         return Err(anyhow!(
             "Hex string must be non-empty and have an even length."
         ));
     }
-    Ok(bytes)
+    Ok(())
 }
 
 struct AceSlice<'a> {
@@ -463,18 +565,18 @@ fn read_ace_at_offset(buf: &[u8], cursor: usize) -> Result<AceSlice<'_>> {
             ACE_HEADER_SIZE + SID_FIXED_HEADER_SIZE
         ));
     }
-    let ace_type = buf[cursor];
-    let ace_flags = buf[cursor + 4];
+    let ace_type = buf[cursor + ACE_TYPE_OFFSET];
+    let ace_flags = buf[cursor + ACE_FLAGS_OFFSET];
     let access_mask = u32::from_le_bytes([
-        buf[cursor + 8],
-        buf[cursor + 9],
-        buf[cursor + 10],
-        buf[cursor + 11],
+        buf[cursor + ACE_ACCESS_MASK_OFFSET],
+        buf[cursor + ACE_ACCESS_MASK_OFFSET + 1],
+        buf[cursor + ACE_ACCESS_MASK_OFFSET + 2],
+        buf[cursor + ACE_ACCESS_MASK_OFFSET + 3],
     ]);
 
     let sid_offset = cursor + ACE_HEADER_SIZE;
-    let sub_authority_count = buf[sid_offset + 1];
-    let sid_size = SID_FIXED_HEADER_SIZE + 4 * sub_authority_count as usize;
+    let sub_authority_count = buf[sid_offset + SID_SUB_AUTHORITY_COUNT_OFFSET];
+    let sid_size = SID_FIXED_HEADER_SIZE + SID_SUB_AUTHORITY_SIZE * sub_authority_count as usize;
     if total - sid_offset < sid_size {
         return Err(anyhow!(
             "Truncated SID at byte offset {} (need {} bytes, have {}).",
@@ -498,12 +600,27 @@ fn read_ace_at_offset(buf: &[u8], cursor: usize) -> Result<AceSlice<'_>> {
 /// of capability names matched along the way. When `verbose` is true, a
 /// per-ACE diagnostic line is emitted to stdout.
 ///
-/// Accepts a pre-built `CapabilityIndex`. Use this in any hot loop that
-/// walks many ACE buffers in a row — building the index is
-/// O(table_size) and you only want to do it once. Hot-loop callers
-/// should prefer `invoke_ace_walk_with_index_into` to avoid the
-/// throwaway `HashSet` allocation per blob.
-pub fn invoke_ace_walk_with_index(
+/// Emit a one-shot warning when a capability SID is recognized on an
+/// allow ACE that grants nothing.
+///
+/// Fires at most once per process so a long trace cannot spam the
+/// console. See the call site for why this is worth reporting.
+fn warn_zero_mask_capability_once(name: &str) {
+    static WARNED: std::sync::Once = std::sync::Once::new();
+    WARNED.call_once(|| {
+        eprintln!(
+            "warning: allow ACE for capability \"{name}\" has a zero access mask and was not \
+             treated as a capability request. If capabilities are missing from the generated \
+             config, this filter is the first thing to check."
+        );
+    });
+}
+
+/// Walk every ACE in `buf`, returning the matched capability names.
+/// Allocates a `HashSet` per call — hot-loop callers should prefer
+/// [`invoke_ace_walk_with_index_into`].
+#[cfg(test)]
+pub(crate) fn invoke_ace_walk_with_index(
     buf: &[u8],
     index: &CapabilityIndex,
     verbose: bool,
@@ -513,9 +630,9 @@ pub fn invoke_ace_walk_with_index(
     Ok(found)
 }
 
-/// R5-17: variant that writes directly into a caller-provided
-/// `&mut HashSet<String>`. Avoids allocating + draining a throwaway
-/// `HashSet` per ACE blob in the hot loop.
+/// Walk every ACE in `buf`, inserting matched capability names into
+/// `found`. This is the shared implementation every other entry point
+/// funnels through.
 pub fn invoke_ace_walk_with_index_into(
     buf: &[u8],
     index: &CapabilityIndex,
@@ -527,18 +644,43 @@ pub fn invoke_ace_walk_with_index_into(
 
     while cursor < buf.len() {
         let ace = read_ace_at_offset(buf, cursor)?;
-        let is_allow_ace = matches!(ace.ace_type, 0x00 | 0x09);
+        let is_allow_ace = matches!(
+            ace.ace_type,
+            ACE_TYPE_ACCESS_ALLOWED | ACE_TYPE_ACCESS_ALLOWED_CALLBACK
+        );
+        // An allow ACE that grants nothing is not evidence that the
+        // workload needs the capability. Accepting zero-mask ACEs lets a
+        // crafted DACL inject arbitrary capability names into the
+        // generated policy, so require an actual grant.
+        let grants_access = ace.access_mask != 0;
         let resolution = index.resolve(ace.sid_bytes);
 
         if is_allow_ace {
-            match &resolution {
-                SidResolution::Capability(name) => {
-                    found.insert(name.to_string());
+            let matched = match &resolution {
+                SidResolution::Capability(name) | SidResolution::GroupCapability(name) => {
+                    Some(*name)
                 }
-                SidResolution::GroupCapability(name) => {
-                    found.insert(name.to_string());
+                SidResolution::Unknown => None,
+            };
+            if let Some(name) = matched {
+                if grants_access {
+                    // Only allocate when the name is genuinely new. The
+                    // set saturates at the handful of known capabilities
+                    // within the first few events, so an unconditional
+                    // `to_string()` would allocate-hash-drop on
+                    // essentially every remaining ACE in the trace.
+                    if !found.contains(name) {
+                        found.insert(name.to_string());
+                    }
+                } else {
+                    // The zero-mask filter above is a hardening measure
+                    // derived from what a grant *should* look like, not
+                    // from a captured trace. If this provider really does
+                    // emit capability ACEs with an empty mask, the filter
+                    // would silently disable extraction entirely — so say
+                    // so once rather than failing quietly.
+                    warn_zero_mask_capability_once(name);
                 }
-                SidResolution::Unknown => {}
             }
         }
 
@@ -571,11 +713,15 @@ pub fn invoke_ace_walk_with_index_into(
 }
 
 /// Convenience wrapper that builds a fresh capability table per call.
-/// Prefer `invoke_ace_walk_with_index` (with a reused index) in any loop.
+/// Used by the one-shot `plm extract-caps` CLI path; any loop should
+/// build a [`CapabilityIndex`] once and use
+/// [`invoke_ace_walk_with_index_into`].
 pub fn invoke_ace_walk(buf: &[u8], verbose: bool) -> Result<HashSet<String>> {
     let table = build_capability_table();
     let index = CapabilityIndex::from_table(&table);
-    invoke_ace_walk_with_index(buf, &index, verbose)
+    let mut found: HashSet<String> = HashSet::new();
+    invoke_ace_walk_with_index_into(buf, &index, verbose, &mut found)?;
+    Ok(found)
 }
 
 /// Top-level entry point matching the script's `-HexBytes` invocation.
@@ -586,10 +732,10 @@ pub fn extract_caps(hex_bytes: &str, verbose: bool) -> Result<HashSet<String>> {
 
 /// Per-event variant that takes a pre-built `CapabilityIndex` so the
 /// O(table_size) build cost is paid once per parse, not per ACE blob.
-/// Prefer `extract_caps_with_index_into` (which writes into a
-/// caller-owned set) for the production hot loop; this variant is kept
-/// for tests and callers that want a fresh `HashSet` per blob.
-pub fn extract_caps_with_index(
+/// Allocates a fresh `HashSet` and decode buffer per call; the
+/// production hot loop uses [`extract_caps_with_index_into`] instead.
+#[cfg(test)]
+pub(crate) fn extract_caps_with_index(
     hex_bytes: &str,
     index: &CapabilityIndex,
     verbose: bool,
@@ -598,16 +744,18 @@ pub fn extract_caps_with_index(
     invoke_ace_walk_with_index(&bytes, index, verbose)
 }
 
-/// R5-17: hot-path variant that writes directly into a caller-provided
-/// `&mut HashSet<String>` to skip the per-blob throwaway HashSet.
+/// Hot-path variant: writes matches into a caller-provided
+/// `&mut HashSet<String>` and decodes through a caller-provided scratch
+/// buffer, so a steady-state event costs no allocation at all.
 pub fn extract_caps_with_index_into(
     hex_bytes: &str,
     index: &CapabilityIndex,
     verbose: bool,
+    scratch: &mut Vec<u8>,
     found: &mut HashSet<String>,
 ) -> Result<()> {
-    let bytes = parse_hex_string(hex_bytes)?;
-    invoke_ace_walk_with_index_into(&bytes, index, verbose, found)
+    parse_hex_string_into(hex_bytes, scratch)?;
+    invoke_ace_walk_with_index_into(scratch, index, verbose, found)
 }
 
 #[cfg(test)]
@@ -656,14 +804,12 @@ mod tests {
     }
 
     fn build_ace(mask: u32, sid: &[u8]) -> Vec<u8> {
-        let mut v = Vec::new();
-        v.push(0u8); // ace_type
-        v.extend_from_slice(&[0, 0, 0]); // padding
-        v.extend_from_slice(&[0, 0, 0, 0]); // flags (4 bytes, low byte = ace_flags)
-        v.extend_from_slice(&mask.to_le_bytes());
-        v.extend_from_slice(sid);
-        v
+        build_ace_typed(ACE_TYPE_ACCESS_ALLOWED, mask, sid)
     }
+
+    /// A realistic non-zero grant mask, for tests that care about the
+    /// capability actually being requested rather than about masks.
+    const GRANT: u32 = 0x0012_0089;
 
     #[test]
     fn read_ace_at_offset_decodes_well_known_sid() {
@@ -709,8 +855,8 @@ mod tests {
     fn build_ace_typed(ace_type: u8, mask: u32, sid: &[u8]) -> Vec<u8> {
         let mut v = Vec::new();
         v.push(ace_type);
-        v.extend_from_slice(&[0, 0, 0]);
-        v.extend_from_slice(&[0, 0, 0, 0]);
+        v.extend_from_slice(&[0, 0, 0]); // padding
+        v.extend_from_slice(&[0, 0, 0, 0]); // flags (low byte meaningful)
         v.extend_from_slice(&mask.to_le_bytes());
         v.extend_from_slice(sid);
         v
@@ -727,8 +873,8 @@ mod tests {
         let idx = CapabilityIndex::from_table(&table);
 
         let mut buf = Vec::new();
-        buf.extend_from_slice(&build_ace(0, &sid));
-        buf.extend_from_slice(&build_ace(0, &sid));
+        buf.extend_from_slice(&build_ace(GRANT, &sid));
+        buf.extend_from_slice(&build_ace(GRANT, &sid));
 
         let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
         assert!(caps.contains("internetClient"));
@@ -747,12 +893,12 @@ mod tests {
         }];
         let idx = CapabilityIndex::from_table(&table);
 
-        let buf = build_ace_typed(0x01, 0, &sid);
+        let buf = build_ace_typed(0x01, GRANT, &sid);
         let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
         assert!(caps.is_empty(), "deny ACE must not produce capability");
 
         // Allow-callback ACE (0x09) should still grant.
-        let buf = build_ace_typed(0x09, 0, &sid);
+        let buf = build_ace_typed(ACE_TYPE_ACCESS_ALLOWED_CALLBACK, GRANT, &sid);
         let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
         assert!(caps.contains("internetClient"));
     }
@@ -783,7 +929,7 @@ mod tests {
             group_sid: None,
         }];
         let idx = CapabilityIndex::from_table(&table);
-        let hex = hex_for_bytes(&build_ace(0, &sid));
+        let hex = hex_for_bytes(&build_ace(GRANT, &sid));
 
         let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
         assert!(caps.contains("documentsLibrary"));
@@ -800,15 +946,16 @@ mod tests {
         }];
         let idx = CapabilityIndex::from_table(&table);
         let mut buf = Vec::new();
-        buf.extend_from_slice(&build_ace(0, &sid));
-        buf.extend_from_slice(&build_ace(0, &sid));
+        buf.extend_from_slice(&build_ace(GRANT, &sid));
+        buf.extend_from_slice(&build_ace(GRANT, &sid));
         let hex = hex_for_bytes(&buf);
 
         // Pre-seed with an unrelated entry — extract_caps must
         // PRESERVE existing members, not overwrite them.
         let mut found: HashSet<String> = HashSet::new();
         found.insert("preexisting".into());
-        extract_caps_with_index_into(&hex, &idx, false, &mut found).unwrap();
+        let mut scratch = Vec::new();
+        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
         assert!(found.contains("preexisting"));
         assert!(found.contains("internetClient"));
     }
@@ -827,8 +974,253 @@ mod tests {
         let sid = well_world_sid();
         let table: Vec<CapabilityEntry> = Vec::new();
         let idx = CapabilityIndex::from_table(&table);
-        let hex = hex_for_bytes(&build_ace(0, &sid));
+        let hex = hex_for_bytes(&build_ace(GRANT, &sid));
         let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
         assert!(caps.is_empty());
+    }
+
+    // ---- adversarial / malformed ACE buffers -----------------------------
+    //
+    // The blob is attacker-influenceable: it arrives as hex text inside
+    // an ETW payload emitted while an untrusted workload runs. These
+    // pin "errors, never panics, never over-reads" on the shapes a
+    // hostile or truncated buffer can take.
+
+    fn cap_index_for(sid: &[u8], name: &str) -> CapabilityIndex {
+        CapabilityIndex::from_table(&[CapabilityEntry {
+            name: name.into(),
+            app_package_sid: Some(sid.to_vec()),
+            group_sid: None,
+        }])
+    }
+
+    #[test]
+    fn zero_mask_allow_ace_does_not_grant_capability() {
+        // An allow ACE that grants nothing is not evidence the workload
+        // needs the capability; accepting it would let a crafted DACL
+        // inject capability names into the generated policy.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let caps = invoke_ace_walk_with_index(&build_ace(0, &sid), &idx, false).unwrap();
+        assert!(
+            caps.is_empty(),
+            "zero-mask allow ACE must not produce a capability"
+        );
+    }
+
+    #[test]
+    fn valid_ace_followed_by_truncated_ace_is_an_error() {
+        // The first ACE is well-formed; the trailing bytes are not a
+        // complete ACE. The walk must fail rather than silently
+        // accepting the partial trailer.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let mut buf = build_ace(GRANT, &sid);
+        buf.extend_from_slice(&[0u8; 6]); // too short for another ACE
+        assert!(invoke_ace_walk_with_index(&buf, &idx, false).is_err());
+    }
+
+    #[test]
+    fn maximal_sub_authority_count_without_bytes_is_an_error() {
+        // SubAuthorityCount is a u8, so a hostile blob can claim 255
+        // sub-authorities (1020 bytes) while supplying none. The size
+        // computation must not overflow or over-read.
+        let mut sid = vec![1u8, 255, 0, 0, 0, 0, 0, 1];
+        sid.extend_from_slice(&[0, 0, 0, 0]);
+        let buf = build_ace(GRANT, &sid);
+        assert!(read_ace_at_offset(&buf, 0).is_err());
+    }
+
+    #[test]
+    fn ace_exactly_at_buffer_boundary_decodes() {
+        // Exact-fit buffer: the walk must terminate cleanly rather than
+        // attempting to read one ACE past the end.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let buf = build_ace(GRANT, &sid);
+        let ace = read_ace_at_offset(&buf, 0).expect("exact-fit ACE should decode");
+        assert_eq!(ace.next_cursor, buf.len());
+        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        assert!(caps.contains("internetClient"));
+    }
+
+    #[test]
+    fn single_trailing_byte_after_valid_ace_is_an_error() {
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let mut buf = build_ace(GRANT, &sid);
+        buf.push(0xFF);
+        assert!(invoke_ace_walk_with_index(&buf, &idx, false).is_err());
+    }
+
+    #[test]
+    fn malformed_hex_shapes_are_rejected_without_panic() {
+        let idx = CapabilityIndex::from_table(&[]);
+        for bad in ["ABC", "not-hex", "", "   \n", "AB CD E"] {
+            let mut scratch = Vec::new();
+            let mut found = HashSet::new();
+            assert!(
+                extract_caps_with_index_into(bad, &idx, false, &mut scratch, &mut found).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+            assert!(
+                scratch.is_empty(),
+                "scratch must be left clean after a failed decode"
+            );
+        }
+    }
+
+    #[test]
+    fn scratch_buffer_is_reused_across_decodes() {
+        // Regression guard for the per-event allocation fix: decoding
+        // through a shared buffer must not leak bytes from the previous
+        // event into the next one.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let hex = hex_for_bytes(&build_ace(GRANT, &sid));
+        let mut scratch = Vec::new();
+        let mut found = HashSet::new();
+
+        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
+        let after_first = scratch.len();
+        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
+
+        assert_eq!(
+            scratch.len(),
+            after_first,
+            "reused scratch must not accumulate across decodes"
+        );
+        assert_eq!(found.len(), 1);
+    }
+
+    #[test]
+    fn sorted_capability_names_orders_case_insensitively() {
+        // Backs the `plm extract-caps` output ordering, which is
+        // otherwise only reachable by running the binary.
+        let caps: HashSet<String> = ["Zebra", "apple", "Banana"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            sorted_capability_names(&caps),
+            vec!["apple", "Banana", "Zebra"]
+        );
+    }
+
+    #[test]
+    fn sorted_capability_names_handles_empty_set() {
+        let caps: HashSet<String> = HashSet::new();
+        assert!(sorted_capability_names(&caps).is_empty());
+    }
+
+    /// TODO(golden-fixture): this module's ACE layout (12-byte header,
+    /// SID at `[12..]`) is inherited from `extract_caps.ps1` and differs
+    /// from the packed Win32 `ACCESS_ALLOWED_ACE` (SID at `[8..]`).
+    /// Every fixture here is built with the same layout it asserts, so
+    /// the suite cannot tell the two apart. Capture one real
+    /// `EventID=14` DACL blob, paste its hex here, and assert the
+    /// expected capability set — that single fixture is what makes the
+    /// layout constants authoritative.
+    #[test]
+    #[ignore = "needs a real captured EventID=14 ACE blob; see TODO above"]
+    fn golden_fixture_needed_real_ace_blob_decodes() {
+        unimplemented!("paste a captured ACE blob and its expected capabilities");
+    }
+}
+
+/// Exercises the Windows FFI seam (`DeriveCapabilitySidsFromName`, SID
+/// copy-out, `LocalFree` cleanup) that the cross-platform tests cannot
+/// reach: on non-Windows the table is an empty stub, so a green CI run
+/// says nothing about whether real SID resolution works.
+#[cfg(all(test, target_os = "windows"))]
+mod windows_ffi_tests {
+    use super::*;
+
+    #[test]
+    fn build_capability_table_derives_real_sids() {
+        let built = build_capability_table_with_diagnostics();
+
+        // Every known name is either derived or counted as a failure —
+        // entries must never silently disappear.
+        assert_eq!(
+            built.entries.len() + built.derive_failures,
+            KNOWN_CAPABILITIES.len(),
+            "every known capability must be either derived or counted as a failure"
+        );
+
+        // A stock Windows host resolves at least the common capabilities.
+        // If this host resolves none, the diagnostics must say so rather
+        // than reporting a clean empty table.
+        if built.entries.is_empty() {
+            assert_eq!(built.derive_failures, KNOWN_CAPABILITIES.len());
+            return;
+        }
+
+        for entry in &built.entries {
+            assert!(!entry.name.is_empty());
+            assert!(
+                entry.app_package_sid.is_some() || entry.group_sid.is_some(),
+                "derived entry {} carried no SID",
+                entry.name
+            );
+            // Any SID the OS handed back must be structurally valid —
+            // this is what proves the copy-out length arithmetic is right.
+            for sid in [&entry.app_package_sid, &entry.group_sid]
+                .into_iter()
+                .flatten()
+            {
+                assert!(
+                    sid_to_string(sid).is_some(),
+                    "derived SID for {} did not round-trip through ConvertSidToStringSid",
+                    entry.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn real_derived_sid_resolves_through_the_index() {
+        // End-to-end on real OS data: derive a capability SID, build an
+        // ACE around it, and confirm the walker recovers the name.
+        let built = build_capability_table_with_diagnostics();
+        let Some(entry) = built
+            .entries
+            .iter()
+            .find(|e| e.app_package_sid.is_some())
+            .cloned()
+        else {
+            // Host derived nothing; covered by the assertion above.
+            return;
+        };
+        let sid = entry.app_package_sid.clone().unwrap();
+        let index = CapabilityIndex::from_table(&built.entries);
+
+        let mut ace = vec![ACE_TYPE_ACCESS_ALLOWED, 0, 0, 0];
+        ace.extend_from_slice(&[0, 0, 0, 0]);
+        ace.extend_from_slice(&0x0012_0089u32.to_le_bytes());
+        ace.extend_from_slice(&sid);
+
+        let mut found = HashSet::new();
+        invoke_ace_walk_with_index_into(&ace, &index, false, &mut found).unwrap();
+        assert!(
+            found.contains(&entry.name),
+            "walker did not recover {} from a real derived SID",
+            entry.name
+        );
+    }
+
+    #[test]
+    fn repeated_table_builds_are_stable_and_do_not_leak_handles() {
+        // Each build does a LocalAlloc/LocalFree round-trip per name;
+        // repeating it must produce identical output.
+        let a = build_capability_table_with_diagnostics();
+        let b = build_capability_table_with_diagnostics();
+        assert_eq!(a.entries.len(), b.entries.len());
+        assert_eq!(a.derive_failures, b.derive_failures);
+        for (x, y) in a.entries.iter().zip(b.entries.iter()) {
+            assert_eq!(x.name, y.name);
+            assert_eq!(x.app_package_sid, y.app_package_sid);
+            assert_eq!(x.group_sid, y.group_sid);
+        }
     }
 }

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -69,6 +69,12 @@ const SID_SUB_AUTHORITY_SIZE: usize = 4;
 /// `ACCESS_ALLOWED_ACE_TYPE` — grants the access in the mask.
 const ACE_TYPE_ACCESS_ALLOWED: u8 = 0x00;
 /// `ACCESS_ALLOWED_CALLBACK_ACE_TYPE` — same grant, callback variant.
+///
+/// Recognized so the walker can reject it explicitly. A callback ACE
+/// carries a conditional-expression `OpaqueData` blob after the SID, and
+/// the only field that describes its length is `AceSize` — which this
+/// header layout does not carry. Its framing is therefore unresolvable
+/// here; see [`read_ace_at_offset`].
 const ACE_TYPE_ACCESS_ALLOWED_CALLBACK: u8 = 0x09;
 
 /// Capability names we want to recognize when their SID appears in an
@@ -586,6 +592,23 @@ fn read_ace_at_offset(buf: &[u8], cursor: usize) -> Result<AceSlice<'_>> {
         ));
     }
     let ace_type = buf[cursor + ACE_TYPE_OFFSET];
+    // A callback ACE is followed by a conditional-expression
+    // `OpaqueData` blob whose length lives in `AceSize` — a field this
+    // header layout does not carry. Advancing past the SID alone would
+    // read that opaque data as the next ACE header, so every ACE after
+    // it (and the capabilities they grant) would be decoded from
+    // attacker-influenced offsets. Refuse the blob instead: the caller
+    // stages matches and drops them on `Err`, so this is fail-closed.
+    // Lift this once a captured EventID=14 payload establishes the
+    // framing.
+    if ace_type == ACE_TYPE_ACCESS_ALLOWED_CALLBACK {
+        return Err(anyhow!(
+            "Unsupported callback ACE (type 0x{:02X}) at byte offset {}: its trailing OpaqueData \
+             has no length field in this header layout, so the rest of the blob cannot be framed.",
+            ACE_TYPE_ACCESS_ALLOWED_CALLBACK,
+            cursor
+        ));
+    }
     let ace_flags = buf[cursor + ACE_FLAGS_OFFSET];
     let access_mask = u32::from_le_bytes([
         buf[cursor + ACE_ACCESS_MASK_OFFSET],
@@ -673,10 +696,9 @@ pub fn invoke_ace_walk_with_index_into(
 
     while cursor < buf.len() {
         let ace = read_ace_at_offset(buf, cursor)?;
-        let is_allow_ace = matches!(
-            ace.ace_type,
-            ACE_TYPE_ACCESS_ALLOWED | ACE_TYPE_ACCESS_ALLOWED_CALLBACK
-        );
+        // Callback ACEs are rejected in `read_ace_at_offset`, so only the
+        // plain allow type can reach here.
+        let is_allow_ace = ace.ace_type == ACE_TYPE_ACCESS_ALLOWED;
         // An allow ACE that grants nothing is not evidence that the
         // workload needs the capability. Accepting zero-mask ACEs lets a
         // crafted DACL inject arbitrary capability names into the
@@ -973,10 +995,50 @@ mod tests {
         let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
         assert!(caps.is_empty(), "deny ACE must not produce capability");
 
-        // Allow-callback ACE (0x09) should still grant.
+        // A callback ACE (0x09) is followed by conditional OpaqueData
+        // with no length field in this header layout, so the walk cannot
+        // be framed past it. It must fail closed rather than grant.
         let buf = build_ace_typed(ACE_TYPE_ACCESS_ALLOWED_CALLBACK, GRANT, &sid);
-        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
-        assert!(caps.contains("internetClient"));
+        let err = invoke_ace_walk_with_index(&buf, &idx, false)
+            .expect_err("callback ACE framing is unresolvable and must be rejected");
+        assert!(
+            err.to_string().contains("callback ACE"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn callback_ace_aborts_the_walk_so_later_aces_are_never_misframed() {
+        // The bytes trailing a callback ACE are its OpaqueData, not the
+        // next ACE header. Decoding onward would resolve capabilities
+        // from attacker-chosen offsets, so the whole blob is refused.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+
+        let mut buf = build_ace(GRANT, &sid);
+        buf.extend_from_slice(&build_ace_typed(
+            ACE_TYPE_ACCESS_ALLOWED_CALLBACK,
+            GRANT,
+            &sid,
+        ));
+
+        let mut found = HashSet::new();
+        let err = invoke_ace_walk_with_index_into(&buf, &idx, false, &mut found)
+            .expect_err("a callback ACE must abort the walk");
+        assert!(
+            err.to_string().contains("callback ACE"),
+            "unexpected error: {err}"
+        );
+        // The walk stages as it goes, so the leading ACE is already in
+        // `found` when the error fires. That is the documented
+        // partial-write contract which obliges callers to pass a
+        // per-blob scratch set and discard it on `Err` — asserted here so
+        // the fail-closed duty stays visible if this test is revisited.
+        assert_eq!(
+            found.len(),
+            1,
+            "partial write expected; callers must discard this set on Err"
+        );
     }
 
     // ---- public entry points: extract_caps* ------------------------------

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -633,6 +633,16 @@ pub(crate) fn invoke_ace_walk_with_index(
 /// Walk every ACE in `buf`, inserting matched capability names into
 /// `found`. This is the shared implementation every other entry point
 /// funnels through.
+///
+/// **Partial results on error.** The walk inserts as it goes, so a
+/// buffer that decodes cleanly up to a corrupt tail leaves the
+/// already-matched names in `found` and still returns `Err`. This is
+/// deliberate: those earlier ACEs parsed correctly, and discarding them
+/// would lose real capability evidence because of an unrelated trailing
+/// byte. Callers must therefore treat `Err` as "this blob was truncated,
+/// count it as data loss" rather than "nothing was written" — see
+/// `access_failure::consume_access_failure`, which counts the failure
+/// into `parse_failures` while keeping the partial set.
 pub fn invoke_ace_walk_with_index_into(
     buf: &[u8],
     index: &CapabilityIndex,
@@ -1018,6 +1028,27 @@ mod tests {
         let mut buf = build_ace(GRANT, &sid);
         buf.extend_from_slice(&[0u8; 6]); // too short for another ACE
         assert!(invoke_ace_walk_with_index(&buf, &idx, false).is_err());
+    }
+
+    #[test]
+    fn truncated_tail_keeps_capabilities_matched_before_the_failure() {
+        // Pins the documented partial-result contract: the walk inserts
+        // as it goes, so names matched before a corrupt tail survive the
+        // Err. Callers rely on this (they count the failure rather than
+        // discarding the set), so a change here is a behavior change.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        let mut buf = build_ace(GRANT, &sid);
+        buf.extend_from_slice(&[0u8; 6]);
+
+        let mut found = HashSet::new();
+        let err = invoke_ace_walk_with_index_into(&buf, &idx, false, &mut found);
+
+        assert!(err.is_err(), "truncated tail must still report an error");
+        assert!(
+            found.contains("internetClient"),
+            "capabilities matched before the truncation must be retained"
+        );
     }
 
     #[test]

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -634,15 +634,14 @@ pub(crate) fn invoke_ace_walk_with_index(
 /// `found`. This is the shared implementation every other entry point
 /// funnels through.
 ///
-/// **Partial results on error.** The walk inserts as it goes, so a
+/// **Partial writes on error.** The walk inserts as it goes, so a
 /// buffer that decodes cleanly up to a corrupt tail leaves the
-/// already-matched names in `found` and still returns `Err`. This is
-/// deliberate: those earlier ACEs parsed correctly, and discarding them
-/// would lose real capability evidence because of an unrelated trailing
-/// byte. Callers must therefore treat `Err` as "this blob was truncated,
-/// count it as data loss" rather than "nothing was written" — see
-/// `access_failure::consume_access_failure`, which counts the failure
-/// into `parse_failures` while keeping the partial set.
+/// already-matched names in `found` *and* returns `Err`. Callers that
+/// feed a security policy must therefore treat `Err` as fail-closed:
+/// pass a per-blob scratch set and discard it on error rather than
+/// pointing this at their accumulated set. See
+/// `access_failure::consume_access_failure`, which stages into
+/// `ParseAccumulator::ace_matches` and only promotes on `Ok`.
 pub fn invoke_ace_walk_with_index_into(
     buf: &[u8],
     index: &CapabilityIndex,
@@ -1031,11 +1030,11 @@ mod tests {
     }
 
     #[test]
-    fn truncated_tail_keeps_capabilities_matched_before_the_failure() {
-        // Pins the documented partial-result contract: the walk inserts
-        // as it goes, so names matched before a corrupt tail survive the
-        // Err. Callers rely on this (they count the failure rather than
-        // discarding the set), so a change here is a behavior change.
+    fn truncated_tail_writes_partially_so_callers_must_stage() {
+        // Pins the low-level contract that motivates fail-closed
+        // staging in `consume_access_failure`: the walker DOES leave
+        // matches behind on error, which is exactly why a caller must
+        // not point it at an accumulated policy set.
         let sid = well_world_sid();
         let idx = cap_index_for(&sid, "internetClient");
         let mut buf = build_ace(GRANT, &sid);
@@ -1047,7 +1046,7 @@ mod tests {
         assert!(err.is_err(), "truncated tail must still report an error");
         assert!(
             found.contains("internetClient"),
-            "capabilities matched before the truncation must be retained"
+            "walker writes as it goes; callers must stage and discard on Err"
         );
     }
 

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -225,13 +225,6 @@ const KNOWN_CAPABILITIES: &[&str] = &[
     "cortanaSpeechAccessory",
 ];
 
-#[derive(Debug, Clone)]
-pub struct CapabilityEntry {
-    pub name: String,
-    pub app_package_sid: Option<Vec<u8>>,
-    pub group_sid: Option<Vec<u8>>,
-}
-
 #[cfg(target_os = "windows")]
 fn to_wide_z(s: &str) -> Vec<u16> {
     wxc_common::string_util::to_wide(s)
@@ -316,9 +309,14 @@ pub(crate) fn ascii_ci_cmp(a: &str, b: &str) -> std::cmp::Ordering {
 /// Capability names in stable display order.
 ///
 /// Extracted from the `plm extract-caps` CLI arm so the ordering is
-/// testable without spawning the binary.
-pub fn sorted_capability_names(caps: &HashSet<String>) -> Vec<&str> {
-    let mut out: Vec<&str> = caps.iter().map(String::as_str).collect();
+/// testable without spawning the binary. Generic over the element type
+/// so it serves both the borrowed set the extractor produces and the
+/// owned set carried in a `ParseResult`.
+pub fn sorted_capability_names<S>(caps: &HashSet<S>) -> Vec<&str>
+where
+    S: std::borrow::Borrow<str> + Eq + std::hash::Hash,
+{
+    let mut out: Vec<&str> = caps.iter().map(|s| s.borrow()).collect();
     out.sort_by(|a, b| ascii_ci_cmp(a, b));
     out
 }
@@ -329,26 +327,20 @@ pub fn known_capability_count() -> usize {
     KNOWN_CAPABILITIES.len()
 }
 
-/// Outcome of building the capability table, including how many known
-/// capability names the OS refused to resolve.
+/// Build the SID → capability index by calling
+/// `DeriveCapabilitySidsFromName` for each known capability.
 ///
-/// A silently-empty table is indistinguishable from "this workload
-/// needed no capabilities": every subsequent lookup misses and the
-/// generated config omits capabilities entirely. Callers use
-/// `derive_failures` / an empty `entries` to warn instead.
-pub struct CapabilityTable {
-    pub entries: Vec<CapabilityEntry>,
-    pub derive_failures: usize,
-}
-
-/// Build the table of (capability name, AppPackage SID, Group SID) tuples
-/// by calling `DeriveCapabilitySidsFromName` for each known capability.
-/// Capabilities the OS rejects are counted in `derive_failures` rather
-/// than silently dropped.
+/// The index is built directly rather than through an intermediate
+/// table: the OS is its only producer and every consumer wants the map,
+/// so the extra vector was pure conversion cost. Capabilities the OS
+/// rejects are counted in [`CapabilityIndex::derive_failures`] rather
+/// than silently dropped — an index that resolved nothing is
+/// indistinguishable from "this workload needed no capabilities",
+/// because every lookup misses and the generated config omits
+/// capabilities entirely.
 #[cfg(target_os = "windows")]
-pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
-    let mut out = Vec::with_capacity(KNOWN_CAPABILITIES.len());
-    let mut derive_failures = 0usize;
+pub fn build_capability_index() -> CapabilityIndex {
+    let mut index = CapabilityIndex::with_capacity(KNOWN_CAPABILITIES.len() * 2);
 
     for &name in KNOWN_CAPABILITIES {
         let wide = to_wide_z(name);
@@ -367,22 +359,21 @@ pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
             )
         };
         if ok.is_err() {
-            derive_failures += 1;
+            index.derive_failures += 1;
             continue;
         }
+        index.resolved_capabilities += 1;
 
         // First entry of each array is the canonical SID; alternate
         // encodings (when present) are not currently matched. Each is read
         // through a bounded slice (see `first_sid_bytes`) so the access is
         // tied to the count the OS reported rather than a raw dereference.
-        let app_package_sid = unsafe { first_sid_bytes(cap_sids, cap_count) };
-        let group_sid = unsafe { first_sid_bytes(group_sids, group_count) };
-
-        out.push(CapabilityEntry {
-            name: name.to_string(),
-            app_package_sid,
-            group_sid,
-        });
+        if let Some(sid) = unsafe { first_sid_bytes(cap_sids, cap_count) } {
+            index.insert_package_sid(sid, name);
+        }
+        if let Some(sid) = unsafe { first_sid_bytes(group_sids, group_count) } {
+            index.insert_group_sid(sid, name);
+        }
 
         unsafe {
             free_sid_array(cap_sids, cap_count);
@@ -390,27 +381,44 @@ pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
         }
     }
 
-    CapabilityTable {
-        entries: out,
-        derive_failures,
-    }
+    index
 }
 
 /// Non-Windows stub: there is no equivalent to
 /// `DeriveCapabilitySidsFromName` on Linux/macOS. Returning an empty
-/// table keeps the pure parts of this module (parse_hex_string, ACE
+/// index keeps the pure parts of this module (parse_hex_string, ACE
 /// byte walker, CapabilityIndex) callable in cross-platform tests.
 #[cfg(not(target_os = "windows"))]
-pub fn build_capability_table_with_diagnostics() -> CapabilityTable {
-    CapabilityTable {
-        entries: Vec::new(),
-        derive_failures: 0,
-    }
+pub fn build_capability_index() -> CapabilityIndex {
+    CapabilityIndex::with_capacity(0)
 }
 
-/// Convenience wrapper that discards the build diagnostics.
-pub fn build_capability_table() -> Vec<CapabilityEntry> {
-    build_capability_table_with_diagnostics().entries
+/// Build the capability index and report what this OS refused to
+/// resolve.
+///
+/// Discovery belongs at the CLI boundary rather than inside
+/// `parse_events`: querying the live OS mid-parse makes a fixed `.etl`
+/// fixture yield different results across Windows versions and
+/// impossible to exercise on non-Windows CI. Callers build the index
+/// here and inject it, so the parser itself is deterministic.
+pub fn discover_capabilities(verbose: bool) -> CapabilityIndex {
+    let index = build_capability_index();
+    if index.resolved_capabilities() == 0 {
+        eprintln!(
+            "warning: no AppContainer capability SIDs could be derived on this host \
+             ({} of {} known names rejected); no capabilities will be detected.",
+            index.derive_failures(),
+            known_capability_count()
+        );
+    } else if index.derive_failures() > 0 && verbose {
+        println!(
+            "Note: {} of {} known capability names were rejected by this OS and will not be \
+             matched.",
+            index.derive_failures(),
+            known_capability_count()
+        );
+    }
+    index
 }
 
 /// Encoded length of the SID at the front of `bytes`, or `None` when
@@ -464,57 +472,130 @@ pub fn sid_to_string(_sid_bytes: &[u8]) -> Option<String> {
     None
 }
 
-/// Result of resolving a SID against the capability table.
-pub enum SidResolution<'a> {
-    Capability(&'a str),
-    GroupCapability(&'a str),
-    Unknown,
-}
-
-/// Indexed view of a capability table for O(1) SID lookup. A linear
+/// Indexed view of the OS capability SIDs for O(1) lookup. A linear
 /// scan over ~150 entries per ACE dominates CPU time on traces with
 /// thousands of ACEs.
 ///
 /// The map keys are SID byte sequences; the value pairs the matched
 /// capability name with a flag distinguishing the package-SID variant
-/// (`false`) from the group-SID variant (`true`). Owns its keys so it
-/// can be carried alongside the table inside `ParseAccumulator` without
-/// the self-referential lifetime headaches that the previous
-/// borrowing form imposed on callers.
+/// (`false`) from the group-SID variant (`true`). It owns its keys so
+/// it can be carried inside `ParseAccumulator` without the
+/// self-referential lifetime headaches that a borrowing form imposes on
+/// callers.
+///
+/// Names are `&'static str` borrowed straight out of
+/// [`KNOWN_CAPABILITIES`], so resolving and staging a match allocates
+/// nothing — a `String` is materialized only when a capability is first
+/// promoted into a trace-wide result set.
 pub struct CapabilityIndex {
-    by_sid: HashMap<Vec<u8>, (String, bool)>,
+    by_sid: HashMap<Vec<u8>, (&'static str, bool)>,
+    resolved_capabilities: usize,
+    derive_failures: usize,
 }
+
+/// A `(capability name, package SID, group SID)` triple, as
+/// [`CapabilityIndex::for_test`] accepts them.
+#[cfg(test)]
+pub(crate) type TestCapabilityEntry<'a> = (&'static str, Option<&'a [u8]>, Option<&'a [u8]>);
 
 impl CapabilityIndex {
-    pub fn from_table(table: &[CapabilityEntry]) -> Self {
-        let mut by_sid: HashMap<Vec<u8>, (String, bool)> = HashMap::with_capacity(table.len() * 2);
-        for entry in table {
-            if let Some(s) = &entry.app_package_sid {
-                by_sid.insert(s.clone(), (entry.name.clone(), false));
-            }
-            if let Some(s) = &entry.group_sid {
-                // App-package SID wins on conflict (it's the canonical
-                // form); only insert the group SID when no entry exists.
-                by_sid
-                    .entry(s.clone())
-                    .or_insert((entry.name.clone(), true));
-            }
+    fn with_capacity(sids: usize) -> Self {
+        Self {
+            by_sid: HashMap::with_capacity(sids),
+            resolved_capabilities: 0,
+            derive_failures: 0,
         }
-        Self { by_sid }
     }
 
-    pub fn resolve<'a>(&'a self, sid_bytes: &[u8]) -> SidResolution<'a> {
-        if let Some((name, is_group)) = self.by_sid.get(sid_bytes) {
-            return if *is_group {
-                SidResolution::GroupCapability(name.as_str())
-            } else {
-                SidResolution::Capability(name.as_str())
-            };
+    fn insert_package_sid(&mut self, sid: Vec<u8>, name: &'static str) {
+        self.by_sid.insert(sid, (name, false));
+    }
+
+    fn insert_group_sid(&mut self, sid: Vec<u8>, name: &'static str) {
+        // App-package SID wins on conflict (it's the canonical form);
+        // only insert the group SID when no entry exists.
+        self.by_sid.entry(sid).or_insert((name, true));
+    }
+
+    /// Known capability names this OS resolved.
+    pub fn resolved_capabilities(&self) -> usize {
+        self.resolved_capabilities
+    }
+
+    /// Known capability names this OS refused to resolve.
+    pub fn derive_failures(&self) -> usize {
+        self.derive_failures
+    }
+
+    /// Resolve a SID to `(capability name, matched via the group SID)`.
+    ///
+    /// The `is_group` flag only distinguishes verbose diagnostic text;
+    /// both variants are equally strong evidence of a request, which is
+    /// why this is a flag rather than a dedicated enum.
+    pub fn resolve(&self, sid_bytes: &[u8]) -> Option<(&'static str, bool)> {
+        self.by_sid.get(sid_bytes).copied()
+    }
+
+    /// Test seam: iterate the indexed `(SID bytes, capability name,
+    /// matched via group SID)` triples. Lets the Windows FFI tests
+    /// validate what the OS actually handed back without reintroducing
+    /// an intermediate table on the production path.
+    #[cfg(test)]
+    pub(crate) fn iter_sids(&self) -> impl Iterator<Item = (&[u8], &'static str, bool)> {
+        self.by_sid
+            .iter()
+            .map(|(sid, (name, is_group))| (sid.as_slice(), *name, *is_group))
+    }
+
+    /// Test seam: build an index without touching the OS. Mirrors the
+    /// insertion order `build_capability_index` uses, so package SIDs
+    /// win over group SIDs exactly as they do in production.
+    #[cfg(test)]
+    pub(crate) fn for_test(entries: &[TestCapabilityEntry<'_>]) -> Self {
+        let mut index = Self::with_capacity(entries.len() * 2);
+        for &(name, package_sid, group_sid) in entries {
+            index.resolved_capabilities += 1;
+            if let Some(sid) = package_sid {
+                index.insert_package_sid(sid.to_vec(), name);
+            }
+            if let Some(sid) = group_sid {
+                index.insert_group_sid(sid.to_vec(), name);
+            }
         }
-        SidResolution::Unknown
+        index
     }
 }
 
+/// Per-trace scratch and diagnostics for the ACE walk.
+///
+/// Owned by the caller so one trace reuses a single hex-decode buffer
+/// and a single staging set, and so the zero-mask condition is counted
+/// per parse rather than once per process.
+#[derive(Default)]
+pub struct AceWalkState {
+    /// Reusable hex-decode buffer for the per-event ACE blob.
+    scratch: Vec<u8>,
+    /// Per-blob staging set. Entries are borrowed, so staging a match
+    /// costs no allocation no matter how many events repeat it.
+    pub(crate) matches: HashSet<&'static str>,
+    zero_mask_capabilities: usize,
+}
+
+impl AceWalkState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allow ACEs that named a known capability but granted nothing, and
+    /// so were not treated as capability requests.
+    pub fn zero_mask_capabilities(&self) -> usize {
+        self.zero_mask_capabilities
+    }
+}
+
+/// Decode a hex string into a fresh buffer. Test-only: production paths
+/// decode through [`AceWalkState`]'s reusable scratch buffer.
+#[cfg(test)]
 pub(crate) fn parse_hex_string(hex_input: &str) -> Result<Vec<u8>> {
     let mut out = Vec::new();
     parse_hex_string_into(hex_input, &mut out)?;
@@ -639,57 +720,23 @@ fn read_ace_at_offset(buf: &[u8], cursor: usize) -> Result<AceSlice<'_>> {
     })
 }
 
-/// Walk every ACE in `buf` and return the case-insensitively-deduped set
-/// of capability names matched along the way. When `verbose` is true, a
-/// per-ACE diagnostic line is emitted to stdout.
+/// Walk every ACE in `buf`, staging matched capability names in
+/// `found` and counting zero-mask hits in `zero_mask_capabilities`.
+/// When `verbose` is true a per-ACE diagnostic line goes to stdout.
 ///
-/// Emit a one-shot warning when a capability SID is recognized on an
-/// allow ACE that grants nothing.
-///
-/// Fires at most once per process so a long trace cannot spam the
-/// console. See the call site for why this is worth reporting.
-fn warn_zero_mask_capability_once(name: &str) {
-    static WARNED: std::sync::Once = std::sync::Once::new();
-    WARNED.call_once(|| {
-        eprintln!(
-            "warning: allow ACE for capability \"{name}\" has a zero access mask and was not \
-             treated as a capability request. If capabilities are missing from the generated \
-             config, this filter is the first thing to check."
-        );
-    });
-}
-
-/// Walk every ACE in `buf`, returning the matched capability names.
-/// Allocates a `HashSet` per call — hot-loop callers should prefer
-/// [`invoke_ace_walk_with_index_into`].
-#[cfg(test)]
-pub(crate) fn invoke_ace_walk_with_index(
+/// **Partial writes on error.** The walk stages as it goes, so a buffer
+/// that decodes cleanly up to a corrupt tail leaves the already-matched
+/// names in `found` *and* returns `Err`. Callers that feed a security
+/// policy must therefore treat `Err` as fail-closed: stage per blob and
+/// discard on error rather than pointing this at an accumulated set.
+/// See `access_failure::consume_access_failure`, which stages into
+/// `AceWalkState::matches` and only promotes on `Ok`.
+fn walk_aces(
     buf: &[u8],
     index: &CapabilityIndex,
     verbose: bool,
-) -> Result<HashSet<String>> {
-    let mut found: HashSet<String> = HashSet::new();
-    invoke_ace_walk_with_index_into(buf, index, verbose, &mut found)?;
-    Ok(found)
-}
-
-/// Walk every ACE in `buf`, inserting matched capability names into
-/// `found`. This is the shared implementation every other entry point
-/// funnels through.
-///
-/// **Partial writes on error.** The walk inserts as it goes, so a
-/// buffer that decodes cleanly up to a corrupt tail leaves the
-/// already-matched names in `found` *and* returns `Err`. Callers that
-/// feed a security policy must therefore treat `Err` as fail-closed:
-/// pass a per-blob scratch set and discard it on error rather than
-/// pointing this at their accumulated set. See
-/// `access_failure::consume_access_failure`, which stages into
-/// `ParseAccumulator::ace_matches` and only promotes on `Ok`.
-pub fn invoke_ace_walk_with_index_into(
-    buf: &[u8],
-    index: &CapabilityIndex,
-    verbose: bool,
-    found: &mut HashSet<String>,
+    found: &mut HashSet<&'static str>,
+    zero_mask_capabilities: &mut usize,
 ) -> Result<()> {
     let mut cursor = 0usize;
     let mut ace_index = 0usize;
@@ -707,43 +754,29 @@ pub fn invoke_ace_walk_with_index_into(
         let resolution = index.resolve(ace.sid_bytes);
 
         if is_allow_ace {
-            let matched = match &resolution {
-                SidResolution::Capability(name) | SidResolution::GroupCapability(name) => {
-                    Some(*name)
-                }
-                SidResolution::Unknown => None,
-            };
-            if let Some(name) = matched {
+            if let Some((name, _is_group)) = resolution {
                 if grants_access {
-                    // Only allocate when the name is genuinely new. The
-                    // set saturates at the handful of known capabilities
-                    // within the first few events, so an unconditional
-                    // `to_string()` would allocate-hash-drop on
-                    // essentially every remaining ACE in the trace.
-                    if !found.contains(name) {
-                        found.insert(name.to_string());
-                    }
+                    // Staging a borrowed name never allocates, so there
+                    // is no reason to test membership first.
+                    found.insert(name);
                 } else {
                     // The zero-mask filter above is a hardening measure
                     // derived from what a grant *should* look like, not
                     // from a captured trace. If this provider really does
                     // emit capability ACEs with an empty mask, the filter
-                    // would silently disable extraction entirely — so say
-                    // so once rather than failing quietly.
-                    warn_zero_mask_capability_once(name);
+                    // would silently disable extraction entirely — so
+                    // count it and let the caller report it once per
+                    // trace rather than failing quietly.
+                    *zero_mask_capabilities += 1;
                 }
             }
         }
 
         if verbose {
-            let resolved_str = match &resolution {
-                SidResolution::Capability(name) => format!("capability \"{name}\""),
-                SidResolution::GroupCapability(name) => {
-                    format!("capability \"{name}\" (group SID)")
-                }
-                SidResolution::Unknown => {
-                    "<no known capability/account matches this SID>".to_string()
-                }
+            let resolved_str = match resolution {
+                Some((name, false)) => format!("capability \"{name}\""),
+                Some((name, true)) => format!("capability \"{name}\" (group SID)"),
+                None => "<no known capability/account matches this SID>".to_string(),
             };
             let sid_str =
                 sid_to_string(ace.sid_bytes).unwrap_or_else(|| "<invalid SID>".to_string());
@@ -763,50 +796,40 @@ pub fn invoke_ace_walk_with_index_into(
     Ok(())
 }
 
-/// Convenience wrapper that builds a fresh capability table per call.
-/// Used by the one-shot `plm extract-caps` CLI path; any loop should
-/// build a [`CapabilityIndex`] once and use
-/// [`invoke_ace_walk_with_index_into`].
-pub fn invoke_ace_walk(buf: &[u8], verbose: bool) -> Result<HashSet<String>> {
-    let table = build_capability_table();
-    let index = CapabilityIndex::from_table(&table);
-    let mut found: HashSet<String> = HashSet::new();
-    invoke_ace_walk_with_index_into(buf, &index, verbose, &mut found)?;
-    Ok(found)
+/// One-shot entry point for the `plm extract-caps` CLI: decode a hex
+/// blob against a freshly built index and return what it matched.
+///
+/// Builds an index per call, so any loop should build a
+/// [`CapabilityIndex`] once and use [`extract_caps_into`] instead.
+pub fn extract_caps(hex_bytes: &str, verbose: bool) -> Result<HashSet<&'static str>> {
+    let index = build_capability_index();
+    let mut state = AceWalkState::new();
+    extract_caps_into(hex_bytes, &index, verbose, &mut state)?;
+    Ok(state.matches)
 }
 
-/// Top-level entry point matching the script's `-HexBytes` invocation.
-pub fn extract_caps(hex_bytes: &str, verbose: bool) -> Result<HashSet<String>> {
-    let bytes = parse_hex_string(hex_bytes)?;
-    invoke_ace_walk(&bytes, verbose)
-}
-
-/// Per-event variant that takes a pre-built `CapabilityIndex` so the
-/// O(table_size) build cost is paid once per parse, not per ACE blob.
-/// Allocates a fresh `HashSet` and decode buffer per call; the
-/// production hot loop uses [`extract_caps_with_index_into`] instead.
-#[cfg(test)]
-pub(crate) fn extract_caps_with_index(
+/// Hot-path entry point: decode `hex_bytes` through `state`'s scratch
+/// buffer and stage matches in `state.matches`, so a steady-state event
+/// costs no allocation at all.
+///
+/// `state.matches` is deliberately **not** cleared here — the staging
+/// set is the caller's fail-closed boundary, so the caller clears
+/// before each blob and promotes only on `Ok`.
+pub fn extract_caps_into(
     hex_bytes: &str,
     index: &CapabilityIndex,
     verbose: bool,
-) -> Result<HashSet<String>> {
-    let bytes = parse_hex_string(hex_bytes)?;
-    invoke_ace_walk_with_index(&bytes, index, verbose)
-}
-
-/// Hot-path variant: writes matches into a caller-provided
-/// `&mut HashSet<String>` and decodes through a caller-provided scratch
-/// buffer, so a steady-state event costs no allocation at all.
-pub fn extract_caps_with_index_into(
-    hex_bytes: &str,
-    index: &CapabilityIndex,
-    verbose: bool,
-    scratch: &mut Vec<u8>,
-    found: &mut HashSet<String>,
+    state: &mut AceWalkState,
 ) -> Result<()> {
+    // Destructured so the scratch buffer and the staging set are
+    // borrowed disjointly.
+    let AceWalkState {
+        scratch,
+        matches,
+        zero_mask_capabilities,
+    } = state;
     parse_hex_string_into(hex_bytes, scratch)?;
-    invoke_ace_walk_with_index_into(scratch, index, verbose, found)
+    walk_aces(scratch, index, verbose, matches, zero_mask_capabilities)
 }
 
 #[cfg(test)]
@@ -938,16 +961,31 @@ mod tests {
 
     #[test]
     fn capability_index_resolves_app_package_and_group_sids() {
-        let table = vec![CapabilityEntry {
-            name: "internetClient".into(),
-            app_package_sid: Some(well_world_sid()),
-            group_sid: None,
-        }];
-        let idx = CapabilityIndex::from_table(&table);
-        match idx.resolve(&well_world_sid()) {
-            SidResolution::Capability(n) => assert_eq!(n, "internetClient"),
-            _ => panic!("expected Capability"),
-        }
+        let sid = well_world_sid();
+        let idx = CapabilityIndex::for_test(&[("internetClient", Some(&sid), None)]);
+        assert_eq!(idx.resolve(&sid), Some(("internetClient", false)));
+
+        // The group SID resolves to the same name, flagged as a group
+        // match; an unknown SID resolves to nothing.
+        let group = vec![1u8, 1, 0, 0, 0, 0, 0, 5, 7, 0, 0, 0];
+        let idx = CapabilityIndex::for_test(&[("documentsLibrary", None, Some(&group))]);
+        assert_eq!(idx.resolve(&group), Some(("documentsLibrary", true)));
+        assert_eq!(idx.resolve(&sid), None);
+    }
+
+    #[test]
+    fn capability_index_prefers_the_package_sid_on_conflict() {
+        // Both names claim the same SID; the package variant is the
+        // canonical form and must win, exactly as it does when the OS
+        // builder inserts them.
+        let sid = well_world_sid();
+        let idx = CapabilityIndex::for_test(&[
+            ("internetClient", Some(&sid), None),
+            ("documentsLibrary", None, Some(&sid)),
+        ]);
+        assert_eq!(idx.resolve(&sid), Some(("internetClient", false)));
+        assert_eq!(idx.resolved_capabilities(), 2);
+        assert_eq!(idx.derive_failures(), 0);
     }
 
     fn build_ace_typed(ace_type: u8, mask: u32, sid: &[u8]) -> Vec<u8> {
@@ -960,46 +998,63 @@ mod tests {
         v
     }
 
+    /// Explicit walk setup. Production stages through an
+    /// [`AceWalkState`], so tests that only care about matched names
+    /// assemble the pieces here rather than keeping a wrapper on the
+    /// module's public surface that production never calls.
+    fn walk_with_zero_mask(
+        buf: &[u8],
+        index: &CapabilityIndex,
+    ) -> (Result<()>, HashSet<&'static str>, usize) {
+        let mut found = HashSet::new();
+        let mut zero_mask = 0usize;
+        let outcome = walk_aces(buf, index, false, &mut found, &mut zero_mask);
+        (outcome, found, zero_mask)
+    }
+
+    fn walk(buf: &[u8], index: &CapabilityIndex) -> Result<HashSet<&'static str>> {
+        let (outcome, found, _) = walk_with_zero_mask(buf, index);
+        outcome.map(|()| found)
+    }
+
+    /// Explicit hex-path setup, mirroring how the parser hot loop calls
+    /// [`extract_caps_into`].
+    fn extract(hex: &str, index: &CapabilityIndex) -> Result<HashSet<&'static str>> {
+        let mut state = AceWalkState::new();
+        extract_caps_into(hex, index, false, &mut state)?;
+        Ok(state.matches)
+    }
+
     #[test]
-    fn invoke_ace_walk_with_index_collects_matched_caps() {
+    fn ace_walk_collects_matched_caps() {
         let sid = well_world_sid();
-        let table = vec![CapabilityEntry {
-            name: "internetClient".into(),
-            app_package_sid: Some(sid.clone()),
-            group_sid: None,
-        }];
-        let idx = CapabilityIndex::from_table(&table);
+        let idx = cap_index_for(&sid, "internetClient");
 
         let mut buf = Vec::new();
         buf.extend_from_slice(&build_ace(GRANT, &sid));
         buf.extend_from_slice(&build_ace(GRANT, &sid));
 
-        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        let caps = walk(&buf, &idx).unwrap();
         assert!(caps.contains("internetClient"));
         assert_eq!(caps.len(), 1);
     }
 
     #[test]
-    fn invoke_ace_walk_skips_access_denied_ace() {
+    fn ace_walk_skips_access_denied_ace() {
         // R5-6: an ACCESS_DENIED ACE (type 0x01) for a capability SID
         // does NOT grant the capability and must not be promoted.
         let sid = well_world_sid();
-        let table = vec![CapabilityEntry {
-            name: "internetClient".into(),
-            app_package_sid: Some(sid.clone()),
-            group_sid: None,
-        }];
-        let idx = CapabilityIndex::from_table(&table);
+        let idx = cap_index_for(&sid, "internetClient");
 
         let buf = build_ace_typed(0x01, GRANT, &sid);
-        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        let caps = walk(&buf, &idx).unwrap();
         assert!(caps.is_empty(), "deny ACE must not produce capability");
 
         // A callback ACE (0x09) is followed by conditional OpaqueData
         // with no length field in this header layout, so the walk cannot
         // be framed past it. It must fail closed rather than grant.
         let buf = build_ace_typed(ACE_TYPE_ACCESS_ALLOWED_CALLBACK, GRANT, &sid);
-        let err = invoke_ace_walk_with_index(&buf, &idx, false)
+        let err = walk(&buf, &idx)
             .expect_err("callback ACE framing is unresolvable and must be rejected");
         assert!(
             err.to_string().contains("callback ACE"),
@@ -1022,9 +1077,8 @@ mod tests {
             &sid,
         ));
 
-        let mut found = HashSet::new();
-        let err = invoke_ace_walk_with_index_into(&buf, &idx, false, &mut found)
-            .expect_err("a callback ACE must abort the walk");
+        let (outcome, found, _) = walk_with_zero_mask(&buf, &idx);
+        let err = outcome.expect_err("a callback ACE must abort the walk");
         assert!(
             err.to_string().contains("callback ACE"),
             "unexpected error: {err}"
@@ -1032,7 +1086,7 @@ mod tests {
         // The walk stages as it goes, so the leading ACE is already in
         // `found` when the error fires. That is the documented
         // partial-write contract which obliges callers to pass a
-        // per-blob scratch set and discard it on `Err` — asserted here so
+        // per-blob staging set and discard it on `Err` — asserted here so
         // the fail-closed duty stays visible if this test is revisited.
         assert_eq!(
             found.len(),
@@ -1041,13 +1095,11 @@ mod tests {
         );
     }
 
-    // ---- public entry points: extract_caps* ------------------------------
+    // ---- public entry points: extract_caps_into --------------------------
     //
-    // the public surface (`extract_caps`,
-    // `extract_caps_with_index`, `extract_caps_with_index_into`) had
-    // no direct tests. Pin the hex-decode → ACE walk → resolve glue
-    // here so a regression in any of those layers fails fast rather
-    // than surfacing only via the WPR-driven integration harness.
+    // Pin the hex-decode → ACE walk → resolve glue so a regression in
+    // any of those layers fails fast rather than surfacing only via the
+    // WPR-driven integration harness.
 
     fn hex_for_bytes(bytes: &[u8]) -> String {
         use std::fmt::Write;
@@ -1059,61 +1111,49 @@ mod tests {
     }
 
     #[test]
-    fn extract_caps_with_index_decodes_hex_and_matches_capability() {
+    fn extract_caps_into_decodes_hex_and_matches_capability() {
         let sid = well_world_sid();
-        let table = vec![CapabilityEntry {
-            name: "documentsLibrary".into(),
-            app_package_sid: Some(sid.clone()),
-            group_sid: None,
-        }];
-        let idx = CapabilityIndex::from_table(&table);
+        let idx = cap_index_for(&sid, "documentsLibrary");
         let hex = hex_for_bytes(&build_ace(GRANT, &sid));
 
-        let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
+        let caps = extract(&hex, &idx).unwrap();
         assert!(caps.contains("documentsLibrary"));
         assert_eq!(caps.len(), 1);
     }
 
     #[test]
-    fn extract_caps_with_index_into_writes_into_caller_set() {
+    fn extract_caps_into_preserves_existing_staged_entries() {
         let sid = well_world_sid();
-        let table = vec![CapabilityEntry {
-            name: "internetClient".into(),
-            app_package_sid: Some(sid.clone()),
-            group_sid: None,
-        }];
-        let idx = CapabilityIndex::from_table(&table);
+        let idx = cap_index_for(&sid, "internetClient");
         let mut buf = Vec::new();
         buf.extend_from_slice(&build_ace(GRANT, &sid));
         buf.extend_from_slice(&build_ace(GRANT, &sid));
         let hex = hex_for_bytes(&buf);
 
-        // Pre-seed with an unrelated entry — extract_caps must
-        // PRESERVE existing members, not overwrite them.
-        let mut found: HashSet<String> = HashSet::new();
-        found.insert("preexisting".into());
-        let mut scratch = Vec::new();
-        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
-        assert!(found.contains("preexisting"));
-        assert!(found.contains("internetClient"));
+        // Pre-seed the staging set — `extract_caps_into` deliberately
+        // does not clear it, because clearing is the caller's
+        // fail-closed boundary.
+        let mut state = AceWalkState::new();
+        state.matches.insert("preexisting");
+        extract_caps_into(&hex, &idx, false, &mut state).unwrap();
+        assert!(state.matches.contains("preexisting"));
+        assert!(state.matches.contains("internetClient"));
     }
 
     #[test]
-    fn extract_caps_with_index_rejects_malformed_hex() {
-        let table: Vec<CapabilityEntry> = Vec::new();
-        let idx = CapabilityIndex::from_table(&table);
-        assert!(extract_caps_with_index("not-hex", &idx, false).is_err());
-        assert!(extract_caps_with_index("ABC", &idx, false).is_err());
+    fn extract_caps_into_rejects_malformed_hex() {
+        let idx = CapabilityIndex::for_test(&[]);
+        assert!(extract("not-hex", &idx).is_err());
+        assert!(extract("ABC", &idx).is_err());
     }
 
     #[test]
-    fn extract_caps_with_index_returns_empty_for_no_match() {
-        // SID doesn't match any capability entry in the table.
+    fn extract_caps_into_returns_empty_for_no_match() {
+        // SID doesn't match any capability entry in the index.
         let sid = well_world_sid();
-        let table: Vec<CapabilityEntry> = Vec::new();
-        let idx = CapabilityIndex::from_table(&table);
+        let idx = CapabilityIndex::for_test(&[]);
         let hex = hex_for_bytes(&build_ace(GRANT, &sid));
-        let caps = extract_caps_with_index(&hex, &idx, false).unwrap();
+        let caps = extract(&hex, &idx).unwrap();
         assert!(caps.is_empty());
     }
 
@@ -1124,12 +1164,8 @@ mod tests {
     // pin "errors, never panics, never over-reads" on the shapes a
     // hostile or truncated buffer can take.
 
-    fn cap_index_for(sid: &[u8], name: &str) -> CapabilityIndex {
-        CapabilityIndex::from_table(&[CapabilityEntry {
-            name: name.into(),
-            app_package_sid: Some(sid.to_vec()),
-            group_sid: None,
-        }])
+    fn cap_index_for(sid: &[u8], name: &'static str) -> CapabilityIndex {
+        CapabilityIndex::for_test(&[(name, Some(sid), None)])
     }
 
     #[test]
@@ -1139,11 +1175,29 @@ mod tests {
         // inject capability names into the generated policy.
         let sid = well_world_sid();
         let idx = cap_index_for(&sid, "internetClient");
-        let caps = invoke_ace_walk_with_index(&build_ace(0, &sid), &idx, false).unwrap();
+        let (outcome, caps, zero_mask) = walk_with_zero_mask(&build_ace(0, &sid), &idx);
+        outcome.unwrap();
         assert!(
             caps.is_empty(),
             "zero-mask allow ACE must not produce a capability"
         );
+        // Counted rather than warned inline, so the condition is
+        // reported once per trace and is assertable here.
+        assert_eq!(zero_mask, 1);
+    }
+
+    #[test]
+    fn zero_mask_counter_is_per_walk_not_per_process() {
+        // Regression guard for the process-global `Once` this replaced:
+        // two independent walks must each observe the condition, in any
+        // order, so test outcomes never depend on execution sequence.
+        let sid = well_world_sid();
+        let idx = cap_index_for(&sid, "internetClient");
+        for _ in 0..2 {
+            let (outcome, _, zero_mask) = walk_with_zero_mask(&build_ace(0, &sid), &idx);
+            outcome.unwrap();
+            assert_eq!(zero_mask, 1, "each walk counts independently");
+        }
     }
 
     #[test]
@@ -1155,7 +1209,7 @@ mod tests {
         let idx = cap_index_for(&sid, "internetClient");
         let mut buf = build_ace(GRANT, &sid);
         buf.extend_from_slice(&[0u8; 6]); // too short for another ACE
-        assert!(invoke_ace_walk_with_index(&buf, &idx, false).is_err());
+        assert!(walk(&buf, &idx).is_err());
     }
 
     #[test]
@@ -1169,10 +1223,12 @@ mod tests {
         let mut buf = build_ace(GRANT, &sid);
         buf.extend_from_slice(&[0u8; 6]);
 
-        let mut found = HashSet::new();
-        let err = invoke_ace_walk_with_index_into(&buf, &idx, false, &mut found);
+        let (outcome, found, _) = walk_with_zero_mask(&buf, &idx);
 
-        assert!(err.is_err(), "truncated tail must still report an error");
+        assert!(
+            outcome.is_err(),
+            "truncated tail must still report an error"
+        );
         assert!(
             found.contains("internetClient"),
             "walker writes as it goes; callers must stage and discard on Err"
@@ -1199,7 +1255,7 @@ mod tests {
         let buf = build_ace(GRANT, &sid);
         let ace = read_ace_at_offset(&buf, 0).expect("exact-fit ACE should decode");
         assert_eq!(ace.next_cursor, buf.len());
-        let caps = invoke_ace_walk_with_index(&buf, &idx, false).unwrap();
+        let caps = walk(&buf, &idx).unwrap();
         assert!(caps.contains("internetClient"));
     }
 
@@ -1209,21 +1265,20 @@ mod tests {
         let idx = cap_index_for(&sid, "internetClient");
         let mut buf = build_ace(GRANT, &sid);
         buf.push(0xFF);
-        assert!(invoke_ace_walk_with_index(&buf, &idx, false).is_err());
+        assert!(walk(&buf, &idx).is_err());
     }
 
     #[test]
     fn malformed_hex_shapes_are_rejected_without_panic() {
-        let idx = CapabilityIndex::from_table(&[]);
+        let idx = CapabilityIndex::for_test(&[]);
         for bad in ["ABC", "not-hex", "", "   \n", "AB CD E"] {
-            let mut scratch = Vec::new();
-            let mut found = HashSet::new();
+            let mut state = AceWalkState::new();
             assert!(
-                extract_caps_with_index_into(bad, &idx, false, &mut scratch, &mut found).is_err(),
+                extract_caps_into(bad, &idx, false, &mut state).is_err(),
                 "expected {bad:?} to be rejected"
             );
             assert!(
-                scratch.is_empty(),
+                state.scratch.is_empty(),
                 "scratch must be left clean after a failed decode"
             );
         }
@@ -1237,19 +1292,18 @@ mod tests {
         let sid = well_world_sid();
         let idx = cap_index_for(&sid, "internetClient");
         let hex = hex_for_bytes(&build_ace(GRANT, &sid));
-        let mut scratch = Vec::new();
-        let mut found = HashSet::new();
+        let mut state = AceWalkState::new();
 
-        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
-        let after_first = scratch.len();
-        extract_caps_with_index_into(&hex, &idx, false, &mut scratch, &mut found).unwrap();
+        extract_caps_into(&hex, &idx, false, &mut state).unwrap();
+        let after_first = state.scratch.len();
+        extract_caps_into(&hex, &idx, false, &mut state).unwrap();
 
         assert_eq!(
-            scratch.len(),
+            state.scratch.len(),
             after_first,
             "reused scratch must not accumulate across decodes"
         );
-        assert_eq!(found.len(), 1);
+        assert_eq!(state.matches.len(), 1);
     }
 
     #[test]
@@ -1296,44 +1350,33 @@ mod windows_ffi_tests {
     use super::*;
 
     #[test]
-    fn build_capability_table_derives_real_sids() {
-        let built = build_capability_table_with_diagnostics();
+    fn build_capability_index_derives_real_sids() {
+        let index = build_capability_index();
 
-        // Every known name is either derived or counted as a failure —
-        // entries must never silently disappear.
+        // Every known name is either resolved or counted as a failure —
+        // capabilities must never silently disappear.
         assert_eq!(
-            built.entries.len() + built.derive_failures,
+            index.resolved_capabilities() + index.derive_failures(),
             KNOWN_CAPABILITIES.len(),
             "every known capability must be either derived or counted as a failure"
         );
 
         // A stock Windows host resolves at least the common capabilities.
         // If this host resolves none, the diagnostics must say so rather
-        // than reporting a clean empty table.
-        if built.entries.is_empty() {
-            assert_eq!(built.derive_failures, KNOWN_CAPABILITIES.len());
+        // than reporting a clean empty index.
+        if index.resolved_capabilities() == 0 {
+            assert_eq!(index.derive_failures(), KNOWN_CAPABILITIES.len());
             return;
         }
 
-        for entry in &built.entries {
-            assert!(!entry.name.is_empty());
-            assert!(
-                entry.app_package_sid.is_some() || entry.group_sid.is_some(),
-                "derived entry {} carried no SID",
-                entry.name
-            );
+        for (sid, name, _is_group) in index.iter_sids() {
+            assert!(!name.is_empty());
             // Any SID the OS handed back must be structurally valid —
             // this is what proves the copy-out length arithmetic is right.
-            for sid in [&entry.app_package_sid, &entry.group_sid]
-                .into_iter()
-                .flatten()
-            {
-                assert!(
-                    sid_to_string(sid).is_some(),
-                    "derived SID for {} did not round-trip through ConvertSidToStringSid",
-                    entry.name
-                );
-            }
+            assert!(
+                sid_to_string(sid).is_some(),
+                "derived SID for {name} did not round-trip through ConvertSidToStringSid"
+            );
         }
     }
 
@@ -1341,18 +1384,11 @@ mod windows_ffi_tests {
     fn real_derived_sid_resolves_through_the_index() {
         // End-to-end on real OS data: derive a capability SID, build an
         // ACE around it, and confirm the walker recovers the name.
-        let built = build_capability_table_with_diagnostics();
-        let Some(entry) = built
-            .entries
-            .iter()
-            .find(|e| e.app_package_sid.is_some())
-            .cloned()
-        else {
+        let index = build_capability_index();
+        let Some((sid, name)) = index.iter_sids().next().map(|(s, n, _)| (s.to_vec(), n)) else {
             // Host derived nothing; covered by the assertion above.
             return;
         };
-        let sid = entry.app_package_sid.clone().unwrap();
-        let index = CapabilityIndex::from_table(&built.entries);
 
         let mut ace = vec![ACE_TYPE_ACCESS_ALLOWED, 0, 0, 0];
         ace.extend_from_slice(&[0, 0, 0, 0]);
@@ -1360,26 +1396,29 @@ mod windows_ffi_tests {
         ace.extend_from_slice(&sid);
 
         let mut found = HashSet::new();
-        invoke_ace_walk_with_index_into(&ace, &index, false, &mut found).unwrap();
+        let mut zero_mask = 0usize;
+        walk_aces(&ace, &index, false, &mut found, &mut zero_mask).unwrap();
         assert!(
-            found.contains(&entry.name),
-            "walker did not recover {} from a real derived SID",
-            entry.name
+            found.contains(name),
+            "walker did not recover {name} from a real derived SID"
         );
     }
 
     #[test]
-    fn repeated_table_builds_are_stable_and_do_not_leak_handles() {
+    fn repeated_index_builds_are_stable_and_do_not_leak_handles() {
         // Each build does a LocalAlloc/LocalFree round-trip per name;
         // repeating it must produce identical output.
-        let a = build_capability_table_with_diagnostics();
-        let b = build_capability_table_with_diagnostics();
-        assert_eq!(a.entries.len(), b.entries.len());
-        assert_eq!(a.derive_failures, b.derive_failures);
-        for (x, y) in a.entries.iter().zip(b.entries.iter()) {
-            assert_eq!(x.name, y.name);
-            assert_eq!(x.app_package_sid, y.app_package_sid);
-            assert_eq!(x.group_sid, y.group_sid);
-        }
+        let a = build_capability_index();
+        let b = build_capability_index();
+        assert_eq!(a.resolved_capabilities(), b.resolved_capabilities());
+        assert_eq!(a.derive_failures(), b.derive_failures());
+
+        let mut a_pairs: Vec<(Vec<u8>, &str, bool)> =
+            a.iter_sids().map(|(s, n, g)| (s.to_vec(), n, g)).collect();
+        let mut b_pairs: Vec<(Vec<u8>, &str, bool)> =
+            b.iter_sids().map(|(s, n, g)| (s.to_vec(), n, g)).collect();
+        a_pairs.sort();
+        b_pairs.sort();
+        assert_eq!(a_pairs, b_pairs);
     }
 }

--- a/src/host/plm/src/extract_caps.rs
+++ b/src/host/plm/src/extract_caps.rs
@@ -407,10 +407,30 @@ pub fn build_capability_table() -> Vec<CapabilityEntry> {
     build_capability_table_with_diagnostics().entries
 }
 
+/// Encoded length of the SID at the front of `bytes`, or `None` when
+/// `bytes` is too short to hold the fixed header or the sub-authority
+/// array that header declares.
+///
+/// This is the bounds check that must run *before* any raw pointer to
+/// `bytes` reaches Win32: the SID APIs read `8 + 4 * SubAuthorityCount`
+/// bytes through the pointer, and these blobs come from
+/// attacker-influenceable trace data.
+#[cfg(any(target_os = "windows", test))]
+fn encoded_sid_len(bytes: &[u8]) -> Option<usize> {
+    let sub_authority_count = *bytes.get(SID_SUB_AUTHORITY_COUNT_OFFSET)? as usize;
+    let len = SID_FIXED_HEADER_SIZE + SID_SUB_AUTHORITY_SIZE * sub_authority_count;
+    (bytes.len() >= len).then_some(len)
+}
+
 /// Best-effort string form of a SID for diagnostics. Returns `None` if the
 /// bytes aren't a valid SID.
 #[cfg(target_os = "windows")]
 pub fn sid_to_string(sid_bytes: &[u8]) -> Option<String> {
+    // `IsValidSid` dereferences the pointer to read the fixed header and
+    // the declared sub-authority array, so prove the slice is large
+    // enough first. Without this, callers passing a short slice (e.g.
+    // `&[]` or `&[1]`) make Win32 read past the end of the allocation.
+    encoded_sid_len(sid_bytes)?;
     let psid = PSID(sid_bytes.as_ptr() as *mut _);
     unsafe {
         if !IsValidSid(psid).as_bool() {
@@ -843,6 +863,53 @@ mod tests {
         sid.extend_from_slice(&[0, 0, 0, 0]); // only one sub_authority
         let buf = build_ace(0, &sid);
         assert!(read_ace_at_offset(&buf, 0).is_err());
+    }
+
+    // ---- SID bounds checking (no raw pointer reaches Win32 unproven) -----
+
+    #[test]
+    fn encoded_sid_len_accepts_a_well_formed_sid() {
+        // S-1-1-0: 8-byte fixed header + one 4-byte sub-authority.
+        assert_eq!(encoded_sid_len(&well_world_sid()), Some(12));
+    }
+
+    #[test]
+    fn encoded_sid_len_rejects_slices_shorter_than_the_fixed_header() {
+        // Nothing at all, and a slice too short to even hold the
+        // SubAuthorityCount byte, let alone the identifier authority.
+        assert_eq!(encoded_sid_len(&[]), None);
+        assert_eq!(encoded_sid_len(&[1]), None);
+        // Declares zero sub-authorities but is still one byte short of
+        // the 8-byte fixed header.
+        assert_eq!(encoded_sid_len(&[1, 0, 0, 0, 0, 0, 0]), None);
+    }
+
+    #[test]
+    fn encoded_sid_len_rejects_subauthority_count_beyond_the_slice() {
+        // Declares 5 sub-authorities (needs 28 bytes) but carries one.
+        let mut sid = vec![1u8, 5, 0, 0, 0, 0, 0, 1];
+        sid.extend_from_slice(&[0, 0, 0, 0]);
+        assert_eq!(encoded_sid_len(&sid), None);
+        // A count of 255 must not overflow into a small length.
+        let sid = vec![1u8, 255, 0, 0, 0, 0, 0, 1];
+        assert_eq!(encoded_sid_len(&sid), None);
+    }
+
+    #[test]
+    fn sid_to_string_rejects_undersized_slices_without_reading_out_of_bounds() {
+        // These are the inputs that previously handed an unproven
+        // pointer to `IsValidSid`. Each must be rejected by the Rust-side
+        // bounds check before Win32 sees the slice; a regression here is
+        // an out-of-bounds read rather than a failed assertion, so this
+        // is most valuable under a sanitizer.
+        assert_eq!(sid_to_string(&[]), None);
+        assert_eq!(sid_to_string(&[1]), None);
+        assert_eq!(sid_to_string(&[1, 0, 0, 0, 0, 0, 0]), None);
+
+        // Header claims more sub-authorities than the buffer holds.
+        let mut truncated = vec![1u8, 5, 0, 0, 0, 0, 0, 1];
+        truncated.extend_from_slice(&[0, 0, 0, 0]);
+        assert_eq!(sid_to_string(&truncated), None);
     }
 
     // ---- CapabilityIndex -------------------------------------------------

--- a/src/host/plm/src/lib.rs
+++ b/src/host/plm/src/lib.rs
@@ -10,6 +10,7 @@ pub mod access_failure;
 pub mod config;
 pub mod coordination;
 pub mod event_parser;
+pub mod extract_caps;
 pub mod profile_gen;
 
 #[cfg(target_os = "windows")]

--- a/src/host/plm/src/log.rs
+++ b/src/host/plm/src/log.rs
@@ -75,7 +75,10 @@ pub fn run(
     let cwd = std::env::current_dir()
         .ok()
         .map(|p| p.to_string_lossy().trim_end_matches('\\').to_string());
-    let parse = parse_events(&trace_file, cwd.as_deref(), verbose);
+    // Discover capability SIDs here, at the CLI boundary, so the parse
+    // itself is deterministic and can be driven with an injected index.
+    let capability_index = crate::extract_caps::discover_capabilities(verbose);
+    let parse = parse_events(&trace_file, cwd.as_deref(), verbose, capability_index);
 
     // Clean up the temp .etl regardless of parse outcome.
     let _ = std::fs::remove_file(&trace_file);

--- a/src/host/plm/src/main.rs
+++ b/src/host/plm/src/main.rs
@@ -6,8 +6,9 @@
 //! Subcommands:
 //! - `start`: cancel any active WPR trace and start a new one using
 //!   `plm.wprp!AccessFailureProfile`.
-//! - `stop`: stop the trace and write `trace.etl` into a log directory.
+//! - `stop`: stop the trace and process captured events.
 //! - `log`: interactive — Enter to start, Enter to stop.
+//! - `extract-caps`: standalone ACE decoder.
 //!
 //! The functional binary wraps WPR / ETW / EventLog APIs that have no
 //! cross-platform equivalent and is therefore Windows-only. On
@@ -36,7 +37,7 @@ use std::time::Duration;
 #[cfg(target_os = "windows")]
 use plm::coordination::{singleton_bypass_requested, wait_until_cleared, PLM_LOG_START_IN_FLIGHT};
 #[cfg(target_os = "windows")]
-use plm::{log, profile_gen, start, stop};
+use plm::{extract_caps, log, profile_gen, start, stop};
 
 /// Raw `HANDLE` value of the named-mutex singleton acquired by
 /// `acquire_singleton_if_needed` (zero when unheld). Stashed in a
@@ -261,6 +262,16 @@ enum Cmd {
         #[arg(long)]
         verbose_logging: bool,
     },
+    /// Run extract_caps on a hex-encoded ACE blob and print matched
+    /// capability names. Mirrors the standalone usage of extract_caps.ps1.
+    ExtractCaps {
+        /// Hex-encoded ACE buffer (whitespace allowed, even length).
+        #[arg(long)]
+        hex_bytes: String,
+        /// Emit per-ACE diagnostic output.
+        #[arg(long)]
+        verbose_logging: bool,
+    },
     /// Interactive: press Enter to start logging, press Enter again to stop.
     Log {
         /// Override path to plm.wprp. Defaults to <exe dir>\plm.wprp.
@@ -428,6 +439,18 @@ fn main() -> Result<()> {
                 },
                 &exe,
             )
+        }
+        Cmd::ExtractCaps {
+            hex_bytes,
+            verbose_logging,
+        } => {
+            let caps = extract_caps::extract_caps(&hex_bytes, verbose_logging)?;
+            let mut sorted: Vec<&String> = caps.iter().collect();
+            sorted.sort();
+            for c in sorted {
+                println!("{c}");
+            }
+            Ok(())
         }
         Cmd::Log {
             wprp,

--- a/src/host/plm/src/main.rs
+++ b/src/host/plm/src/main.rs
@@ -445,9 +445,7 @@ fn main() -> Result<()> {
             verbose_logging,
         } => {
             let caps = extract_caps::extract_caps(&hex_bytes, verbose_logging)?;
-            let mut sorted: Vec<&String> = caps.iter().collect();
-            sorted.sort();
-            for c in sorted {
+            for c in extract_caps::sorted_capability_names(&caps) {
                 println!("{c}");
             }
             Ok(())

--- a/src/host/plm/src/stop.rs
+++ b/src/host/plm/src/stop.rs
@@ -140,7 +140,10 @@ pub fn run(opts: StopOptions, exe_dir: &Path) -> Result<()> {
         .ok()
         .map(|p| p.to_string_lossy().trim_end_matches('\\').to_string());
 
-    let parse = parse_events(&trace_file, cwd.as_deref(), opts.verbose)?;
+    // Discover capability SIDs here, at the CLI boundary, so the parse
+    // itself is deterministic and can be driven with an injected index.
+    let capability_index = crate::extract_caps::discover_capabilities(opts.verbose);
+    let parse = parse_events(&trace_file, cwd.as_deref(), opts.verbose, capability_index)?;
 
     write_detection_summary(&parse.valid_access_events, &parse.requested_capabilities);
     write_requested_capabilities_summary(&parse.requested_capabilities, opts.verbose);


### PR DESCRIPTION
## 📖 Description

**PR 4 of 6** — stacked on PR3. Adds **capability extraction**.

- New `extract_caps` module: decodes the DACL ACE blob attached to each `EventID=14` event and resolves capability SIDs to names via `DeriveCapabilitySidsFromName`.
  - Process-static capability table (built once via `build_capability_table`) so the per-event hot path avoids the syscall + `LocalAlloc`/`LocalFree` round-trip.
  - `CapabilityIndex` for O(1) SID-bytes → name resolution per ACE.
- `event_parser`:
  - `ParsedEvent` gains `complex_data_4_idx` (index of the 5th `<ComplexData>` sibling — the ACE blob) so the largest per-event field is borrowed, not cloned.
  - `ParseAccumulator` gains the capability table/index.
- `access_failure::consume_access_failure` walks the ACE blob through `extract_caps_with_index_into` and accumulates `requested_capabilities`.
- `config::merge_capabilities` — full body replaces the PR3 stub. Resolves the containment sub-object case-insensitively, dedupes case-insensitively, sorts via an allocation-free ASCII compare, and emits a stderr warning when the backend has no `capabilities` array.
- New `plm extract-caps` CLI subcommand for parser debugging on a single hex ACE blob.

UI policy lands in PR5.

## 🔗 References

- Base: **PR3** (`user/lilybarkley/plm-pr3-config-gen`)
- Next: PR5 — UI policy (`EventID=27` decode + `uiPolicy` merge)

## 🔍 Validation

- `cargo build -p plm --target x86_64-pc-windows-msvc` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p plm --target x86_64-pc-windows-msvc --all-targets -- -D warnings` — clean
- `cargo test -p plm --target x86_64-pc-windows-msvc` — **52 passed** (15 new: ACE blob decode, capability dedupe/sort, `merge_capabilities` with mixed-case inputs and unsupported-backend warning path).

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/587)