### PR TITLE
Permissive Learning Mode 5/6 UI Policy

### DIFF
--- a/src/host/plm/readme.md
+++ b/src/host/plm/readme.md
@@ -1,37 +1,39 @@
 # PLM — Permissive Learning Mode
 
-`plm.exe` is the Windows-only trace driver for permissive learning mode. Long-form, it captures the access-denied events emitted by Windows' permissive sandbox layer, decodes them into structured findings, and merges those findings back into an MXC container config so the next enforcing run succeeds.
+`plm.exe` captures the access-denied events emitted by Windows' permissive sandbox layer, decodes them into structured findings, and (optionally) merges those findings back into an MXC container config so the next enforcing run succeeds without changes to the workload.
 
-This PR introduces **capability extraction**: `EventID=14` DACL ACE blobs are decoded into AppContainer capability names via `extract_caps`, and those names are merged into `processContainer.capabilities`. UI relaxation arrives in a subsequent PR.
-
-PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mode-permissive-learning-mode); the standalone CLI documented here is for capturing traces, interactive iteration, and debugging the parser itself.
+PLM is invoked automatically by [`wxc-exec --audit`](../../../README.md#audit-mode-permissive-learning-mode); the standalone CLI documented here is for re-processing captured traces, interactive iteration, and debugging the parser itself.
 
 ## How it works
 
 1. **Capture** — `plm start` calls `wpr -start <plm.wprp>!AccessFailureProfile -filemode`, enabling the `Microsoft-Windows-Privacy-Auditing-PermissiveLearningMode` and `Microsoft-Windows-Kernel-General` ETW providers in a secure realtime collector.
-2. **Run** — the operator runs the workload. The OS-side permissive sandbox logs `EventID=14` / `EventID=27` for every access that *would* have been denied.
+2. **Run** — the operator runs the workload. The OS-side permissive sandbox logs an `EventID=14` for every file/capability access that *would* have been denied, and an `EventID=27` for every UI operation that *would* have been blocked by a Win32k or Job UI Limit. Operations are allowed to proceed regardless.
 3. **Stop** — `plm stop` calls `wpr -stop <trace.etl>` and walks the `.etl` with `EvtQuery` / `EvtRender`.
-4. **Parse** — for each `EventID=14`, the parser pulls the file path / access mask and decodes the DACL ACE blob into AppContainer capability names. `EventID=27` UI relaxation lands in a later PR.
-5. **Merge** — file paths are added to `filesystem.readwritePaths` / `filesystem.readonlyPaths`; capability names are added to `processContainer.capabilities` (deduplicated case-insensitively against any capabilities already authored there, then sorted); results are written as `Adjusted_<name>.json` next to the captured trace.
+4. **Parse** — for each `EventID=14`, the parser pulls the file path / access mask and feeds the embedded DACL ACE blob to `DeriveCapabilitySidsFromName` to identify any AppContainer capability the process needed. For each `EventID=27`, it decodes the violation `Category` (`CONVERT_TO_GUI` or `UI_OPERATION`) and `Detail` bit (`JOB_OBJECT_UILIMIT_*`).
+5. **Merge** — when a `--config-path` is supplied, the findings are merged into a copy of the config and written as `Adjusted_<name>.json` next to the captured trace.
 
 > **Capability merge caveats.** Capabilities are only merged into a `processContainer` block — backends that cannot express AppContainer capabilities (LXC, Windows Sandbox, …) are left untouched and the discovered set is reported on stderr instead. The reserved names `learningModeLogging` and `permissiveLearningMode` are never written back, because `processContainer.capabilities` rejects them.
 
-## Layout (this PR)
+The schema mapping for UI relaxations is documented in [`docs/process-container/UIPolicy_Schema.md`](../../../docs/process-container/UIPolicy_Schema.md).
 
-| File                    | Role                                                                              |
-|-------------------------|-----------------------------------------------------------------------------------|
-| `src/main.rs`           | `clap` dispatch for `plm start` / `plm stop` / `plm log` / `plm extract-caps`     |
-| `src/start.rs`          | `wpr -cancel` (best-effort) + `wpr -start …!AccessFailureProfile -filemode`       |
-| `src/stop.rs`           | `wpr -stop` (or skip with `--trace-file`) + parse + FS/capability merge           |
-| `src/log.rs`            | Interactive mode: Enter to start, Enter to stop, then diff vs a blank config      |
-| `src/event_parser.rs`   | `EvtQuery` / `EvtRender` walk; shared `ParseAccumulator` + per-event dispatcher   |
-| `src/access_failure.rs` | `EventID=14` decoder: file-path normalization, post-XPath filters, ACE blob -> capabilities |
-| `src/access_event.rs`   | `LearningModeAccessEvent` plain struct                                            |
-| `src/extract_caps.rs`   | DACL ACE blob decoder; resolves capability SIDs via `DeriveCapabilitySidsFromName` |
-| `src/config.rs`         | JSON load/mutate; FS + capability merge into containment-backend section          |
-| `src/coordination.rs`   | Cross-process singleton named-mutex + bypass-env-var coordination for `plm log`   |
-| `src/wpr_path.rs`       | Resolves `wpr.exe` to its absolute `%SystemRoot%\System32` path (PATH-spoof-safe) |
-| `src/profile_gen.rs`    | Inline WPR profile (`EMBEDDED_WPRP`) + run-time writer that drops `plm.wprp` next to `plm.exe` when missing |
+## Layout
+
+| File                  | Role                                                                                |
+|-----------------------|-------------------------------------------------------------------------------------|
+| `src/main.rs`         | `clap` dispatch for `plm start` / `plm stop` / `plm log` / `plm extract-caps`       |
+| `src/start.rs`        | `wpr -cancel` (best-effort) + `wpr -start …!AccessFailureProfile -filemode`         |
+| `src/stop.rs`         | `wpr -stop` (or skip with `--trace-file`) + parse + merge + write `Adjusted_*.json` |
+| `src/log.rs`          | Interactive mode: Enter to start, Enter to stop, then diff vs a blank config        |
+| `src/event_parser.rs`   | `EvtQuery` / `EvtRender` walk; shared `ParseAccumulator` + per-event dispatcher |
+| `src/access_failure.rs` | `EventID=14` decoder: file-path normalization, post-XPath filters, ACE-blob ingestion |
+| `src/ui_violation.rs`   | `EventID=27` decoder: hex-payload + named-data parsers, category classification |
+| `src/extract_caps.rs` | ACE blob walk + `DeriveCapabilitySidsFromName` capability resolution                |
+| `src/config.rs`       | JSON load/mutate/save; path & capability merge; `apply_ui_operation_flags`          |
+| `src/access_event.rs` | `LearningModeAccessEvent` plain struct                                              |
+| `src/ui_limits.rs`    | `JOB_OBJECT_UILIMIT_*` constants + UI-violation category constants                  |
+| `src/coordination.rs` | Cross-process singleton named-mutex + bypass-env-var coordination for `plm log`     |
+| `src/wpr_path.rs`     | Resolves `wpr.exe` to its absolute `%SystemRoot%\System32` path (PATH-spoof-safe)   |
+| `src/profile_gen.rs`  | Inline WPR profile (`EMBEDDED_WPRP`) + run-time writer that drops `plm.wprp` next to `plm.exe` when missing |
 
 ## CLI
 
@@ -49,7 +51,7 @@ plm.exe start [--wprp <path>]
 
 ### `plm stop`
 
-Stops the active trace (or accepts a previously captured one).
+Stops the active trace (or re-parses an existing one), prints a detection summary, and writes `Adjusted_*.json` when a config is supplied.
 
 ```powershell
 plm.exe stop [--config-path <path>] [--log-dir <path>] [--bin-path <path>]
@@ -58,23 +60,79 @@ plm.exe stop [--config-path <path>] [--log-dir <path>] [--bin-path <path>]
 
 `--config-path` drives an in-memory merge of discovered file paths and capabilities against the input config and persists the result as `Adjusted_<name>.json` in the log directory. The adjusted config is written next to the operator's config snapshot in `--log-dir`; there is deliberately no flag to redirect it to an arbitrary path, because `plm.exe` runs elevated and an operator-named output path would be an admin-privileged arbitrary-write primitive. The write is atomic (temp file in the same directory, then rename over the destination) so a downstream enforcing run never observes a truncated policy.
 
-### `plm extract-caps`
+| Flag                      | Default                                  | Purpose                                                                              |
+|---------------------------|------------------------------------------|--------------------------------------------------------------------------------------|
+| `--config-path`           | *(none)*                                 | MXC container config (JSON) to merge findings into. Without it, only the summary is printed. |
+| `--log-dir`               | `<exe dir>\logs\<timestamp>`             | Destination for `trace.etl`, the copied input config, and `Adjusted_*.json`.         |
+| `--bin-path`              | `<exe dir>`                              | App binary location. Events targeting this exact path are skipped as self-access.    |
+| `--trace-file`            | `<log-dir>\trace.etl`                    | Re-process an existing `.etl` instead of stopping a live WPR session. Skips `wpr -stop`. |
+| `--verbose-logging`       | off                                      | Per-event / per-ACE diagnostics on stdout, including skip reasons.                   |
 
-Decode a raw hex-encoded DACL ACE buffer into a sorted list of AppContainer capability names. Useful for debugging the ACE decoder against ETW payloads dumped by other tools.
+The merge pipeline:
 
-```powershell
-plm.exe extract-caps --hex-bytes <hex> [--verbose-logging]
-```
+1. **File paths** — every `EventID=14` whose path passes the validity filters is added to `filesystem.readwritePaths` or `filesystem.readonlyPaths` based on the OR-ed access mask, excluding anything already in `filesystem.deniedPaths`.
+2. **Capabilities** — every resolved capability name not already present is appended to the containment block's `capabilities` array.
+3. **UI subsystem** — any `CONVERT_TO_GUI` violation flips `ui.disable` to `false` so Win32k syscalls succeed.
+4. **UI operations** — every `UI_OPERATION` violation contributes its `JOB_OBJECT_UILIMIT_*` bit to a mask which is then mapped per the [UI policy schema](../../../docs/process-container/UIPolicy_Schema.md) — e.g. `WRITECLIPBOARD` widens `ui.clipboard`, `HANDLES` relaxes `processContainer.ui.isolation`, `INJECTION` sets `ui.injection = true`.
+
+An `Adjusted_*.json` is written whenever the trace yielded *any* mergeable finding — file path, capability, `CONVERT_TO_GUI`, or `UI_OPERATION`.
 
 > **An empty result does not mean the blob contained no capabilities.** Only names on the module's built-in known-capability list are recognized, and only when the OS resolves them via `DeriveCapabilitySidsFromName` — names this Windows build rejects are skipped at table-build time, and any SID that is not in the resulting index is ignored. Capabilities are also only collected from *allow* ACEs that grant a non-zero access mask. Use `--verbose-logging` to see per-ACE decisions, including SIDs that resolved to nothing.
 
 ### `plm log`
 
-Interactive iteration mode: press Enter to start a trace, run the workload, press Enter again to stop. It then synthesizes a blank config, runs the filesystem merge, and prints the resulting config as a "diff against a blank config" preview.
+Interactive iteration mode: press Enter to start a trace, run the workload, press Enter again to stop. Prints the diff that would be applied to a blank (`{}`) config — useful for authoring a policy from scratch.
 
 ```powershell
 plm.exe log [--wprp <path>] [--verbose-logging]
 ```
+
+### `plm extract-caps`
+
+Standalone capability decoder for a hex-encoded ACE blob. Mirrors the original PowerShell `extract_caps.ps1` and is mainly useful for parser debugging.
+
+```powershell
+plm.exe extract-caps --hex-bytes "<hex>" [--verbose-logging]
+```
+
+## Workflow examples
+
+### From scratch with `wxc-exec`
+
+```powershell
+# wxc-exec --audit starts the trace, runs the workload in permissive mode,
+# stops the trace, and writes Adjusted_<config>.json next to the captured .etl.
+wxc-exec.exe --audit C:\policies\my-app.json
+```
+
+The adjusted config can be diff-ed against the input and copied back over the
+original once it looks right.
+
+### Manual capture / replay
+
+```powershell
+# 1. Start a trace.
+plm.exe start
+
+# 2. Run the workload to be profiled (anywhere — different shell is fine).
+my-app.exe
+
+# 3. Stop the trace and merge findings into a config.
+plm.exe stop --config-path C:\policies\my-app.json
+```
+
+### Re-process a captured trace
+
+Useful after editing the parser, or when an operator hands you a `.etl` from
+a machine without `plm.exe` installed:
+
+```powershell
+plm.exe stop --trace-file C:\temp\trace.etl `
+             --config-path C:\policies\my-app.json `
+             --log-dir   C:\temp\plm-out
+```
+
+`--trace-file` bypasses `wpr -stop`, so it works whether or not a WPR session is live.
 
 ## Building
 
@@ -87,15 +145,41 @@ cargo build -p plm --target x86_64-pc-windows-msvc
 cargo build -p plm --target x86_64-pc-windows-msvc --release
 ```
 
-The WPR profile is embedded into `plm.exe` itself (see `src/profile_gen.rs`); on first use of `plm start` / `plm log`, `profile_gen::ensure_wprp_next_to_exe` writes it to disk next to the binary if no `plm.wprp` is already present. `build.bat` from the repo root builds `plm.exe` and stages it next to `wxc-exec.exe` for the `--audit` integration.
+The WPR profile is embedded into `plm.exe` itself (see `src/profile_gen.rs`); on first use of `plm start` / `plm log`, `profile_gen::ensure_wprp_next_to_exe` writes it to disk next to the binary if no `plm.wprp` is already present. There is no separate file in the repo and nothing for `build.rs` to stage. `build.bat` from the repo root builds `plm.exe` and stages it next to `wxc-exec.exe` for the `--audit` integration.
+
+## ETW event reference
+
+| EventID | Provider                                                       | Meaning                                              | Decoded into                                |
+|---------|----------------------------------------------------------------|------------------------------------------------------|---------------------------------------------|
+| 14      | `Microsoft-Windows-Privacy-Auditing-PermissiveLearningMode`    | File / capability access that would have been denied | `valid_access_events`, `requested_capabilities` |
+| 27      | `Microsoft-Windows-Privacy-Auditing-PermissiveLearningMode`    | UI operation blocked by Job UI Limits or Win32k disable | `need_ui` (CONVERT_TO_GUI) or `ui_operation_flags` (UI_OPERATION) |
+
+The full `JOB_OBJECT_UILIMIT_*` constant set lives in
+[`src/ui_limits.rs`](src/ui_limits.rs) alongside the
+`CONVERT_TO_GUI` / `UI_OPERATION` category constants. UI events whose payload
+cannot be decoded are surfaced in `--verbose-logging` output and otherwise
+ignored — they do not contribute to either relaxation.
+
+## Filtering
+
+For transparency, `plm.exe stop` filters events at four layers; `--verbose-logging` prints a line for every skip:
+
+1. **WPR profile** — only the two providers above end up in the `.etl`.
+2. **EvtQuery XPath** — `*[System[EventID=14 or EventID=27]]` drops everything else.
+3. **EventID=14 post-filters** — skip `\Device\MountPointManager`, empty paths, paths under the current working directory at parse time, non-drive-letter paths, the app accessing its own binary, and paths containing illegal Win32 filename characters.
+4. **EventID=27 classification** — unknown categories are counted but contribute no relaxation; undecodable payloads are reported in verbose mode and otherwise ignored.
 
 ## Limitations
 
-- **Windows-only.** Uses `wpr.exe` and Job-Object UI-limit semantics that have no portable equivalent.
+- **Windows-only.** Uses `wpr.exe`, `EvtQuery`, `DeriveCapabilitySidsFromName`, and Job-Object UI-limit semantics that have no portable equivalent.
 - **Deny matching is enforced on literal, lexically-normalized paths only.** `config::normalize_path` strips verbatim/device prefixes, lowercases, collapses separators, and rejects ADS / `.` / `..`, but it is filesystem-free and does **not** resolve directory junctions, symlinks/reparse points, or 8.3 short names. 8.3 short-name aliases of a denied directory are detected lexically and refused promotion (fail-closed), but a junction/symlink alias (e.g. `C:\work\link` → `C:\Secrets`) is a lexically distinct path that will **not** match a deny entry and can therefore be promoted into the persisted `Adjusted_*.json`. Operators must deny the canonical target path; aliasing the target through a reparse point is a known gap. See the deny-matching code in `src/config.rs`.
-- **No UI extraction yet.** `plm stop` writes `Adjusted_<name>.json` with the discovered file paths and AppContainer capabilities. UI-policy extraction (`EventID=27`) arrives in a subsequent PR.
+- **AppContainer/BaseContainer scope.** Only operations gated by the OS permissive-learning-mode auditing layer produce events — plain Win32 access checks outside the AppContainer envelope are invisible to PLM.
+- **Capability names limited to `KNOWN_CAPABILITIES`.** New named capabilities require an entry in [`src/extract_caps.rs`](src/extract_caps.rs). Capabilities the local OS doesn't recognise via `DeriveCapabilitySidsFromName` are silently dropped at table-build time.
+- **No targeted UI grants.** `apply_ui_operation_flags` widens whole policy fields (e.g. `ui.injection = true`); the schema doesn't yet support per-target grants like `UserHandleGrantAccess`.
+- **`--audit` plumbing only forwards file configs.** Policies passed as base64 don't carry a path, so `wxc-exec --audit` runs `plm stop` without `--config-path` — you'll get the detection summary but no `Adjusted_*.json`. Run `plm stop --trace-file …` afterwards against the file form of the policy to merge.
 
 ## See also
 
+- [`docs/process-container/UIPolicy_Schema.md`](../../../docs/process-container/UIPolicy_Schema.md) — UI policy schema and `JOB_OBJECT_UILIMIT_*` mappings
 - [`docs/process-container/guide.md`](../../../docs/process-container/guide.md) — process-container backend overview
 - [README → Debugging → Audit Mode](../../../README.md#audit-mode-permissive-learning-mode) — `wxc-exec --audit` integration

--- a/src/host/plm/src/config.rs
+++ b/src/host/plm/src/config.rs
@@ -1,8 +1,8 @@
 //! Port of the config-update logic from `stop_plm_logging.ps1`.
 //!
-//! Reads an MXC container config (JSON) and merges discovered
-//! file-access paths and AppContainer capabilities into it, then writes
-//! the result out as `Adjusted_*.json`.
+//! Reads an MXC container config (JSON), merges discovered file-access
+//! paths and capabilities into it, and writes an `Adjusted_*.json` next
+//! to it.
 
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
@@ -530,13 +530,13 @@ pub fn update_from_access_events(
             }
         };
 
-        // Self-access filter: events whose path equals the audited
-        // application's binary (in any spelling — raw, verbatim,
-        // lower/upper case) are noise and skipped. The verbatim-prefixed
-        // variant matters because `stop.rs` canonicalises bin_path via
-        // `canonicalize()`, which on Windows returns the `\\?\C:\…` form
-        // while ETW reports the plain `C:\…` form; comparing only the
-        // raw strings let the binary path leak into the output
+        // Self-access filter: events whose path equals the wxc-exec
+        // binary (in any spelling — raw, verbatim, lower/upper case)
+        // are noise and skipped. The verbatim-prefixed variant matters
+        // because `stop.rs` canonicalises bin_path via `canonicalize()`,
+        // which on Windows returns the `\\?\C:\…` form while ETW
+        // reports the plain `C:\…` form; comparing only the raw strings
+        // let the binary path leak into the output
         // config as a readonly entry.
         let is_self_event = ev.file_path.eq_ignore_ascii_case(bin_path)
             || bin_path_norm
@@ -674,25 +674,249 @@ pub fn update_from_access_events(
     })
 }
 
-pub fn write_added_paths_summary(added: &AddedPaths, verbose: bool) {
-    // The added-paths summary is diagnostic chatter on stdout; only emit
-    // it when the caller asked for verbose output so a normal run leaves
-    // stdout for the generated config alone.
-    if !verbose {
-        return;
+/// Mirror of `Set-UISubsystemEnabled` in the PowerShell version.
+pub fn set_ui_subsystem_enabled(config: &mut Value) -> Result<()> {
+    let obj = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("config root must be a JSON object"))?;
+    if !obj.contains_key("ui") {
+        obj.insert("ui".into(), json!({}));
     }
-    println!();
-    if !added.readwrite.is_empty() {
-        println!("Added to readwritePaths ({}):", added.readwrite.len());
-        for p in &added.readwrite {
-            println!("  + {p}");
+    let ui = obj
+        .get_mut("ui")
+        .and_then(|v| v.as_object_mut())
+        .ok_or_else(|| anyhow::anyhow!("`ui` must be a JSON object"))?;
+    // CONVERT_TO_GUI violations mean the contained process needed the
+    // Win32k GUI subsystem. Set `ui.disable = false` unconditionally so
+    // the next run grants access (regardless of whether the key was
+    // present before).
+    ui.insert("disable".into(), Value::Bool(false));
+    println!("Enabling access to GUI subsystem ");
+    Ok(())
+}
+
+/// Apply the relaxations implied by the OR of `JOB_OBJECT_UILIMIT_*` bits
+/// observed in `UI_OPERATION` violations. Each bit names a UI limit the
+/// contained process tripped; the corresponding `ui.*` or
+/// `processContainer.ui.*` field is widened just enough to let the
+/// operation succeed next time.
+///
+/// Per `docs/process-container/UIPolicy_Schema.md` and the 0.7-alpha
+/// schema, cross-platform fields live at top-level `ui` while backend-
+/// specific fields live under `processContainer.ui`:
+///
+/// Top-level `ui` (cross-platform):
+/// * `READCLIPBOARD` / `WRITECLIPBOARD`  -> `ui.clipboard`
+/// * `INJECTION` -> `ui.injection = true`
+/// * `disable` is also cleared at top-level when any flag is applied.
+///
+/// `processContainer.ui` (Windows / process-container only):
+/// * `SYSTEMPARAMETERS` / `DISPLAYSETTINGS` -> `processContainer.ui.systemSettings`
+/// * `HANDLES` / `GLOBALATOMS` -> `processContainer.ui.isolation`
+/// * `DESKTOP` / `EXITWINDOWS` -> `processContainer.ui.desktopSystemControl = true`
+/// * `IME` -> `processContainer.ui.ime = true`
+///
+/// The function is additive: when a field already grants the requested
+/// operation it is left alone; when it grants the complementary half (e.g.
+/// existing `clipboard: "read"` plus a fresh `WRITECLIPBOARD` violation)
+/// the value is widened to `"all"`.
+pub fn apply_ui_operation_flags(config: &mut Value, flags: u32) -> Result<()> {
+    use crate::ui_limits::{
+        JOB_OBJECT_UILIMIT_DESKTOP, JOB_OBJECT_UILIMIT_DISPLAYSETTINGS,
+        JOB_OBJECT_UILIMIT_EXITWINDOWS, JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES,
+        JOB_OBJECT_UILIMIT_IME, JOB_OBJECT_UILIMIT_INJECTION, JOB_OBJECT_UILIMIT_READCLIPBOARD,
+        JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS, JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+    };
+
+    if flags == 0 {
+        return Ok(());
+    }
+
+    // Pre-compute which sub-trees we need to touch so each block can
+    // bail out early when its bits aren't set. Shape validation still
+    // happens inside each block, not up-front — callers that pass a
+    // malformed `processContainer` may see top-level `ui` already
+    // mutated when the inner branch errors out. Both callers
+    // (`log::run`, `stop::run`) propagate with `?` and discard the
+    // half-mutated value, so this is safe in practice.
+    let need_top_ui = flags
+        & (JOB_OBJECT_UILIMIT_READCLIPBOARD
+            | JOB_OBJECT_UILIMIT_WRITECLIPBOARD
+            | JOB_OBJECT_UILIMIT_INJECTION)
+        != 0
+        || flags != 0; // `disable: false` always written when flags != 0
+    let need_pc_ui = flags
+        & (JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS
+            | JOB_OBJECT_UILIMIT_DISPLAYSETTINGS
+            | JOB_OBJECT_UILIMIT_HANDLES
+            | JOB_OBJECT_UILIMIT_GLOBALATOMS
+            | JOB_OBJECT_UILIMIT_DESKTOP
+            | JOB_OBJECT_UILIMIT_EXITWINDOWS
+            | JOB_OBJECT_UILIMIT_IME)
+        != 0;
+
+    let obj = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("config root must be a JSON object"))?;
+
+    // -- top-level `ui` (clipboard / injection / disable) -----------------
+    if need_top_ui {
+        if !obj.contains_key("ui") {
+            obj.insert("ui".into(), json!({}));
+        }
+        let ui = obj
+            .get_mut("ui")
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| anyhow::anyhow!("`ui` must be a JSON object"))?;
+
+        let need_read = flags & JOB_OBJECT_UILIMIT_READCLIPBOARD != 0;
+        let need_write = flags & JOB_OBJECT_UILIMIT_WRITECLIPBOARD != 0;
+        if need_read || need_write {
+            let current = ui
+                .get("clipboard")
+                .and_then(|v| v.as_str())
+                .unwrap_or("none")
+                .to_string();
+            let (cur_r, cur_w) = clipboard_capabilities(&current);
+            let new = pick_clipboard(cur_r || need_read, cur_w || need_write);
+            ui.insert("clipboard".into(), Value::String(new.into()));
+        }
+
+        if flags & JOB_OBJECT_UILIMIT_INJECTION != 0 {
+            ui.insert("injection".into(), Value::Bool(true));
+        }
+
+        // A non-empty `ui.*` policy only makes sense with the GUI subsystem on.
+        // The schema default for `ui.disable` is `true`, in which case the
+        // runner silently ignores every other `ui.*` field — so when we are
+        // applying ANY relaxation (`flags != 0`), unconditionally insert
+        // `disable: false`. Without this, a UI_OPERATION-only trace (e.g.
+        // GLOBALATOMS-only, which doesn't co-fire CONVERT_TO_GUI) writes
+        // a config the runner discards — meaning the trace never converges.
+        ui.insert("disable".into(), Value::Bool(false));
+    }
+
+    // -- processContainer.ui (Windows backend-specific) -------------------
+    if need_pc_ui {
+        if !obj.contains_key("processContainer") {
+            obj.insert("processContainer".into(), json!({}));
+        }
+        let pc = obj
+            .get_mut("processContainer")
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| anyhow::anyhow!("`processContainer` must be a JSON object"))?;
+        if !pc.contains_key("ui") {
+            pc.insert("ui".into(), json!({}));
+        }
+        let pc_ui = pc
+            .get_mut("ui")
+            .and_then(|v| v.as_object_mut())
+            .ok_or_else(|| anyhow::anyhow!("`processContainer.ui` must be a JSON object"))?;
+
+        // -- systemSettings -----------------------------------------------
+        let need_params = flags & JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS != 0;
+        let need_display = flags & JOB_OBJECT_UILIMIT_DISPLAYSETTINGS != 0;
+        if need_params || need_display {
+            let current = pc_ui
+                .get("systemSettings")
+                .and_then(|v| v.as_str())
+                .unwrap_or("none")
+                .to_string();
+            let (cur_p, cur_d) = system_settings_capabilities(&current);
+            let new = pick_system_settings(cur_p || need_params, cur_d || need_display);
+            pc_ui.insert("systemSettings".into(), Value::String(new.into()));
+        }
+
+        // -- isolation ----------------------------------------------------
+        let need_other_handles = flags & JOB_OBJECT_UILIMIT_HANDLES != 0;
+        let need_global_atoms = flags & JOB_OBJECT_UILIMIT_GLOBALATOMS != 0;
+        if need_other_handles || need_global_atoms {
+            let current = pc_ui
+                .get("isolation")
+                .and_then(|v| v.as_str())
+                .unwrap_or("container")
+                .to_string();
+            let (cur_h, cur_a) = isolation_restrictions(&current);
+            let new_h = cur_h && !need_other_handles;
+            let new_a = cur_a && !need_global_atoms;
+            let new = pick_isolation(new_h, new_a);
+            pc_ui.insert("isolation".into(), Value::String(new.into()));
+        }
+
+        // -- desktopSystemControl (DESKTOP + EXITWINDOWS) -----------------
+        if flags & (JOB_OBJECT_UILIMIT_DESKTOP | JOB_OBJECT_UILIMIT_EXITWINDOWS) != 0 {
+            pc_ui.insert("desktopSystemControl".into(), Value::Bool(true));
+        }
+
+        // -- ime ----------------------------------------------------------
+        if flags & JOB_OBJECT_UILIMIT_IME != 0 {
+            pc_ui.insert("ime".into(), Value::Bool(true));
         }
     }
-    if !added.readonly.is_empty() {
-        println!("Added to readonlyPaths ({}):", added.readonly.len());
-        for p in &added.readonly {
-            println!("  + {p}");
-        }
+
+    Ok(())
+}
+
+fn clipboard_capabilities(value: &str) -> (bool, bool) {
+    // (can_read, can_write)
+    match value {
+        "all" => (true, true),
+        "read" => (true, false),
+        "write" => (false, true),
+        _ => (false, false), // "none" or anything unrecognised
+    }
+}
+
+fn pick_clipboard(read: bool, write: bool) -> &'static str {
+    match (read, write) {
+        (true, true) => "all",
+        (true, false) => "read",
+        (false, true) => "write",
+        (false, false) => "none",
+    }
+}
+
+fn system_settings_capabilities(value: &str) -> (bool, bool) {
+    // (can_params, can_display)
+    match value {
+        "all" => (true, true),
+        "parameters" => (true, false),
+        "display" => (false, true),
+        _ => (false, false),
+    }
+}
+
+fn pick_system_settings(params: bool, display: bool) -> &'static str {
+    match (params, display) {
+        (true, true) => "all",
+        (true, false) => "parameters",
+        (false, true) => "display",
+        (false, false) => "none",
+    }
+}
+
+fn isolation_restrictions(value: &str) -> (bool, bool) {
+    // (handles_restricted, atoms_restricted) for each isolation value.
+    // Per UIPolicy_Schema.md:
+    //   container = HANDLES + GLOBALATOMS
+    //   handles   = HANDLES
+    //   atoms     = GLOBALATOMS
+    //   desktop   = neither
+    match value {
+        "container" => (true, true),
+        "handles" => (true, false),
+        "atoms" => (false, true),
+        "desktop" => (false, false),
+        _ => (true, true),
+    }
+}
+
+fn pick_isolation(handles_restricted: bool, atoms_restricted: bool) -> &'static str {
+    match (handles_restricted, atoms_restricted) {
+        (true, true) => "container",
+        (true, false) => "handles",
+        (false, true) => "atoms",
+        (false, false) => "desktop",
     }
 }
 
@@ -758,9 +982,10 @@ pub fn save_adjusted_config(config: &Value, path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Decode a Windows file access mask into a |-separated list of the
-/// mnemonic flag names PLM cares about. Unknown bits are reported as a
-/// trailing OTHER(0x...) token so nothing is silently dropped.
+/// Decode a Windows file access mask into a `|`-separated list of the
+/// mnemonic flag names PLM cares about (the same constants used to
+/// classify read vs. write above). Unknown bits are reported as a
+/// trailing `OTHER(0x...)` token so nothing is silently dropped.
 fn decode_access_mask(mask: u32) -> String {
     let mut parts: Vec<&str> = Vec::new();
     let mut covered: u32 = 0;
@@ -772,6 +997,8 @@ fn decode_access_mask(mask: u32) -> String {
     }
     let leftover = mask & !covered;
     if leftover != 0 {
+        // Render leftover bits as a hex token; allocate into a static-
+        // lifetime-free string by appending after join.
         let joined = parts.join("|");
         if joined.is_empty() {
             return format!("OTHER(0x{leftover:X})");
@@ -796,10 +1023,17 @@ fn classify_mask(mask: u32) -> &'static str {
     }
 }
 
-/// Print every unique file path observed in vents with the OR-ed
+/// Print every unique file path observed in `events` with the OR-ed
 /// access mask requested against it, plus the set of capabilities
-/// discovered in the trace. UI-violation summary lands in a later PR.
-pub fn write_detection_summary(events: &[LearningModeAccessEvent], capabilities: &HashSet<String>) {
+/// discovered in the trace. Always emitted (independent of verbose).
+pub fn write_detection_summary(
+    events: &[LearningModeAccessEvent],
+    capabilities: &HashSet<String>,
+    ui_event_count: u32,
+    ui_events: &[crate::ui_limits::UiEvent],
+    ui_operation_flags: u32,
+) {
+    use crate::ui_limits::{ui_limit_name, CONVERT_TO_GUI, UI_OPERATION};
     use std::collections::BTreeMap;
 
     let mut per_path: BTreeMap<&str, u32> = BTreeMap::new();
@@ -824,6 +1058,78 @@ pub fn write_detection_summary(events: &[LearningModeAccessEvent], capabilities:
     }
 
     println!();
+    println!(
+        "Detected UI injection events ({ui_event_count}, parsed {}):",
+        ui_events.len()
+    );
+    if ui_event_count == 0 {
+        println!("  (none)");
+    } else {
+        let mut convert_to_gui = 0u32;
+        let mut ui_operation = 0u32;
+        if ui_events.is_empty() {
+            println!("  (no payloads could be decoded)");
+        } else {
+            for ui in ui_events {
+                let denied = match ui.denied {
+                    Some(true) => "denied",
+                    Some(false) => "allowed",
+                    None => "denied=(absent)",
+                };
+                let category_name = match ui.category {
+                    CONVERT_TO_GUI => "CONVERT_TO_GUI",
+                    UI_OPERATION => "UI_OPERATION",
+                    _ => "UNKNOWN",
+                };
+                let detail_name = if ui.category == UI_OPERATION {
+                    ui_limit_name(ui.detail).unwrap_or("UNKNOWN")
+                } else {
+                    "-"
+                };
+                println!(
+                    "  + {} pid={} seq={} category=0x{:08X} ({}) detail=0x{:08X} ({}) {}",
+                    if ui.process_name.is_empty() {
+                        "(unknown)"
+                    } else {
+                        ui.process_name.as_str()
+                    },
+                    ui.process_id,
+                    ui.sequence_number,
+                    ui.category,
+                    category_name,
+                    ui.detail,
+                    detail_name,
+                    denied,
+                );
+                match ui.category {
+                    CONVERT_TO_GUI => convert_to_gui += 1,
+                    UI_OPERATION => ui_operation += 1,
+                    _ => {}
+                }
+            }
+        }
+        if convert_to_gui > 0 {
+            println!("  + ui.disable will be set to false (UI subsystem required)");
+        }
+        if ui_operation > 0 {
+            println!(
+                "  + ui.* / processContainer.ui.* policy will be relaxed for blocked operations (flags=0x{:04X}):",
+                ui_operation_flags
+            );
+            for bit_pos in 0..16 {
+                let bit = 1u32 << bit_pos;
+                if ui_operation_flags & bit != 0 {
+                    println!(
+                        "      - 0x{:04X} ({})",
+                        bit,
+                        ui_limit_name(bit).unwrap_or("UNKNOWN")
+                    );
+                }
+            }
+        }
+    }
+
+    println!();
     println!("Detected capabilities ({}):", capabilities.len());
     if capabilities.is_empty() {
         println!("  (none)");
@@ -832,6 +1138,28 @@ pub fn write_detection_summary(events: &[LearningModeAccessEvent], capabilities:
         sorted.sort();
         for c in sorted {
             println!("  + {c}");
+        }
+    }
+}
+
+pub fn write_added_paths_summary(added: &AddedPaths, verbose: bool) {
+    // The added-paths summary is diagnostic chatter on stdout; only emit
+    // it when the caller asked for verbose output so a normal run leaves
+    // stdout for the generated config alone.
+    if !verbose {
+        return;
+    }
+    println!();
+    if !added.readwrite.is_empty() {
+        println!("Added to readwritePaths ({}):", added.readwrite.len());
+        for p in &added.readwrite {
+            println!("  + {p}");
+        }
+    }
+    if !added.readonly.is_empty() {
+        println!("Added to readonlyPaths ({}):", added.readonly.len());
+        for p in &added.readonly {
+            println!("  + {p}");
         }
     }
 }
@@ -1488,6 +1816,372 @@ mod tests {
     fn initialize_filesystem_rejects_wrong_typed_filesystem() {
         let mut cfg = json!({ "filesystem": "deny" });
         assert!(initialize_filesystem(&mut cfg).is_err());
+    }
+
+    #[test]
+    fn set_ui_subsystem_enabled_rejects_non_object_ui() {
+        let mut cfg = json!({ "ui": "disabled" });
+        assert!(set_ui_subsystem_enabled(&mut cfg).is_err());
+    }
+
+    #[test]
+    fn set_ui_subsystem_enabled_always_writes_false() {
+        // Was previously inverted -- this locks in the fix.
+        let mut cfg = json!({});
+        set_ui_subsystem_enabled(&mut cfg).unwrap();
+        assert_eq!(cfg["ui"]["disable"], json!(false));
+
+        let mut cfg2 = json!({ "ui": { "disable": true } });
+        set_ui_subsystem_enabled(&mut cfg2).unwrap();
+        assert_eq!(cfg2["ui"]["disable"], json!(false));
+    }
+
+    // ---- apply_ui_operation_flags ----------------------------------------
+
+    #[test]
+    fn apply_ui_flags_clipboard_widens_to_all() {
+        use crate::ui_limits::{
+            JOB_OBJECT_UILIMIT_READCLIPBOARD, JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+        };
+        let mut cfg = json!({});
+        apply_ui_operation_flags(
+            &mut cfg,
+            JOB_OBJECT_UILIMIT_READCLIPBOARD | JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+        )
+        .unwrap();
+        assert_eq!(cfg["ui"]["clipboard"], json!("all"));
+    }
+
+    // asymmetric / widening clipboard branches.
+
+    #[test]
+    fn apply_ui_flags_read_clipboard_only_sets_read() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_READCLIPBOARD;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_READCLIPBOARD).unwrap();
+        assert_eq!(cfg["ui"]["clipboard"], json!("read"));
+    }
+
+    #[test]
+    fn apply_ui_flags_write_clipboard_only_sets_write() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_WRITECLIPBOARD;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_WRITECLIPBOARD).unwrap();
+        assert_eq!(cfg["ui"]["clipboard"], json!("write"));
+    }
+
+    #[test]
+    fn apply_ui_flags_read_widens_existing_write_to_all() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_READCLIPBOARD;
+        let mut cfg = json!({ "ui": { "clipboard": "write" } });
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_READCLIPBOARD).unwrap();
+        assert_eq!(cfg["ui"]["clipboard"], json!("all"));
+    }
+
+    #[test]
+    fn apply_ui_flags_write_widens_existing_read_to_all() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_WRITECLIPBOARD;
+        let mut cfg = json!({ "ui": { "clipboard": "read" } });
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_WRITECLIPBOARD).unwrap();
+        assert_eq!(cfg["ui"]["clipboard"], json!("all"));
+    }
+
+    #[test]
+    fn apply_ui_flags_system_settings_widening_from_existing_parameters() {
+        // pre-existing "parameters" + new DISPLAYSETTINGS → "all"
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_DISPLAYSETTINGS;
+        let mut cfg = json!({ "processContainer": { "ui": { "systemSettings": "parameters" } } });
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_DISPLAYSETTINGS).unwrap();
+        assert_eq!(
+            cfg["processContainer"]["ui"]["systemSettings"],
+            json!("all")
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_ime_sets_true() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_IME;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_IME).unwrap();
+        assert_eq!(cfg["processContainer"]["ui"]["ime"], json!(true));
+    }
+
+    #[test]
+    fn apply_ui_flags_desktop_or_exitwindows_sets_desktop_system_control() {
+        use crate::ui_limits::{JOB_OBJECT_UILIMIT_DESKTOP, JOB_OBJECT_UILIMIT_EXITWINDOWS};
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_DESKTOP).unwrap();
+        assert_eq!(
+            cfg["processContainer"]["ui"]["desktopSystemControl"],
+            json!(true)
+        );
+
+        let mut cfg2 = json!({});
+        apply_ui_operation_flags(&mut cfg2, JOB_OBJECT_UILIMIT_EXITWINDOWS).unwrap();
+        assert_eq!(
+            cfg2["processContainer"]["ui"]["desktopSystemControl"],
+            json!(true)
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_injection_sets_true() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_INJECTION;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_INJECTION).unwrap();
+        assert_eq!(cfg["ui"]["injection"], json!(true));
+    }
+
+    #[test]
+    fn apply_ui_flags_rejects_non_object_ui() {
+        let mut cfg = json!({ "ui": null });
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_IME;
+        assert!(apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_IME).is_err());
+    }
+
+    #[test]
+    fn apply_ui_flags_rejects_non_object_process_container() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_IME;
+        let mut cfg = json!({ "processContainer": "not-an-object" });
+        let err = apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_IME)
+            .expect_err("non-object processContainer must error");
+        assert!(
+            err.to_string().contains("processContainer"),
+            "error must identify the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_rejects_non_object_process_container_ui() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_GLOBALATOMS;
+        let mut cfg = json!({ "processContainer": { "ui": null } });
+        let err = apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_GLOBALATOMS)
+            .expect_err("non-object processContainer.ui must error");
+        assert!(
+            err.to_string().contains("processContainer.ui"),
+            "error must identify the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_always_sets_disable_false_when_any_flag_applied() {
+        // schema default for `ui.disable` is `true`,
+        // in which case the runner ignores all other ui.* fields. We must
+        // unconditionally clear it whenever ANY relaxation is applied so
+        // a UI_OPERATION-only trace (e.g. GLOBALATOMS) actually converges.
+        use crate::ui_limits::{JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_IME};
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_GLOBALATOMS).unwrap();
+        assert_eq!(cfg["ui"]["disable"], json!(false));
+
+        let mut cfg2 = json!({});
+        apply_ui_operation_flags(&mut cfg2, JOB_OBJECT_UILIMIT_IME).unwrap();
+        assert_eq!(cfg2["ui"]["disable"], json!(false));
+
+        // No-op when flags == 0: no `ui` object created.
+        let mut cfg3 = json!({});
+        apply_ui_operation_flags(&mut cfg3, 0).unwrap();
+        assert!(cfg3.get("ui").is_none());
+    }
+
+    // explicit coverage for the systemSettings and
+    // isolation branches that were previously only exercised indirectly.
+
+    #[test]
+    fn apply_ui_flags_system_parameters_widens_system_settings() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS).unwrap();
+        assert_eq!(
+            cfg["processContainer"]["ui"]["systemSettings"],
+            json!("parameters")
+        );
+        assert_eq!(cfg["ui"]["disable"], json!(false));
+    }
+
+    #[test]
+    fn apply_ui_flags_display_settings_widens_system_settings() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_DISPLAYSETTINGS;
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_DISPLAYSETTINGS).unwrap();
+        assert_eq!(
+            cfg["processContainer"]["ui"]["systemSettings"],
+            json!("display")
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_system_params_and_display_combine_to_all() {
+        use crate::ui_limits::{
+            JOB_OBJECT_UILIMIT_DISPLAYSETTINGS, JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS,
+        };
+        let mut cfg = json!({});
+        apply_ui_operation_flags(
+            &mut cfg,
+            JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS | JOB_OBJECT_UILIMIT_DISPLAYSETTINGS,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg["processContainer"]["ui"]["systemSettings"],
+            json!("all")
+        );
+    }
+
+    #[test]
+    fn apply_ui_flags_handles_relaxes_isolation_to_atoms() {
+        use crate::ui_limits::JOB_OBJECT_UILIMIT_HANDLES;
+        // Default isolation is "container" (handles + atoms restricted);
+        // granting HANDLES drops the handles restriction → "atoms".
+        let mut cfg = json!({});
+        apply_ui_operation_flags(&mut cfg, JOB_OBJECT_UILIMIT_HANDLES).unwrap();
+        assert_eq!(cfg["processContainer"]["ui"]["isolation"], json!("atoms"));
+    }
+
+    #[test]
+    fn apply_ui_flags_handles_and_global_atoms_drop_to_desktop_isolation() {
+        use crate::ui_limits::{JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES};
+        let mut cfg = json!({});
+        apply_ui_operation_flags(
+            &mut cfg,
+            JOB_OBJECT_UILIMIT_HANDLES | JOB_OBJECT_UILIMIT_GLOBALATOMS,
+        )
+        .unwrap();
+        assert_eq!(cfg["processContainer"]["ui"]["isolation"], json!("desktop"));
+    }
+
+    // ---- merge_capabilities ----------------------------------------------
+
+    #[test]
+    fn merge_capabilities_dedups_case_insensitively_and_sorts() {
+        // Existing config pre-seeds the camelCase key the schema requires.
+        let mut cfg = json!({
+            "containment": "processcontainer",
+            "processContainer": { "capabilities": ["InternetClient"] }
+        });
+        let req: HashSet<String> = ["internetclient", "registryRead"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        let caps = cfg["processContainer"]["capabilities"].as_array().unwrap();
+        // Only one of {InternetClient, internetclient} survives, plus
+        // registryRead. Result is case-insensitively sorted.
+        let names: Vec<&str> = caps.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(names.len(), 2);
+        assert!(names
+            .iter()
+            .any(|n| n.eq_ignore_ascii_case("internetclient")));
+        assert!(names.iter().any(|n| n.eq_ignore_ascii_case("registryRead")));
+    }
+
+    /// PLM previously used the `containment` enum value (lowercase
+    /// `processcontainer`) as the sub-object key. The schema requires
+    /// camelCase `processContainer`. The merge no longer synthesizes a
+    /// missing block at all (see
+    /// `merge_capabilities_is_noop_without_process_container`), but when
+    /// one exists under any spelling it must be reused rather than
+    /// duplicated under a second casing.
+    #[test]
+    fn merge_capabilities_reuses_existing_block_without_adding_a_second_casing() {
+        let mut cfg = json!({ "processcontainer": { "capabilities": [] } });
+        let req: HashSet<String> = ["internetClient"].iter().map(|s| s.to_string()).collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        assert!(
+            cfg.get("processContainer").is_none(),
+            "must not insert a second camelCase variant"
+        );
+        let caps = cfg["processcontainer"]["capabilities"].as_array().unwrap();
+        assert_eq!(caps.len(), 1);
+        assert_eq!(caps[0].as_str().unwrap(), "internetClient");
+    }
+
+    #[test]
+    fn merge_capabilities_preserves_existing_camel_case_subobject() {
+        let mut cfg = json!({
+            "containment": "processcontainer",
+            "processContainer": { "capabilities": ["foo"] }
+        });
+        let req: HashSet<String> = ["bar"].iter().map(|s| s.to_string()).collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        assert!(cfg.get("processcontainer").is_none());
+        assert_eq!(
+            cfg["processContainer"]["capabilities"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    // merge_capabilities must silently no-op (no
+    // panic, no error) when the config has no `containment` set.
+    #[test]
+    fn merge_capabilities_silently_skips_when_containment_missing() {
+        let mut cfg = json!({});
+        let req: HashSet<String> = ["internetClient"].iter().map(|s| s.to_string()).collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        assert!(cfg.get("processContainer").is_none());
+    }
+
+    #[test]
+    fn merge_capabilities_silently_skips_when_containment_blank() {
+        let mut cfg = json!({ "containment": "   " });
+        let req: HashSet<String> = ["internetClient"].iter().map(|s| s.to_string()).collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        assert!(cfg.get("processContainer").is_none());
+    }
+
+    // non-PC backends must NOT have capabilities
+    // misfiled into a `processContainer` sub-object. They have no
+    // `capabilities` array in their schema; the merge is a no-op.
+    #[test]
+    fn merge_capabilities_skips_for_non_processcontainer_backends() {
+        for backend in [
+            "lxc",
+            "wslc",
+            "windows_sandbox",
+            "seatbelt",
+            "isolation_session",
+        ] {
+            let mut cfg = json!({ "containment": backend });
+            let req: HashSet<String> = ["internetClient"].iter().map(|s| s.to_string()).collect();
+            merge_capabilities(&mut cfg, &req).unwrap();
+            assert!(
+                cfg.get("processContainer").is_none(),
+                "backend {backend} must not get a processContainer sub-object"
+            );
+            // Backends with their own section MAY have one pre-existing
+            // on the config; merge_capabilities must not introduce one.
+            // Verify the only top-level key is still `containment`.
+            let top_keys: Vec<&String> = cfg.as_object().unwrap().keys().collect();
+            assert_eq!(
+                top_keys.len(),
+                1,
+                "backend {backend}: unexpected top-level keys {top_keys:?}"
+            );
+        }
+    }
+
+    // merge is additive-only. Even when the
+    // requested set is disjoint from existing capabilities, every
+    // pre-existing capability must survive the merge.
+    #[test]
+    fn merge_capabilities_preserves_existing_capability_not_in_requested_set() {
+        let mut cfg = json!({
+            "containment": "processcontainer",
+            "processContainer": { "capabilities": ["foo", "bar"] }
+        });
+        let req: HashSet<String> = ["baz"].iter().map(|s| s.to_string()).collect();
+        merge_capabilities(&mut cfg, &req).unwrap();
+        let names: Vec<&str> = cfg["processContainer"]["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert!(names.iter().any(|n| n.eq_ignore_ascii_case("foo")));
+        assert!(names.iter().any(|n| n.eq_ignore_ascii_case("bar")));
+        assert!(names.iter().any(|n| n.eq_ignore_ascii_case("baz")));
     }
 
     // R5-31: load_config rejects malformed JSON files with a useful

--- a/src/host/plm/src/event_parser.rs
+++ b/src/host/plm/src/event_parser.rs
@@ -1,12 +1,22 @@
-//! Walks a sequence of WinEvent records produced by the permissive
-//! learning-mode trace and returns the file-access events that survived
-//! filtering, plus the AppContainer capabilities the workload was
-//! observed to need.
+//! Port of `event_dacl_parser.ps1`.
 //!
-//! `EventID=14` records carry both a file path and a DACL ACE blob; the
-//! blob is decoded by `crate::extract_caps` and accumulated into
-//! `requested_capabilities`. UI relaxation (`EventID=27`) lands in a
-//! later PR.
+//! Walks a sequence of WinEvent records produced by the permissive
+//! learning-mode trace and returns:
+//!   - `valid_access_events`: file-access events that survived filtering.
+//!   - `requested_capabilities`: capability names extracted from each
+//!     event's DACL ACE blob via `extract_caps`.
+//!   - `need_ui`: true if any `CONVERT_TO_GUI` violation was observed.
+//!   - `ui_operation_flags`: OR of `Detail` bits from every
+//!     `UI_OPERATION` violation.
+//!
+//! The two event-type decoders live in sibling modules:
+//!   - `crate::access_failure` — `EventID=14` (access failure)
+//!   - `crate::ui_violation`   — `EventID=27` (UI violation)
+//!
+//! This module owns the shared scaffolding: the ETW walker
+//! (`for_each_event_xml` / `render_event_xml`), the per-event XML
+//! decoder (`parse_event_xml` -> `ParsedEvent`), and the mutable
+//! accumulator (`ParseAccumulator`) that the two decoders write into.
 
 use anyhow::Result;
 use chrono::{DateTime, TimeZone, Utc};
@@ -70,12 +80,27 @@ pub struct ParseResult {
     /// and surfaced here so the condition is assertable in tests rather
     /// than depending on process-global warning state.
     pub zero_mask_capabilities: usize,
+    /// True when at least one `CONVERT_TO_GUI` violation was observed.
+    /// Drives `set_ui_subsystem_enabled` (flips `ui.disable` to `false`).
+    pub need_ui: bool,
+    /// Total number of EventID=27 records observed, regardless of category.
+    pub ui_event_count: u32,
+    pub ui_events: Vec<crate::ui_limits::UiEvent>,
+    /// OR of the `Detail` values from every `UI_OPERATION` violation.
+    /// Each bit is one of the `JOB_OBJECT_UILIMIT_*` constants and
+    /// indicates the specific UI limit the contained process tripped.
+    pub ui_operation_flags: u32,
 }
 
 impl ParseResult {
     /// True when the trace produced nothing mergeable into a config.
+    /// `stop::run` uses this to skip the adjusted-config write rather
+    /// than emit a file identical to the input.
     pub fn is_empty(&self) -> bool {
-        self.valid_access_events.is_empty() && self.requested_capabilities.is_empty()
+        self.valid_access_events.is_empty()
+            && self.requested_capabilities.is_empty()
+            && !self.need_ui
+            && self.ui_operation_flags == 0
     }
 }
 
@@ -439,13 +464,16 @@ fn render_event_xml(event: EVT_HANDLE, buf: &mut Vec<u16>) -> Result<String> {
     Ok(String::from_utf16_lossy(trimmed))
 }
 
-/// Decoded XML view of a single event's interesting fields.
+/// Decoded XML view of a single event's interesting fields. Shared
+/// across both event-type decoders.
 pub(crate) struct ParsedEvent {
     pub(crate) event_id: u32,
     pub(crate) time_created: DateTime<Utc>,
     pub(crate) process_id: u32,
     pub(crate) thread_id: u32,
     /// EventData/Data values in document order. May be Data or ComplexData.
+    /// For Data nodes this is the inner text; for ComplexData this is
+    /// also the inner text (concatenated hex-encoded blob).
     pub(crate) event_data: Vec<String>,
     /// Index into `event_data` of the 5th `<ComplexData>` sibling (the
     /// DACL ACE blob on `EventID=14` access events). `None` if fewer
@@ -453,6 +481,14 @@ pub(crate) struct ParsedEvent {
     /// rather than cloned to avoid a second `String` allocation of the
     /// largest per-event field.
     pub(crate) complex_data_4_idx: Option<usize>,
+    /// EventData/Data entries paired with their `Name` attribute (when
+    /// set), in document order. Used for events whose schema is
+    /// resolved at render time (`EventID=27` with provider manifest).
+    pub(crate) event_data_named: Vec<(String, String)>,
+    /// Hex-encoded `<ProcessingErrorData><EventPayload>` body for
+    /// events whose manifest schema can't be resolved at render time.
+    /// UI injection events are commonly delivered this way.
+    pub(crate) processing_error_payload: Option<String>,
 }
 
 pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
@@ -501,7 +537,9 @@ pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
         process_id: acc.process_id,
         thread_id: acc.thread_id,
         event_data: acc.event_data,
+        event_data_named: acc.event_data_named,
         complex_data_4_idx: acc.complex_data_4_idx,
+        processing_error_payload: acc.processing_error_payload,
     })
 }
 
@@ -510,7 +548,11 @@ pub(crate) fn parse_event_xml(xml: &str) -> Option<ParsedEvent> {
 /// never captured here.
 enum Capture {
     EventId,
-    Data { is_complex: bool },
+    Payload,
+    Data {
+        is_complex: bool,
+        name: Option<String>,
+    },
 }
 
 /// Streaming replacement for the former per-event roxmltree DOM. Walks
@@ -525,21 +567,26 @@ struct StreamAcc {
     saw_system: bool,
     in_system: bool,
     in_event_data: bool,
+    in_processing_error: bool,
     // `seen_*` guards reproduce roxmltree's `find(..)` first-match
-    // semantics: a second `<EventID>`/`<TimeCreated>`/`<Execution>`
-    // must not overwrite the first, even when the first failed to parse.
+    // semantics: a second `<EventID>`/`<TimeCreated>`/`<Execution>`/
+    // `<EventPayload>` must not overwrite the first, even when the first
+    // failed to parse.
     seen_event_id: bool,
     seen_time_created: bool,
     seen_execution: bool,
+    seen_payload: bool,
     event_id: u32,
     time_created: Option<DateTime<Utc>>,
     process_id: u32,
     thread_id: u32,
     event_data: Vec<String>,
+    event_data_named: Vec<(String, String)>,
     // Position of the 5th `<ComplexData>` sibling (the DACL ACE blob),
     // tracked instead of cloning that multi-KB text a second time.
     complex_data_4_idx: Option<usize>,
     complex_index: usize,
+    processing_error_payload: Option<String>,
     capture: Option<(Capture, String)>,
 }
 
@@ -556,6 +603,11 @@ impl StreamAcc {
             b"EventData" => {
                 if !is_empty {
                     self.in_event_data = true;
+                }
+            }
+            b"ProcessingErrorData" => {
+                if !is_empty {
+                    self.in_processing_error = true;
                 }
             }
             b"EventID" if self.in_system && !self.seen_event_id => {
@@ -586,11 +638,26 @@ impl StreamAcc {
             }
             b"Data" | b"ComplexData" if self.in_event_data => {
                 let is_complex = name.local_name().as_ref() == b"ComplexData";
-                if is_empty {
-                    self.finish_data(is_complex, String::new());
+                // `Name` is only consumed by the UI-event path; skip the
+                // attribute scan + clone for every other event.
+                let name = if self.event_id == EVENT_ID_UI_VIOLATION {
+                    attr_value(e, b"Name")
                 } else {
-                    self.capture = Some((Capture::Data { is_complex }, String::new()));
+                    None
+                };
+                if is_empty {
+                    self.finish_data(is_complex, name, String::new());
+                } else {
+                    self.capture = Some((Capture::Data { is_complex, name }, String::new()));
                 }
+            }
+            b"EventPayload" if self.in_processing_error && !self.seen_payload => {
+                self.seen_payload = true;
+                if !is_empty {
+                    self.capture = Some((Capture::Payload, String::new()));
+                }
+                // Empty `<EventPayload/>` -> empty text -> filtered to
+                // `None`, which is already the default.
             }
             _ => {}
         }
@@ -606,11 +673,13 @@ impl StreamAcc {
         match local {
             b"System" => self.in_system = false,
             b"EventData" => self.in_event_data = false,
+            b"ProcessingErrorData" => self.in_processing_error = false,
             _ => {}
         }
         let matches = matches!(
             (&self.capture, local),
             (Some((Capture::EventId, _)), b"EventID")
+                | (Some((Capture::Payload, _)), b"EventPayload")
                 | (Some((Capture::Data { .. }, _)), b"Data" | b"ComplexData")
         );
         if !matches {
@@ -619,11 +688,20 @@ impl StreamAcc {
         let (kind, text) = self.capture.take().unwrap();
         match kind {
             Capture::EventId => self.event_id = text.parse::<u32>().unwrap_or(0),
-            Capture::Data { is_complex } => self.finish_data(is_complex, text),
+            Capture::Payload => {
+                if !text.trim().is_empty() {
+                    self.processing_error_payload = Some(text);
+                }
+            }
+            Capture::Data { is_complex, name } => self.finish_data(is_complex, name, text),
         }
     }
 
-    fn finish_data(&mut self, is_complex: bool, text: String) {
+    fn finish_data(&mut self, is_complex: bool, name: Option<String>, text: String) {
+        if let Some(name) = name {
+            // Clone only when we actually emit the named entry.
+            self.event_data_named.push((name, text.clone()));
+        }
         let pushed_idx = self.event_data.len();
         self.event_data.push(text);
         if is_complex {
@@ -644,9 +722,9 @@ fn attr_value(e: &BytesStart<'_>, name: &[u8]) -> Option<String> {
         .map(|v| v.into_owned())
 }
 
-/// Mutable per-trace accumulator. Fields are `pub(crate)` so the
-/// sibling event-type decoders can write into them directly without an
-/// inflated method surface.
+/// Mutable per-trace accumulator. Shared across the EventID=14 and
+/// EventID=27 decoders; fields are `pub(crate)` so the sibling modules
+/// can write into them directly without an inflated method surface.
 pub(crate) struct ParseAccumulator {
     /// Cached lowercase form of the trace's current directory with
     /// trailing `\\` trimmed (computed once at construction so the hot
@@ -676,6 +754,10 @@ pub(crate) struct ParseAccumulator {
     /// rather than aborting the trace, but the running total is surfaced
     /// at the end of a parse so silent data loss is observable.
     pub(crate) parse_failures: usize,
+    pub(crate) need_ui: bool,
+    pub(crate) ui_event_count: u32,
+    pub(crate) ui_events: Vec<crate::ui_limits::UiEvent>,
+    pub(crate) ui_operation_flags: u32,
     pub(crate) capability_index: extract_caps::CapabilityIndex,
     /// Per-trace scratch and diagnostics for the ACE walk.
     ///
@@ -730,6 +812,10 @@ impl ParseAccumulator {
             access_event_index: HashMap::new(),
             requested_capabilities: HashSet::new(),
             parse_failures: 0,
+            need_ui: false,
+            ui_event_count: 0,
+            ui_events: Vec::new(),
+            ui_operation_flags: 0,
             capability_index,
             ace_walk: extract_caps::AceWalkState::new(),
         }
@@ -737,7 +823,8 @@ impl ParseAccumulator {
 
     /// Hot-path CWD / drive-letter filter for access events. Uses
     /// precomputed lowercase forms of `current_directory` to avoid two
-    /// `String` allocs per event.
+    /// `String` allocs per event. Logic must stay in sync with the free
+    /// `crate::access_failure::is_skippable` used by unit tests.
     pub(crate) fn is_skippable(&self, file_path: &str) -> bool {
         if let (Some(cwd_lowercase), cwd_prefix) = (&self.cwd_lc_trimmed, &self.cwd_lc_prefix) {
             let normalized_path = file_path.trim_end_matches('\\');
@@ -784,11 +871,9 @@ impl ParseAccumulator {
         false
     }
 
-    /// Per-event entry point. Decodes the XML, dispatches by event id,
-    /// and silently swallows malformed records (so a bad event mid-trace
-    /// doesn't abort the rest). EventID=27 (UI violation) is recognized
-    /// by the XPath filter today but contributes no relaxation until the
-    /// UI-policy PR.
+    /// Per-event entry point. Decodes the XML, dispatches by event id
+    /// to the matching sibling module, and silently swallows malformed
+    /// records (so a bad event mid-trace doesn't abort the rest).
     fn consume(&mut self, xml: &str) {
         let Some(ev) = parse_event_xml(xml) else {
             self.parse_failures += 1;
@@ -798,11 +883,11 @@ impl ParseAccumulator {
             return;
         };
         match ev.event_id {
-            EVENT_ID_ACCESS_FAILURE => crate::access_failure::consume_access_failure(self, ev),
-            EVENT_ID_UI_VIOLATION => {
-                // UI-violation dispatch arrives in a later PR.
-            }
-            _ => {}
+            EVENT_ID_UI_VIOLATION => crate::ui_violation::consume_ui_violation(self, ev),
+            // EventID=14 is the only other id the XPath filter admits;
+            // any other id reaches here only via the fixture-test seam
+            // and we treat it as a (silently-rejected) access event.
+            _ => crate::access_failure::consume_access_failure(self, ev),
         }
     }
 
@@ -837,6 +922,10 @@ impl ParseAccumulator {
             requested_capabilities: self.requested_capabilities,
             parse_failures: self.parse_failures,
             zero_mask_capabilities: self.ace_walk.zero_mask_capabilities(),
+            need_ui: self.need_ui,
+            ui_event_count: self.ui_event_count,
+            ui_events: self.ui_events,
+            ui_operation_flags: self.ui_operation_flags,
         }
     }
 }
@@ -881,7 +970,12 @@ where
 mod tests {
     use super::*;
     use crate::access_failure::{make_event_xml, FILE_PATH_INDEX};
+    use crate::ui_limits::{JOB_OBJECT_UILIMIT_WRITECLIPBOARD, UI_OPERATION};
+    use crate::ui_violation::make_ui_event_xml;
 
+    // EventData property indexes are owned by `access_failure`; this
+    // test only references `FILE_PATH_INDEX` (index 2) for parity with
+    // the historical assertion.
     const ACCESS_MASK_INDEX: usize = 5;
 
     #[test]
@@ -916,10 +1010,56 @@ mod tests {
         assert!(parse_event_xml("<not-an-event/>").is_none());
     }
 
+    /// `parse_events` (the live entry point that drives `EvtQuery`
+    /// against a real `.etl`) can't run from unit tests, but the
+    /// per-event accumulator it feeds is shared with
+    /// `parse_events_from_xml`. Cover a heterogeneous mixed stream —
+    /// multiple access events, a UI event, a malformed record in the
+    /// middle, and a CWD-filtered noise event — so any regression in
+    /// the mixed-stream dispatch (event-id routing,
+    /// continue-on-malformed, CWD filter) surfaces from `cargo test`.
+    #[test]
+    fn parse_events_from_xml_mixed_stream_integration() {
+        let xmls: Vec<String> = vec![
+            make_event_xml("C:\\Workdir\\real_target.txt", "0x1"),
+            "<not-an-event/>".to_string(),
+            // CWD-filtered noise: under the supplied cwd, must be skipped.
+            make_event_xml("C:\\Repo\\src\\test_scaffold.rs", "0x1"),
+            make_event_xml("C:\\Workdir\\other.txt", "0x2"),
+            make_ui_event_xml(UI_OPERATION, JOB_OBJECT_UILIMIT_WRITECLIPBOARD),
+        ];
+        let result = parse_events_from_xml(
+            xmls.iter(),
+            Some("C:\\Repo"),
+            false,
+            extract_caps::CapabilityIndex::for_test(&[]),
+        );
+
+        assert_eq!(
+            result.valid_access_events.len(),
+            2,
+            "expected exactly two valid access events (the other two were \
+             malformed and cwd-filtered respectively)"
+        );
+        assert_eq!(result.ui_event_count, 1);
+        assert_eq!(result.ui_operation_flags, JOB_OBJECT_UILIMIT_WRITECLIPBOARD);
+        assert!(!result.need_ui);
+
+        assert_eq!(
+            result.valid_access_events[0].file_path,
+            "C:\\Workdir\\real_target.txt"
+        );
+        assert_eq!(
+            result.valid_access_events[1].file_path,
+            "C:\\Workdir\\other.txt"
+        );
+    }
+
+    /// Narrower companion to the mixed-stream test: a single fs-only
+    /// event, so a regression in access-failure dispatch alone is
+    /// distinguishable from one in the mixed-stream routing.
     #[test]
     fn parse_events_from_xml_drives_access_failure_dispatch() {
-        // Single fs-only event; ensure the dispatcher runs and the
-        // event is collected.
         let xml = make_event_xml("C:\\app\\foo.txt", "0x1");
         let result = parse_events_from_xml(
             vec![xml],

--- a/src/host/plm/src/lib.rs
+++ b/src/host/plm/src/lib.rs
@@ -12,6 +12,8 @@ pub mod coordination;
 pub mod event_parser;
 pub mod extract_caps;
 pub mod profile_gen;
+pub mod ui_limits;
+pub mod ui_violation;
 
 #[cfg(target_os = "windows")]
 pub mod log;

--- a/src/host/plm/src/log.rs
+++ b/src/host/plm/src/log.rs
@@ -1,12 +1,12 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 //! Interactive "logging" mode.
 //!
 //! 1. Prompts the user to press Enter to start logging.
 //! 2. Starts a WPR trace (same `AccessFailureProfile` used by `start`).
 //! 3. Prompts the user to press Enter to stop logging.
-//! 4. Stops the trace into a temp .etl and reports where it landed.
+//! 4. Stops the trace into a temp .etl, parses it, and prints the
+//!    changes that *would* be merged into a blank (empty `{}`) config.
+//!
+//! The trace .etl file is cleaned up after parsing.
 
 use anyhow::{Context, Result};
 use chrono::Local;
@@ -15,7 +15,9 @@ use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 
 use crate::config::{
-    deny_file_set, initialize_filesystem, update_from_access_events, write_added_paths_summary,
+    apply_ui_operation_flags, deny_file_set, initialize_filesystem, merge_capabilities,
+    set_ui_subsystem_enabled, update_from_access_events, write_added_paths_summary,
+    write_detection_summary, write_requested_capabilities_summary,
 };
 use crate::coordination::PLM_LOG_START_IN_FLIGHT;
 use crate::event_parser::parse_events;
@@ -59,7 +61,7 @@ pub fn run(
 
     prompt_enter("Press Enter to stop logging...")?;
 
-    // Per-run trace file in temp; PID + sub-second component prevents
+    // Per-run trace file in temp; sub-second component prevents
     // parallel `plm log` invocations from colliding on the same .etl.
     let stamp = Local::now().format("%Y-%m-%d_%H%M%S%.3f").to_string();
     let trace_file: PathBuf = std::env::temp_dir().join(format!("plm_log_{stamp}.etl"));
@@ -85,9 +87,19 @@ pub fn run(
 
     let parse = parse?;
 
-    // Synthesize a blank config and run the FS merge to preview what a
-    // policy authored from scratch would receive. Capability and UI
-    // merging arrive in later PRs.
+    write_detection_summary(
+        &parse.valid_access_events,
+        &parse.requested_capabilities,
+        parse.ui_event_count,
+        &parse.ui_events,
+        parse.ui_operation_flags,
+    );
+    write_requested_capabilities_summary(&parse.requested_capabilities, verbose);
+
+    // Synthesize a blank config and run the same merge logic the real
+    // `stop` subcommand uses. We deliberately do not pass a containment
+    // name -- a blank config has none, so `merge_capabilities` is a
+    // no-op; instead, print the full requested-capabilities list below.
     let mut blank: Value = json!({});
     initialize_filesystem(&mut blank)?;
     let deny = deny_file_set(&blank);
@@ -103,6 +115,33 @@ pub fn run(
         &deny,
         verbose,
     )?;
+
+    if parse.need_ui {
+        set_ui_subsystem_enabled(&mut blank)?;
+    }
+    if parse.ui_operation_flags != 0 {
+        apply_ui_operation_flags(&mut blank, parse.ui_operation_flags)?;
+    }
+
+    // `merge_capabilities` requires a `containment` name on the config,
+    // which a blank config doesn't have. Print the full set of requested
+    // capabilities here so the operator still sees what was discovered.
+    if !parse.requested_capabilities.is_empty() {
+        println!();
+        println!(
+            "Requested capabilities ({}):",
+            parse.requested_capabilities.len()
+        );
+        let mut sorted: Vec<&String> = parse.requested_capabilities.iter().collect();
+        sorted.sort();
+        for c in sorted {
+            println!("  + {c}");
+        }
+    } else {
+        // Still call through so existing call-site stays exercised even
+        // when the set is empty -- this is a no-op for a blank config.
+        merge_capabilities(&mut blank, &parse.requested_capabilities)?;
+    }
 
     write_added_paths_summary(&added, verbose);
 

--- a/src/host/plm/src/main.rs
+++ b/src/host/plm/src/main.rs
@@ -240,7 +240,7 @@ enum Cmd {
         #[arg(long)]
         wprp: Option<PathBuf>,
     },
-    /// Stop the trace and write `trace.etl` into a log directory.
+    /// Stop the trace and (optionally) merge findings into a config.
     Stop {
         /// Directory for trace.etl, copied input config, and Adjusted_*.json.
         #[arg(long)]
@@ -272,7 +272,8 @@ enum Cmd {
         #[arg(long)]
         verbose_logging: bool,
     },
-    /// Interactive: press Enter to start logging, press Enter again to stop.
+    /// Interactive: press Enter to start logging, press Enter again to
+    /// stop, then print the changes a blank config would receive.
     Log {
         /// Override path to plm.wprp. Defaults to <exe dir>\plm.wprp.
         #[arg(long)]

--- a/src/host/plm/src/stop.rs
+++ b/src/host/plm/src/stop.rs
@@ -10,20 +10,31 @@ use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
 use crate::config::{
-    deny_file_set, initialize_filesystem, load_config, merge_capabilities,
-    resolve_adjusted_config_path, save_adjusted_config, update_from_access_events,
-    write_added_paths_summary, write_detection_summary, write_requested_capabilities_summary,
+    apply_ui_operation_flags, deny_file_set, initialize_filesystem, load_config,
+    merge_capabilities, resolve_adjusted_config_path, save_adjusted_config,
+    set_ui_subsystem_enabled, update_from_access_events, write_added_paths_summary,
+    write_detection_summary, write_requested_capabilities_summary,
 };
-use crate::event_parser::parse_events;
+use crate::event_parser::{parse_events, ParseResult};
 use crate::wpr_path::wpr_command;
+
+/// "Skip adjusted config" predicate extracted from the inline check
+/// in `run`. A trace that produced no access events, no capability
+/// requests, no `CONVERT_TO_GUI` hint, and no `UI_OPERATION` flags has
+/// nothing to merge — emitting an `Adjusted_*.json` byte-identical to
+/// the input would only confuse the harness's diff-based pass/fail
+/// signal.
+pub fn should_skip_adjusted(parse: &ParseResult) -> bool {
+    parse.is_empty()
+}
 
 pub struct StopOptions {
     pub log_dir: Option<PathBuf>,
     pub bin_path: Option<PathBuf>,
     pub config_path: Option<PathBuf>,
-    /// When set, skip `wpr -stop` and treat the supplied .etl as the
-    /// captured trace. Useful for re-processing a previously captured
-    /// trace without an active WPR session.
+    /// When set, skip `wpr -stop` and parse the supplied .etl directly.
+    /// Useful for re-processing a previously captured trace without an
+    /// active WPR session.
     pub trace_file: Option<PathBuf>,
     pub verbose: bool,
 }
@@ -87,22 +98,19 @@ pub fn resolve_bin_path(opt: Option<&Path>, exe_dir: &Path) -> (PathBuf, Option<
                 e
             );
             // Prefer the raw operator-supplied path over silently
-            // substituting exe_dir; that would drop operator intent.
+            // substituting exe_dir; the previous behavior swallowed
+            // operator intent entirely.
             (raw.to_path_buf(), Some(warning))
         }
     }
 }
 
 pub fn run(opts: StopOptions, exe_dir: &Path) -> Result<()> {
-    // $LogDir defaults to "<exe dir>\logs\<timestamp>_pid<PID>".
-    // Including PID + sub-second component avoids collisions when
-    // parallel PLM tasks finish in the same second.
+    // $LogDir defaults to "<exe dir>\logs\<timestamp>". The sub-second
+    // component makes parallel PLM runs finishing in the same second
+    // land in distinct directories.
     let log_dir = opts.log_dir.unwrap_or_else(|| {
-        let stamp = format!(
-            "{}_pid{}",
-            Local::now().format("%Y-%m-%d_%H%M%S%.3f"),
-            std::process::id()
-        );
+        let stamp = Local::now().format("%Y-%m-%d_%H%M%S%.3f").to_string();
         exe_dir.join("logs").join(stamp)
     });
     std::fs::create_dir_all(&log_dir)
@@ -145,7 +153,13 @@ pub fn run(opts: StopOptions, exe_dir: &Path) -> Result<()> {
     let capability_index = crate::extract_caps::discover_capabilities(opts.verbose);
     let parse = parse_events(&trace_file, cwd.as_deref(), opts.verbose, capability_index)?;
 
-    write_detection_summary(&parse.valid_access_events, &parse.requested_capabilities);
+    write_detection_summary(
+        &parse.valid_access_events,
+        &parse.requested_capabilities,
+        parse.ui_event_count,
+        &parse.ui_events,
+        parse.ui_operation_flags,
+    );
     write_requested_capabilities_summary(&parse.requested_capabilities, opts.verbose);
 
     let config_path = match opts.config_path.as_ref() {
@@ -175,10 +189,10 @@ pub fn run(opts: StopOptions, exe_dir: &Path) -> Result<()> {
     std::fs::copy(config_path, &dest_config)
         .with_context(|| format!("failed to copy {}", config_path.display()))?;
 
-    if parse.is_empty() {
-        // Nothing mergeable -- skip producing an Adjusted_*.json (which
-        // would be byte-identical to the input and confuse the harness's
-        // diff-based pass/fail signal).
+    // Skip the adjusted config only when the trace yielded nothing
+    // mergeable. Bailing on file/capability emptiness alone would
+    // silently drop UI-only traces.
+    if should_skip_adjusted(&parse) {
         return Ok(());
     }
 
@@ -201,6 +215,13 @@ pub fn run(opts: StopOptions, exe_dir: &Path) -> Result<()> {
 
     if !parse.requested_capabilities.is_empty() {
         merge_capabilities(&mut config, &parse.requested_capabilities)?;
+    }
+
+    if parse.need_ui {
+        set_ui_subsystem_enabled(&mut config)?;
+    }
+    if parse.ui_operation_flags != 0 {
+        apply_ui_operation_flags(&mut config, parse.ui_operation_flags)?;
     }
 
     let adjusted = resolve_adjusted_config_path(&dest_config)?;
@@ -255,6 +276,67 @@ fn same_config_target(a: &Path, b: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::access_event::LearningModeAccessEvent;
+    use std::collections::HashSet;
+
+    fn empty_parse() -> ParseResult {
+        ParseResult {
+            valid_access_events: Vec::new(),
+            requested_capabilities: HashSet::new(),
+            parse_failures: 0,
+            zero_mask_capabilities: 0,
+            need_ui: false,
+            ui_event_count: 0,
+            ui_events: Vec::new(),
+            ui_operation_flags: 0,
+        }
+    }
+
+    fn dummy_event() -> LearningModeAccessEvent {
+        LearningModeAccessEvent {
+            time_created: chrono::Utc::now(),
+            process_id: 0,
+            thread_id: 0,
+            file_path: "C:\\foo".into(),
+            access_mask: 0,
+        }
+    }
+
+    // Pin the "skip adjusted config" predicate against each
+    // single-signal ParseResult plus the all-empty case.
+
+    #[test]
+    fn should_skip_when_completely_empty() {
+        assert!(should_skip_adjusted(&empty_parse()));
+    }
+
+    #[test]
+    fn should_not_skip_when_access_events_present() {
+        let mut p = empty_parse();
+        p.valid_access_events.push(dummy_event());
+        assert!(!should_skip_adjusted(&p));
+    }
+
+    #[test]
+    fn should_not_skip_when_requested_capability_present() {
+        let mut p = empty_parse();
+        p.requested_capabilities.insert("internetClient".into());
+        assert!(!should_skip_adjusted(&p));
+    }
+
+    #[test]
+    fn should_not_skip_when_need_ui_set() {
+        let mut p = empty_parse();
+        p.need_ui = true;
+        assert!(!should_skip_adjusted(&p));
+    }
+
+    #[test]
+    fn should_not_skip_when_ui_operation_flag_set() {
+        let mut p = empty_parse();
+        p.ui_operation_flags = 0x004; // JOB_OBJECT_UILIMIT_WRITECLIPBOARD
+        assert!(!should_skip_adjusted(&p));
+    }
 
     // ---- resolve_bin_path -----------------------------------------------
 

--- a/src/host/plm/src/ui_limits.rs
+++ b/src/host/plm/src/ui_limits.rs
@@ -1,0 +1,70 @@
+//! Cross-platform constants for `JOB_OBJECT_UILIMIT_*` flags, the
+//! learning-mode violation categories, and the parsed `UiEvent`
+//! shape. Pure data — no Win32 deps — so `config` and tests can
+//! reason about UI relaxations without pulling in the Windows-only
+//! event-parsing code.
+
+// ---------------------------------------------------------------------------
+// Learning-mode violation categories (EventID=27 `Category` field).
+// ---------------------------------------------------------------------------
+
+/// The process attempted an operation that requires the Win32k GUI subsystem
+/// while running with `DisallowWin32kSystemCalls` enabled. To relax the
+/// policy the corresponding config flips `ui.disable` from the default
+/// `true` to `false`.
+pub const CONVERT_TO_GUI: u32 = 1;
+
+/// The process attempted a UI operation that was blocked by a Job UI Limit
+/// (`JOB_OBJECT_UILIMIT_*`). The `Detail` field carries the specific
+/// `JOB_OBJECT_UILIMIT_*` bit that fired.
+pub const UI_OPERATION: u32 = 2;
+
+// ---------------------------------------------------------------------------
+// Job Object UI Limit flags. Values match the Win32 `JOB_OBJECT_UILIMIT_*`
+// constants from <winnt.h>.
+// ---------------------------------------------------------------------------
+
+pub const JOB_OBJECT_UILIMIT_HANDLES: u32 = 0x0001;
+pub const JOB_OBJECT_UILIMIT_READCLIPBOARD: u32 = 0x0002;
+pub const JOB_OBJECT_UILIMIT_WRITECLIPBOARD: u32 = 0x0004;
+pub const JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS: u32 = 0x0008;
+pub const JOB_OBJECT_UILIMIT_DISPLAYSETTINGS: u32 = 0x0010;
+pub const JOB_OBJECT_UILIMIT_GLOBALATOMS: u32 = 0x0020;
+pub const JOB_OBJECT_UILIMIT_DESKTOP: u32 = 0x0040;
+pub const JOB_OBJECT_UILIMIT_EXITWINDOWS: u32 = 0x0080;
+pub const JOB_OBJECT_UILIMIT_IME: u32 = 0x0100;
+pub const JOB_OBJECT_UILIMIT_INJECTION: u32 = 0x0200;
+
+/// Human-readable name for a `JOB_OBJECT_UILIMIT_*` bit. Used for
+/// diagnostic output; returns `None` if the bit is not recognised.
+pub fn ui_limit_name(bit: u32) -> Option<&'static str> {
+    Some(match bit {
+        JOB_OBJECT_UILIMIT_HANDLES => "HANDLES",
+        JOB_OBJECT_UILIMIT_READCLIPBOARD => "READCLIPBOARD",
+        JOB_OBJECT_UILIMIT_WRITECLIPBOARD => "WRITECLIPBOARD",
+        JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS => "SYSTEMPARAMETERS",
+        JOB_OBJECT_UILIMIT_DISPLAYSETTINGS => "DISPLAYSETTINGS",
+        JOB_OBJECT_UILIMIT_GLOBALATOMS => "GLOBALATOMS",
+        JOB_OBJECT_UILIMIT_DESKTOP => "DESKTOP",
+        JOB_OBJECT_UILIMIT_EXITWINDOWS => "EXITWINDOWS",
+        JOB_OBJECT_UILIMIT_IME => "IME",
+        JOB_OBJECT_UILIMIT_INJECTION => "INJECTION",
+        _ => return None,
+    })
+}
+
+/// Parsed payload of a UI-injection (EventID=27) event.
+///
+/// Pure data so it can live in a portable module. The decoding paths
+/// (`parse_ui_event_payload`, `parse_ui_event_from_named`) live in the
+/// Windows-only `event_parser` module because they share a hex-decoding
+/// helper with the ACE walker.
+#[derive(Debug, Clone)]
+pub struct UiEvent {
+    pub process_name: String,
+    pub process_id: u64,
+    pub sequence_number: u64,
+    pub category: u32,
+    pub detail: u32,
+    pub denied: Option<bool>,
+}

--- a/src/host/plm/src/ui_violation.rs
+++ b/src/host/plm/src/ui_violation.rs
@@ -1,0 +1,368 @@
+//! EventID=27 (UI violation) decode + consume.
+//!
+//! The Permissive-Learning-Mode provider emits one `EventID=27` per
+//! UI operation that *would* have been blocked by a Job UI Limit or
+//! a Win32k subsystem disable. The payload commonly arrives as an
+//! opaque `<ProcessingErrorData><EventPayload>` hex blob (when the
+//! consumer can't resolve the provider manifest); when the manifest
+//! IS available we get named `<Data Name="…">` children instead.
+//!
+//! This module owns both decoders, the fixed-width binary layout
+//! reader, and the per-event accumulator helper that classifies a
+//! decoded `UiEvent` by category (`CONVERT_TO_GUI` -> `need_ui`;
+//! `UI_OPERATION` -> OR into `ui_operation_flags`).
+
+use crate::event_parser::{ParseAccumulator, ParsedEvent};
+use crate::ui_limits::{ui_limit_name, UiEvent, CONVERT_TO_GUI, UI_OPERATION};
+
+// ---- Payload decoders ---------------------------------------------------
+
+/// Documented hex-payload layout:
+///
+/// * `process_name` — UTF-8 / ASCII bytes, null-terminated.
+/// * `process_id` — 8 bytes, little-endian.
+/// * `sequence_number` — 8 bytes, little-endian.
+/// * `category` — 4 bytes, little-endian.
+/// * `detail` — 4 bytes, little-endian.
+/// * `denied` — 0, 1, or 4 trailing bytes; non-zero means denied.
+fn read_u32_le(bytes: &[u8], off: &mut usize) -> Option<u32> {
+    let end = off.checked_add(4)?;
+    if end > bytes.len() {
+        return None;
+    }
+    let mut arr = [0u8; 4];
+    arr.copy_from_slice(&bytes[*off..end]);
+    *off = end;
+    Some(u32::from_le_bytes(arr))
+}
+
+fn read_u64_le(bytes: &[u8], off: &mut usize) -> Option<u64> {
+    let end = off.checked_add(8)?;
+    if end > bytes.len() {
+        return None;
+    }
+    let mut arr = [0u8; 8];
+    arr.copy_from_slice(&bytes[*off..end]);
+    *off = end;
+    Some(u64::from_le_bytes(arr))
+}
+
+/// Decode a UI-injection event payload from its hex representation.
+/// Returns `None` if the hex is malformed or the payload is shorter
+/// than the documented fixed-width tail.
+pub fn parse_ui_event_payload(payload_hex: &str) -> Option<UiEvent> {
+    let mut bytes = Vec::new();
+    crate::extract_caps::parse_hex_string_into(payload_hex, &mut bytes).ok()?;
+
+    let null_pos = bytes.iter().position(|&b| b == 0)?;
+    let process_name = String::from_utf8_lossy(&bytes[..null_pos]).into_owned();
+    let mut off = null_pos + 1;
+
+    let process_id = read_u64_le(&bytes, &mut off)?;
+    let sequence_number = read_u64_le(&bytes, &mut off)?;
+    let category = read_u32_le(&bytes, &mut off)?;
+    let detail = read_u32_le(&bytes, &mut off)?;
+
+    // `denied` is optional: trailing 0, 1, or 4 bytes have been
+    // observed in the wild. Anything else means the payload doesn't
+    // match the documented layout.
+    let denied = match bytes.len().checked_sub(off) {
+        Some(0) => None,
+        Some(1) => Some(bytes[off] != 0),
+        Some(4) => {
+            let mut a = [0u8; 4];
+            a.copy_from_slice(&bytes[off..off + 4]);
+            Some(u32::from_le_bytes(a) != 0)
+        }
+        _ => return None,
+    };
+
+    Some(UiEvent {
+        process_name,
+        process_id,
+        sequence_number,
+        category,
+        detail,
+        denied,
+    })
+}
+
+/// Parse an integer that may be written as decimal or `0x`-prefixed hex.
+fn parse_u64_loose(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if let Some(rest) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(rest, 16).ok()
+    } else {
+        s.parse::<u64>().ok()
+    }
+}
+
+/// Decode a UI-injection event whose `EventData` carries named `Data`
+/// children (i.e. the consumer resolved the provider manifest).
+/// Recognised names: `ProcessName`, `ProcessId`, `SequenceNumber`,
+/// `Category`, `Detail`, optional `Denied` (`true`/`false`/integer).
+pub fn parse_ui_event_from_named(named: &[(String, String)]) -> Option<UiEvent> {
+    let mut process_name: Option<String> = None;
+    let mut process_id: Option<u64> = None;
+    let mut sequence_number: Option<u64> = None;
+    let mut category: Option<u32> = None;
+    let mut detail: Option<u32> = None;
+    let mut denied: Option<bool> = None;
+
+    for (name, val) in named {
+        match name.as_str() {
+            "ProcessName" => process_name = Some(val.clone()),
+            "ProcessId" => process_id = parse_u64_loose(val),
+            "SequenceNumber" => sequence_number = parse_u64_loose(val),
+            "Category" => category = parse_u64_loose(val).map(|v| v as u32),
+            "Detail" => detail = parse_u64_loose(val).map(|v| v as u32),
+            "Denied" => {
+                let t = val.trim();
+                denied = match t.to_ascii_lowercase().as_str() {
+                    "true" | "1" => Some(true),
+                    "false" | "0" => Some(false),
+                    _ => parse_u64_loose(t).map(|v| v != 0),
+                };
+            }
+            _ => {}
+        }
+    }
+
+    Some(UiEvent {
+        process_name: process_name?,
+        process_id: process_id?,
+        sequence_number: sequence_number?,
+        category: category?,
+        detail: detail?,
+        denied,
+    })
+}
+
+// ---- Per-event consume --------------------------------------------------
+
+/// Per-event consume helper for `EventID=27`. Prefers the manifest-
+/// resolved named form, falls back to the opaque hex payload, then
+/// classifies the result by `category`.
+pub(crate) fn consume_ui_violation(acc: &mut ParseAccumulator, ev: ParsedEvent) {
+    acc.ui_event_count += 1;
+
+    let ui_opt = parse_ui_event_from_named(&ev.event_data_named).or_else(|| {
+        ev.processing_error_payload
+            .as_deref()
+            .and_then(parse_ui_event_payload)
+    });
+
+    match ui_opt {
+        Some(ui) => {
+            // Classify by category: CONVERT_TO_GUI -> `ui.disable=false`
+            // (set via `need_ui`); UI_OPERATION -> per-bit field
+            // relaxation via `ui_operation_flags`.
+            match ui.category {
+                CONVERT_TO_GUI => acc.need_ui = true,
+                UI_OPERATION => acc.ui_operation_flags |= ui.detail,
+                _ => {}
+            }
+            if acc.verbose {
+                let detail_name = if ui.category == UI_OPERATION {
+                    ui_limit_name(ui.detail).unwrap_or("UNKNOWN")
+                } else {
+                    "-"
+                };
+                println!(
+                    "UI Injection event: process={} pid={} seq={} category=0x{:08X} detail=0x{:08X} ({}) denied={}",
+                    ui.process_name,
+                    ui.process_id,
+                    ui.sequence_number,
+                    ui.category,
+                    ui.detail,
+                    detail_name,
+                    match ui.denied {
+                        Some(true) => "true",
+                        Some(false) => "false",
+                        None => "(absent)",
+                    },
+                );
+            }
+            acc.ui_events.push(ui);
+        }
+        None => {
+            // Undecodable payload: surface in verbose mode but ignore
+            // otherwise. We can't tell the category, so there's no safe
+            // relaxation to apply — assuming CONVERT_TO_GUI would over-
+            // grant `ui.disable=false` on traces whose only undecoded
+            // events were UI_OPERATION variants.
+            if acc.verbose {
+                if let Some(hex) = ev.processing_error_payload.as_deref() {
+                    println!(
+                        "UI Injection event observed (payload did not match expected layout, ignored: {hex})"
+                    );
+                } else {
+                    println!(
+                        "UI Injection event observed (no EventData / ProcessingErrorData, ignored)"
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ---- Test helpers -------------------------------------------------------
+
+/// Build an `EventID=27` XML record whose payload is delivered as an
+/// opaque `<ProcessingErrorData><EventPayload>` hex blob — the common
+/// rendering when the consumer doesn't have the provider manifest.
+#[cfg(test)]
+pub(crate) fn make_ui_event_xml(category: u32, detail: u32) -> String {
+    // Layout: process_name\0 | pid u64 | seq u64 | category u32 | detail u32 | denied u8
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"App");
+    bytes.push(0);
+    bytes.extend_from_slice(&1u64.to_le_bytes());
+    bytes.extend_from_slice(&2u64.to_le_bytes());
+    bytes.extend_from_slice(&category.to_le_bytes());
+    bytes.extend_from_slice(&detail.to_le_bytes());
+    bytes.push(1);
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(hex, "{:02X}", b);
+    }
+    format!(
+        r#"<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+          <System>
+            <EventID>27</EventID>
+            <TimeCreated SystemTime="2024-01-02T03:04:05.000Z"/>
+            <Execution ProcessID="1" ThreadID="2"/>
+          </System>
+          <ProcessingErrorData>
+            <EventPayload>{hex}</EventPayload>
+          </ProcessingErrorData>
+        </Event>"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_parser::parse_events_from_xml;
+    use crate::ui_limits::{JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES};
+
+    fn hex_for(bytes: &[u8]) -> String {
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            use std::fmt::Write;
+            let _ = write!(s, "{:02X}", b);
+        }
+        s
+    }
+
+    #[test]
+    fn parse_ui_event_payload_decodes_fixed_layout() {
+        // process_name="test\0", pid=1, seq=2, category=UI_OPERATION,
+        // detail=JOB_OBJECT_UILIMIT_GLOBALATOMS, denied trailing byte 1.
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"test");
+        bytes.push(0);
+        bytes.extend_from_slice(&1u64.to_le_bytes());
+        bytes.extend_from_slice(&2u64.to_le_bytes());
+        bytes.extend_from_slice(&UI_OPERATION.to_le_bytes());
+        bytes.extend_from_slice(&JOB_OBJECT_UILIMIT_GLOBALATOMS.to_le_bytes());
+        bytes.push(1);
+        let ui = parse_ui_event_payload(&hex_for(&bytes)).expect("should decode");
+        assert_eq!(ui.process_name, "test");
+        assert_eq!(ui.process_id, 1);
+        assert_eq!(ui.sequence_number, 2);
+        assert_eq!(ui.category, UI_OPERATION);
+        assert_eq!(ui.detail, JOB_OBJECT_UILIMIT_GLOBALATOMS);
+        assert_eq!(ui.denied, Some(true));
+    }
+
+    #[test]
+    fn parse_ui_event_payload_rejects_truncated() {
+        let bytes = b"test\0";
+        assert!(parse_ui_event_payload(&hex_for(bytes)).is_none());
+    }
+
+    #[test]
+    fn parse_ui_event_from_named_recognises_decimal_and_hex() {
+        let named = vec![
+            ("ProcessName".to_string(), "App".to_string()),
+            ("ProcessId".to_string(), "42".to_string()),
+            ("SequenceNumber".to_string(), "0x10".to_string()),
+            ("Category".to_string(), "2".to_string()),
+            ("Detail".to_string(), "0x20".to_string()),
+            ("Denied".to_string(), "true".to_string()),
+        ];
+        let ui = parse_ui_event_from_named(&named).expect("should decode");
+        assert_eq!(ui.process_name, "App");
+        assert_eq!(ui.process_id, 42);
+        assert_eq!(ui.sequence_number, 0x10);
+        assert_eq!(ui.category, UI_OPERATION);
+        assert_eq!(ui.detail, JOB_OBJECT_UILIMIT_GLOBALATOMS);
+        assert_eq!(ui.denied, Some(true));
+    }
+
+    /// The parser produces a `ui_operation_flags` bitmap;
+    /// `apply_ui_operation_flags` rewrites the config's `ui.*` and
+    /// `processContainer.ui.*` fields.
+    /// The two halves are tested individually but their bit-value
+    /// contract is not — this integration test pins it. A drift between
+    /// `JOB_OBJECT_UILIMIT_*` here and in `config.rs` will fail this
+    /// test even when both halves' unit tests still pass.
+    #[test]
+    fn ui_event_xml_drives_config_relaxation_through_apply_ui_flags() {
+        let xmls = [make_ui_event_xml(UI_OPERATION, JOB_OBJECT_UILIMIT_HANDLES)];
+        let parse = parse_events_from_xml(
+            xmls.iter(),
+            None,
+            false,
+            crate::extract_caps::CapabilityIndex::for_test(&[]),
+        );
+
+        assert_eq!(
+            parse.ui_event_count, 1,
+            "EventID=27 should be counted as a UI event"
+        );
+        assert_eq!(
+            parse.ui_operation_flags, JOB_OBJECT_UILIMIT_HANDLES,
+            "UI_OPERATION detail must OR into ui_operation_flags",
+        );
+        assert!(
+            !parse.need_ui,
+            "UI_OPERATION (not CONVERT_TO_GUI) must not set need_ui",
+        );
+
+        let mut config =
+            serde_json::json!({ "processContainer": { "ui": { "isolation": "handles" } } });
+        crate::config::apply_ui_operation_flags(&mut config, parse.ui_operation_flags)
+            .expect("apply_ui_operation_flags");
+        assert_eq!(
+            config["processContainer"]["ui"]["isolation"], "desktop",
+            "HANDLES relaxation should widen processContainer.ui.isolation handles -> desktop"
+        );
+    }
+
+    /// `CONVERT_TO_GUI` violations flow through `set_ui_subsystem_enabled`
+    /// rather than `apply_ui_operation_flags`. Pin that integration too.
+    #[test]
+    fn ui_convert_to_gui_event_sets_need_ui() {
+        let xmls = [make_ui_event_xml(CONVERT_TO_GUI, 0)];
+        let parse = parse_events_from_xml(
+            xmls.iter(),
+            None,
+            false,
+            crate::extract_caps::CapabilityIndex::for_test(&[]),
+        );
+
+        assert_eq!(parse.ui_event_count, 1);
+        assert!(parse.need_ui, "CONVERT_TO_GUI must set need_ui");
+        assert_eq!(
+            parse.ui_operation_flags, 0,
+            "CONVERT_TO_GUI must NOT contribute to ui_operation_flags",
+        );
+
+        let mut config = serde_json::json!({});
+        crate::config::set_ui_subsystem_enabled(&mut config).expect("set_ui_subsystem_enabled");
+        assert_eq!(config["ui"]["disable"], false);
+    }
+}


### PR DESCRIPTION
## 📖 Description

**PR 5 of 6** — stacked on PR4. Adds **UI-policy relaxation**.

- New `ui_limits` + `ui_violation` modules: decode `EventID=27` payloads (both rendered XML and `<ProcessingErrorData><EventPayload>` hex form). Recognizes `CONVERT_TO_GUI` and `UI_OPERATION` violations and tracks the `JOB_OBJECT_UILIMIT_*` `Detail` bits.
- `event_parser`:
  - `ParsedEvent` gains `event_data_named` (only populated when `event_id == 27`) and `processing_error_payload`.
  - `ParseAccumulator` / `ParseResult` gain `need_ui`, `ui_event_count`, `ui_events`, `ui_operation_flags`.
  - `consume` dispatches `EventID=27` to `ui_violation::consume_ui_violation`.
- `config`:
  - `set_ui_subsystem_enabled` flips `processContainer.uiPolicy.ui.disable` to `false`.
  - `apply_ui_operation_flags` ORs observed `JOB_OBJECT_UILIMIT_*` bits into the appropriate `uiPolicy` sub-keys (clipboard, system settings, isolation, plus the simple boolean limits).
  - `write_detection_summary` extended with UI parameters; new UI section in the printed summary.
- `stop` / `log` honor the new fields: skip the adjusted-config write only when there's nothing mergeable in any axis, and invoke `set_ui_subsystem_enabled` / `apply_ui_operation_flags` when the trace reports UI activity.
- UI-policy schema mapping documented in [`docs/base-process-container/UIPolicy_Schema.md`](docs/base-process-container/UIPolicy_Schema.md).

## 🔗 References

- Base: **PR4** (`user/lilybarkley/plm-pr4-cap-extraction`)
- Next: PR6 — testing artifacts (`plm_tester` workload binary, `tests/configs/plm_configs`, `run_plm_test.ps1`)
- Schema reference: [`docs/base-process-container/UIPolicy_Schema.md`](docs/base-process-container/UIPolicy_Schema.md)

## 🔍 Validation

- `cargo build -p plm --target x86_64-pc-windows-msvc` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p plm --target x86_64-pc-windows-msvc --all-targets -- -D warnings` — clean
- `cargo test -p plm --target x86_64-pc-windows-msvc` — **126 passed** (74 new: rendered + processing-error UI variants, both violation categories, every `JOB_OBJECT_UILIMIT_*` mask path, mixed-stream integration through `parse_events_from_xml`, full `write_detection_summary` UI section, `should_skip_adjusted` predicate).

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/588)