### PR TITLE
Sign isolation_session PowerShell scripts staged into the vpack

### DIFF
--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -151,3 +151,17 @@ extends:
                   $scriptsSrc | Copy-Item -Destination $scriptsDest -Force
                   $configsSrc | Copy-Item -Destination $configsDest -Force
                   Write-Host "Staged $($scriptsSrc.Count) scripts and $($configsSrc.Count) configs into isolation_session\main"
+
+            # Authenticode-sign the staged PowerShell scripts so Code Sign
+            # Validation (CSV) passes and the vpack ships signed scripts. The
+            # downloaded wxc binaries arrive pre-signed from MXC-Official-Build;
+            # only these source-staged .ps1 scripts need signing here. The
+            # 'external_distribution' profile maps to CP-230012 (Microsoft
+            # Authenticode) — the same cert used to sign the binaries.
+            - task: onebranch.pipeline.signing@1
+              displayName: Sign isolation_session scripts
+              inputs:
+                command: sign
+                signing_profile: external_distribution
+                files_to_sign: '**/*.ps1'
+                search_root: $(ob_outputDirectory)

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -155,13 +155,11 @@ extends:
             # Authenticode-sign the staged PowerShell scripts so Code Sign
             # Validation (CSV) passes and the vpack ships signed scripts. The
             # downloaded wxc binaries arrive pre-signed from MXC-Official-Build;
-            # only these source-staged .ps1 scripts need signing here. The
-            # 'external_distribution' profile maps to CP-230012 (Microsoft
-            # Authenticode) — the same cert used to sign the binaries.
+            # only these source-staged .ps1 scripts need signing here.
             - task: onebranch.pipeline.signing@1
               displayName: Sign isolation_session scripts
               inputs:
                 command: sign
                 signing_profile: external_distribution
                 files_to_sign: '**/*.ps1'
-                search_root: $(ob_outputDirectory)
+                search_root: $(ob_outputDirectory)\isolation_session\main\scripts


### PR DESCRIPTION
## 📖 Description
The `MXC-VPack-Publish` (OneBranch) build started failing **CodeSign Validation (CSV)** with `CodeSign.MissingSigningCert` on the three `isolation_session` PowerShell scripts that #583 stages into the vpack .

## 🔗 References
Follow-up to #583 (which introduced the staged scripts).

## 🔍 Validation
Pipeline-only change. YAML validated locally. Signing task syntax matches the standard OneBranch usage (`command: sign` + `signing_profile: external_distribution`) used across Microsoft OneBranch pipelines (e.g. PowerShell/PowerShell, microsoft/edit). Full validation on the next `MXC-VPack-Publish` run.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/590)