### PR TITLE
[Bubblewrap/LXC/WSLC] Add object-based filesystem-policy validation, most restrictive wins

### DIFF
--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -101,11 +101,24 @@ impl SandboxBackend for BubblewrapScriptRunner {
         self.validate(request)?;
         // Object-based FS-policy normalization (D6): tighten aliases of the same
         // host object to the strictest intent (deny > ro > rw). Done here, close
-        // to mount, on a clone — config_parser stays string-only and the TOCTOU
-        // window between check and mount is minimized.
-        let mut normalized = request.clone();
-        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
-        let child = self.spawn_bwrap(&normalized, logger, stdio)?;
+        // to mount — config_parser stays string-only and the TOCTOU window
+        // between check and mount is minimized. Only clone the request when an
+        // aliasing conflict actually needs tightening (the common case is none).
+        let normalized;
+        let request = match wxc_common::filesystem_object::normalize_object_conflicts(
+            &request.policy,
+            logger,
+        ) {
+            Some(policy) => {
+                normalized = ExecutionRequest {
+                    policy,
+                    ..request.clone()
+                };
+                &normalized
+            }
+            None => request,
+        };
+        let child = self.spawn_bwrap(request, logger, stdio)?;
         Ok(Box::new(BubblewrapSandboxProcess::new(child)))
     }
 }

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -103,20 +103,22 @@ impl SandboxBackend for BubblewrapScriptRunner {
         // host object to the strictest intent (deny > ro > rw). Done here, close
         // to mount — config_parser stays string-only and the TOCTOU window
         // between check and mount is minimized. Only clone the request when an
-        // aliasing conflict actually needs tightening (the common case is none).
+        // aliasing conflict actually needs tightening (the common case is none);
+        // an unresolvable path with deniedPaths present fails closed.
         let normalized;
         let request = match wxc_common::filesystem_object::normalize_object_conflicts(
             &request.policy,
             logger,
         ) {
-            Some(policy) => {
+            Ok(Some(policy)) => {
                 normalized = ExecutionRequest {
                     policy,
                     ..request.clone()
                 };
                 &normalized
             }
-            None => request,
+            Ok(None) => request,
+            Err(msg) => return Err(ScriptResponse::error(&msg)),
         };
         let child = self.spawn_bwrap(request, logger, stdio)?;
         Ok(Box::new(BubblewrapSandboxProcess::new(child)))

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -99,7 +99,13 @@ impl SandboxBackend for BubblewrapScriptRunner {
     ) -> Result<Box<dyn SandboxProcess>, ScriptResponse> {
         validate_common(request)?;
         self.validate(request)?;
-        let child = self.spawn_bwrap(request, logger, stdio)?;
+        // Object-based FS-policy normalization (D6): tighten aliases of the same
+        // host object to the strictest intent (deny > ro > rw). Done here, close
+        // to mount, on a clone — config_parser stays string-only and the TOCTOU
+        // window between check and mount is minimized.
+        let mut normalized = request.clone();
+        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
+        let child = self.spawn_bwrap(&normalized, logger, stdio)?;
         Ok(Box::new(BubblewrapSandboxProcess::new(child)))
     }
 }

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -91,10 +91,22 @@ impl LxcScriptRunner {
     fn run_internal(&self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {
         // Object-based FS-policy normalization (D6): tighten aliases of the same
         // host object to the strictest intent (deny > ro > rw) before building
-        // mounts. See `wxc_common::filesystem_object`.
-        let mut normalized = request.clone();
-        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
-        let request = &normalized;
+        // mounts. See `wxc_common::filesystem_object`. Only clone the request
+        // when an aliasing conflict actually needs tightening.
+        let normalized;
+        let request = match wxc_common::filesystem_object::normalize_object_conflicts(
+            &request.policy,
+            logger,
+        ) {
+            Some(policy) => {
+                normalized = ExecutionRequest {
+                    policy,
+                    ..request.clone()
+                };
+                &normalized
+            }
+            None => request,
+        };
 
         // Validate required LXC fields
         if self.config.distribution.is_empty() || self.config.release.is_empty() {

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -92,20 +92,22 @@ impl LxcScriptRunner {
         // Object-based FS-policy normalization (D6): tighten aliases of the same
         // host object to the strictest intent (deny > ro > rw) before building
         // mounts. See `wxc_common::filesystem_object`. Only clone the request
-        // when an aliasing conflict actually needs tightening.
+        // when an aliasing conflict actually needs tightening; an unresolvable
+        // path with deniedPaths present fails closed.
         let normalized;
         let request = match wxc_common::filesystem_object::normalize_object_conflicts(
             &request.policy,
             logger,
         ) {
-            Some(policy) => {
+            Ok(Some(policy)) => {
                 normalized = ExecutionRequest {
                     policy,
                     ..request.clone()
                 };
                 &normalized
             }
-            None => request,
+            Ok(None) => request,
+            Err(msg) => return ScriptResponse::error(&msg),
         };
 
         // Validate required LXC fields

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -89,6 +89,13 @@ impl LxcScriptRunner {
 
     /// Core execution logic.
     fn run_internal(&self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {
+        // Object-based FS-policy normalization (D6): tighten aliases of the same
+        // host object to the strictest intent (deny > ro > rw) before building
+        // mounts. See `wxc_common::filesystem_object`.
+        let mut normalized = request.clone();
+        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
+        let request = &normalized;
+
         // Validate required LXC fields
         if self.config.distribution.is_empty() || self.config.release.is_empty() {
             return ScriptResponse::error(

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -857,6 +857,14 @@ impl WSLContainerRunner {
     ) -> ScriptResponse {
         let _ = writeln!(logger, "[WSLC] Starting WSL Container runner");
 
+        // Object-based FS-policy normalization (D6): tighten aliases of the same
+        // host object to the strictest intent (deny > ro > rw) before mapping to
+        // volume mounts. See `wxc_common::filesystem_object`. (A path moved to
+        // `denied` is simply not mounted by WSLC — unmounted = invisible.)
+        let mut normalized = request.clone();
+        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
+        let request = &normalized;
+
         // -- Init: COM + SDK + preflight --
         let sdk = match Self::init_and_load_sdk(logger) {
             Ok(r) => r,

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -860,10 +860,22 @@ impl WSLContainerRunner {
         // Object-based FS-policy normalization (D6): tighten aliases of the same
         // host object to the strictest intent (deny > ro > rw) before mapping to
         // volume mounts. See `wxc_common::filesystem_object`. (A path moved to
-        // `denied` is simply not mounted by WSLC — unmounted = invisible.)
-        let mut normalized = request.clone();
-        wxc_common::filesystem_object::normalize_object_conflicts(&mut normalized.policy, logger);
-        let request = &normalized;
+        // `denied` is simply not mounted by WSLC — unmounted = invisible.) Only
+        // clone the request when an aliasing conflict actually needs tightening.
+        let normalized;
+        let request = match wxc_common::filesystem_object::normalize_object_conflicts(
+            &request.policy,
+            logger,
+        ) {
+            Some(policy) => {
+                normalized = ExecutionRequest {
+                    policy,
+                    ..request.clone()
+                };
+                &normalized
+            }
+            None => request,
+        };
 
         // -- Init: COM + SDK + preflight --
         let sdk = match Self::init_and_load_sdk(logger) {

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -861,20 +861,22 @@ impl WSLContainerRunner {
         // host object to the strictest intent (deny > ro > rw) before mapping to
         // volume mounts. See `wxc_common::filesystem_object`. (A path moved to
         // `denied` is simply not mounted by WSLC — unmounted = invisible.) Only
-        // clone the request when an aliasing conflict actually needs tightening.
+        // clone the request when an aliasing conflict actually needs tightening;
+        // an unresolvable path with deniedPaths present fails closed.
         let normalized;
         let request = match wxc_common::filesystem_object::normalize_object_conflicts(
             &request.policy,
             logger,
         ) {
-            Some(policy) => {
+            Ok(Some(policy)) => {
                 normalized = ExecutionRequest {
                     policy,
                     ..request.clone()
                 };
                 &normalized
             }
-            None => request,
+            Ok(None) => request,
+            Err(msg) => return ScriptResponse::error(&msg),
         };
 
         // -- Init: COM + SDK + preflight --

--- a/src/core/wxc_common/src/filesystem_object.rs
+++ b/src/core/wxc_common/src/filesystem_object.rs
@@ -1,0 +1,416 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Object-based filesystem-policy normalization (roadmap item D6 —
+//! "object-based policy validation").
+//!
+//! The string-level [`crate::config_parser::normalize_filesystem_paths`] already
+//! resolves *same path string* appearing in multiple lists via
+//! most-restrictive-wins (`deny` > `readonly` > `readwrite`). This module
+//! handles the harder case: two **different** path strings that resolve to the
+//! **same filesystem object** (via bind mounts, symlinks, or hard links) but
+//! carry conflicting intents — e.g. `readwritePaths: ["/mnt/storage/data"]` and
+//! `deniedPaths: ["/data"]` where `/data` is a bind mount of the former. The
+//! agent could reach the "denied" object through the read-write alias.
+//!
+//! Because Linux mount namespaces (and the WSLC SDK) are *path*-based, denying
+//! one path to an object cannot deny another path to the same object (that's the
+//! non-actionable "object-based enforcement" gap). The only thing we can do at
+//! config time is **normalize**: detect aliases of the same object and tighten
+//! every alias to the strictest intent among them, emitting a warning per
+//! tightened path. We never reject — conflicting intents are resolved
+//! deterministically.
+//!
+//! This does file I/O (`stat`/`CreateFile`), so — per design review — it lives
+//! here in `wxc_common` and is invoked by each backend runner close to the
+//! point of enforcement (NOT in `config_parser`, which stays string-only). This
+//! both honors that separation and shrinks the TOCTOU window between the check
+//! and the backend actually building its mounts.
+
+use crate::logger::Logger;
+use crate::models::ContainerPolicy;
+
+/// Intent class for a policy path, ordered least → most restrictive so that
+/// `max()` yields the strictest intent in a group of aliases.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum Intent {
+    ReadWrite,
+    ReadOnly,
+    Denied,
+}
+
+impl Intent {
+    /// The JSON config list name this intent maps to (for diagnostics).
+    fn list_name(self) -> &'static str {
+        match self {
+            Intent::ReadWrite => "readwritePaths",
+            Intent::ReadOnly => "readonlyPaths",
+            Intent::Denied => "deniedPaths",
+        }
+    }
+}
+
+/// Opaque identity of a filesystem object. Two paths with the same `ObjectId`
+/// refer to the same underlying object even if reached via different names
+/// (bind mount, symlink, or hard link).
+#[cfg(unix)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct ObjectId {
+    dev: u64,
+    ino: u64,
+}
+
+#[cfg(windows)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct ObjectId {
+    volume_serial: u64,
+    file_id: u128,
+}
+
+#[cfg(not(any(unix, windows)))]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+struct ObjectId {
+    _unused: u8,
+}
+
+/// Resolve a path to its filesystem-object identity, following symlinks so two
+/// names for the same target collide. Returns `None` when the path cannot be
+/// stat'd (missing, permission denied, etc.) — such paths are left untouched
+/// (their existence is handled separately as an advisory warning).
+#[cfg(unix)]
+fn object_id(path: &str) -> Option<ObjectId> {
+    use std::os::unix::fs::MetadataExt;
+    // `metadata` follows symlinks, giving the target object's identity.
+    let md = std::fs::metadata(path).ok()?;
+    Some(ObjectId {
+        dev: md.dev(),
+        ino: md.ino(),
+    })
+}
+
+#[cfg(windows)]
+fn object_id(path: &str) -> Option<ObjectId> {
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Storage::FileSystem::{
+        CreateFileW, FileIdInfo, GetFileInformationByHandleEx, FILE_FLAG_BACKUP_SEMANTICS,
+        FILE_ID_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+
+    let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
+    let share = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
+
+    // Desired access 0: we need no data access to query identity, only a handle.
+    // FILE_FLAG_BACKUP_SEMANTICS lets the same call open directories as well as
+    // files. SAFETY: `wide` is a local NUL-terminated buffer; all other pointers
+    // are NULL.
+    let handle = unsafe {
+        CreateFileW(
+            PCWSTR(wide.as_ptr()),
+            0,
+            share,
+            None,
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            None,
+        )
+    };
+    let handle = match handle {
+        Ok(h) if !h.is_invalid() => h,
+        _ => return None,
+    };
+
+    let mut info = FILE_ID_INFO::default();
+    // SAFETY: `handle` is valid; `info` is a correctly sized out-param.
+    let rc = unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileIdInfo,
+            &mut info as *mut FILE_ID_INFO as *mut core::ffi::c_void,
+            std::mem::size_of::<FILE_ID_INFO>() as u32,
+        )
+    };
+    // SAFETY: `handle` came from a successful CreateFileW above.
+    unsafe {
+        let _ = CloseHandle(handle);
+    }
+    if rc.is_err() {
+        return None;
+    }
+    Some(ObjectId {
+        volume_serial: info.VolumeSerialNumber,
+        file_id: u128::from_le_bytes(info.FileId.Identifier),
+    })
+}
+
+#[cfg(not(any(unix, windows)))]
+fn object_id(_path: &str) -> Option<ObjectId> {
+    None
+}
+
+/// Normalize cross-path object conflicts in `policy` in place.
+///
+/// For each set of policy paths that resolve to the same filesystem object but
+/// carry differing intents, the looser-intent paths are moved into the strictest
+/// intent's list (`deny` > `readonly` > `readwrite`) and a warning is logged for
+/// each moved path. Paths that can't be stat'd are left as-is. This never
+/// removes a path entirely or rejects the config; it only tightens intents.
+///
+/// Run this *after* the string-level normalization in `config_parser`, close to
+/// where the backend builds its mounts.
+pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Logger) {
+    if policy.readwrite_paths.is_empty()
+        && policy.readonly_paths.is_empty()
+        && policy.denied_paths.is_empty()
+    {
+        return;
+    }
+
+    use std::collections::{HashMap, HashSet};
+
+    // Flatten every (path, intent) in a stable order: rw, then ro, then denied.
+    let mut entries: Vec<(String, Intent)> = Vec::with_capacity(
+        policy.readwrite_paths.len() + policy.readonly_paths.len() + policy.denied_paths.len(),
+    );
+    for p in &policy.readwrite_paths {
+        entries.push((p.clone(), Intent::ReadWrite));
+    }
+    for p in &policy.readonly_paths {
+        entries.push((p.clone(), Intent::ReadOnly));
+    }
+    for p in &policy.denied_paths {
+        entries.push((p.clone(), Intent::Denied));
+    }
+
+    // Group entry indices by object identity (skip unstattable paths).
+    let mut groups: HashMap<ObjectId, Vec<usize>> = HashMap::new();
+    for (i, (path, _)) in entries.iter().enumerate() {
+        if let Some(id) = object_id(path) {
+            groups.entry(id).or_default().push(i);
+        }
+    }
+
+    // Final intent per entry (defaults to its declared intent).
+    let mut final_intent: Vec<Intent> = entries.iter().map(|(_, it)| *it).collect();
+
+    for members in groups.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        // Strictest intent among the aliases.
+        let target = members.iter().map(|&i| entries[i].1).max().unwrap();
+        if members.iter().all(|&i| entries[i].1 == target) {
+            // All aliases already share the strictest intent — redundant, not a
+            // conflict.
+            continue;
+        }
+        // A representative alias already at the strictest intent (for the message).
+        let rep = members
+            .iter()
+            .copied()
+            .find(|&i| entries[i].1 == target)
+            .unwrap();
+        let rep_path = entries[rep].0.clone();
+        for &i in members {
+            if entries[i].1 < target {
+                logger.log_line(&format!(
+                    "Filesystem path '{}' ({}) and '{}' ({}) resolve to the same filesystem \
+                     object; applying most-restrictive intent ({}) to '{}'",
+                    entries[i].0,
+                    entries[i].1.list_name(),
+                    rep_path,
+                    target.list_name(),
+                    target.list_name(),
+                    entries[i].0,
+                ));
+                final_intent[i] = target;
+            }
+        }
+    }
+
+    // Rebuild the three lists from the resolved intents, preserving original
+    // ordering and de-duplicating within each list.
+    let mut rw = Vec::new();
+    let mut ro = Vec::new();
+    let mut dn = Vec::new();
+    let mut seen_rw = HashSet::new();
+    let mut seen_ro = HashSet::new();
+    let mut seen_dn = HashSet::new();
+    for (i, (path, _)) in entries.into_iter().enumerate() {
+        match final_intent[i] {
+            Intent::ReadWrite => {
+                if seen_rw.insert(path.clone()) {
+                    rw.push(path);
+                }
+            }
+            Intent::ReadOnly => {
+                if seen_ro.insert(path.clone()) {
+                    ro.push(path);
+                }
+            }
+            Intent::Denied => {
+                if seen_dn.insert(path.clone()) {
+                    dn.push(path);
+                }
+            }
+        }
+    }
+    policy.readwrite_paths = rw;
+    policy.readonly_paths = ro;
+    policy.denied_paths = dn;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logger::{Logger, Mode};
+
+    fn policy(rw: &[&str], ro: &[&str], dn: &[&str]) -> ContainerPolicy {
+        ContainerPolicy {
+            readwrite_paths: rw.iter().map(|s| s.to_string()).collect(),
+            readonly_paths: ro.iter().map(|s| s.to_string()).collect(),
+            denied_paths: dn.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn empty_policy_is_noop() {
+        let mut p = ContainerPolicy::default();
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+        assert!(p.readwrite_paths.is_empty());
+        assert!(p.readonly_paths.is_empty());
+        assert!(p.denied_paths.is_empty());
+    }
+
+    #[test]
+    fn missing_paths_left_untouched() {
+        // Non-existent paths can't be stat'd, so no grouping / no change.
+        let mut p = policy(
+            &["/nonexistent/mxc-test-rw"],
+            &["/nonexistent/mxc-test-ro"],
+            &["/nonexistent/mxc-test-dn"],
+        );
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+        assert_eq!(p.readwrite_paths, vec!["/nonexistent/mxc-test-rw"]);
+        assert_eq!(p.readonly_paths, vec!["/nonexistent/mxc-test-ro"]);
+        assert_eq!(p.denied_paths, vec!["/nonexistent/mxc-test-dn"]);
+    }
+
+    #[test]
+    fn distinct_objects_with_different_intents_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::write(&a, b"a").unwrap();
+        std::fs::write(&b, b"b").unwrap();
+        let (a, b) = (a.to_str().unwrap(), b.to_str().unwrap());
+
+        let mut p = policy(&[a], &[b], &[]);
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+        assert_eq!(p.readwrite_paths, vec![a.to_string()]);
+        assert_eq!(p.readonly_paths, vec![b.to_string()]);
+    }
+
+    #[test]
+    fn same_object_same_intent_is_not_a_conflict() {
+        // Two distinct paths to the same object, both read-write — redundant but
+        // not a conflict, so nothing moves.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, b"x").unwrap();
+        #[cfg(unix)]
+        let alias = {
+            let link = dir.path().join("alias");
+            std::os::unix::fs::symlink(&target, &link).unwrap();
+            link
+        };
+        #[cfg(not(unix))]
+        let alias = target.clone();
+
+        let (t, a) = (target.to_str().unwrap(), alias.to_str().unwrap());
+        let mut p = policy(&[t, a], &[], &[]);
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+        assert_eq!(p.readonly_paths.len(), 0);
+        assert_eq!(p.denied_paths.len(), 0);
+        // Both remain read-write (order preserved).
+        assert!(p.readwrite_paths.contains(&t.to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_rw_and_denied_tightens_to_denied() {
+        // `target` is RW, `link` (a symlink to it) is denied → both become denied.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::write(&target, b"secret").unwrap();
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        let (t, l) = (target.to_str().unwrap(), link.to_str().unwrap());
+
+        let mut p = policy(&[t], &[], &[l]);
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+
+        assert!(
+            p.readwrite_paths.is_empty(),
+            "rw alias of a denied object must be tightened to denied"
+        );
+        assert!(p.denied_paths.contains(&t.to_string()));
+        assert!(p.denied_paths.contains(&l.to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hardlink_rw_and_readonly_tightens_to_readonly() {
+        // Hard link: two names, same inode. RW + RO → both read-only.
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        std::fs::write(&a, b"data").unwrap();
+        let b = dir.path().join("b");
+        std::fs::hard_link(&a, &b).unwrap();
+        let (a, b) = (a.to_str().unwrap(), b.to_str().unwrap());
+
+        let mut p = policy(&[a], &[b], &[]);
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+
+        assert!(
+            p.readwrite_paths.is_empty(),
+            "rw alias of a read-only object must be tightened to read-only"
+        );
+        assert!(p.readonly_paths.contains(&a.to_string()));
+        assert!(p.readonly_paths.contains(&b.to_string()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn denied_wins_over_both_rw_and_ro_aliases() {
+        // Three aliases of one object across all three lists → all denied.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("obj");
+        std::fs::write(&target, b"x").unwrap();
+        let l1 = dir.path().join("l1");
+        let l2 = dir.path().join("l2");
+        std::os::unix::fs::symlink(&target, &l1).unwrap();
+        std::os::unix::fs::symlink(&target, &l2).unwrap();
+        let (t, a, b) = (
+            target.to_str().unwrap(),
+            l1.to_str().unwrap(),
+            l2.to_str().unwrap(),
+        );
+
+        // t = rw, a = ro, b = denied.
+        let mut p = policy(&[t], &[a], &[b]);
+        let mut logger = Logger::new(Mode::Buffer);
+        normalize_object_conflicts(&mut p, &mut logger);
+
+        assert!(p.readwrite_paths.is_empty());
+        assert!(p.readonly_paths.is_empty());
+        assert_eq!(p.denied_paths.len(), 3);
+    }
+}

--- a/src/core/wxc_common/src/filesystem_object.rs
+++ b/src/core/wxc_common/src/filesystem_object.rs
@@ -15,11 +15,18 @@
 //!
 //! Because Linux mount namespaces (and the WSLC SDK) are *path*-based, denying
 //! one path to an object cannot deny another path to the same object (that's the
-//! non-actionable "object-based enforcement" gap). The only thing we can do at
-//! config time is **normalize**: detect aliases of the same object and tighten
-//! every alias to the strictest intent among them, emitting a warning per
-//! tightened path. We never reject — conflicting intents are resolved
-//! deterministically.
+//! non-actionable "object-based enforcement" gap). The best we can do at config
+//! time is **normalize**: detect aliases of the same object and tighten every
+//! alias to the strictest intent among them, emitting a warning per tightened
+//! path. Conflicting intents are resolved deterministically rather than erroring.
+//!
+//! **Fail-closed exception.** The normalization above relies on resolving each
+//! path to an object identity. When a path cannot be resolved (permission
+//! denied, unreachable mount, I/O error — as opposed to *cleanly missing*) and
+//! `deniedPaths` are present, MXC cannot prove that path is not an undetectable
+//! alias that would bypass a deny. Rather than proceed looser than intended, the
+//! config is **rejected** (fail closed). Cleanly-missing paths do not trigger
+//! this — they are genuinely absent, so there is nothing to alias.
 //!
 //! This does file I/O (`stat`/`CreateFile`), so — per design review — it lives
 //! here in `wxc_common` and is invoked by each backend runner close to the
@@ -73,25 +80,52 @@ struct ObjectId {
     _unused: u8,
 }
 
+/// Outcome of resolving a policy path to its filesystem-object identity.
+enum PathResolution {
+    /// The path resolved to a concrete object.
+    Object(ObjectId),
+    /// The path is cleanly missing (`ENOENT`/`ENOTDIR` or `ERROR_*_NOT_FOUND`).
+    /// Nothing to alias; safe to skip. (Existence is surfaced separately by the
+    /// parse-time existence warning.)
+    Absent,
+    /// The path exists (or may exist) but its identity could not be determined —
+    /// permission denied, an unreachable mount, or another I/O error. This is
+    /// the fail-closed trigger when `deniedPaths` are present.
+    Unknown,
+}
+
 /// Resolve a path to its filesystem-object identity, following symlinks so two
-/// names for the same target collide. Returns `None` when the path cannot be
-/// stat'd (missing, permission denied, etc.) — such paths are left untouched
-/// (their existence is handled separately as an advisory warning).
+/// names for the same target collide.
+///
+/// Distinguishes a *cleanly missing* path ([`PathResolution::Absent`]) from one
+/// that exists-or-might-exist but cannot be examined
+/// ([`PathResolution::Unknown`]), so the caller can fail closed on the latter
+/// without rejecting the common "path created at mount time" case.
 #[cfg(unix)]
-fn object_id(path: &str) -> Option<ObjectId> {
+fn resolve_object(path: &str) -> PathResolution {
     use std::os::unix::fs::MetadataExt;
     // `metadata` follows symlinks, giving the target object's identity.
-    let md = std::fs::metadata(path).ok()?;
-    Some(ObjectId {
-        dev: md.dev(),
-        ino: md.ino(),
-    })
+    match std::fs::metadata(path) {
+        Ok(md) => PathResolution::Object(ObjectId {
+            dev: md.dev(),
+            ino: md.ino(),
+        }),
+        // Genuine non-existence is safe to skip; any other errno (EACCES from an
+        // untraversable parent, ESTALE/ETIMEDOUT from a dead mount, ...) means we
+        // could not examine the path.
+        Err(e) => match e.raw_os_error() {
+            Some(libc::ENOENT) | Some(libc::ENOTDIR) => PathResolution::Absent,
+            _ => PathResolution::Unknown,
+        },
+    }
 }
 
 #[cfg(windows)]
-fn object_id(path: &str) -> Option<ObjectId> {
+fn resolve_object(path: &str) -> PathResolution {
     use windows::core::PCWSTR;
-    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
+    };
     use windows::Win32::Storage::FileSystem::{
         CreateFileW, FileIdInfo, GetFileInformationByHandleEx, FILE_FLAG_BACKUP_SEMANTICS,
         FILE_ID_INFO, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
@@ -120,7 +154,16 @@ fn object_id(path: &str) -> Option<ObjectId> {
     };
     let handle = match handle {
         Ok(h) if !h.is_invalid() => h,
-        _ => return None,
+        _ => {
+            // Distinguish a cleanly-missing path from an unexaminable one.
+            // SAFETY: reads the thread-local last error set by the failed call.
+            let err = unsafe { GetLastError() };
+            return if err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND {
+                PathResolution::Absent
+            } else {
+                PathResolution::Unknown
+            };
+        }
     };
 
     let mut info = FILE_ID_INFO::default();
@@ -138,17 +181,21 @@ fn object_id(path: &str) -> Option<ObjectId> {
         let _ = CloseHandle(handle);
     }
     if rc.is_err() {
-        return None;
+        // We opened the object but couldn't read its identity — treat as
+        // unexaminable rather than absent.
+        return PathResolution::Unknown;
     }
-    Some(ObjectId {
+    PathResolution::Object(ObjectId {
         volume_serial: info.VolumeSerialNumber,
         file_id: u128::from_le_bytes(info.FileId.Identifier),
     })
 }
 
 #[cfg(not(any(unix, windows)))]
-fn object_id(_path: &str) -> Option<ObjectId> {
-    None
+fn resolve_object(_path: &str) -> PathResolution {
+    // No way to determine object identity on unsupported platforms; treat as
+    // unexaminable so the fail-closed path applies when deniedPaths are present.
+    PathResolution::Unknown
 }
 
 /// Detect cross-path object conflicts and return a tightened copy of `policy`.
@@ -156,33 +203,37 @@ fn object_id(_path: &str) -> Option<ObjectId> {
 /// For each set of policy paths that resolve to the same filesystem object but
 /// carry differing intents, the looser-intent paths are moved into the strictest
 /// intent's list (`deny` > `readonly` > `readwrite`) and a warning is logged for
-/// each moved path. Paths that can't be stat'd are left as-is. This never
-/// removes a path entirely or rejects the config; it only tightens intents.
+/// each moved path. Cleanly-missing paths are left as-is.
 ///
-/// Returns `Some(new_policy)` only when at least one path's intent was
-/// tightened; returns `None` when there is nothing to change (the common case —
-/// no symlink / hard-link / bind-mount aliases among the policy paths), so
-/// callers can avoid cloning the request entirely.
+/// Returns:
+/// - `Ok(Some(new_policy))` when at least one path's intent was tightened.
+/// - `Ok(None)` when there is nothing to change (the common case — no
+///   symlink / hard-link / bind-mount aliases), so callers can avoid cloning the
+///   request entirely.
+/// - `Err(message)` when the config must be **rejected**: a path could not be
+///   resolved to an object (permission denied, unreachable mount, I/O error —
+///   *not* cleanly missing) while `deniedPaths` are present, so an alias that
+///   would bypass a deny cannot be ruled out (fail closed). The message is
+///   suitable for surfacing as a backend error.
 ///
 /// Run this *after* the string-level normalization in `config_parser`, close to
 /// where the backend builds its mounts.
 pub fn normalize_object_conflicts(
     policy: &ContainerPolicy,
     logger: &mut Logger,
-) -> Option<ContainerPolicy> {
-    if policy.readwrite_paths.is_empty()
-        && policy.readonly_paths.is_empty()
-        && policy.denied_paths.is_empty()
-    {
-        return None;
+) -> Result<Option<ContainerPolicy>, String> {
+    let total =
+        policy.readwrite_paths.len() + policy.readonly_paths.len() + policy.denied_paths.len();
+    // A conflict needs at least two paths resolving to the same object, so a
+    // policy with 0 or 1 total paths can never tighten — skip the file I/O.
+    if total <= 1 {
+        return Ok(None);
     }
 
     use std::collections::{HashMap, HashSet};
 
     // Flatten every (path, intent) in a stable order: rw, then ro, then denied.
-    let mut entries: Vec<(String, Intent)> = Vec::with_capacity(
-        policy.readwrite_paths.len() + policy.readonly_paths.len() + policy.denied_paths.len(),
-    );
+    let mut entries: Vec<(String, Intent)> = Vec::with_capacity(total);
     for p in &policy.readwrite_paths {
         entries.push((p.clone(), Intent::ReadWrite));
     }
@@ -193,11 +244,40 @@ pub fn normalize_object_conflicts(
         entries.push((p.clone(), Intent::Denied));
     }
 
-    // Group entry indices by object identity (skip unstattable paths).
+    // Group entry indices by object identity. Resolution has three outcomes:
+    // - `Object`: grouped for conflict detection.
+    // - `Absent` (cleanly missing): skipped — nothing to alias.
+    // - `Unknown` (exists/maybe-exists but unexaminable): when `deniedPaths` are
+    //   present we cannot prove this path is not an undetectable alias that would
+    //   bypass a deny, so we FAIL CLOSED and reject. Without `deniedPaths` there
+    //   is no deny to bypass, so we log it and leave it in place.
+    let has_denied = !policy.denied_paths.is_empty();
     let mut groups: HashMap<ObjectId, Vec<usize>> = HashMap::new();
-    for (i, (path, _)) in entries.iter().enumerate() {
-        if let Some(id) = object_id(path) {
-            groups.entry(id).or_default().push(i);
+    for (i, (path, intent)) in entries.iter().enumerate() {
+        match resolve_object(path) {
+            PathResolution::Object(id) => {
+                groups.entry(id).or_default().push(i);
+            }
+            PathResolution::Absent => {}
+            PathResolution::Unknown if has_denied => {
+                return Err(format!(
+                    "Filesystem path '{}' ({}) could not be resolved to a filesystem object \
+                     (permission denied, unreachable mount, or I/O error). Because deniedPaths \
+                     are present, MXC cannot verify it does not alias a denied object and rejects \
+                     the config rather than risk bypassing the deny. Ensure the path is reachable, \
+                     or remove the offending entry.",
+                    path,
+                    intent.list_name(),
+                ));
+            }
+            PathResolution::Unknown => {
+                logger.log_line(&format!(
+                    "WARNING: filesystem path '{}' ({}) could not be resolved to a filesystem \
+                     object and was not checked for aliasing",
+                    path,
+                    intent.list_name(),
+                ));
+            }
         }
     }
 
@@ -244,7 +324,7 @@ pub fn normalize_object_conflicts(
     // Nothing was tightened: no aliasing conflict, so the caller can keep using
     // the original policy without cloning.
     if !changed {
-        return None;
+        return Ok(None);
     }
 
     // Rebuild the three lists from the resolved intents. Within each list,
@@ -280,7 +360,7 @@ pub fn normalize_object_conflicts(
     new_policy.readwrite_paths = rw;
     new_policy.readonly_paths = ro;
     new_policy.denied_paths = dn;
-    Some(new_policy)
+    Ok(Some(new_policy))
 }
 
 #[cfg(test)]
@@ -297,16 +377,23 @@ mod tests {
         }
     }
 
+    /// Run normalization asserting it does not reject, returning the (optional)
+    /// tightened policy.
+    fn normalize_ok(p: &ContainerPolicy, logger: &mut Logger) -> Option<ContainerPolicy> {
+        normalize_object_conflicts(p, logger).expect("normalization must not reject")
+    }
+
     #[test]
     fn empty_policy_is_noop() {
         let p = ContainerPolicy::default();
         let mut logger = Logger::new(Mode::Buffer);
-        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
+        assert!(normalize_ok(&p, &mut logger).is_none());
     }
 
     #[test]
     fn missing_paths_left_untouched() {
-        // Non-existent paths can't be stat'd, so no grouping / no change.
+        // Cleanly-missing paths resolve to Absent — no grouping, no change, and
+        // (crucially) no fail-closed rejection even with deniedPaths present.
         let p = policy(
             &["/nonexistent/mxc-test-rw"],
             &["/nonexistent/mxc-test-ro"],
@@ -314,9 +401,32 @@ mod tests {
         );
         let mut logger = Logger::new(Mode::Buffer);
         assert!(
-            normalize_object_conflicts(&p, &mut logger).is_none(),
-            "unstattable paths must not trigger a change"
+            normalize_ok(&p, &mut logger).is_none(),
+            "cleanly-missing paths must not trigger a change or a rejection"
         );
+    }
+
+    #[test]
+    fn absent_paths_do_not_warn_or_reject() {
+        // Absent (not Unknown) paths are the benign "created at mount time" case:
+        // no warning, no rejection, even alongside deniedPaths.
+        let p = policy(&["/nonexistent/mxc-a"], &[], &["/nonexistent/mxc-b"]);
+        let mut logger = Logger::new(Mode::Buffer);
+        assert!(normalize_ok(&p, &mut logger).is_none());
+        assert!(
+            !logger.get_buffer().contains("could not be resolved"),
+            "absent paths must not warn about being unresolved"
+        );
+    }
+
+    #[test]
+    fn single_path_skips_all_io() {
+        // A policy with a single path can never form a conflict; the early-return
+        // must avoid touching the filesystem entirely (returns Ok(None)).
+        let p = policy(&["/nonexistent/only-one"], &[], &[]);
+        let mut logger = Logger::new(Mode::Buffer);
+        assert!(normalize_ok(&p, &mut logger).is_none());
+        assert!(logger.get_buffer().is_empty());
     }
 
     #[test]
@@ -331,14 +441,14 @@ mod tests {
         let p = policy(&[a], &[b], &[]);
         let mut logger = Logger::new(Mode::Buffer);
         // Distinct objects, no aliasing: nothing to tighten.
-        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
+        assert!(normalize_ok(&p, &mut logger).is_none());
     }
 
     #[test]
     fn same_object_same_intent_is_not_a_conflict() {
         // Two distinct path strings to the same object via a hard link (works on
-        // both Unix and Windows, and exercises the platform object_id grouping),
-        // both read-write — redundant but not a conflict, so nothing moves.
+        // both Unix and Windows, and exercises the platform object identity
+        // grouping), both read-write — redundant but not a conflict, nothing moves.
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target");
         std::fs::write(&target, b"x").unwrap();
@@ -348,8 +458,7 @@ mod tests {
         let (t, a) = (target.to_str().unwrap(), alias.to_str().unwrap());
         let p = policy(&[t, a], &[], &[]);
         let mut logger = Logger::new(Mode::Buffer);
-        // Same object, same intent: no tightening, so no new policy is produced.
-        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
+        assert!(normalize_ok(&p, &mut logger).is_none());
     }
 
     #[cfg(unix)]
@@ -365,7 +474,7 @@ mod tests {
 
         let p = policy(&[t], &[], &[l]);
         let mut logger = Logger::new(Mode::Buffer);
-        let out = normalize_object_conflicts(&p, &mut logger)
+        let out = normalize_ok(&p, &mut logger)
             .expect("rw+denied aliases of one object must produce a tightened policy");
 
         assert!(
@@ -376,10 +485,12 @@ mod tests {
         assert!(out.denied_paths.contains(&l.to_string()));
     }
 
-    #[cfg(unix)]
+    // Not unix-gated: `std::fs::hard_link` works on Windows too, so this gives
+    // the Windows object identity (FileIdInfo) grouping + rebuild path real
+    // tightening coverage (the symlink-based tightening tests are unix-only).
     #[test]
     fn hardlink_rw_and_readonly_tightens_to_readonly() {
-        // Hard link: two names, same inode. RW + RO → both read-only.
+        // Hard link: two names, same object. RW + RO → both read-only.
         let dir = tempfile::tempdir().unwrap();
         let a = dir.path().join("a");
         std::fs::write(&a, b"data").unwrap();
@@ -389,7 +500,7 @@ mod tests {
 
         let p = policy(&[a], &[b], &[]);
         let mut logger = Logger::new(Mode::Buffer);
-        let out = normalize_object_conflicts(&p, &mut logger)
+        let out = normalize_ok(&p, &mut logger)
             .expect("rw+ro aliases of one object must produce a tightened policy");
 
         assert!(
@@ -420,11 +531,121 @@ mod tests {
         // t = rw, a = ro, b = denied.
         let p = policy(&[t], &[a], &[b]);
         let mut logger = Logger::new(Mode::Buffer);
-        let out = normalize_object_conflicts(&p, &mut logger)
+        let out = normalize_ok(&p, &mut logger)
             .expect("three aliases across all lists must produce a tightened policy");
 
         assert!(out.readwrite_paths.is_empty());
         assert!(out.readonly_paths.is_empty());
         assert_eq!(out.denied_paths.len(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unresolvable_path_with_denied_fails_closed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Root bypasses traversal permission, so this case is only meaningful as
+        // a non-root user.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        // A file inside a directory the caller can't traverse: it exists but
+        // can't be examined (EACCES → Unknown, not Absent). With deniedPaths
+        // present, we cannot rule out an alias bypass, so the config is rejected.
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        let hidden = locked.join("data.txt");
+        std::fs::write(&hidden, b"data").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // The unexaminable path is read-write; a separate denied path is present.
+        let denied = dir.path().join("denied");
+        std::fs::write(&denied, b"x").unwrap();
+        let p = policy(
+            &[hidden.to_str().unwrap()],
+            &[],
+            &[denied.to_str().unwrap()],
+        );
+        let mut logger = Logger::new(Mode::Buffer);
+        let err = normalize_object_conflicts(&p, &mut logger)
+            .expect_err("an unexaminable path with deniedPaths present must fail closed");
+        assert!(
+            err.contains("could not be resolved") && err.contains("deniedPaths"),
+            "expected a fail-closed rejection message, got: {err}"
+        );
+
+        // Restore traversal so the tempdir can recurse in during cleanup.
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unresolvable_path_without_denied_does_not_reject() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+
+        // Same unexaminable path, but NO deniedPaths: there is no deny to bypass,
+        // so it must NOT reject — it is logged and left in place.
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        let hidden = locked.join("data.txt");
+        std::fs::write(&hidden, b"data").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let other = dir.path().join("other");
+        std::fs::write(&other, b"y").unwrap();
+        let p = policy(&[hidden.to_str().unwrap()], &[other.to_str().unwrap()], &[]);
+        let mut logger = Logger::new(Mode::Buffer);
+        assert!(
+            normalize_ok(&p, &mut logger).is_none(),
+            "unexaminable path without deniedPaths must not reject or tighten"
+        );
+        assert!(
+            logger.get_buffer().contains("could not be resolved"),
+            "unexaminable path should be logged"
+        );
+
+        let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unresolvable_path_with_denied_fails_closed_windows() {
+        use std::process::Command;
+
+        // A file with an explicit deny-read ACE cannot be opened even for
+        // FILE_READ_ATTRIBUTES, so resolve_object returns Unknown (ACCESS_DENIED,
+        // not NOT_FOUND). With deniedPaths present, the config must fail closed.
+        let dir = tempfile::tempdir().unwrap();
+        let hidden = dir.path().join("hidden.txt");
+        std::fs::write(&hidden, b"data").unwrap();
+        let h = hidden.to_str().unwrap();
+        let status = Command::new("icacls")
+            .args([h, "/deny", "*S-1-1-0:(R)"])
+            .output()
+            .expect("icacls should run");
+        assert!(status.status.success());
+
+        let denied = dir.path().join("denied.txt");
+        std::fs::write(&denied, b"x").unwrap();
+        let p = policy(&[h], &[], &[denied.to_str().unwrap()]);
+        let mut logger = Logger::new(Mode::Buffer);
+        let err = normalize_object_conflicts(&p, &mut logger)
+            .expect_err("an unexaminable path with deniedPaths present must fail closed");
+        assert!(
+            err.contains("could not be resolved") && err.contains("deniedPaths"),
+            "expected a fail-closed rejection message, got: {err}"
+        );
+
+        // Remove the deny ACE so the tempdir can clean up.
+        let _ = Command::new("icacls")
+            .args([h, "/remove:d", "*S-1-1-0"])
+            .output();
     }
 }

--- a/src/core/wxc_common/src/filesystem_object.rs
+++ b/src/core/wxc_common/src/filesystem_object.rs
@@ -94,20 +94,23 @@ fn object_id(path: &str) -> Option<ObjectId> {
     use windows::Win32::Foundation::CloseHandle;
     use windows::Win32::Storage::FileSystem::{
         CreateFileW, FileIdInfo, GetFileInformationByHandleEx, FILE_FLAG_BACKUP_SEMANTICS,
-        FILE_ID_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        FILE_ID_INFO, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+        OPEN_EXISTING,
     };
 
     let wide: Vec<u16> = path.encode_utf16().chain(std::iter::once(0)).collect();
     let share = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE;
 
-    // Desired access 0: we need no data access to query identity, only a handle.
-    // FILE_FLAG_BACKUP_SEMANTICS lets the same call open directories as well as
-    // files. SAFETY: `wide` is a local NUL-terminated buffer; all other pointers
-    // are NULL.
+    // FILE_READ_ATTRIBUTES is the minimum access GetFileInformationByHandleEx
+    // (FileIdInfo) needs to read the object identity; a zero-access handle can
+    // be rejected (ERROR_ACCESS_DENIED) on some filesystems. We deliberately do
+    // NOT request data-read access. FILE_FLAG_BACKUP_SEMANTICS lets the same
+    // call open directories as well as files. SAFETY: `wide` is a local
+    // NUL-terminated buffer; all other pointers are NULL.
     let handle = unsafe {
         CreateFileW(
             PCWSTR(wide.as_ptr()),
-            0,
+            FILE_READ_ATTRIBUTES.0,
             share,
             None,
             OPEN_EXISTING,
@@ -228,8 +231,10 @@ pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Log
         }
     }
 
-    // Rebuild the three lists from the resolved intents, preserving original
-    // ordering and de-duplicating within each list.
+    // Rebuild the three lists from the resolved intents. Within each list,
+    // entries keep first-seen order across the flattened rw → ro → denied
+    // sequence — so a path tightened from rw to denied lands ahead of paths
+    // originally in denied — de-duplicating within each list.
     let mut rw = Vec::new();
     let mut ro = Vec::new();
     let mut dn = Vec::new();
@@ -317,28 +322,24 @@ mod tests {
 
     #[test]
     fn same_object_same_intent_is_not_a_conflict() {
-        // Two distinct paths to the same object, both read-write — redundant but
-        // not a conflict, so nothing moves.
+        // Two distinct path strings to the same object via a hard link (works on
+        // both Unix and Windows, and exercises the platform object_id grouping),
+        // both read-write — redundant but not a conflict, so nothing moves and
+        // both paths are preserved in order.
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target");
         std::fs::write(&target, b"x").unwrap();
-        #[cfg(unix)]
-        let alias = {
-            let link = dir.path().join("alias");
-            std::os::unix::fs::symlink(&target, &link).unwrap();
-            link
-        };
-        #[cfg(not(unix))]
-        let alias = target.clone();
+        let alias = dir.path().join("alias");
+        std::fs::hard_link(&target, &alias).unwrap();
 
         let (t, a) = (target.to_str().unwrap(), alias.to_str().unwrap());
         let mut p = policy(&[t, a], &[], &[]);
         let mut logger = Logger::new(Mode::Buffer);
         normalize_object_conflicts(&mut p, &mut logger);
-        assert_eq!(p.readonly_paths.len(), 0);
-        assert_eq!(p.denied_paths.len(), 0);
-        // Both remain read-write (order preserved).
-        assert!(p.readwrite_paths.contains(&t.to_string()));
+        assert!(p.readonly_paths.is_empty());
+        assert!(p.denied_paths.is_empty());
+        // Both distinct paths remain read-write, original order preserved.
+        assert_eq!(p.readwrite_paths, vec![t.to_string(), a.to_string()]);
     }
 
     #[cfg(unix)]

--- a/src/core/wxc_common/src/filesystem_object.rs
+++ b/src/core/wxc_common/src/filesystem_object.rs
@@ -151,7 +151,7 @@ fn object_id(_path: &str) -> Option<ObjectId> {
     None
 }
 
-/// Normalize cross-path object conflicts in `policy` in place.
+/// Detect cross-path object conflicts and return a tightened copy of `policy`.
 ///
 /// For each set of policy paths that resolve to the same filesystem object but
 /// carry differing intents, the looser-intent paths are moved into the strictest
@@ -159,14 +159,22 @@ fn object_id(_path: &str) -> Option<ObjectId> {
 /// each moved path. Paths that can't be stat'd are left as-is. This never
 /// removes a path entirely or rejects the config; it only tightens intents.
 ///
+/// Returns `Some(new_policy)` only when at least one path's intent was
+/// tightened; returns `None` when there is nothing to change (the common case —
+/// no symlink / hard-link / bind-mount aliases among the policy paths), so
+/// callers can avoid cloning the request entirely.
+///
 /// Run this *after* the string-level normalization in `config_parser`, close to
 /// where the backend builds its mounts.
-pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Logger) {
+pub fn normalize_object_conflicts(
+    policy: &ContainerPolicy,
+    logger: &mut Logger,
+) -> Option<ContainerPolicy> {
     if policy.readwrite_paths.is_empty()
         && policy.readonly_paths.is_empty()
         && policy.denied_paths.is_empty()
     {
-        return;
+        return None;
     }
 
     use std::collections::{HashMap, HashSet};
@@ -195,6 +203,7 @@ pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Log
 
     // Final intent per entry (defaults to its declared intent).
     let mut final_intent: Vec<Intent> = entries.iter().map(|(_, it)| *it).collect();
+    let mut changed = false;
 
     for members in groups.values() {
         if members.len() < 2 {
@@ -227,8 +236,15 @@ pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Log
                     entries[i].0,
                 ));
                 final_intent[i] = target;
+                changed = true;
             }
         }
+    }
+
+    // Nothing was tightened: no aliasing conflict, so the caller can keep using
+    // the original policy without cloning.
+    if !changed {
+        return None;
     }
 
     // Rebuild the three lists from the resolved intents. Within each list,
@@ -260,9 +276,11 @@ pub fn normalize_object_conflicts(policy: &mut ContainerPolicy, logger: &mut Log
             }
         }
     }
-    policy.readwrite_paths = rw;
-    policy.readonly_paths = ro;
-    policy.denied_paths = dn;
+    let mut new_policy = policy.clone();
+    new_policy.readwrite_paths = rw;
+    new_policy.readonly_paths = ro;
+    new_policy.denied_paths = dn;
+    Some(new_policy)
 }
 
 #[cfg(test)]
@@ -281,27 +299,24 @@ mod tests {
 
     #[test]
     fn empty_policy_is_noop() {
-        let mut p = ContainerPolicy::default();
+        let p = ContainerPolicy::default();
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
-        assert!(p.readwrite_paths.is_empty());
-        assert!(p.readonly_paths.is_empty());
-        assert!(p.denied_paths.is_empty());
+        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
     }
 
     #[test]
     fn missing_paths_left_untouched() {
         // Non-existent paths can't be stat'd, so no grouping / no change.
-        let mut p = policy(
+        let p = policy(
             &["/nonexistent/mxc-test-rw"],
             &["/nonexistent/mxc-test-ro"],
             &["/nonexistent/mxc-test-dn"],
         );
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
-        assert_eq!(p.readwrite_paths, vec!["/nonexistent/mxc-test-rw"]);
-        assert_eq!(p.readonly_paths, vec!["/nonexistent/mxc-test-ro"]);
-        assert_eq!(p.denied_paths, vec!["/nonexistent/mxc-test-dn"]);
+        assert!(
+            normalize_object_conflicts(&p, &mut logger).is_none(),
+            "unstattable paths must not trigger a change"
+        );
     }
 
     #[test]
@@ -313,19 +328,17 @@ mod tests {
         std::fs::write(&b, b"b").unwrap();
         let (a, b) = (a.to_str().unwrap(), b.to_str().unwrap());
 
-        let mut p = policy(&[a], &[b], &[]);
+        let p = policy(&[a], &[b], &[]);
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
-        assert_eq!(p.readwrite_paths, vec![a.to_string()]);
-        assert_eq!(p.readonly_paths, vec![b.to_string()]);
+        // Distinct objects, no aliasing: nothing to tighten.
+        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
     }
 
     #[test]
     fn same_object_same_intent_is_not_a_conflict() {
         // Two distinct path strings to the same object via a hard link (works on
         // both Unix and Windows, and exercises the platform object_id grouping),
-        // both read-write — redundant but not a conflict, so nothing moves and
-        // both paths are preserved in order.
+        // both read-write — redundant but not a conflict, so nothing moves.
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target");
         std::fs::write(&target, b"x").unwrap();
@@ -333,13 +346,10 @@ mod tests {
         std::fs::hard_link(&target, &alias).unwrap();
 
         let (t, a) = (target.to_str().unwrap(), alias.to_str().unwrap());
-        let mut p = policy(&[t, a], &[], &[]);
+        let p = policy(&[t, a], &[], &[]);
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
-        assert!(p.readonly_paths.is_empty());
-        assert!(p.denied_paths.is_empty());
-        // Both distinct paths remain read-write, original order preserved.
-        assert_eq!(p.readwrite_paths, vec![t.to_string(), a.to_string()]);
+        // Same object, same intent: no tightening, so no new policy is produced.
+        assert!(normalize_object_conflicts(&p, &mut logger).is_none());
     }
 
     #[cfg(unix)]
@@ -353,16 +363,17 @@ mod tests {
         std::os::unix::fs::symlink(&target, &link).unwrap();
         let (t, l) = (target.to_str().unwrap(), link.to_str().unwrap());
 
-        let mut p = policy(&[t], &[], &[l]);
+        let p = policy(&[t], &[], &[l]);
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
+        let out = normalize_object_conflicts(&p, &mut logger)
+            .expect("rw+denied aliases of one object must produce a tightened policy");
 
         assert!(
-            p.readwrite_paths.is_empty(),
+            out.readwrite_paths.is_empty(),
             "rw alias of a denied object must be tightened to denied"
         );
-        assert!(p.denied_paths.contains(&t.to_string()));
-        assert!(p.denied_paths.contains(&l.to_string()));
+        assert!(out.denied_paths.contains(&t.to_string()));
+        assert!(out.denied_paths.contains(&l.to_string()));
     }
 
     #[cfg(unix)]
@@ -376,16 +387,17 @@ mod tests {
         std::fs::hard_link(&a, &b).unwrap();
         let (a, b) = (a.to_str().unwrap(), b.to_str().unwrap());
 
-        let mut p = policy(&[a], &[b], &[]);
+        let p = policy(&[a], &[b], &[]);
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
+        let out = normalize_object_conflicts(&p, &mut logger)
+            .expect("rw+ro aliases of one object must produce a tightened policy");
 
         assert!(
-            p.readwrite_paths.is_empty(),
+            out.readwrite_paths.is_empty(),
             "rw alias of a read-only object must be tightened to read-only"
         );
-        assert!(p.readonly_paths.contains(&a.to_string()));
-        assert!(p.readonly_paths.contains(&b.to_string()));
+        assert!(out.readonly_paths.contains(&a.to_string()));
+        assert!(out.readonly_paths.contains(&b.to_string()));
     }
 
     #[cfg(unix)]
@@ -406,12 +418,13 @@ mod tests {
         );
 
         // t = rw, a = ro, b = denied.
-        let mut p = policy(&[t], &[a], &[b]);
+        let p = policy(&[t], &[a], &[b]);
         let mut logger = Logger::new(Mode::Buffer);
-        normalize_object_conflicts(&mut p, &mut logger);
+        let out = normalize_object_conflicts(&p, &mut logger)
+            .expect("three aliases across all lists must produce a tightened policy");
 
-        assert!(p.readwrite_paths.is_empty());
-        assert!(p.readonly_paths.is_empty());
-        assert_eq!(p.denied_paths.len(), 3);
+        assert!(out.readwrite_paths.is_empty());
+        assert!(out.readonly_paths.is_empty());
+        assert_eq!(out.denied_paths.len(), 3);
     }
 }

--- a/src/core/wxc_common/src/lib.rs
+++ b/src/core/wxc_common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cmdline;
 pub mod config_parser;
 pub mod encoding;
 pub mod error;
+pub mod filesystem_object;
 pub mod id;
 pub mod log_symbols;
 pub mod logger;

--- a/tests/configs/bubblewrap_filesystem_object.json
+++ b/tests/configs/bubblewrap_filesystem_object.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.8.0-alpha",
   "containerId": "CLI-Bubblewrap-Object-Validation",
   "containment": "bubblewrap",
   "process": {

--- a/tests/configs/bubblewrap_filesystem_object.json
+++ b/tests/configs/bubblewrap_filesystem_object.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "CLI-Bubblewrap-Object-Validation",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "if cat /mnt/objtest/data/secret.txt 2>/dev/null; then echo OBJECT_LEAK; else echo OBJECT_MASKED_OK; fi"
+  },
+  "filesystem": {
+    "readwritePaths": ["/mnt/objtest/data"],
+    "deniedPaths": ["/mnt/objtest/data_link"]
+  }
+}

--- a/tests/configs/lxc_filesystem_object.json
+++ b/tests/configs/lxc_filesystem_object.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.4.0-alpha",
+  "containerId": "CLI-LXC-Object-Validation",
+  "containment": "lxc",
+  "process": {
+    "commandLine": "if cat /mnt/objdata/secret.txt 2>/dev/null; then echo OBJECT_LEAK; else echo OBJECT_MASKED_OK; fi"
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "lxc": {
+    "distribution": "alpine",
+    "release": "3.23"
+  },
+  "filesystem": {
+    "readwritePaths": ["/mnt/objdata"],
+    "deniedPaths": ["/mnt/objlink"]
+  }
+}

--- a/tests/configs/lxc_filesystem_object.json
+++ b/tests/configs/lxc_filesystem_object.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.0-alpha",
+  "version": "0.8.0-alpha",
   "containerId": "CLI-LXC-Object-Validation",
   "containment": "lxc",
   "process": {

--- a/tests/configs/wslc_filesystem_object.json
+++ b/tests/configs/wslc_filesystem_object.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.5.0-alpha",
+  "containerId": "wslc-object-validation",
+  "containment": "wslc",
+  "process": {
+    "commandLine": "if cat /mnt/c/objtest/data/secret.txt 2>/dev/null; then echo OBJECT_LEAK; else echo OBJECT_MASKED_OK; fi"
+  },
+  "filesystem": {
+    "readwritePaths": ["C:\\objtest\\data"],
+    "deniedPaths": ["C:\\objtest\\data_link"]
+  },
+  "network": {
+    "defaultPolicy": "allow"
+  },
+  "experimental": {
+    "wslc": {
+      "image": "alpine:latest"
+    }
+  }
+}

--- a/tests/configs/wslc_filesystem_object.json
+++ b/tests/configs/wslc_filesystem_object.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.5.0-alpha",
+  "version": "0.8.0-alpha",
   "containerId": "wslc-object-validation",
   "containment": "wslc",
   "process": {

--- a/tests/scripts/run_bwrap_all_tests.sh
+++ b/tests/scripts/run_bwrap_all_tests.sh
@@ -35,6 +35,7 @@ run_test() {
 
 run_test "Basic Bubblewrap" "$SCRIPT_DIR/run_bwrap_basic_test.sh"
 run_test "Bubblewrap Filesystem" "$SCRIPT_DIR/run_bwrap_filesystem_test.sh"
+run_test "Bubblewrap Object Validation" "$SCRIPT_DIR/run_bwrap_filesystem_object_test.sh"
 run_test "Bubblewrap Network Block" "$SCRIPT_DIR/run_bwrap_network_test.sh"
 run_test "Bubblewrap Network Proxy" "$SCRIPT_DIR/run_bwrap_network_proxy_test.sh"
 run_test "Linux Process Default" "$SCRIPT_DIR/run_linux_process_default_test.sh"

--- a/tests/scripts/run_bwrap_filesystem_object_test.sh
+++ b/tests/scripts/run_bwrap_filesystem_object_test.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Bubblewrap object-based filesystem-policy validation test (roadmap D6).
+#
+# Verifies that when two different policy paths resolve to the SAME host
+# object (here: a directory and a symlink to it) but carry conflicting
+# intents, the runner tightens every alias to the most-restrictive intent
+# (deny > ro > rw) BEFORE building mounts — closing the bypass where a
+# "denied" object is still reachable through its read-write alias.
+#
+# The object lives in readwritePaths, so a plain RW bind would expose it
+# (see run_bwrap_filesystem_test.sh for the baseline that RW paths are
+# readable). Here a deniedPaths symlink alias of the same directory must
+# tighten the RW path to denied, so the secret is MASKED inside the sandbox.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+BASE="/mnt/objtest"
+DATA="$BASE/data"
+LINK="$BASE/data_link"
+
+cleanup() { sudo rm -rf "$BASE"; }
+trap cleanup EXIT
+
+# Set up: a real directory with a secret file, plus a symlink alias pointing
+# at the same directory object.
+sudo rm -rf "$BASE"
+sudo mkdir -p "$DATA"
+echo "OBJECT_SECRET" | sudo tee "$DATA/secret.txt" > /dev/null
+sudo ln -s "$DATA" "$LINK"
+
+# Sanity: the secret is readable on the host (so masking inside the sandbox is
+# attributable to the policy, not a broken fixture).
+if ! sudo cat "$DATA/secret.txt" | grep -q "OBJECT_SECRET"; then
+    echo "FAIL: fixture setup — secret.txt not readable on host."
+    exit 1
+fi
+
+# RW path + denied symlink alias of the same object; the object must be masked.
+echo "Running Bubblewrap object-validation test (RW + denied alias, expect masked)..."
+OUTPUT=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_filesystem_object.json" 2>&1 || true)
+echo "$OUTPUT"
+if echo "$OUTPUT" | grep -q "OBJECT_MASKED_OK" && ! echo "$OUTPUT" | grep -q "OBJECT_LEAK"; then
+    echo "PASS: denied alias tightened the read-write path; object masked (bypass closed)."
+else
+    echo "FAIL: object reachable via read-write alias of a denied path (bypass NOT closed)."
+    exit 1
+fi
+
+echo "Bubblewrap object-based validation test complete."

--- a/tests/scripts/run_lxc_all_tests.sh
+++ b/tests/scripts/run_lxc_all_tests.sh
@@ -42,6 +42,7 @@ run_test() {
 
 run_test "Basic LXC" "$SCRIPT_DIR/run_lxc_basic_test.sh"
 run_test "LXC Filesystem" "$SCRIPT_DIR/run_lxc_filesystem_test.sh"
+run_test "LXC Object Validation" "$SCRIPT_DIR/run_lxc_object_test.sh"
 run_test "LXC Network" "$SCRIPT_DIR/run_lxc_network_test.sh"
 run_test "LXC Timeout" "$SCRIPT_DIR/run_lxc_timeout_test.sh"
 run_test "LXC Env+Cwd" "$SCRIPT_DIR/run_lxc_env_cwd_test.sh"

--- a/tests/scripts/run_lxc_object_test.sh
+++ b/tests/scripts/run_lxc_object_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# LXC object-based filesystem-policy validation test (roadmap D6).
+#
+# When two different policy paths resolve to the SAME host object (a directory
+# and a symlink to it) but carry conflicting intents, the runner tightens every
+# alias to the most-restrictive intent (deny > ro > rw) BEFORE building the LXC
+# mount entries — so the object is masked even though it is listed under
+# readwritePaths. (LXC masks a denied directory with a read-only tmpfs; see
+# filesystem_mounts.rs.)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+# Real directory with a secret, plus a symlink alias pointing at the same
+# directory object. Hermetic: dynamic temp paths substituted into the config.
+DATA=$(mktemp -d)
+LINK=$(mktemp -u)
+ln -s "$DATA" "$LINK"
+echo "OBJECT_SECRET" > "$DATA/secret.txt"
+
+cleanup() { rm -rf "$DATA" "$LINK"; }
+trap cleanup EXIT
+
+echo "Running LXC object-validation test (RW + denied alias, expect masked)..."
+echo "Data dir: $DATA"
+echo "Symlink alias: $LINK"
+
+CONFIG=$(sed -e "s|/mnt/objdata|$DATA|g" -e "s|/mnt/objlink|$LINK|g" \
+    "$REPO_DIR/tests/configs/lxc_filesystem_object.json")
+
+OUTPUT=$(echo "$CONFIG" | "$LXC_EXEC" --config /dev/stdin 2>&1 || true)
+echo "$OUTPUT"
+
+if echo "$OUTPUT" | grep -q "OBJECT_MASKED_OK" && ! echo "$OUTPUT" | grep -q "OBJECT_LEAK"; then
+    echo "PASS: denied alias tightened the read-write path; object masked (bypass closed)."
+else
+    echo "FAIL: object reachable via read-write alias of a denied path (bypass NOT closed)."
+    exit 1
+fi
+
+echo "LXC object-based validation test complete."

--- a/tests/scripts/run_wslc_all_tests.ps1
+++ b/tests/scripts/run_wslc_all_tests.ps1
@@ -215,6 +215,25 @@ $null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
     -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))
 $null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "Read succeeded"))
 
+Write-Host "`n--- Object Validation Tests ---" -ForegroundColor Cyan
+# Object-based validation (roadmap D6): a directory under readwritePaths and a
+# Windows junction to that same directory under deniedPaths resolve to one
+# filesystem object; the runner tightens both aliases to denied so the
+# directory is not mounted and its secret is masked. Delegated to a standalone
+# script that owns the directory+junction fixture (the config is never run
+# without its on-disk aliasing).
+$objScript = Join-Path $PSScriptRoot "run_wslc_object_test.ps1"
+$objArgs = @{ WxcExecPath = $WxcExec }
+if ($Debug) { $objArgs.Debug = $true }
+& $objScript @objArgs
+$objPass = ($LASTEXITCODE -eq 0)
+$null = $results.Add(@{
+    Name    = "wslc_filesystem_object.json"
+    Pass    = $objPass
+    Skipped = $false
+    Reason  = $(if ($objPass) { "" } else { "object-validation test failed" })
+})
+
 Write-Host "`n--- Network Tests ---" -ForegroundColor Cyan
 $null = $results.Add((Run-WslcTest "wslc_network_isolated.json"))
 $null = $results.Add((Run-WslcTest "wslc_port_mapping_tcp.json" -OutputContains "PORT_MAPPING_TCP_OK"))

--- a/tests/scripts/run_wslc_object_test.ps1
+++ b/tests/scripts/run_wslc_object_test.ps1
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# WSLC object-based filesystem-policy validation test (roadmap D6).
+#
+# When two different policy paths resolve to the SAME host object (a directory
+# and a Windows junction to it) but carry conflicting intents, the runner
+# tightens every alias to the most-restrictive intent (deny > ro > rw) BEFORE
+# mapping volume mounts. WSLC masks a denied path by simply NOT mounting it
+# (see policy_mapping.rs), so the directory -- though listed under
+# readwritePaths -- is not mounted and its secret is invisible in the container.
+#
+# This script owns the fixture (directory + junction) so the config is never
+# run without its on-disk aliasing -- running the config alone would otherwise
+# pass for the wrong reason (the path simply wouldn't exist).
+#
+# Usage:
+#   .\run_wslc_object_test.ps1                       # auto-discovers wxc-exec.exe
+#   .\run_wslc_object_test.ps1 -WxcExecPath <path>   # explicit binary
+#   .\run_wslc_object_test.ps1 -Debug                # debug build + --debug
+
+param(
+    [switch]$Debug,
+    [string]$WxcExecPath
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$ConfigPath = Join-Path $RepoRoot "tests\configs\wslc_filesystem_object.json"
+
+# Resolve the binary: explicit path, then target-specific and default dirs.
+$Target = "x86_64-pc-windows-msvc"
+$Profile = if ($Debug) { "debug" } else { "release" }
+if ($WxcExecPath) {
+    $WxcExec = $WxcExecPath
+} else {
+    $Candidates = @(
+        (Join-Path $RepoRoot "src\target\$Target\$Profile\wxc-exec.exe"),
+        (Join-Path $RepoRoot "src\target\$Profile\wxc-exec.exe")
+    )
+    $WxcExec = $Candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+}
+if (-not $WxcExec -or -not (Test-Path $WxcExec)) {
+    Write-Host "ERROR: wxc-exec.exe not found. Build with: cargo build --features wslc --release --target $Target" -ForegroundColor Red
+    exit 1
+}
+
+# Fixed path must match tests\configs\wslc_filesystem_object.json.
+$ObjBase = "C:\objtest"
+$DataDir = Join-Path $ObjBase "data"
+$LinkDir = Join-Path $ObjBase "data_link"
+
+function Remove-Fixture {
+    Remove-Item -Recurse -Force $ObjBase -ErrorAction SilentlyContinue
+}
+
+Remove-Fixture
+try {
+    # Real directory with a secret, plus a junction alias pointing at the same
+    # directory object. mklink /J does NOT require administrator.
+    New-Item -ItemType Directory -Path $DataDir -Force | Out-Null
+    Set-Content (Join-Path $DataDir "secret.txt") "OBJECT_SECRET"
+    $null = cmd /c mklink /J "$LinkDir" "$DataDir"
+    if (-not (Test-Path $LinkDir)) {
+        Write-Host "FAIL: fixture setup -- junction not created at $LinkDir" -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host "Running WSLC object-validation test (RW + denied junction alias, expect masked)..."
+    $wxcArgs = @("--experimental")
+    if ($Debug) { $wxcArgs += "--debug" }
+    $wxcArgs += $ConfigPath
+
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    $output = & $WxcExec @wxcArgs 2>&1 | Out-String
+    $ErrorActionPreference = $prev
+    Write-Host $output
+
+    if (($output -match "OBJECT_MASKED_OK") -and ($output -notmatch "OBJECT_LEAK")) {
+        Write-Host "PASS: denied junction alias tightened the read-write path; object masked (bypass closed)." -ForegroundColor Green
+        $exit = 0
+    } else {
+        Write-Host "FAIL: object reachable via read-write alias of a denied path (bypass NOT closed)." -ForegroundColor Red
+        $exit = 1
+    }
+} finally {
+    Remove-Fixture
+}
+
+Write-Host "WSLC object-based validation test complete."
+exit $exit


### PR DESCRIPTION
## 📖 Description
Detect when two different policy path strings resolve to the same host filesystem object (via symlink, hard link, or bind mount) but carry conflicting intents — e.g. readwritePaths:["/mnt/storage/data"] and deniedPaths:["/data"] where /data is a symlink to the former. The existing string-level normalizer in config_parser only catches the same path string in multiple lists; it can't see object aliases.

New wxc_common::filesystem_object::normalize_object_conflicts() stats each policy path (following symlinks), groups by object identity ((dev,ino) on unix; volume-serial + 128-bit file-id on Windows) and tightens every alias of a shared object to the strictest intent among them (deny > readonly > readwrite), logging a warning per tightened path. It never rejects the config and skips paths it can't stat (existence is a separate advisory).

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/593)