### PR TITLE
CI: resolve crate dependencies through the public MxcDependencies feed

### DIFF
--- a/.azure-pipelines/README.md
+++ b/.azure-pipelines/README.md
@@ -1,8 +1,8 @@
 # Configuration Strategy
 
-## For Developers
+## Local development
 
-Developers should to use public registries like `crates.io`
+Developers should use public registries like `crates.io`
 and `npmjs` directly so they can iterate quickly.
 
 ## For CI/Pipelines

--- a/.azure-pipelines/Update.Feed.Dependencies.yml
+++ b/.azure-pipelines/Update.Feed.Dependencies.yml
@@ -1,0 +1,37 @@
+# Seeds the public shine-oss MxcDependencies feed with every crates.io crate in
+# src/Cargo.lock.
+#
+# This pipeline cannot be run with `/azp run`; run it manually from shine-oss
+# (Run pipeline at https://dev.azure.com/shine-oss/mxc/_build?definitionId=33).
+
+parameters:
+  - name: prNumber
+    displayName: GitHub PR number to seed from
+    type: string
+
+trigger: none
+pr: none
+
+jobs:
+  - job: fetch_dependencies
+    displayName: Fetch and cache dependencies
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: self
+        persistCredentials: true
+
+      # Overlay only the lockfile from the PR head onto the trusted checkout. cargo is never
+      # run and only Cargo.lock (data) is read, so no PR code executes. Review the PR's
+      # Cargo.lock first.
+      - script: |
+          set -euo pipefail
+          git fetch origin "pull/${{ parameters.prNumber }}/head"
+          git checkout FETCH_HEAD -- src/Cargo.lock
+          echo "Overlaid Cargo.lock from PR #${{ parameters.prNumber }}"
+        displayName: Overlay Cargo.lock from PR
+
+      - script: python3 .azure-pipelines/scripts/seed_feed.py
+        displayName: Seed the MxcDependencies feed from Cargo.lock
+        env:
+          SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/.azure-pipelines/scripts/seed_feed.py
+++ b/.azure-pipelines/scripts/seed_feed.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Seed the public MxcDependencies cargo feed from src/Cargo.lock.
+
+The feed can be read without credentials, so cargo does not send a token when it reads.
+As a result, cargo cannot make Azure Artifacts pull a missing crate from its crates.io
+upstream. This script instead sends an authenticated request for each locked crate, which
+makes the feed fetch and cache it. Later credential-free reads then resolve every dependency.
+
+The script only reads Cargo.lock and never runs cargo or build scripts, so it is safe to run
+against a fork's lockfile.
+"""
+import json
+import os
+import sys
+import tomllib
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import NamedTuple
+
+FEED_INDEX_URL = "https://pkgs.dev.azure.com/shine-oss/mxc/_packaging/MxcDependencies/Cargo/index"
+CARGO_LOCK = "src/Cargo.lock"
+MAX_WORKERS = 16
+REQUEST_TIMEOUT = 30  # seconds; fail a stuck request instead of hanging the job
+
+
+class Crate(NamedTuple):
+    name: str
+    version: str
+
+
+class _NoFollowRedirects(urllib.request.HTTPRedirectHandler):
+    """Return the feed's redirect response instead of following it.
+
+    An authenticated request for an uncached crate triggers the upstream save and then
+    answers with a 302 to blob storage. The save has already happened, so following the
+    redirect would only download the crate and resend the token to another host.
+    """
+
+    def http_error_302(self, req, fp, code, msg, headers):
+        return fp
+
+    # Route every other redirect status through the same no-follow handler.
+    http_error_301 = http_error_303 = http_error_307 = http_error_308 = http_error_302
+
+
+_opener = urllib.request.build_opener(_NoFollowRedirects)
+
+
+def _authenticated_get(url: str, token: str) -> None:
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+    try:
+        _opener.open(request, timeout=REQUEST_TIMEOUT).close()
+    except OSError as error:
+        raise RuntimeError(f"{url}: {error}") from error
+
+
+def _sparse_index_path(name: str) -> str:
+    """Path cargo uses to locate a crate in a sparse index."""
+    name = name.lower()
+    if len(name) == 1:
+        return f"1/{name}"
+    if len(name) == 2:
+        return f"2/{name}"
+    if len(name) == 3:
+        return f"3/{name[0]}/{name}"
+    return f"{name[:2]}/{name[2:4]}/{name}"
+
+
+def _seed_crate(crate: Crate, download_template: str, token: str) -> None:
+    _authenticated_get(f"{FEED_INDEX_URL}/{_sparse_index_path(crate.name)}", token)
+    download_url = download_template.replace("{crate}", crate.name).replace("{version}", crate.version)
+    _authenticated_get(download_url, token)
+
+
+def _read_locked_crates() -> list[Crate]:
+    with open(CARGO_LOCK, "rb") as lockfile:
+        packages = tomllib.load(lockfile).get("package", [])
+    return [
+        Crate(package["name"], package["version"])
+        for package in packages
+        if "crates.io" in package.get("source", "")
+    ]
+
+
+def main() -> int:
+    token = os.environ.get("SYSTEM_ACCESSTOKEN")
+    if not token:
+        print("SYSTEM_ACCESSTOKEN is not set; cannot authenticate to the feed")
+        return 1
+
+    with urllib.request.urlopen(f"{FEED_INDEX_URL}/config.json") as response:
+        download_template = json.load(response)["dl"]
+
+    crates = _read_locked_crates()
+    print(f"Seeding {len(crates)} crates.io crates into MxcDependencies")
+
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        future_to_crate = {
+            pool.submit(_seed_crate, crate, download_template, token): crate for crate in crates
+        }
+        for future in as_completed(future_to_crate):
+            crate = future_to_crate[future]
+            try:
+                future.result()
+            except RuntimeError as error:
+                failures.append(f"{crate.name} {crate.version}: {error}")
+
+    if failures:
+        print(f"Failed to seed {len(failures)} of {len(crates)} crates:")
+        for failure in sorted(failures):
+            print(f"  {failure}")
+        return 1
+
+    print(f"Seeded all {len(crates)} crates")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.azure-pipelines/templates/1ES.Build.Stages.yml
+++ b/.azure-pipelines/templates/1ES.Build.Stages.yml
@@ -87,6 +87,8 @@ stages:
   dependsOn: []
   jobs:
   - template: Lint.Job.yml
+    parameters:
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
 
 - stage: SDK_Unit_Tests
   displayName: 'SDK Unit Tests'

--- a/.azure-pipelines/templates/Cargo.Setup.Private.yml
+++ b/.azure-pipelines/templates/Cargo.Setup.Private.yml
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Appends the internal Mxc-Azure-Feed cargo config (config.toml) to the
+# workspace .cargo/config.toml and (by default) authenticates cargo to the feed.
+
+parameters:
+- name: authenticate
+  type: boolean
+  default: true
+
+steps:
+  - pwsh: |
+      $cfg = "$(Build.SourcesDirectory)/.cargo/config.toml"
+      New-Item -ItemType Directory -Force -Path (Split-Path $cfg) | Out-Null
+      Add-Content -Path $cfg -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
+    displayName: Setup Cargo Config (Mxc-Azure-Feed)
+
+  - ${{ if eq(parameters.authenticate, true) }}:
+    - task: CargoAuthenticate@0
+      displayName: Authenticate to Mxc-Azure-Feed
+      inputs:
+        configFile: $(Build.SourcesDirectory)/.cargo/config.toml

--- a/.azure-pipelines/templates/Cargo.Setup.Public.yml
+++ b/.azure-pipelines/templates/Cargo.Setup.Public.yml
@@ -4,7 +4,7 @@
 # Appends the public MxcDependencies cargo feed (config.public.toml) to the
 # workspace .cargo/config.toml. Used by Unofficial / fork-PR Rust steps so
 # crate downloads work under 1ES pool network isolation (crates.io is not on
-# the allowlist). Mirrors the Official setup step in Rust.Build.Steps.Official.yml.
+# the allowlist). Mirrors Cargo.Setup.Private.yml (the internal-feed equivalent).
 
 steps:
   - pwsh: |

--- a/.azure-pipelines/templates/Lint.Job.yml
+++ b/.azure-pipelines/templates/Lint.Job.yml
@@ -6,6 +6,9 @@
 # doesn't extend the critical path.
 
 parameters:
+- name: isOfficialBuild
+  type: boolean
+  default: false
 - name: matrix
   type: object
   default:
@@ -68,9 +71,13 @@ jobs:
         parameters:
           targetTriple: $(targetTriple)
 
-      # Redirect crates.io to the public MxcDependencies feed (1ES network
-      # isolation blocks crates.io).
-      - template: Cargo.Setup.Public.yml@self
+      # Official builds resolve crates through the internal Mxc-Azure-Feed; fork/unofficial
+      # builds use the public MxcDependencies mirror. 1ES network isolation blocks crates.io
+      # either way.
+      - ${{ if eq(parameters.isOfficialBuild, true) }}:
+        - template: Cargo.Setup.Private.yml@self
+      - ${{ else }}:
+        - template: Cargo.Setup.Public.yml@self
 
       - script: cargo fmt --all -- --check
         displayName: cargo fmt --check

--- a/.azure-pipelines/templates/Rust.Build.Steps.Official.yml
+++ b/.azure-pipelines/templates/Rust.Build.Steps.Official.yml
@@ -24,9 +24,10 @@ parameters:
 steps:
   # Must run before 1ES.Build.Rust.Setup@1 so the merged config.toml
   # exists at templateContext.rust.{authenticate,install}Options.configFile.
-  - pwsh: |
-      Add-Content -Path "$(Build.SourcesDirectory)/.cargo/config.toml" -Value ("`n" + (Get-Content -Raw "$(Build.SourcesDirectory)/.azure-pipelines/.cargo/config.toml"))
-    displayName: Setup Cargo Config (Mxc-Azure-Feed)
+  # 1ES.Build.Rust.Setup authenticates, so skip CargoAuthenticate here.
+  - template: Cargo.Setup.Private.yml@self
+    parameters:
+      authenticate: false
 
   - task: 1ES.Build.Rust.Setup@1
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@
 - [ ] Linked to an issue
 - [ ] Updated documentation (if applicable)
 - [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
+- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))
 
 ## 📋 Issue Type
 <!-- Select the type that best describes this PR -->
@@ -24,6 +25,10 @@
 ---
 
 GitHub Actions runs the PR validation build automatically. The ADO pipeline
-(`MXC-PR-Build`) is the official build pipeline that signs the binaries; it
-runs on merge to `main` and nightly, and Microsoft reviewers can trigger it
-on a PR with `/azp run`. See [docs/pull-requests.md](../docs/pull-requests.md).
+(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
+Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
+on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).
+
+If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
+the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
+for the steps.

--- a/.github/actions/setup-cargo-feed/action.yml
+++ b/.github/actions/setup-cargo-feed/action.yml
@@ -1,0 +1,10 @@
+name: Setup cargo MxcDependencies feed
+description: >-
+  Append the public MxcDependencies feed config to the repo-root cargo config so
+  cargo resolves through the feed (mirrors the ADO Cargo.Setup.Public step).
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ github.workspace }}
+      run: cat .azure-pipelines/.cargo/config.public.toml >> .cargo/config.toml

--- a/.github/workflows/Build.Linux.Job.yml
+++ b/.github/workflows/Build.Linux.Job.yml
@@ -38,6 +38,9 @@ jobs:
           override: false
           rustflags: ''
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
@@ -45,6 +48,10 @@ jobs:
             src/core/lxc -> target
           key: ${{ matrix.target }}-v2
           cache-on-failure: false
+
+      - name: Install ARM64 cross linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
 
       - name: Build lxc
         run: cargo build --locked --release --target ${{ matrix.target }}

--- a/.github/workflows/Build.MacOS.Job.yml
+++ b/.github/workflows/Build.MacOS.Job.yml
@@ -29,6 +29,9 @@ jobs:
           override: false
           rustflags: ''
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src -> target

--- a/.github/workflows/Build.Windows.Job.yml
+++ b/.github/workflows/Build.Windows.Job.yml
@@ -42,6 +42,9 @@ jobs:
           override: false
           rustflags: ''
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src -> target

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -21,19 +21,28 @@ permissions:
   contents: read
 
 jobs:
+  # Dependency feed check: resolve the locked graph through the public MxcDependencies
+  # feed so a crate not yet in the feed fails at PR time.
+  dependency-feed-check:
+    uses: ./.github/workflows/Dependency.Feed.Check.Job.yml
+
   versioning-checks:
     uses: ./.github/workflows/Versioning.Checks.Job.yml
 
   lint:
+    needs: dependency-feed-check
     uses: ./.github/workflows/Lint.Job.yml
 
   windows:
+    needs: dependency-feed-check
     uses: ./.github/workflows/Build.Windows.Job.yml
 
   linux:
+    needs: dependency-feed-check
     uses: ./.github/workflows/Build.Linux.Job.yml
 
   macos:
+    needs: dependency-feed-check
     uses: ./.github/workflows/Build.MacOS.Job.yml
 
   sdk-unit-tests:

--- a/.github/workflows/Dependency.Feed.Check.Job.yml
+++ b/.github/workflows/Dependency.Feed.Check.Job.yml
@@ -1,0 +1,53 @@
+# Resolves the locked dependency graph through the public MxcDependencies feed so a crate
+# not yet in the feed fails at PR time. On a 401, seed the crate by running the
+# MXC-Update-Feed-Dependencies pipeline in shine-oss with the PR's number (see docs/pull-requests.md).
+
+name: Dependency Feed Check
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Resolve deps through MxcDependencies feed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Surface toolchain file at repo root
+        run: cp src/rust-toolchain.toml rust-toolchain.toml
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          override: false
+          rustflags: ''
+
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
+      # Fetch every locked crate for every target triple (no compile; --target only
+      # changes which cfg-gated deps resolve). A 401 means a crate is not yet in the
+      # feed and the check fails with guidance; any other cargo error fails generically.
+      - name: Fetch all locked crates through the feed (anonymous)
+        working-directory: src
+        run: |
+          set -uo pipefail
+          if cargo fetch --locked \
+            --target x86_64-pc-windows-msvc \
+            --target aarch64-pc-windows-msvc \
+            --target x86_64-unknown-linux-gnu \
+            --target aarch64-unknown-linux-gnu \
+            --target aarch64-apple-darwin 2>&1 | tee fetch.log; then
+            exit 0
+          fi
+          if grep -qiE '401|failed to get successful HTTP response' fetch.log; then
+            echo "::error title=Crate may be missing from the MxcDependencies feed::A locked crate could not be fetched through the feed (HTTP 401 above). If this PR adds a new crates.io dependency, it must be added to the feed before this check can pass."
+            echo "To add it: someone with Contributor access to the shine-oss Mxc project runs the MXC-Update-Feed-Dependencies pipeline using the Run pipeline button, with prNumber set to the PR's number."
+            echo "Details: docs/pull-requests.md (Dependency feed check)."
+          else
+            echo "::error title=cargo fetch failed::cargo fetch failed for a reason other than a feed 401 (see the log above)."
+          fi
+          exit 1

--- a/.github/workflows/Lint.Job.yml
+++ b/.github/workflows/Lint.Job.yml
@@ -51,6 +51,9 @@ jobs:
           override: false
           rustflags: ''
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ matrix.working-directory }} -> target

--- a/.github/workflows/hyperlight-e2e.yml
+++ b/.github/workflows/hyperlight-e2e.yml
@@ -24,6 +24,9 @@ jobs:
           rustup update stable
           rustup target add x86_64-pc-windows-msvc
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/microvm-e2e.yml
+++ b/.github/workflows/microvm-e2e.yml
@@ -25,6 +25,9 @@ jobs:
           rustup update stable
           rustup target add x86_64-pc-windows-msvc
 
+      - name: Point cargo at the MxcDependencies feed
+        uses: ./.github/actions/setup-cargo-feed
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:

--- a/docs/pull-requests.md
+++ b/docs/pull-requests.md
@@ -9,15 +9,37 @@ and macOS arm64 hosts in parallel.
 
 ## Azure Pipelines (optional on PRs, required on `main`)
 
-The ADO pipeline (`MXC-PR-Build`) is the official build pipeline that signs
-the binaries. It runs automatically on merge to `main` and on a nightly
-schedule.
+The ADO pipeline (`MXC-PR-Build`) is the Azure version of the PR pipeline. The official
+and PR Azure pipelines share the same YAML core, so running `/azp run` on a PR before
+check-in is a good way to confirm your change does not inadvertently break that core.
+It runs automatically on merge to `main`.
 
 Microsoft ADO policy disables automatic PR-build runs to prevent unreviewed
 code (e.g. from external forks) from executing on internal pipeline agents.
-A Microsoft employee can manually trigger it on a PR by commenting `/azp run`
-on the pull request. Use this when you want to run the official build against
-a change before merge.
+A Microsoft reviewer with repo write access can manually trigger it on a PR by
+commenting `/azp run` on the pull request. Use this when you want to run the Azure
+build against a change before merge.
 
 Pipeline status:
 [MXC-PR-Build](https://microsoft.visualstudio.com/Dart/_build?definitionId=192146).
+
+## Dependency feed check (`dependency-feed-check`)
+
+GitHub Actions Rust jobs resolve dependencies through the public, anonymous-read
+**MxcDependencies** Azure Artifacts feed (`.azure-pipelines/.cargo/config.public.toml`)
+instead of crates.io, mirroring the network-isolated ADO PR build. A crate not yet cached
+in the feed fails `dependency-feed-check` with an HTTP 401, because the feed only saves a
+crate when an authenticated client requests it.
+
+Only someone with Contributor access to the shine-oss Mxc project can run the seed pipeline. To fix it:
+
+1. Run the [**MXC-Update-Feed-Dependencies**](https://dev.azure.com/shine-oss/mxc/_build?definitionId=33)
+   pipeline in shine-oss using the **Run pipeline** button, with `prNumber` set to the PR's number.
+2. Re-run the failed Rust job.
+
+### Why two feeds
+
+Official (signed) ADO builds use a *separate* internal feed, **Mxc-Azure-Feed**, for the
+internal Rust toolchain and 1ES Rust tasks the public feed can't serve. It auto-refreshes
+on every official build (nightly and per trigger), so only the public **MxcDependencies**
+feed needs the manual steps above.


### PR DESCRIPTION
## 📖 Description

GitHub Actions Rust jobs (lint, the Windows/Linux/macOS builds, and the microvm and hyperlight e2e jobs) now resolve their dependencies through the public, anonymous-read MxcDependencies Azure Artifacts feed instead of crates.io, mirroring the network-isolated ADO build so resolution behaves the same in both.

A new `dependency-feed-check` job gates the platform builds and fails fast with remediation guidance when a PR introduces a crate the feed has not yet cached. Official signed ADO builds continue to use the internal Mxc-Azure-Feed. A manual `MXC-Update-Feed-Dependencies` pipeline seeds the public feed from `src/Cargo.lock` and supports both in-repo and forked PRs.

## 🔍 Validation

Ran the `MXC-Update-Feed-Dependencies` pipeline in shine-oss
([build 354859](https://dev.azure.com/shine-oss/mxc/_build/results?buildId=354859&view=results))
for PR 591; it succeeded and updated the feed with the PR's new crates.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/594)
