### PR TITLE
Disable blank issues so all issues get a type set at creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
## 📖 Description

Adds `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` so that all new issues must be filed through one of the structured issue forms.

**Why:** Blank issues are currently enabled, so issues created without a template bypass the form's `type:` field and arrive with **no GitHub issue type set**. The `labelManagement.issueOpened.yml` policy can back-fill an `Issue-*` label from body markers, but the GitHub Policy Service has **no action to set the issue *type***. Template-less issues therefore land type-less and require manual triage cleanup (recent examples: #478, #483, #507, #512, #550, #553).

All four templates already declare both `type:` and `labels:`, so disabling blank issues guarantees the issue type is set at creation.

Single-file change (`config.yml`, one line).

## 🔗 References

Resolves #600.

## 🔍 Validation

- Confirmed all four `ISSUE_TEMPLATE/*.yml` forms declare a native `type:` (Bug → Bug, Feature → Feature, Task → Task, Documentation → Task).
- `config.yml` syntax matches the documented GitHub schema (`blank_issues_enabled`).
- No workflow, code, or policy files changed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable) <!-- N/A -->
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed) <!-- N/A -->

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

---

Authored with GitHub Copilot assistance.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/601)