### PR TITLE
Plumb deniedPaths to BaseContainer fs_deny, gated on SANDBOX_CAP_FS_DENY

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -100,6 +100,18 @@ The `filesystem` section defines path access policy shared across backends:
 | `readonlyPaths` | string[] | `[]` | Paths the process can read but not write. |
 | `deniedPaths` | string[] | `[]` | Paths the process cannot access at all. |
 
+On Windows, `deniedPaths` is enforced by one of two mechanisms depending on the
+containment tier selected at runtime:
+
+- **BaseContainer (Tier 1):** enforced natively by the OS when the build advertises
+  the `SANDBOX_CAP_FS_DENY` capability. No host filesystem changes are made.
+- **AppContainer (Tier 2/3):** enforced by host-filesystem DENY ACEs, applied before
+  the run and removed on exit. This path is gated by `allowDaclMutation`, requires
+  `WRITE_DAC` on each denied path, and temporarily modifies host security descriptors.
+  Because the ACEs are keyed on the sandbox's derived AppContainer SID, two concurrent
+  runs sharing the same `containerId` can revoke each other's ACEs — use distinct
+  `containerId` values for parallel runs.
+
 ### Fallback Policy
 
 The `fallback` section gates the runner's host-impacting fallbacks. Each flag is an explicit operator consent for a specific mechanism the runner may otherwise pick when the preferred primitive is unavailable. Defaults preserve the pre-fallback-section behavior (all permitted).

--- a/external/windows-sdk/BaseContainerSpecification.fbs
+++ b/external/windows-sdk/BaseContainerSpecification.fbs
@@ -26,6 +26,12 @@
 // --conform verifies that every field/enum/table in the old schema still exists
 // at the same vtable slot, type, and default in the new schema. Any incompatible
 // change produces an error. Add this as a build step or PR gate to catch regressions.
+//
+//  Steps:
+//      cp SandboxSpec.fbs SandboxSpec.previous.fbs
+//      <make changes>
+//      .\flatc.exe --conform SandboxSpec.previous.fbs SandboxSpec.fbs
+//
 
 namespace SandboxTechSpecLayout;
 
@@ -68,6 +74,9 @@ table SandboxSpec {
 
     // Integrity behavior
     integrity:IntegrityLevel = system_default;
+
+    // File Paths that have been denied access
+    fs_deny:[string];
 }
 
 table proxy_info {

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -110,12 +110,12 @@ type PfnQuerySandboxSupport = unsafe extern "system" fn(capabilities: *mut u64) 
 /// `SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX`: when clear, Tier 1 is unusable.
 const SANDBOX_CAP_CREATE_PROCESS_IN_SANDBOX: u64 = 0x0000_0000_0000_0001;
 
-/// `SANDBOX_CAP_DENY_PATHS`: when set, the BaseContainer (Tier 1) backend can
+/// `SANDBOX_CAP_FS_DENY`: when set, the BaseContainer (Tier 1) backend can
 /// enforce `filesystem.deniedPaths`. Bit 0 reports whether the create API is
 /// callable; deny support is expected to light up on a separate bit (currently
 /// assumed bit 1). When clear, `deniedPaths` is rejected at launch and callers
 /// must rely on default-deny plus explicit `readwrite`/`readonly` grants.
-const SANDBOX_CAP_DENY_PATHS: u64 = 0x0000_0000_0000_0002;
+const SANDBOX_CAP_FS_DENY: u64 = 0x0000_0000_0000_0002;
 
 /// True when a Win32 error code signals the BaseContainer feature is not
 /// enabled on this build (symbol present, capability gated off).
@@ -185,7 +185,7 @@ impl BaseContainerRunner {
     /// Whether the BaseContainer (Tier 1) backend can enforce
     /// `filesystem.deniedPaths` on this host.
     ///
-    /// Reads the `SANDBOX_CAP_DENY_PATHS` bit from
+    /// Reads the `SANDBOX_CAP_FS_DENY` bit from
     /// `Experimental_QuerySandboxSupport`. Returns `false` when the query
     /// export is absent or the bit is clear — the behavior on builds where
     /// BaseContainer deny support has not yet shipped, where `deniedPaths` is
@@ -207,7 +207,7 @@ impl BaseContainerRunner {
     /// query call succeeded), NOT an HRESULT. The capability is present only
     /// when the call succeeded and the bit is set.
     fn decode_deny_capability(succeeded: i32, capabilities: u64) -> bool {
-        succeeded != 0 && (capabilities & SANDBOX_CAP_DENY_PATHS) != 0
+        succeeded != 0 && (capabilities & SANDBOX_CAP_FS_DENY) != 0
     }
 
     /// Query `Experimental_QuerySandboxSupport` for the create-process bit.
@@ -313,6 +313,7 @@ impl BaseContainerRunner {
     /// - `capabilities` from `policy.capabilities` (comma-joined)
     /// - `fs_read_write` from `policy.readwrite_paths`
     /// - `fs_read_only` from `policy.readonly_paths`
+    /// - `fs_deny` from `policy.denied_paths`
     /// - `disallow_win32k_system_calls` from `ui.disable`
     /// - `ui_restrictions` bitmask from `ui.to_ui_restrictions_bitmask()`
     /// - `network_policy.proxy.url` from proxy config
@@ -360,6 +361,18 @@ impl BaseContainerRunner {
             let offsets: Vec<_> = request
                 .policy
                 .readonly_paths
+                .iter()
+                .map(|s| builder.create_string(s))
+                .collect();
+            Some(builder.create_vector(&offsets))
+        };
+
+        let fs_deny = if request.policy.denied_paths.is_empty() {
+            None
+        } else {
+            let offsets: Vec<_> = request
+                .policy
+                .denied_paths
                 .iter()
                 .map(|s| builder.create_string(s))
                 .collect();
@@ -414,6 +427,7 @@ impl BaseContainerRunner {
                 capabilities,
                 fs_read_write,
                 fs_read_only,
+                fs_deny,
                 network_policy,
                 ..Default::default()
             },
@@ -1204,9 +1218,14 @@ struct BaseChild {
 
 impl SandboxBackend for BaseContainerRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        if !request.policy.denied_paths.is_empty() {
+        // deniedPaths reaches the OS via the SandboxSpec `fs_deny` field, honored
+        // only when the OS advertises SANDBOX_CAP_FS_DENY. The dispatcher only
+        // routes deny here when supported; fail closed for direct callers.
+        if !request.policy.denied_paths.is_empty()
+            && !crate::fallback_detector::base_container_supports_deny_paths()
+        {
             return Err(ScriptResponse::error(
-                wxc_common::error::DENIED_PATHS_NOT_SUPPORTED_MSG,
+                wxc_common::error::DENIED_PATHS_FEATURE_DISABLED_MSG,
             ));
         }
         if !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty() {
@@ -1512,7 +1531,7 @@ mod tests {
     #[test]
     fn decode_deny_capability_table() {
         // create bit alone does not imply deny support, and vice versa.
-        let cap = SANDBOX_CAP_DENY_PATHS;
+        let cap = SANDBOX_CAP_FS_DENY;
         assert!(!BaseContainerRunner::decode_deny_capability(0, cap)); // FALSE return
         assert!(!BaseContainerRunner::decode_deny_capability(1, 0)); // bit clear
         assert!(BaseContainerRunner::decode_deny_capability(1, cap)); // enabled
@@ -1533,6 +1552,7 @@ mod tests {
         request.policy.capabilities = vec!["internetClient".into(), "registryRead".into()];
         request.policy.readwrite_paths = vec!["C:\\temp".into()];
         request.policy.readonly_paths = vec!["C:\\Windows".into()];
+        request.policy.denied_paths = vec!["C:\\secret".into()];
 
         let bytes = BaseContainerRunner::build_sandbox_spec(&request);
 
@@ -1574,6 +1594,10 @@ mod tests {
         assert_eq!(ro.len(), 1);
         assert_eq!(ro.get(0), "C:\\Windows");
 
+        let deny = spec.fs_deny().unwrap();
+        assert_eq!(deny.len(), 1);
+        assert_eq!(deny.get(0), "C:\\secret");
+
         assert!(spec.network_policy().is_none());
     }
 
@@ -1594,6 +1618,7 @@ mod tests {
         assert!(spec.capabilities().is_none());
         assert!(spec.fs_read_write().is_none());
         assert!(spec.fs_read_only().is_none());
+        assert!(spec.fs_deny().is_none());
         assert!(spec.disallow_win32k_system_calls());
         assert!(spec.network_policy().is_none());
     }
@@ -1731,17 +1756,36 @@ mod tests {
     use wxc_common::sandbox_process::SandboxBackend;
 
     #[test]
-    fn validate_runner_rejects_denied_paths() {
+    fn validate_runner_accepts_denied_paths_when_supported() {
+        let _guard = crate::test_env::DenyPathsGuard::supported(true);
+        let runner = BaseContainerRunner::new();
+        let mut request = ExecutionRequest::default();
+        request.policy.denied_paths = vec!["C:\\secret".into()];
+
+        // May still fail if the BaseContainer API is unavailable, but not for deny.
+        if let Err(err) = runner.validate(&request) {
+            assert!(
+                !err.error_message.contains("deniedPaths")
+                    && !err.error_message.contains("SANDBOX_CAP_FS_DENY"),
+                "deniedPaths should not be rejected when supported, got: {}",
+                err.error_message
+            );
+        }
+    }
+
+    #[test]
+    fn validate_runner_rejects_denied_paths_when_unsupported() {
+        let _guard = crate::test_env::DenyPathsGuard::supported(false);
         let runner = BaseContainerRunner::new();
         let mut request = ExecutionRequest::default();
         request.policy.denied_paths = vec!["C:\\secret".into()];
 
         let err = runner
             .validate(&request)
-            .expect_err("BaseContainer does not yet support deniedPaths");
+            .expect_err("deniedPaths must be rejected when the capability is unavailable");
         assert!(
-            err.error_message.contains("deniedPaths"),
-            "expected message to mention deniedPaths, got: {}",
+            err.error_message.contains("SANDBOX_CAP_FS_DENY"),
+            "expected the capability-gate message, got: {}",
             err.error_message
         );
     }

--- a/src/backends/appcontainer/common/src/dispatcher.rs
+++ b/src/backends/appcontainer/common/src/dispatcher.rs
@@ -12,14 +12,12 @@
 //!
 //! Filesystem-policy enforcement under T1 is delegated entirely to
 //! BaseContainer's own `Experimental_CreateProcessInSandbox` API
-//! (including `deniedPaths` once native deny support lands); the
-//! dispatcher does **not** apply host DACLs in T1. The opaque
-//! `identity` BaseContainer runs the child under is not guaranteed to
-//! match an `AppContainer` SID derived from the same container name, so
-//! adding host-DACL belt-and-suspenders here would risk silently
-//! targeting the wrong principal.
-//!
-//! See `docs/proposals/downlevel_support/basecontainer-fallback-plan-v2.md`.
+//! (`deniedPaths` via the SandboxSpec `fs_deny` field); the dispatcher
+//! does **not** apply host DACLs in T1. When the OS advertises native
+//! deny support the OS enforces `deniedPaths` itself; when it does not,
+//! a denied-paths policy never reaches T1 (the detector falls through to
+//! the AppContainer tiers, which stamp the deny DACLs). So T1 has no
+//! deny ACEs to apply either way.
 //!
 //! # Why T2 (BFS) also gets DACL deny augmentation
 //!
@@ -282,12 +280,10 @@ pub fn dispatch_with_fallback(request: &ExecutionRequest) -> Result<Dispatched, 
     let (runner, dacl_manager): (Box<dyn ScriptRunner>, Option<DaclManager>) = match decision.tier {
         IsolationTier::BaseContainer => {
             // Tier 1 delegates filesystem-policy enforcement to
-            // BaseContainer's native API. We do NOT stamp host-DACL
-            // deny ACEs here because the AppContainer SID derived from
-            // `container_name(request)` is not guaranteed to match the
-            // opaque principal `Experimental_CreateProcessInSandbox`
-            // actually runs the child under; a mismatch would render
-            // the ACEs inert and silently un-enforce `deniedPaths`.
+            // BaseContainer's native API. We stamp no host-DACL deny ACEs
+            // here: the detector only routes a denied-paths policy to T1
+            // when the OS enforces `fs_deny` natively, so there is nothing
+            // for a host DACL to add.
             let runner: Box<dyn ScriptRunner> = Box::new(Runner::new(BaseContainerRunner::new()));
             (runner, None)
         }
@@ -412,10 +408,8 @@ mod tests {
     fn dispatch_t1_with_denied_paths_has_no_dacl() {
         // T1 delegates filesystem-policy enforcement (including
         // `deniedPaths`) to BaseContainer's native API; the dispatcher
-        // does not stamp host-DACL deny ACEs on the T1 path, so no
-        // `DaclManager` is attached regardless of the `deniedPaths`
-        // contents. See the module-level doc for the principal-match
-        // reasoning.
+        // attaches no `DaclManager` on the T1 path regardless of the
+        // `deniedPaths` contents.
         let _g = ForceTierGuard::set("base-container");
         let (policy, _tmp) = policy_with_denied_temp();
         let req = test_request(policy);

--- a/src/backends/appcontainer/common/src/fallback_detector.rs
+++ b/src/backends/appcontainer/common/src/fallback_detector.rs
@@ -164,16 +164,23 @@ pub fn detect(
 
     // Tier 1 — BaseContainer
     if prefer_base_container && is_base_container_usable() {
-        if denied {
-            ensure_dacl_augmentation_allowed(policy)?;
-            verify_write_dac_all(&policy.denied_paths)?;
+        // Keep deny on Tier 1 only with native fs_deny support
+        // (SANDBOX_CAP_FS_DENY); T1 applies no host DACL, so otherwise
+        // fall through to a DACL-enforcing tier.
+        if !denied || base_container_supports_deny_paths() {
+            return Ok(TierDecision {
+                tier: IsolationTier::BaseContainer,
+                needs_dacl_augmentation: false,
+                bfscfg_path: None,
+                warnings,
+            });
         }
-        return Ok(TierDecision {
-            tier: IsolationTier::BaseContainer,
-            needs_dacl_augmentation: denied,
-            bfscfg_path: None,
-            warnings,
-        });
+        warnings.push(
+            "BaseContainer usable but this OS does not advertise SANDBOX_CAP_FS_DENY; \
+             deniedPaths cannot be enforced natively at Tier 1 — falling back to AppContainer \
+             for deniedPaths enforcement"
+                .to_string(),
+        );
     }
     // Tier 2 — AppContainer + BFS
     //
@@ -186,8 +193,7 @@ pub fn detect(
     // entirely and fall through to Tier 3 (AppContainer + DACL).
     if cfg!(feature = "tier2_bfs") {
         warnings.push(
-            "BaseContainer API not present or not preferred; falling back to AppContainer + BFS"
-                .to_string(),
+            "BaseContainer tier not selected; falling back to AppContainer + BFS".to_string(),
         );
 
         // When the policy has no filesystem rules at all there is
@@ -215,7 +221,7 @@ pub fn detect(
         warnings.push("bfscfg.exe not present; falling back to AppContainer + DACL".to_string());
     } else {
         warnings.push(
-            "BaseContainer API not present or not preferred, and AppContainer + BFS is not \
+            "BaseContainer tier not selected, and AppContainer + BFS is not \
              compiled into this binary; falling back to AppContainer + DACL"
                 .to_string(),
         );
@@ -465,6 +471,23 @@ pub fn is_base_container_usable() -> bool {
     *USABLE.get_or_init(crate::base_container_runner::BaseContainerRunner::is_base_container_usable)
 }
 
+/// Whether the OS advertises native deny-paths enforcement
+/// (`SANDBOX_CAP_FS_DENY`, i.e. it honors the SandboxSpec `fs_deny` field).
+/// [`detect`] uses this to keep deny on Tier 1; otherwise it falls through to a
+/// DACL-enforcing tier. Probed once and cached for the process lifetime.
+pub fn base_container_supports_deny_paths() -> bool {
+    // Test seam: force the capability without real OS support.
+    #[cfg(test)]
+    if let Ok(forced) = std::env::var("MXC_FORCE_DENY_PATHS") {
+        return forced == "1";
+    }
+
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(
+        crate::base_container_runner::BaseContainerRunner::base_container_supports_deny_paths,
+    )
+}
+
 /// Returns `Ok(Some(path))` when `bfscfg.exe` is present, where `path`
 /// is the **absolute** path the caller MUST pass to
 /// `CreateProcessW`'s `lpApplicationName` (or as a quoted absolute
@@ -707,6 +730,74 @@ mod tests {
             detect(&policy, true),
             Err(FallbackError::DaclFallbackDisabled)
         ));
+    }
+
+    /// Tier 1 keeps a denied-paths policy (native `fs_deny`, no host DACL) when
+    /// `SANDBOX_CAP_FS_DENY` is advertised.
+    #[test]
+    fn denied_paths_stay_on_t1_when_capability_present() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_TIER");
+            std::env::set_var("MXC_FORCE_BC_USABLE", "1");
+            std::env::set_var("MXC_FORCE_DENY_PATHS", "1");
+        }
+        let policy = policy_with_denied();
+        let d = detect(&policy, true).expect("native deny support keeps T1");
+        // SAFETY: serialized by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_BC_USABLE");
+            std::env::remove_var("MXC_FORCE_DENY_PATHS");
+        }
+        assert!(matches!(d.tier, IsolationTier::BaseContainer));
+        assert!(!d.needs_dacl_augmentation);
+    }
+
+    /// Without `SANDBOX_CAP_FS_DENY`, deny must not stay on Tier 1; it falls
+    /// through to a DACL-enforcing AppContainer tier.
+    #[test]
+    fn denied_paths_fall_through_when_capability_absent() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_TIER");
+            std::env::set_var("MXC_FORCE_BC_USABLE", "1");
+            std::env::set_var("MXC_FORCE_DENY_PATHS", "0");
+        }
+        // Temp dir so the DACL-tier WRITE_DAC precheck succeeds for a non-admin user.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let mut policy = ContainerPolicy::default();
+        policy
+            .denied_paths
+            .push(dir.path().to_string_lossy().into_owned());
+        policy.fallback.allow_dacl_mutation = true;
+        let d = detect(&policy, true).expect("falls through to a DACL tier");
+        // SAFETY: serialized by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_BC_USABLE");
+            std::env::remove_var("MXC_FORCE_DENY_PATHS");
+        }
+        assert!(
+            !matches!(d.tier, IsolationTier::BaseContainer),
+            "deny without native capability must not stay on T1, got {:?}",
+            d.tier
+        );
+        assert!(d.needs_dacl_augmentation);
+        assert!(
+            d.warnings.iter().any(|w| w.contains("SANDBOX_CAP_FS_DENY")),
+            "expected the capability-absent fall-through warning, got: {:?}",
+            d.warnings
+        );
+        // The API is present and was preferred here — fall-through warnings must
+        // not claim otherwise.
+        assert!(
+            !d.warnings
+                .iter()
+                .any(|w| w.contains("not present or not preferred")),
+            "fall-through warnings must not claim the API is absent, got: {:?}",
+            d.warnings
+        );
     }
     #[test]
     fn force_tier_env_var_parses_all_three_values() {

--- a/src/backends/appcontainer/common/src/probe.rs
+++ b/src/backends/appcontainer/common/src/probe.rs
@@ -59,7 +59,7 @@ pub struct ProbeFacts {
     /// run a binary that reports `true` here.
     pub bfs_compiled_in: bool,
     /// Whether the BaseContainer (Tier 1) tier can enforce
-    /// `filesystem.deniedPaths` on this host (the `SANDBOX_CAP_DENY_PATHS` bit
+    /// `filesystem.deniedPaths` on this host (the `SANDBOX_CAP_FS_DENY` bit
     /// from `Experimental_QuerySandboxSupport`). `false` on builds where deny
     /// support has not yet shipped, where `deniedPaths` is rejected at launch.
     /// Tier 3 (AppContainer + DACL) enforces `deniedPaths` via DENY ACEs

--- a/src/backends/appcontainer/common/src/test_env.rs
+++ b/src/backends/appcontainer/common/src/test_env.rs
@@ -95,6 +95,32 @@ impl Drop for BcUsableGuard {
     }
 }
 
+/// RAII guard for `MXC_FORCE_DENY_PATHS`, mirroring [`BcUsableGuard`]. Forces
+/// `base_container_supports_deny_paths()` to a fixed value in tests.
+pub(crate) struct DenyPathsGuard {
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl DenyPathsGuard {
+    pub(crate) fn supported(supported: bool) -> Self {
+        let guard = lock();
+        // SAFETY: env-var mutation is gated by ENV_LOCK.
+        unsafe {
+            std::env::set_var("MXC_FORCE_DENY_PATHS", if supported { "1" } else { "0" });
+        }
+        DenyPathsGuard { _lock: guard }
+    }
+}
+
+impl Drop for DenyPathsGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialized by ENV_LOCK still held in `_lock`.
+        unsafe {
+            std::env::remove_var("MXC_FORCE_DENY_PATHS");
+        }
+    }
+}
+
 /// RAII guard for `MXC_BFSCFG_PATH`, mirroring [`ForceTierGuard`].
 ///
 /// Only compiled in under the `tier2_bfs` feature, because the

--- a/src/core/generated/base_container_specification/src/base_container_layout/sandbox_spec_generated.rs
+++ b/src/core/generated/base_container_specification/src/base_container_layout/sandbox_spec_generated.rs
@@ -30,6 +30,7 @@ impl<'a> SandboxSpec<'a> {
     pub const VT_FS_READ_ONLY: ::flatbuffers::VOffsetT = 20;
     pub const VT_NETWORK_POLICY: ::flatbuffers::VOffsetT = 22;
     pub const VT_INTEGRITY: ::flatbuffers::VOffsetT = 24;
+    pub const VT_FS_DENY: ::flatbuffers::VOffsetT = 26;
 
     #[inline]
     pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -47,6 +48,9 @@ impl<'a> SandboxSpec<'a> {
     ) -> ::flatbuffers::WIPOffset<SandboxSpec<'bldr>> {
         let mut builder = SandboxSpecBuilder::new(_fbb);
         builder.add_ui_restrictions(args.ui_restrictions);
+        if let Some(x) = args.fs_deny {
+            builder.add_fs_deny(x);
+        }
         if let Some(x) = args.network_policy {
             builder.add_network_policy(x);
         }
@@ -95,6 +99,11 @@ impl<'a> SandboxSpec<'a> {
             .network_policy()
             .map(|x| alloc::boxed::Box::new(x.unpack()));
         let integrity = self.integrity();
+        let fs_deny = self.fs_deny().map(|x| {
+            x.iter()
+                .map(|s| alloc::string::ToString::to_string(s))
+                .collect()
+        });
         SandboxSpecT {
             version,
             app_container,
@@ -106,6 +115,7 @@ impl<'a> SandboxSpec<'a> {
             fs_read_only,
             network_policy,
             integrity,
+            fs_deny,
         }
     }
 
@@ -227,6 +237,19 @@ impl<'a> SandboxSpec<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn fs_deny(
+        &self,
+    ) -> Option<::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab.get::<::flatbuffers::ForwardsUOffset<
+                ::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>,
+            >>(SandboxSpec::VT_FS_DENY, None)
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for SandboxSpec<'_> {
@@ -262,6 +285,9 @@ impl ::flatbuffers::Verifiable for SandboxSpec<'_> {
                 false,
             )?
             .visit_field::<IntegrityLevel>("integrity", Self::VT_INTEGRITY, false)?
+            .visit_field::<::flatbuffers::ForwardsUOffset<
+                ::flatbuffers::Vector<'_, ::flatbuffers::ForwardsUOffset<&'_ str>>,
+            >>("fs_deny", Self::VT_FS_DENY, false)?
             .finish();
         Ok(())
     }
@@ -285,6 +311,11 @@ pub struct SandboxSpecArgs<'a> {
     >,
     pub network_policy: Option<::flatbuffers::WIPOffset<NetworkPolicy<'a>>>,
     pub integrity: IntegrityLevel,
+    pub fs_deny: Option<
+        ::flatbuffers::WIPOffset<
+            ::flatbuffers::Vector<'a, ::flatbuffers::ForwardsUOffset<&'a str>>,
+        >,
+    >,
 }
 impl<'a> Default for SandboxSpecArgs<'a> {
     #[inline]
@@ -300,6 +331,7 @@ impl<'a> Default for SandboxSpecArgs<'a> {
             fs_read_only: None,
             network_policy: None,
             integrity: IntegrityLevel::system_default,
+            fs_deny: None,
         }
     }
 }
@@ -388,6 +420,16 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> SandboxSpecBuilder<'a, 'b, A>
         );
     }
     #[inline]
+    pub fn add_fs_deny(
+        &mut self,
+        fs_deny: ::flatbuffers::WIPOffset<
+            ::flatbuffers::Vector<'b, ::flatbuffers::ForwardsUOffset<&'b str>>,
+        >,
+    ) {
+        self.fbb_
+            .push_slot_always::<::flatbuffers::WIPOffset<_>>(SandboxSpec::VT_FS_DENY, fs_deny);
+    }
+    #[inline]
     pub fn new(
         _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
     ) -> SandboxSpecBuilder<'a, 'b, A> {
@@ -421,6 +463,7 @@ impl ::core::fmt::Debug for SandboxSpec<'_> {
         ds.field("fs_read_only", &self.fs_read_only());
         ds.field("network_policy", &self.network_policy());
         ds.field("integrity", &self.integrity());
+        ds.field("fs_deny", &self.fs_deny());
         ds.finish()
     }
 }
@@ -437,6 +480,7 @@ pub struct SandboxSpecT {
     pub fs_read_only: Option<alloc::vec::Vec<alloc::string::String>>,
     pub network_policy: Option<alloc::boxed::Box<NetworkPolicyT>>,
     pub integrity: IntegrityLevel,
+    pub fs_deny: Option<alloc::vec::Vec<alloc::string::String>>,
 }
 impl Default for SandboxSpecT {
     fn default() -> Self {
@@ -451,6 +495,7 @@ impl Default for SandboxSpecT {
             fs_read_only: None,
             network_policy: None,
             integrity: IntegrityLevel::system_default,
+            fs_deny: None,
         }
     }
 }
@@ -478,6 +523,10 @@ impl SandboxSpecT {
         });
         let network_policy = self.network_policy.as_ref().map(|x| x.pack(_fbb));
         let integrity = self.integrity;
+        let fs_deny = self.fs_deny.as_ref().map(|x| {
+            let w: alloc::vec::Vec<_> = x.iter().map(|s| _fbb.create_string(s)).collect();
+            _fbb.create_vector(&w)
+        });
         SandboxSpec::create(
             _fbb,
             &SandboxSpecArgs {
@@ -491,6 +540,7 @@ impl SandboxSpecT {
                 fs_read_only,
                 network_policy,
                 integrity,
+                fs_deny,
             },
         )
     }

--- a/src/core/wxc_common/src/error.rs
+++ b/src/core/wxc_common/src/error.rs
@@ -50,9 +50,18 @@ impl From<std::io::Error> for WxcError {
 
 #[cfg(target_os = "windows")]
 pub const DENIED_PATHS_NOT_SUPPORTED_MSG: &str =
-    "filesystem.deniedPaths is not yet supported on Windows. Paths are denied by \
-     default unless granted via readwritePaths or readonlyPaths. Remove deniedPaths, \
-     or narrow readwritePaths/readonlyPaths to exclude the path you wanted to deny.";
+    "filesystem.deniedPaths is not supported by this AppContainer filesystem mode. \
+     Paths are denied by default unless granted via readwritePaths or readonlyPaths. \
+     Remove deniedPaths, or narrow readwritePaths/readonlyPaths to exclude the path \
+     you wanted to deny.";
+
+#[cfg(target_os = "windows")]
+pub const DENIED_PATHS_FEATURE_DISABLED_MSG: &str =
+    "filesystem.deniedPaths cannot be enforced by the BaseContainer backend on this \
+     OS build: it does not advertise the native deny-paths capability \
+     (SANDBOX_CAP_FS_DENY via Experimental_QuerySandboxSupport). Run on a build with \
+     BaseContainer deny support, or use schema version '0.4.0-alpha' to select the \
+     AppContainer backend (which enforces deniedPaths via DENY ACEs).";
 
 #[cfg(target_os = "windows")]
 pub const HOST_LISTS_NOT_SUPPORTED_MSG: &str =


### PR DESCRIPTION
This PR plumbs `deniedPaths` into the BaseContainer SandboxSpec `fs_deny` FlatBuffer field so the OS enforces denied paths natively at Tier 1, gated on the OS-advertised `SANDBOX_CAP_FS_DENY` capability. When the capability is absent, a denied-paths policy falls through to a DACL-enforcing AppContainer tier (T2/T3) rather than staying on Tier 1 (where the dispatcher applies no host DACL), so deny is never silently dropped.

Details

* BaseContainerSpecification.fbs / sandbox_spec_generated.rs: add the additive `fs_deny:[string]` field so deniedPaths reach Experimental_CreateProcessInSandbox.
* base_container_runner.rs: emit `fs_deny` from `denied_paths`; `validate` accepts deniedPaths only when the OS advertises SANDBOX_CAP_FS_DENY (via the existing `base_container_supports_deny_paths()` query) and otherwise fails closed -- this runner has no DACL fallback of its own.
* fallback_detector.rs: `detect` keeps a denied-paths policy on Tier 1 only when the capability is present (native fs_deny, no host DACL); otherwise it falls through to the AppContainer DACL tiers. Adds a process-cached, test-seamed `base_container_supports_deny_paths()` wrapper mirroring `is_base_container_usable()`.
* Rename the capability bit SANDBOX_CAP_DENY_PATHS -> SANDBOX_CAP_FS_DENY to match the OS-side capability name; correct the dispatcher comments to state why T1 needs no host DACL (the OS enforces deny natively when the capability is present, and denied-paths policies never reach T1 otherwise).
* error.rs: add DENIED_PATHS_FEATURE_DISABLED_MSG for the capability-absent direct-caller rejection.

Tests

* cargo test -p appcontainer_common -p wxc_common: 129 + 359 passed, including new fallback-detector tests (T1 native-deny when capability present; fall-through when absent) and runner validate tests (accept/reject by capability) using a new MXC_FORCE_DENY_PATHS test seam.
* cargo fmt --all -- --check; cargo clippy -p appcontainer_common -p wxc_common --all-targets -- -D warnings; cargo check --workspace --all-targets: all clean.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/603)