### PR TITLE
[Bubblewrap] Resolve bwrap policy mounts by most-specific-path-wins

### DIFF
--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -7,6 +7,7 @@
 //! arguments without spawning any processes, so it compiles and can be
 //! unit-tested on every host (Windows, macOS, Linux).
 
+use wxc_common::filesystem_resolve::FsIntent;
 use wxc_common::models::{ExecutionRequest, NetworkPolicy, ProxyAddress};
 
 /// Env var keys that the proxy block manages. Listed here so we can strip
@@ -161,21 +162,31 @@ pub fn build_args(request: &ExecutionRequest, proxy_address: Option<&ProxyAddres
     args.extend(["--proc".into(), "/proc".into()]);
     args.extend(["--tmpfs".into(), "/tmp".into()]);
 
-    // Read-write paths (override the base ro-bind and any standard mount
-    // they overlap).
-    for path in &request.policy.readwrite_paths {
-        args.extend(["--bind".into(), path.clone(), path.clone()]);
-    }
-
-    // Read-only paths (already covered by the base ro-bind, but listed
-    // explicitly so the intent is clear and they override any rw parent).
-    for path in &request.policy.readonly_paths {
-        args.extend(["--ro-bind".into(), path.clone(), path.clone()]);
-    }
-
-    // Denied paths: mask with an empty tmpfs so contents are invisible.
-    for path in &request.policy.denied_paths {
-        args.extend(["--tmpfs".into(), path.clone()]);
+    // Policy mounts, emitted in most-specific-path-wins order so a deeper path
+    // always overrides a shallower ancestor with a different intent regardless
+    // of which policy list it came from (e.g. `readwritePaths: ["/data/secrets"]`
+    // must survive `deniedPaths: ["/data"]`). bwrap applies mounts in order and
+    // the last at a path wins, so walking the specificity-ordered list last —
+    // after the baseline + virtual filesystems above — gives the intended
+    // precedence. `resolve_mount_order` assumes object normalization already ran
+    // (it does, in the runner before `build_args`), so exact same-path conflicts
+    // are already collapsed to the strictest intent.
+    for mount in wxc_common::filesystem_resolve::resolve_mount_order(&request.policy) {
+        match mount.intent {
+            // Read-write: override the base ro-bind and any standard mount.
+            FsIntent::ReadWrite => {
+                args.extend(["--bind".into(), mount.path.clone(), mount.path.clone()]);
+            }
+            // Read-only: already covered by the base ro-bind, but listed
+            // explicitly so the intent is clear and it overrides any rw parent.
+            FsIntent::ReadOnly => {
+                args.extend(["--ro-bind".into(), mount.path.clone(), mount.path.clone()]);
+            }
+            // Denied: mask with an empty tmpfs so contents are invisible.
+            FsIntent::Denied => {
+                args.extend(["--tmpfs".into(), mount.path.clone()]);
+            }
+        }
     }
 
     // -- Working directory -------------------------------------------------
@@ -309,6 +320,57 @@ mod tests {
         assert!(
             secrets_mount.is_some(),
             "denied path should be tmpfs-masked"
+        );
+    }
+
+    /// Helper: index of the `op` mount whose **destination** path is `path`.
+    /// `--tmpfs` emits `op DEST` (one path); `--bind`/`--ro-bind` emit
+    /// `op SRC DEST`, so the destination is the second path. Matching the
+    /// destination (rather than the arg immediately after the op) keeps this
+    /// correct even if the backend ever emits `SRC != DEST`. Searches from the
+    /// end so a policy mount is matched rather than a same-named baseline entry.
+    fn policy_mount_pos(args: &[String], op: &str, path: &str) -> usize {
+        let dest_offset = if op == "--tmpfs" { 1 } else { 2 };
+        (0..args.len())
+            .rev()
+            .find(|&i| args[i] == op && args.get(i + dest_offset).map(String::as_str) == Some(path))
+            .unwrap_or_else(|| panic!("expected `{op} ... {path}` in args: {args:?}"))
+    }
+
+    /// A deep denied path must be emitted AFTER a shallower read-write ancestor
+    /// so the mask wins on the subtree (most-specific-path-wins).
+    #[test]
+    fn deep_denied_child_masks_rw_parent() {
+        let mut r = base_request();
+        r.policy.readwrite_paths = vec!["/data".into()];
+        r.policy.denied_paths = vec!["/data/secrets".into()];
+        let args = build_args(&r, None);
+
+        let parent = policy_mount_pos(&args, "--bind", "/data");
+        let child = policy_mount_pos(&args, "--tmpfs", "/data/secrets");
+        assert!(
+            child > parent,
+            "denied /data/secrets (pos {child}) must come after rw /data (pos {parent}) \
+             so it masks the subtree: {args:?}"
+        );
+    }
+
+    /// Regression for the previously-broken case: a deep read-write path under a
+    /// shallower denied parent must be emitted AFTER the parent tmpfs so the deep
+    /// bind is not shadowed by the mask (most-specific-path-wins).
+    #[test]
+    fn deep_rw_child_survives_denied_parent() {
+        let mut r = base_request();
+        r.policy.readwrite_paths = vec!["/data/secrets".into()];
+        r.policy.denied_paths = vec!["/data".into()];
+        let args = build_args(&r, None);
+
+        let parent = policy_mount_pos(&args, "--tmpfs", "/data");
+        let child = policy_mount_pos(&args, "--bind", "/data/secrets");
+        assert!(
+            child > parent,
+            "rw /data/secrets (pos {child}) must come after denied /data (pos {parent}) \
+             so the deep bind is not shadowed by the mask: {args:?}"
         );
     }
 

--- a/src/core/wxc_common/src/filesystem_resolve.rs
+++ b/src/core/wxc_common/src/filesystem_resolve.rs
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Filesystem-policy **most-specific-path-wins** mount ordering (roadmap D4).
+//!
+//! The Linux containment backends (Bubblewrap, LXC) realise the filesystem
+//! policy as an ordered list of mounts, and the kernel applies "the last mount
+//! at a path wins". Overlap between a `readwritePaths` / `readonlyPaths` /
+//! `deniedPaths` entry and one of its ancestors or descendants is therefore
+//! resolved by **emission order**, not by path specificity. Emitting the three
+//! lists in a fixed category order (rw, then ro, then denied) gets some overlaps
+//! right by luck and others wrong: e.g. `readwritePaths: ["/data/secrets"]` with
+//! `deniedPaths: ["/data"]` emits the deep read-write bind first and then masks
+//! the whole `/data` subtree over it, so the *less* specific intent wins.
+//!
+//! [`resolve_mount_order`] fixes this by returning the policy paths ordered so
+//! that a **deeper (more specific) path is always emitted after — and therefore
+//! overrides — any shallower ancestor** with a different intent. A backend then
+//! emits its baseline / virtual filesystems first and walks this ordered list
+//! last, so the most-specific policy intent wins at every path regardless of
+//! which list it came from.
+//!
+//! This resolver only **reorders**; it does not drop or merge entries. Exact
+//! same-path conflicts across lists (e.g. the same object in both `readonlyPaths`
+//! and `deniedPaths`) are resolved upstream to the most-restrictive intent by
+//! [`crate::filesystem_object::normalize_object_conflicts`], which every runner
+//! calls before building its mounts — so no exact-duplicate same-path conflicts
+//! reach this function.
+
+use crate::models::ContainerPolicy;
+
+/// The access intent a resolved mount carries into the backend, mapped from the
+/// policy list the path came from.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FsIntent {
+    /// From `readwritePaths` — read+write bind.
+    ReadWrite,
+    /// From `readonlyPaths` — read-only bind.
+    ReadOnly,
+    /// From `deniedPaths` — masked (invisible) inside the sandbox.
+    Denied,
+}
+
+/// A single policy path paired with its intent, ready for a backend to emit as a
+/// mount. Ordered relative to its peers by [`resolve_mount_order`].
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ResolvedMount {
+    /// The host path exactly as it appears in the policy (not normalized — the
+    /// backend still owns path-to-mount translation).
+    pub path: String,
+    /// The intent this path was declared with.
+    pub intent: FsIntent,
+}
+
+/// Number of path components in `path`, used as the specificity key: a deeper
+/// path (more components) is more specific. Splits on both `/` and `\` and
+/// ignores empty segments so a leading slash and any trailing slash do not skew
+/// the count (`/data` and `/data/` are both depth 1; `/data/secrets` is depth 2).
+fn specificity(path: &str) -> usize {
+    path.split(['/', '\\']).filter(|s| !s.is_empty()).count()
+}
+
+/// Orders the policy's filesystem paths so that a more-specific (deeper) path is
+/// always emitted **after** — and therefore overrides — a less-specific ancestor
+/// with a different intent, for any backend that applies mounts in order with
+/// "last at a path wins" semantics.
+///
+/// The sort is **stable** and ascending by specificity, so:
+/// - shallower paths come first, deeper paths last (deepest wins);
+/// - paths of equal depth keep their category order (read-write, then
+///   read-only, then denied), matching the backends' historical emission order
+///   so an exact-depth tie still resolves denied-over-ro-over-rw.
+///
+/// Assumes [`crate::filesystem_object::normalize_object_conflicts`] has already
+/// collapsed any exact same-path conflicts; this function does not merge or drop
+/// entries, it only reorders them.
+pub fn resolve_mount_order(policy: &ContainerPolicy) -> Vec<ResolvedMount> {
+    // Collect in category order (rw, ro, denied). A stable sort below preserves
+    // this order for equal-depth ties, so denied still wins over ro over rw at
+    // the same path depth — matching the backends' pre-resolver emission order.
+    let mut mounts: Vec<ResolvedMount> = Vec::with_capacity(
+        policy.readwrite_paths.len() + policy.readonly_paths.len() + policy.denied_paths.len(),
+    );
+    for path in &policy.readwrite_paths {
+        mounts.push(ResolvedMount {
+            path: path.clone(),
+            intent: FsIntent::ReadWrite,
+        });
+    }
+    for path in &policy.readonly_paths {
+        mounts.push(ResolvedMount {
+            path: path.clone(),
+            intent: FsIntent::ReadOnly,
+        });
+    }
+    for path in &policy.denied_paths {
+        mounts.push(ResolvedMount {
+            path: path.clone(),
+            intent: FsIntent::Denied,
+        });
+    }
+
+    mounts.sort_by_key(|m| specificity(&m.path));
+    mounts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy(rw: &[&str], ro: &[&str], denied: &[&str]) -> ContainerPolicy {
+        ContainerPolicy {
+            readwrite_paths: rw.iter().map(|s| s.to_string()).collect(),
+            readonly_paths: ro.iter().map(|s| s.to_string()).collect(),
+            denied_paths: denied.iter().map(|s| s.to_string()).collect(),
+            ..ContainerPolicy::default()
+        }
+    }
+
+    fn order(mounts: &[ResolvedMount]) -> Vec<(&str, FsIntent)> {
+        mounts.iter().map(|m| (m.path.as_str(), m.intent)).collect()
+    }
+
+    #[test]
+    fn deeper_denied_child_comes_after_shallower_rw_parent() {
+        // rw /data, denied /data/secrets: the deep denied path must be emitted
+        // last so it masks the subtree even though /data is read-write.
+        let p = policy(&["/data"], &[], &["/data/secrets"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/data", FsIntent::ReadWrite),
+                ("/data/secrets", FsIntent::Denied),
+            ]
+        );
+    }
+
+    #[test]
+    fn deeper_rw_child_comes_after_shallower_denied_parent() {
+        // denied /data, rw /data/secrets: previously the /data tmpfs was emitted
+        // last and shadowed the deep bind (less-specific won). The resolver must
+        // now emit the deeper /data/secrets rw mount last so it wins.
+        let p = policy(&["/data/secrets"], &[], &["/data"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/data", FsIntent::Denied),
+                ("/data/secrets", FsIntent::ReadWrite),
+            ]
+        );
+    }
+
+    #[test]
+    fn three_level_nesting_orders_shallow_to_deep() {
+        let p = policy(&["/a/b/c"], &["/a"], &["/a/b"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/a", FsIntent::ReadOnly),
+                ("/a/b", FsIntent::Denied),
+                ("/a/b/c", FsIntent::ReadWrite),
+            ]
+        );
+    }
+
+    #[test]
+    fn equal_depth_keeps_category_order_rw_ro_denied() {
+        // Three sibling paths at the same depth: order is stable and follows the
+        // category order so a same-depth tie resolves denied last (wins).
+        let p = policy(&["/x"], &["/y"], &["/z"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/x", FsIntent::ReadWrite),
+                ("/y", FsIntent::ReadOnly),
+                ("/z", FsIntent::Denied),
+            ]
+        );
+    }
+
+    #[test]
+    fn trailing_slash_does_not_change_specificity() {
+        // "/data/" and "/data" are the same depth; the deeper child still wins.
+        let p = policy(&["/data/"], &[], &["/data/secrets"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/data/", FsIntent::ReadWrite),
+                ("/data/secrets", FsIntent::Denied),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_overlapping_paths_pass_through_by_depth() {
+        // Unrelated paths: no overlap to resolve, just ordered shallow-to-deep.
+        let p = policy(&["/srv/app/data"], &["/usr"], &["/opt/secret"]);
+        let resolved = resolve_mount_order(&p);
+        assert_eq!(
+            order(&resolved),
+            vec![
+                ("/usr", FsIntent::ReadOnly),
+                ("/opt/secret", FsIntent::Denied),
+                ("/srv/app/data", FsIntent::ReadWrite),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_policy_yields_no_mounts() {
+        assert!(resolve_mount_order(&ContainerPolicy::default()).is_empty());
+    }
+}

--- a/src/core/wxc_common/src/lib.rs
+++ b/src/core/wxc_common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod encoding;
 pub mod error;
 pub mod filesystem_access;
 pub mod filesystem_object;
+pub mod filesystem_resolve;
 pub mod id;
 pub mod log_symbols;
 pub mod logger;

--- a/tests/configs/bubblewrap_most_specific_denied_parent.json
+++ b/tests/configs/bubblewrap_most_specific_denied_parent.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-MostSpecific-DeniedParent",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "D=/mnt/msptest/data; if cat \"$D/secret_child/keep.txt\" 2>/dev/null | grep -q CHILD_KEPT; then echo CHILD_OK; else echo CHILD_MISSING; fi; if echo w > \"$D/secret_child/written.txt\" 2>/dev/null && grep -q w \"$D/secret_child/written.txt\" 2>/dev/null; then echo CHILD_WRITE_OK; else echo CHILD_WRITE_FAIL; fi; if cat \"$D/sibling.txt\" 2>/dev/null | grep -q PARENT_SECRET; then echo PARENT_LEAK; else echo PARENT_MASKED_OK; fi"
+  },
+  "filesystem": {
+    "readwritePaths": ["/mnt/msptest/data/secret_child"],
+    "deniedPaths": ["/mnt/msptest/data"]
+  }
+}

--- a/tests/configs/bubblewrap_most_specific_rw_parent.json
+++ b/tests/configs/bubblewrap_most_specific_rw_parent.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-MostSpecific-RwParent",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "P=/mnt/msptest2/proj; if cat \"$P/notes.txt\" 2>/dev/null | grep -q PROJ_NOTES; then echo PARENT_OK; else echo PARENT_MISSING; fi; if echo w > \"$P/written.txt\" 2>/dev/null && grep -q w \"$P/written.txt\" 2>/dev/null; then echo PARENT_WRITE_OK; else echo PARENT_WRITE_FAIL; fi; if cat \"$P/secrets/key.txt\" 2>/dev/null | grep -q DEEP_SECRET || ls \"$P/secrets\" 2>/dev/null | grep -q .; then echo DEEP_LEAK; else echo DEEP_MASKED_OK; fi"
+  },
+  "filesystem": {
+    "readwritePaths": ["/mnt/msptest2/proj"],
+    "deniedPaths": ["/mnt/msptest2/proj/secrets"]
+  }
+}

--- a/tests/scripts/run_bwrap_all_tests.sh
+++ b/tests/scripts/run_bwrap_all_tests.sh
@@ -36,6 +36,7 @@ run_test() {
 run_test "Basic Bubblewrap" "$SCRIPT_DIR/run_bwrap_basic_test.sh"
 run_test "Bubblewrap Filesystem" "$SCRIPT_DIR/run_bwrap_filesystem_test.sh"
 run_test "Bubblewrap Object Validation" "$SCRIPT_DIR/run_bwrap_filesystem_object_test.sh"
+run_test "Bubblewrap Most-Specific Path" "$SCRIPT_DIR/run_bwrap_most_specific_test.sh"
 run_test "Bubblewrap Network Block" "$SCRIPT_DIR/run_bwrap_network_test.sh"
 run_test "Bubblewrap Network Proxy" "$SCRIPT_DIR/run_bwrap_network_proxy_test.sh"
 run_test "Linux Process Default" "$SCRIPT_DIR/run_linux_process_default_test.sh"

--- a/tests/scripts/run_bwrap_most_specific_test.sh
+++ b/tests/scripts/run_bwrap_most_specific_test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Bubblewrap most-specific-path-wins filesystem tests (roadmap D4).
+#
+# The Linux backends realise the filesystem policy as an ordered list of mounts
+# with "last mount at a path wins" semantics. The resolver orders paths so that
+# a deeper (more specific) path always overrides a shallower ancestor with a
+# different intent, regardless of which policy list it came from. These E2E
+# tests exercise both directions:
+#
+#   1. denied parent + read-write child: the deep child punches through the
+#      masked parent and stays readable/writable, while a non-re-bound sibling
+#      of the denied parent stays masked.
+#   2. read-write parent + denied child: the deep denied secret stays masked
+#      while the rest of the writable parent remains accessible.
+#
+# Both denied paths are directories (masked with tmpfs), so these tests do not
+# depend on the denied-file masking work tracked separately.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+BASE1="/mnt/msptest"
+BASE2="/mnt/msptest2"
+
+cleanup() { sudo rm -rf "$BASE1" "$BASE2"; }
+trap cleanup EXIT
+
+FAIL=0
+
+# --- Scenario 1: denied parent, read-write child -----------------------------
+# /data is denied (masked), but /data/secret_child is read-write. The deep child
+# must survive the masked parent; a sibling under the denied parent must not.
+sudo rm -rf "$BASE1"
+sudo mkdir -p "$BASE1/data/secret_child"
+echo "CHILD_KEPT" | sudo tee "$BASE1/data/secret_child/keep.txt" > /dev/null
+echo "PARENT_SECRET" | sudo tee "$BASE1/data/sibling.txt" > /dev/null
+sudo chown -R "$(id -u):$(id -g)" "$BASE1/data/secret_child"
+
+echo "Running Bubblewrap most-specific test 1 (denied parent, rw child)..."
+OUT1=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_most_specific_denied_parent.json" 2>&1 || true)
+echo "$OUT1"
+
+if echo "$OUT1" | grep -q "CHILD_OK" && echo "$OUT1" | grep -q "CHILD_WRITE_OK" \
+    && echo "$OUT1" | grep -q "PARENT_MASKED_OK" \
+    && ! echo "$OUT1" | grep -qE "CHILD_MISSING|CHILD_WRITE_FAIL|PARENT_LEAK"; then
+    echo "PASS: rw child survived denied parent; parent sibling masked."
+else
+    echo "FAIL: most-specific rw child did not win over denied parent."
+    FAIL=1
+fi
+
+# --- Scenario 2: read-write parent, denied child -----------------------------
+# /proj is read-write, but /proj/secrets is denied (masked). The parent stays
+# accessible while the deep secret must be masked.
+sudo rm -rf "$BASE2"
+sudo mkdir -p "$BASE2/proj/secrets"
+echo "PROJ_NOTES" | sudo tee "$BASE2/proj/notes.txt" > /dev/null
+echo "DEEP_SECRET" | sudo tee "$BASE2/proj/secrets/key.txt" > /dev/null
+sudo chown -R "$(id -u):$(id -g)" "$BASE2/proj"
+
+echo "Running Bubblewrap most-specific test 2 (rw parent, denied child)..."
+OUT2=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_most_specific_rw_parent.json" 2>&1 || true)
+echo "$OUT2"
+
+if echo "$OUT2" | grep -q "PARENT_OK" && echo "$OUT2" | grep -q "PARENT_WRITE_OK" \
+    && echo "$OUT2" | grep -q "DEEP_MASKED_OK" \
+    && ! echo "$OUT2" | grep -qE "PARENT_MISSING|PARENT_WRITE_FAIL|DEEP_LEAK"; then
+    echo "PASS: denied child masked under read-write parent."
+else
+    echo "FAIL: most-specific denied child did not win over rw parent."
+    FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi
+
+echo "Bubblewrap most-specific-path-wins tests complete."


### PR DESCRIPTION
## 📖 Description
The Bubblewrap backend emitted filesystem-policy mounts as three fixed loops (readwritePaths, then readonlyPaths, then deniedPaths). Because bwrap applies mounts in order and the last mount at a path wins, overlap between a path and one of its ancestors was resolved by emission order, not by path specificity. This got some overlaps right by luck and others wrong: `readwritePaths: ["/data/secrets"]` with `deniedPaths: ["/data"]` emitted the deep read-write bind first and then masked the whole /data subtree over it, so the less-specific intent won.

 Add a shared, backend-agnostic `resolve_mount_order` resolver in wxc_common that returns the policy paths ordered by specificity, so a deeper (more specific) path is always emitted after — and therefore overrides — a shallower ancestor with a different intent. Equal-depth ties keep the historical category order (rw, ro, denied) so a same-depth tie still resolves denied over ro over rw. The resolver only reorders; it assumes `normalize_object_conflicts` has already collapsed exact same-path conflicts, which every runner calls before building its mounts.

Wire the Bubblewrap backend to walk the resolved order instead of the three separate loops. LXC and WSLC are unchanged; the resolver lives in wxc_common so the LXC backend can consume it in a follow-up.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/608)