### PR TITLE
Add CodeQL static analysis workflow for Rust and TypeScript

### DIFF
--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -38,7 +38,7 @@ jobs:
           - language: rust
             runner: windows-latest
             target: x86_64-pc-windows-msvc
-            build-mode: manual
+            build-mode: none
 
     steps:
       - uses: actions/checkout@v4
@@ -49,9 +49,13 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
-      # ---- Rust: build manually so CodeQL observes a real compilation. ----
-      # autobuild does not know about the MxcDependencies feed or the pinned
-      # toolchain, so mirror the Lint job's setup.
+      # ---- Rust: CodeQL's Rust extractor is buildless (build-mode: none). It
+      # does not compile the workspace; instead it runs `cargo metadata` to
+      # resolve the crate graph and extracts straight from source. We still
+      # surface the pinned toolchain and the MxcDependencies feed so that
+      # dependency resolution succeeds (the private feed 401s otherwise). No
+      # `cargo build` is run, so the feature-gated backends' build workarounds
+      # (hyperlight/microvm/windows_sandbox) are irrelevant here.
       - name: Surface toolchain file at repo root
         if: matrix.language == 'rust'
         shell: bash
@@ -69,15 +73,6 @@ jobs:
       - name: Point cargo at the MxcDependencies feed
         if: matrix.language == 'rust'
         uses: ./.github/actions/setup-cargo-feed
-
-      - name: Build Rust workspace
-        if: matrix.language == 'rust'
-        working-directory: src
-        # Default features only: this keeps the CodeQL build off the
-        # feature-gated backends (hyperlight/microvm/windows_sandbox) that need
-        # extra CI workarounds. Trade-off: those backends are not covered by
-        # this scan. Expand --features here if that coverage becomes needed.
-        run: cargo build --locked --target ${{ matrix.target }}
 
       # ---- JS/TS: no build required; CodeQL extracts the source directly. ----
 

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id
     name: Analyze (${{ matrix.language }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
@@ -76,7 +77,7 @@ jobs:
         # feature-gated backends (hyperlight/microvm/windows_sandbox) that need
         # extra CI workarounds. Trade-off: those backends are not covered by
         # this scan. Expand --features here if that coverage becomes needed.
-        run: cargo build --target ${{ matrix.target }}
+        run: cargo build --locked --target ${{ matrix.target }}
 
       # ---- JS/TS: no build required; CodeQL extracts the source directly. ----
 

--- a/.github/workflows/CodeQL.yml
+++ b/.github/workflows/CodeQL.yml
@@ -1,0 +1,86 @@
+name: CodeQL
+
+# Static analysis (SAST) for the TypeScript SDK and the Rust workspace.
+# Runs on pushes/PRs to main and on a weekly schedule so newly-published
+# advisories are caught even without a code change.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays at 06:00 UTC
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+
+    permissions:
+      security-events: write
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            runner: ubuntu-latest
+            build-mode: none
+          - language: rust
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            build-mode: manual
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # ---- Rust: build manually so CodeQL observes a real compilation. ----
+      # autobuild does not know about the MxcDependencies feed or the pinned
+      # toolchain, so mirror the Lint job's setup.
+      - name: Surface toolchain file at repo root
+        if: matrix.language == 'rust'
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: cp src/rust-toolchain.toml rust-toolchain.toml
+
+      - name: Setup Rust toolchain
+        if: matrix.language == 'rust'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          override: false
+          rustflags: ''
+
+      - name: Point cargo at the MxcDependencies feed
+        if: matrix.language == 'rust'
+        uses: ./.github/actions/setup-cargo-feed
+
+      - name: Build Rust workspace
+        if: matrix.language == 'rust'
+        working-directory: src
+        # Default features only: this keeps the CodeQL build off the
+        # feature-gated backends (hyperlight/microvm/windows_sandbox) that need
+        # extra CI workarounds. Trade-off: those backends are not covered by
+        # this scan. Expand --features here if that coverage becomes needed.
+        run: cargo build --target ${{ matrix.target }}
+
+      # ---- JS/TS: no build required; CodeQL extracts the source directly. ----
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Adds `.github/workflows/CodeQL.yml` to enable CodeQL static analysis (SAST) for the repo. Verified against the live repo that CodeQL is the one security feature not yet present (Dependabot and Copilot code review already run); the code-scanning API currently returns "no analysis found".

**What it does**
- Runs on `push`/`pull_request` to `main` plus a weekly `schedule` (Mon 06:00 UTC), so newly-published advisories are caught even without a code change.
- Matrix over two languages, both **buildless** (`build-mode: none`):
  - **`javascript-typescript`** on `ubuntu-latest` (the SDK). CodeQL extracts straight from source; no build needed.
  - **`rust`** on `windows-latest`. CodeQL's Rust extractor is buildless-only, so it runs **no `cargo build`** — it resolves the crate graph via `cargo metadata` and extracts from source. The job still surfaces `src/rust-toolchain.toml` at the repo root (so the pinned toolchain is honored) and appends the public MxcDependencies feed via the existing `./.github/actions/setup-cargo-feed` composite action, so that dependency resolution succeeds (the private feed 401s otherwise).
- `permissions` scoped to `security-events: write` + `contents: read`; `concurrency` cancels superseded runs.

**Note on Rust coverage:** because the Rust extractor is buildless, this scan does not depend on compiling any feature-gated backend (hyperlight/microvm/windows_sandbox), and there are no backend-specific build workarounds to import. The extractor analyzes the workspace source directly. (An earlier revision of this PR used `build-mode: manual` with a `cargo build`; that failed because CodeQL's Rust extractor does not support `manual` — only `none` — so it was switched to the buildless mode. The description and code now both reflect the buildless approach.)

Results will populate the **Security → Code scanning** tab once merged to `main`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/621)