### PR TITLE
Phase 3d: add actionable configuration parse errors

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,7 +120,7 @@ The Rust workspace (`src/`) implements multiple sandboxing backends behind the `
 
 ### Config flow
 
-1. User provides JSON config (file or base64) → `config_parser.rs` deserializes into the typed wire model (`wxc_common::wire`) → validates and maps to `ExecutionRequest` (the internal execution model in `models.rs`)
+1. User provides JSON config (file or base64) → `config_deserialize.rs` performs path-aware typed deserialization into the wire model (`wxc_common::wire`) → `config_parser.rs` validates and maps it to `ExecutionRequest` (the internal execution model in `models.rs`)
 2. `ExecutionRequest` includes the containment backend selection, process config, filesystem/network policies, and optional experimental features
 3. The appropriate `ScriptRunner` implementation executes the process and returns `ScriptResponse`
 
@@ -214,7 +214,7 @@ The workspace is organized into six top-level directories under `src/`:
 
 ### Config parser pattern
 
-The parser deserializes JSON directly into the typed wire model (`wxc_common::wire`), the single source of truth for the config shape (it also generates the JSON schema). `config_parser.rs` then maps the wire types to the validated domain structs in `models.rs`. The stable surface uses `deny_unknown_fields` (closed); the `experimental` block is permissive.
+The parser deserializes JSON directly into the typed wire model (`wxc_common::wire`), the single source of truth for the config shape (it also generates the JSON schema). All typed config deserialization goes through `config_deserialize.rs`, which distinguishes syntax errors from typed policy errors and adds the complete JSON path plus source line/column when available; state-aware backend errors are prefixed with their full `experimental.<backend>.<phase>` location. `config_parser.rs` then maps the wire types to the validated domain structs in `models.rs`. The stable surface uses `deny_unknown_fields` (closed); the `experimental` block is permissive.
 
 ### TypeScript conventions
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -722,6 +722,24 @@ state-aware mode so `stdout` remains parseable without sentinels. (One-shot disp
 keeps its existing `stdout` logger behaviour — the stricter routing applies to
 state-aware only.)
 
+Configuration parse-phase failures that occur **after** the request is
+discriminated as state-aware (i.e. the `phase` field was recognized) follow the
+state-aware contract: the typed `{error}` envelope is the only primary output,
+while the human-readable actionable parse diagnostic is written only to
+configured auxiliary sinks (`--log-file` and the Windows diagnostic console). It
+is not duplicated to the logger's primary console/buffer output, so such a parse
+failure does not add stderr noise even with `--debug`. Dispatch-time failures,
+including typed per-backend configuration errors, use the same auxiliary-only
+diagnostic routing before the executor emits their typed `{error}` envelope.
+
+Failures that occur **before** discrimination is possible — malformed base64,
+non-UTF-8 bytes, or JSON so malformed that the `phase` field cannot be read —
+cannot be attributed to the state-aware path, so they retain the legacy
+behavior: the diagnostic is written to the primary output (stderr) and **no**
+`{error}` envelope is emitted. Callers that require an envelope even for
+unparseable input should validate that the payload is well-formed JSON before
+invoking `wxc-exec`.
+
 For exec specifically, MXC diagnostic output mixes with the script's own stderr when
 `--debug` is passed. This is a small amount of pre- and post-dispatch noise; consumers
 wanting clean separation should use `--log-file <path>` instead, which routes diagnostic
@@ -1029,26 +1047,30 @@ implements one trait, the other, or both, depending on its declared participatio
 
 ### 9.1 Wire envelope (Rust mirror)
 
-MXC's parser at `src/core/wxc_common/src/config_parser.rs` deserializes the
-wire-format JSON directly into the typed wire model in
-`src/core/wxc_common/src/wire.rs` (`wire::MxcConfig`), then maps it into the
-typed domain models (`convert_wire_config` → `ExecutionRequest`, with `From`
-impls beside the domain types for the trivial enum/struct conversions) before
-dispatch. The state-aware path reuses this same wire model.
+`src/core/wxc_common/src/config_deserialize.rs` performs path-aware JSON
+deserialization into the typed wire model in
+`src/core/wxc_common/src/wire.rs` (`wire::MxcConfig`).
+`src/core/wxc_common/src/config_parser.rs` discriminates request shape,
+validates the wire model, and maps it into the typed domain models
+(`convert_wire_config` → `ExecutionRequest`, with `From` impls beside the
+domain types for trivial enum/struct conversions). The state-aware path reuses
+this wire model while retaining its per-backend `experimental` subtree for
+dispatch-time typing.
 
 ```rust
 // In config_parser.rs — discrimination is by presence of the `phase` key in
-// the decoded JSON; both shapes deserialize into the one wire::MxcConfig type,
-// which declares `phase` / `sandboxId` and the per-backend `experimental` block.
-let value: serde_json::Value = serde_json::from_str(&json_str)?;
-if value.get("phase").is_some() {
-    // state-aware: peel off the raw `experimental` block (typed per-backend at
-    // dispatch), deserialize the rest into wire::MxcConfig, then map.
-    convert_wire_state_aware(value, logger, allow_missing_command)
+// the source JSON without building a full untyped request tree.
+let discriminator: RequestDiscriminator<'_> =
+    config_deserialize::from_str(&json_str)?;
+if discriminator.phase.is_some() {
+    convert_wire_state_aware(
+        &json_str,
+        discriminator.experimental,
+        logger,
+        allow_missing_command,
+    )
 } else {
-    // one-shot: deserialize wire::MxcConfig from the source text (preserving
-    // serde line/column diagnostics) and map.
-    let cfg: wire::MxcConfig = serde_json::from_str(&json_str)?;
+    let cfg: wire::MxcConfig = config_deserialize::from_str(&json_str)?;
     convert_wire_config(cfg, logger, true, allow_missing_command)
 }
 ```
@@ -1073,8 +1095,10 @@ state-aware-only fields (`phase`, `sandboxId`, `experimental.<backend>.<phase>`)
 are extracted alongside the `ExecutionRequest` and bundled into a
 `ParsedStateAwareRequest` domain model — `{ request: ExecutionRequest, phase:
 Phase, containment: Option<ContainmentBackend>, sandbox_id: Option<String>,
-experimental_raw: Option<serde_json::Value> }` — that the dispatcher consumes
-(§9.3). The bundling does not modify `ExecutionRequest`'s shape. Domain models
+experimental_raw: Option<serde_json::Value>, source_text: Option<Box<str>> }` —
+that the dispatcher consumes (§9.3). `source_text` retains the decoded request
+text so per-backend per-phase config errors can be reported with whole-file
+source location (§9.3). The bundling does not modify `ExecutionRequest`'s shape. Domain models
 are exposed to the dispatch layer; the wire types are an implementation detail of
 the parser and schema generation.
 
@@ -1426,7 +1450,13 @@ prefix) or `malformed_id` (no prefix structure) per §8.
 `Result<Option<C>, MxcError>`: it navigates the wire `experimental.<backend_key>.<phase_name>`
 JSON value and deserialises it into `C` when present, returns `Ok(None)` when absent,
 and surfaces malformed JSON as `malformed_request`. The dispatcher passes
-`B::BACKEND_KEY` so each backend reads from its own slot.
+`B::BACKEND_KEY` so each backend reads from its own slot. Typed errors carry the
+complete `experimental.<backend>.<phase>.<field>` JSON path **and** whole-file
+source location (line/column), at parity with base-config errors: the phase-config
+sub-slice is deserialised positionally out of the retained request text and its
+fragment-local serde location is translated back to whole-file coordinates. If the
+sub-slice cannot be located, deserialisation falls back to the value-based path,
+which still reports the JSON path (without a source location).
 `sandbox_id_required()` enforces that non-provision phases carry a `sandboxId`,
 returning `&str` on success or `malformed_request` on absence. `validate_exec_common`
 is a free function in `validator.rs` that checks cross-backend per-phase invariants

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -438,6 +438,16 @@ HRESULT EnumerateSandboxSpecVersionInfo(
 
 Negotiation failures are **typed and actionable** — never a silent fallback:
 
+- **JSON and policy-shape failures** distinguish malformed JSON syntax from
+  valid JSON that does not match the typed wire contract. Typed failures name
+  the full policy path (for example, `network.proxy.localhost`), retain Serde's
+  expected type/value information, and include source line/column when parsing
+  directly from request text. State-aware per-backend configuration errors are
+  prefixed with their full `experimental.<backend>.<phase>` location. Diagnostic
+  text escapes control characters, and errors at secret-bearing paths redact the
+  submitted value. After the root JSON value, only whitespace is accepted;
+  trailing JSON values or other trailing content are rejected as malformed
+  syntax.
 - **Schema-range failures** (Stage 1) carry a clear "older than supported" /
   "newer than supported" message telling the caller whether to update the config
   or upgrade `wxc-exec`.

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -2118,6 +2118,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2430,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -3118,8 +3135,10 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "tempfile",
  "thiserror",
+ "unicode-general-category",
  "url",
  "uuid",
  "widestring",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -96,6 +96,8 @@ windows = { version = "0.62", features = [
 windows-core = "0.62"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_path_to_error = "0.1"
+unicode-general-category = "1"
 thiserror = "2"
 anyhow = "1"
 base64 = "0.22"

--- a/src/core/mxc_engine/src/state_aware.rs
+++ b/src/core/mxc_engine/src/state_aware.rs
@@ -5,8 +5,8 @@
 //!
 //! The single home for resolving a parsed state-aware request to its backend
 //! and driving the per-phase flow. It centralizes the backend-specific
-//! construction that previously lived inline in `wxc-exec` so the binary can
-//! shrink to a thin CLI shell.
+//! construction that would otherwise live inline in `wxc-exec` so the binary
+//! can shrink to a thin CLI shell.
 //!
 //! Backends whose `StatefulSandboxBackend` impl lives in a `backends/*` crate
 //! (which depends on `wxc_common`, so the construction can't live inside
@@ -174,6 +174,7 @@ mod tests {
             sandbox_id: None,
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
 
         let error = run_state_aware(parsed, false).unwrap_err();

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -255,7 +255,7 @@ fn apply_command_override(
     }
 }
 
-/// The correlation-vector action a state-aware phase should take, decided purely
+/// The plan for producing this phase's correlation vector, derived
 /// from the phase and the relayed value. Returned by [`plan_correlation_vector`]
 /// so the seed-vs-spin decision is unit-testable without touching the RNG/clock;
 /// the caller executes the plan against the (nondeterministic) operators.
@@ -321,6 +321,16 @@ fn inject_correlation_vector(outcome: &mut Result<DispatchOutcome, MxcError>, cv
             );
         }
     }
+}
+
+/// On a state-aware dispatch failure, record the error only on the auxiliary
+/// diagnostic sinks (`--log-file` and the diagnostic pipe) via
+/// [`Logger::log_diagnostic_line`]. It is deliberately kept out of the primary
+/// console/buffer output so it never interleaves with the stdout response
+/// envelope; the failure reason still reaches the client through the JSON error
+/// envelope on stdout.
+fn log_state_aware_dispatch_error(logger: &mut Logger, error: &MxcError) {
+    logger.log_diagnostic_line(&error.to_string());
 }
 
 /// Drives the state-aware dispatch flow. On envelope success, writes the
@@ -423,6 +433,13 @@ fn run_state_aware_main(
         elapsed,
     );
 
+    // On dispatch failure, route the error to the auxiliary diagnostic sinks
+    // only (log file / diagnostic pipe) — never the primary buffer/stderr — so
+    // the stdout error envelope written below stays the single client-facing
+    // channel and is not shadowed by a duplicate on stderr.
+    if let Err(error) = &outcome {
+        log_state_aware_dispatch_error(logger, error);
+    }
     // Diagnostic buffer flushes to stderr regardless of success/failure so it
     // never interleaves with the stdout envelope.
     let buffered = logger.get_buffer().to_string();
@@ -1228,17 +1245,16 @@ fn main() {
         }
         mark_audit_active();
         _audit_guard = Some(AuditTraceGuard);
-        // previously this was
-        // `let _ = run_plm_command(...)`, which discarded the failure
-        // status. If plm start failed (missing plm.exe, wpr session
-        // conflict not resolved, etc.), the workload ran with
-        // `permissiveLearningMode` injected into the sandbox policy
-        // but with zero WPR recording — an empty Adjusted_*.json
-        // looked like "no denials." Bail explicitly on start failure
-        // so the operator sees the error and the policy isn't
-        // silently relaxed.
+        // Bail explicitly on `plm start` failure rather than
+        // discarding the failure status. If plm start failed
+        // (missing plm.exe, wpr session conflict not resolved,
+        // etc.), the workload would run with `permissiveLearningMode`
+        // injected into the sandbox policy but with zero WPR
+        // recording — an empty Adjusted_*.json looks like "no
+        // denials." Bailing lets the operator see the error and the
+        // policy isn't silently relaxed.
         //
-        // bracket the spawn with
+        // Bracket the spawn with
         // AUDIT_START_IN_FLIGHT so the console-control handler waits
         // for it to drain before deciding whether to issue `wpr
         // -cancel` (closes the Ctrl+C race where cancel arrives
@@ -1283,13 +1299,13 @@ fn main() {
     // its exit code. Done before the runner is dropped so the trace
     // tooling sees a fully-quiesced workload.
     //
-    // only clear `AUDIT_ACTIVE` when `plm stop` actually
-    // succeeded. Previously the flag was cleared unconditionally,
-    // which silently leaked the kernel ETW session whenever stop
-    // failed (missing plm.exe, spawn fail, wpr -stop non-zero) and
-    // simultaneously turned `AuditTraceGuard::drop` and the Ctrl-C
-    // handler into no-ops. On failure we now leave the flag set so
-    // the stack guard's `Drop` runs `wpr -cancel` for us.
+    // Only clear `AUDIT_ACTIVE` when `plm stop` actually
+    // succeeded. Clearing it unconditionally would silently leak
+    // the kernel ETW session whenever stop failed (missing
+    // plm.exe, spawn fail, wpr -stop non-zero) and simultaneously
+    // turn `AuditTraceGuard::drop` and the Ctrl-C handler into
+    // no-ops. On failure, leave the flag set so the stack guard's
+    // `Drop` runs `wpr -cancel` for us.
     #[cfg(target_os = "windows")]
     if cli.audit {
         let mut stop_args: Vec<std::ffi::OsString> = vec![std::ffi::OsString::from("stop")];
@@ -1430,6 +1446,31 @@ mod tests {
                 .expect_err("non-ProcessContainer backend must reject --audit");
             assert!(error.contains(containment.wire_name()));
         }
+    }
+
+    #[test]
+    fn state_aware_dispatch_errors_use_only_auxiliary_diagnostic_sinks() {
+        let directory = tempfile::tempdir().unwrap();
+        let log_path = directory.path().join("mxc.log");
+        let mut logger = test_logger();
+        logger.enable_file_sink(&log_path).unwrap();
+        let error = MxcError::malformed_request(
+            "Invalid configuration at `experimental.wslc.start.portMappings[0].windowsPort`",
+        );
+
+        log_state_aware_dispatch_error(&mut logger, &error);
+
+        assert!(
+            logger.get_buffer().is_empty(),
+            "the JSON envelope must retain primary output ownership"
+        );
+        drop(logger);
+        let log = std::fs::read_to_string(log_path).unwrap();
+        assert_eq!(
+            log.matches("experimental.wslc.start.portMappings[0].windowsPort")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1722,6 +1763,7 @@ mod tests {
             sandbox_id: Some("iso:wxc-1234".into()),
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
 
         let err = command_override_context_for_state_aware(&parsed, true).unwrap_err();

--- a/src/core/wxc_common/Cargo.toml
+++ b/src/core/wxc_common/Cargo.toml
@@ -12,7 +12,9 @@ schema-gen = ["dep:schemars"]
 
 [dependencies]
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
+serde_path_to_error = { workspace = true }
+unicode-general-category = { workspace = true }
 thiserror = { workspace = true }
 base64 = { workspace = true }
 url = { workspace = true }

--- a/src/core/wxc_common/src/config_deserialize.rs
+++ b/src/core/wxc_common/src/config_deserialize.rs
@@ -1,0 +1,748 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::fmt;
+
+use serde::{de::DeserializeOwned, Deserialize, Deserializer};
+use serde_json::{error::Category, Value};
+use unicode_general_category::{get_general_category, GeneralCategory};
+
+/// Field-name substrings that mark a value as secret-bearing. Matched anywhere
+/// within a single path segment, so `token` catches `wamToken`, `secret`
+/// catches `clientSecret`, and so on.
+const SECRET_PATH_MARKERS: &[&str] = &[
+    "token",
+    "password",
+    "secret",
+    "credential",
+    "apikey",
+    "accesskey",
+    "privatekey",
+    "passphrase",
+    "pwd",
+    "bearer",
+    "saskey",
+    "connectionstring",
+];
+
+/// Whole path segments that mark a value as secret-bearing. Matched as a
+/// complete field name (not a substring) so they never collide with unrelated
+/// fields such as `username`. `user` is the credential bundle
+/// (`user: { upn, wamToken }`): a shape error where the object is expected is
+/// pathed at `user`, not at `wamToken`, so the whole subtree must be marked.
+/// Over-redaction fails safe — it only replaces an error value with a location,
+/// never leaks one.
+const SECRET_PATH_SEGMENTS: &[&str] = &["user"];
+
+/// A JSON deserialization failure with the path at which typed policy parsing
+/// failed. Syntax errors have no meaningful policy path.
+#[derive(Debug)]
+pub(crate) struct ConfigDeserializeError {
+    path: Option<String>,
+    source: serde_json::Error,
+    /// Whole-file `(line, column)` that overrides the location baked into
+    /// `source` when the error was produced from a sub-slice of a larger
+    /// request (e.g. a state-aware `experimental.<backend>.<phase>` fragment).
+    /// `None` leaves `source`'s own location untouched.
+    location_override: Option<(usize, usize)>,
+}
+
+impl ConfigDeserializeError {
+    fn from_path_error(error: serde_path_to_error::Error<serde_json::Error>) -> Self {
+        let path = error.path().to_string();
+        let path = (path != ".").then_some(path);
+        Self {
+            path,
+            source: error.into_inner(),
+            location_override: None,
+        }
+    }
+
+    /// Override the source location rendered by `Display` with whole-file
+    /// coordinates. Used when translating a fragment-local serde location back
+    /// to its position in the complete request text.
+    pub(crate) fn with_source_location(mut self, line: usize, column: usize) -> Self {
+        self.location_override = Some((line, column));
+        self
+    }
+
+    /// The `(line, column)` serde recorded for this error, or `None` when serde
+    /// could not attribute a position (it reports line 0 in that case).
+    pub(crate) fn source_line_column(&self) -> Option<(usize, usize)> {
+        let line = self.source.line();
+        (line > 0).then(|| (line, self.source.column()))
+    }
+
+    /// Prefix a path produced while deserializing a JSON subtree with its path
+    /// in the complete request.
+    pub(crate) fn with_prefix(mut self, prefix: &str) -> Self {
+        self.path = Some(match self.path.take() {
+            None => prefix.to_string(),
+            Some(path) if path.starts_with('[') => format!("{prefix}{path}"),
+            Some(path) => format!("{prefix}.{path}"),
+        });
+        self
+    }
+
+    fn path_contains_secret(&self) -> bool {
+        self.path.as_deref().is_some_and(|path| {
+            path.to_ascii_lowercase().split('.').any(|segment| {
+                // Match on the field name only, dropping any array-index suffix
+                // so `field[0]` matches on `field`.
+                let field = segment.split('[').next().unwrap_or(segment);
+                SECRET_PATH_SEGMENTS.contains(&field)
+                    || SECRET_PATH_MARKERS
+                        .iter()
+                        .any(|marker| field.contains(marker))
+            })
+        })
+    }
+}
+
+impl fmt::Display for ConfigDeserializeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let source = if self.path_contains_secret() {
+            redact_secret_value(&self.source)
+        } else {
+            self.source.to_string()
+        };
+        // Remap the source's baked-in `line/column` to whole-file coordinates
+        // before escaping so all downstream guarantees (control-char escaping,
+        // secret redaction, syntax-vs-data branch) still hold unchanged.
+        let source = match self.location_override {
+            Some((line, column)) => rewrite_trailing_location(&source, line, column),
+            None => source,
+        };
+        let source = escape_control_characters(&source);
+        match self.source.classify() {
+            Category::Syntax | Category::Eof => {
+                write!(formatter, "Invalid JSON syntax: {source}")
+            }
+            Category::Data => match self.path.as_deref() {
+                Some(path) => write!(
+                    formatter,
+                    "Invalid configuration at `{}`: {source}",
+                    escape_control_characters(path)
+                ),
+                None => write!(formatter, "Invalid configuration: {source}"),
+            },
+            // Current constructors cannot produce reader I/O failures. Keep a
+            // defensive message in case a reader-backed constructor is added.
+            Category::Io => write!(formatter, "Unable to read JSON configuration: {source}"),
+        }
+    }
+}
+
+fn redact_secret_value(source: &serde_json::Error) -> String {
+    let line = source.line();
+    let column = source.column();
+    if line > 0 {
+        return format!("invalid secret value at line {line} column {column}");
+    }
+    "invalid secret value".to_string()
+}
+
+/// Replace a trailing serde-style ` at line <N> column <M>` suffix in a rendered
+/// error message with the supplied whole-file `line`/`column`. serde_json emits
+/// this stable suffix on positioned errors; if it is absent (unpositioned
+/// message), the location is appended so the caller still gets coordinates.
+fn rewrite_trailing_location(rendered: &str, line: usize, column: usize) -> String {
+    let replacement = format!(" at line {line} column {column}");
+    if let Some(index) = rendered.rfind(" at line ") {
+        if is_location_suffix(&rendered[index..]) {
+            return format!("{}{}", &rendered[..index], replacement);
+        }
+    }
+    format!("{rendered}{replacement}")
+}
+
+/// True when `suffix` is exactly ` at line <digits> column <digits>` with no
+/// trailing text — serde_json's positioned-error suffix shape.
+fn is_location_suffix(suffix: &str) -> bool {
+    let Some(rest) = suffix.strip_prefix(" at line ") else {
+        return false;
+    };
+    let (line_digits, rest) = split_leading_digits(rest);
+    if line_digits.is_empty() {
+        return false;
+    }
+    let Some(rest) = rest.strip_prefix(" column ") else {
+        return false;
+    };
+    let (column_digits, rest) = split_leading_digits(rest);
+    !column_digits.is_empty() && rest.is_empty()
+}
+
+fn split_leading_digits(text: &str) -> (&str, &str) {
+    let end = text
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(text.len());
+    text.split_at(end)
+}
+
+/// 1-based `(line, column)` (serde_json semantics) → byte offset within `text`.
+///
+/// Column arithmetic assumes ASCII configs (bytes == columns); the parser only
+/// ever hands us JSON, which is ASCII outside string literals, and offsets are
+/// only used to translate error positions. Returns `None` when the position is
+/// out of range so callers can fall back gracefully.
+fn byte_offset_of_line_col(text: &str, line: usize, column: usize) -> Option<usize> {
+    if line == 0 || column == 0 {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut current_line = 1usize;
+    let mut line_start = 0usize;
+    let mut index = 0usize;
+    while current_line < line && index < bytes.len() {
+        if bytes[index] == b'\n' {
+            current_line += 1;
+            line_start = index + 1;
+        }
+        index += 1;
+    }
+    if current_line < line {
+        return None;
+    }
+    let offset = line_start + (column - 1);
+    (offset <= text.len()).then_some(offset)
+}
+
+/// Byte offset within `text` → 1-based `(line, column)` (serde_json semantics).
+///
+/// Line counting is byte-exact; column arithmetic assumes ASCII (see
+/// [`byte_offset_of_line_col`]). Operates on bytes to avoid slicing panics on a
+/// non-char-boundary offset.
+fn line_col_of_byte_offset(text: &str, offset: usize) -> (usize, usize) {
+    let bytes = text.as_bytes();
+    let end = offset.min(bytes.len());
+    let mut line = 1usize;
+    let mut last_newline: Option<usize> = None;
+    for (index, byte) in bytes.iter().enumerate().take(end) {
+        if *byte == b'\n' {
+            line += 1;
+            last_newline = Some(index);
+        }
+    }
+    let column = match last_newline {
+        Some(index) => end - index,
+        None => end + 1,
+    };
+    (line, column)
+}
+
+/// Translate a `ConfigDeserializeError` produced by deserializing `fragment`
+/// (which begins at byte `fragment_offset` within `source_text`) so its
+/// rendered location reports whole-file coordinates instead of fragment-local
+/// ones. Any step that cannot be resolved returns `err` unchanged.
+pub(crate) fn remap_error_to_source(
+    err: ConfigDeserializeError,
+    fragment: &str,
+    fragment_offset: usize,
+    source_text: &str,
+) -> ConfigDeserializeError {
+    let Some((line, column)) = err.source_line_column() else {
+        return err;
+    };
+    let Some(local_offset) = byte_offset_of_line_col(fragment, line, column) else {
+        return err;
+    };
+    let global_offset = fragment_offset + local_offset;
+    let (global_line, global_column) = line_col_of_byte_offset(source_text, global_offset);
+    err.with_source_location(global_line, global_column)
+}
+
+fn escape_control_characters(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        if character.is_control() {
+            escaped.extend(character.escape_default());
+        } else if is_diagnostic_format_character(character) {
+            escaped.extend(character.escape_unicode());
+        } else {
+            escaped.push(character);
+        }
+    }
+    escaped
+}
+
+/// Escape control and invisible-format characters in free-form, user-controlled
+/// text before it reaches a diagnostic sink. Shared with the manual
+/// (non-serde) semantic validators so every user-derived diagnostic honors the
+/// same "no raw control/format bytes in diagnostics" guarantee.
+pub(crate) fn escape_diagnostic_text(value: &str) -> String {
+    escape_control_characters(value)
+}
+
+/// Invisible Unicode formatting characters (general category `Cf`) and the
+/// line/paragraph separators (`Zl`/`Zp`) that `char::is_control()` does **not**
+/// cover. Escaping these is a deliberate security control, not incidental
+/// hardening: escaping bidirectional overrides/isolates (U+202A–U+202E,
+/// U+2066–U+2069, category `Cf`) defends against "Trojan Source"
+/// (CVE-2021-42574) visual-spoofing of diagnostics, escaping the line/paragraph
+/// separators (U+2028/U+2029) prevents forging hard line breaks that some
+/// terminals/log viewers honor, and escaping zero-width / joiner / interlinear
+/// characters (also `Cf`) prevents concealing or forging log and error-envelope
+/// content rendered in a terminal or editor.
+fn is_diagnostic_format_character(character: char) -> bool {
+    matches!(
+        get_general_category(character),
+        GeneralCategory::Format
+            | GeneralCategory::LineSeparator
+            | GeneralCategory::ParagraphSeparator
+    )
+}
+
+impl std::error::Error for ConfigDeserializeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+fn deserialize_with_path<'de, T, D>(deserializer: D) -> Result<T, ConfigDeserializeError>
+where
+    T: Deserialize<'de>,
+    D: Deserializer<'de, Error = serde_json::Error>,
+{
+    serde_path_to_error::deserialize(deserializer).map_err(ConfigDeserializeError::from_path_error)
+}
+
+pub(crate) fn from_str<'de, T>(json: &'de str) -> Result<T, ConfigDeserializeError>
+where
+    T: Deserialize<'de>,
+{
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    let value = deserialize_with_path(&mut deserializer)?;
+    deserializer
+        .end()
+        .map_err(|source| ConfigDeserializeError {
+            path: None,
+            source,
+            location_override: None,
+        })?;
+    Ok(value)
+}
+
+pub(crate) fn from_value<T>(value: Value) -> Result<T, ConfigDeserializeError>
+where
+    T: DeserializeOwned,
+{
+    deserialize_with_path(value)
+}
+
+pub(crate) fn from_value_ref<'de, T>(value: &'de Value) -> Result<T, ConfigDeserializeError>
+where
+    T: Deserialize<'de>,
+{
+    deserialize_with_path(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    #[allow(dead_code)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(deny_unknown_fields)]
+    #[allow(dead_code)]
+    struct Inner {
+        count: u16,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct Secret {
+        wam_token: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct NumericSecret {
+        api_token: u32,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct MapOuter {
+        items: HashMap<String, Inner>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct UserHolder {
+        user: Secret,
+    }
+
+    #[test]
+    fn redacts_scalar_supplied_where_credential_subtree_is_expected() {
+        // A token supplied where the `user` object is expected pathes the error
+        // at `user`, not at `wamToken`; the whole credential subtree must still
+        // redact so the scalar is never echoed into diagnostics or the envelope.
+        let error = from_str::<UserHolder>(r#"{"user": "super-secret-bearer-token"}"#).unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            message.contains("Invalid configuration at `user`"),
+            "got: {message}"
+        );
+        assert!(message.contains("invalid secret value"), "got: {message}");
+        assert!(
+            !message.contains("super-secret-bearer-token"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn data_errors_include_the_nested_path_and_source_location() {
+        let error = from_str::<Outer>(
+            r#"{
+                "inner": {
+                    "count": 70000
+                }
+            }"#,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.path.as_deref(), Some("inner.count"));
+        let message = error.to_string();
+        assert!(message.contains("Invalid configuration at `inner.count`"));
+        assert!(message.contains("expected u16"));
+        assert!(message.contains("line 3"));
+    }
+
+    #[test]
+    fn syntax_errors_are_distinguished_from_typed_config_errors() {
+        let error = from_str::<Outer>(r#"{"inner": {"count": 1}"#).unwrap_err();
+        let message = error.to_string();
+        assert!(message.starts_with("Invalid JSON syntax:"));
+        assert!(message.contains("line 1"));
+    }
+
+    #[test]
+    fn trailing_json_data_is_rejected() {
+        let error = from_str::<Outer>(r#"{"inner": {"count": 1}} {"second": true}"#).unwrap_err();
+        assert!(error.to_string().starts_with("Invalid JSON syntax:"));
+    }
+
+    #[test]
+    fn subtree_paths_can_be_prefixed_with_their_request_location() {
+        let value = serde_json::json!({"count": "many"});
+        let error = from_value_ref::<Inner>(&value)
+            .unwrap_err()
+            .with_prefix("experimental.example.start");
+
+        assert_eq!(
+            error.path.as_deref(),
+            Some("experimental.example.start.count")
+        );
+        assert!(error
+            .to_string()
+            .contains("experimental.example.start.count"));
+    }
+
+    #[test]
+    fn root_level_errors_have_no_policy_path_or_rust_type_name() {
+        let error = from_str::<crate::wire::MxcConfig>(r#""not an object""#).unwrap_err();
+        assert_eq!(error.path.as_deref(), None);
+        let message = error.to_string();
+        assert!(message.contains("expected a configuration object"));
+        assert!(!message.contains("MxcConfig"));
+    }
+
+    #[test]
+    fn array_subtree_paths_are_prefixed_without_an_extra_dot() {
+        let value = serde_json::json!([{"count": "many"}]);
+        let error = from_value_ref::<Vec<Inner>>(&value)
+            .unwrap_err()
+            .with_prefix("experimental.example.start");
+
+        assert_eq!(
+            error.path.as_deref(),
+            Some("experimental.example.start[0].count")
+        );
+    }
+
+    #[test]
+    fn from_value_reports_the_typed_error_path() {
+        let value = serde_json::json!({"inner": {"count": "many"}});
+        let error = from_value::<Outer>(value).unwrap_err();
+
+        assert_eq!(error.path.as_deref(), Some("inner.count"));
+        assert!(error.to_string().contains("expected u16"));
+    }
+
+    #[test]
+    fn display_escapes_control_characters_from_paths_and_sources() {
+        let json = "{\"items\":{\"forged\\n\\u001b[31mline\":{\"count\":\"value\\n\\u001b[32m\"}}}";
+        let error = from_str::<MapOuter>(json).unwrap_err();
+        let message = error.to_string();
+
+        assert!(!message.contains('\n'));
+        assert!(!message.contains('\u{1b}'));
+        assert!(message.contains("\\n"), "got: {message}");
+        assert!(message.contains("\\u{1b}"), "got: {message}");
+    }
+
+    #[test]
+    fn display_escapes_unicode_format_characters_from_paths_and_sources() {
+        let json = "{\"items\":{\"forged\u{202e}line\":{\"count\":\"value\u{200b}hidden\"}}}";
+        let error = from_str::<MapOuter>(json).unwrap_err();
+        let message = error.to_string();
+
+        assert!(!message.contains('\u{202e}'));
+        assert!(!message.contains('\u{200b}'));
+        assert!(message.contains("\\u{202e}"), "got: {message}");
+        assert!(message.contains("\\u{200b}"), "got: {message}");
+    }
+
+    #[test]
+    fn display_redacts_values_at_secret_bearing_paths() {
+        let error = from_str::<Secret>(r#"{"wamToken": 123456789}"#).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("Invalid configuration at `wamToken`"));
+        assert!(message.contains("invalid secret value"));
+        assert!(message.contains("line 1"));
+        assert!(!message.contains("123456789"));
+    }
+
+    #[test]
+    fn secret_redaction_never_parses_attacker_controlled_error_text() {
+        let error = from_str::<NumericSecret>(
+            r#"{"apiToken": "expected leak-of-secret-data", "other": true}"#,
+        )
+        .unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("Invalid configuration at `apiToken`"));
+        assert!(message.contains("invalid secret value at line 1 column"));
+        assert!(!message.contains("expected leak-of-secret-data"));
+        assert!(!message.contains("leak-of-secret-data"));
+    }
+
+    #[test]
+    fn secret_markers_are_detected_case_insensitively() {
+        for path in [
+            "wamToken",
+            "adminPassword",
+            "clientSecret",
+            "serviceCredential",
+            "apiKey",
+            "accessKey",
+            "privateKey",
+            "passphrase",
+            "pwd",
+            "bearer",
+            "sasKey",
+            "connectionString",
+        ] {
+            let error = ConfigDeserializeError {
+                path: Some(path.to_string()),
+                source: serde_json::from_str::<Secret>(r#"{"wamToken": 123456789}"#).unwrap_err(),
+                location_override: None,
+            };
+
+            assert!(
+                error.to_string().contains("invalid secret value"),
+                "path {path} was not treated as sensitive"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_key_suffixes_are_not_treated_as_secrets() {
+        let error = ConfigDeserializeError {
+            path: Some("monkey".to_string()),
+            source: serde_json::from_str::<Secret>(r#"{"wamToken": 123456789}"#).unwrap_err(),
+            location_override: None,
+        };
+
+        assert!(!error.to_string().contains("invalid secret value"));
+    }
+
+    #[test]
+    fn user_segment_is_secret_but_similar_field_names_are_not() {
+        // `user` marks the credential bundle when matched as a whole path
+        // segment. It must redact at the segment itself, nested under a parent,
+        // with an array index, and at any descendant — but must NOT collide with
+        // unrelated fields that merely contain the substring `user`.
+        let redacted = [
+            "user",
+            "experimental.isolationSession.user",
+            "experimental.isolationSession.user.upn",
+            "users[0].user",
+        ];
+        for path in redacted {
+            let error = ConfigDeserializeError {
+                path: Some(path.to_string()),
+                source: serde_json::from_str::<Secret>(r#"{"wamToken": 123456789}"#).unwrap_err(),
+                location_override: None,
+            };
+            assert!(
+                error.to_string().contains("invalid secret value"),
+                "path {path} should be treated as sensitive"
+            );
+        }
+
+        let not_redacted = ["username", "userProfile", "userName", "superuser"];
+        for path in not_redacted {
+            let error = ConfigDeserializeError {
+                path: Some(path.to_string()),
+                source: serde_json::from_str::<Secret>(r#"{"wamToken": 123456789}"#).unwrap_err(),
+                location_override: None,
+            };
+            assert!(
+                !error.to_string().contains("invalid secret value"),
+                "path {path} should NOT be treated as sensitive"
+            );
+        }
+    }
+
+    #[test]
+    fn escapes_line_and_paragraph_separators() {
+        // U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) render as
+        // hard line breaks in some terminals/log viewers, so they must be
+        // escaped to prevent forged multi-line diagnostics.
+        let escaped = escape_diagnostic_text("a\u{2028}b\u{2029}c");
+
+        assert!(!escaped.contains('\u{2028}'));
+        assert!(!escaped.contains('\u{2029}'));
+        assert!(escaped.contains("\\u{2028}"), "got: {escaped}");
+        assert!(escaped.contains("\\u{2029}"), "got: {escaped}");
+    }
+
+    #[test]
+    fn leaves_plain_text_unchanged() {
+        let plain = "plain diagnostic text 123";
+        assert_eq!(escape_diagnostic_text(plain), plain);
+    }
+
+    #[test]
+    fn byte_offset_and_line_col_round_trip() {
+        let text = "line one\nline two\nline three\n";
+        // Walk every byte offset and confirm the offset -> (line,col) -> offset
+        // round-trip is stable.
+        for offset in 0..=text.len() {
+            let (line, column) = line_col_of_byte_offset(text, offset);
+            assert_eq!(
+                byte_offset_of_line_col(text, line, column),
+                Some(offset),
+                "round trip failed at offset {offset} -> ({line},{column})"
+            );
+        }
+    }
+
+    #[test]
+    fn line_col_of_byte_offset_hand_computed_cases() {
+        let text = "abc\ndefgh\nij";
+        // Offset 0 is line 1 column 1.
+        assert_eq!(line_col_of_byte_offset(text, 0), (1, 1));
+        // Offset 2 ('c') is line 1 column 3.
+        assert_eq!(line_col_of_byte_offset(text, 2), (1, 3));
+        // Offset 4 (start of "defgh") is line 2 column 1.
+        assert_eq!(line_col_of_byte_offset(text, 4), (2, 1));
+        // Offset 7 ('g') is line 2 column 4.
+        assert_eq!(line_col_of_byte_offset(text, 7), (2, 4));
+        // Offset 10 (start of "ij") is line 3 column 1.
+        assert_eq!(line_col_of_byte_offset(text, 10), (3, 1));
+    }
+
+    #[test]
+    fn byte_offset_of_line_col_hand_computed_and_out_of_range() {
+        let text = "abc\ndefgh\nij";
+        // Line 2 column 1 is the byte after the first newline.
+        assert_eq!(byte_offset_of_line_col(text, 2, 1), Some(4));
+        // Line 3 column 2 -> 'j'.
+        assert_eq!(byte_offset_of_line_col(text, 3, 2), Some(11));
+        // A line beyond the text has no offset.
+        assert_eq!(byte_offset_of_line_col(text, 9, 1), None);
+        // serde reports 0 for unknown positions; reject those.
+        assert_eq!(byte_offset_of_line_col(text, 0, 1), None);
+        assert_eq!(byte_offset_of_line_col(text, 1, 0), None);
+    }
+
+    #[test]
+    fn rewrite_trailing_location_replaces_existing_suffix() {
+        let rendered = "missing field `configuration_id` at line 2 column 5";
+        let rewritten = rewrite_trailing_location(rendered, 7, 11);
+        assert_eq!(
+            rewritten,
+            "missing field `configuration_id` at line 7 column 11"
+        );
+    }
+
+    #[test]
+    fn rewrite_trailing_location_appends_when_absent() {
+        let rendered = "some message without a position";
+        let rewritten = rewrite_trailing_location(rendered, 3, 4);
+        assert_eq!(
+            rewritten,
+            "some message without a position at line 3 column 4"
+        );
+    }
+
+    #[test]
+    fn serde_json_positioned_error_display_contract_is_pinned() {
+        // `rewrite_trailing_location` recognizes and replaces serde_json's
+        // rendered ` at line <N> column <M>` suffix. Pin that upstream Display
+        // contract so a format change is caught here rather than silently
+        // producing duplicated coordinates in diagnostics.
+        let err = serde_json::from_str::<i32>("\n  \"x\"").unwrap_err();
+        assert!(err.line() > 0, "expected a positioned error");
+        let rendered = err.to_string();
+        let suffix = format!(" at line {} column {}", err.line(), err.column());
+        assert!(
+            rendered.ends_with(&suffix),
+            "serde_json positioned-error suffix drifted: {rendered:?}"
+        );
+        assert!(
+            is_location_suffix(&suffix),
+            "positioned-error suffix no longer matches the recognized shape: {suffix:?}"
+        );
+
+        // And the rewrite must replace, not append, so coordinates never double.
+        let rewritten = rewrite_trailing_location(&rendered, 9, 3);
+        assert!(rewritten.ends_with(" at line 9 column 3"));
+        assert_eq!(
+            rewritten.matches(" at line ").count(),
+            1,
+            "coordinates were duplicated instead of replaced: {rewritten:?}"
+        );
+    }
+
+    #[test]
+    fn remap_error_translates_fragment_local_location_to_whole_file() {
+        // A fragment that starts several lines into the whole file. The typed
+        // error inside it must be reported at its whole-file line/column.
+        let source_text = "line1\nline2\nline3\n{\n  \"count\": \"many\"\n}\n";
+        let fragment = "{\n  \"count\": \"many\"\n}";
+        let fragment_offset = source_text.find(fragment).unwrap();
+
+        let err = from_str::<Inner>(fragment).unwrap_err();
+        // Fragment-local location: line 2 of the fragment.
+        assert_eq!(err.source_line_column().map(|(l, _)| l), Some(2));
+
+        let remapped = remap_error_to_source(err, fragment, fragment_offset, source_text);
+        let message = remapped.to_string();
+        // The offending field sits on whole-file line 5.
+        assert!(
+            message.contains("line 5"),
+            "expected whole-file line 5, got: {message}"
+        );
+        assert!(
+            !message.contains("line 2"),
+            "still fragment-local: {message}"
+        );
+    }
+}

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use std::fmt::Write;
-use std::fs;
+use std::{borrow::Cow, fs};
 
+use crate::config_deserialize;
 use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
@@ -16,6 +16,8 @@ use crate::models::{
 use crate::mxc_error::MxcError;
 use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
 use crate::wire;
+use serde::{Deserialize, Deserializer};
+use serde_json::value::RawValue;
 
 /// Categorised error from `load_mxc_request`. The `wxc-exec` driver uses the
 /// variant to choose the failure-output convention: state-aware failures
@@ -31,6 +33,44 @@ pub enum ParseError {
     /// Discriminated as state-aware; conversion to `ParsedStateAwareRequest`
     /// failed. Carries an `MxcError` so the driver can emit a typed envelope.
     StateAware(MxcError),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ErrorOutput {
+    Primary,
+    DiagnosticOnly,
+}
+
+impl ParseError {
+    fn output(&self) -> ErrorOutput {
+        match self {
+            Self::Decode(_) | Self::OneShot(_) => ErrorOutput::Primary,
+            Self::StateAware(_) => ErrorOutput::DiagnosticOnly,
+        }
+    }
+
+    fn message(&self) -> String {
+        match self {
+            Self::Decode(error) | Self::OneShot(error) => error.to_string(),
+            Self::StateAware(error) => error.to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(expecting = "a configuration object")]
+struct RequestDiscriminator<'a> {
+    #[serde(borrow, default, deserialize_with = "deserialize_present_raw")]
+    phase: Option<&'a RawValue>,
+    #[serde(borrow, default, deserialize_with = "deserialize_present_raw")]
+    experimental: Option<&'a RawValue>,
+}
+
+fn deserialize_present_raw<'de, D>(deserializer: D) -> Result<Option<&'de RawValue>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    <&RawValue>::deserialize(deserializer).map(Some)
 }
 
 // ---------- Public API ----------
@@ -79,14 +119,16 @@ pub fn load_request_with_options(
     logger: &mut Logger,
     opts: LoadOptions,
 ) -> Result<ExecutionRequest, WxcError> {
-    let json_str = decode_request_input(input, logger, opts.is_base64)?;
+    let result = (|| {
+        let json_str = decode_request_input_without_logging(input, opts.is_base64)?;
 
-    let cfg: wire::MxcConfig = serde_json::from_str(&json_str).map_err(|e| {
-        logger.log_line("Error parsing JSON");
-        WxcError::ConfigParse(format!("JSON parse error: {}", e))
-    })?;
+        let cfg: wire::MxcConfig = config_deserialize::from_str(&json_str)
+            .map_err(|error| WxcError::ConfigParse(error.to_string()))?;
 
-    convert_wire_config(cfg, logger, true, opts.allow_missing_command)
+        convert_wire_config(cfg, logger, true, opts.allow_missing_command)
+    })();
+    log_one_shot_error(logger, &result);
+    result
 }
 
 /// Build a request from an already-parsed wire-format config [`Value`], running
@@ -101,12 +143,14 @@ pub fn load_request_from_value(
     logger: &mut Logger,
     allow_missing_command: bool,
 ) -> Result<ExecutionRequest, WxcError> {
-    let cfg: wire::MxcConfig = serde_json::from_value(config).map_err(|e| {
-        logger.log_line("Error parsing JSON");
-        WxcError::ConfigParse(format!("JSON parse error: {}", e))
-    })?;
+    let result = (|| {
+        let cfg: wire::MxcConfig = config_deserialize::from_value(config)
+            .map_err(|error| WxcError::ConfigParse(error.to_string()))?;
 
-    convert_wire_config(cfg, logger, true, allow_missing_command)
+        convert_wire_config(cfg, logger, true, allow_missing_command)
+    })();
+    log_one_shot_error(logger, &result);
+    result
 }
 /// driver can pick the right output convention per path (envelope on stdout
 /// for state-aware, diagnostic on stderr for one-shot and pre-discrimination
@@ -135,9 +179,16 @@ pub fn load_mxc_request_with_options(
     logger: &mut Logger,
     opts: LoadOptions,
 ) -> Result<MxcRequest, ParseError> {
-    let json_str =
-        decode_request_input(input, logger, opts.is_base64).map_err(ParseError::Decode)?;
-    parse_mxc_request_json(&json_str, logger, opts.allow_missing_command)
+    let result = (|| {
+        let json_str = decode_request_input_without_logging(input, opts.is_base64)
+            .map_err(ParseError::Decode)?;
+        parse_mxc_request_json(&json_str, logger, opts.allow_missing_command)
+    })();
+
+    if let Err(error) = &result {
+        log_error(logger, &error.message(), error.output());
+    }
+    result
 }
 
 /// Parse an MXC request from a **raw JSON string** (already decoded — not a file
@@ -148,73 +199,81 @@ pub fn load_mxc_request_from_json(
     json_str: &str,
     logger: &mut Logger,
 ) -> Result<MxcRequest, ParseError> {
-    parse_mxc_request_json(json_str, logger, /*allow_missing_command=*/ false)
+    let result = parse_mxc_request_json(json_str, logger, /*allow_missing_command=*/ false);
+    if let Err(error) = &result {
+        log_error(logger, &error.message(), error.output());
+    }
+    result
 }
 
 /// Shared parse core over an already-decoded JSON string.
+///
+/// Borrows only the discriminator and the raw state-aware backend block, then
+/// deserialises the typed model directly from source text so policy errors
+/// retain line and column information (`serde_json::Value` would discard it).
 fn parse_mxc_request_json(
     json_str: &str,
     logger: &mut Logger,
     allow_missing_command: bool,
 ) -> Result<MxcRequest, ParseError> {
-    // Parse once into a generic JSON value so we can (a) discriminate one-shot
-    // vs state-aware by presence of the `phase` key and (b) capture the raw
-    // `experimental` block for the state-aware path, where it is typed
-    // per-backend at dispatch time rather than at parse time.
-    let parsed_json: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
-        logger.log_line("Error parsing JSON");
-        ParseError::Decode(WxcError::ConfigParse(format!("JSON parse error: {}", e)))
-    })?;
+    let discriminator: RequestDiscriminator<'_> = config_deserialize::from_str(json_str)
+        .map_err(|error| ParseError::Decode(WxcError::ConfigParse(error.to_string())))?;
 
-    if parsed_json.get("phase").is_some() {
-        convert_wire_state_aware(parsed_json, logger, allow_missing_command)
-            .map(MxcRequest::StateAware)
-            .map_err(|e| ParseError::StateAware(MxcError::malformed_request(e.to_string())))
+    if discriminator.phase.is_some() {
+        convert_wire_state_aware(
+            json_str,
+            discriminator.experimental,
+            logger,
+            allow_missing_command,
+        )
+        .map(MxcRequest::StateAware)
+        .map_err(|e| ParseError::StateAware(MxcError::malformed_request(e.to_string())))
     } else {
-        // Re-deserialize from the source text (not the already-parsed
-        // `parsed_json`) so serde's line/column context is preserved in error
-        // messages on this trust boundary; `from_value` discards it, turning a
-        // typo or out-of-range field into an unlocalised "expected u16"-style dump.
-        let cfg: wire::MxcConfig = serde_json::from_str(json_str).map_err(|e| {
-            logger.log_line("Error parsing JSON");
-            ParseError::OneShot(WxcError::ConfigParse(format!("JSON parse error: {}", e)))
-        })?;
+        let cfg: wire::MxcConfig = config_deserialize::from_str(json_str)
+            .map_err(|error| ParseError::OneShot(WxcError::ConfigParse(error.to_string())))?;
         convert_wire_config(cfg, logger, true, allow_missing_command)
             .map(MxcRequest::OneShot)
             .map_err(ParseError::OneShot)
     }
 }
 
-/// Reads a request from disk or decodes it from base64. Public so the driver
-/// can decode once and reuse the JSON across multiple parse attempts; the
-/// internal `load_request` and `load_mxc_request` use it too.
-pub fn decode_request_input(
-    input: &str,
-    logger: &mut Logger,
-    is_base64: bool,
-) -> Result<String, WxcError> {
+fn log_one_shot_error<T>(logger: &mut Logger, result: &Result<T, WxcError>) {
+    if let Err(error) = result {
+        log_error(logger, &error.to_string(), ErrorOutput::Primary);
+    }
+}
+
+fn log_error(logger: &mut Logger, message: &str, output: ErrorOutput) {
+    match output {
+        ErrorOutput::Primary => logger.log_line(message),
+        ErrorOutput::DiagnosticOnly => logger.log_diagnostic_line(message),
+    }
+}
+
+/// Reads a request from disk or decodes it from base64.
+fn decode_request_input_without_logging(input: &str, is_base64: bool) -> Result<String, WxcError> {
     if is_base64 {
         let bytes = base64_decode(input).map_err(|_| {
-            let msg = "Failed to decode base64 configuration";
-            logger.log_line(msg);
-            WxcError::ConfigParse(msg.to_string())
+            WxcError::ConfigParse("Failed to decode base64 configuration".to_string())
         })?;
         String::from_utf8(bytes).map_err(|_| {
-            let msg = "Base64 decoded content is not valid UTF-8";
-            logger.log_line(msg);
-            WxcError::ConfigParse(msg.to_string())
+            WxcError::ConfigParse("Base64 decoded content is not valid UTF-8".to_string())
         })
     } else {
+        // The file path is untrusted input; on Linux/macOS it may contain
+        // newlines or terminal control characters. Escape it before embedding
+        // in diagnostics so a missing/unreadable file cannot inject forged
+        // multi-line log output.
+        let safe_input = config_deserialize::escape_diagnostic_text(input);
         if !std::path::Path::new(input).exists() {
-            let _ = write!(logger, "Configuration file not found: {}", input);
             return Err(WxcError::ConfigParse(format!(
-                "Configuration file not found: {}",
-                input
+                "Configuration file not found: {safe_input}"
             )));
         }
         fs::read_to_string(input).map_err(|e| {
-            let _ = write!(logger, "Failed to open configuration file: {}", input);
-            WxcError::ConfigParse(format!("Failed to read configuration file: {}", e))
+            WxcError::ConfigParse(format!(
+                "Failed to read configuration file '{safe_input}': {e}"
+            ))
         })
     }
 }
@@ -237,7 +296,7 @@ const KNOWN_EXPERIMENTAL_BACKENDS: &[&str] = &["windows_sandbox", "wslc", "isola
 
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
-fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), WxcError> {
+fn validate_schema_version(version: &str) -> Result<(), WxcError> {
     if version.is_empty() {
         return Ok(());
     }
@@ -245,12 +304,10 @@ fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), Wxc
     // Parse the version, stripping pre-release suffix for comparison
     // (e.g., "0.4.0-alpha" is treated as "0.4.0")
     let parsed = semver::Version::parse(version).map_err(|_| {
-        let msg = format!(
+        WxcError::ConfigParse(format!(
             "Invalid schema version '{}': must be semver (e.g., 'X.Y.Z' or 'X.Y.Z-alpha')",
-            version
-        );
-        logger.log_line(&msg);
-        WxcError::ConfigParse(msg)
+            config_deserialize::escape_diagnostic_text(version)
+        ))
     })?;
 
     let req = semver::VersionReq::parse(SUPPORTED_VERSION).unwrap();
@@ -260,38 +317,37 @@ fn validate_schema_version(version: &str, logger: &mut Logger) -> Result<(), Wxc
     let comparable = semver::Version::new(parsed.major, parsed.minor, parsed.patch);
     if !req.matches(&comparable) {
         let min = semver::VersionReq::parse(">=0.6").unwrap();
+        let safe_version = config_deserialize::escape_diagnostic_text(version);
         let msg = if !min.matches(&comparable) {
             format!(
                 "Config schema version '{}' is older than supported (supported: {}). Update your config.",
-                version, SUPPORTED_VERSION
+                safe_version, SUPPORTED_VERSION
             )
         } else {
             format!(
                 "Config schema version '{}' is newer than supported (supported: {}). Upgrade wxc-exec.",
-                version, SUPPORTED_VERSION
+                safe_version, SUPPORTED_VERSION
             )
         };
-        logger.log_line(&msg);
         return Err(WxcError::ConfigParse(msg));
     }
     Ok(())
 }
 
-fn validate_filesystem_paths(
-    policy: &ContainerPolicy,
-    logger: &mut Logger,
-) -> Result<(), WxcError> {
-    validate_paths(&policy.readonly_paths, logger)?;
-    validate_paths(&policy.readwrite_paths, logger)?;
-    validate_paths(&policy.denied_paths, logger)?;
+fn validate_filesystem_paths(policy: &ContainerPolicy) -> Result<(), WxcError> {
+    validate_paths(&policy.readonly_paths)?;
+    validate_paths(&policy.readwrite_paths)?;
+    validate_paths(&policy.denied_paths)?;
     Ok(())
 }
 
-fn validate_paths(paths: &[String], logger: &mut Logger) -> Result<(), WxcError> {
+fn validate_paths(paths: &[String]) -> Result<(), WxcError> {
     for path in paths {
         if path.contains('"') {
-            let msg = format!("Filesystem path '{}' contains invalid character '\"'", path);
-            logger.log_line(&msg);
+            let msg = format!(
+                "Filesystem path '{}' contains invalid character '\"'",
+                config_deserialize::escape_diagnostic_text(path)
+            );
             return Err(WxcError::ConfigParse(msg));
         }
     }
@@ -328,14 +384,14 @@ fn normalize_filesystem_paths(policy: &mut ContainerPolicy, logger: &mut Logger)
             logger.log_line(&format!(
                 "Filesystem path '{}' appears in 'readwritePaths' and 'deniedPaths'; \
                  applying most-restrictive intent (denied)",
-                p
+                config_deserialize::escape_diagnostic_text(p)
             ));
             false
         } else if readonly.contains(p) {
             logger.log_line(&format!(
                 "Filesystem path '{}' appears in 'readwritePaths' and 'readonlyPaths'; \
                  applying most-restrictive intent (readonly)",
-                p
+                config_deserialize::escape_diagnostic_text(p)
             ));
             false
         } else {
@@ -347,7 +403,7 @@ fn normalize_filesystem_paths(policy: &mut ContainerPolicy, logger: &mut Logger)
             logger.log_line(&format!(
                 "Filesystem path '{}' appears in 'readonlyPaths' and 'deniedPaths'; \
                  applying most-restrictive intent (denied)",
-                p
+                config_deserialize::escape_diagnostic_text(p)
             ));
             false
         } else {
@@ -366,7 +422,8 @@ fn normalize_filesystem_paths(policy: &mut ContainerPolicy, logger: &mut Logger)
                 logger.log_line(&format!(
                     "WARNING: filesystem path '{}' (in '{}') does not exist on the host; \
                      the backend may fail at mount time",
-                    path, list_name
+                    config_deserialize::escape_diagnostic_text(path),
+                    list_name
                 ));
             }
         }
@@ -478,7 +535,6 @@ fn present_backend_sections(cfg: &wire::MxcConfig) -> Vec<&'static str> {
 fn validate_single_backend_section(
     containment: ContainmentBackend,
     present_sections: &[&'static str],
-    logger: &mut Logger,
 ) -> Result<(), WxcError> {
     let allowed_section = containment.section_path();
     let extras: Vec<&'static str> = present_sections
@@ -507,7 +563,6 @@ fn validate_single_backend_section(
             extras.join(", "),
         ),
     };
-    logger.log_line(&msg);
     Err(WxcError::ConfigParse(msg))
 }
 
@@ -518,7 +573,6 @@ fn validate_single_backend_section(
 fn validate_experimental_backend_keys(
     containment: Option<&ContainmentBackend>,
     experimental_raw: Option<&serde_json::Value>,
-    logger: &mut Logger,
 ) -> Result<(), WxcError> {
     let Some(serde_json::Value::Object(map)) = experimental_raw else {
         return Ok(());
@@ -554,7 +608,6 @@ fn validate_experimental_backend_keys(
          remove the unused section(s).",
         qualified.join(", "),
     );
-    logger.log_line(&msg);
     Err(WxcError::ConfigParse(msg))
 }
 
@@ -661,14 +714,14 @@ fn convert_wire_config(
     // input is a state-aware-shaped payload sent to a one-shot entry point;
     // reject it loudly rather than silently executing it as a one-shot.
     if cfg.phase.is_some() {
-        let msg = "'phase' is only valid on state-aware lifecycle requests".to_string();
-        logger.log_line(&msg);
-        return Err(WxcError::ConfigParse(msg));
+        return Err(WxcError::ConfigParse(
+            "'phase' is only valid on state-aware lifecycle requests".to_string(),
+        ));
     }
     if cfg.sandbox_id.is_some() {
-        let msg = "'sandboxId' is only valid on state-aware lifecycle requests".to_string();
-        logger.log_line(&msg);
-        return Err(WxcError::ConfigParse(msg));
+        return Err(WxcError::ConfigParse(
+            "'sandboxId' is only valid on state-aware lifecycle requests".to_string(),
+        ));
     }
     if cfg.correlation_vector.is_some() {
         let msg = "'correlationVector' is only valid on state-aware lifecycle requests".to_string();
@@ -682,7 +735,7 @@ fn convert_wire_config(
     let schema_version = cfg.version.unwrap_or_default();
 
     // Validate the schema version up front so an unsupported version fails fast.
-    validate_schema_version(&schema_version, logger)?;
+    validate_schema_version(&schema_version)?;
 
     let container_id = cfg.container_id.unwrap_or_default();
 
@@ -695,13 +748,11 @@ fn convert_wire_config(
             let script_code = match process.command_line {
                 Some(s) if !s.is_empty() => s,
                 Some(_) if command_required => {
-                    logger.log_line("process.commandLine cannot be empty");
                     return Err(WxcError::ConfigParse(
                         "process.commandLine cannot be empty".to_string(),
                     ));
                 }
                 None if command_required => {
-                    logger.log_line("Missing required field: process.commandLine");
                     return Err(WxcError::ConfigParse(
                         "Missing required field: process.commandLine".to_string(),
                     ));
@@ -736,7 +787,7 @@ fn convert_wire_config(
     // intents and the omitted case resolve to the OS-native backend here.
     let containment = map_wire_containment(cfg.containment.as_ref());
 
-    validate_single_backend_section(containment.clone(), &present_backend_sections, logger)?;
+    validate_single_backend_section(containment.clone(), &present_backend_sections)?;
 
     // LXC configuration
     let lxc_config = match cfg.lxc {
@@ -846,7 +897,7 @@ enforced; access denials are recorded for diagnostics.\n",
             policy.readonly_paths = v;
         }
     }
-    validate_filesystem_paths(&policy, logger)?;
+    validate_filesystem_paths(&policy)?;
     normalize_filesystem_paths(&mut policy, logger);
 
     // Fallback section
@@ -867,7 +918,6 @@ enforced; access denials are recorded for diagnostics.\n",
             {
                 let msg = "Network proxy is only supported with the 'processcontainer', \
                            'bubblewrap', or 'seatbelt' containment backends";
-                logger.log_line(msg);
                 return Err(WxcError::ConfigParse(msg.to_string()));
             }
             policy.network_proxy = proxy_config;
@@ -906,7 +956,6 @@ enforced; access denials are recorded for diagnostics.\n",
                        network.enforcementMode='firewall' or 'both'. The cooperative \
                        env-var proxy enforces hosts at the proxy layer; iptables-based \
                        enforcement requires privilege and is mutually exclusive.";
-            logger.log_line(msg);
             return Err(WxcError::ConfigParse(msg.to_string()));
         }
 
@@ -974,7 +1023,6 @@ enforced; access denials are recorded for diagnostics.\n",
                        MXC does not forward host lists to it. Use \
                        'network.proxy.builtinTestServer: true' (testing only) for \
                        MXC-enforced host filtering, or remove the host policy.";
-            logger.log_line(msg);
             return Err(WxcError::ConfigParse(msg.to_string()));
         }
 
@@ -1045,14 +1093,12 @@ enforced; access denials are recorded for diagnostics.\n",
                         let msg = format!(
                             "experimental.wslc.portMappings[{idx}]: 'windowsPort' must be > 0"
                         );
-                        logger.log_line(&msg);
                         return Err(WxcError::ConfigParse(msg));
                     }
                     if m.container_port == 0 {
                         let msg = format!(
                             "experimental.wslc.portMappings[{idx}]: 'containerPort' must be > 0"
                         );
-                        logger.log_line(&msg);
                         return Err(WxcError::ConfigParse(msg));
                     }
                     // Only TCP is representable in the wire model
@@ -1080,7 +1126,6 @@ enforced; access denials are recorded for diagnostics.\n",
                              for protocol '{}'",
                             pm.windows_port, pm.protocol
                         );
-                        logger.log_line(&msg);
                         return Err(WxcError::ConfigParse(msg));
                     }
                 }
@@ -1102,7 +1147,6 @@ enforced; access denials are recorded for diagnostics.\n",
             let msg = "'experimental.seatbelt' has moved to the stable section; \
                        use top-level 'seatbelt' instead."
                 .to_string();
-            logger.log_line(&msg);
             return Err(WxcError::ConfigParse(msg));
         }
         let telemetry = raw_exp.telemetry.map(|raw_t| TelemetryConfig {
@@ -1153,15 +1197,17 @@ enforced; access denials are recorded for diagnostics.\n",
 }
 
 fn convert_wire_state_aware(
-    mut value: serde_json::Value,
+    json: &str,
+    experimental: Option<&RawValue>,
     logger: &mut Logger,
     allow_missing_command: bool,
 ) -> Result<ParsedStateAwareRequest, WxcError> {
-    // Capture the raw `experimental` block before typed deserialize; it is typed
-    // per-backend at dispatch time, not here.
-    let experimental_raw = value
-        .as_object_mut()
-        .and_then(|map| map.remove("experimental"));
+    let experimental_raw = experimental
+        .map(|raw| {
+            config_deserialize::from_str::<serde_json::Value>(raw.get())
+                .map_err(|error| WxcError::ConfigParse(error.to_string()))
+        })
+        .transpose()?;
 
     // Peeling `experimental` off above also removes it from the typed
     // deserialize, so a non-object value (e.g. `"experimental": 42`) would slip
@@ -1172,16 +1218,15 @@ fn convert_wire_state_aware(
     // on both paths and is accepted.)
     if let Some(exp) = experimental_raw.as_ref() {
         if !exp.is_null() && !exp.is_object() {
-            let msg = "invalid `experimental`: expected an object".to_string();
-            logger.log_line(&msg);
-            return Err(WxcError::ConfigParse(msg));
+            return Err(WxcError::ConfigParse(
+                "Invalid configuration at `experimental`: expected an object".to_string(),
+            ));
         }
     }
 
-    let mut cfg: wire::MxcConfig = serde_json::from_value(value).map_err(|e| {
-        logger.log_line("Error parsing JSON");
-        WxcError::ConfigParse(format!("JSON parse error: {}", e))
-    })?;
+    let base_json = mask_state_aware_experimental(json, experimental)?;
+    let mut cfg: wire::MxcConfig = config_deserialize::from_str(&base_json)
+        .map_err(|error| WxcError::ConfigParse(error.to_string()))?;
 
     // `phase` is the state-aware discriminator and is constrained by the wire
     // enum; absence here would be a logic error in the caller's discrimination.
@@ -1204,7 +1249,8 @@ fn convert_wire_state_aware(
     // The one-shot path errors on `experimental.seatbelt` in `convert_wire_config`,
     // but the state-aware path peels `experimental` into `experimental_raw`
     // before that runs, so without this check the block would be silently
-    // discarded (the same silent-policy-drop class as the F1 stable sections).
+    // discarded (the same silent-policy-drop class as the moved-to-stable
+    // sections).
     if let Some(serde_json::Value::Object(exp)) = experimental_raw.as_ref() {
         for key in ["seatbelt", "macos_sandbox"] {
             if exp.contains_key(key) {
@@ -1212,13 +1258,12 @@ fn convert_wire_state_aware(
                     "'experimental.{key}' has moved to the stable section; \
                      use top-level 'seatbelt' instead."
                 );
-                logger.log_line(&msg);
                 return Err(WxcError::ConfigParse(msg));
             }
         }
     }
 
-    validate_experimental_backend_keys(containment.as_ref(), experimental_raw.as_ref(), logger)?;
+    validate_experimental_backend_keys(containment.as_ref(), experimental_raw.as_ref())?;
 
     let sandbox_id = cfg.sandbox_id.clone();
     let correlation_vector = cfg.correlation_vector.clone();
@@ -1247,7 +1292,6 @@ fn convert_wire_state_aware(
              Remove them; per-backend policy and lifecycle are fixed at provision time.",
             stray.join(", ")
         );
-        logger.log_line(&msg);
         return Err(WxcError::ConfigParse(msg));
     }
 
@@ -1279,9 +1323,13 @@ fn convert_wire_state_aware(
     {
         let telemetry: TelemetryConfig =
             serde_json::from_value(telemetry_val.clone()).map_err(|e| {
-                let msg = format!("invalid experimental.telemetry: {e}");
-                logger.log_line(&msg);
-                WxcError::ConfigParse(msg)
+                // Do not log here: state-aware parse errors are routed centrally
+                // and exactly once by the outer `load_mxc_request*` wrapper via
+                // `log_error(..., ErrorOutput::DiagnosticOnly)`. Logging here as
+                // well would produce a duplicate auxiliary diagnostic.
+                // Returning the error keeps stdout clean (envelope-owned) and
+                // yields a single auxiliary-sink line.
+                WxcError::ConfigParse(format!("invalid experimental.telemetry: {e}"))
             })?;
         request.experimental.telemetry = Some(telemetry);
     }
@@ -1293,7 +1341,76 @@ fn convert_wire_state_aware(
         sandbox_id,
         correlation_vector,
         experimental_raw,
+        // Retain the decoded request text so the dispatcher can deserialize each
+        // `experimental.<backend>.<phase>` sub-slice positionally and report
+        // typed errors with whole-file line/column (parity with base config).
+        source_text: Some(json.to_owned().into_boxed_str()),
     })
+}
+
+/// Byte range `[start, end)` of the borrowed `experimental` value within the
+/// original request text.
+///
+/// `raw` is `serde_json`'s borrowed `RawValue` for the `experimental` field,
+/// which — for `&str` input — is a sub-slice of `json`; its pointer therefore
+/// lies within `json`'s allocation and its length stays within bounds. The
+/// checks below make that invariant explicit and fail closed if a future caller
+/// ever passes a `raw` not borrowed from `json` (unreachable on the normal
+/// parser path).
+fn experimental_source_span(json: &str, raw: &str) -> Result<(usize, usize), WxcError> {
+    let locate_err = || {
+        WxcError::ConfigParse("Unable to locate the experimental configuration block".to_string())
+    };
+    let start = (raw.as_ptr() as usize)
+        .checked_sub(json.as_ptr() as usize)
+        .filter(|start| *start <= json.len())
+        .ok_or_else(locate_err)?;
+    let end = start
+        .checked_add(raw.len())
+        .filter(|end| *end <= json.len())
+        .ok_or_else(locate_err)?;
+    Ok((start, end))
+}
+
+fn mask_state_aware_experimental<'a>(
+    json: &'a str,
+    experimental: Option<&RawValue>,
+) -> Result<Cow<'a, str>, WxcError> {
+    let Some(experimental) = experimental else {
+        return Ok(Cow::Borrowed(json));
+    };
+
+    let raw = experimental.get();
+    let (start, end) = experimental_source_span(json, raw)?;
+    let (prefix, suffix) = match (json.get(..start), json.get(end..)) {
+        (Some(prefix), Some(suffix)) => (prefix, suffix),
+        _ => {
+            return Err(WxcError::ConfigParse(
+                "Unable to locate the experimental configuration block".to_string(),
+            ))
+        }
+    };
+
+    // State-aware backend config is retained separately and typed at dispatch.
+    // Replace it with an empty object of identical byte/line length so the base
+    // wire model validates cross-cutting fields without shifting source
+    // coordinates. ASCII spaces preserve byte offsets; retained CR/LF preserve
+    // lines. The caller already verified that `raw` is an object.
+    let mut masked = String::with_capacity(json.len());
+    masked.push_str(prefix);
+    let mut braces = ['{', '}'].into_iter();
+    for byte in raw.bytes() {
+        match byte {
+            b'\r' => masked.push('\r'),
+            b'\n' => masked.push('\n'),
+            _ => masked.push(braces.next().unwrap_or(' ')),
+        }
+    }
+    debug_assert!(braces.next().is_none());
+    masked.push_str(suffix);
+    debug_assert_eq!(masked.len(), json.len());
+
+    Ok(Cow::Owned(masked))
 }
 
 #[cfg(test)]
@@ -1501,6 +1618,44 @@ mod tests {
     }
 
     #[test]
+    fn state_aware_malformed_telemetry_logs_once_and_keeps_primary_clean() {
+        // The malformed-telemetry error must reach the auxiliary
+        // diagnostic sink exactly once (routed centrally by the outer
+        // `load_mxc_request` wrapper), never duplicated, and must never touch the
+        // primary buffer/stdout that the state-aware JSON envelope owns.
+        let json = r#"{
+            "phase": "provision",
+            "containment": "isolation_session",
+            "experimental": {"telemetry": 42}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("diag.log");
+        let mut logger = Logger::new(Mode::Buffer);
+        logger.enable_file_sink(&log_path).unwrap();
+
+        let result = load_mxc_request(&encoded, &mut logger, true);
+        assert!(
+            matches!(result, Err(ParseError::StateAware(_))),
+            "got {result:?}"
+        );
+        assert!(
+            logger.get_buffer().is_empty(),
+            "state-aware error must not touch the primary buffer: {:?}",
+            logger.get_buffer()
+        );
+        drop(logger);
+
+        let logged = std::fs::read_to_string(&log_path).unwrap();
+        assert_eq!(
+            logged.matches("invalid experimental.telemetry").count(),
+            1,
+            "expected exactly one auxiliary diagnostic, got: {logged:?}"
+        );
+    }
+
+    #[test]
     fn state_aware_non_object_experimental_is_rejected() {
         // A non-object `experimental` (here a bare number) is a hard parse error
         // on the one-shot path (typed `Option<Experimental>`); the state-aware
@@ -1558,15 +1713,163 @@ mod tests {
     #[test]
     fn state_aware_unknown_phase_is_rejected() {
         let json = r#"{"phase": "teleport"}"#;
-        let r = load_mxc(json);
-        assert!(matches!(r, Err(ParseError::StateAware(_))), "got {:?}", r);
+        let error = match load_mxc(json) {
+            Err(ParseError::StateAware(error)) => error,
+            other => panic!("expected state-aware error, got {other:?}"),
+        };
+        assert!(error.message.contains("Invalid configuration at `phase`"));
+        assert!(error.message.contains("unknown variant `teleport`"));
+    }
+
+    #[test]
+    fn present_null_phase_is_still_discriminated_as_state_aware() {
+        let error = match load_mxc(r#"{"phase": null}"#) {
+            Err(ParseError::StateAware(error)) => error,
+            other => panic!("expected state-aware error, got {other:?}"),
+        };
+
+        assert!(error.message.contains("Missing required field: phase"));
     }
 
     #[test]
     fn state_aware_unknown_containment_is_rejected() {
-        let json = r#"{"phase": "provision", "containment": "totally_made_up"}"#;
-        let r = load_mxc(json);
-        assert!(matches!(r, Err(ParseError::StateAware(_))), "got {:?}", r);
+        let json = r#"{
+            "phase": "provision",
+            "containment": "totally_made_up"
+        }"#;
+        let error = match load_mxc(json) {
+            Err(ParseError::StateAware(error)) => error,
+            other => panic!("expected state-aware error, got {other:?}"),
+        };
+        assert!(
+            error
+                .message
+                .contains("Invalid configuration at `containment`"),
+            "got: {}",
+            error.message
+        );
+        assert!(error.message.contains("unknown variant `totally_made_up`"));
+        assert!(error.message.contains("line 3"));
+    }
+
+    #[test]
+    fn state_aware_mask_preserves_locations_after_multiline_experimental() {
+        let json = r#"{
+            "phase": "provision",
+            "experimental": {
+                "future_backend": {
+                    "nested": true
+                }
+            },
+            "process": {"timeout": "soon"}
+        }"#;
+        let error = match load_mxc(json) {
+            Err(ParseError::StateAware(error)) => error,
+            other => panic!("expected state-aware error, got {other:?}"),
+        };
+
+        assert!(
+            error
+                .message
+                .contains("Invalid configuration at `process.timeout`"),
+            "got: {}",
+            error.message
+        );
+        assert!(error.message.contains("line 8"), "got: {}", error.message);
+    }
+
+    #[test]
+    fn state_aware_mask_handles_empty_object_at_root_boundaries() {
+        for json in [
+            r#"{"experimental":{},"phase":"provision"}"#,
+            r#"{"phase":"provision","experimental":{}}"#,
+        ] {
+            let discriminator: RequestDiscriminator<'_> =
+                config_deserialize::from_str(json).unwrap();
+            let masked = mask_state_aware_experimental(json, discriminator.experimental).unwrap();
+
+            assert_eq!(masked.len(), json.len());
+            let config: wire::MxcConfig = config_deserialize::from_str(&masked).unwrap();
+            assert!(matches!(config.phase, Some(wire::Phase::Provision)));
+        }
+    }
+
+    #[test]
+    fn state_aware_mask_handles_whitespace_only_multiline_object() {
+        let json = "{\n  \"phase\": \"provision\",\n  \"experimental\": {\r\n    \r\n  }\n}";
+        let discriminator: RequestDiscriminator<'_> = config_deserialize::from_str(json).unwrap();
+        let masked = mask_state_aware_experimental(json, discriminator.experimental).unwrap();
+
+        assert_eq!(masked.len(), json.len());
+        assert_eq!(
+            masked.bytes().filter(|byte| *byte == b'\n').count(),
+            json.bytes().filter(|byte| *byte == b'\n').count()
+        );
+        let config: wire::MxcConfig = config_deserialize::from_str(&masked).unwrap();
+        assert!(matches!(config.phase, Some(wire::Phase::Provision)));
+    }
+
+    #[test]
+    fn experimental_source_span_locates_the_borrowed_block() {
+        let json = r#"{"phase":"provision","experimental":{"a":{"b":1}}}"#;
+        let discriminator: RequestDiscriminator<'_> = config_deserialize::from_str(json).unwrap();
+        let raw = discriminator.experimental.unwrap().get();
+
+        let (start, end) = experimental_source_span(json, raw).unwrap();
+        assert_eq!(&json[start..end], raw);
+        assert_eq!(&json[start..start + 1], "{");
+        assert_eq!(&json[end - 1..end], "}");
+    }
+
+    #[test]
+    fn experimental_source_span_rejects_a_foreign_slice() {
+        // A `raw` not borrowed from `json` must fail closed rather than compute
+        // an out-of-range offset — the invariant guard the masking relies on.
+        let json = r#"{"experimental":{}}"#;
+        let foreign = String::from("{}");
+        let error = experimental_source_span(json, foreign.as_str()).unwrap_err();
+        assert!(matches!(error, WxcError::ConfigParse(_)));
+    }
+
+    #[test]
+    fn state_aware_mask_span_contains_only_braces_spaces_and_newlines() {
+        let json = "{\n  \"experimental\": {\n    \"wslc\": { \"image\": \"py\" }\n  },\n  \"phase\": \"provision\"\n}";
+        let discriminator: RequestDiscriminator<'_> = config_deserialize::from_str(json).unwrap();
+        let raw = discriminator.experimental.unwrap().get();
+        let (start, end) = experimental_source_span(json, raw).unwrap();
+        let masked = mask_state_aware_experimental(json, discriminator.experimental).unwrap();
+
+        // The masked span replaces content with exactly one `{`, one `}`,
+        // spaces, and preserved newlines; everything outside is byte-identical.
+        assert_eq!(masked[..start], json[..start]);
+        assert_eq!(masked[end..], json[end..]);
+        let span = &masked[start..end];
+        assert!(span
+            .bytes()
+            .all(|b| matches!(b, b'{' | b'}' | b' ' | b'\r' | b'\n')));
+        assert_eq!(span.bytes().filter(|b| *b == b'{').count(), 1);
+        assert_eq!(span.bytes().filter(|b| *b == b'}').count(), 1);
+    }
+
+    #[test]
+    fn state_aware_rejects_non_object_experimental_block() {
+        // `null` maps to "absent" and is accepted (see
+        // `state_aware_null_experimental_is_accepted`); only non-null,
+        // non-object values are rejected.
+        for value in [r#""oops""#, "42", "[]"] {
+            let json = format!(r#"{{"phase":"provision","experimental":{value}}}"#);
+            let error = match load_mxc(&json) {
+                Err(ParseError::StateAware(error)) => error,
+                other => panic!("expected state-aware error for {value}, got {other:?}"),
+            };
+            assert!(
+                error
+                    .message
+                    .ends_with("Invalid configuration at `experimental`: expected an object"),
+                "got: {}",
+                error.message
+            );
+        }
     }
 
     #[test]
@@ -1593,6 +1896,29 @@ mod tests {
         assert_eq!(req.script_code, "echo hello");
         assert_eq!(req.script_timeout, 0);
         assert!(req.working_directory.is_empty());
+    }
+
+    #[test]
+    fn load_request_from_value_reports_and_logs_typed_error_path() {
+        let config = serde_json::json!({
+            "process": {
+                "commandLine": "echo hello",
+                "timeout": "soon"
+            }
+        });
+        let mut logger = test_logger();
+
+        let error = load_request_from_value(config, &mut logger, false).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("Invalid configuration at `process.timeout`"));
+        assert!(message.contains("expected u32"));
+        assert_eq!(
+            logger
+                .get_buffer()
+                .matches("Invalid configuration at `process.timeout`")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1699,6 +2025,104 @@ mod tests {
             msg.contains("unknown variant") && msg.contains("invalid"),
             "expected serde unknown-variant rejection, got: {msg}"
         );
+        assert!(
+            msg.contains("Invalid configuration at `network.defaultPolicy`"),
+            "expected the policy path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn wrong_value_type_reports_path_and_source_location() {
+        let json = r#"{
+            "process": {
+                "commandLine": "echo x",
+                "timeout": "soon"
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let error = load_request(&encoded, &mut logger, true).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("Invalid configuration at `process.timeout`"),
+            "expected the field path, got: {message}"
+        );
+        assert!(
+            message.contains("invalid type") && message.contains("expected u32"),
+            "expected the type mismatch, got: {message}"
+        );
+        assert!(
+            message.contains("line 4"),
+            "expected the source line, got: {message}"
+        );
+        assert_eq!(
+            logger
+                .get_buffer()
+                .lines()
+                .filter(|line| line.contains("process.timeout"))
+                .count(),
+            1,
+            "the path-aware diagnostic should be logged once"
+        );
+    }
+
+    #[test]
+    fn state_aware_parse_errors_reach_diagnostic_file_without_stderr_duplication() {
+        let directory = tempfile::tempdir().unwrap();
+        let log_path = directory.path().join("mxc.log");
+        let mut logger = test_logger();
+        logger.enable_file_sink(&log_path).unwrap();
+        let encoded = base64_encode(br#"{"phase":"teleport"}"#);
+
+        let result = load_mxc_request(&encoded, &mut logger, true);
+        assert!(matches!(result, Err(ParseError::StateAware(_))));
+        assert!(
+            logger.get_buffer().is_empty(),
+            "the JSON error envelope owns the primary state-aware output"
+        );
+
+        drop(logger);
+        let log = std::fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("Invalid configuration at `phase`"));
+        assert!(log.contains("unknown variant `teleport`"));
+    }
+
+    #[test]
+    fn out_of_range_value_reports_path() {
+        let json =
+            r#"{"process":{"commandLine":"echo x"},"network":{"proxy":{"localhost":70000}}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let error = load_request(&encoded, &mut logger, true).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("Invalid configuration at `network.proxy.localhost`"),
+            "expected the field path, got: {message}"
+        );
+        assert!(
+            message.contains("70000") && message.contains("expected u16"),
+            "expected the range mismatch, got: {message}"
+        );
+    }
+
+    #[test]
+    fn malformed_json_is_reported_as_syntax_not_policy_data() {
+        let json = r#"{"process":{"commandLine":"echo x"}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let error = load_request(&encoded, &mut logger, true).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("Invalid JSON syntax:"),
+            "expected a syntax error, got: {message}"
+        );
+        assert!(
+            !message.contains("Invalid configuration at"),
+            "syntax errors should not claim a policy path: {message}"
+        );
     }
 
     #[test]
@@ -1732,6 +2156,59 @@ mod tests {
         let mut logger = test_logger();
         let result = load_request("nonexistent.json", &mut logger, false);
         assert!(result.is_err());
+        assert_eq!(
+            logger
+                .get_buffer()
+                .matches("Configuration file not found: nonexistent.json")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn file_not_found_path_with_newline_is_escaped() {
+        // A file path is untrusted input and may contain a newline on
+        // Linux/macOS; the diagnostic must escape it so it cannot inject a
+        // forged multi-line log entry.
+        let mut logger = test_logger();
+        let result = load_request("missing\nfile.json", &mut logger, false);
+        assert!(result.is_err());
+
+        let message = match result.unwrap_err() {
+            WxcError::ConfigParse(message) => message,
+            other => panic!("expected ConfigParse error, got: {other:?}"),
+        };
+        assert!(!message.contains('\n'), "raw newline leaked: {message}");
+        assert!(message.contains("missing\\nfile.json"), "got: {message}");
+    }
+
+    #[test]
+    fn empty_file_path_error_is_logged_once() {
+        let mut logger = test_logger();
+        let result = load_request("", &mut logger, false);
+        assert!(result.is_err());
+        assert_eq!(
+            logger
+                .get_buffer()
+                .matches("Configuration file not found:")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn file_read_error_is_logged_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let mut logger = test_logger();
+        let result = load_request(directory.path().to_str().unwrap(), &mut logger, false);
+        assert!(result.is_err());
+        assert_eq!(
+            logger
+                .get_buffer()
+                .matches("Failed to read configuration file")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1739,6 +2216,58 @@ mod tests {
         let mut logger = test_logger();
         let result = load_request("not-valid-base64!!!", &mut logger, true);
         assert!(result.is_err());
+        assert_eq!(
+            logger
+                .get_buffer()
+                .lines()
+                .filter(|line| line.contains("Failed to decode base64 configuration"))
+                .count(),
+            1,
+            "the fatal diagnostic should be logged once"
+        );
+    }
+
+    #[test]
+    fn console_mode_logs_decode_errors_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let log_path = directory.path().join("mxc.log");
+        let mut logger = Logger::new(Mode::Console);
+        logger.enable_file_sink(&log_path).unwrap();
+
+        let result = load_request("not-valid-base64!!!", &mut logger, true);
+        assert!(result.is_err());
+
+        drop(logger);
+        let log = std::fs::read_to_string(log_path).unwrap();
+        assert_eq!(
+            log.matches("Failed to decode base64 configuration").count(),
+            1,
+            "console mode should emit one decode diagnostic"
+        );
+    }
+
+    #[test]
+    fn state_aware_semantic_errors_stay_off_primary_output() {
+        let directory = tempfile::tempdir().unwrap();
+        let log_path = directory.path().join("mxc.log");
+        let mut logger = test_logger();
+        logger.enable_file_sink(&log_path).unwrap();
+        let encoded = base64_encode(br#"{"phase":"provision","experimental":{"seatbelt":{}}}"#);
+
+        let result = load_mxc_request(&encoded, &mut logger, true);
+        assert!(matches!(result, Err(ParseError::StateAware(_))));
+        assert!(
+            logger.get_buffer().is_empty(),
+            "the JSON envelope owns primary state-aware error output"
+        );
+
+        drop(logger);
+        let log = std::fs::read_to_string(log_path).unwrap();
+        assert_eq!(
+            log.matches("'experimental.seatbelt' has moved").count(),
+            1,
+            "state-aware diagnostics should reach auxiliary sinks exactly once"
+        );
     }
 
     #[test]
@@ -1747,6 +2276,7 @@ mod tests {
         let mut logger = test_logger();
         let result = load_request(&encoded, &mut logger, true);
         assert!(result.is_err());
+        assert!(logger.get_buffer().contains("Invalid JSON syntax:"));
     }
 
     #[test]
@@ -3131,6 +3661,10 @@ mod tests {
             msg.contains("unknown field") && msg.contains("bogus"),
             "nested unknown field should be rejected, got: {msg}"
         );
+        assert!(
+            msg.contains("Invalid configuration at `process.bogus`"),
+            "expected the unknown field path, got: {msg}"
+        );
     }
 
     #[test]
@@ -3166,7 +3700,7 @@ mod tests {
     fn experimental_port_mapping_unknown_field_accepted() {
         // The experimental surface is intentionally permissive (forward-compat):
         // an unknown field on a nested experimental struct must be tolerated and
-        // the known fields preserved (positive proof of F2 / R2-5).
+        // the known fields preserved.
         let json = r#"{"process": {"commandLine": "echo hi"}, "containment": "wslc", "experimental": {"wslc": {"image": "python:3.12", "portMappings": [{"windowsPort": 8080, "containerPort": 80, "futureField": "ignored"}]}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
@@ -3361,7 +3895,7 @@ mod tests {
     fn state_aware_rejects_experimental_seatbelt() {
         // `experimental.seatbelt` moved to the stable section; the state-aware
         // path must reject it with the migration message, not silently discard
-        // it (R2-1 — the experimental-channel completion of F1).
+        // it.
         let json = r#"{
             "phase": "provision",
             "containment": "isolation_session",
@@ -3532,6 +4066,43 @@ mod tests {
 
         let result = load_request(&encoded, &mut logger, true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn schema_version_error_escapes_control_characters() {
+        // The invalid version is free-form user input echoed into a manual
+        // (non-serde) diagnostic; it must not carry raw ESC / newline bytes.
+        let error = validate_schema_version("1.\u{1b}[31m0\nX").unwrap_err();
+        let message = error.to_string();
+        assert!(!message.contains('\u{1b}'), "got: {message}");
+        assert!(!message.contains('\n'), "got: {message}");
+        assert!(
+            message.contains("\\u{1b}") || message.contains("\\x1b"),
+            "got: {message}"
+        );
+    }
+
+    #[test]
+    fn root_object_expecting_text_is_pinned_across_both_parse_passes() {
+        // serde's `expecting` attribute requires a string literal, so the
+        // wording is duplicated on `RequestDiscriminator` and `wire::MxcConfig`.
+        // Pin both diagnostics so the two parse passes cannot drift.
+        let discriminator_err =
+            match config_deserialize::from_str::<RequestDiscriminator<'_>>(r#""not an object""#) {
+                Ok(_) => panic!("non-object root must fail discriminator parse"),
+                Err(error) => error,
+            };
+        let wire_err = match config_deserialize::from_str::<wire::MxcConfig>(r#""not an object""#) {
+            Ok(_) => panic!("non-object root must fail wire parse"),
+            Err(error) => error,
+        };
+
+        assert!(discriminator_err
+            .to_string()
+            .contains("expected a configuration object"));
+        assert!(wire_err
+            .to_string()
+            .contains("expected a configuration object"));
     }
 
     #[test]

--- a/src/core/wxc_common/src/lib.rs
+++ b/src/core/wxc_common/src/lib.rs
@@ -4,6 +4,7 @@
 // Platform-agnostic modules (shared by wxc-exec, lxc-exec, mxc-exec-mac
 // and every backend crate).
 pub mod cmdline;
+mod config_deserialize;
 pub mod config_parser;
 pub mod encoding;
 pub mod error;

--- a/src/core/wxc_common/src/logger.rs
+++ b/src/core/wxc_common/src/logger.rs
@@ -235,6 +235,12 @@ impl Logger {
                 self.buffer.push('\n');
             }
         }
+        self.log_diagnostic_line(msg);
+    }
+
+    /// Write a complete line only to configured auxiliary diagnostic sinks,
+    /// without duplicating it in the primary console/buffer output.
+    pub fn log_diagnostic_line(&mut self, msg: &str) {
         if let Some(ref mut f) = self.file {
             let secs = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/core/wxc_common/src/state_aware_dispatch.rs
+++ b/src/core/wxc_common/src/state_aware_dispatch.rs
@@ -122,6 +122,11 @@ pub fn dispatch_state_aware<B: StatefulSandboxBackend>(
         Phase::Exec => {
             let sandbox_id = parsed.sandbox_id_required()?.to_string();
             let config = parsed.deserialize_config::<B::ExecConfig>(B::BACKEND_KEY, "exec")?;
+            // Everything needed for exec is now owned (`request` clone, owned
+            // `sandbox_id`, owned `config`); drop the parsed request so its
+            // retained decoded source text and raw `experimental` tree are not
+            // held for the (potentially long) blocking child run + stdio relay.
+            drop(parsed);
             validate_exec_common(&request)?;
             backend.validate_exec(&sandbox_id, &request, config.as_ref())?;
             if dry_run {
@@ -496,6 +501,7 @@ mod tests {
             sandbox_id: sandbox_id.map(String::from),
             correlation_vector: None,
             experimental_raw: exp,
+            source_text: None,
         }
     }
 
@@ -657,6 +663,12 @@ mod tests {
         let p = parsed(Phase::Start, Some("typed:abc"), Some(exp));
         let err = dispatch_state_aware(&mut b, p, false).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message.contains("experimental.typed_stub.start"),
+            "expected envelope-ready error path, got: {}",
+            err.message
+        );
+        assert_eq!(b.captured_start_config.into_inner(), None);
     }
 
     // ---------- run_state_aware / resolve_backend ----------
@@ -672,6 +684,7 @@ mod tests {
             sandbox_id: None,
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         let err = run_state_aware(p, false).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::UnsupportedPhase);
@@ -686,6 +699,7 @@ mod tests {
             sandbox_id: None,
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         let err = run_state_aware(p, false).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedRequest);
@@ -700,6 +714,7 @@ mod tests {
             sandbox_id: Some("iso:wxc-abcd1234".into()),
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         assert_eq!(
             resolve_backend(&p).unwrap(),
@@ -716,6 +731,7 @@ mod tests {
             sandbox_id: Some("wsb:deadbeef".into()),
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         assert_eq!(
             resolve_backend(&p).unwrap(),
@@ -732,6 +748,7 @@ mod tests {
             sandbox_id: Some("unknownxyz:abc".into()),
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         let err = resolve_backend(&p).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::UnsupportedContainment);
@@ -746,6 +763,7 @@ mod tests {
             sandbox_id: Some("no-colon".into()),
             correlation_vector: None,
             experimental_raw: None,
+            source_text: None,
         };
         let err = resolve_backend(&p).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedId);

--- a/src/core/wxc_common/src/state_aware_request.rs
+++ b/src/core/wxc_common/src/state_aware_request.rs
@@ -16,9 +16,13 @@
 //! `experimental_raw` via `deserialize_config<C>`, and asserts
 //! `sandbox_id_required` for non-provision phases.
 
+use std::collections::HashMap;
+
 use serde::de::DeserializeOwned;
+use serde_json::value::RawValue;
 use serde_json::Value;
 
+use crate::config_deserialize;
 use crate::models::{ContainmentBackend, ExecutionRequest};
 use crate::mxc_error::MxcError;
 
@@ -90,6 +94,12 @@ pub struct ParsedStateAwareRequest {
     /// `{ <backend_key>: { <phase_name>: <typed-config>, ... }, ... }`.
     /// `deserialize_config<C>` navigates the two layers.
     pub experimental_raw: Option<Value>,
+    /// Full DECODED request text, retained so `deserialize_config<C>` can
+    /// deserialize the `experimental.<backend>.<phase>` sub-slice positionally
+    /// and report typed errors with whole-file (line, column) coordinates —
+    /// parity with base-config errors. `None` disables the positional path and
+    /// falls back to the value-based `experimental_raw` deserialize.
+    pub source_text: Option<Box<str>>,
 }
 
 impl ParsedStateAwareRequest {
@@ -105,6 +115,9 @@ impl ParsedStateAwareRequest {
         backend_key: &str,
         phase_name: &str,
     ) -> Result<Option<C>, MxcError> {
+        // Presence gate over the parsed value tree. Cheap, and preserves the
+        // established "backend key or phase key absent => None" behavior
+        // regardless of whether the positional path below is available.
         let Some(exp) = self.experimental_raw.as_ref() else {
             return Ok(None);
         };
@@ -114,16 +127,41 @@ impl ParsedStateAwareRequest {
         let Some(phase_value) = backend_obj.get(phase_name) else {
             return Ok(None);
         };
-        // Deserialize directly from the borrowed `&Value` — no need to clone
-        // the (potentially large) backend config subtree first.
-        <C as serde::Deserialize>::deserialize(phase_value)
+
+        let prefix = format!("experimental.{backend_key}.{phase_name}");
+
+        // Preferred path: deserialize the phase config directly from its
+        // sub-slice of the retained source text so typed errors carry
+        // whole-file line/column, matching base-config diagnostics. Any failure
+        // to locate the sub-slice falls through to the value-based path so a
+        // would-be typed error is never turned into a navigation panic.
+        if let Some(source_text) = self.source_text.as_deref() {
+            if let Some((fragment, fragment_offset)) =
+                locate_phase_fragment(source_text, backend_key, phase_name)
+            {
+                return match config_deserialize::from_str::<C>(fragment) {
+                    Ok(config) => Ok(Some(config)),
+                    Err(error) => {
+                        let error = config_deserialize::remap_error_to_source(
+                            error,
+                            fragment,
+                            fragment_offset,
+                            source_text,
+                        );
+                        Err(MxcError::malformed_request(
+                            error.with_prefix(&prefix).to_string(),
+                        ))
+                    }
+                };
+            }
+        }
+
+        // Fallback: value-based deserialize. A `serde_json::Value` carries no
+        // source offsets, so these errors keep only the JSON-path prefix (the
+        // prior behavior) — no regression.
+        config_deserialize::from_value_ref(phase_value)
             .map(Some)
-            .map_err(|e| {
-                MxcError::malformed_request(format!(
-                    "invalid config at experimental.{}.{}: {}",
-                    backend_key, phase_name, e
-                ))
-            })
+            .map_err(|error| MxcError::malformed_request(error.with_prefix(&prefix).to_string()))
     }
 
     /// Returns the `sandbox_id` for non-provision phases. Surfaces a missing
@@ -136,6 +174,40 @@ impl ParsedStateAwareRequest {
     }
 }
 
+/// Navigate the retained request text to the `experimental.<backend>.<phase>`
+/// sub-slice, returning the fragment (borrowed from `source_text`) and its byte
+/// offset within `source_text`.
+///
+/// Each layer is re-parsed as a map of owned-key → borrowed [`RawValue`], so the
+/// returned fragment is a genuine sub-slice of `source_text` whose byte offset is
+/// the pointer delta. Returns `None` when any navigation step fails or the
+/// located fragment is not contained within `source_text` (mirroring the
+/// fail-closed containment check used by the base-config source-span logic), so
+/// the caller falls back to the value-based path rather than fabricating an
+/// offset.
+///
+/// Map keys are deserialized as owned `String` (not borrowed `&str`): the
+/// permissive `experimental` object may carry sibling keys containing JSON
+/// escapes (e.g. `"is\u006Flation_session"`), which cannot be borrowed as
+/// `&str` and would otherwise fail the whole-map parse and silently drop the
+/// positional (line/column) diagnostics. Only the values are borrowed, so the
+/// returned fragment still points into `source_text`.
+fn locate_phase_fragment<'a>(
+    source_text: &'a str,
+    backend_key: &str,
+    phase_name: &str,
+) -> Option<(&'a str, usize)> {
+    let top: HashMap<String, &RawValue> = serde_json::from_str(source_text).ok()?;
+    let experimental = top.get("experimental")?;
+    let backends: HashMap<String, &RawValue> = serde_json::from_str(experimental.get()).ok()?;
+    let backend = backends.get(backend_key)?;
+    let phases: HashMap<String, &RawValue> = serde_json::from_str(backend.get()).ok()?;
+    let fragment = phases.get(phase_name)?.get();
+
+    let offset = (fragment.as_ptr() as usize).checked_sub(source_text.as_ptr() as usize)?;
+    (offset.checked_add(fragment.len())? <= source_text.len()).then_some((fragment, offset))
+}
+
 /// Public bridge between parser and dispatcher.
 #[derive(Debug, Clone)]
 pub enum MxcRequest {
@@ -146,6 +218,7 @@ pub enum MxcRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::IsolationSessionConfig;
     use crate::mxc_error::MxcErrorCode;
     use serde::Deserialize;
     use serde_json::json;
@@ -153,6 +226,21 @@ mod tests {
     #[derive(Debug, Deserialize, PartialEq, Eq)]
     struct DummyStartConfig {
         configuration_id: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct ArrayStartConfig {
+        port_mappings: Vec<ArrayPortMapping>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct ArrayPortMapping {
+        windows_port: u16,
+        container_port: u16,
     }
 
     fn parsed_with_experimental(exp: Option<Value>, phase: Phase) -> ParsedStateAwareRequest {
@@ -163,6 +251,25 @@ mod tests {
             sandbox_id: None,
             correlation_vector: None,
             experimental_raw: exp,
+            source_text: None,
+        }
+    }
+
+    /// Build a request from full request text, populating both `experimental_raw`
+    /// (the presence gate) and `source_text` (the positional path) the way the
+    /// real parser does — so `deserialize_config` exercises the whole-file
+    /// coordinate translation.
+    fn parsed_with_source(source_text: &str, phase: Phase) -> ParsedStateAwareRequest {
+        let full: Value = serde_json::from_str(source_text).expect("valid JSON");
+        let experimental_raw = full.get("experimental").cloned();
+        ParsedStateAwareRequest {
+            request: ExecutionRequest::default(),
+            phase,
+            containment: None,
+            sandbox_id: None,
+            correlation_vector: None,
+            experimental_raw,
+            source_text: Some(source_text.to_owned().into_boxed_str()),
         }
     }
 
@@ -225,6 +332,352 @@ mod tests {
             .deserialize_config::<DummyStartConfig>("isolation_session", "start")
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message.contains("experimental.isolation_session.start"),
+            "expected the complete subtree path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("missing field `configuration_id`"),
+            "expected the missing field, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_reports_whole_file_line_for_typed_error() {
+        // The offending `configuration_id` value sits on whole-file line 5.
+        let source_text = "\
+{
+  \"experimental\": {
+    \"isolation_session\": {
+      \"start\": {
+        \"configuration_id\": 42
+      }
+    }
+  }
+}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message
+                .contains("experimental.isolation_session.start.configuration_id"),
+            "expected the full subtree path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("line 5"),
+            "expected whole-file line 5, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_whole_file_line_is_computed_not_hardcoded() {
+        // Same shape as above, shifted down by two leading fields so the
+        // offending value lands on whole-file line 7 instead of line 5.
+        let source_text = "\
+{
+  \"sandboxId\": \"iso:wxc-abcd1234\",
+  \"correlationVector\": \"cv.1\",
+  \"experimental\": {
+    \"isolation_session\": {
+      \"start\": {
+        \"configuration_id\": 42
+      }
+    }
+  }
+}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert!(
+            err.message
+                .contains("experimental.isolation_session.start.configuration_id"),
+            "expected the full subtree path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("line 7"),
+            "expected whole-file line 7, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("line 5"),
+            "location must be computed, not hardcoded, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_falls_back_to_path_only_without_source_text() {
+        // With no retained source text the value-based path is used: the typed
+        // error still carries the full path prefix (prior behavior), no panic.
+        let exp = json!({
+            "isolation_session": { "start": { "wrong_field": 42 } }
+        });
+        let parsed = parsed_with_experimental(Some(exp), Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message.contains("experimental.isolation_session.start"),
+            "expected the subtree path in the fallback path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("missing field `configuration_id`"),
+            "expected the missing field, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_reports_complete_array_element_path() {
+        let exp = json!({
+            "wslc": {
+                "start": {
+                    "portMappings": [
+                        {
+                            "windowsPort": "8080",
+                            "containerPort": 80
+                        }
+                    ]
+                }
+            }
+        });
+        let parsed = parsed_with_experimental(Some(exp), Phase::Start);
+
+        let error = parsed
+            .deserialize_config::<ArrayStartConfig>("wslc", "start")
+            .unwrap_err();
+
+        assert_eq!(error.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            error
+                .message
+                .contains("experimental.wslc.start.portMappings[0].windowsPort"),
+            "expected complete array element path, got: {}",
+            error.message
+        );
+        assert!(error.message.contains("expected u16"));
+    }
+
+    #[test]
+    fn deserialize_config_redacts_secret_values() {
+        let exp = json!({
+            "isolation_session": {
+                "start": {
+                    "user": {
+                        "upn": "alice@contoso.com",
+                        "wamToken": 123456789
+                    }
+                }
+            }
+        });
+        let parsed = parsed_with_experimental(Some(exp), Phase::Start);
+
+        let error = parsed
+            .deserialize_config::<IsolationSessionConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert!(error
+            .message
+            .contains("experimental.isolation_session.start.user.wamToken"));
+        assert!(error.message.contains("invalid secret value"));
+        assert!(!error.message.contains("123456789"));
+    }
+
+    #[test]
+    fn deserialize_config_preserves_location_with_escaped_sibling_key() {
+        // A sibling key in the permissive `experimental` object carries a JSON
+        // escape (`\u005F` decodes to `_`). A borrowed-`&str`-keyed map parse
+        // cannot borrow such a key and would fail the whole-map parse, silently
+        // dropping the positional path; owned `String` keys keep the whole-file
+        // line/column intact. The offending value sits on whole-file line 6
+        // (fragment-local line 2), proving the positional path still ran.
+        let source_text = "\
+{
+  \"experimental\": {
+    \"sib\\u005Fling\": {},
+    \"isolation_session\": {
+      \"start\": {
+        \"configuration_id\": 42
+      }
+    }
+  }
+}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message
+                .contains("experimental.isolation_session.start.configuration_id"),
+            "expected the full subtree path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("line 6"),
+            "escaped sibling key must not drop positional path (want line 6), got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("line 2"),
+            "location must be whole-file, not fragment-local, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_reports_exact_whole_file_column() {
+        // The offending value is not at column 1, so an exact column assertion
+        // proves the column is computed and remapped, not ignored or hardcoded.
+        let source_text = "\
+{
+  \"experimental\": {
+    \"isolation_session\": {
+      \"start\": { \"configuration_id\": 42 }
+    }
+  }
+}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        // `42` sits on whole-file line 4; serde reports the column at the end of
+        // the integer token. The exact coordinate is asserted so a regression in
+        // the fragment→whole-file offset math is caught.
+        assert!(
+            err.message.contains("line 4 column 39"),
+            "expected exact whole-file coordinate 'line 4 column 39', got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_preserves_line_across_crlf_source() {
+        // Line counting keys on `\n`, so CRLF endings must not shift the
+        // whole-file line. (Column arithmetic is ASCII-by-design per
+        // `byte_offset_of_line_col`; only the line is asserted here.)
+        let source_text =
+            "{\r\n  \"experimental\": {\r\n    \"isolation_session\": {\r\n      \"start\": {\r\n        \"configuration_id\": 42\r\n      }\r\n    }\r\n  }\r\n}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert!(
+            err.message.contains("line 5"),
+            "CRLF endings must not shift the whole-file line (want line 5), got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_positional_path_redacts_secret_with_whole_file_location() {
+        // Positional (source_text) path AND secret redaction together: the
+        // wamToken secret value is malformed; the message must redact the value,
+        // carry the full path, and report the whole-file line (7), not the
+        // fragment-local one.
+        let source_text = "\
+{
+  \"experimental\": {
+    \"isolation_session\": {
+      \"start\": {
+        \"user\": {
+          \"upn\": \"alice@contoso.com\",
+          \"wamToken\": 123456789
+        }
+      }
+    }
+  }
+}";
+        let parsed = parsed_with_source(source_text, Phase::Start);
+
+        let err = parsed
+            .deserialize_config::<IsolationSessionConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert!(
+            err.message
+                .contains("experimental.isolation_session.start.user.wamToken"),
+            "expected the full secret path, got: {}",
+            err.message
+        );
+        assert!(err.message.contains("invalid secret value"));
+        assert!(
+            !err.message.contains("123456789"),
+            "secret leaked: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("line 7"),
+            "expected whole-file secret location line 7, got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn deserialize_config_falls_back_when_source_text_present_but_locator_fails() {
+        // `source_text` is present and the presence gate passes, but the
+        // retained text shapes `experimental.isolation_session` as a scalar, so
+        // `locate_phase_fragment` cannot navigate to the phase fragment. The
+        // code must fall back to the value-based path (path prefix, no source
+        // coordinates) rather than panic or fabricate a location.
+        let parsed = ParsedStateAwareRequest {
+            request: ExecutionRequest::default(),
+            phase: Phase::Start,
+            containment: None,
+            sandbox_id: None,
+            correlation_vector: None,
+            experimental_raw: Some(json!({
+                "isolation_session": { "start": { "wrong_field": 42 } }
+            })),
+            source_text: Some(
+                r#"{"experimental":{"isolation_session":5}}"#
+                    .to_owned()
+                    .into_boxed_str(),
+            ),
+        };
+
+        let err = parsed
+            .deserialize_config::<DummyStartConfig>("isolation_session", "start")
+            .unwrap_err();
+
+        assert_eq!(err.code, MxcErrorCode::MalformedRequest);
+        assert!(
+            err.message.contains("experimental.isolation_session.start"),
+            "expected the subtree path from the fallback path, got: {}",
+            err.message
+        );
+        assert!(
+            err.message.contains("missing field `configuration_id`"),
+            "expected the missing field, got: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("line "),
+            "fallback path carries no source coordinates, got: {}",
+            err.message
+        );
     }
 
     #[test]

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -35,7 +35,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schema-gen", schemars(title = "MXC Configuration"))]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(
+    rename_all = "camelCase",
+    deny_unknown_fields,
+    expecting = "a configuration object"
+)]
 pub struct MxcConfig {
     /// Optional JSON Schema reference for editor validation. Accepted but
     /// ignored by the parser.
@@ -431,6 +435,8 @@ pub enum LaunchMethod {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 pub struct Experimental {
+    // Keep every direct field optional: state-aware parsing temporarily
+    // substitutes `{}` while validating cross-cutting fields from source text.
     /// Placeholder feature for testing experimental infrastructure.
     pub test: Option<TestFeature>,
     /// Windows Sandbox backend config.


### PR DESCRIPTION
This PR adds actionable configuration parse errors: the parser reports
malformed JSON separately from typed policy-shape errors and includes the full
policy path plus whole-file source location in every diagnostic, without leaking
secrets or letting untrusted text corrupt diagnostics or the state-aware stdout
response envelope.

## Details

* New `config_deserialize` module: a path-aware deserialize layer that
  distinguishes JSON syntax errors from typed policy errors, attaching the full
  JSON path and whole-file line/column, escaping control and invisible
  formatting characters (incl. U+2028/U+2029 and bidi overrides), and redacting
  secret-bearing values. Format-character detection uses the
  `unicode-general-category` crate (Format | LineSeparator | ParagraphSeparator),
  so the Cf/Zl/Zp set tracks the crate's Unicode tables.
* Secret redaction is path-driven: a value is redacted when its policy path
  carries a secret marker. Descriptive markers (`token`, `secret`, `password`,
  ...) match anywhere within a path segment (so `wamToken` / `clientSecret`
  redact), while `user` is matched as a whole path segment so the credential
  bundle (`user: { upn, wamToken }`) redacts even when a scalar is supplied
  where the object is expected, without colliding with unrelated fields like
  `username`.
* State-aware per-backend per-phase configs deserialize positionally from the
  retained request text, so typed errors carry whole-file coordinates matching
  base-config errors; navigation uses owned-key maps so escaped sibling keys
  never silently drop the location, with graceful fallback to the value-based
  path.
* Request loading borrows `RawValue` to discriminate one-shot vs state-aware
  without building a full untyped AST, masking the `experimental` subtree to
  preserve base-config source locations.
* Diagnostic routing keeps stdout reserved for the state-aware envelope and
  script output; parse and dispatch errors go to auxiliary sinks (log file /
  diagnostic pipe) only and are emitted exactly once. Filesystem-path and
  schema-version diagnostics escape untrusted text via the shared
  `escape_diagnostic_text` helper.
* Exec dispatch drops the parsed request (and its retained source text) before
  the blocking child run and stdio relay.
* Docs updated: `docs/versioning.md`, the state-aware API doc, and the
  copilot-instructions config-flow description.

## Tests

* Added parser coverage: syntax-vs-typed classification, whole-file line/column
  (computed, not hardcoded), escaped-sibling-key location preservation, exact
  column, CRLF line stability, positional secret redaction, source-present
  locator fallback, malformed-telemetry single auxiliary emission with an empty
  primary buffer, a pinned `serde_json` positioned-error display-suffix
  contract, format-character escaping (U+202E/U+200B/U+2028/U+2029), and
  segment-aware secret paths (`user` / nested `user` / `user.upn` / `[i].user`
  redact; `username` / `userProfile` do not).
* `cargo fmt --all -- --check`: passed.
* `cargo clippy -p wxc_common -p mxc_engine -p wxc --all-targets -- -D warnings`:
  clean.
* `cargo test -p wxc_common -p wxc`: 538 + 28 passed.
* `node scripts/versioning/check-schema-codegen.js`,
  `check-sdk-types-codegen.js`, `check-schema-versions.js`: passed.
