### PR TITLE
Add process container tests for uncovered cases.

### DIFF
--- a/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
@@ -108,11 +108,18 @@ fn test_configs() {
         "C:\\temp\\wxc_test_allowed",
         "C:\\temp\\wxc_test_allowedreadonly",
         "C:\\temp\\wxc_test_denied",
+        "C:\\temp\\wxc_test_gitproj",
+        "C:\\temp\\wxc_test_gitexisting",
+        "C:\\temp\\wxc_test_outside",
     ]);
     temp.write_absolute_file(
         "C:\\temp\\wxc_test_allowedreadonly\\test_input.txt",
         "Test Input",
     );
+    // Pre-seed a protected child inside a writable parent (the `.git` protection
+    // regression scenario) and an out-of-policy secret for the deny tests.
+    temp.write_absolute_file("C:\\temp\\wxc_test_gitexisting\\.git\\config", "ORIGINAL");
+    temp.write_absolute_file("C:\\temp\\wxc_test_outside\\secret.txt", "SECRET");
 
     let result = run_test_driver(&test_configs_dir(), &[]);
     assert_success(&result);

--- a/tests/configs/processcontainer_denied_outside_grants.json
+++ b/tests/configs/processcontainer_denied_outside_grants.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-DeniedOutsideGrants",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"(echo x>C:\\temp\\wxc_test_outside\\leak.txt) 2>nul && (echo LEAK:outside_write&exit 1) || (echo OK:outside_write_denied) & (type C:\\temp\\wxc_test_outside\\secret.txt 2>nul | findstr SECRET >nul) && (echo LEAK:outside_read&exit 1) || (echo OK:outside_read_denied) & (echo x>C:\\temp\\wxc_test_allowed\\inside_ok.txt) 2>nul && (echo OK:inside_write) || (echo FAIL:inside_write&exit 1) & exit 0\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_allowed"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_git_denied_casevariation.json
+++ b/tests/configs/processcontainer_git_denied_casevariation.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Git-DeniedCaseVariation",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"cd /d C:\\temp\\wxc_test_gitproj & mkdir .GiT 2>nul & if exist .GiT (echo LEAK:GiT_created&rmdir .GiT 2>nul&exit 1) else (echo OK:GiT_create_denied) & exit 0\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_gitproj"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ],
+    "deniedPaths": [
+      "C:\\temp\\wxc_test_gitproj\\.git"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_git_denied_existing.json
+++ b/tests/configs/processcontainer_git_denied_existing.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Git-DeniedExisting",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"cd /d C:\\temp\\wxc_test_gitexisting & echo HACKED> .git\\config 2>nul & (type .git\\config 2>nul | findstr HACKED >nul) && (echo LEAK:config_overwritten&exit 1) || (echo OK:config_write_denied) & echo x> parent_ok.txt & if exist parent_ok.txt (echo OK:parent_write) else (echo FAIL:parent_write&exit 1) & exit 0\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_gitexisting"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ],
+    "deniedPaths": [
+      "C:\\temp\\wxc_test_gitexisting\\.git"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_git_denied_missing.json
+++ b/tests/configs/processcontainer_git_denied_missing.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Git-DeniedMissing",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"cd /d C:\\temp\\wxc_test_gitproj & mkdir .git 2>nul & if exist .git (echo LEAK:git_created&rmdir .git 2>nul&exit 1) else (echo OK:git_create_denied) & echo x> ws_ok.txt & if exist ws_ok.txt (echo OK:ws_write) else (echo FAIL:ws_write&exit 1) & exit 0\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_gitproj"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ],
+    "deniedPaths": [
+      "C:\\temp\\wxc_test_gitproj\\.git"
+    ]
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_network_dns_blocked.json
+++ b/tests/configs/processcontainer_network_dns_blocked.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Network-DnsBlocked",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"nslookup -timeout=2 example.com 1.1.1.1 >nul 2>&1 && (echo LEAK:dns&exit 1) || (echo OK:dns_blocked&exit 0)\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_allowed"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ]
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "capabilities"
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_network_icmp_blocked.json
+++ b/tests/configs/processcontainer_network_icmp_blocked.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Network-IcmpBlocked",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"ping -n 1 -w 3000 1.1.1.1 >nul 2>&1 && (echo LEAK:icmp&exit 1) || (echo OK:icmp_blocked&exit 0)\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_allowed"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ]
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "capabilities"
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_network_tcp_blocked.json
+++ b/tests/configs/processcontainer_network_tcp_blocked.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Network-TcpBlocked",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -Command \"$ErrorActionPreference='SilentlyContinue'; $c=New-Object System.Net.Sockets.TcpClient; $h=$c.BeginConnect('1.1.1.1',445,$null,$null); if ($h.AsyncWaitHandle.WaitOne(3000) -and $c.Connected) { $c.Close(); Write-Output LEAK:tcp; exit 1 } else { Write-Output OK:tcp_blocked; exit 0 }\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_allowed"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ]
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "capabilities"
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/configs/processcontainer_network_unc_blocked.json
+++ b/tests/configs/processcontainer_network_unc_blocked.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-ProcessContainer-Network-UncBlocked",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "C:\\Windows\\System32\\cmd.exe /c \"net use \\\\1.1.1.1\\IPC$ /persistent:no >nul 2>&1 && (net use \\\\1.1.1.1\\IPC$ /delete >nul 2>&1&echo LEAK:unc&exit 1) || (echo OK:unc_blocked&exit 0)\"",
+    "timeout": 30000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "C:\\temp\\wxc_test_allowed"
+    ],
+    "readonlyPaths": [
+      "C:\\Windows"
+    ]
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "capabilities"
+  },
+  "ui": {
+    "disable": false
+  }
+}

--- a/tests/scripts/run_test_configs.ps1
+++ b/tests/scripts/run_test_configs.ps1
@@ -37,7 +37,10 @@ if (-not (Test-Path $TestDriver)) {
 $TempDirs = @(
     "C:\temp\wxc_test_allowed",
     "C:\temp\wxc_test_allowedreadonly",
-    "C:\temp\wxc_test_denied"
+    "C:\temp\wxc_test_denied",
+    "C:\temp\wxc_test_gitproj",
+    "C:\temp\wxc_test_gitexisting",
+    "C:\temp\wxc_test_outside"
 )
 
 try {
@@ -45,6 +48,11 @@ try {
         New-Item -ItemType Directory -Path $dir -Force | Out-Null
     }
     Set-Content -Path "C:\temp\wxc_test_allowedreadonly\test_input.txt" -Value "Test Input"
+    # Pre-seed a protected child inside a writable parent (the `.git` protection
+    # regression scenario) and an out-of-policy secret for the deny tests.
+    New-Item -ItemType Directory -Path "C:\temp\wxc_test_gitexisting\.git" -Force | Out-Null
+    Set-Content -Path "C:\temp\wxc_test_gitexisting\.git\config" -Value "ORIGINAL"
+    Set-Content -Path "C:\temp\wxc_test_outside\secret.txt" -Value "SECRET"
 
     Write-Host "Running wxc-test-driver against tests/configs..." -ForegroundColor Cyan
     & $TestDriver $TestConfigsDir


### PR DESCRIPTION
## 📖 Description
Adds Windows ProcessContainer characterization tests for filesystem and network-egress scenarios that had no equivalent in MXC's own test corpus. All are self-asserting config-driven tests picked up automatically by  wxc-test-driver  (via the existing  test_test_configs  E2E test); no production code changes.

Coverage gaps closed

Protected child inside a writable parent ( .git -style protection). The ProcessContainer path had no analogue to the Bubblewrap  most_specific_*  tests, even though this exact scenario regressed and was fixed previously. Three new configs lock it in:

•  processcontainer_git_denied_missing.json  — denying  .git  blocks creation even when it doesn't exist yet; the workspace stays writable.
•  processcontainer_git_denied_casevariation.json  — the deny also blocks the case variant  .GiT  (Windows case-insensitive FS).
•  processcontainer_git_denied_existing.json  — a pre-seeded  .git\config  cannot be overwritten from inside the sandbox while its parent remains writable.

Low-level network egress. The existing network tests only cover HTTP(S) allow/block. Four new  defaultPolicy: block  configs assert distinct egress vectors are blocked:

•  processcontainer_network_icmp_blocked.json  (ICMP /  ping )
•  processcontainer_network_dns_blocked.json  (DNS via  nslookup )
•  processcontainer_network_tcp_blocked.json  (raw  TcpClient  to :445)
•  processcontainer_network_unc_blocked.json  (SMB/UNC via  net use \\…\IPC$ )

Out-of-policy deny.  processcontainer_denied_outside_grants.json  — reads/writes to a path in no grant are denied, while an in-grant write still succeeds.

Test harness wiring

•  e2e_windows.rs::test_configs()  and  tests/scripts/run_test_configs.ps1  now create the new temp workspaces and pre-seed  .git\config  =  ORIGINAL  and  secret.txt  =  SECRET  for the existing-child and out-of-policy cases.

## 🔍 Validation

• Schema/parser: all 8 pass  validate-configs  (183 configs) and  wxc-exec --dry-run  (exit 0).
• Real run (BaseContainer, un-prepped box): deny enforcement verified —  mkdir .git  and overwriting an existing  .git\config  are both blocked, and the host-side  .git\config  remained  ORIGINAL .
• Full suite green:  cargo test --workspace ;  e2e_windows  (6 passed / 12 ignored);  cargo fmt / clippy  on the touched crate; all versioning/codegen gates; node SDK  npm test  (181/0);  dotnet test  (5/5).

⚠️ The write-side of the filesystem tests and the network-egress enforcement can only be fully exercised on an elevated, host-prepped lane — identical to the existing  #[ignore]  ProcessContainer tests. On an ordinary box these launch, parse, and confirm deny enforcement; the first prepared-lane CI run validates the write/network assertions.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/644)