### PR TITLE
Harden the Windows Sandbox state-aware daemon and lifecycle

### DIFF
--- a/docs/windows-sandbox/windows-sandbox-reference.md
+++ b/docs/windows-sandbox/windows-sandbox-reference.md
@@ -67,9 +67,23 @@ A phase process sends:
 Single-flight admission returns `ERR busy` while another execution owns the
 guest slot and `ERR not_ready` while the VM is booting.
 
-The daemon restores or poisons the guest slot and releases its mutex before
-writing the terminal exit frame. This makes terminal completion the point at
-which a new execution may be admitted.
+The daemon restores or marks-unusable the guest slot and releases its mutex
+before writing the terminal exit frame. This makes terminal completion the point
+at which a new execution may be admitted.
+
+The daemon record (`daemon.json`) also carries the IPC wire-protocol version the
+daemon speaks, and the version is negotiated on the wire, not merely advertised.
+The client sends its version as the trailing token of the `EXEC` line
+(`EXEC <nonce> <proto>`), and the daemon refuses a mismatch with
+`ERR protocol …` **before** any frame exchange. Because the check is enforced by
+the daemon, it also protects a client that never consults the record. A client
+that predates versioning sends no token and is treated as the legacy version
+(`1`), so a future daemon still refuses it rather than misframing its request. A
+daemon left by a different mxc install can still authenticate (its nonce is in
+the record), but a mismatched line/frame format is rejected cleanly. Such a
+sandbox must be torn down at the process level (see `--force-reclaim`) and
+re-provisioned. `stop`/`deprovision` still use the stable single-line `STOP`
+command so an orphaned VM can always be reclaimed.
 
 ## Host State
 
@@ -94,6 +108,7 @@ which a new execution may be admitted.
   <sandbox-token>\
     record.json
     config\wxc-windows-sandbox.wsb
+    daemon.log
     rendezvous\
       bootstrap.cmd
       bootstrap.log
@@ -159,7 +174,14 @@ The daemon:
 6. Serves `PING`, `EXEC`, and `STOP`.
 
 Start polls the record until readiness or timeout. A stale daemon or VM is
-reclaimed only when recorded process identities intersect the live set.
+reclaimed only when recorded process identities intersect the live set. If the
+host's single VM slot is already held by another VM owner (a concurrent one-shot
+run or another live daemon), the daemon exits with a distinct busy code and
+start surfaces `backend_unavailable` rather than an opaque error.
+
+The detached daemon's stderr is captured to `daemon.log` in the per-sandbox
+record directory (owner-only, alongside `record.json`), so boot, teardown, and
+orphan-reclaim failures in the VM-owning process are diagnosable after the fact.
 
 ### Exec
 
@@ -175,6 +197,12 @@ guest connection mid-session, so there is no automatic recovery back to a ready
 state. Every subsequent exec fails fast with the recorded reason, while `stop`
 and `deprovision` continue to work. To run again, tear the sandbox down
 (`stop`/`deprovision`) and provision a fresh one.
+
+A host-side watchdog bounds each exec: if the guest never reports completion
+within its own `timeout` plus a fixed grace, the daemon stops waiting, marks the
+slot unusable, and returns a synthetic timeout exit frame. This keeps a
+frozen-but-alive guest from wedging the single-flight slot indefinitely — the VM
+crash watchdog only fires once the VM processes are actually gone.
 
 ### Stop and deprovision
 
@@ -264,6 +292,8 @@ Inspect state-aware records under:
 ```powershell
 $root = Join-Path $env:TEMP "wxc-wsb\state-aware"
 Get-Content (Join-Path $root "daemon.json")
+# Detached daemon diagnostics (per sandbox token):
+Get-Content (Join-Path $root "<sandbox-token>\daemon.log")
 ```
 
 Check host processes:

--- a/src/backends/windows_sandbox/daemon/src/control_server.rs
+++ b/src/backends/windows_sandbox/daemon/src/control_server.rs
@@ -11,13 +11,15 @@ use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, MutexGuard, Notify, Semaphore};
-use tokio::time::timeout;
+use tokio::time::{timeout, Instant};
 
 use windows_sandbox_lifecycle::bridge::{
-    reconnect_data_streams, stream_exec_on_guest, write_exit_frame, GuestConnection,
+    host_watchdog_deadline, reconnect_data_streams, stream_exec_on_guest, write_exit_frame,
+    GuestConnection, HOST_WATCHDOG_GRACE,
 };
 use windows_sandbox_lifecycle::control_plane::{
-    IPC_ERR, IPC_ERR_BUSY, IPC_ERR_NOT_READY, IPC_EXEC, IPC_PING, IPC_STOP,
+    parse_client_protocol, IPC_ERR, IPC_ERR_BUSY, IPC_ERR_NOT_READY, IPC_ERR_PROTOCOL, IPC_EXEC,
+    IPC_PING, IPC_PROTOCOL_VERSION, IPC_STOP,
 };
 use windows_sandbox_lifecycle::ipc_exec;
 
@@ -219,9 +221,13 @@ async fn handle_client(
     };
 
     let trimmed = line.trim();
-    let mut parts = trimmed.splitn(2, ' ');
+    // `EXEC` may carry a trailing IPC-protocol-version token: split into up to
+    // three parts (verb, nonce, optional version). The nonce is a space-free
+    // uuid, so it is always exactly the second token.
+    let mut parts = trimmed.splitn(3, ' ');
     let verb = parts.next().unwrap_or("");
     let supplied = parts.next().unwrap_or("");
+    let proto_token = parts.next().unwrap_or("");
 
     if supplied != nonce {
         writer.write_all(b"ERR auth\n").await.ok();
@@ -239,7 +245,7 @@ async fn handle_client(
         shutdown.notify_one();
         Ok(())
     } else if verb == IPC_EXEC {
-        handle_exec(reader, writer, guest, guest_nonce, permit).await
+        handle_exec(reader, writer, guest, guest_nonce, permit, proto_token).await
     } else {
         writer.write_all(b"ERR unknown command\n").await.ok();
         Ok(())
@@ -255,7 +261,36 @@ async fn handle_exec(
     guest: &Arc<Mutex<GuestSlot>>,
     guest_nonce: &GuestNonce,
     permit: tokio::sync::OwnedSemaphorePermit,
+    proto_token: &str,
 ) -> Result<()> {
+    // Reject a wire-protocol mismatch before any frame I/O: a client from a
+    // different mxc install may frame its `ExecStart` differently, so we must
+    // not parse it. An absent token is a pre-versioning client (legacy version).
+    match parse_client_protocol(proto_token) {
+        Some(v) if v == IPC_PROTOCOL_VERSION => {}
+        Some(v) => {
+            writer
+                .write_all(
+                    format!(
+                        "{IPC_ERR} {IPC_ERR_PROTOCOL} client v{v} != daemon v{IPC_PROTOCOL_VERSION}\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .ok();
+            return Ok(());
+        }
+        None => {
+            writer
+                .write_all(
+                    format!("{IPC_ERR} {IPC_ERR_PROTOCOL} malformed version token\n").as_bytes(),
+                )
+                .await
+                .ok();
+            return Ok(());
+        }
+    }
+
     let req = match timeout(
         EXEC_REQUEST_TIMEOUT,
         ipc_exec::read_exec_start_async(&mut reader),
@@ -331,7 +366,46 @@ async fn handle_exec(
     drop(permit);
 
     let exec_id = format!("exec-{}", EXEC_COUNTER.fetch_add(1, Ordering::Relaxed));
-    match stream_exec_on_guest(&mut conn, &exec_id, &req, &mut reader, &mut writer).await {
+
+    // Host-side watchdog: a frozen-but-alive guest (never sends Exit, never
+    // closes its streams) would otherwise wedge the single-flight slot forever.
+    // The deadline is honoured *inside* the relay loop at frame boundaries, so a
+    // timeout can never truncate a data frame and desync the client's decode.
+    // `None` == infinite budget (`timeout_ms == u32::MAX`), as in one-shot.
+    let deadline =
+        host_watchdog_deadline(req.timeout_ms, HOST_WATCHDOG_GRACE).map(|d| Instant::now() + d);
+    let stream_result = stream_exec_on_guest(
+        &mut conn,
+        &exec_id,
+        &req,
+        &mut reader,
+        &mut writer,
+        deadline,
+    )
+    .await;
+    match stream_result {
+        Ok(outcome) if outcome.timed_out => {
+            // Watchdog fired at a frame boundary: the guest connection is no
+            // longer trustworthy, so mark the slot Unusable and hand the client
+            // a clean terminal exit frame (no partial data frame precedes it).
+            let msg = format!(
+                "guest did not report completion within the host watchdog ({}ms guest \
+                 timeout + {}s grace); the sandbox may be frozen",
+                req.timeout_ms,
+                HOST_WATCHDOG_GRACE.as_secs()
+            );
+            eprintln!("[wsb-daemon] exec {exec_id}: {msg}");
+            let released = restore_and_release_guest_slot(slot, GuestSlot::Unusable(msg.clone()));
+            if outcome.ipc_alive {
+                if let Err(e) = write_released_exit_frame(&mut writer, released, -1, &msg).await {
+                    eprintln!(
+                        "[wsb-daemon] exec {exec_id}: failed to send watchdog exit frame: {e:#}"
+                    );
+                }
+            } else {
+                let _ = released;
+            }
+        }
         Ok(outcome) => {
             let reconnect =
                 reconnect_data_streams(&mut conn, addr, outcome.control_residual, guest_nonce)
@@ -648,6 +722,80 @@ mod tests {
         assert!(
             resp.starts_with(&format!("{IPC_ERR} bad request:")),
             "expected ERR bad request prefix, got {resp:?}"
+        );
+
+        shutdown.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn exec_with_matching_protocol_version_reaches_admission() {
+        // An explicit version token equal to the daemon's passes the handshake,
+        // so admission runs and (against Booting) yields `ERR not ready`.
+        let (addr, shutdown, handle) = spawn_test_server(GuestSlot::Booting).await;
+
+        let mut s = tokio::net::TcpStream::connect(addr).await.unwrap();
+        s.write_all(format!("EXEC test-nonce-deadbeef {IPC_PROTOCOL_VERSION}\n").as_bytes())
+            .await
+            .unwrap();
+        let start = ExecStart {
+            script_code: "echo hi".to_string(),
+            working_directory: String::new(),
+            timeout_ms: 5_000,
+        };
+        s.write_all(&ipc_exec::encode_exec_start(&start).unwrap())
+            .await
+            .unwrap();
+        s.shutdown().await.ok();
+        let resp = read_to_string(&mut s).await;
+        assert_eq!(
+            resp,
+            format!("{IPC_ERR} {IPC_ERR_NOT_READY}\n"),
+            "got {resp:?}"
+        );
+
+        shutdown.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn exec_with_mismatched_protocol_version_yields_err_protocol() {
+        // A version the daemon does not speak is refused before any frame I/O.
+        let (addr, shutdown, handle) = spawn_test_server(GuestSlot::Booting).await;
+
+        let mismatch = IPC_PROTOCOL_VERSION + 1;
+        let mut s = tokio::net::TcpStream::connect(addr).await.unwrap();
+        s.write_all(format!("EXEC test-nonce-deadbeef {mismatch}\n").as_bytes())
+            .await
+            .unwrap();
+        s.shutdown().await.ok();
+        let resp = read_to_string(&mut s).await;
+        assert_eq!(
+            resp,
+            format!(
+                "{IPC_ERR} {IPC_ERR_PROTOCOL} client v{mismatch} != daemon v{IPC_PROTOCOL_VERSION}\n"
+            ),
+            "got {resp:?}"
+        );
+
+        shutdown.notify_one();
+        let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn exec_with_malformed_protocol_token_yields_err_protocol() {
+        let (addr, shutdown, handle) = spawn_test_server(GuestSlot::Booting).await;
+
+        let mut s = tokio::net::TcpStream::connect(addr).await.unwrap();
+        s.write_all(b"EXEC test-nonce-deadbeef notanumber\n")
+            .await
+            .unwrap();
+        s.shutdown().await.ok();
+        let resp = read_to_string(&mut s).await;
+        assert_eq!(
+            resp,
+            format!("{IPC_ERR} {IPC_ERR_PROTOCOL} malformed version token\n"),
+            "got {resp:?}"
         );
 
         shutdown.notify_one();

--- a/src/backends/windows_sandbox/daemon/src/main.rs
+++ b/src/backends/windows_sandbox/daemon/src/main.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result};
 use tokio::sync::{Mutex, Notify};
 use windows_sandbox_lifecycle::control_plane::{
     self, process_creation_time, DaemonRecord, MappedFolderRecord, VmOwnership, VmProcId,
-    RECORD_SCHEMA_VERSION,
+    IPC_PROTOCOL_VERSION, RECORD_SCHEMA_VERSION,
 };
 use windows_sandbox_lifecycle::rendezvous::{
     GUEST_CONNECT_TIMEOUT, RENDEZVOUS_POLL_INTERVAL, RENDEZVOUS_TIMEOUT,
@@ -25,6 +25,9 @@ const VM_WATCHDOG_POLL_INTERVAL_SECS: u64 = 5;
 /// Consecutive gone polls required before the crash watchdog fires.
 const VM_WATCHDOG_GONE_CONFIRMATIONS: u32 = 3;
 
+/// How long to wait for the host's single VM slot before declaring it busy. On
+/// timeout the daemon exits [`control_plane::DAEMON_EXIT_VM_SLOT_BUSY`], which
+/// `start` maps to `backend_unavailable`.
 const HOST_VM_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 /// Parsed daemon command-line arguments.
@@ -99,8 +102,24 @@ async fn main() -> Result<()> {
     let sandbox_id = record.sandbox_id.clone();
     let mapped = to_mapped_folders(&record.mapped_folders);
 
-    let _vm_lock = control_plane::HostVmLock::acquire(HOST_VM_LOCK_TIMEOUT)
-        .context("acquire host Windows Sandbox VM slot")?;
+    let _vm_lock = match control_plane::HostVmLock::try_acquire(HOST_VM_LOCK_TIMEOUT)
+        .context("acquire host Windows Sandbox VM slot")?
+    {
+        Some(lock) => lock,
+        None => {
+            // Slot held by another VM owner. Exit with a distinct code so
+            // `start` maps it to `backend_unavailable` rather than an opaque
+            // error; a real create/wait failure instead propagates via `?`
+            // above. No record written yet, so nothing to clean up.
+            eprintln!(
+                "[wsb-daemon] host Windows Sandbox VM slot is busy (held by another VM owner); \
+                 exiting {} after waiting {:?}",
+                control_plane::DAEMON_EXIT_VM_SLOT_BUSY,
+                HOST_VM_LOCK_TIMEOUT
+            );
+            std::process::exit(control_plane::DAEMON_EXIT_VM_SLOT_BUSY);
+        }
+    };
 
     let prior = control_plane::read_daemon_record().ok().flatten();
 
@@ -210,6 +229,7 @@ async fn main() -> Result<()> {
         nonce: args.nonce.clone(),
         active_sandbox_id: sandbox_id.clone(),
         ready: false,
+        protocol_version: IPC_PROTOCOL_VERSION,
         vm_processes: Vec::new(),
     };
     control_plane::write_daemon_record(&starting).context("write starting daemon record")?;

--- a/src/backends/windows_sandbox/lifecycle/src/bridge.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/bridge.rs
@@ -35,12 +35,12 @@ const MAX_CAPTURED_OUTPUT_BYTES: usize = 64 * 1024 * 1024;
 /// Grace added to the guest's own `timeout_ms` to form the host watchdog
 /// deadline: covers guest process teardown and final output drain. If the guest
 /// freezes and never reports, the host stops waiting after `timeout_ms + grace`.
-const HOST_WATCHDOG_GRACE: Duration = Duration::from_secs(30);
+pub const HOST_WATCHDOG_GRACE: Duration = Duration::from_secs(30);
 
 /// Host watchdog deadline for one guest execution. `None` for an infinite guest
 /// budget (`u32::MAX`, the normalized "no timeout"); otherwise `timeout_ms +
 /// grace`, saturating against overflow.
-fn host_watchdog_deadline(timeout_ms: u32, grace: Duration) -> Option<Duration> {
+pub fn host_watchdog_deadline(timeout_ms: u32, grace: Duration) -> Option<Duration> {
     if timeout_ms == u32::MAX {
         None
     } else {
@@ -524,18 +524,29 @@ pub struct StreamExecOutcome {
     pub exit_code: i32,
     /// The guest's error message accompanying the exit (empty on success).
     pub error_message: String,
+    /// `true` if the host watchdog fired before the guest reported completion.
+    /// When set, `exit_code`/`error_message` are unspecified and the caller
+    /// synthesises the terminal frame; the guest slot must be marked unusable.
+    pub timed_out: bool,
 }
 
 /// Run one guest execution and stream stdout/stderr to the IPC client.
 ///
 /// The terminal exit frame is written separately after the guest slot is
 /// restored for reuse.
+///
+/// `deadline`, when `Some`, bounds the whole execution: it is a host watchdog
+/// for a frozen-but-alive guest. It is honoured **only at frame boundaries**
+/// (between `select!` iterations), never mid-frame, so a partially-written data
+/// frame can never be followed by the terminal frame. On expiry the loop breaks
+/// and the returned outcome has `timed_out == true`.
 pub async fn stream_exec_on_guest<R, W>(
     conn: &mut GuestConnection,
     exec_id: &str,
     req: &ExecStart,
     ipc_reader: &mut R,
     ipc: &mut W,
+    deadline: Option<tokio::time::Instant>,
 ) -> Result<StreamExecOutcome>
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -563,6 +574,7 @@ where
     let mut stdout_seen: u64 = 0;
     let mut stderr_seen: u64 = 0;
     let mut exit: Option<(i32, String)> = None;
+    let mut timed_out = false;
     let mut post_exit_deadline: Option<tokio::time::Instant> = None;
     let mut ctrl_buf: Vec<u8> = Vec::with_capacity(256);
     let mut so = [0u8; 8192];
@@ -688,7 +700,35 @@ where
                 stdout_done = true;
                 stderr_done = true;
             }
+            // Host watchdog. Observed only here, between whole-frame relays, so
+            // it never interrupts a `write_data_frame_split` mid-frame. `None`
+            // (infinite budget) parks on `pending` and never fires.
+            _ = async {
+                match deadline {
+                    Some(d) => tokio::time::sleep_until(d).await,
+                    None => std::future::pending::<()>().await,
+                }
+            } => {
+                eprintln!(
+                    "[daemon] exec {exec_id}: host watchdog fired; abandoning frozen guest"
+                );
+                timed_out = true;
+                break;
+            }
         }
+    }
+
+    if timed_out {
+        // The guest is untrustworthy; the caller marks the slot unusable and
+        // synthesises the terminal frame. Break happened at a frame boundary,
+        // so the IPC stream carries no partial data frame.
+        return Ok(StreamExecOutcome {
+            control_residual: ctrl_buf,
+            ipc_alive,
+            exit_code: -1,
+            error_message: String::new(),
+            timed_out: true,
+        });
     }
 
     let (exit_code, error_message) = match exit {
@@ -701,6 +741,7 @@ where
         ipc_alive,
         exit_code,
         error_message,
+        timed_out: false,
     })
 }
 
@@ -948,6 +989,75 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn stream_exec_watchdog_fires_at_frame_boundary_without_partial_frame() {
+        // Regression: the streaming watchdog is honoured *inside* the relay loop
+        // at frame boundaries, so a timeout can never truncate a data frame and
+        // leave the client's decoder desynced. The guest emits output then goes
+        // silent (never Exit); the watchdog must fire, and everything written to
+        // the IPC client must be complete, decodable frames with no residue.
+        let nonce = generate_nonce().expect("generate nonce");
+        let (addr, fake_rx) = spawn_fake_guest(nonce.clone()).await;
+        let mut conn = connect_to_guest(addr, Duration::from_secs(5), &nonce)
+            .await
+            .expect("connect_to_guest must succeed");
+        // Hold `fake` for the whole call so the control channel stays open: a
+        // closed control would end the loop with an error, not a timeout.
+        let mut fake = fake_rx
+            .await
+            .expect("fake-guest oneshot")
+            .expect("fake-guest accept");
+
+        // Pre-load guest stdout; the relay drains it before parking on control.
+        fake.stdout.write_all(b"helloworld").await.unwrap();
+
+        let req = ExecStart {
+            script_code: "sleep".to_string(),
+            working_directory: String::new(),
+            timeout_ms: 60_000,
+        };
+        let mut ipc_reader: &[u8] = b"";
+        let mut ipc_writer: Vec<u8> = Vec::new();
+        let deadline = Some(tokio::time::Instant::now() + Duration::from_millis(150));
+
+        // The 5s guard turns a watchdog-never-fires regression into a failure
+        // instead of a hang; the real watchdog fires at 150ms.
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(5),
+            stream_exec_on_guest(
+                &mut conn,
+                "exec-wd",
+                &req,
+                &mut ipc_reader,
+                &mut ipc_writer,
+                deadline,
+            ),
+        )
+        .await
+        .expect("watchdog must return within the guard window")
+        .expect("stream returns Ok");
+        drop(fake);
+
+        assert!(outcome.timed_out, "watchdog must report a timeout");
+
+        let mut cur = std::io::Cursor::new(ipc_writer);
+        let mut payload = Vec::new();
+        while let Some(frame) = ipc_exec::read_frame(&mut cur).unwrap() {
+            assert_eq!(
+                frame.kind,
+                Some(FrameKind::Stdout),
+                "only stdout frames expected before the (caller-written) terminal frame"
+            );
+            payload.extend_from_slice(&frame.payload);
+        }
+        assert_eq!(
+            cur.position() as usize,
+            cur.get_ref().len(),
+            "no trailing partial frame may remain in the IPC stream"
+        );
+        assert_eq!(payload, b"helloworld");
+    }
+
     // In-process guest for bridge and reconnect integration tests.
 
     struct FakeGuestSide {
@@ -1083,6 +1193,7 @@ mod tests {
             &req,
             &mut ipc_reader,
             &mut ipc_writer,
+            None,
         );
 
         let (_fake_back, outcome) = tokio::join!(fake_side, host_side);
@@ -1159,6 +1270,7 @@ mod tests {
             &req,
             &mut ipc_reader_side,
             &mut ipc_out,
+            None,
         );
 
         let (stdin_recv, outcome) = tokio::join!(fake_side, host_side);
@@ -1227,6 +1339,7 @@ mod tests {
             &req,
             &mut empty_reader,
             &mut server_write,
+            None,
         );
 
         let (_fake, outcome) = tokio::join!(fake_side, host_side);

--- a/src/backends/windows_sandbox/lifecycle/src/control_plane.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/control_plane.rs
@@ -18,6 +18,32 @@ pub use os::*;
 /// incompatibly; readers reject mismatches via [`check_schema`].
 pub const RECORD_SCHEMA_VERSION: u32 = 1;
 
+/// IPC wire-protocol version: the line protocol (`PING`/`STOP`/`EXEC`) plus the
+/// [`crate::ipc_exec`] frame format. Bump on any incompatible framing change so
+/// a daemon left by a *different* mxc install is refused rather than driven
+/// against a mismatched peer. Versioned separately from [`RECORD_SCHEMA_VERSION`]
+/// (the on-disk shape), which it need not track.
+///
+/// The version is negotiated on the wire, not merely advertised in `daemon.json`:
+/// the client sends its version as the trailing token of the `EXEC` line and the
+/// daemon refuses a mismatch *before* any frame I/O (see [`parse_client_protocol`]).
+/// This makes the check bilateral and daemon-enforced, so it also protects a
+/// client that never reads the record. A client that predates versioning sends no
+/// token and is treated as [`LEGACY_IPC_PROTOCOL_VERSION`].
+pub const IPC_PROTOCOL_VERSION: u32 = 1;
+
+/// IPC wire-protocol version attributed to a *pre-versioning* client — one that
+/// sends `EXEC <nonce>` with no trailing version token. Fixed at the wire format
+/// that shipped before versioning and must never change: it is how a future
+/// daemon recognises and cleanly refuses a legacy client instead of misframing
+/// its differently-shaped request.
+pub const LEGACY_IPC_PROTOCOL_VERSION: u32 = 1;
+
+/// Daemon exit code signalling it could not acquire the host's single VM slot
+/// (busy); `start` maps it to `backend_unavailable`. Outside the `0`/`1`
+/// success/failure range so it is unambiguous (`75` == sysexits `EX_TEMPFAIL`).
+pub const DAEMON_EXIT_VM_SLOT_BUSY: i32 = 75;
+
 /// Lifecycle state of a provisioned state-aware sandbox.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -93,9 +119,22 @@ pub struct DaemonRecord {
     pub active_sandbox_id: String,
     /// `false` while the daemon is booting; `true` once the VM is ready.
     pub ready: bool,
+    /// IPC wire-protocol version this daemon speaks (see [`IPC_PROTOCOL_VERSION`]).
+    /// Absent (pre-versioning) records default to `0`, i.e. incompatible.
+    #[serde(default)]
+    pub protocol_version: u32,
     /// Positive ownership proof for reclaiming an orphaned VM.
     #[serde(default)]
     pub vm_processes: Vec<VmProcId>,
+}
+
+impl DaemonRecord {
+    /// True iff this daemon speaks this build's IPC wire protocol
+    /// ([`IPC_PROTOCOL_VERSION`]). A mismatch means a different mxc install left
+    /// it: it authenticates but must not be driven with mismatched framing.
+    pub fn protocol_compatible(&self) -> bool {
+        self.protocol_version == IPC_PROTOCOL_VERSION
+    }
 }
 
 /// Startup action for an already-running VM.
@@ -508,9 +547,11 @@ pub fn remove_sandbox_dir(token: &str) -> std::io::Result<()> {
 }
 
 // Daemon line protocol on `127.0.0.1:<ipc_port>`:
-//   request  : `<VERB> <nonce>\n`
+//   request  : `<VERB> <nonce>[ <proto>]\n`
 //   response : `OK\n` | `PONG\n` | `ERR <message>\n`
-// `EXEC` continues into a binary frame stream after its status line.
+// `EXEC` continues into a binary frame stream after its status line. The
+// optional trailing `<proto>` is the client's IPC wire-protocol version; only
+// `EXEC` consumes it (see [`parse_client_protocol`]).
 
 /// Liveness/echo verb. Response: `PONG`.
 pub const IPC_PING: &str = "PING";
@@ -532,10 +573,42 @@ pub const IPC_ERR_BUSY: &str = "busy";
 /// Exec-admission reason token: the guest slot exists but is still booting.
 /// Emitted by the daemon as `ERR not ready`, matched by the client.
 pub const IPC_ERR_NOT_READY: &str = "not ready";
+/// Exec-admission reason token: the client speaks a different IPC wire-protocol
+/// version than this daemon (a daemon/client left by a different mxc install).
+/// Emitted by the daemon as `ERR protocol <detail>`; the client maps a status
+/// line whose reason starts with this token to `backend_unavailable`.
+pub const IPC_ERR_PROTOCOL: &str = "protocol";
+
+/// Resolve the IPC wire-protocol version an `EXEC <nonce> [proto]` line declares.
+///
+/// An absent token (`""`) is a pre-versioning client and maps to
+/// [`LEGACY_IPC_PROTOCOL_VERSION`]; a well-formed numeric token maps to its
+/// value. A present-but-non-numeric token is malformed and yields `None`, which
+/// the daemon rejects rather than guessing a version.
+pub fn parse_client_protocol(token: &str) -> Option<u32> {
+    if token.is_empty() {
+        return Some(LEGACY_IPC_PROTOCOL_VERSION);
+    }
+    token.parse::<u32>().ok()
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_client_protocol_maps_absent_present_and_malformed() {
+        // Absent token = pre-versioning client = legacy version.
+        assert_eq!(parse_client_protocol(""), Some(LEGACY_IPC_PROTOCOL_VERSION));
+        // Well-formed numeric tokens map to their value.
+        assert_eq!(parse_client_protocol("1"), Some(1));
+        assert_eq!(parse_client_protocol("2"), Some(2));
+        assert_eq!(parse_client_protocol("0"), Some(0));
+        // Present-but-non-numeric is malformed, not a guessed version.
+        assert_eq!(parse_client_protocol("abc"), None);
+        assert_eq!(parse_client_protocol("-1"), None);
+        assert_eq!(parse_client_protocol("1.0"), None);
+    }
 
     #[test]
     fn paths_are_nested_under_root() {
@@ -579,6 +652,7 @@ mod tests {
             nonce: "abc123".to_string(),
             active_sandbox_id: "wsb:deadbeef".to_string(),
             ready: true,
+            protocol_version: IPC_PROTOCOL_VERSION,
             vm_processes: vec![VmProcId {
                 pid: 5678,
                 creation_time: 99,
@@ -587,6 +661,38 @@ mod tests {
         atomic_write_json(&path, &rec).unwrap();
         let back: DaemonRecord = read_json(&path).unwrap().unwrap();
         assert_eq!(back, rec);
+    }
+
+    #[test]
+    fn protocol_compatible_matches_current_and_rejects_others() {
+        let mut rec = daemon_record_with(Vec::new());
+        assert_eq!(rec.protocol_version, IPC_PROTOCOL_VERSION);
+        assert!(rec.protocol_compatible());
+
+        rec.protocol_version = 0;
+        assert!(!rec.protocol_compatible());
+        rec.protocol_version = IPC_PROTOCOL_VERSION + 1;
+        assert!(!rec.protocol_compatible());
+    }
+
+    #[test]
+    fn daemon_record_without_protocol_version_reads_incompatible() {
+        // A record serialised by a pre-versioning daemon has no
+        // `protocol_version` key. It must still deserialise (serde default) and
+        // read back as protocol-incompatible rather than erroring or matching.
+        let json = r#"{
+            "schema_version": 1,
+            "pid": 1,
+            "pid_creation_time": 1,
+            "ipc_port": 1,
+            "nonce": "n",
+            "active_sandbox_id": "wsb:x",
+            "ready": true
+        }"#;
+        let rec: DaemonRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(rec.protocol_version, 0);
+        assert!(!rec.protocol_compatible());
+        assert!(rec.vm_processes.is_empty());
     }
 
     #[test]
@@ -631,6 +737,7 @@ mod tests {
             nonce: "n".to_string(),
             active_sandbox_id: "wsb:x".to_string(),
             ready: true,
+            protocol_version: IPC_PROTOCOL_VERSION,
             vm_processes,
         }
     }
@@ -877,6 +984,7 @@ mod tests {
             nonce: "n".to_string(),
             active_sandbox_id: active.to_string(),
             ready: true,
+            protocol_version: IPC_PROTOCOL_VERSION,
             vm_processes,
         }
     }
@@ -1005,6 +1113,7 @@ mod tests {
             nonce: "n".to_string(),
             active_sandbox_id: "wsb:x".to_string(),
             ready: true,
+            protocol_version: IPC_PROTOCOL_VERSION,
             vm_processes: Vec::new(),
         };
         assert!(daemon_alive(&rec));
@@ -1023,6 +1132,7 @@ mod tests {
             nonce: "n".to_string(),
             active_sandbox_id: "wsb:x".to_string(),
             ready: true,
+            protocol_version: IPC_PROTOCOL_VERSION,
             vm_processes: Vec::new(),
         };
         assert!(!daemon_alive(&rec));

--- a/src/backends/windows_sandbox/lifecycle/src/control_plane/os.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/control_plane/os.rs
@@ -296,16 +296,17 @@ pub fn terminate_processes(_targets: &[VmProcId]) -> usize {
 // Cross-process named mutexes
 // ---------------------------------------------------------------------------
 
-/// Acquire a Windows named mutex, waiting up to `timeout`. Returns the handle
-/// and whether we own it (always `true` on success; the handle must be released
-/// + closed on drop). Shared by [`TransitionLock`] and [`HostVmLock`].
+/// Try to acquire the named mutex, distinguishing contention from failure.
+/// Returns the owned handle on success (closed on drop), `Ok(None)` when the
+/// wait times out because another owner holds it (the caller may treat this as
+/// "busy"), and `Err` for a create/wait failure, which is not contention.
 #[cfg(windows)]
-fn named_mutex_acquire(
+fn named_mutex_try_acquire(
     name: &str,
     timeout: std::time::Duration,
-) -> Result<windows::Win32::Foundation::HANDLE> {
+) -> Result<Option<windows::Win32::Foundation::HANDLE>> {
     use windows::core::PCWSTR;
-    use windows::Win32::Foundation::{WAIT_ABANDONED, WAIT_OBJECT_0};
+    use windows::Win32::Foundation::{WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT};
     use windows::Win32::System::Threading::{CreateMutexW, WaitForSingleObject};
 
     let wide: Vec<u16> = name.encode_utf16().chain(std::iter::once(0)).collect();
@@ -322,13 +323,35 @@ fn named_mutex_acquire(
         // WAIT_ABANDONED: a previous holder died without releasing. We now own
         // the mutex; the protected state is reconciled separately via records /
         // process-identity proof, so taking ownership here is correct.
-        Ok(handle)
-    } else {
+        Ok(Some(handle))
+    } else if wait == WAIT_TIMEOUT {
+        // Contention: another owner holds the mutex. Not an error.
         // SAFETY: closing the handle we just created; we do not own the mutex.
         unsafe {
             let _ = windows::Win32::Foundation::CloseHandle(handle);
         }
-        anyhow::bail!("timed out acquiring named mutex {name:?} after {timeout:?}");
+        Ok(None)
+    } else {
+        // WAIT_FAILED or any other unexpected result is a real failure.
+        // SAFETY: closing the handle we just created; we do not own the mutex.
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(handle);
+        }
+        anyhow::bail!("waiting on named mutex {name:?} failed (wait result {wait:?})");
+    }
+}
+
+/// Acquire the named mutex, returning `Err` on either contention (timeout) or a
+/// real failure. Callers that need to distinguish the two use
+/// [`named_mutex_try_acquire`].
+#[cfg(windows)]
+fn named_mutex_acquire(
+    name: &str,
+    timeout: std::time::Duration,
+) -> Result<windows::Win32::Foundation::HANDLE> {
+    match named_mutex_try_acquire(name, timeout)? {
+        Some(handle) => Ok(handle),
+        None => anyhow::bail!("timed out acquiring named mutex {name:?} after {timeout:?}"),
     }
 }
 
@@ -399,6 +422,17 @@ impl HostVmLock {
             owned: true,
         })
     }
+
+    /// Try to acquire the host VM-slot mutex. `Ok(None)` means it is held by
+    /// another VM owner ("busy"); `Err` is a real create/wait failure, not busy.
+    pub fn try_acquire(timeout: std::time::Duration) -> Result<Option<Self>> {
+        Ok(
+            named_mutex_try_acquire(HOST_VM_MUTEX_NAME, timeout)?.map(|handle| Self {
+                handle,
+                owned: true,
+            }),
+        )
+    }
 }
 
 #[cfg(windows)]
@@ -416,5 +450,55 @@ pub struct HostVmLock;
 impl HostVmLock {
     pub fn acquire(_timeout: std::time::Duration) -> Result<Self> {
         Ok(Self)
+    }
+
+    pub fn try_acquire(_timeout: std::time::Duration) -> Result<Option<Self>> {
+        Ok(Some(Self))
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_mutex_try_acquire_reports_contention_as_none_not_err() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        // Unique name per run so the test never collides with a real host VM
+        // mutex or a concurrent test run.
+        let name = format!("Local\\mxc-test-mutex-{}", uuid::Uuid::new_v4());
+        let (held_tx, held_rx) = mpsc::channel::<()>();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+
+        // A separate thread must own the mutex: a named mutex is recursive per
+        // thread, so the same thread could re-acquire it without contending.
+        let holder_name = name.clone();
+        let holder = std::thread::spawn(move || {
+            let handle = named_mutex_try_acquire(&holder_name, Duration::from_secs(5))
+                .expect("holder: create should succeed")
+                .expect("holder: should acquire the free mutex");
+            held_tx.send(()).unwrap();
+            release_rx.recv().ok();
+            named_mutex_release(handle, true);
+        });
+
+        held_rx.recv().expect("holder should signal ownership");
+
+        // The mutex is genuinely held elsewhere: contention must be Ok(None)
+        // (busy), never Err. Err is reserved for real create/wait failures.
+        let contended = named_mutex_try_acquire(&name, Duration::from_millis(50))
+            .expect("a contended acquire must not error");
+        assert!(contended.is_none(), "expected None (busy), got a handle");
+
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+
+        // Once released, a fresh try must succeed (Ok(Some)).
+        let reacquired = named_mutex_try_acquire(&name, Duration::from_secs(5))
+            .expect("create should succeed")
+            .expect("mutex should be free after the holder released it");
+        named_mutex_release(reacquired, true);
     }
 }

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -26,8 +26,8 @@ use windows::Win32::Foundation::HANDLE;
 use crate::control_plane::{
     self, generate_nonce, live_daemon, read_daemon_record, read_sandbox_record,
     running_process_creation_time, sandbox_dir, DaemonRecord, MappedFolderRecord, SandboxRecord,
-    SandboxState, TransitionLock, IPC_ERR, IPC_ERR_BUSY, IPC_ERR_NOT_READY, IPC_EXEC, IPC_OK,
-    IPC_STOP,
+    SandboxState, TransitionLock, IPC_ERR, IPC_ERR_BUSY, IPC_ERR_NOT_READY, IPC_ERR_PROTOCOL,
+    IPC_EXEC, IPC_OK, IPC_STOP,
 };
 use crate::error::OneShotError;
 use crate::ipc_exec::{self, ExecExit, ExecStart, FrameKind};
@@ -238,6 +238,13 @@ fn map_exec_status_error(status: &str) -> MxcError {
             MxcError::backend_error("sandbox is busy: another exec is already running")
         }
         Some(IPC_ERR_NOT_READY) => MxcError::not_started("sandbox is not ready for exec yet"),
+        // A wire-protocol mismatch means a daemon from a different mxc install
+        // holds the VM: surface it as unavailable, matching `ensure_daemon_protocol`.
+        Some(r) if r.starts_with(IPC_ERR_PROTOCOL) => MxcError::backend_unavailable(format!(
+            "daemon rejected exec (wire-protocol mismatch): {}. Tear the stale VM down \
+             (e.g. force-reclaim on a fresh start) and retry.",
+            status.trim()
+        )),
         _ => MxcError::backend_error(format!("daemon rejected exec: {}", status.trim())),
     }
 }
@@ -293,8 +300,15 @@ fn run_exec_stream(daemon: &DaemonRecord, request: &ExecutionRequest) -> Result<
 
     {
         let mut w = &stream;
-        writeln!(w, "{IPC_EXEC} {}", daemon.nonce)
-            .map_err(|e| MxcError::backend_error(format!("send EXEC line: {e}")))?;
+        // Declare our IPC wire-protocol version so the daemon refuses a mismatch
+        // (a daemon from a different mxc install) before any frame exchange.
+        writeln!(
+            w,
+            "{IPC_EXEC} {} {}",
+            daemon.nonce,
+            control_plane::IPC_PROTOCOL_VERSION
+        )
+        .map_err(|e| MxcError::backend_error(format!("send EXEC line: {e}")))?;
         ipc_exec::write_exec_start(&mut w, &exec_start)
             .map_err(|e| MxcError::backend_error(format!("send ExecStart: {e}")))?;
         w.flush()
@@ -452,6 +466,12 @@ fn ipc_command(port: u16, verb: &str, nonce: &str) -> Result<String, MxcError> {
     Ok(line.trim().to_string())
 }
 
+/// Path to the detached daemon's diagnostic log (`<root>\<token>\daemon.log`),
+/// inside the owner-only per-sandbox record directory.
+fn daemon_log_path(token: &str) -> std::path::PathBuf {
+    sandbox_dir(token).join("daemon.log")
+}
+
 /// Spawn the detached daemon and pass its auth nonce over stdin.
 fn spawn_daemon(token: &str, nonce: &str) -> Result<std::process::Child, MxcError> {
     use std::io::Write;
@@ -460,12 +480,27 @@ fn spawn_daemon(token: &str, nonce: &str) -> Result<std::process::Child, MxcErro
     let daemon_path = resolve_sibling_binary(crate::constants::DAEMON_BINARY_NAME)
         .map_err(|e| MxcError::backend_error(format!("locate daemon binary: {e}")))?;
 
+    // Capture the detached daemon's stderr: its only window into boot /
+    // teardown / orphan-reclaim failures. Append so a mid-session restart keeps
+    // prior diagnostics.
+    let log_path = daemon_log_path(token);
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| MxcError::backend_error(format!("open daemon log {log_path:?}: {e}")))?;
+    // Match the owner-only record-dir DACL. Best-effort: the log holds no secret
+    // (never the nonce), so a DACL hiccup must not block start.
+    if let Err(e) = control_plane::set_owner_only_file(&log_path) {
+        eprintln!("[wsb] WARNING: could not secure daemon log {log_path:?}: {e:#}");
+    }
+
     let mut child = Command::new(&daemon_path)
         .arg("--token")
         .arg(token)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::from(log))
         .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
         .spawn()
         .map_err(|e| MxcError::backend_error(format!("spawn daemon {daemon_path:?}: {e}")))?;
@@ -536,6 +571,28 @@ fn stop_spawned_daemon_best_effort(
         }
     }
     let _ = child.kill();
+}
+
+/// True if a daemon exit during `start` signals VM-slot contention
+/// ([`control_plane::DAEMON_EXIT_VM_SLOT_BUSY`]) rather than an opaque failure.
+fn daemon_exit_is_vm_slot_busy(code: Option<i32>) -> bool {
+    code == Some(control_plane::DAEMON_EXIT_VM_SLOT_BUSY)
+}
+
+/// Reject a live daemon whose IPC wire protocol differs from this build's: it
+/// was left by a different mxc install, so its frame format may not match ours.
+/// The operator tears the stale VM down (e.g. `--force-reclaim`) and retries.
+fn ensure_daemon_protocol(daemon: &DaemonRecord) -> Result<(), MxcError> {
+    if daemon.protocol_compatible() {
+        return Ok(());
+    }
+    Err(MxcError::backend_unavailable(format!(
+        "the active Windows Sandbox daemon speaks IPC protocol v{} but this build speaks v{}; \
+         refusing to drive it. Tear down the stale VM (e.g. force-reclaim on a fresh start) and \
+         retry.",
+        daemon.protocol_version,
+        control_plane::IPC_PROTOCOL_VERSION
+    )))
 }
 
 impl StatefulSandboxBackend for WindowsSandboxRunner {
@@ -642,8 +699,16 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
             }
             match child.try_wait() {
                 Ok(Some(status)) => {
+                    if daemon_exit_is_vm_slot_busy(status.code()) {
+                        return Err(MxcError::backend_unavailable(
+                            "another Windows Sandbox VM is active on this host; only one is \
+                             supported. The daemon could not acquire the VM slot; retry once the \
+                             other run finishes.",
+                        ));
+                    }
                     return Err(MxcError::backend_error(format!(
-                        "daemon exited during start ({status}); see daemon logs"
+                        "daemon exited during start ({status}); see daemon log at {:?}",
+                        daemon_log_path(token)
                     )));
                 }
                 Ok(None) => {}
@@ -708,6 +773,12 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
                 "sandbox {sandbox_id} is still starting"
             )));
         }
+        // Fast-fail on a protocol-mismatched daemon using the record. The daemon
+        // also enforces this on the wire (via the EXEC version token), so this is
+        // a pre-check, not the sole guard. stop/deprovision stay permitted: their
+        // single-line STOP is stable, and refusing it would strand the VM we most
+        // need to tear down.
+        ensure_daemon_protocol(&daemon)?;
 
         // Stream the execution synchronously, relaying stdout/stderr live to
         // this process's stdio. Mirrors isolation_session: the relay completes
@@ -979,6 +1050,52 @@ mod tests {
     }
 
     #[test]
+    fn vm_slot_busy_exit_code_is_recognized() {
+        assert!(daemon_exit_is_vm_slot_busy(Some(
+            control_plane::DAEMON_EXIT_VM_SLOT_BUSY
+        )));
+        assert!(!daemon_exit_is_vm_slot_busy(Some(1)));
+        assert!(!daemon_exit_is_vm_slot_busy(Some(0)));
+        // A daemon killed by a signal / with no code must not be mistaken for
+        // the VM-slot-busy sentinel.
+        assert!(!daemon_exit_is_vm_slot_busy(None));
+    }
+
+    fn daemon_record_with_protocol(protocol_version: u32) -> DaemonRecord {
+        DaemonRecord {
+            schema_version: control_plane::RECORD_SCHEMA_VERSION,
+            pid: 1,
+            pid_creation_time: 1,
+            ipc_port: 1,
+            nonce: "n".into(),
+            active_sandbox_id: "wsb:x".into(),
+            ready: true,
+            protocol_version,
+            vm_processes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn ensure_daemon_protocol_accepts_current_and_refuses_mismatch() {
+        let ok = daemon_record_with_protocol(control_plane::IPC_PROTOCOL_VERSION);
+        assert!(ensure_daemon_protocol(&ok).is_ok());
+
+        // A daemon from a pre-versioning install (default 0) or a different
+        // build must be refused as backend_unavailable.
+        let stale = daemon_record_with_protocol(0);
+        assert_eq!(
+            ensure_daemon_protocol(&stale).unwrap_err().code,
+            MxcErrorCode::BackendUnavailable
+        );
+
+        let newer = daemon_record_with_protocol(control_plane::IPC_PROTOCOL_VERSION + 1);
+        assert_eq!(
+            ensure_daemon_protocol(&newer).unwrap_err().code,
+            MxcErrorCode::BackendUnavailable
+        );
+    }
+
+    #[test]
     fn extract_token_unwraps_wsb_prefix() {
         assert_eq!(extract_token("wsb:deadbeef").unwrap(), "deadbeef");
     }
@@ -1197,6 +1314,17 @@ mod tests {
     }
 
     #[test]
+    fn map_exec_status_error_protocol_is_backend_unavailable() {
+        let err = map_exec_status_error("ERR protocol client v1 != daemon v2");
+        assert_eq!(err.code, MxcErrorCode::BackendUnavailable);
+        assert!(
+            err.message.contains("client v1 != daemon v2"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    #[test]
     fn map_exec_status_error_without_err_prefix_uses_whole_status() {
         // Defensive: a status line missing the `ERR` prefix is still surfaced
         // verbatim rather than swallowed.
@@ -1400,6 +1528,7 @@ mod tests {
             nonce: "fixture".into(),
             active_sandbox_id: other_sandbox_id.into(),
             ready: true,
+            protocol_version: control_plane::IPC_PROTOCOL_VERSION,
             vm_processes: Vec::new(),
         };
         control_plane::write_daemon_record(&record).expect("write fixture daemon record");
@@ -1420,6 +1549,7 @@ mod tests {
             nonce: "stale".into(),
             active_sandbox_id: active_sandbox_id.into(),
             ready: false,
+            protocol_version: control_plane::IPC_PROTOCOL_VERSION,
             vm_processes: Vec::new(),
         };
         control_plane::write_daemon_record(&record).expect("write stale daemon record");


### PR DESCRIPTION
This PR hardens the Windows Sandbox state-aware daemon and lifecycle: it makes
daemon diagnostics observable, bounds a frozen guest with a cancellation-safe
exec watchdog, reports VM-slot contention coherently, and versions the
client/daemon IPC wire protocol behind a bilateral, daemon-enforced handshake.
Each change is backend-only, with no SDK or wire-schema impact.

**Details**

* **Daemon diagnostics are captured.** The daemon emits ~40 `[wsb-daemon]`
  diagnostics, and the VM-owning detached process is exactly where boot /
  teardown / orphan-reclaim failures need to be observable. `spawn_daemon`
  redirects the daemon's stderr to `daemon.log` in the per-sandbox owner-only
  record directory (append), and the start-timeout error names the concrete log
  path.
* **The streaming exec path has a cancellation-safe host-side watchdog.** A
  frozen-but-alive guest (the VM crash watchdog only fires once the VM processes
  are *gone*) would otherwise wedge the single-flight slot indefinitely. The
  watchdog deadline lives inside `stream_exec_on_guest`'s `select!` loop and is
  honoured only at frame boundaries, so a timeout can never truncate a data
  frame and desync the client's decoder. On expiry the daemon marks the guest
  slot Unusable and sends the client a clean synthetic timeout exit frame (the
  client reads with no deadline once streaming starts, so it is freed too).
* **VM-slot contention is reported coherently.** `HostVmLock::try_acquire`
  distinguishes genuine contention (the wait timed out) from a real create/wait
  failure: on contention the daemon exits with a distinct
  `DAEMON_EXIT_VM_SLOT_BUSY` code that `start` maps to `backend_unavailable`,
  while a real mutex failure propagates as an opaque backend error (with
  daemon.log diagnostics) rather than being mis-reported as busy. (`start` does
  not hold the slot itself — the daemon must own it for the VM's lifetime, so
  holding it across the spawn would deadlock; the distinct-exit-code mapping
  achieves the same observable outcome without that hazard.)
* **The IPC wire protocol is versioned behind a bilateral, daemon-enforced
  handshake.** The client declares its version as the trailing token of the
  `EXEC` line (`EXEC <nonce> <proto>`); the daemon refuses a mismatched or
  malformed version with `ERR protocol` before any frame I/O, so a
  differently-framed request is never parsed. An absent token maps to
  `LEGACY_IPC_PROTOCOL_VERSION`, so a future daemon cleanly refuses a legacy
  client instead of misframing it. `DaemonRecord` also carries a
  `protocol_version` (added with `#[serde(default)]` so a pre-versioning record
  reads back as incompatible) as a client-side fast-path (`ensure_daemon_protocol`).
  An orphaned daemon from a prior install authenticates (its nonce is in the
  record) but is refused when its wire version differs. `stop`/`deprovision`
  keep using the stable single-line `STOP` command (explicit `OK` ack) so an
  orphaned VM can always be reclaimed.
* Docs: `docs/windows-sandbox/windows-sandbox-reference.md` covers the
  daemon.log sink, the exec watchdog, the VM-slot busy mapping, and the
  wire-protocol handshake.

**Tests**

* Unit tests: `protocol_compatible` and a serde-default case (a pre-versioning
  record deserialises and reads back protocol-incompatible), `parse_client_protocol`,
  `ensure_daemon_protocol` accept/refuse, the `vm_slot_busy` exit-code
  classifier, a two-thread `named_mutex_try_acquire` test asserting a contended
  mutex returns `Ok(None)` (busy) rather than `Err`, the daemon `EXEC`
  matching/mismatched/malformed-version handshake, the `ERR protocol` status
  mapping to `backend_unavailable`, and a watchdog frame-boundary regression
  asserting no partial data frame precedes the terminal frame.
* `cargo fmt --all -- --check` and `cargo clippy` (affected crates,
  `-D warnings`): clean.
* `cargo test` (aarch64-pc-windows-msvc): windows_sandbox_lifecycle 180,
  wxc_windows_sandbox_daemon 27 — all pass.
