### PR TITLE
[LXC] Fix denied-symlink and most-specific masking that aborted the container

### DIFF
--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -28,7 +28,7 @@
 use std::collections::HashSet;
 use std::fmt::Write as FmtWrite;
 use std::os::unix::process::CommandExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::time::Duration;
 
@@ -597,33 +597,43 @@ fn is_file_mask_target(path: &str) -> bool {
 ///
 /// `std::fs::canonicalize` resolves symlinks at every level but requires the
 /// **whole** path to exist. To also cover not-yet-created denied paths under a
-/// symlinked ancestor, this walks up to the deepest existing ancestor,
-/// canonicalizes it, then re-appends the non-existent tail. Returns `None` only
-/// when no ancestor can be canonicalized (e.g. a relative path with no existing
-/// root).
+/// symlinked ancestor, this walks the components from the root: every existing
+/// prefix is canonicalized (following symlinks exactly like the kernel), while
+/// `.` and `..` in the not-yet-existent tail are folded lexically. Folding `..`
+/// this way is safe because a component that does not exist cannot be a symlink,
+/// so the result matches the target the kernel's path resolution would reach.
+/// Returns `None` only for an empty path.
+///
+/// A naive backward walk that collected `file_name()` silently dropped `..`
+/// components (Rust returns `None` for a `..` file name) and reconstructed the
+/// wrong target: `/link/missing/../secret` became `/real/missing/secret`
+/// instead of `/real/secret`, so the mask landed on a bystander path and the
+/// real denied target stayed exposed.
 fn resolve_through_symlinks(path: &Path) -> Option<PathBuf> {
-    // Fast path: the whole path exists, so canonicalize resolves every component.
-    if let Ok(real) = std::fs::canonicalize(path) {
-        return Some(real);
-    }
-    // Otherwise find the deepest existing ancestor, canonicalize it, and
-    // re-append the components below it that do not exist on the host yet.
-    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
-    let mut cur = path;
-    while let Some(parent) = cur.parent() {
-        if let Some(name) = cur.file_name() {
-            tail.push(name);
-        }
-        if let Ok(real_parent) = std::fs::canonicalize(parent) {
-            let mut result = real_parent;
-            for name in tail.iter().rev() {
-                result.push(name);
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => result.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
             }
-            return Some(result);
+            Component::Normal(name) => {
+                result.push(name);
+                // Canonicalize the prefix so far so symlinks are followed while
+                // it still exists; once a component is missing, canonicalize
+                // fails and the remaining tail is folded lexically above.
+                if let Ok(real) = std::fs::canonicalize(&result) {
+                    result = real;
+                }
+            }
         }
-        cur = parent;
     }
-    None
+    if result.as_os_str().is_empty() {
+        None
+    } else {
+        Some(result)
+    }
 }
 
 #[cfg(test)]
@@ -846,5 +856,41 @@ mod tests {
         assert!(plan.paths.is_none());
         // The dangling link is still masked, as a file.
         assert!(plan.files.contains(&link.to_string_lossy().into_owned()));
+    }
+
+    /// A denied path that traverses `..` under a symlinked ancestor with a
+    /// missing intermediate directory must fold the `..` and resolve to the real
+    /// target the kernel would reach. Regression test for a `..`-dropping bug
+    /// that reconstructed a bystander target (`/real/missing/secret`) and left
+    /// the real denied path (`/real/secret`) exposed.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_denied_paths_folds_dotdot_under_symlinked_ancestor() {
+        use wxc_common::logger::{Logger, Mode};
+        let dir = tempfile::tempdir().unwrap();
+        let base = std::fs::canonicalize(dir.path()).unwrap();
+        let real = base.join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = base.join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        // Deny .../link/missing/../secret — `missing` does not exist and the
+        // `..` cancels it, so the real target is .../real/secret.
+        let denied = link.join("missing").join("..").join("secret");
+        let policy = wxc_common::models::ContainerPolicy {
+            denied_paths: vec![denied.to_string_lossy().into_owned()],
+            ..Default::default()
+        };
+
+        let mut logger = Logger::new(Mode::Buffer);
+        let plan = resolve_denied_paths(&policy, &mut logger).expect("must not fail closed");
+        let out = plan
+            .paths
+            .expect("`..` under a symlinked ancestor must be rewritten");
+        assert_eq!(
+            out,
+            vec![real.join("secret").to_string_lossy().into_owned()],
+            "`..` must fold so the mask targets the real denied path, not a bystander"
+        );
     }
 }

--- a/src/backends/lxc/common/src/filesystem_mounts.rs
+++ b/src/backends/lxc/common/src/filesystem_mounts.rs
@@ -9,7 +9,7 @@
 //! - `readonlyPaths` → `bind,ro` mount
 //! - `deniedPaths` → masked (inaccessible inside container)
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use wxc_common::filesystem_resolve::{resolve_mount_order, FsIntent};
 use wxc_common::logger::Logger;
@@ -54,30 +54,45 @@ fn denied_path_is_file(host_path: &str) -> bool {
 ///
 /// `std::fs::canonicalize` resolves symlinks at every level but requires the
 /// **whole** path to exist. To also cover a denied path that does not yet exist
-/// under a symlinked ancestor, this walks up to the deepest existing ancestor,
-/// canonicalizes it, then re-appends the non-existent tail. Returns `None` only
-/// when no ancestor can be canonicalized. Mirrors the Bubblewrap backend's
-/// `resolve_through_symlinks` so both backends mask the same real target.
+/// under a symlinked ancestor, this walks the components from the root:
+/// every existing prefix is canonicalized (following symlinks exactly like the
+/// kernel), while `.` and `..` in the not-yet-existent tail are folded
+/// lexically. Folding `..` this way is safe because a component that does not
+/// exist cannot be a symlink, so the result matches the target the kernel's
+/// path resolution would reach. Returns `None` only for an empty path. Mirrors
+/// the Bubblewrap backend's `resolve_through_symlinks` so both backends mask the
+/// same real target.
+///
+/// A naive backward walk that collected `file_name()` silently dropped `..`
+/// components (Rust returns `None` for a `..` file name) and reconstructed the
+/// wrong target: `/link/missing/../secret` became `/real/missing/secret`
+/// instead of `/real/secret`, so the mask landed on a bystander path and the
+/// real denied target stayed exposed.
 fn resolve_through_symlinks(path: &Path) -> Option<PathBuf> {
-    if let Ok(real) = std::fs::canonicalize(path) {
-        return Some(real);
-    }
-    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
-    let mut cur = path;
-    while let Some(parent) = cur.parent() {
-        if let Some(name) = cur.file_name() {
-            tail.push(name);
-        }
-        if let Ok(real_parent) = std::fs::canonicalize(parent) {
-            let mut result = real_parent;
-            for name in tail.iter().rev() {
-                result.push(name);
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => result.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
             }
-            return Some(result);
+            Component::Normal(name) => {
+                result.push(name);
+                // Canonicalize the prefix so far so symlinks are followed while
+                // it still exists; once a component is missing, canonicalize
+                // fails and the remaining tail is folded lexically above.
+                if let Ok(real) = std::fs::canonicalize(&result) {
+                    result = real;
+                }
+            }
         }
-        cur = parent;
     }
-    None
+    if result.as_os_str().is_empty() {
+        None
+    } else {
+        Some(result)
+    }
 }
 
 /// Resolve a denied host path to the real host target that must be masked.
@@ -355,6 +370,38 @@ mod tests {
         // A path with no symlink component is returned as its canonical self.
         let plain = resolve_denied_host_path(real_file.to_str().unwrap()).unwrap();
         assert_eq!(plain, real_file.canonicalize().unwrap().to_str().unwrap());
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A denied path that traverses `..` under a symlinked ancestor with a
+    /// missing intermediate directory must fold the `..` and resolve to the
+    /// real target the kernel would reach, so the mask lands on the denied path
+    /// itself. Regression test for a `..`-dropping bug that reconstructed a
+    /// bystander target (`/real/missing/secret`) and left the real denied path
+    /// (`/real/secret`) exposed.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_denied_host_path_folds_dotdot_under_symlinked_ancestor() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!("mxc_lxc_dotdot_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let real = base.join("real");
+        let link = base.join("link");
+        std::fs::create_dir_all(&real).expect("create real dir");
+        symlink(&real, &link).expect("symlink ancestor to real");
+
+        // `<link>/missing/../secret`: `missing` does not exist and the `..`
+        // cancels it, so the real target is `<real>/secret`.
+        let denied = format!("{}/missing/../secret", link.to_str().unwrap());
+        let resolved = resolve_denied_host_path(&denied).unwrap();
+        let expected = real.canonicalize().unwrap().join("secret");
+        assert_eq!(
+            resolved,
+            expected.to_str().unwrap(),
+            "`..` must fold so the mask targets the real denied path, not a bystander"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/src/backends/lxc/common/src/filesystem_mounts.rs
+++ b/src/backends/lxc/common/src/filesystem_mounts.rs
@@ -104,10 +104,23 @@ fn resolve_through_symlinks(path: &Path) -> Option<PathBuf> {
 /// protection. This is the same reason the Bubblewrap backend resolves denied
 /// paths (`resolve_denied_paths`) before masking.
 ///
-/// Returns the original path unchanged when it does not traverse a symlink or
-/// cannot be resolved. Fails closed if a resolved path is not valid UTF-8: the
-/// LXC config is a `String` pipeline that cannot represent it faithfully, and a
-/// lossy replacement could mask the wrong path and leave the target exposed.
+/// Resolution goes through [`resolve_through_symlinks`], which canonicalizes
+/// every existing prefix (following symlinks like the kernel) and folds a
+/// not-yet-existing tail lexically. An existing, non-symlink path therefore
+/// comes back in its canonical absolute form — not necessarily byte-identical to
+/// the input; only a path that resolves to nothing (empty) is returned
+/// unchanged.
+///
+/// Fails closed in two cases, because emitting the mask anyway would silently
+/// mask the wrong path or abort `lxc-start` with an opaque error:
+/// - the resolved path is not valid UTF-8 — the LXC config is a `String`
+///   pipeline that cannot represent it faithfully, and a lossy replacement could
+///   mask the wrong path and leave the target exposed; or
+/// - the resolved path is *still* a symlink — a dangling or otherwise
+///   unresolvable link. Masking over a symlink node aborts the container, and
+///   unlike Bubblewrap (which tolerates a `/dev/null` bind over a symlink node)
+///   the LXC mount pipeline cannot guarantee that, so refusing to start is the
+///   safe, deterministic choice.
 fn resolve_denied_host_path(host_path: &str) -> Result<String, String> {
     match resolve_through_symlinks(Path::new(host_path)) {
         Some(resolved) => {
@@ -118,6 +131,21 @@ fn resolve_denied_host_path(host_path: &str) -> Result<String, String> {
                     host_path
                 )
             })?;
+            // Fail closed if resolution left a symlink in place (a dangling or
+            // otherwise unresolvable link): masking over/through it would abort
+            // the container, so refuse to start rather than emit a broken mount.
+            // A non-existent (but non-symlink) tail returns `Err` from
+            // `symlink_metadata` and is treated as safe to mask as an empty dir.
+            if std::fs::symlink_metadata(real)
+                .map(|meta| meta.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                return Err(format!(
+                    "deniedPaths entry {:?} resolves to {:?}, which is still a symlink (dangling \
+                     or unresolvable) and cannot be safely masked; refusing to start.",
+                    host_path, real
+                ));
+            }
             Ok(real.to_owned())
         }
         None => Ok(host_path.to_owned()),
@@ -140,6 +168,36 @@ fn has_rebound_descendant(container_path: &str, rebound: &[String]) -> bool {
     rebound.iter().any(|c| c.starts_with(&prefix))
 }
 
+/// Container-side comparison forms of a single re-bound (rw/ro) path: the path
+/// as written, and — when it traverses a symlink — its symlink-resolved real
+/// target. Both are leading-slash-trimmed for comparison against denied
+/// directories in [`has_rebound_descendant`].
+///
+/// A denied directory is masked at its *resolved* path (see
+/// [`resolve_denied_host_path`]). A child re-bound through a symlinked ancestor
+/// (e.g. `readwritePaths: ["/mnt/x/link/child"]` under
+/// `deniedPaths: ["/mnt/x/link"]`, where `link` is a host symlink visible via a
+/// parent bind) physically lands *inside* that resolved mask, so the descendant
+/// check must see the child's resolved form to select the writable mask and
+/// avoid the read-only-tmpfs `mkdir` abort. Emitting the original form too keeps
+/// the plain (no-symlink) case matching unchanged. Resolution here is
+/// best-effort (comparison only): a path that cannot be resolved contributes
+/// just its original form.
+fn rebound_comparison_paths(host_path: &str) -> Vec<String> {
+    let original = host_path.trim_start_matches('/').to_string();
+    let mut out = Vec::with_capacity(2);
+    if let Some(resolved) = resolve_through_symlinks(Path::new(host_path)) {
+        if let Some(resolved) = resolved.to_str() {
+            let resolved = resolved.trim_start_matches('/').to_string();
+            if resolved != original {
+                out.push(resolved);
+            }
+        }
+    }
+    out.push(original);
+    out
+}
+
 /// Configure filesystem bind mounts on the container based on the policy.
 ///
 /// Adds `lxc.mount.entry` config items for each path in the policy.
@@ -154,10 +212,15 @@ pub fn configure_filesystem_mounts(
     // whether a denied *directory* must be masked with a writable tmpfs so a
     // more-specific descendant's mountpoint can be created inside it. Mirrors
     // the Bubblewrap backend, which masks denied dirs with a writable `--tmpfs`.
+    // Each mount contributes both its literal path and — when it traverses a
+    // symlink — its resolved real target, because a denied directory is masked
+    // at its resolved path; a child re-bound through a symlinked ancestor lands
+    // inside that resolved mask and must still be detected as a descendant (see
+    // `rebound_comparison_paths`).
     let rebound_container_paths: Vec<String> = mounts
         .iter()
         .filter(|m| matches!(m.intent, FsIntent::ReadWrite | FsIntent::ReadOnly))
-        .map(|m| m.path.trim_start_matches('/').to_string())
+        .flat_map(|m| rebound_comparison_paths(&m.path))
         .collect();
 
     for mount in &mounts {
@@ -224,8 +287,12 @@ pub fn configure_filesystem_mounts(
                     // tmpfs so the mountpoint can be created — the host directory
                     // stays hidden underneath, only the ephemeral tmpfs is
                     // writable, and the descendant bind lands on top of it. This
-                    // mirrors the Bubblewrap backend's writable `--tmpfs`.
-                    format!("tmpfs {} tmpfs create=dir 0 0", container_path)
+                    // mirrors the Bubblewrap backend's writable `--tmpfs`. Cap it
+                    // at a small `size=1m`: the mask only needs to hold empty
+                    // mountpoint directories, so bounding it prevents sandboxed
+                    // code from exhausting host memory by writing into the
+                    // ephemeral tmpfs.
+                    format!("tmpfs {} tmpfs size=1m,create=dir 0 0", container_path)
                 } else {
                     format!("tmpfs {} tmpfs ro,size=0,create=dir 0 0", container_path)
                 };
@@ -357,15 +424,24 @@ mod tests {
         // A denied symlink is rewritten to its real target, and the mask type is
         // chosen from that target (dir -> tmpfs, file -> /dev/null).
         let resolved_dir = resolve_denied_host_path(link_to_dir.to_str().unwrap()).unwrap();
-        assert_eq!(resolved_dir, real_dir.canonicalize().unwrap().to_str().unwrap());
-        assert!(!denied_path_is_file(&resolved_dir), "symlink->dir masks as dir");
+        assert_eq!(
+            resolved_dir,
+            real_dir.canonicalize().unwrap().to_str().unwrap()
+        );
+        assert!(
+            !denied_path_is_file(&resolved_dir),
+            "symlink->dir masks as dir"
+        );
 
         let resolved_file = resolve_denied_host_path(link_to_file.to_str().unwrap()).unwrap();
         assert_eq!(
             resolved_file,
             real_file.canonicalize().unwrap().to_str().unwrap()
         );
-        assert!(denied_path_is_file(&resolved_file), "symlink->file masks as file");
+        assert!(
+            denied_path_is_file(&resolved_file),
+            "symlink->file masks as file"
+        );
 
         // A path with no symlink component is returned as its canonical self.
         let plain = resolve_denied_host_path(real_file.to_str().unwrap()).unwrap();
@@ -401,6 +477,64 @@ mod tests {
             resolved,
             expected.to_str().unwrap(),
             "`..` must fold so the mask targets the real denied path, not a bystander"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A denied path that resolves to a *dangling* symlink (its target does not
+    /// exist) must fail closed: masking over the symlink node aborts the
+    /// container, so refusing to start is the safe, deterministic outcome.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_denied_host_path_fails_closed_on_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!("mxc_lxc_dangling_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).expect("create base");
+        let dangling = base.join("dangling");
+        symlink(base.join("nonexistent_target"), &dangling).expect("create dangling symlink");
+
+        let err = resolve_denied_host_path(dangling.to_str().unwrap())
+            .expect_err("a dangling denied symlink must fail closed");
+        assert!(
+            err.contains("still a symlink"),
+            "error must explain the residual symlink: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// A rw/ro child re-bound through a symlinked ancestor must contribute its
+    /// symlink-resolved form so a denied parent masked at its resolved path still
+    /// detects the descendant. Without the resolved form the prefix compare would
+    /// miss it, (re)select the read-only `size=0` mask, and abort when LXC tries
+    /// to create the child mountpoint inside it.
+    #[cfg(unix)]
+    #[test]
+    fn rebound_comparison_paths_detects_child_under_symlinked_denied_parent() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!("mxc_lxc_rebound_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let real = base.join("real");
+        let link = base.join("link");
+        std::fs::create_dir_all(real.join("child")).expect("create real/child");
+        symlink(&real, &link).expect("symlink link -> real");
+
+        // Denied parent "<base>/link" is masked at its resolved path "<base>/real".
+        let denied = resolve_denied_host_path(link.to_str().unwrap()).unwrap();
+        let denied_container = denied.trim_start_matches('/');
+
+        // The rw child is referenced via the symlink: "<base>/link/child".
+        let child = format!("{}/child", link.to_str().unwrap());
+        let rebound = rebound_comparison_paths(&child);
+
+        assert!(
+            has_rebound_descendant(denied_container, &rebound),
+            "resolved child must be seen as a descendant of the resolved denied parent: \
+             denied={denied_container:?} rebound={rebound:?}"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/src/backends/lxc/common/src/filesystem_mounts.rs
+++ b/src/backends/lxc/common/src/filesystem_mounts.rs
@@ -9,6 +9,8 @@
 //! - `readonlyPaths` → `bind,ro` mount
 //! - `deniedPaths` → masked (inaccessible inside container)
 
+use std::path::{Path, PathBuf};
+
 use wxc_common::filesystem_resolve::{resolve_mount_order, FsIntent};
 use wxc_common::logger::Logger;
 use wxc_common::models::ContainerPolicy;
@@ -47,6 +49,82 @@ fn denied_path_is_file(host_path: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Resolve every symlink in `path` (leaf and ancestors) to a real filesystem
+/// path, tolerating trailing components that do not exist yet.
+///
+/// `std::fs::canonicalize` resolves symlinks at every level but requires the
+/// **whole** path to exist. To also cover a denied path that does not yet exist
+/// under a symlinked ancestor, this walks up to the deepest existing ancestor,
+/// canonicalizes it, then re-appends the non-existent tail. Returns `None` only
+/// when no ancestor can be canonicalized. Mirrors the Bubblewrap backend's
+/// `resolve_through_symlinks` so both backends mask the same real target.
+fn resolve_through_symlinks(path: &Path) -> Option<PathBuf> {
+    if let Ok(real) = std::fs::canonicalize(path) {
+        return Some(real);
+    }
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut cur = path;
+    while let Some(parent) = cur.parent() {
+        if let Some(name) = cur.file_name() {
+            tail.push(name);
+        }
+        if let Ok(real_parent) = std::fs::canonicalize(parent) {
+            let mut result = real_parent;
+            for name in tail.iter().rev() {
+                result.push(name);
+            }
+            return Some(result);
+        }
+        cur = parent;
+    }
+    None
+}
+
+/// Resolve a denied host path to the real host target that must be masked.
+///
+/// A denied path is realised as a mask mount over the container-side path; if
+/// that path is (or traverses) a symlink, LXC aborts, because the kernel refuses
+/// to mount over — or through — a symlink (an anti-symlink-attack protection).
+/// Masking the resolved real target hides the same object without tripping that
+/// protection. This is the same reason the Bubblewrap backend resolves denied
+/// paths (`resolve_denied_paths`) before masking.
+///
+/// Returns the original path unchanged when it does not traverse a symlink or
+/// cannot be resolved. Fails closed if a resolved path is not valid UTF-8: the
+/// LXC config is a `String` pipeline that cannot represent it faithfully, and a
+/// lossy replacement could mask the wrong path and leave the target exposed.
+fn resolve_denied_host_path(host_path: &str) -> Result<String, String> {
+    match resolve_through_symlinks(Path::new(host_path)) {
+        Some(resolved) => {
+            let real = resolved.to_str().ok_or_else(|| {
+                format!(
+                    "deniedPaths entry {:?} resolves to a non-UTF-8 host path that cannot be \
+                     safely masked; refusing to start.",
+                    host_path
+                )
+            })?;
+            Ok(real.to_owned())
+        }
+        None => Ok(host_path.to_owned()),
+    }
+}
+
+/// Whether any re-bound (read-write or read-only) mount is nested strictly
+/// inside the denied directory at `container_path`.
+///
+/// When a denied directory contains a re-bound descendant, LXC must create that
+/// descendant's mountpoint **inside** the directory's mask before binding it. A
+/// read-only, zero-size tmpfs rejects that `mkdir` and the container aborts, so
+/// such a directory must instead be masked with a writable tmpfs (see the
+/// `FsIntent::Denied` branch). `container_path` and `rebound` are both
+/// leading-slash-trimmed container paths, so a trailing `/` on the prefix keeps
+/// the match at a path boundary (`data` never matches `database`) and excludes
+/// an exact same-path entry (which is not a descendant).
+fn has_rebound_descendant(container_path: &str, rebound: &[String]) -> bool {
+    let prefix = format!("{container_path}/");
+    rebound.iter().any(|c| c.starts_with(&prefix))
+}
+
 /// Configure filesystem bind mounts on the container based on the policy.
 ///
 /// Adds `lxc.mount.entry` config items for each path in the policy.
@@ -55,7 +133,19 @@ pub fn configure_filesystem_mounts(
     policy: &ContainerPolicy,
     logger: &mut Logger,
 ) -> Result<(), String> {
-    for mount in resolve_mount_order(policy) {
+    let mounts = resolve_mount_order(policy);
+
+    // Container-side paths of every re-bound (rw/ro) mount, used to decide
+    // whether a denied *directory* must be masked with a writable tmpfs so a
+    // more-specific descendant's mountpoint can be created inside it. Mirrors
+    // the Bubblewrap backend, which masks denied dirs with a writable `--tmpfs`.
+    let rebound_container_paths: Vec<String> = mounts
+        .iter()
+        .filter(|m| matches!(m.intent, FsIntent::ReadWrite | FsIntent::ReadOnly))
+        .map(|m| m.path.trim_start_matches('/').to_string())
+        .collect();
+
+    for mount in &mounts {
         let host_path = &mount.path;
         validate_path(host_path)?;
         let container_path = host_path.trim_start_matches('/');
@@ -82,17 +172,45 @@ pub fn configure_filesystem_mounts(
                 container.set_config_item("lxc.mount.entry", &mount_entry)?;
             }
             FsIntent::Denied => {
-                // Classify the denied path from the HOST path, not the container
-                // rootfs path. Denied paths are host paths, and the rootfs path
-                // (`<lxc_path>/<name>/rootfs/<container_path>`) does not exist
-                // until mounts are applied, so inspecting it would always look
-                // "missing" and mask every deny as a directory. Host reality
-                // decides the `create=` type instead.
-                let is_file = denied_path_is_file(host_path);
+                // Resolve the denied path through symlinks to its real host
+                // target BEFORE masking. Masking mounts a tmpfs (dir) or a
+                // /dev/null bind (file) over the container-side path; if that
+                // path is a symlink, LXC aborts the container because the kernel
+                // refuses to mount over/through a symlink. Masking the resolved
+                // real target hides the same object without the abort. (The
+                // Bubblewrap backend resolves denied paths for the same reason.)
+                let real_host = resolve_denied_host_path(host_path)?;
+                if real_host != *host_path {
+                    logger.log_line(&format!(
+                        "Denied path {} resolves through a symlink; masking its real target {}",
+                        host_path, real_host
+                    ));
+                }
+                validate_path(&real_host)?;
+                let container_path = real_host.trim_start_matches('/');
+
+                // Classify the denied path from the resolved HOST path, not the
+                // container rootfs path. Denied paths are host paths, and the
+                // rootfs path (`<lxc_path>/<name>/rootfs/<container_path>`) does
+                // not exist until mounts are applied, so inspecting it would
+                // always look "missing" and mask every deny as a directory.
+                // Host reality decides the `create=` type instead.
+                let is_file = denied_path_is_file(&real_host);
 
                 // Use /dev/null bind mount for files, tmpfs for directories.
                 let mount_entry = if is_file {
                     format!("/dev/null {} none bind,ro,create=file 0 0", container_path)
+                } else if has_rebound_descendant(container_path, &rebound_container_paths) {
+                    // A more-specific rw/ro path is re-bound INSIDE this denied
+                    // directory (most-specific-wins). LXC must create that
+                    // descendant's mountpoint inside this mask, which a
+                    // read-only, zero-size tmpfs rejects (the mkdir fails with
+                    // EROFS/ENOSPC and the container aborts). Use a writable
+                    // tmpfs so the mountpoint can be created — the host directory
+                    // stays hidden underneath, only the ephemeral tmpfs is
+                    // writable, and the descendant bind lands on top of it. This
+                    // mirrors the Bubblewrap backend's writable `--tmpfs`.
+                    format!("tmpfs {} tmpfs create=dir 0 0", container_path)
                 } else {
                     format!("tmpfs {} tmpfs ro,size=0,create=dir 0 0", container_path)
                 };
@@ -158,6 +276,27 @@ mod tests {
     }
 
     #[test]
+    fn has_rebound_descendant_detects_nested_rebind_only() {
+        let rebound = vec![
+            "mnt/msptest/data/secret_child".to_string(),
+            "mnt/other/rw".to_string(),
+        ];
+        // A denied parent that contains a re-bound child needs a writable mask.
+        assert!(has_rebound_descendant("mnt/msptest/data", &rebound));
+        // A denied directory with no nested re-bind keeps the tight mask.
+        assert!(!has_rebound_descendant("mnt/msptest/empty", &rebound));
+        // A shared string prefix that is not a path boundary is NOT a descendant
+        // ("data" must not match "database").
+        assert!(!has_rebound_descendant("mnt/msptest/dat", &rebound));
+        // An exact same-path entry is not a descendant (same-path ties are
+        // collapsed upstream and must not force a writable mask).
+        assert!(!has_rebound_descendant(
+            "mnt/msptest/data/secret_child",
+            &rebound
+        ));
+    }
+
+    #[test]
     fn denied_path_is_file_reflects_host_reality() {
         use std::io::Write;
         let base = std::env::temp_dir();
@@ -179,5 +318,44 @@ mod tests {
 
         let _ = std::fs::remove_file(&file_path);
         let _ = std::fs::remove_dir_all(&dir_path);
+    }
+
+    /// A denied *symlink* must be resolved to its real target before masking, so
+    /// the mask never lands on the symlink node (which aborts the container).
+    /// symlink->dir stays a directory mask; symlink->file becomes a file mask.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_denied_host_path_rewrites_symlink_to_real_target() {
+        use std::os::unix::fs::symlink;
+
+        let base = std::env::temp_dir().join(format!("mxc_lxc_symresolve_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let real_dir = base.join("real_dir");
+        let real_file = base.join("real_file.txt");
+        let link_to_dir = base.join("link_to_dir");
+        let link_to_file = base.join("link_to_file");
+        std::fs::create_dir_all(&real_dir).expect("create real dir");
+        std::fs::write(&real_file, b"x").expect("create real file");
+        symlink(&real_dir, &link_to_dir).expect("symlink to dir");
+        symlink(&real_file, &link_to_file).expect("symlink to file");
+
+        // A denied symlink is rewritten to its real target, and the mask type is
+        // chosen from that target (dir -> tmpfs, file -> /dev/null).
+        let resolved_dir = resolve_denied_host_path(link_to_dir.to_str().unwrap()).unwrap();
+        assert_eq!(resolved_dir, real_dir.canonicalize().unwrap().to_str().unwrap());
+        assert!(!denied_path_is_file(&resolved_dir), "symlink->dir masks as dir");
+
+        let resolved_file = resolve_denied_host_path(link_to_file.to_str().unwrap()).unwrap();
+        assert_eq!(
+            resolved_file,
+            real_file.canonicalize().unwrap().to_str().unwrap()
+        );
+        assert!(denied_path_is_file(&resolved_file), "symlink->file masks as file");
+
+        // A path with no symlink component is returned as its canonical self.
+        let plain = resolve_denied_host_path(real_file.to_str().unwrap()).unwrap();
+        assert_eq!(plain, real_file.canonicalize().unwrap().to_str().unwrap());
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }


### PR DESCRIPTION
Follow-up to #630 (merged). Linked work item: AB#62861419.

#630 added LXC denied-path masking and the most-specific-path resolver, but two runtime paths abort the LXC container at startup. Neither is exercised by CI, which does not run the root+LXC end-to-end scripts under `tests/scripts/run_lxc_*_test.sh` (they need root, LXC, and a Linux host), so #630 merged green with both latent.

### 1. Denied symlink masking
A denied path that is (or traverses) a symlink was masked by mounting a tmpfs / `/dev/null` bind over the symlink node. The kernel refuses to mount over or through a symlink, so `lxc-start` aborted (`Received container state "ABORTING"`). Each denied path is now resolved to its real host target before masking, mirroring the Bubblewrap backend''s `resolve_denied_paths` / `resolve_through_symlinks`.

### 2. Most-specific-path masking
A denied *directory* containing a re-bound rw/ro descendant (e.g. `deniedPaths: ["/mnt/x/data"]` + `readwritePaths: ["/mnt/x/data/child"]`) was masked with a read-only, zero-size tmpfs. LXC must create the descendant''s mountpoint **inside** that mask, and `mkdir` in a `ro,size=0` tmpfs fails (EROFS/ENOSPC), so the container aborted. Such a directory is now masked with a **writable** tmpfs so the mountpoint can be created (mirroring Bubblewrap''s writable `--tmpfs`); leaf denies keep the tight `ro,size=0` mask.

Both fixes are localized to `src/backends/lxc/common/src/filesystem_mounts.rs`. **No schema or wire-format changes.** The test configs/scripts that exercise them already landed in #630.

### Validation (Linux + LXC host, as root)
- `tests/scripts/run_lxc_all_tests.sh` — **8/8 pass** (previously aborted on *Most-Specific Path* and *Denied Masking*).
- `cargo test -p lxc_common` — **42/42** (adds a unit test for the writable-mask descendant check).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/662)