### PR TITLE
Add processContainer.captureDenials config for Windows denial capture

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -61,8 +61,9 @@ production configs and the dev schema when working on experimental features:
         "leastPrivilege": false,
         "capabilities": ["internetClient"],
         "captureDenials": {                // Windows-only: record the process's access
-            "outputPath": "C:\\logs\\denials.etl"  // attempts to a learning-mode ETL trace.
-        }                                  // Omit outputPath for a managed per-run temp file.
+            "outputPath": "C:\\logs\\denials.etl"  // attempts to a learning-mode ETL trace. The
+        }                                  // parent dir must already exist; omit outputPath
+                                           // for a managed per-run temp file.
     },
 
     "lxc": {                               // LXC-specific

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -61,6 +61,10 @@ production configs and the dev schema when working on experimental features:
         "leastPrivilege": false,
         "capabilities": ["internetClient"],
         "captureDenials": {                // Windows-only: record the process's access
+            "mode": "block-and-log",       // "block-and-log" (default): access stays denied and
+                                           // is logged (deny-by-default preserved). "allow-and-log":
+                                           // access is allowed and logged (audit; relaxes
+                                           // deny-by-default, emits a security warning).
             "outputPath": "C:\\logs\\denials.etl"  // attempts to a learning-mode ETL trace. The
         }                                  // parent dir must already exist; omit outputPath
                                            // for a managed per-run temp file.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -59,7 +59,10 @@ production configs and the dev schema when working on experimental features:
 
     "processContainer": {                  // Process-based container-specific
         "leastPrivilege": false,
-        "capabilities": ["internetClient"]
+        "capabilities": ["internetClient"],
+        "captureDenials": {                // Windows-only: record the process's access
+            "outputPath": "C:\\logs\\denials.etl"  // attempts to a learning-mode ETL trace.
+        }                                  // Omit outputPath for a managed per-run temp file.
     },
 
     "lxc": {                               // LXC-specific

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -61,8 +61,8 @@ production configs and the dev schema when working on experimental features:
         "leastPrivilege": false,
         "capabilities": ["internetClient"],
         "captureDenials": {                // Windows-only: record the process's access
-            "mode": "block-and-log",       // "block-and-log" (default): access stays denied and
-                                           // is logged (deny-by-default preserved). "allow-and-log":
+            "mode": "block",               // "block" (default): access stays denied and
+                                           // is logged (deny-by-default preserved). "allow":
                                            // access is allowed and logged (audit; relaxes
                                            // deny-by-default, emits a security warning).
             "outputPath": "C:\\logs\\denials.etl"  // attempts to a learning-mode ETL trace. The

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -48,6 +48,17 @@
       "additionalProperties": false,
       "description": "Windows denial-capture settings. The presence of the `captureDenials` object enables capture; all fields are optional.",
       "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CaptureDenialsMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block-and-log` when omitted."
+        },
         "outputPath": {
           "description": "Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist.",
           "type": [
@@ -57,6 +68,25 @@
         }
       },
       "type": "object"
+    },
+    "CaptureDenialsMode": {
+      "description": "How `captureDenials` handles each ungranted access check while recording it.",
+      "oneOf": [
+        {
+          "description": "`block-and-log` — the access stays **denied** and the denial is recorded. Deny-by-default containment is preserved; this is the safe default.",
+          "enum": [
+            "block-and-log"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "`allow-and-log` — the access is **allowed** and recorded (audit mode). This relaxes deny-by-default for the run, so it is a security-sensitive choice and the runner emits a security warning.",
+          "enum": [
+            "allow-and-log"
+          ],
+          "type": "string"
+        }
+      ]
     },
     "ClipboardPolicy": {
       "description": "Clipboard access level.",

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -49,7 +49,7 @@
       "description": "Windows denial-capture settings. The presence of the `captureDenials` object enables capture; all fields are optional.",
       "properties": {
         "outputPath": {
-          "description": "Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist and be writable.",
+          "description": "Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist.",
           "type": [
             "string",
             "null"

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -44,6 +44,20 @@
       },
       "type": "object"
     },
+    "CaptureDenials": {
+      "additionalProperties": false,
+      "description": "Windows denial-capture settings. The presence of the `captureDenials` object enables capture; all fields are optional.",
+      "properties": {
+        "outputPath": {
+          "description": "Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist and be writable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "ClipboardPolicy": {
       "description": "Clipboard access level.",
       "enum": [
@@ -645,6 +659,17 @@
             "array",
             "null"
           ]
+        },
+        "captureDenials": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CaptureDenials"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Windows denial capture. When present, the runner records the sandboxed process's access attempts to a learning-mode ETL trace for later inspection. Requires a host that exposes the learning-mode OS API."
         },
         "learningMode": {
           "description": "AppContainer permissive learning mode.",

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -57,7 +57,7 @@
               "type": "null"
             }
           ],
-          "description": "How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block-and-log` when omitted."
+          "description": "How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block` when omitted."
         },
         "outputPath": {
           "description": "Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist.",
@@ -73,16 +73,16 @@
       "description": "How `captureDenials` handles each ungranted access check while recording it.",
       "oneOf": [
         {
-          "description": "`block-and-log` — the access stays **denied** and the denial is recorded. Deny-by-default containment is preserved; this is the safe default.",
+          "description": "`block` — the access stays **denied** and the denial is recorded. Deny-by-default containment is preserved; this is the safe default.",
           "enum": [
-            "block-and-log"
+            "block"
           ],
           "type": "string"
         },
         {
-          "description": "`allow-and-log` — the access is **allowed** and recorded (audit mode). This relaxes deny-by-default for the run, so it is a security-sensitive choice and the runner emits a security warning.",
+          "description": "`allow` — the access is **allowed** and recorded (audit mode). This relaxes deny-by-default for the run, so it is a security-sensitive choice and the runner emits a security warning.",
           "enum": [
-            "allow-and-log"
+            "allow"
           ],
           "type": "string"
         }

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -42,10 +42,19 @@ export interface BaseProcessUi {
  */
 export interface CaptureDenials {
   /**
+   * How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block-and-log` when omitted.
+   */
+  mode?: CaptureDenialsMode | null;
+  /**
    * Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist.
    */
   outputPath?: string | null;
 }
+
+/**
+ * How `captureDenials` handles each ungranted access check while recording it.
+ */
+export type CaptureDenialsMode = "block-and-log" | "allow-and-log";
 
 /**
  * Clipboard access level.

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -42,7 +42,7 @@ export interface BaseProcessUi {
  */
 export interface CaptureDenials {
   /**
-   * Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist and be writable.
+   * Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist.
    */
   outputPath?: string | null;
 }

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -38,6 +38,16 @@ export interface BaseProcessUi {
 }
 
 /**
+ * Windows denial-capture settings. The presence of the `captureDenials` object enables capture; all fields are optional.
+ */
+export interface CaptureDenials {
+  /**
+   * Absolute path where the denial ETL trace is written. The caller names the path; the OS opens it under the caller's own identity when the trace is sealed. When omitted, MXC writes the trace to a managed per-run temporary file. The parent directory must already exist and be writable.
+   */
+  outputPath?: string | null;
+}
+
+/**
  * Clipboard access level.
  */
 export type ClipboardPolicy = "none" | "read" | "write" | "all";
@@ -299,6 +309,10 @@ export interface ProcessContainer {
    * AppContainer capabilities (e.g. `internetClient`, `registryRead`).
    */
   capabilities?: string[] | null;
+  /**
+   * Windows denial capture. When present, the runner records the sandboxed process's access attempts to a learning-mode ETL trace for later inspection. Requires a host that exposes the learning-mode OS API.
+   */
+  captureDenials?: CaptureDenials | null;
   /**
    * AppContainer permissive learning mode.
    */

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -42,7 +42,7 @@ export interface BaseProcessUi {
  */
 export interface CaptureDenials {
   /**
-   * How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block-and-log` when omitted.
+   * How each ungranted access check is handled while it is recorded. Both modes log every access the policy does not grant to the ETL trace; the mode only decides whether that access is blocked or allowed. Defaults to `block` when omitted.
    */
   mode?: CaptureDenialsMode | null;
   /**
@@ -54,7 +54,7 @@ export interface CaptureDenials {
 /**
  * How `captureDenials` handles each ungranted access check while recording it.
  */
-export type CaptureDenialsMode = "block-and-log" | "allow-and-log";
+export type CaptureDenialsMode = "block" | "allow";
 
 /**
  * Clipboard access level.

--- a/sdk/node/tests/unit/wire-conformance.test.ts
+++ b/sdk/node/tests/unit/wire-conformance.test.ts
@@ -199,10 +199,14 @@ type _WslcWireKeys = AssertTrue<Equivalent<OnlyInWire<WslcConfig, WireWslc>, nev
 type _PortMappingWireKeys = AssertTrue<Equivalent<OnlyInWire<PublicPortMapping, WirePortMapping>, never>>;
 type _LxcWireKeys = AssertTrue<Equivalent<OnlyInWire<LxcConfig, WireLxc>, never>>;
 
-// `processContainer.learningMode` is a wire field the SDK does not expose (the
-// AppContainer permissive learning mode is not surfaced through the policy API).
+// `processContainer.learningMode` and `processContainer.captureDenials` are wire
+// fields the SDK does not yet expose (the AppContainer learning-mode features are
+// not surfaced through the policy API).
 type _ProcessContainerWireKeys = AssertTrue<
-  Equivalent<OnlyInWire<ProcessContainerConfig, WireProcessContainer>, 'learningMode'>
+  Equivalent<
+    OnlyInWire<ProcessContainerConfig, WireProcessContainer>,
+    'learningMode' | 'captureDenials'
+  >
 >;
 
 // `seatbelt.guiAccess` and `seatbelt.launchMethod` are wire fields the one-shot

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -8,10 +8,10 @@ use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
-    ContainerPolicy, ContainmentBackend, ExecutionRequest, ExperimentalConfig,
-    IsolationSessionConfig, LifecycleConfig, LxcConfig, NetworkEnforcementMode, NetworkPolicy,
-    PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig, TelemetryConfig, TestFeatureConfig,
-    UiPolicy, WindowsSandboxConfig, WslcConfig,
+    CaptureDenialsConfig, ContainerPolicy, ContainmentBackend, ExecutionRequest,
+    ExperimentalConfig, IsolationSessionConfig, LifecycleConfig, LxcConfig, NetworkEnforcementMode,
+    NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig, TelemetryConfig,
+    TestFeatureConfig, UiPolicy, WindowsSandboxConfig, WslcConfig,
 };
 use crate::mxc_error::MxcError;
 use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
@@ -592,6 +592,43 @@ fn map_wire_containment(c: Option<&wire::Containment>) -> ContainmentBackend {
     }
 }
 
+/// Validates a caller-specified `processContainer.captureDenials.outputPath`: it
+/// must be an absolute path whose parent directory already exists (the runner
+/// opens the file there when it seals the trace, under the caller's own
+/// identity). A relative path or a missing parent yields an actionable error.
+fn validate_capture_denials_output_path(path: &str, logger: &mut Logger) -> Result<(), WxcError> {
+    let candidate = std::path::Path::new(path);
+    if !candidate.is_absolute() {
+        let msg = format!(
+            "processContainer.captureDenials.outputPath must be an absolute path: '{path}'"
+        );
+        logger.log_line(&msg);
+        return Err(WxcError::ConfigParse(msg));
+    }
+    match candidate.parent() {
+        // An absolute path always has a parent; an empty parent means the path
+        // is a filesystem root, which cannot be a trace file.
+        Some(parent) if parent.as_os_str().is_empty() => {
+            let msg = format!(
+                "processContainer.captureDenials.outputPath must name a file, not a \
+                 directory root: '{path}'"
+            );
+            logger.log_line(&msg);
+            Err(WxcError::ConfigParse(msg))
+        }
+        Some(parent) if !parent.is_dir() => {
+            let msg = format!(
+                "processContainer.captureDenials.outputPath parent directory does not \
+                 exist: '{}'",
+                parent.display()
+            );
+            logger.log_line(&msg);
+            Err(WxcError::ConfigParse(msg))
+        }
+        _ => Ok(()),
+    }
+}
+
 // `allow_missing_command` relaxes the `require_process == true` arms so that a
 // CLI command-line override (provided by the driver after parsing) can stand in
 // for `process.commandLine`. When set, a missing or empty `commandLine` is
@@ -742,6 +779,20 @@ fn convert_wire_config(
                 } else {
                     true
                 }
+            });
+        }
+
+        // captureDenials (Windows denial capture). Presence enables capture: the
+        // runner records the process's access attempts to a learning-mode ETL
+        // trace while enforcement stays unchanged. The optional outputPath names
+        // where the trace is sealed; validate it eagerly so a bad path fails at
+        // parse time rather than deep in the runner.
+        if let Some(cd) = ac.capture_denials {
+            if let Some(path) = cd.output_path.as_deref() {
+                validate_capture_denials_output_path(path, logger)?;
+            }
+            policy.capture_denials = Some(CaptureDenialsConfig {
+                output_path: cd.output_path,
             });
         }
 
@@ -1738,6 +1789,98 @@ mod tests {
         assert_eq!(req.policy.capabilities[0], "internetClient");
         assert_eq!(req.policy.capabilities[1], "privateNetworkClientServer");
         assert_eq!(req.policy.capabilities[2], "documentsLibrary");
+    }
+
+    #[test]
+    fn capture_denials_absent_leaves_policy_none() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(req.policy.capture_denials.is_none());
+    }
+
+    #[test]
+    fn capture_denials_presence_enables_capture_without_path() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {"captureDenials": {}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cd = req
+            .policy
+            .capture_denials
+            .expect("captureDenials presence should enable capture");
+        assert!(cd.output_path.is_none());
+    }
+
+    #[test]
+    fn capture_denials_threads_valid_absolute_output_path() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("denials.etl");
+        let path_json = serde_json::to_string(&path.to_string_lossy()).unwrap();
+        let json = format!(
+            r#"{{
+                "process": {{"commandLine": "print('test')"}},
+                "containment": "processcontainer",
+                "processContainer": {{"captureDenials": {{"outputPath": {path_json}}}}}
+            }}"#
+        );
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cd = req.policy.capture_denials.expect("captureDenials present");
+        assert_eq!(
+            cd.output_path.as_deref(),
+            Some(path.to_string_lossy().as_ref())
+        );
+    }
+
+    #[test]
+    fn capture_denials_relative_output_path_rejected() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {"captureDenials": {"outputPath": "relative/denials.etl"}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let err = load_request(&encoded, &mut logger, true)
+            .expect_err("a relative outputPath must be rejected");
+        assert!(
+            format!("{err:?}").contains("absolute"),
+            "error should mention the absolute-path requirement: {err:?}"
+        );
+    }
+
+    #[test]
+    fn capture_denials_missing_parent_dir_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Parent directory `nonexistent` is never created.
+        let path = dir.path().join("nonexistent").join("denials.etl");
+        let path_json = serde_json::to_string(&path.to_string_lossy()).unwrap();
+        let json = format!(
+            r#"{{
+                "process": {{"commandLine": "print('test')"}},
+                "containment": "processcontainer",
+                "processContainer": {{"captureDenials": {{"outputPath": {path_json}}}}}
+            }}"#
+        );
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let err = load_request(&encoded, &mut logger, true)
+            .expect_err("an outputPath whose parent is missing must be rejected");
+        assert!(
+            format!("{err:?}").contains("parent directory does not"),
+            "error should mention the missing parent directory: {err:?}"
+        );
     }
 
     #[test]

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -8,10 +8,10 @@ use crate::encoding::base64_decode;
 use crate::error::WxcError;
 use crate::logger::Logger;
 use crate::models::{
-    CaptureDenialsConfig, ContainerPolicy, ContainmentBackend, ExecutionRequest,
-    ExperimentalConfig, IsolationSessionConfig, LifecycleConfig, LxcConfig, NetworkEnforcementMode,
-    NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig, TelemetryConfig,
-    TestFeatureConfig, UiPolicy, WindowsSandboxConfig, WslcConfig,
+    CaptureDenialsConfig, CaptureDenialsMode, ContainerPolicy, ContainmentBackend,
+    ExecutionRequest, ExperimentalConfig, IsolationSessionConfig, LifecycleConfig, LxcConfig,
+    NetworkEnforcementMode, NetworkPolicy, PortMapping, ProxyAddress, ProxyConfig, SeatbeltConfig,
+    TelemetryConfig, TestFeatureConfig, UiPolicy, WindowsSandboxConfig, WslcConfig,
 };
 use crate::mxc_error::MxcError;
 use crate::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase};
@@ -791,15 +791,23 @@ fn convert_wire_config(
         }
 
         // captureDenials (Windows denial capture). Presence enables capture: the
-        // runner records the process's access attempts to a learning-mode ETL
-        // trace while enforcement stays unchanged. The optional outputPath names
-        // where the trace is sealed; validate it eagerly so a bad path fails at
-        // parse time rather than deep in the runner.
+        // runner records the process's ungranted access attempts to a
+        // learning-mode ETL trace. `mode` decides whether each recorded access is
+        // blocked (`block-and-log`, the default) or allowed (`allow-and-log`).
+        // The optional outputPath names where the trace is sealed; validate it
+        // eagerly so a bad path fails at parse time rather than deep in the runner.
         if let Some(cd) = ac.capture_denials {
             if let Some(path) = cd.output_path.as_deref() {
                 validate_capture_denials_output_path(path, logger)?;
             }
+            let mode = match cd.mode {
+                Some(wire::CaptureDenialsMode::AllowAndLog) => CaptureDenialsMode::AllowAndLog,
+                Some(wire::CaptureDenialsMode::BlockAndLog) | None => {
+                    CaptureDenialsMode::BlockAndLog
+                }
+            };
             policy.capture_denials = Some(CaptureDenialsConfig {
+                mode,
                 output_path: cd.output_path,
             });
         }
@@ -1827,6 +1835,56 @@ mod tests {
             .capture_denials
             .expect("captureDenials presence should enable capture");
         assert!(cd.output_path.is_none());
+        // Omitting `mode` defaults to the safe block-and-log behavior.
+        assert_eq!(cd.mode, CaptureDenialsMode::BlockAndLog);
+    }
+
+    #[test]
+    fn capture_denials_mode_block_and_log_is_parsed() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {"captureDenials": {"mode": "block-and-log"}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cd = req.policy.capture_denials.expect("captureDenials present");
+        assert_eq!(cd.mode, CaptureDenialsMode::BlockAndLog);
+    }
+
+    #[test]
+    fn capture_denials_mode_allow_and_log_is_parsed() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {"captureDenials": {"mode": "allow-and-log"}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        let cd = req.policy.capture_denials.expect("captureDenials present");
+        assert_eq!(cd.mode, CaptureDenialsMode::AllowAndLog);
+    }
+
+    #[test]
+    fn capture_denials_unknown_mode_rejected() {
+        let json = r#"{
+            "process": {"commandLine": "print('test')"},
+            "containment": "processcontainer",
+            "processContainer": {"captureDenials": {"mode": "audit"}}
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let err = load_request(&encoded, &mut logger, true)
+            .expect_err("an unknown captureDenials mode must be rejected");
+        // serde surfaces the accepted variants; the message must name both so
+        // the error is actionable.
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("block-and-log") && msg.contains("allow-and-log"),
+            "error should list the valid modes: {msg}"
+        );
     }
 
     #[test]

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -606,8 +606,16 @@ fn validate_capture_denials_output_path(path: &str, logger: &mut Logger) -> Resu
         return Err(WxcError::ConfigParse(msg));
     }
     match candidate.parent() {
-        // An absolute path always has a parent; an empty parent means the path
-        // is a filesystem root, which cannot be a trace file.
+        // A filesystem root ("/", "C:\\") has either no parent (`None`) or an
+        // empty parent, and cannot name a trace file.
+        None => {
+            let msg = format!(
+                "processContainer.captureDenials.outputPath must name a file, not a \
+                 directory root: '{path}'"
+            );
+            logger.log_line(&msg);
+            Err(WxcError::ConfigParse(msg))
+        }
         Some(parent) if parent.as_os_str().is_empty() => {
             let msg = format!(
                 "processContainer.captureDenials.outputPath must name a file, not a \
@@ -1822,7 +1830,7 @@ mod tests {
     }
 
     #[test]
-    fn capture_denials_threads_valid_absolute_output_path() {
+    fn capture_denials_accepts_valid_absolute_output_path() {
         let dir = tempfile::tempdir().expect("temp dir");
         let path = dir.path().join("denials.etl");
         let path_json = serde_json::to_string(&path.to_string_lossy()).unwrap();
@@ -1880,6 +1888,29 @@ mod tests {
         assert!(
             format!("{err:?}").contains("parent directory does not"),
             "error should mention the missing parent directory: {err:?}"
+        );
+    }
+
+    #[test]
+    fn capture_denials_filesystem_root_output_path_rejected() {
+        // A bare filesystem root has no parent (`Path::parent()` == None) and
+        // cannot name a trace file. Use a platform-appropriate root.
+        let root = if cfg!(windows) { "C:\\" } else { "/" };
+        let root_json = serde_json::to_string(root).unwrap();
+        let json = format!(
+            r#"{{
+                "process": {{"commandLine": "print('test')"}},
+                "containment": "processcontainer",
+                "processContainer": {{"captureDenials": {{"outputPath": {root_json}}}}}
+            }}"#
+        );
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let err = load_request(&encoded, &mut logger, true)
+            .expect_err("a filesystem-root outputPath must be rejected");
+        assert!(
+            format!("{err:?}").contains("directory root"),
+            "error should mention the directory-root rejection: {err:?}"
         );
     }
 

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -793,7 +793,7 @@ fn convert_wire_config(
         // captureDenials (Windows denial capture). Presence enables capture: the
         // runner records the process's ungranted access attempts to a
         // learning-mode ETL trace. `mode` decides whether each recorded access is
-        // blocked (`block-and-log`, the default) or allowed (`allow-and-log`).
+        // blocked (`block`, the default) or allowed (`allow`).
         // The optional outputPath names where the trace is sealed; validate it
         // eagerly so a bad path fails at parse time rather than deep in the runner.
         if let Some(cd) = ac.capture_denials {
@@ -801,10 +801,8 @@ fn convert_wire_config(
                 validate_capture_denials_output_path(path, logger)?;
             }
             let mode = match cd.mode {
-                Some(wire::CaptureDenialsMode::AllowAndLog) => CaptureDenialsMode::AllowAndLog,
-                Some(wire::CaptureDenialsMode::BlockAndLog) | None => {
-                    CaptureDenialsMode::BlockAndLog
-                }
+                Some(wire::CaptureDenialsMode::Allow) => CaptureDenialsMode::Allow,
+                Some(wire::CaptureDenialsMode::Block) | None => CaptureDenialsMode::Block,
             };
             policy.capture_denials = Some(CaptureDenialsConfig {
                 mode,
@@ -1835,36 +1833,36 @@ mod tests {
             .capture_denials
             .expect("captureDenials presence should enable capture");
         assert!(cd.output_path.is_none());
-        // Omitting `mode` defaults to the safe block-and-log behavior.
-        assert_eq!(cd.mode, CaptureDenialsMode::BlockAndLog);
+        // Omitting `mode` defaults to the safe block behavior.
+        assert_eq!(cd.mode, CaptureDenialsMode::Block);
     }
 
     #[test]
-    fn capture_denials_mode_block_and_log_is_parsed() {
+    fn capture_denials_mode_block_is_parsed() {
         let json = r#"{
             "process": {"commandLine": "print('test')"},
             "containment": "processcontainer",
-            "processContainer": {"captureDenials": {"mode": "block-and-log"}}
+            "processContainer": {"captureDenials": {"mode": "block"}}
         }"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
         let req = load_request(&encoded, &mut logger, true).unwrap();
         let cd = req.policy.capture_denials.expect("captureDenials present");
-        assert_eq!(cd.mode, CaptureDenialsMode::BlockAndLog);
+        assert_eq!(cd.mode, CaptureDenialsMode::Block);
     }
 
     #[test]
-    fn capture_denials_mode_allow_and_log_is_parsed() {
+    fn capture_denials_mode_allow_is_parsed() {
         let json = r#"{
             "process": {"commandLine": "print('test')"},
             "containment": "processcontainer",
-            "processContainer": {"captureDenials": {"mode": "allow-and-log"}}
+            "processContainer": {"captureDenials": {"mode": "allow"}}
         }"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
         let req = load_request(&encoded, &mut logger, true).unwrap();
         let cd = req.policy.capture_denials.expect("captureDenials present");
-        assert_eq!(cd.mode, CaptureDenialsMode::AllowAndLog);
+        assert_eq!(cd.mode, CaptureDenialsMode::Allow);
     }
 
     #[test]
@@ -1882,7 +1880,7 @@ mod tests {
         // the error is actionable.
         let msg = format!("{err:?}");
         assert!(
-            msg.contains("block-and-log") && msg.contains("allow-and-log"),
+            msg.contains("block") && msg.contains("allow"),
             "error should list the valid modes: {msg}"
         );
     }

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -595,7 +595,8 @@ fn map_wire_containment(c: Option<&wire::Containment>) -> ContainmentBackend {
 /// Validates a caller-specified `processContainer.captureDenials.outputPath`: it
 /// must be an absolute path whose parent directory already exists (the runner
 /// opens the file there when it seals the trace, under the caller's own
-/// identity). A relative path or a missing parent yields an actionable error.
+/// identity). The path itself must not be an existing directory. A relative
+/// path, directory path, or missing parent yields an actionable error.
 fn validate_capture_denials_output_path(path: &str, logger: &mut Logger) -> Result<(), WxcError> {
     let candidate = std::path::Path::new(path);
     if !candidate.is_absolute() {
@@ -629,6 +630,14 @@ fn validate_capture_denials_output_path(path: &str, logger: &mut Logger) -> Resu
                 "processContainer.captureDenials.outputPath parent directory does not \
                  exist: '{}'",
                 parent.display()
+            );
+            logger.log_line(&msg);
+            Err(WxcError::ConfigParse(msg))
+        }
+        Some(_) if candidate.is_dir() => {
+            let msg = format!(
+                "processContainer.captureDenials.outputPath must name a file, not an \
+                 existing directory: '{path}'"
             );
             logger.log_line(&msg);
             Err(WxcError::ConfigParse(msg))
@@ -1967,6 +1976,28 @@ mod tests {
         assert!(
             format!("{err:?}").contains("directory root"),
             "error should mention the directory-root rejection: {err:?}"
+        );
+    }
+
+    #[test]
+    fn capture_denials_existing_directory_output_path_rejected() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path_json = serde_json::to_string(&dir.path().to_string_lossy()).unwrap();
+        let json = format!(
+            r#"{{
+                "process": {{"commandLine": "print('test')"}},
+                "containment": "processcontainer",
+                "processContainer": {{"captureDenials": {{"outputPath": {path_json}}}}}
+            }}"#
+        );
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true)
+            .expect_err("an existing directory outputPath must be rejected");
+        assert!(
+            format!("{err:?}").contains("existing directory"),
+            "error should identify the directory path: {err:?}"
         );
     }
 

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -564,14 +564,30 @@ pub struct ContainerPolicy {
 
 /// Windows denial-capture settings (from `processContainer.captureDenials`).
 /// The presence of this struct on [`ContainerPolicy::capture_denials`] enables
-/// capture; the runner records the sandboxed process's access attempts to a
-/// learning-mode ETL trace while enforcement stays unchanged.
+/// capture; the runner records the sandboxed process's ungranted access
+/// attempts to a learning-mode ETL trace. [`CaptureDenialsConfig::mode`]
+/// decides whether each recorded access is blocked (default) or allowed.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct CaptureDenialsConfig {
+    /// How each ungranted access check is handled while it is recorded.
+    /// Defaults to [`CaptureDenialsMode::BlockAndLog`].
+    pub mode: CaptureDenialsMode,
     /// Absolute path where the denial ETL trace is written. When `None`, the
     /// runner falls back to a managed per-run temporary file.
     pub output_path: Option<String>,
+}
+
+/// How `captureDenials` handles each ungranted access check while recording it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CaptureDenialsMode {
+    /// The access stays denied and the denial is recorded; deny-by-default
+    /// containment is preserved. Safe default.
+    #[default]
+    BlockAndLog,
+    /// The access is allowed and recorded (audit mode); deny-by-default is
+    /// relaxed for the run. Security-sensitive — the runner warns.
+    AllowAndLog,
 }
 
 /// Port mapping for host↔container port forwarding.

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -556,6 +556,22 @@ pub struct ContainerPolicy {
     pub ui: UiPolicy,
     /// BaseProcessContainer-specific UI config (Windows only, from processContainer.ui).
     pub base_process_ui: BaseProcessUiConfig,
+    /// Windows denial capture (from `processContainer.captureDenials`). When
+    /// `Some`, the runner records the sandboxed process's ungranted access
+    /// attempts to a learning-mode ETL trace. `None` disables capture.
+    pub capture_denials: Option<CaptureDenialsConfig>,
+}
+
+/// Windows denial-capture settings (from `processContainer.captureDenials`).
+/// The presence of this struct on [`ContainerPolicy::capture_denials`] enables
+/// capture; the runner records the sandboxed process's access attempts to a
+/// learning-mode ETL trace while enforcement stays unchanged.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CaptureDenialsConfig {
+    /// Absolute path where the denial ETL trace is written. When `None`, the
+    /// runner falls back to a managed per-run temporary file.
+    pub output_path: Option<String>,
 }
 
 /// Port mapping for host↔container port forwarding.

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -571,7 +571,7 @@ pub struct ContainerPolicy {
 #[serde(default)]
 pub struct CaptureDenialsConfig {
     /// How each ungranted access check is handled while it is recorded.
-    /// Defaults to [`CaptureDenialsMode::BlockAndLog`].
+    /// Defaults to [`CaptureDenialsMode::Block`].
     pub mode: CaptureDenialsMode,
     /// Absolute path where the denial ETL trace is written. When `None`, the
     /// runner falls back to a managed per-run temporary file.
@@ -584,10 +584,10 @@ pub enum CaptureDenialsMode {
     /// The access stays denied and the denial is recorded; deny-by-default
     /// containment is preserved. Safe default.
     #[default]
-    BlockAndLog,
+    Block,
     /// The access is allowed and recorded (audit mode); deny-by-default is
     /// relaxed for the run. Security-sensitive — the runner warns.
-    AllowAndLog,
+    Allow,
 }
 
 /// Port mapping for host↔container port forwarding.

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -210,7 +210,7 @@ pub struct CaptureDenials {
     /// Absolute path where the denial ETL trace is written. The caller names
     /// the path; the OS opens it under the caller's own identity when the trace
     /// is sealed. When omitted, MXC writes the trace to a managed per-run
-    /// temporary file. The parent directory must already exist and be writable.
+    /// temporary file. The parent directory must already exist.
     pub output_path: Option<String>,
 }
 

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -207,11 +207,30 @@ pub struct ProcessContainer {
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CaptureDenials {
+    /// How each ungranted access check is handled while it is recorded. Both
+    /// modes log every access the policy does not grant to the ETL trace; the
+    /// mode only decides whether that access is blocked or allowed. Defaults to
+    /// `block-and-log` when omitted.
+    pub mode: Option<CaptureDenialsMode>,
     /// Absolute path where the denial ETL trace is written. The caller names
     /// the path; the OS opens it under the caller's own identity when the trace
     /// is sealed. When omitted, MXC writes the trace to a managed per-run
     /// temporary file. The parent directory must already exist.
     pub output_path: Option<String>,
+}
+
+/// How `captureDenials` handles each ungranted access check while recording it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum CaptureDenialsMode {
+    /// `block-and-log` — the access stays **denied** and the denial is recorded.
+    /// Deny-by-default containment is preserved; this is the safe default.
+    BlockAndLog,
+    /// `allow-and-log` — the access is **allowed** and recorded (audit mode).
+    /// This relaxes deny-by-default for the run, so it is a security-sensitive
+    /// choice and the runner emits a security warning.
+    AllowAndLog,
 }
 
 /// BaseProcessContainer UI isolation settings.

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -193,8 +193,25 @@ pub struct ProcessContainer {
     pub learning_mode: Option<bool>,
     /// AppContainer capabilities (e.g. `internetClient`, `registryRead`).
     pub capabilities: Option<Vec<String>>,
+    /// Windows denial capture. When present, the runner records the sandboxed
+    /// process's access attempts to a learning-mode ETL trace for later
+    /// inspection. Requires a host that exposes the learning-mode OS API.
+    pub capture_denials: Option<CaptureDenials>,
     /// BaseProcessContainer UI settings (Windows).
     pub ui: Option<BaseProcessUi>,
+}
+
+/// Windows denial-capture settings. The presence of the `captureDenials`
+/// object enables capture; all fields are optional.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CaptureDenials {
+    /// Absolute path where the denial ETL trace is written. The caller names
+    /// the path; the OS opens it under the caller's own identity when the trace
+    /// is sealed. When omitted, MXC writes the trace to a managed per-run
+    /// temporary file. The parent directory must already exist and be writable.
+    pub output_path: Option<String>,
 }
 
 /// BaseProcessContainer UI isolation settings.

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -210,7 +210,7 @@ pub struct CaptureDenials {
     /// How each ungranted access check is handled while it is recorded. Both
     /// modes log every access the policy does not grant to the ETL trace; the
     /// mode only decides whether that access is blocked or allowed. Defaults to
-    /// `block-and-log` when omitted.
+    /// `block` when omitted.
     pub mode: Option<CaptureDenialsMode>,
     /// Absolute path where the denial ETL trace is written. The caller names
     /// the path; the OS opens it under the caller's own identity when the trace
@@ -224,13 +224,13 @@ pub struct CaptureDenials {
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum CaptureDenialsMode {
-    /// `block-and-log` — the access stays **denied** and the denial is recorded.
+    /// `block` — the access stays **denied** and the denial is recorded.
     /// Deny-by-default containment is preserved; this is the safe default.
-    BlockAndLog,
-    /// `allow-and-log` — the access is **allowed** and recorded (audit mode).
+    Block,
+    /// `allow` — the access is **allowed** and recorded (audit mode).
     /// This relaxes deny-by-default for the run, so it is a security-sensitive
     /// choice and the runner emits a security warning.
-    AllowAndLog,
+    Allow,
 }
 
 /// BaseProcessContainer UI isolation settings.

--- a/tests/examples/29_capture_denials.json
+++ b/tests/examples/29_capture_denials.json
@@ -7,8 +7,6 @@
   },
   "processContainer": {
     "capabilities": ["internetClient"],
-    "captureDenials": {
-      "outputPath": "C:\\logs\\mxc-denials.etl"
-    }
+    "captureDenials": {}
   }
 }

--- a/tests/examples/29_capture_denials.json
+++ b/tests/examples/29_capture_denials.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-CaptureDenials",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "python -c \"print('Capture-denials demo: ungranted access attempts are recorded to an ETL trace')\""
+  },
+  "processContainer": {
+    "capabilities": ["internetClient"],
+    "captureDenials": {
+      "outputPath": "C:\\logs\\mxc-denials.etl"
+    }
+  }
+}

--- a/tests/examples/29_capture_denials.json
+++ b/tests/examples/29_capture_denials.json
@@ -7,6 +7,6 @@
   },
   "processContainer": {
     "capabilities": ["internetClient"],
-    "captureDenials": {}
+    "captureDenials": { "mode": "block-and-log" }
   }
 }

--- a/tests/examples/29_capture_denials.json
+++ b/tests/examples/29_capture_denials.json
@@ -7,6 +7,6 @@
   },
   "processContainer": {
     "capabilities": ["internetClient"],
-    "captureDenials": { "mode": "block-and-log" }
+    "captureDenials": { "mode": "block" }
   }
 }


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [ ] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Adds a `captureDenials` object under `processContainer` that will enable the
Windows learning-mode trace. This is the **config-contract** half of the
learning-mode denial-capture feature — pure plumbing, no runtime behavior yet.

**Shape** — `processContainer.captureDenials: { mode?: "block" | "allow", outputPath?: string }`:
- Presence of the object enables capture.
- `mode` (optional) selects how each ungranted access check is handled while it
  is recorded. Both modes log every access the policy does not grant; the mode
  only decides whether that access is blocked or allowed:
  - `block` (**default**) — the access stays **denied** and the denial
    is recorded. Deny-by-default containment is preserved; the safe default.
  - `allow` — the access is **allowed** and recorded (audit mode). This
    relaxes deny-by-default for the run, so it is security-sensitive and the
    runner emits a security warning.
  - Omitting `mode` defaults to `block`. An unknown value is rejected at
    parse time with an error naming both valid modes.
- `outputPath` (optional) names where the ETL trace is sealed. The OS model is
  caller-controlled (`StopLearningModeTrace(trace, lpOutputPath)`), so the
  caller names the path; it is opened under the caller''s own identity. When
  omitted, the runner will fall back to a managed per-run temp file.
- The path is validated at parse time (must be absolute with an existing parent
  directory) with actionable errors.

**What''s in scope (this PR):**
- Wire model (`wire::CaptureDenials` + `wire::CaptureDenialsMode` on `wire::ProcessContainer`).
- Domain model (`CaptureDenialsConfig` + `CaptureDenialsMode` on `ContainerPolicy.capture_denials`).
- Parser mapping + validation in `config_parser.rs`.
- Regenerated dev schema (`schemas/dev/mxc-config.schema.0.8.0-dev.json`) and SDK
  wire types (`sdk/node/src/generated/wire.ts`) via `mxc_schema_gen` (codegen —
  not hand-edited).
- Docs (`docs/schema.md`) + example (`tests/examples/29_capture_denials.json`).
- Unit tests (parse/validate/mode) + all schema/version/codegen gates green.

**What''s intentionally NOT here (follow-up integration PR):**
- Auto-injection of the `learningModeLogging` capability when `captureDenials`
  is set — that reuses the capability recognition from the capabilities PR.
- The runner trace lifecycle (Start -> run -> Stop -> write ETL) and the
  block-vs-allow enforcement behind each `mode` — that consumes the
  learning-mode OS API.

Both land in the integration PR stacked on top of the capabilities + consume-API
PRs plus this one.

### Related Issues

- #622 (learning-mode capabilities — provides `learningModeLogging` recognition)
- #661 (consume the learning-mode OS API — the capture engine)

### Validation

- `cargo test -p wxc_common` — 466 pass (9 `captureDenials` tests, incl. 4 `mode` tests)
- `cargo fmt --all -- --check`, `cargo clippy -p wxc_common --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `npm run test:unit` (SDK) — 201 pass
- `node scripts/versioning/{validate-configs,check-schema-codegen,check-sdk-types-codegen,check-schema-versions}.js`

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/663)