### PR TITLE
ci: add Runner Access Probe workflow (draft)

### DIFF
--- a/.github/workflows/runner-access-probe.yml
+++ b/.github/workflows/runner-access-probe.yml
@@ -53,8 +53,10 @@ jobs:
   larger-runner-probe:
     name: Larger runner probe
     # On a pull_request run there is no dispatch input, so the literal below is used.
-    #                                                     vvvvvvvvvvvvv  <<< EDIT LABEL HERE >>>
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    # NOTE: 'ubuntu-latest-4-cores' is a GUESS at a common larger-runner naming
+    # convention -- this org's real label may differ. Swap it for the actual label
+    # if you know one.                                    vvvvvvvvvvvvvvvvvvvvvv  <<< EDIT LABEL HERE >>>
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest-4-cores' }}
     timeout-minutes: 10
     # Never fail the PR because of this probe -- a missing runner shows up as a
     # cancelled/queued job, not a red required check.

--- a/.github/workflows/runner-access-probe.yml
+++ b/.github/workflows/runner-access-probe.yml
@@ -1,0 +1,70 @@
+name: Runner Access Probe
+
+# Empirical probe to check whether this repository can schedule a GitHub *larger*
+# runner (a.k.a. premium / custom-size hosted runner). This exists because the repo
+# Settings -> Actions -> Runners page is not visible to non-admins in this org, so the
+# only reliable way to check access is to try to schedule a job and watch what happens.
+#
+# HOW IT WORKS
+#   The "larger-runner-probe" job requests a candidate runner label. Then:
+#     * It starts and prints its specs  => the repo HAS access to that label.
+#     * It stays "Queued / Waiting for a runner" and never starts => NO access.
+#       (That is your answer -- cancel the run.)
+#
+# HOW TO USE ON A DRAFT PR
+#   1. Push once as-is. Both jobs run on ubuntu-latest and should go green -- this
+#      confirms the workflow itself is valid.
+#   2. Change the single literal marked  <<< EDIT LABEL HERE >>>  below to the larger
+#      runner label you want to test (e.g. ubuntu-24.04-16core), then push again.
+#   3. Open the PR's Checks tab and watch the "larger-runner-probe" job.
+#        - Started + green  => access confirmed (specs are in the log).
+#        - Stuck "Waiting for a runner" for more than ~1-2 min => no access; cancel it.
+#
+# AFTER THIS FILE IS ON THE DEFAULT BRANCH
+#   You can also re-run it from the Actions tab via "Run workflow" and type any label
+#   in the input box, without editing the file.
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Larger-runner label to probe (e.g. ubuntu-24.04-16core)
+        required: false
+        default: ubuntu-latest
+
+permissions: {}
+
+jobs:
+  baseline:
+    name: Baseline (ubuntu-latest control)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Report runner details
+        shell: bash
+        run: |
+          echo "This is the standard-runner control -- it should always run."
+          echo "runner.name = ${RUNNER_NAME}"
+          echo "runner.os   = ${RUNNER_OS}"
+          echo "runner.arch = ${RUNNER_ARCH}"
+          node -e "const o=require('os');console.log('cpus  =',o.cpus().length);console.log('memGB =',(o.totalmem()/1e9).toFixed(1));console.log('plat  =',o.platform(),o.arch())"
+
+  larger-runner-probe:
+    name: Larger runner probe
+    # On a pull_request run there is no dispatch input, so the literal below is used.
+    #                                                     vvvvvvvvvvvvv  <<< EDIT LABEL HERE >>>
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    # Never fail the PR because of this probe -- a missing runner shows up as a
+    # cancelled/queued job, not a red required check.
+    continue-on-error: true
+    steps:
+      - name: Report runner details
+        shell: bash
+        run: |
+          echo "A runner picked up this job -- the requested label IS available to this repo."
+          echo "runner.name = ${RUNNER_NAME}"
+          echo "runner.os   = ${RUNNER_OS}"
+          echo "runner.arch = ${RUNNER_ARCH}"
+          node -e "const o=require('os');console.log('cpus  =',o.cpus().length);console.log('memGB =',(o.totalmem()/1e9).toFixed(1));console.log('plat  =',o.platform(),o.arch())"


### PR DESCRIPTION
## 📖 Description

Adds `.github/workflows/runner-access-probe.yml`, a throwaway diagnostic workflow that empirically checks whether `microsoft/mxc` can schedule a GitHub **larger runner** (premium / custom-size hosted runner).

This is needed because the repo **Settings → Actions → Runners** page is not visible to non-admins in this org ("You don't have access to repository options"), so actually trying to schedule a job is the only reliable way to verify access.

**How it works**
- `baseline` job (ubuntu-latest) — always runs; prints CPU/RAM/OS. Confirms the workflow is valid and gives a standard-runner spec baseline.
- `larger-runner-probe` job — requests a candidate runner label:
  - **Starts + green** → the repo has access to that label (specs printed in the log).
  - **Stuck on "Waiting for a runner"** → no access; cancel the run. That is the negative answer.
- `continue-on-error: true` + `timeout-minutes` so a missing runner never blocks or hangs required checks.

**How to use**
1. First push runs both jobs on `ubuntu-latest` → should go green (proves the workflow works).
2. Change the single literal marked `<<< EDIT LABEL HERE >>>` to the larger-runner label to test (e.g. `ubuntu-24.04-16core`) and push.
3. Watch the `larger-runner-probe` job in the Checks tab.

> ⚠️ Draft / diagnostic only — not meant to merge. Delete the branch once access is confirmed.

## 🔗 References

_No linked issue; ad-hoc runner-access probe._

## 🔍 Validation

Workflow YAML is self-contained (no repo checkout, no external actions). Initial run targets `ubuntu-latest` for both jobs; the larger-runner target is a one-line edit.

## ✅ Checklist

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/670)