### PR TITLE
Stop the dev schema advertising a stop/deprovision config for IsolationSession

### DIFF
--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -260,19 +260,8 @@
       "type": "object"
     },
     "IsolationSession": {
-      "description": "IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting (`provision` / `start` / `stop` / `deprovision`).",
+      "description": "IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`/`deprovision`/`exec` take no config payload — they are invoked via the top-level `phase` field with `sandboxId`.",
       "properties": {
-        "deprovision": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IsolationSessionPhase"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "State-aware deprovision-phase configuration."
-        },
         "provision": {
           "anyOf": [
             {
@@ -294,17 +283,6 @@
             }
           ],
           "description": "State-aware start-phase configuration."
-        },
-        "stop": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/IsolationSessionPhase"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "State-aware stop-phase configuration."
         },
         "user": {
           "anyOf": [

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -260,7 +260,7 @@
       "type": "object"
     },
     "IsolationSession": {
-      "description": "IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`/`deprovision`/`exec` take no config payload — they are invoked via the top-level `phase` field with `sandboxId`.",
+      "description": "IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`, `deprovision`, and `exec` take no per-phase config payload: `stop` and `deprovision` are invoked with only the top-level `phase` and `sandboxId`, and `exec` additionally carries the top-level `process` block.",
       "properties": {
         "provision": {
           "anyOf": [

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -107,13 +107,9 @@ export interface Filesystem {
 }
 
 /**
- * IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting (`provision` / `start` / `stop` / `deprovision`).
+ * IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`/`deprovision`/`exec` take no config payload — they are invoked via the top-level `phase` field with `sandboxId`.
  */
 export interface IsolationSession {
-  /**
-   * State-aware deprovision-phase configuration.
-   */
-  deprovision?: IsolationSessionPhase | null;
   /**
    * State-aware provision-phase configuration.
    */
@@ -122,10 +118,6 @@ export interface IsolationSession {
    * State-aware start-phase configuration.
    */
   start?: IsolationSessionPhase | null;
-  /**
-   * State-aware stop-phase configuration.
-   */
-  stop?: IsolationSessionPhase | null;
   /**
    * Optional Entra cloud-agent user bundle (one-shot).
    */

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -107,7 +107,7 @@ export interface Filesystem {
 }
 
 /**
- * IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`/`deprovision`/`exec` take no config payload — they are invoked via the top-level `phase` field with `sandboxId`.
+ * IsolationSession backend config. Carries the one-shot `user` field and the per-phase state-aware nesting for the phases that take config (`provision` / `start`). `stop`, `deprovision`, and `exec` take no per-phase config payload: `stop` and `deprovision` are invoked with only the top-level `phase` and `sandboxId`, and `exec` additionally carries the top-level `process` block.
  */
 export interface IsolationSession {
   /**

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -319,11 +319,13 @@ mod tests {
     // The generated JSON schema (`schemas/dev/`) and the SDK wire types
     // (`sdk/node/src/generated/wire.ts`) are both emitted from
     // `wxc_common::wire::IsolationSession`, while the phases that actually
-    // accept a config are the associated types on the impl above. Nothing
-    // links the two at compile time, so the pair below pins both halves:
-    // the wire model must nest a per-phase key exactly for the phases whose
-    // config type is not `()`. When they disagree, the schema advertises a
-    // payload `deserialize_config` then rejects.
+    // accept a config are the associated types on the impl above. On the
+    // state-aware path the wire model is never constructed — the dispatcher
+    // deserializes raw JSON straight into those associated types — so nothing
+    // couples the two at compile time. The tests below pin that contract from
+    // both directions: the key set the wire model advertises, that the `()`
+    // phases reject a payload, and that the phases which do take one still
+    // accept the payload the wire model describes.
 
     #[test]
     fn wire_model_nests_config_only_for_phases_that_take_one() {
@@ -372,6 +374,38 @@ mod tests {
             serde_json::from_value::<ExecConfig>(payload).is_err(),
             "exec accepted a config payload"
         );
+    }
+
+    #[test]
+    fn phases_with_a_config_accept_the_wire_payload() {
+        type ProvisionConfig = <IsolationSessionRunner as StatefulSandboxBackend>::ProvisionConfig;
+        type StartConfig = <IsolationSessionRunner as StatefulSandboxBackend>::StartConfig;
+
+        // Derive the payload from the wire type instead of a JSON literal: the
+        // wire model is only the schema source on this path, so a serde rename
+        // on either side would go unnoticed. Both config types are
+        // `#[serde(default)]` with no `deny_unknown_fields`, so a renamed key
+        // does not error — it drops the bundle and provisions a local sandbox
+        // for a caller who asked for an Entra one.
+        let phase = wxc_common::wire::IsolationSessionPhase {
+            user: Some(wxc_common::wire::IsolationUser {
+                upn: "alice@contoso.com".to_string(),
+                wam_token: "tok".to_string(),
+            }),
+        };
+        let payload = serde_json::to_value(&phase).unwrap();
+
+        let provision: ProvisionConfig = serde_json::from_value(payload.clone()).unwrap();
+        let u = provision
+            .user
+            .expect("provision dropped the wire user bundle");
+        assert_eq!(u.upn, "alice@contoso.com");
+        assert_eq!(u.wam_token, "tok");
+
+        let start: StartConfig = serde_json::from_value(payload).unwrap();
+        let u = start.user.expect("start dropped the wire user bundle");
+        assert_eq!(u.upn, "alice@contoso.com");
+        assert_eq!(u.wam_token, "tok");
     }
 
     fn request_with_filesystem_policy() -> ExecutionRequest {

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -314,6 +314,66 @@ mod tests {
         );
     }
 
+    // ====== Wire-model / backend config parity ======
+
+    // The generated JSON schema (`schemas/dev/`) and the SDK wire types
+    // (`sdk/node/src/generated/wire.ts`) are both emitted from
+    // `wxc_common::wire::IsolationSession`, while the phases that actually
+    // accept a config are the associated types on the impl above. Nothing
+    // links the two at compile time, so the pair below pins both halves:
+    // the wire model must nest a per-phase key exactly for the phases whose
+    // config type is not `()`. When they disagree, the schema advertises a
+    // payload `deserialize_config` then rejects.
+
+    #[test]
+    fn wire_model_nests_config_only_for_phases_that_take_one() {
+        // Field-by-field construction is deliberate: adding a per-phase field
+        // to the wire struct breaks this test's compilation, forcing a
+        // decision about whether the backend honors it.
+        let wire = wxc_common::wire::IsolationSession {
+            user: None,
+            provision: None,
+            start: None,
+        };
+        let value = serde_json::to_value(&wire).unwrap();
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            ["provision", "start", "user"],
+            "wire model nests a per-phase config for a phase the backend takes none for"
+        );
+    }
+
+    #[test]
+    fn phases_without_a_config_reject_a_payload() {
+        type StopConfig = <IsolationSessionRunner as StatefulSandboxBackend>::StopConfig;
+        type DeprovisionConfig =
+            <IsolationSessionRunner as StatefulSandboxBackend>::DeprovisionConfig;
+        type ExecConfig = <IsolationSessionRunner as StatefulSandboxBackend>::ExecConfig;
+
+        // These are `()`, which deserializes only from null, so any object in
+        // the slot is a hard error at dispatch.
+        let payload = serde_json::json!({ "user": { "upn": "a@b.com", "wamToken": "t" } });
+        assert!(
+            serde_json::from_value::<StopConfig>(payload.clone()).is_err(),
+            "stop accepted a config payload"
+        );
+        assert!(
+            serde_json::from_value::<DeprovisionConfig>(payload.clone()).is_err(),
+            "deprovision accepted a config payload"
+        );
+        assert!(
+            serde_json::from_value::<ExecConfig>(payload).is_err(),
+            "exec accepted a config payload"
+        );
+    }
+
     fn request_with_filesystem_policy() -> ExecutionRequest {
         ExecutionRequest {
             policy: ContainerPolicy {

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -485,9 +485,10 @@ pub enum TransportProtocol {
 
 /// IsolationSession backend config. Carries the one-shot `user` field and
 /// the per-phase state-aware nesting for the phases that take config
-/// (`provision` / `start`). `stop`/`deprovision`/`exec` take no config
-/// payload — they are invoked via the top-level `phase` field with
-/// `sandboxId`.
+/// (`provision` / `start`). `stop`, `deprovision`, and `exec` take no
+/// per-phase config payload: `stop` and `deprovision` are invoked with only
+/// the top-level `phase` and `sandboxId`, and `exec` additionally carries
+/// the top-level `process` block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -484,8 +484,10 @@ pub enum TransportProtocol {
 }
 
 /// IsolationSession backend config. Carries the one-shot `user` field and
-/// the per-phase state-aware nesting (`provision` / `start` / `stop` /
-/// `deprovision`).
+/// the per-phase state-aware nesting for the phases that take config
+/// (`provision` / `start`). `stop`/`deprovision`/`exec` take no config
+/// payload — they are invoked via the top-level `phase` field with
+/// `sandboxId`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
@@ -496,10 +498,6 @@ pub struct IsolationSession {
     pub provision: Option<IsolationSessionPhase>,
     /// State-aware start-phase configuration.
     pub start: Option<IsolationSessionPhase>,
-    /// State-aware stop-phase configuration.
-    pub stop: Option<IsolationSessionPhase>,
-    /// State-aware deprovision-phase configuration.
-    pub deprovision: Option<IsolationSessionPhase>,
 }
 
 /// Per-phase IsolationSession configuration (state-aware lifecycle).


### PR DESCRIPTION
## 📖 Description

`wire::IsolationSession` reused a single `IsolationSessionPhase` (which carries `user`) for all four per-phase state-aware slots, but the IsolationSession backend's `StatefulSandboxBackend` impl declares `StopConfig`, `DeprovisionConfig`, and `ExecConfig` as `()`. The generated dev schema and SDK wire types therefore advertised an optional `user` payload under `experimental.isolationSession.stop` and `.deprovision` that the dispatcher rejects: `deserialize_config` into `()` accepts only `null`, so a caller who follows the schema gets `malformed_request`.

This drops the `stop` and `deprovision` fields from `wire::IsolationSession` and regenerates the two generated artifacts.

No behavior change. The TypeScript SDK never emitted those slots (it lifts `version` to the envelope top level), so only a hand-authored raw-JSON caller reading the schema could be misled. The `stop` and `deprovision` phases are still invoked exactly as before, via the top-level `phase` field with `sandboxId`.

`schemas/stable/*.json` are immutable release artifacts and are untouched; the fix applies to the dev line going forward.

Documentation needs no change, and this was verified rather than assumed: `docs/isolation-session/state-aware-rust.md` already lists the stop and deprovision `*Config` types as `()`, and the nesting example in `docs/schema.md` already shows only `start`. The docs were correct; the generated schema was the outlier.

## 🔗 References

Found during a code study of the state-aware IsolationSession lifecycle; no existing issue tracks it.

## 🔍 Validation

Codegen and versioning gates: `check-schema-codegen`, `check-sdk-types-codegen`, and `validate-configs` all green against the regenerated artifacts.

Lint: `cargo fmt --all -- --check`, and `cargo clippy --locked --all-targets --all-features --release -- -D warnings`.

Rust: Windows release build + test matrix with the `isolation_session` feature both ON and OFF; `wxc_host_prep` tests run elevated.

SDK: `sdk/node` build, unit tests, and integration tests green.

IsolationSession E2E on an isolation-capable VM: the one-shot, state-aware, and SDK-node integration suites all green, plus the manual interactive TTY tests operator-confirmed.

Regression tests added in the iso backend crate, where both halves of the contract are visible. `wire_model_nests_config_only_for_phases_that_take_one` pins the wire model's per-phase key set — it builds the struct field-by-field, so adding a per-phase field breaks the test's compilation instead of silently regenerating a schema that promises a payload the backend rejects. `phases_without_a_config_reject_a_payload` pins that the `()` config phases reject a payload. The existing codegen gate proves only that the artifacts match the wire model, not that the wire model matches the backend — the gap that allowed this drift.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📋 Issue Type

- [x] Bug fix

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/683)