### PR TITLE
Add iso session test bundle for os vpack

### DIFF
--- a/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
+++ b/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
@@ -1,0 +1,76 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# IsoSession-MXC-TestPackage pipeline (standalone, no 1ES template)
+#
+# Builds wxc-exec with --features isolation_session and publishes internal
+# pipeline artifacts for deployment to Windows 11 targets with IsoEnvBroker
+# (IsolationSession) APIs.
+#
+# TWO PACKAGES: one bundle per mirrored MXC branch, each under its own
+# artifact name (consumed by the OS-side MXC integration); names must match the
+# contract Packages list in scripts/devloop-contract.psd1 there):
+#   - main    -> mxc-iso-test-bundle-main-x64
+#   - feature -> mxc-iso-test-bundle-feature-x64
+#
+# these packages will be consumed by the Vpack.Package.Job.yml job.
+
+trigger: none
+
+name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+parameters:
+  - name: TestBundlesBranches
+    type: object
+    default:
+      Main:
+        artifactName: mxc-iso-test-bundle-main-x64
+        checkoutRepo: mxc_main
+        packageName: main
+      FeatureInternal:
+        artifactName: mxc-iso-test-bundle-feature-x64
+        checkoutRepo: mxc_iso_session_feature
+        packageName: feature
+
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+  - repository: mxc_main
+    type: github
+    name: microsoft/mxc
+    endpoint: MXC-GitHub-Connection
+    ref: refs/heads/main
+  - repository: mxc_iso_session_feature
+    type: github
+    name: microsoft/mxc
+    endpoint: MXC-GitHub-Connection
+    ref: refs/heads/feature/isolation-session-internal
+
+variables:
+  outputDirectory: $(Build.SourcesDirectory)/out/iso-test-bundle
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    sdl:
+      sourceRepositoriesToScan:
+        include:
+        - repository: mxc_main
+        - repository: mxc_iso_session_feature
+
+    stages:
+    - stage: Build_IsolationSession
+      displayName: 'Isolation Session Test Bundle'
+      jobs:
+      - ${{ each item in parameters.TestBundlesBranches }}:
+        - template: /.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml@self
+          parameters:
+            packageName: ${{ item.value.packageName }}
+            checkoutRepo: ${{ item.value.checkoutRepo }}
+            artifactName: ${{ item.value.artifactName }}

--- a/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
+++ b/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
@@ -49,7 +49,9 @@ resources:
     ref: refs/heads/feature/isolation-session-internal
 
 variables:
-  outputDirectory: $(Build.SourcesDirectory)/out/iso-test-bundle
+  - group: MXC-ESRP-Signing
+  - name: outputDirectory
+    value: $(Build.SourcesDirectory)/out/iso-test-bundle
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
@@ -74,3 +76,10 @@ extends:
             packageName: ${{ item.value.packageName }}
             checkoutRepo: ${{ item.value.checkoutRepo }}
             artifactName: ${{ item.value.artifactName }}
+            ESRPInfo:
+              serviceName: $(serviceName)
+              tenantId: $(tenantId)
+              azureKeyVaultName: $(azureKeyVaultName)
+              authCertName: $(authCertName)
+              signCertName: $(signCertName)
+              clientId: $(clientId)

--- a/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
+++ b/.azure-pipelines/1ES.IsolationSession.TestBundle.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# IsoSession-MXC-TestPackage pipeline (standalone, no 1ES template)
+# IsoSession-MXC-TestPackage pipeline (1ES Official template)
 #
 # Builds wxc-exec with --features isolation_session and publishes internal
 # pipeline artifacts for deployment to Windows 11 targets with IsoEnvBroker

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -1,0 +1,189 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+#
+# Parameterized "package isolation_session test bundle" job used by
+# 1ES.IsolationSession.TestBundle.yml. Builds wxc-exec with
+# --features isolation_session from the given source repo resource and
+# publishes the bundle under the given pipeline artifact name. Artfacts
+# produced by this job are intended for OS vpack consumption so they wxc-exec
+# can be invoked from the IsoEnvBroker (IsolationSession) APIs on Windows 11 targets
+# for testing.
+#
+# Two packages (main + feature/isolation-session-internal) are built by
+# invoking this template once per package.
+
+parameters:
+# The repository resource alias to check out
+- name: checkoutRepo
+  type: string
+
+# The published pipeline artifact name
+- name: artifactName
+  type: string
+
+# Short id ('main'/'feature') for a unique job name
+- name: packageName
+  type: string
+
+jobs:
+- job: package_iso_test_bundle_${{ parameters.packageName }}
+  displayName: 'Package Isolation Session Test Bundle (${{ parameters.packageName }}, x64)'
+  timeoutInMinutes: 60
+  variables:
+    triplet: x86_64-pc-windows-msvc
+    CARGO_TARGET_DIR: c:/t/target
+    artifactPrefix: wxc-binaries
+    workingDirectory: $(Pipeline.Workspace)/s/src
+    configTomlPath: $(Pipeline.Workspace)/s/.cargo/config.toml
+    npmrcPath: '$(Agent.TempDirectory)/mxc.npmrc'
+    NPM_CONFIG_USERCONFIG: '$(npmrcPath)'
+
+  templateContext:
+    rust:
+      rustToolchain:
+        toolchainFeed: https://microsoft.pkgs.visualstudio.com/Dart/_packaging/Mxc-Azure-Feed/nuget/v3/index.json
+        version: 'ms-prod-1.93'
+      workingDirectory: $(workingDirectory)
+      authenticateOptions:
+        configFile: $(configTomlPath)
+      installOptions:
+        configFile: $(configTomlPath)
+      cacheOptions:
+        enabled: true
+        enableTargetCache: true
+      artifactOptions:
+        suffix: ${{ parameters.packageName }} 
+ 
+  steps:
+  - checkout: ${{ parameters.checkoutRepo }}
+    path: s
+
+  - powershell: |
+      Copy-Item `
+        "$(Build.SourcesDirectory)/.azure-pipelines/.npm/.npmrc" `
+        "$(npmrcPath)"
+    displayName: 'Prepare npm configuration'
+
+  - task: NpmAuthenticate@0
+    displayName: 'Authenticate npm'
+    inputs:
+      workingFile: '$(npmrcPath)'
+
+  - template: Rust.Build.Steps.Official.yml@self
+    parameters:
+      targetTriple: $(triplet)
+      workingDirectory: $(workingDirectory)
+      cargoFeatures: isolation_session
+      enableTest: 'false'
+
+  # Build the SDK and integration tests so the Node E2E suite can be
+  # included in the test bundle.  The SDK has a native dep (node-pty)
+  # that requires node-gyp; the windows-2022 image has VS build tools.
+  - task: NodeTool@1
+    displayName: Use Node.js 20
+    inputs:
+      version: '20.x'
+
+  # Populate sdk/node/bin/x64 with the freshly-built wxc-exec.exe so the SDK
+  # resolves its binary at runtime.  (build.bat does this; the pipeline
+  # must replicate it since we only build wxc-exec, not the full repo.)
+  - powershell: |
+      $sdkBin = "$(Build.SourcesDirectory)/sdk/node/bin/x64"
+      New-Item -ItemType Directory -Force -Path $sdkBin | Out-Null
+      Copy-Item "$(CARGO_TARGET_DIR)/x86_64-pc-windows-msvc/release/wxc-exec.exe" "$sdkBin/"
+      Write-Host "  -> sdk/node/bin/x64/wxc-exec.exe"
+    displayName: 'Stage wxc-exec into SDK bin'
+
+  - script: npm ci && npm run build
+    displayName: 'Build SDK (@microsoft/mxc-sdk)'
+    workingDirectory: sdk/node
+
+  - script: npm ci && npm run build
+    displayName: 'Build SDK integration tests'
+    workingDirectory: sdk/node/tests/integration
+
+  # Stage the test bundle for publishing as a pipeline artifact.
+  - powershell: |
+      $out = "$(outputDirectory)"
+      New-Item -ItemType Directory -Force -Path "$out/bin/x64", "$out/test_configs", "$out/test_scripts" | Out-Null
+
+      # wxc-exec binary (isolation_session enabled)
+      Copy-Item "$(CARGO_TARGET_DIR)/x86_64-pc-windows-msvc/release/wxc-exec.exe" "$out/bin/x64/"
+      Write-Host "  -> bin/x64/wxc-exec.exe"
+
+      # Test configs (isolation_session subset)
+      $configs = Get-ChildItem "$(Build.SourcesDirectory)/tests/configs/isolation_session_*.json"
+      foreach ($f in $configs) {
+          Copy-Item $f.FullName "$out/test_configs/"
+          Write-Host "  -> test_configs/$($f.Name)"
+      }
+
+      # Test scripts
+      $scripts = @(
+          'run_isolation_session_tests.ps1',
+          'run_isolation_session_state_aware_tests.ps1',
+          'run_test_configs.ps1'
+      )
+      foreach ($s in $scripts) {
+          $src = "$(Build.SourcesDirectory)/tests/scripts/$s"
+          if (Test-Path $src) {
+              Copy-Item $src "$out/test_scripts/"
+              Write-Host "  -> test_scripts/$s"
+          }
+      }
+
+      # SDK integration tests (Node E2E suite)
+      $sdkInteg = "$out/sdk-integration"
+      $integSrc = "$(Build.SourcesDirectory)/sdk/node/tests/integration"
+      $sdkRoot  = "$(Build.SourcesDirectory)/sdk/node"
+      New-Item -ItemType Directory -Force -Path $sdkInteg | Out-Null
+
+      # Built test files, runner, and package.json
+      Copy-Item -Recurse "$integSrc/dist" "$sdkInteg/dist"
+      Copy-Item "$integSrc/package.json" "$sdkInteg/package.json"
+      Copy-Item "$integSrc/run-tests.js" "$sdkInteg/run-tests.js"
+
+      # node_modules — skip the @microsoft symlink (it points back into
+      # the repo and would recurse).  Copy the SDK's published shape
+      # directly into @microsoft/mxc-sdk instead.
+      $integNm = "$integSrc/node_modules"
+      $stagingNm = "$sdkInteg/node_modules"
+      New-Item -ItemType Directory -Force -Path $stagingNm | Out-Null
+      foreach ($entry in Get-ChildItem -Path $integNm -Force) {
+          if ($entry.Name -eq '@microsoft') { continue }
+          Copy-Item -Recurse -Force $entry.FullName "$stagingNm/$($entry.Name)"
+      }
+      $sdkStaged = "$stagingNm/@microsoft/mxc-sdk"
+      New-Item -ItemType Directory -Force -Path $sdkStaged | Out-Null
+      Copy-Item -Recurse "$sdkRoot/bin" "$sdkStaged/bin"
+      Copy-Item -Recurse "$sdkRoot/dist" "$sdkStaged/dist"
+      Copy-Item "$sdkRoot/package.json" "$sdkStaged/package.json"
+      if (Test-Path "$sdkRoot/LICENSE.md") {
+          Copy-Item "$sdkRoot/LICENSE.md" "$sdkStaged/LICENSE.md"
+      }
+      Copy-Item -Recurse "$sdkRoot/node_modules" "$sdkStaged/node_modules"
+      Write-Host "  -> sdk-integration/ (Node E2E suite)"
+
+      # Manifest
+      $manifest = @{
+          format_version = 1
+          produced_at    = (Get-Date).ToUniversalTime().ToString('o')
+          commit_sha     = "$(Build.SourceVersion)"
+          build_id       = "$(Build.BuildId)"
+          pipeline       = "$(Build.DefinitionName)"
+          triplet        = "x86_64-pc-windows-msvc"
+          package        = "${{ parameters.packageName }}"
+          features       = @('isolation_session')
+      }
+      $manifest | ConvertTo-Json -Depth 3 | Set-Content "$out/manifest.json" -Encoding UTF8
+      Write-Host "  -> manifest.json"
+
+      Write-Host "`n==> Bundle assembled at $out"
+      Get-ChildItem $out -Recurse -File | ForEach-Object { Write-Host "  $($_.FullName.Replace($out, ''))" }
+    displayName: 'Assemble test bundle'
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: 'Publish Isolation Test Bundle (${{ parameters.packageName }})'
+    inputs:
+      path: '$(outputDirectory)'
+      artifactName: ${{ parameters.artifactName }}

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -4,8 +4,8 @@
 # Parameterized "package isolation_session test bundle" job used by
 # 1ES.IsolationSession.TestBundle.yml. Builds wxc-exec with
 # --features isolation_session from the given source repo resource and
-# publishes the bundle under the given pipeline artifact name. Artfacts
-# produced by this job are intended for OS vpack consumption so they wxc-exec
+# publishes the bundle under the given pipeline artifact name. Artifacts
+# produced by this job are intended for OS vpack consumption so that wxc-exec
 # can be invoked from the IsoEnvBroker (IsolationSession) APIs on Windows 11 targets
 # for testing.
 #

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -185,7 +185,7 @@ jobs:
           format_version = 1
           produced_at    = (Get-Date).ToUniversalTime().ToString('o')
           branch_name    = "${{ parameters.checkoutRepo }}"
-          commit_sha     = "$(Build.SourceVersion)"
+          commit_sha     = (git -C "$(Build.SourcesDirectory)" rev-parse HEAD).Trim()
           build_id       = "$(Build.BuildId)"
           pipeline       = "$(Build.DefinitionName)"
           triplet        = "x86_64-pc-windows-msvc"

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -135,7 +135,8 @@ jobs:
       # Test scripts
       $scripts = @(
           'run_isolation_session_tests.ps1',
-          'run_isolation_session_state_aware_tests.ps1'
+          'run_isolation_session_state_aware_tests.ps1',
+          'run_isolation_session_resize_smoke.ps1'
       )
       foreach ($s in $scripts) {
           $src = "$(Build.SourcesDirectory)/tests/scripts/$s"

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -198,45 +198,45 @@ jobs:
 
   # Test sign (CP-230072) the staged binaries so the vpack ships signed binaries.
   - task: EsrpCodeSigning@5
-        displayName: Code Sign
-        inputs:
-          ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
-          AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
-          AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }}
-          AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
-          AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
-          AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
-          FolderPath: $(outputDirectory)
-          Pattern: |
-            **/*.dll
-            **/*.ps1
-            **/*.exe
+    displayName: Code Sign
+    inputs:
+      ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
+      AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
+      AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }}
+      AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
+      AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
+      AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
+      FolderPath: $(outputDirectory)
+      Pattern: |
+        **/*.dll
+        **/*.ps1
+        **/*.exe
 
-          UseMinimatch: true
-          signConfigType: 'inlineSignParams'
-          inlineOperation: >-
-            [
-              {
-                "KeyCode": "CP-230072", 
-                "OperationCode": "SigntoolSign",
-                "ToolName": "sign",
-                "ToolVersion": "1.0",
-                "Parameters": {
-                  "OpusName": "Microsoft",
-                  "OpusInfo": "https://www.microsoft.com",
-                  "FileDigest": "/fd SHA256",
-                  "PageHash": "/NPH",
-                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                }
-              },
-              {
-                "KeyCode": "CP-230012",
-                "OperationCode": "SigntoolVerify",
-                "ToolName": "sign",
-                "ToolVersion": "1.0",
-                "Parameters": {}
-              }
-            ]
+      UseMinimatch: true
+      signConfigType: 'inlineSignParams'
+      inlineOperation: >-
+        [
+          {
+            "KeyCode": "CP-230072", 
+            "OperationCode": "SigntoolSign",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {
+              "OpusName": "Microsoft",
+              "OpusInfo": "https://www.microsoft.com",
+              "FileDigest": "/fd SHA256",
+              "PageHash": "/NPH",
+              "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            }
+          },
+          {
+            "KeyCode": "CP-230012",
+            "OperationCode": "SigntoolVerify",
+            "ToolName": "sign",
+            "ToolVersion": "1.0",
+            "Parameters": {}
+          }
+        ]
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: 'Publish Isolation Test Bundle (${{ parameters.packageName }})'

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -135,7 +135,7 @@ jobs:
       # Test scripts
       $scripts = @(
           'run_isolation_session_tests.ps1',
-          'run_isolation_session_state_aware_tests.ps1',
+          'run_isolation_session_state_aware_tests.ps1'
       )
       foreach ($s in $scripts) {
           $src = "$(Build.SourcesDirectory)/tests/scripts/$s"
@@ -182,6 +182,7 @@ jobs:
       $manifest = @{
           format_version = 1
           produced_at    = (Get-Date).ToUniversalTime().ToString('o')
+          branch_name    = "${{ parameters.checkoutRepo }}"
           commit_sha     = "$(Build.SourceVersion)"
           build_id       = "$(Build.BuildId)"
           pipeline       = "$(Build.DefinitionName)"

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -25,6 +25,16 @@ parameters:
 - name: packageName
   type: string
 
+- name: ESRPInfo
+  type: object
+  default:
+    serviceName: ''
+    tenantId: ''
+    azureKeyVaultName: ''
+    authCertName: ''
+    signCertName: ''
+    clientId: ''
+
 jobs:
 - job: package_iso_test_bundle_${{ parameters.packageName }}
   displayName: 'Package Isolation Session Test Bundle (${{ parameters.packageName }}, x64)'
@@ -112,7 +122,11 @@ jobs:
       Write-Host "  -> bin/x64/wxc-exec.exe"
 
       # Test configs (isolation_session subset)
-      $configs = Get-ChildItem "$(Build.SourcesDirectory)/tests/configs/isolation_session_*.json"
+      $configs = @(Get-ChildItem "$(Build.SourcesDirectory)/tests/configs/isolation_session_*.json" -File)
+      if ($configs.Count -eq 0) {
+          throw "No isolation_session test configs found under tests/configs"
+      }
+
       foreach ($f in $configs) {
           Copy-Item $f.FullName "$out/test_configs/"
           Write-Host "  -> test_configs/$($f.Name)"
@@ -122,14 +136,14 @@ jobs:
       $scripts = @(
           'run_isolation_session_tests.ps1',
           'run_isolation_session_state_aware_tests.ps1',
-          'run_test_configs.ps1'
       )
       foreach ($s in $scripts) {
           $src = "$(Build.SourcesDirectory)/tests/scripts/$s"
-          if (Test-Path $src) {
-              Copy-Item $src "$out/test_scripts/"
-              Write-Host "  -> test_scripts/$s"
-          }
+          if (-not (Test-Path -LiteralPath $src -PathType Leaf)) {
+               throw "Required test script not found: $src"
+           }
+          Copy-Item $src "$out/test_scripts/"
+          Write-Host "  -> test_scripts/$s"
       }
 
       # SDK integration tests (Node E2E suite)
@@ -181,6 +195,48 @@ jobs:
       Write-Host "`n==> Bundle assembled at $out"
       Get-ChildItem $out -Recurse -File | ForEach-Object { Write-Host "  $($_.FullName.Replace($out, ''))" }
     displayName: 'Assemble test bundle'
+
+  # Test sign (CP-230072) the staged binaries so the vpack ships signed binaries.
+  - task: EsrpCodeSigning@5
+        displayName: Code Sign
+        inputs:
+          ConnectedServiceName: ${{ parameters.ESRPInfo.serviceName }}
+          AppRegistrationClientId: ${{ parameters.ESRPInfo.clientId }}
+          AppRegistrationTenantId: ${{ parameters.ESRPInfo.tenantId }}
+          AuthAKVName: ${{ parameters.ESRPInfo.azureKeyVaultName }}
+          AuthCertName: ${{ parameters.ESRPInfo.authCertName }}
+          AuthSignCertName: ${{ parameters.ESRPInfo.signCertName }}
+          FolderPath: $(outputDirectory)
+          Pattern: |
+            **/*.dll
+            **/*.ps1
+            **/*.exe
+
+          UseMinimatch: true
+          signConfigType: 'inlineSignParams'
+          inlineOperation: >-
+            [
+              {
+                "KeyCode": "CP-230072", 
+                "OperationCode": "SigntoolSign",
+                "ToolName": "sign",
+                "ToolVersion": "1.0",
+                "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                }
+              },
+              {
+                "KeyCode": "CP-230012",
+                "OperationCode": "SigntoolVerify",
+                "ToolName": "sign",
+                "ToolVersion": "1.0",
+                "Parameters": {}
+              }
+            ]
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: 'Publish Isolation Test Bundle (${{ parameters.packageName }})'

--- a/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
+++ b/.azure-pipelines/templates/IsolationSession.TestBundle.Build.Job.yml
@@ -153,7 +153,9 @@ jobs:
       New-Item -ItemType Directory -Force -Path $sdkInteg | Out-Null
 
       # Built test files, runner, and package.json
-      Copy-Item -Recurse "$integSrc/dist" "$sdkInteg/dist"
+      New-Item -ItemType Directory -Force -Path "$sdkInteg/dist" | Out-Null
+      Copy-Item "$integSrc/dist/isolation-session-*.test.js" "$sdkInteg/dist/"
+      Copy-Item "$integSrc/dist/test-helpers.js" "$sdkInteg/dist/"
       Copy-Item "$integSrc/package.json" "$sdkInteg/package.json"
       Copy-Item "$integSrc/run-tests.js" "$sdkInteg/run-tests.js"
 

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -37,6 +37,11 @@ resources:
       source: 'MXC-Official-Build'
       trigger: none
 
+    # Source of the isolation_session test bundle.
+    - pipeline: IsoSession-TestPackage
+      source: 'MXC-Iso-Session'
+      trigger: none
+
 extends:
   template: v2/Microsoft.Official.yml@templates
   parameters:
@@ -115,6 +120,15 @@ extends:
                 symbols/wxc-exec.pdb
                 _manifest/**
 
+            # Download both isolation_session test packages (main and feature/isolation-session-internal) to stage into the vpack.
+            - download: Iso-Session-TestPackage-main
+              displayName: Download isolation_session x64 (main)
+              artifact: mxc-iso-test-bundle-main-x64
+            
+            - download: Iso-Session-TestPackage-feature
+              displayName: Download isolation_session x64 (feature/isolation-session-internal)
+              artifact: mxc-iso-test-bundle-feature-x64
+
             - task: PowerShell@2
               displayName: Stage binaries for vpack
               inputs:
@@ -123,45 +137,27 @@ extends:
                   $src = "$(Pipeline.Workspace)\MXC"
                   Copy-Item -Recurse -Force "$src\wxc-binaries-x86_64-pc-windows-msvc"  "$(ob_outputDirectory)\x64"
                   Copy-Item -Recurse -Force "$src\wxc-binaries-aarch64-pc-windows-msvc" "$(ob_outputDirectory)\arm64"
+
                   # OneBranch's "Publish VPack SBOM Manifest" step expects
                   # _manifest/spdx_2.2/ at the top of VPackContents. The
                   # per-arch SBOMs are identical source-wise, so promote x64's.
                   Copy-Item -Recurse -Force "$(ob_outputDirectory)\x64\_manifest" "$(ob_outputDirectory)\_manifest"
 
-            # Stage the current isolation_session test collateral into the vpack
-            # under isolation_session/main/, so the OS side can run these tests.
-            # Copies every *isolation_session* file from tests/scripts and
-            # tests/configs into scripts/ and configs/ subfolders.
-            - task: PowerShell@2
-              displayName: Stage isolation_session tests for vpack
-              inputs:
-                targetType: inline
-                script: |
-                  $ErrorActionPreference = 'Stop'
-                  # Enumerate matches first so a stale/empty pattern fails fast
-                  # with a clear message, instead of a generic Copy-Item error or
-                  # a silently-empty folder in the vpack.
-                  $scriptsSrc = Get-ChildItem "$(Build.SourcesDirectory)\tests\scripts\*isolation_session*" -File
-                  $configsSrc = Get-ChildItem "$(Build.SourcesDirectory)\tests\configs\*isolation_session*" -File
-                  if (-not $scriptsSrc) { throw "No *isolation_session* scripts found under tests\scripts" }
-                  if (-not $configsSrc) { throw "No *isolation_session* configs found under tests\configs" }
-
-                  $scriptsDest = "$(ob_outputDirectory)\isolation_session\main\scripts"
-                  $configsDest = "$(ob_outputDirectory)\isolation_session\main\configs"
-                  New-Item -ItemType Directory -Force -Path $scriptsDest | Out-Null
-                  New-Item -ItemType Directory -Force -Path $configsDest | Out-Null
-                  $scriptsSrc | Copy-Item -Destination $scriptsDest -Force
-                  $configsSrc | Copy-Item -Destination $configsDest -Force
-                  Write-Host "Staged $($scriptsSrc.Count) scripts and $($configsSrc.Count) configs into isolation_session\main"
+                  # Stage isolation_session test collateral into the vpack under isolation_session/
+                  $isoSrcMain = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-main-x64"
+                  Copy-Item -Recurse -Force "$isoSrcMain\*" "$(ob_outputDirectory)\isolation_session\main"
+                  
+                  $isoSrcFeature = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-feature-x64"
+                  Copy-Item -Recurse -Force "$isoSrcFeature\*" "$(ob_outputDirectory)\isolation_session\feature"
 
             # Authenticode-sign the staged PowerShell scripts so Code Sign
             # Validation (CSV) passes and the vpack ships signed scripts. The
             # downloaded wxc binaries arrive pre-signed from MXC-Official-Build;
-            # only these source-staged .ps1 scripts need signing here.
+            # only these source-staged .ps1 scripts and binaries from iso session pipeline need signing here.
             - task: onebranch.pipeline.signing@1
               displayName: Sign isolation_session scripts
               inputs:
                 command: sign
                 signing_profile: external_distribution
-                files_to_sign: '**/*.ps1'
-                search_root: $(ob_outputDirectory)\isolation_session\main\scripts
+                files_to_sign: '**/*.ps1;**/*.dll;**/*.exe'
+                search_root: $(ob_outputDirectory)\isolation_session

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -145,19 +145,11 @@ extends:
 
                   # Stage isolation_session test collateral into the vpack under isolation_session/
                   $isoSrcMain = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-main-x64"
-                  Copy-Item -Recurse -Force "$isoSrcMain\*" "$(ob_outputDirectory)\isolation_session\main"
+                  $isoDestMain = "$(ob_outputDirectory)\isolation_session\main"
+                  New-Item -ItemType Directory -Force -Path $isoDestMain | Out-Null
+                  Copy-Item -Recurse -Force "$isoSrcMain\*" $isoDestMain
                   
                   $isoSrcFeature = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-feature-x64"
-                  Copy-Item -Recurse -Force "$isoSrcFeature\*" "$(ob_outputDirectory)\isolation_session\feature"
-
-            # Authenticode-sign the staged PowerShell scripts so Code Sign
-            # Validation (CSV) passes and the vpack ships signed scripts. The
-            # downloaded wxc binaries arrive pre-signed from MXC-Official-Build;
-            # only these source-staged .ps1 scripts and binaries from iso session pipeline need signing here.
-            - task: onebranch.pipeline.signing@1
-              displayName: Sign isolation_session scripts
-              inputs:
-                command: sign
-                signing_profile: external_distribution
-                files_to_sign: '**/*.ps1;**/*.dll;**/*.exe'
-                search_root: $(ob_outputDirectory)\isolation_session
+                  $isoDestFeature = "$(ob_outputDirectory)\isolation_session\feature"
+                  New-Item -ItemType Directory -Force -Path $isoDestFeature | Out-Null
+                  Copy-Item -Recurse -Force "$isoSrcFeature\*" $isoDestFeature

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -125,7 +125,7 @@ extends:
               displayName: Download isolation_session x64 (main)
               artifact: mxc-iso-test-bundle-main-x64
             
-            - download: Iso-Session-TestPackage-feature
+            - download: IsoSession-TestPackage
               displayName: Download isolation_session x64 (feature/isolation-session-internal)
               artifact: mxc-iso-test-bundle-feature-x64
 

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -121,7 +121,7 @@ extends:
                 _manifest/**
 
             # Download both isolation_session test packages (main and feature/isolation-session-internal) to stage into the vpack.
-            - download: Iso-Session-TestPackage-main
+            - download: IsoSession-TestPackage
               displayName: Download isolation_session x64 (main)
               artifact: mxc-iso-test-bundle-main-x64
             


### PR DESCRIPTION
## 📖 Description
<!-- Describe what this PR changes, why, and any limitations. -->
The isolation session team needs to be able to run mxc  from both main and their feature branch in windows nightly test passes to confirm their new features/refactors don't break MXC. They also want to test out experimental features for the iso session backend that may not be on Windows insider builds yet to confirm functionality with MXC before they check into main. These additions are done via their feature/isolation_session_feature-internal branch in the MXC repo. This PR adds the azure templates needed to package up wxc-exec, iso session configs and scripts from both main branch and the feature branch so they can be packaged into our Vpack.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/692)