### PR TITLE
Add sealed ETL denial analysis

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1266,6 +1266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "learning_mode_core"
+version = "0.7.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "learning_mode_windows"
 version = "0.7.0"
 dependencies = [

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1279,6 +1279,7 @@ name = "learning_mode_windows"
 version = "0.7.0"
 dependencies = [
  "flatbuffers",
+ "learning_mode_core",
  "sandbox_spec",
  "thiserror",
  "windows",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "core/wxc",
     "core/wxc_common",
+    "core/learning_mode_core",
     "core/lxc",
     "core/mxc_darwin",
     "core/mxc-sdk",
@@ -113,6 +114,7 @@ windows_sandbox_lifecycle = { path = "backends/windows_sandbox/lifecycle" }
 isolation_session_common = { path = "backends/isolation_session/common" }
 hyperlight_common = { path = "backends/hyperlight/common" }
 learning_mode_windows = { path = "backends/learning_mode/windows" }
+learning_mode_core = { path = "core/learning_mode_core" }
 nanvix_runner = { path = "backends/nanvix/runner" }
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }

--- a/src/backends/learning_mode/windows/Cargo.toml
+++ b/src/backends/learning_mode/windows/Cargo.toml
@@ -9,6 +9,7 @@ thiserror = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 wxc_common = { workspace = true }
+learning_mode_core = { workspace = true }
 windows = { workspace = true }
 windows-core = { workspace = true }
 

--- a/src/backends/learning_mode/windows/examples/lm_analyze.rs
+++ b/src/backends/learning_mode/windows/examples/lm_analyze.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Decode a sealed learning-mode `.etl` into the captureDenials NDJSON
+//! output stream, or dump its raw ETW events for schema discovery.
+//!
+//! Usage:
+//!
+//! ```text
+//! # Emit the DeniedResource NDJSON stream (0x1E-framed) to stdout:
+//! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl>
+//!
+//! # Dump every decoded event (id + property name/value pairs):
+//! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl> --raw
+//! ```
+//!
+//! Exit codes: `0` = decoded; `2` = wrong platform / bad args; `1` = decode
+//! failed.
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    eprintln!("lm_analyze is Windows-only");
+    std::process::exit(2);
+}
+
+#[cfg(target_os = "windows")]
+fn main() {
+    std::process::exit(windows_impl::run());
+}
+
+#[cfg(target_os = "windows")]
+mod windows_impl {
+    use std::collections::BTreeMap;
+    use std::io::Write;
+    use std::path::Path;
+
+    use learning_mode_core::{emit, DenialAnalyzer, DenialSummary};
+    use learning_mode_windows::{decode_raw_events, EtlDenialAnalyzer};
+
+    pub fn run() -> i32 {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        let Some(etl_path) = args.first() else {
+            eprintln!("usage: lm_analyze <path-to.etl> [--raw]");
+            return 2;
+        };
+        let raw = args.iter().any(|a| a == "--raw");
+        let path = Path::new(etl_path);
+
+        if raw {
+            dump_raw(path)
+        } else {
+            emit_ndjson(path)
+        }
+    }
+
+    /// Decodes denials and writes the 0x1E-framed NDJSON stream to stdout.
+    fn emit_ndjson(path: &Path) -> i32 {
+        let denials = match EtlDenialAnalyzer.analyze(path) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!("analyze failed: {e}");
+                return 1;
+            }
+        };
+        let summary = DenialSummary::new(0, denials.len(), false);
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        if let Err(e) = emit::write_stream(&mut handle, &denials, &summary) {
+            eprintln!("write failed: {e}");
+            return 1;
+        }
+        eprintln!("lm_analyze: {} unique denial(s)", denials.len());
+        0
+    }
+
+    /// Dumps every decoded event, plus a per-event-id histogram, so the
+    /// real provider/ID/field schema can be confirmed against hardware.
+    fn dump_raw(path: &Path) -> i32 {
+        let events = match decode_raw_events(path) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("decode failed: {e}");
+                return 1;
+            }
+        };
+
+        let mut histogram: BTreeMap<u16, usize> = BTreeMap::new();
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        for ev in &events {
+            *histogram.entry(ev.event_id).or_default() += 1;
+            let props: Vec<String> = ev.props.iter().map(|(k, v)| format!("{k}={v}")).collect();
+            let _ = writeln!(out, "event {} | {}", ev.event_id, props.join(" | "));
+        }
+        let _ = writeln!(out, "--- {} event(s) total ---", events.len());
+        for (id, count) in &histogram {
+            let _ = writeln!(out, "  id {id}: {count}");
+        }
+        0
+    }
+}

--- a/src/backends/learning_mode/windows/examples/lm_analyze.rs
+++ b/src/backends/learning_mode/windows/examples/lm_analyze.rs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Decode a sealed learning-mode `.etl` into the captureDenials NDJSON
-//! output stream, or dump its raw ETW events for schema discovery.
+//! Decode a sealed learning-mode `.etl` into the captureDenials RFC 7464
+//! JSON text sequence, or dump its raw ETW events for schema discovery.
 //!
 //! Usage:
 //!
 //! ```text
-//! # Emit the DeniedResource NDJSON stream (0x1E-framed) to stdout:
+//! # Emit the DeniedResource JSON text sequence (0x1E-framed) to stdout:
 //! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl> --exit-code <code>
 //!
 //! # Dump every decoded event (id + property name/value pairs):
@@ -53,7 +53,7 @@ mod windows_impl {
                 eprintln!("--exit-code <code> is required unless --raw is used");
                 return 2;
             };
-            emit_ndjson(path, exit_code)
+            emit_json_sequence(path, exit_code)
         }
     }
 
@@ -62,8 +62,8 @@ mod windows_impl {
         args.get(index + 1)?.parse().ok()
     }
 
-    /// Decodes denials and writes the 0x1E-framed NDJSON stream to stdout.
-    fn emit_ndjson(path: &Path, exit_code: i32) -> i32 {
+    /// Decodes denials and writes the RFC 7464 JSON text sequence to stdout.
+    fn emit_json_sequence(path: &Path, exit_code: i32) -> i32 {
         let analysis = match EtlDenialAnalyzer.analyze(path) {
             Ok(d) => d,
             Err(e) => {

--- a/src/backends/learning_mode/windows/examples/lm_analyze.rs
+++ b/src/backends/learning_mode/windows/examples/lm_analyze.rs
@@ -4,6 +4,10 @@
 //! Decode a sealed learning-mode `.etl` into the captureDenials RFC 7464
 //! JSON text sequence, or dump its raw ETW events for schema discovery.
 //!
+//! This is a developer diagnostic for inspecting captured traces manually.
+//! End users and SDK agents do not invoke it: the BaseContainer runner seals
+//! and consumes the trace automatically during normal `captureDenials` use.
+//!
 //! Usage:
 //!
 //! ```text

--- a/src/backends/learning_mode/windows/examples/lm_analyze.rs
+++ b/src/backends/learning_mode/windows/examples/lm_analyze.rs
@@ -35,7 +35,7 @@ mod windows_impl {
     use std::path::Path;
 
     use learning_mode_core::{emit, DenialAnalyzer, DenialSummary};
-    use learning_mode_windows::{decode_raw_events, EtlDenialAnalyzer};
+    use learning_mode_windows::{visit_raw_events, EtlDenialAnalyzer};
 
     pub fn run() -> i32 {
         let args: Vec<String> = std::env::args().skip(1).collect();
@@ -97,25 +97,40 @@ mod windows_impl {
     /// Dumps every decoded event, plus a per-event-id histogram, so the
     /// real provider/ID/field schema can be confirmed against hardware.
     fn dump_raw(path: &Path) -> i32 {
-        let events = match decode_raw_events(path) {
-            Ok(e) => e,
-            Err(e) => {
-                eprintln!("decode failed: {e}");
-                return 1;
+        let mut histogram: BTreeMap<(String, u16), usize> = BTreeMap::new();
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        let event_count = {
+            let mut visitor = |ev: &learning_mode_windows::DecodedEventParts| {
+                let provider = format!("{:?}", ev.provider);
+                *histogram
+                    .entry((provider.clone(), ev.event_id))
+                    .or_default() += 1;
+                let props: Vec<String> = ev.props.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                writeln!(
+                    out,
+                    "provider {} event {} | {}",
+                    provider,
+                    ev.event_id,
+                    props.join(" | ")
+                )
+            };
+            match visit_raw_events(path, &mut visitor) {
+                Ok(count) => count,
+                Err(e) => {
+                    eprintln!("decode failed: {e}");
+                    return 1;
+                }
             }
         };
 
-        let mut histogram: BTreeMap<u16, usize> = BTreeMap::new();
-        let stdout = std::io::stdout();
-        let mut out = stdout.lock();
-        for ev in &events {
-            *histogram.entry(ev.event_id).or_default() += 1;
-            let props: Vec<String> = ev.props.iter().map(|(k, v)| format!("{k}={v}")).collect();
-            let _ = writeln!(out, "event {} | {}", ev.event_id, props.join(" | "));
+        if writeln!(out, "--- {event_count} event(s) total ---").is_err() {
+            return 1;
         }
-        let _ = writeln!(out, "--- {} event(s) total ---", events.len());
-        for (id, count) in &histogram {
-            let _ = writeln!(out, "  id {id}: {count}");
+        for ((provider, id), count) in &histogram {
+            if writeln!(out, "  provider {provider:?} id {id}: {count}").is_err() {
+                return 1;
+            }
         }
         0
     }

--- a/src/backends/learning_mode/windows/examples/lm_analyze.rs
+++ b/src/backends/learning_mode/windows/examples/lm_analyze.rs
@@ -8,7 +8,7 @@
 //!
 //! ```text
 //! # Emit the DeniedResource NDJSON stream (0x1E-framed) to stdout:
-//! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl>
+//! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl> --exit-code <code>
 //!
 //! # Dump every decoded event (id + property name/value pairs):
 //! cargo run -p learning_mode_windows --example lm_analyze -- <path-to.etl> --raw
@@ -40,7 +40,7 @@ mod windows_impl {
     pub fn run() -> i32 {
         let args: Vec<String> = std::env::args().skip(1).collect();
         let Some(etl_path) = args.first() else {
-            eprintln!("usage: lm_analyze <path-to.etl> [--raw]");
+            eprintln!("usage: lm_analyze <path-to.etl> [--raw | --exit-code <code>]");
             return 2;
         };
         let raw = args.iter().any(|a| a == "--raw");
@@ -49,27 +49,48 @@ mod windows_impl {
         if raw {
             dump_raw(path)
         } else {
-            emit_ndjson(path)
+            let Some(exit_code) = parse_exit_code(&args) else {
+                eprintln!("--exit-code <code> is required unless --raw is used");
+                return 2;
+            };
+            emit_ndjson(path, exit_code)
         }
     }
 
+    fn parse_exit_code(args: &[String]) -> Option<i32> {
+        let index = args.iter().position(|arg| arg == "--exit-code")?;
+        args.get(index + 1)?.parse().ok()
+    }
+
     /// Decodes denials and writes the 0x1E-framed NDJSON stream to stdout.
-    fn emit_ndjson(path: &Path) -> i32 {
-        let denials = match EtlDenialAnalyzer.analyze(path) {
+    fn emit_ndjson(path: &Path, exit_code: i32) -> i32 {
+        let analysis = match EtlDenialAnalyzer.analyze(path) {
             Ok(d) => d,
             Err(e) => {
                 eprintln!("analyze failed: {e}");
                 return 1;
             }
         };
-        let summary = DenialSummary::new(0, denials.len(), false);
+        let summary = DenialSummary::new(
+            exit_code,
+            analysis.denials.len(),
+            analysis.denied_resources_truncated,
+        );
         let stdout = std::io::stdout();
         let mut handle = stdout.lock();
-        if let Err(e) = emit::write_stream(&mut handle, &denials, &summary) {
+        if let Err(e) = emit::write_stream(&mut handle, &analysis.denials, &summary) {
             eprintln!("write failed: {e}");
             return 1;
         }
-        eprintln!("lm_analyze: {} unique denial(s)", denials.len());
+        eprintln!(
+            "lm_analyze: {} unique denial(s){}",
+            analysis.denials.len(),
+            if analysis.denied_resources_truncated {
+                " (truncated)"
+            } else {
+                ""
+            }
+        );
         0
     }
 

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -54,10 +54,22 @@ pub struct EtlDenialAnalyzer;
 impl DenialAnalyzer for EtlDenialAnalyzer {
     fn analyze(&self, source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError> {
         let events = process_trace_file(source_path)?;
-        Ok(dedup_to_resources(events.iter().filter_map(|e| {
-            extract_denial(&e.parts, e.pid, e.filetime)
-        })))
+        Ok(resources_from_events(&events))
     }
+}
+
+/// Runs the pure decode composition over already-collected events:
+/// route each event through [`extract_denial`], then normalise +
+/// de-duplicate into public [`DeniedResource`]s. Split out from
+/// [`EtlDenialAnalyzer::analyze`] so it can be tested with hand-built events
+/// that mirror real traces, without a live ETW/TDH read (which needs the
+/// provider manifests registered on the machine).
+fn resources_from_events(events: &[CollectedEvent]) -> Vec<DeniedResource> {
+    dedup_to_resources(
+        events
+            .iter()
+            .filter_map(|e| extract_denial(&e.parts, e.pid, e.filetime)),
+    )
 }
 
 /// Decodes every event in the ETL into `(event_id, props)` pairs, for
@@ -237,5 +249,164 @@ mod tests {
             .analyze(Path::new(r"C:\does\not\exist\nope.etl"))
             .unwrap_err();
         assert!(matches!(err, AnalyzeError::Open { .. }), "got {err:?}");
+    }
+
+    // ---- decode composition over real event shapes ------------------------
+    //
+    // These exercise the full `analyze` pipeline minus the OS trace read:
+    // `extract_denial` routing -> path normalisation -> dedup. The events
+    // mirror captures taken on hardware for both learning modes (see the
+    // module/extractor docs); a live ETW/TDH read isn't used because it
+    // needs the provider manifests registered on the machine.
+
+    fn event(event_id: u16, pid: u32, filetime: u64, kv: &[(&str, &str)]) -> CollectedEvent {
+        CollectedEvent {
+            pid,
+            filetime,
+            parts: DecodedEventParts {
+                event_id,
+                props: kv
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                    .collect(),
+            },
+        }
+    }
+
+    /// Mirrors the real `Mode="Normal"` (block-and-log) capture: file/registry
+    /// access checks as event 14 plus a compact capability denial as event 28.
+    #[test]
+    fn block_and_log_shape_decodes_and_classifies() {
+        let events = vec![
+            // File write (DELETE | FILE_READ_DATA -> Write), \??\ prefix.
+            event(
+                14,
+                5480,
+                10,
+                &[
+                    ("Mode", "\"Normal\""),
+                    ("ObjectType", "\"File\""),
+                    ("ObjectName", "\"\\??\\C:\\data\\test\\bin\\\""),
+                    ("AccessMask", "0x10001"),
+                ],
+            ),
+            // Registry read (KEY_READ 0x20019 -> Read) stays kernel-form.
+            event(
+                14,
+                6860,
+                11,
+                &[
+                    ("Mode", "\"Normal\""),
+                    ("ObjectType", "\"Key\""),
+                    ("ObjectName", "\"\\REGISTRY\\USER\\.DEFAULT\\Console\""),
+                    ("AccessMask", "0x20019"),
+                ],
+            ),
+            // Capability denial (event 28) -> empty path, unknown access.
+            event(
+                28,
+                0,
+                12,
+                &[
+                    ("ProcessName", "\"conhost.exe\""),
+                    ("ProcessId", "0x1acc"),
+                    ("Denied", "true"),
+                ],
+            ),
+        ];
+
+        let out = resources_from_events(&events);
+        assert_eq!(out.len(), 3);
+
+        assert_eq!(out[0].path, r"C:\data\test\bin\");
+        assert_eq!(out[0].resource_type, ResourceType::File);
+        assert_eq!(out[0].access_type, AccessType::Write);
+        assert_eq!(out[0].pid, 5480);
+
+        assert_eq!(out[1].path, r"\REGISTRY\USER\.DEFAULT\Console");
+        assert_eq!(out[1].resource_type, ResourceType::Other);
+        assert_eq!(out[1].access_type, AccessType::Read);
+
+        assert_eq!(out[2].path, "");
+        assert_eq!(out[2].resource_type, ResourceType::Capability);
+        assert_eq!(out[2].access_type, AccessType::Unknown);
+        assert_eq!(out[2].pid, 0x1acc, "pid from payload ProcessId");
+    }
+
+    /// Mirrors the real `Mode="Permissive"` (allow-and-log) capture: the same
+    /// file/registry checks plus a capability check folded into an
+    /// empty-`ObjectType` event 14 (there is no event 28 in this mode).
+    #[test]
+    fn allow_and_log_shape_folds_capability_into_event_14() {
+        let events = vec![
+            event(
+                14,
+                2292,
+                20,
+                &[
+                    ("Mode", "\"Permissive\""),
+                    ("ObjectType", "\"File\""),
+                    ("ObjectName", "\"\\??\\C:\\data\\test\\bin\\\""),
+                    ("AccessMask", "0x10001"),
+                ],
+            ),
+            // Empty ObjectType == brokered-capability check.
+            event(
+                14,
+                5900,
+                21,
+                &[
+                    ("Mode", "\"Permissive\""),
+                    ("ObjectType", "\"\""),
+                    ("ObjectName", "\"\""),
+                    ("AccessMask", "0x1"),
+                ],
+            ),
+        ];
+
+        let out = resources_from_events(&events);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].path, r"C:\data\test\bin\");
+        assert_eq!(out[0].access_type, AccessType::Write);
+        assert_eq!(out[1].resource_type, ResourceType::Capability);
+        assert_eq!(out[1].path, "");
+        assert_eq!(out[1].access_type, AccessType::Unknown);
+    }
+
+    /// Both a permissive empty-`ObjectType` event 14 and a block-mode event 28
+    /// capability denial reduce to the same `("", Unknown)` key, so they
+    /// collapse to a single capability resource.
+    #[test]
+    fn empty_path_capabilities_collapse_to_one() {
+        let events = vec![
+            event(
+                14,
+                1,
+                1,
+                &[
+                    ("ObjectType", "\"\""),
+                    ("ObjectName", "\"\""),
+                    ("AccessMask", "0x1"),
+                ],
+            ),
+            event(28, 0, 2, &[("ProcessId", "0x10"), ("Denied", "true")]),
+            event(28, 0, 3, &[("ProcessId", "0x20"), ("Denied", "true")]),
+        ];
+        let out = resources_from_events(&events);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].resource_type, ResourceType::Capability);
+        assert_eq!(out[0].path, "");
+    }
+
+    /// Non-actionable object types and not-denied capability records are
+    /// dropped by the pipeline; unknown event IDs are ignored.
+    #[test]
+    fn non_actionable_events_are_dropped() {
+        let events = vec![
+            event(14, 1, 1, &[("ObjectType", "\"Section\"")]),
+            event(28, 0, 2, &[("ProcessId", "0x10"), ("Denied", "false")]),
+            event(9999, 1, 3, &[("Foo", "\"bar\"")]),
+        ];
+        assert!(resources_from_events(&events).is_empty());
     }
 }

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Sealed-ETL decoder: turns the `.etl` that [`crate::CaptureSession::finish`]
+//! produces into cross-platform [`DeniedResource`]s.
+//!
+//! The trace is opened in **file mode** (`EVENT_TRACE_LOGFILEW.LogFileName`,
+//! without `PROCESS_TRACE_MODE_REAL_TIME`). `ProcessTrace` walks every
+//! buffered event and returns on its own at end-of-file, so there is no
+//! controller session to stop and no worker thread to join — we run it
+//! synchronously, collect the decoded events, then extract and
+//! de-duplicate denials.
+//!
+//! [`EtlDenialAnalyzer`] implements the cross-platform
+//! [`learning_mode_core::DenialAnalyzer`] trait so the runner and tests can
+//! depend on the abstraction rather than this Windows-specific decoder.
+
+use std::collections::HashSet;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+
+use learning_mode_core::{AnalyzeError, DenialAnalyzer, DeniedResource};
+use windows::core::PWSTR;
+use windows::Win32::System::Diagnostics::Etw::{
+    CloseTrace, OpenTraceW, ProcessTrace, EVENT_RECORD, EVENT_TRACE_LOGFILEW,
+    PROCESS_TRACE_MODE_EVENT_RECORD,
+};
+
+use crate::extractors::{extract_denial, DecodedEventParts, RawDenial};
+use crate::{path_norm, tdh_decode};
+
+/// `OpenTraceW` returns this sentinel (`(TRACEHANDLE)-1`) on failure.
+const INVALID_PROCESSTRACE_HANDLE: u64 = u64::MAX;
+
+/// One decoded ETW event, retaining the header context the extractors need.
+struct CollectedEvent {
+    pid: u32,
+    filetime: u64,
+    parts: DecodedEventParts,
+}
+
+/// Accumulates decoded events during a `ProcessTrace` pass. A pointer to
+/// this is handed to ETW via `EVENT_TRACE_LOGFILEW.Context` and read back
+/// in the record callback.
+#[derive(Default)]
+struct Accumulator {
+    events: Vec<CollectedEvent>,
+}
+
+/// A [`DenialAnalyzer`] over a sealed learning-mode `.etl` file.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EtlDenialAnalyzer;
+
+impl DenialAnalyzer for EtlDenialAnalyzer {
+    fn analyze(&self, source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError> {
+        let events = process_trace_file(source_path)?;
+        Ok(dedup_to_resources(events.iter().filter_map(|e| {
+            extract_denial(&e.parts, e.pid, e.filetime)
+        })))
+    }
+}
+
+/// Decodes every event in the ETL into `(event_id, props)` pairs, for
+/// schema discovery / diagnostics. Preserves the on-disk order.
+///
+/// # Errors
+///
+/// Returns [`AnalyzeError`] if the trace cannot be opened or processed.
+pub fn decode_raw_events(source_path: &Path) -> Result<Vec<DecodedEventParts>, AnalyzeError> {
+    Ok(process_trace_file(source_path)?
+        .into_iter()
+        .map(|e| e.parts)
+        .collect())
+}
+
+/// De-duplicates raw denials by `(user-visible path, accessType)`,
+/// normalising kernel paths to drive-letter form and preserving first-seen
+/// order.
+fn dedup_to_resources<I: IntoIterator<Item = RawDenial>>(raws: I) -> Vec<DeniedResource> {
+    let mut seen: HashSet<(String, learning_mode_core::AccessType)> = HashSet::new();
+    let mut out = Vec::new();
+    for raw in raws {
+        let path =
+            path_norm::to_user_visible(&raw.object_name).unwrap_or_else(|| raw.object_name.clone());
+        if seen.insert((path.clone(), raw.access_type)) {
+            out.push(DeniedResource {
+                path,
+                resource_type: raw.resource_type,
+                access_type: raw.access_type,
+                pid: raw.pid,
+                filetime: raw.filetime,
+            });
+        }
+    }
+    out
+}
+
+/// Opens `source_path` as an ETL log file, runs `ProcessTrace` to
+/// completion, and returns the decoded events.
+fn process_trace_file(source_path: &Path) -> Result<Vec<CollectedEvent>, AnalyzeError> {
+    // Fail fast with a clear error if the file is missing/unreadable,
+    // rather than surfacing an opaque OpenTraceW Win32 code.
+    std::fs::File::open(source_path).map_err(|source| AnalyzeError::Open {
+        path: source_path.display().to_string(),
+        source,
+    })?;
+
+    let mut name_wide: Vec<u16> = source_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let mut accumulator = Accumulator::default();
+
+    let mut logfile: EVENT_TRACE_LOGFILEW = unsafe { core::mem::zeroed() };
+    logfile.LogFileName = PWSTR(name_wide.as_mut_ptr());
+    logfile.Anonymous1.ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD;
+    logfile.Anonymous2.EventRecordCallback = Some(event_record_callback);
+    logfile.Context = std::ptr::addr_of_mut!(accumulator).cast();
+
+    // SAFETY: `logfile` and `name_wide` outlive the OpenTraceW call; the
+    // callback pointer is valid and the Context points at a live stack
+    // value that outlives the ProcessTrace call below.
+    let handle = unsafe { OpenTraceW(&mut logfile) };
+    if handle.Value == INVALID_PROCESSTRACE_HANDLE {
+        let code = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1) as u32;
+        return Err(AnalyzeError::Decode(format!(
+            "OpenTraceW failed for '{}': Win32 error {code}",
+            source_path.display()
+        )));
+    }
+
+    let handles = [handle];
+    // SAFETY: `handles` is valid for the call. In file mode ProcessTrace
+    // processes all buffered events (invoking our callback synchronously
+    // on this thread) and returns at end-of-file.
+    let status = unsafe { ProcessTrace(&handles, None, None) };
+
+    // SAFETY: closing the consumer handle we opened above. Idempotent.
+    unsafe {
+        let _ = CloseTrace(handle);
+    }
+
+    // ERROR_SUCCESS (0) and ERROR_CANCELLED (1223) are both acceptable
+    // terminal states for a completed file trace.
+    if status.0 != 0 && status.0 != 1223 {
+        return Err(AnalyzeError::Decode(format!(
+            "ProcessTrace failed for '{}': Win32 error {}",
+            source_path.display(),
+            status.0
+        )));
+    }
+
+    Ok(accumulator.events)
+}
+
+/// ETW record callback, invoked by `ProcessTrace` for every event in the
+/// file. Decodes the event via TDH and appends it to the [`Accumulator`]
+/// pointed to by `EVENT_RECORD.UserContext`.
+///
+/// # Safety
+/// Invoked by ETW with a valid `EVENT_RECORD` whose `UserContext` is the
+/// `Accumulator` pointer we set on `EVENT_TRACE_LOGFILEW.Context`.
+unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD) {
+    if event_record.is_null() {
+        return;
+    }
+    // SAFETY: ETW guarantees a valid record; we only read POD header fields.
+    let header = unsafe { (*event_record).EventHeader };
+    let context = unsafe { (*event_record).UserContext } as *mut Accumulator;
+    if context.is_null() {
+        return;
+    }
+
+    // SAFETY: `context` is the live Accumulator we passed via Context, and
+    // ProcessTrace invokes this callback synchronously on our thread, so no
+    // aliasing/concurrency with the owner occurs.
+    let acc = unsafe { &mut *context };
+
+    if let Some(parts) = unsafe { tdh_decode::decode_event_parts(event_record) } {
+        acc.events.push(CollectedEvent {
+            pid: header.ProcessId,
+            filetime: header.TimeStamp as u64,
+            parts,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use learning_mode_core::{AccessType, ResourceType};
+
+    fn raw(path: &str, access: AccessType, rt: ResourceType) -> RawDenial {
+        RawDenial {
+            pid: 1,
+            resource_type: rt,
+            object_name: path.to_string(),
+            access_type: access,
+            filetime: 1,
+            event_id: 4907,
+        }
+    }
+
+    #[test]
+    fn dedup_collapses_repeated_path_access_pairs() {
+        let denials = vec![
+            raw(r"C:\a", AccessType::Read, ResourceType::File),
+            raw(r"C:\a", AccessType::Read, ResourceType::File),
+            raw(r"C:\a", AccessType::Write, ResourceType::File),
+            raw(r"C:\b", AccessType::Read, ResourceType::File),
+        ];
+        let out = dedup_to_resources(denials);
+        assert_eq!(out.len(), 3, "unique (path, access) pairs");
+        assert_eq!(out[0].path, r"C:\a");
+        assert_eq!(out[0].access_type, AccessType::Read);
+        assert_eq!(out[1].access_type, AccessType::Write);
+        assert_eq!(out[2].path, r"C:\b");
+    }
+
+    #[test]
+    fn dedup_preserves_first_seen_order() {
+        let denials = vec![
+            raw(r"C:\z", AccessType::Read, ResourceType::File),
+            raw(r"C:\a", AccessType::Read, ResourceType::File),
+        ];
+        let out = dedup_to_resources(denials);
+        assert_eq!(out[0].path, r"C:\z");
+        assert_eq!(out[1].path, r"C:\a");
+    }
+
+    #[test]
+    fn analyze_missing_file_returns_open_error() {
+        let analyzer = EtlDenialAnalyzer;
+        let err = analyzer
+            .analyze(Path::new(r"C:\does\not\exist\nope.etl"))
+            .unwrap_err();
+        assert!(matches!(err, AnalyzeError::Open { .. }), "got {err:?}");
+    }
+}

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -90,8 +90,18 @@ impl<'visitor> Accumulator<'visitor> {
     }
 
     fn add_raw_denial(&mut self, raw: RawDenial) {
-        let path =
-            path_norm::to_user_visible(&raw.object_name).unwrap_or_else(|| raw.object_name.clone());
+        let path = if raw.resource_type == learning_mode_core::ResourceType::File {
+            match path_norm::to_user_visible(&raw.object_name) {
+                Some(path) if path_norm::is_user_visible_absolute(&path) => path,
+                Some(_) => return,
+                None if path_norm::is_user_visible_absolute(&raw.object_name) => {
+                    raw.object_name.clone()
+                }
+                None => return,
+            }
+        } else {
+            path_norm::to_user_visible(&raw.object_name).unwrap_or_else(|| raw.object_name.clone())
+        };
         let dedup_path = match raw.resource_type {
             learning_mode_core::ResourceType::File | learning_mode_core::ResourceType::Other => {
                 path.to_ascii_lowercase()
@@ -372,6 +382,34 @@ mod tests {
         let out = dedup_to_resources(denials).denials;
         assert_eq!(out[0].path, r"C:\z");
         assert_eq!(out[1].path, r"C:\a");
+    }
+
+    #[test]
+    fn file_denials_require_a_canonical_user_visible_path() {
+        let denials = vec![
+            raw(
+                r"\Device\Mup\server\share\file.txt",
+                AccessType::Read,
+                ResourceType::File,
+            ),
+            raw(
+                r"\Device\UnknownVolume\file.txt",
+                AccessType::Read,
+                ResourceType::File,
+            ),
+            raw(r"\??\C:relative.txt", AccessType::Read, ResourceType::File),
+            raw(r"\??\PIPE\name", AccessType::Read, ResourceType::File),
+            raw(
+                r"\Device\Mup\server\pipe\name",
+                AccessType::Read,
+                ResourceType::File,
+            ),
+        ];
+
+        let out = dedup_to_resources(denials).denials;
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, r"\\server\share\file.txt");
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -14,6 +14,15 @@
 //! [`EtlDenialAnalyzer`] implements the cross-platform
 //! [`learning_mode_core::DenialAnalyzer`] trait so the runner and tests can
 //! depend on the abstraction rather than this Windows-specific decoder.
+//!
+//! The diagnostic console has a separate real-time, display-oriented ETW
+//! consumer in `tools/mxc_diagnostic_console`. It is a binary-private module
+//! that owns trace sessions and channels arbitrary provider events to a UI.
+//! This backend instead reads sealed files synchronously, filters a fixed
+//! provider/event vocabulary, bounds results, and propagates target decode
+//! failures. Depending on the tool would invert the workspace dependency
+//! direction; shared generic TDH primitives can be extracted later if another
+//! runtime consumer needs them.
 
 use std::collections::HashSet;
 use std::os::windows::ffi::OsStrExt;

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -8,8 +8,8 @@
 //! without `PROCESS_TRACE_MODE_REAL_TIME`). `ProcessTrace` walks every
 //! buffered event and returns on its own at end-of-file, so there is no
 //! controller session to stop and no worker thread to join — we run it
-//! synchronously, collect the decoded events, then extract and
-//! de-duplicate denials.
+//! synchronously and extract/de-duplicate denials inside the callback so large
+//! traces do not accumulate every decoded event in memory.
 //!
 //! [`EtlDenialAnalyzer`] implements the cross-platform
 //! [`learning_mode_core::DenialAnalyzer`] trait so the runner and tests can
@@ -19,32 +19,99 @@ use std::collections::HashSet;
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 
-use learning_mode_core::{AnalyzeError, DenialAnalyzer, DeniedResource};
+use learning_mode_core::{AnalysisResult, AnalyzeError, DenialAnalyzer, DeniedResource};
 use windows::core::PWSTR;
 use windows::Win32::System::Diagnostics::Etw::{
     CloseTrace, OpenTraceW, ProcessTrace, EVENT_RECORD, EVENT_TRACE_LOGFILEW,
     PROCESS_TRACE_MODE_EVENT_RECORD,
 };
 
-use crate::extractors::{extract_denial, DecodedEventParts, RawDenial};
+use crate::extractors::{extract_denial, is_learning_mode_event, DecodedEventParts, RawDenial};
 use crate::{path_norm, tdh_decode};
 
 /// `OpenTraceW` returns this sentinel (`(TRACEHANDLE)-1`) on failure.
 const INVALID_PROCESSTRACE_HANDLE: u64 = u64::MAX;
+const MAX_UNIQUE_DENIALS: usize = 10_000;
 
 /// One decoded ETW event, retaining the header context the extractors need.
+#[cfg(test)]
 struct CollectedEvent {
     pid: u32,
     filetime: u64,
     parts: DecodedEventParts,
 }
 
-/// Accumulates decoded events during a `ProcessTrace` pass. A pointer to
-/// this is handed to ETW via `EVENT_TRACE_LOGFILEW.Context` and read back
-/// in the record callback.
-#[derive(Default)]
+#[derive(Clone, Copy)]
+enum CollectionMode {
+    Analyze,
+    Raw,
+}
+
+/// Accumulates bounded analysis results or raw diagnostic events during a
+/// `ProcessTrace` pass.
 struct Accumulator {
-    events: Vec<CollectedEvent>,
+    mode: CollectionMode,
+    denials: Vec<DeniedResource>,
+    seen: HashSet<(String, learning_mode_core::AccessType)>,
+    truncated: bool,
+    raw_events: Vec<DecodedEventParts>,
+    decode_error: Option<String>,
+}
+
+impl Accumulator {
+    fn analyze() -> Self {
+        Self {
+            mode: CollectionMode::Analyze,
+            denials: Vec::new(),
+            seen: HashSet::new(),
+            truncated: false,
+            raw_events: Vec::new(),
+            decode_error: None,
+        }
+    }
+
+    fn raw() -> Self {
+        Self {
+            mode: CollectionMode::Raw,
+            ..Self::analyze()
+        }
+    }
+
+    fn add_raw_denial(&mut self, raw: RawDenial) {
+        let path =
+            path_norm::to_user_visible(&raw.object_name).unwrap_or_else(|| raw.object_name.clone());
+        let dedup_path = match raw.resource_type {
+            learning_mode_core::ResourceType::File | learning_mode_core::ResourceType::Other => {
+                path.to_ascii_lowercase()
+            }
+            _ => path.clone(),
+        };
+        if self.seen.contains(&(dedup_path.clone(), raw.access_type)) {
+            return;
+        }
+        if self.denials.len() >= MAX_UNIQUE_DENIALS {
+            self.truncated = true;
+            return;
+        }
+        self.seen.insert((dedup_path, raw.access_type));
+        self.denials.push(DeniedResource {
+            path,
+            resource_type: raw.resource_type,
+            access_type: raw.access_type,
+            pid: raw.pid,
+            filetime: raw.filetime,
+        });
+    }
+
+    fn into_analysis(self) -> Result<AnalysisResult, AnalyzeError> {
+        if let Some(error) = self.decode_error {
+            return Err(AnalyzeError::Decode(error));
+        }
+        Ok(AnalysisResult {
+            denials: self.denials,
+            denied_resources_truncated: self.truncated,
+        })
+    }
 }
 
 /// A [`DenialAnalyzer`] over a sealed learning-mode `.etl` file.
@@ -52,9 +119,8 @@ struct Accumulator {
 pub struct EtlDenialAnalyzer;
 
 impl DenialAnalyzer for EtlDenialAnalyzer {
-    fn analyze(&self, source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError> {
-        let events = process_trace_file(source_path)?;
-        Ok(resources_from_events(&events))
+    fn analyze(&self, source_path: &Path) -> Result<AnalysisResult, AnalyzeError> {
+        process_trace_file(source_path, CollectionMode::Analyze)?.into_analysis()
     }
 }
 
@@ -64,7 +130,8 @@ impl DenialAnalyzer for EtlDenialAnalyzer {
 /// [`EtlDenialAnalyzer::analyze`] so it can be tested with hand-built events
 /// that mirror real traces, without a live ETW/TDH read (which needs the
 /// provider manifests registered on the machine).
-fn resources_from_events(events: &[CollectedEvent]) -> Vec<DeniedResource> {
+#[cfg(test)]
+fn resources_from_events(events: &[CollectedEvent]) -> AnalysisResult {
     dedup_to_resources(
         events
             .iter()
@@ -79,37 +146,33 @@ fn resources_from_events(events: &[CollectedEvent]) -> Vec<DeniedResource> {
 ///
 /// Returns [`AnalyzeError`] if the trace cannot be opened or processed.
 pub fn decode_raw_events(source_path: &Path) -> Result<Vec<DecodedEventParts>, AnalyzeError> {
-    Ok(process_trace_file(source_path)?
-        .into_iter()
-        .map(|e| e.parts)
-        .collect())
+    let accumulator = process_trace_file(source_path, CollectionMode::Raw)?;
+    if let Some(error) = accumulator.decode_error {
+        return Err(AnalyzeError::Decode(error));
+    }
+    Ok(accumulator.raw_events)
 }
 
 /// De-duplicates raw denials by `(user-visible path, accessType)`,
 /// normalising kernel paths to drive-letter form and preserving first-seen
 /// order.
-fn dedup_to_resources<I: IntoIterator<Item = RawDenial>>(raws: I) -> Vec<DeniedResource> {
-    let mut seen: HashSet<(String, learning_mode_core::AccessType)> = HashSet::new();
-    let mut out = Vec::new();
+#[cfg(test)]
+fn dedup_to_resources<I: IntoIterator<Item = RawDenial>>(raws: I) -> AnalysisResult {
+    let mut accumulator = Accumulator::analyze();
     for raw in raws {
-        let path =
-            path_norm::to_user_visible(&raw.object_name).unwrap_or_else(|| raw.object_name.clone());
-        if seen.insert((path.clone(), raw.access_type)) {
-            out.push(DeniedResource {
-                path,
-                resource_type: raw.resource_type,
-                access_type: raw.access_type,
-                pid: raw.pid,
-                filetime: raw.filetime,
-            });
-        }
+        accumulator.add_raw_denial(raw);
     }
-    out
+    accumulator
+        .into_analysis()
+        .expect("pure denial accumulation cannot decode-fail")
 }
 
 /// Opens `source_path` as an ETL log file, runs `ProcessTrace` to
 /// completion, and returns the decoded events.
-fn process_trace_file(source_path: &Path) -> Result<Vec<CollectedEvent>, AnalyzeError> {
+fn process_trace_file(
+    source_path: &Path,
+    mode: CollectionMode,
+) -> Result<Accumulator, AnalyzeError> {
     // Fail fast with a clear error if the file is missing/unreadable,
     // rather than surfacing an opaque OpenTraceW Win32 code.
     std::fs::File::open(source_path).map_err(|source| AnalyzeError::Open {
@@ -123,7 +186,10 @@ fn process_trace_file(source_path: &Path) -> Result<Vec<CollectedEvent>, Analyze
         .chain(std::iter::once(0))
         .collect();
 
-    let mut accumulator = Accumulator::default();
+    let mut accumulator = match mode {
+        CollectionMode::Analyze => Accumulator::analyze(),
+        CollectionMode::Raw => Accumulator::raw(),
+    };
 
     let mut logfile: EVENT_TRACE_LOGFILEW = unsafe { core::mem::zeroed() };
     logfile.LogFileName = PWSTR(name_wide.as_mut_ptr());
@@ -164,7 +230,7 @@ fn process_trace_file(source_path: &Path) -> Result<Vec<CollectedEvent>, Analyze
         )));
     }
 
-    Ok(accumulator.events)
+    Ok(accumulator)
 }
 
 /// ETW record callback, invoked by `ProcessTrace` for every event in the
@@ -190,12 +256,28 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
     // aliasing/concurrency with the owner occurs.
     let acc = unsafe { &mut *context };
 
-    if let Some(parts) = unsafe { tdh_decode::decode_event_parts(event_record) } {
-        acc.events.push(CollectedEvent {
-            pid: header.ProcessId,
-            filetime: header.TimeStamp as u64,
-            parts,
-        });
+    let provider = header.ProviderId;
+    let event_id = header.EventDescriptor.Id;
+    if matches!(acc.mode, CollectionMode::Analyze) && !is_learning_mode_event(provider, event_id) {
+        return;
+    }
+
+    match unsafe { tdh_decode::decode_event_parts(event_record) } {
+        Ok(parts) => match acc.mode {
+            CollectionMode::Analyze => {
+                if let Some(raw) = extract_denial(&parts, header.ProcessId, header.TimeStamp as u64)
+                {
+                    acc.add_raw_denial(raw);
+                }
+            }
+            CollectionMode::Raw => acc.raw_events.push(parts),
+        },
+        Err(error) => {
+            if acc.decode_error.is_none() {
+                acc.decode_error =
+                    Some(format!("provider {:?} event {event_id}: {error}", provider));
+            }
+        }
     }
 }
 
@@ -223,7 +305,7 @@ mod tests {
             raw(r"C:\a", AccessType::Write, ResourceType::File),
             raw(r"C:\b", AccessType::Read, ResourceType::File),
         ];
-        let out = dedup_to_resources(denials);
+        let out = dedup_to_resources(denials).denials;
         assert_eq!(out.len(), 3, "unique (path, access) pairs");
         assert_eq!(out[0].path, r"C:\a");
         assert_eq!(out[0].access_type, AccessType::Read);
@@ -237,9 +319,34 @@ mod tests {
             raw(r"C:\z", AccessType::Read, ResourceType::File),
             raw(r"C:\a", AccessType::Read, ResourceType::File),
         ];
-        let out = dedup_to_resources(denials);
+        let out = dedup_to_resources(denials).denials;
         assert_eq!(out[0].path, r"C:\z");
         assert_eq!(out[1].path, r"C:\a");
+    }
+
+    #[test]
+    fn dedup_is_case_insensitive_and_preserves_first_spelling() {
+        let denials = vec![
+            raw(r"C:\Data\File.txt", AccessType::Read, ResourceType::File),
+            raw(r"c:\data\file.TXT", AccessType::Read, ResourceType::File),
+        ];
+        let out = dedup_to_resources(denials).denials;
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, r"C:\Data\File.txt");
+    }
+
+    #[test]
+    fn result_is_bounded_and_reports_truncation() {
+        let denials = (0..=MAX_UNIQUE_DENIALS).map(|index| {
+            raw(
+                &format!(r"C:\data\{index}.txt"),
+                AccessType::Read,
+                ResourceType::File,
+            )
+        });
+        let out = dedup_to_resources(denials);
+        assert_eq!(out.denials.len(), MAX_UNIQUE_DENIALS);
+        assert!(out.denied_resources_truncated);
     }
 
     #[test]
@@ -249,6 +356,17 @@ mod tests {
             .analyze(Path::new(r"C:\does\not\exist\nope.etl"))
             .unwrap_err();
         assert!(matches!(err, AnalyzeError::Open { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn target_event_decode_failure_is_reported() {
+        let accumulator = Accumulator {
+            decode_error: Some("event 14 malformed".to_string()),
+            ..Accumulator::analyze()
+        };
+        let error = accumulator.into_analysis().expect_err("decode must fail");
+        assert!(matches!(error, AnalyzeError::Decode(_)));
+        assert!(error.to_string().contains("event 14 malformed"));
     }
 
     // ---- decode composition over real event shapes ------------------------
@@ -264,6 +382,11 @@ mod tests {
             pid,
             filetime,
             parts: DecodedEventParts {
+                provider: if event_id == 4907 {
+                    crate::extractors::PRIVACY_LEARNING_MODE_PROVIDER
+                } else {
+                    crate::extractors::KERNEL_GENERAL_PROVIDER
+                },
                 event_id,
                 props: kv
                     .iter()
@@ -276,7 +399,7 @@ mod tests {
     /// Mirrors the real `Mode="Normal"` (`block`) capture: file/registry
     /// access checks as event 14 plus a compact capability denial as event 28.
     #[test]
-    fn block_and_log_shape_decodes_and_classifies() {
+    fn block_shape_decodes_and_classifies() {
         let events = vec![
             // File write (DELETE | FILE_READ_DATA -> Write), \??\ prefix.
             event(
@@ -302,7 +425,7 @@ mod tests {
                     ("AccessMask", "0x20019"),
                 ],
             ),
-            // Capability denial (event 28) -> empty path, unknown access.
+            // Capability denial (event 28) with a decoded identifier.
             event(
                 28,
                 0,
@@ -311,11 +434,12 @@ mod tests {
                     ("ProcessName", "\"conhost.exe\""),
                     ("ProcessId", "0x1acc"),
                     ("Denied", "true"),
+                    ("PackageSid", "S-1-15-3-1"),
                 ],
             ),
         ];
 
-        let out = resources_from_events(&events);
+        let out = resources_from_events(&events).denials;
         assert_eq!(out.len(), 3);
 
         assert_eq!(out[0].path, r"C:\data\test\bin\");
@@ -327,7 +451,7 @@ mod tests {
         assert_eq!(out[1].resource_type, ResourceType::Other);
         assert_eq!(out[1].access_type, AccessType::Read);
 
-        assert_eq!(out[2].path, "");
+        assert_eq!(out[2].path, "S-1-15-3-1");
         assert_eq!(out[2].resource_type, ResourceType::Capability);
         assert_eq!(out[2].access_type, AccessType::Unknown);
         assert_eq!(out[2].pid, 0x1acc, "pid from payload ProcessId");
@@ -337,7 +461,7 @@ mod tests {
     /// file/registry checks plus a capability check folded into an
     /// empty-`ObjectType` event 14 (there is no event 28 in this mode).
     #[test]
-    fn allow_and_log_shape_folds_capability_into_event_14() {
+    fn allow_shape_omits_unidentified_capability_event() {
         let events = vec![
             event(
                 14,
@@ -364,20 +488,14 @@ mod tests {
             ),
         ];
 
-        let out = resources_from_events(&events);
-        assert_eq!(out.len(), 2);
+        let out = resources_from_events(&events).denials;
+        assert_eq!(out.len(), 1);
         assert_eq!(out[0].path, r"C:\data\test\bin\");
         assert_eq!(out[0].access_type, AccessType::Write);
-        assert_eq!(out[1].resource_type, ResourceType::Capability);
-        assert_eq!(out[1].path, "");
-        assert_eq!(out[1].access_type, AccessType::Unknown);
     }
 
-    /// Both a permissive empty-`ObjectType` event 14 and a block-mode event 28
-    /// capability denial reduce to the same `("", Unknown)` key, so they
-    /// collapse to a single capability resource.
     #[test]
-    fn empty_path_capabilities_collapse_to_one() {
+    fn unidentified_capability_events_are_omitted() {
         let events = vec![
             event(
                 14,
@@ -392,10 +510,7 @@ mod tests {
             event(28, 0, 2, &[("ProcessId", "0x10"), ("Denied", "true")]),
             event(28, 0, 3, &[("ProcessId", "0x20"), ("Denied", "true")]),
         ];
-        let out = resources_from_events(&events);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].resource_type, ResourceType::Capability);
-        assert_eq!(out[0].path, "");
+        assert!(resources_from_events(&events).denials.is_empty());
     }
 
     /// Non-actionable object types and not-denied capability records are
@@ -407,6 +522,6 @@ mod tests {
             event(28, 0, 2, &[("ProcessId", "0x10"), ("Denied", "false")]),
             event(9999, 1, 3, &[("Foo", "\"bar\"")]),
         ];
-        assert!(resources_from_events(&events).is_empty());
+        assert!(resources_from_events(&events).denials.is_empty());
     }
 }

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -47,33 +47,45 @@ enum CollectionMode {
     Raw,
 }
 
-/// Accumulates bounded analysis results or raw diagnostic events during a
-/// `ProcessTrace` pass.
-struct Accumulator {
+type RawEventVisitor<'a> = dyn FnMut(&DecodedEventParts) -> std::io::Result<()> + 'a;
+
+/// Accumulates bounded analysis results or streams raw diagnostic events
+/// during a `ProcessTrace` pass.
+struct Accumulator<'visitor> {
     mode: CollectionMode,
     denials: Vec<DeniedResource>,
     seen: HashSet<(String, learning_mode_core::AccessType)>,
     truncated: bool,
-    raw_events: Vec<DecodedEventParts>,
+    raw_visitor: Option<&'visitor mut RawEventVisitor<'visitor>>,
+    raw_event_count: usize,
     decode_error: Option<String>,
+    visitor_panic: Option<Box<dyn std::any::Any + Send>>,
 }
 
-impl Accumulator {
+impl<'visitor> Accumulator<'visitor> {
     fn analyze() -> Self {
         Self {
             mode: CollectionMode::Analyze,
             denials: Vec::new(),
             seen: HashSet::new(),
             truncated: false,
-            raw_events: Vec::new(),
+            raw_visitor: None,
+            raw_event_count: 0,
             decode_error: None,
+            visitor_panic: None,
         }
     }
 
-    fn raw() -> Self {
+    fn raw(visitor: &'visitor mut RawEventVisitor<'visitor>) -> Self {
         Self {
             mode: CollectionMode::Raw,
-            ..Self::analyze()
+            denials: Vec::new(),
+            seen: HashSet::new(),
+            truncated: false,
+            raw_visitor: Some(visitor),
+            raw_event_count: 0,
+            decode_error: None,
+            visitor_panic: None,
         }
     }
 
@@ -103,6 +115,19 @@ impl Accumulator {
         });
     }
 
+    fn visit_raw_event(&mut self, parts: &DecodedEventParts) {
+        let Some(visitor) = self.raw_visitor.as_mut() else {
+            return;
+        };
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| visitor(parts))) {
+            Ok(Ok(())) => self.raw_event_count += 1,
+            Ok(Err(error)) => {
+                self.decode_error = Some(format!("raw event consumer failed: {error}"));
+            }
+            Err(payload) => self.visitor_panic = Some(payload),
+        }
+    }
+
     fn into_analysis(self) -> Result<AnalysisResult, AnalyzeError> {
         if let Some(error) = self.decode_error {
             return Err(AnalyzeError::Decode(error));
@@ -120,7 +145,9 @@ pub struct EtlDenialAnalyzer;
 
 impl DenialAnalyzer for EtlDenialAnalyzer {
     fn analyze(&self, source_path: &Path) -> Result<AnalysisResult, AnalyzeError> {
-        process_trace_file(source_path, CollectionMode::Analyze)?.into_analysis()
+        let mut accumulator = Accumulator::analyze();
+        process_trace_file(source_path, &mut accumulator)?;
+        accumulator.into_analysis()
     }
 }
 
@@ -139,18 +166,23 @@ fn resources_from_events(events: &[CollectedEvent]) -> AnalysisResult {
     )
 }
 
-/// Decodes every event in the ETL into `(event_id, props)` pairs, for
-/// schema discovery / diagnostics. Preserves the on-disk order.
+/// Streams every decoded event in the ETL to `visitor` for schema discovery
+/// and diagnostics, preserving on-disk order without retaining the trace in
+/// memory. Returns the number of events delivered.
 ///
 /// # Errors
 ///
 /// Returns [`AnalyzeError`] if the trace cannot be opened or processed.
-pub fn decode_raw_events(source_path: &Path) -> Result<Vec<DecodedEventParts>, AnalyzeError> {
-    let accumulator = process_trace_file(source_path, CollectionMode::Raw)?;
+pub fn visit_raw_events(
+    source_path: &Path,
+    visitor: &mut RawEventVisitor<'_>,
+) -> Result<usize, AnalyzeError> {
+    let mut accumulator = Accumulator::raw(visitor);
+    process_trace_file(source_path, &mut accumulator)?;
     if let Some(error) = accumulator.decode_error {
         return Err(AnalyzeError::Decode(error));
     }
-    Ok(accumulator.raw_events)
+    Ok(accumulator.raw_event_count)
 }
 
 /// De-duplicates raw denials by `(user-visible path, accessType)`,
@@ -171,8 +203,8 @@ fn dedup_to_resources<I: IntoIterator<Item = RawDenial>>(raws: I) -> AnalysisRes
 /// completion, and returns the decoded events.
 fn process_trace_file(
     source_path: &Path,
-    mode: CollectionMode,
-) -> Result<Accumulator, AnalyzeError> {
+    accumulator: &mut Accumulator<'_>,
+) -> Result<(), AnalyzeError> {
     // Fail fast with a clear error if the file is missing/unreadable,
     // rather than surfacing an opaque OpenTraceW Win32 code.
     std::fs::File::open(source_path).map_err(|source| AnalyzeError::Open {
@@ -186,16 +218,11 @@ fn process_trace_file(
         .chain(std::iter::once(0))
         .collect();
 
-    let mut accumulator = match mode {
-        CollectionMode::Analyze => Accumulator::analyze(),
-        CollectionMode::Raw => Accumulator::raw(),
-    };
-
     let mut logfile: EVENT_TRACE_LOGFILEW = unsafe { core::mem::zeroed() };
     logfile.LogFileName = PWSTR(name_wide.as_mut_ptr());
     logfile.Anonymous1.ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD;
     logfile.Anonymous2.EventRecordCallback = Some(event_record_callback);
-    logfile.Context = std::ptr::addr_of_mut!(accumulator).cast();
+    logfile.Context = std::ptr::from_mut(accumulator).cast();
 
     // SAFETY: `logfile` and `name_wide` outlive the OpenTraceW call; the
     // callback pointer is valid and the Context points at a live stack
@@ -220,6 +247,10 @@ fn process_trace_file(
         let _ = CloseTrace(handle);
     }
 
+    if let Some(payload) = accumulator.visitor_panic.take() {
+        std::panic::resume_unwind(payload);
+    }
+
     // ERROR_SUCCESS (0) and ERROR_CANCELLED (1223) are both acceptable
     // terminal states for a completed file trace.
     if status.0 != 0 && status.0 != 1223 {
@@ -230,7 +261,7 @@ fn process_trace_file(
         )));
     }
 
-    Ok(accumulator)
+    Ok(())
 }
 
 /// ETW record callback, invoked by `ProcessTrace` for every event in the
@@ -246,7 +277,7 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
     }
     // SAFETY: ETW guarantees a valid record; we only read POD header fields.
     let header = unsafe { (*event_record).EventHeader };
-    let context = unsafe { (*event_record).UserContext } as *mut Accumulator;
+    let context = unsafe { (*event_record).UserContext } as *mut Accumulator<'_>;
     if context.is_null() {
         return;
     }
@@ -255,6 +286,9 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
     // ProcessTrace invokes this callback synchronously on our thread, so no
     // aliasing/concurrency with the owner occurs.
     let acc = unsafe { &mut *context };
+    if acc.decode_error.is_some() || acc.visitor_panic.is_some() {
+        return;
+    }
 
     let provider = header.ProviderId;
     let event_id = header.EventDescriptor.Id;
@@ -270,7 +304,7 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
                     acc.add_raw_denial(raw);
                 }
             }
-            CollectionMode::Raw => acc.raw_events.push(parts),
+            CollectionMode::Raw => acc.visit_raw_event(&parts),
         },
         Err(error) => {
             if acc.decode_error.is_none() {
@@ -285,6 +319,22 @@ unsafe extern "system" fn event_record_callback(event_record: *mut EVENT_RECORD)
 mod tests {
     use super::*;
     use learning_mode_core::{AccessType, ResourceType};
+
+    #[test]
+    fn raw_visitor_panic_is_captured_inside_callback_state() {
+        let mut visitor =
+            |_: &DecodedEventParts| -> std::io::Result<()> { panic!("simulated visitor panic") };
+        let mut accumulator = Accumulator::raw(&mut visitor);
+        let parts = DecodedEventParts {
+            provider: windows::core::GUID::from_u128(0),
+            event_id: 1,
+            props: Vec::new(),
+        };
+
+        accumulator.visit_raw_event(&parts);
+
+        assert!(accumulator.visitor_panic.is_some());
+    }
 
     fn raw(path: &str, access: AccessType, rt: ResourceType) -> RawDenial {
         RawDenial {

--- a/src/backends/learning_mode/windows/src/etl_decode.rs
+++ b/src/backends/learning_mode/windows/src/etl_decode.rs
@@ -273,7 +273,7 @@ mod tests {
         }
     }
 
-    /// Mirrors the real `Mode="Normal"` (block-and-log) capture: file/registry
+    /// Mirrors the real `Mode="Normal"` (`block`) capture: file/registry
     /// access checks as event 14 plus a compact capability denial as event 28.
     #[test]
     fn block_and_log_shape_decodes_and_classifies() {
@@ -333,7 +333,7 @@ mod tests {
         assert_eq!(out[2].pid, 0x1acc, "pid from payload ProcessId");
     }
 
-    /// Mirrors the real `Mode="Permissive"` (allow-and-log) capture: the same
+    /// Mirrors the real `Mode="Permissive"` (`allow`) capture: the same
     /// file/registry checks plus a capability check folded into an
     /// empty-`ObjectType` event 14 (there is no event 28 in this mode).
     #[test]

--- a/src/backends/learning_mode/windows/src/extractors.rs
+++ b/src/backends/learning_mode/windows/src/extractors.rs
@@ -1,0 +1,583 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ETW event -> [`RawDenial`] extractors.
+//!
+//! These operate on the generic [`DecodedEventParts`] shape produced by
+//! [`crate::tdh_decode`], so they can be unit-tested with hand-built
+//! fixtures without a live/sealed ETW trace. A [`RawDenial`] still carries
+//! the *kernel-form* object path; [`crate::etl_decode`] path-normalises and
+//! de-duplicates them into the public
+//! [`learning_mode_core::DeniedResource`].
+//!
+//! ## Event vocabulary
+//!
+//! The learning-mode ETL carries a set of event IDs that map onto the
+//! resource types we surface. This list grows as more denial sources are
+//! decoded; unknown event IDs are discarded. The IDs handled today:
+//!
+//! - **14 / 4907 — access check** — the primary denial event
+//!   (`ObjectType` / `ObjectName` / `AccessMask`). `ObjectType` selects the
+//!   resource type: `File` → [`ResourceType::File`], `Key` →
+//!   [`ResourceType::Other`] (registry), and an **empty** `ObjectType` is a
+//!   brokered-capability check → [`ResourceType::Capability`]. Any other
+//!   object type (Section, Process, Thread, ...) is dropped (not actionable
+//!   via sandbox policy). The [`AccessType`] is derived from the
+//!   `AccessMask` field (see [`access_type_from_mask`]). Emitted under both
+//!   learning modes (`block-and-log` → `Mode="Normal"`, `allow-and-log` →
+//!   `Mode="Permissive"`).
+//! - **27 — `LearningModeViolation`** — UI-surface denials →
+//!   [`ResourceType::Ui`]. Carries no usable access mask, so the access type
+//!   stays [`AccessType::Unknown`].
+//! - **28 — capability denial** — a compact capability-access-manager
+//!   record (`Denied` / `PackageSid` / `ProcessId`), emitted under
+//!   `block-and-log`; `allow-and-log` folds the same information into the
+//!   empty-`ObjectType` event 14 above. Mapped to [`ResourceType::Capability`].
+//!   The capability *name* is carried in the `PackageSid` blob and is not
+//!   yet decoded, so the resource path is left empty for now (see the crate
+//!   mode caveat).
+
+use learning_mode_core::{AccessType, ResourceType};
+
+/// Pre-decoded event payload handed to the extractors.
+///
+/// The trace consumer decodes each raw `EVENT_RECORD` into this shape via
+/// [`crate::tdh_decode::decode_event_parts`] before routing it here. The
+/// extractors take only this representation so they stay unit-testable.
+#[derive(Debug, Clone)]
+pub struct DecodedEventParts {
+    /// Originating ETW event ID.
+    pub event_id: u16,
+    /// `(name, value)` pairs from the decoded payload. String values are
+    /// often TDH-quoted; extractors trim the surrounding quotes.
+    pub props: Vec<(String, String)>,
+}
+
+/// A denial extracted from one ETW event, before path normalisation and
+/// de-duplication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawDenial {
+    /// Process ID that triggered the denial.
+    pub pid: u32,
+    /// Classified resource type.
+    pub resource_type: ResourceType,
+    /// Object name in kernel form (e.g. `\Device\HarddiskVolumeN\...`) or,
+    /// for non-file resources, the raw identifier the event carried. Empty
+    /// when the event carries no resolvable name (e.g. a capability denial
+    /// whose name is still encoded in an undecoded SID blob).
+    pub object_name: String,
+    /// Access the workload was attempting.
+    pub access_type: AccessType,
+    /// Kernel `FILETIME` of the event.
+    pub filetime: u64,
+    /// Originating ETW event ID (kept for diagnostics).
+    pub event_id: u16,
+}
+
+/// Routes a decoded event to the matching extractor by its event ID.
+///
+/// Returns `None` for events that are not learning-mode denials or that
+/// carry an object type we don't surface.
+pub fn extract_denial(parts: &DecodedEventParts, pid: u32, filetime: u64) -> Option<RawDenial> {
+    match parts.event_id {
+        14 | 4907 => build_denial_from_access_check(parts, pid, filetime),
+        27 => build_denial_from_learning_mode(parts, pid, filetime),
+        28 => build_denial_from_capability(parts, pid, filetime),
+        _ => None,
+    }
+}
+
+/// Builds a [`RawDenial`] from an access-check (event 14 / 4907) payload.
+///
+/// The `ObjectType` field selects the resource type: `File` and `Key`
+/// (registry) map to concrete resources, an **empty** `ObjectType` is a
+/// brokered-capability check, and any other object type (Section, Process,
+/// Thread, ...) is dropped as not actionable via sandbox policy. An absent
+/// `ObjectType` field drops the event.
+///
+/// For file/registry resources the [`AccessType`] is derived from the
+/// event's `AccessMask` field (the desired access the caller was denied;
+/// see [`access_type_from_mask`]); when the field is absent or unparseable
+/// the type falls back to [`AccessType::Unknown`] so a decode gap never
+/// drops the denial itself. Capability checks carry a mask that is not a
+/// read/write/execute verb, so their access type is left `Unknown`.
+pub fn build_denial_from_access_check(
+    parts: &DecodedEventParts,
+    pid: u32,
+    filetime: u64,
+) -> Option<RawDenial> {
+    let object_type = find_prop(&parts.props, "ObjectType")?;
+    let object_type_str = object_type.trim_matches('"');
+
+    let resource_type = match object_type_str {
+        "File" => ResourceType::File,
+        "Key" => ResourceType::Other,
+        // A present-but-empty object type is a brokered-capability check.
+        "" => ResourceType::Capability,
+        _ => return None,
+    };
+
+    let object_name = find_prop(&parts.props, "ObjectName")
+        .map(|v| v.trim_matches('"').to_string())
+        .unwrap_or_default();
+
+    let access_type = if resource_type == ResourceType::Capability {
+        // Capability checks report a mask (often 0x1) that is not a
+        // read/write/execute verb, so don't run the file/registry
+        // classifier over it.
+        AccessType::Unknown
+    } else {
+        // Registry keys and files share the standard/generic mask bits but
+        // assign different meanings to the object-specific low bits, so the
+        // classifier needs to know which vocabulary applies.
+        let is_registry = object_type_str == "Key";
+        find_prop(&parts.props, "AccessMask")
+            .and_then(|v| parse_u32(v))
+            .map(|mask| access_type_from_mask(mask, is_registry))
+            .unwrap_or(AccessType::Unknown)
+    };
+
+    Some(RawDenial {
+        pid,
+        resource_type,
+        object_name,
+        access_type,
+        filetime,
+        event_id: parts.event_id,
+    })
+}
+
+/// Builds a [`RawDenial`] from a `LearningModeViolation` (event 27) payload.
+///
+/// These represent UI-surface denials; the resource identifier is taken
+/// from the first UI-ish field present. The event carries no usable access
+/// mask, so the access type stays [`AccessType::Unknown`].
+pub fn build_denial_from_learning_mode(
+    parts: &DecodedEventParts,
+    pid: u32,
+    filetime: u64,
+) -> Option<RawDenial> {
+    let object_name = find_prop(&parts.props, "ObjectName")
+        .or_else(|| find_prop(&parts.props, "ResourceName"))
+        .or_else(|| find_prop(&parts.props, "ProcessName"))
+        .map(|v| v.trim_matches('"').to_string())
+        .unwrap_or_default();
+
+    Some(RawDenial {
+        pid,
+        resource_type: ResourceType::Ui,
+        object_name,
+        access_type: AccessType::Unknown,
+        filetime,
+        event_id: parts.event_id,
+    })
+}
+
+/// Builds a [`RawDenial`] from a capability-denial (event 28) payload.
+///
+/// Emitted under `block-and-log`. The record reports a `Denied` boolean; we
+/// only surface actual denials. The originating process is taken from the
+/// payload `ProcessId` (which is more precise than the ETW header pid for
+/// brokered checks) when present, else the header pid. The capability name
+/// is carried in the `PackageSid` blob and is not yet decoded, so the
+/// resource name is left empty for now.
+pub fn build_denial_from_capability(
+    parts: &DecodedEventParts,
+    pid: u32,
+    filetime: u64,
+) -> Option<RawDenial> {
+    // If the record explicitly reports the check as not-denied, skip it;
+    // absence of the field is treated as a denial (fail open on decode gap).
+    if let Some(denied) = find_prop(&parts.props, "Denied") {
+        if !denied.trim_matches('"').eq_ignore_ascii_case("true") {
+            return None;
+        }
+    }
+
+    let pid = find_prop(&parts.props, "ProcessId")
+        .and_then(|v| parse_u32(v))
+        .unwrap_or(pid);
+
+    // Prefer a decoded capability name if a future decoder surfaces one;
+    // otherwise leave the name empty until the PackageSid blob is decoded.
+    let object_name = find_prop(&parts.props, "CapabilityName")
+        .or_else(|| find_prop(&parts.props, "Capability"))
+        .map(|v| v.trim_matches('"').to_string())
+        .unwrap_or_default();
+
+    Some(RawDenial {
+        pid,
+        resource_type: ResourceType::Capability,
+        object_name,
+        access_type: AccessType::Unknown,
+        filetime,
+        event_id: parts.event_id,
+    })
+}
+
+/// Parses a `"0x…"` / decimal / bare-hex property value into a `u32`.
+///
+/// The `AccessMask` and `ProcessId` templates render as `win:HexInt32`, so
+/// the TDH decoder emits a `"0x…"` string (e.g. `"0x120089"`, `"0x1acc"`).
+/// We accept a leading `0x`/`0X` (hex) and, defensively, a bare decimal or
+/// bare-hex form in case a future decoder path formats it differently.
+/// Returns `None` when the value can't be parsed as a 32-bit integer.
+fn parse_u32(raw: &str) -> Option<u32> {
+    let s = raw.trim().trim_matches('"').trim();
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        return u32::from_str_radix(hex, 16).ok();
+    }
+    // No explicit prefix: prefer decimal, fall back to hex.
+    s.parse::<u32>()
+        .ok()
+        .or_else(|| u32::from_str_radix(s, 16).ok())
+}
+
+/// Classifies a Windows access mask into a single [`AccessType`].
+///
+/// A mask often requests several rights at once (e.g. `FILE_GENERIC_READ`
+/// bundles multiple read bits). Since `AccessType` is single-valued, we
+/// return the highest-privilege intent present, in the order
+/// **Write → Execute → Read**, so an approval that grants the reported type
+/// also covers everything else the caller asked for. Mutating rights that
+/// have no dedicated variant (delete, create, take-ownership, change DACL)
+/// fold into `Write`. A mask with no recognised right (e.g. only
+/// `SYNCHRONIZE` or `MAXIMUM_ALLOWED`) yields [`AccessType::Unknown`].
+///
+/// `is_registry` selects the object-specific low-bit vocabulary: files and
+/// registry keys share the standard/generic bits but disagree on bits like
+/// `0x10` (`FILE_WRITE_EA` vs `KEY_NOTIFY`) and `0x20` (`FILE_EXECUTE` vs
+/// `KEY_CREATE_LINK`).
+fn access_type_from_mask(mask: u32, is_registry: bool) -> AccessType {
+    // Standard rights (object-type independent).
+    const DELETE: u32 = 0x0001_0000;
+    const READ_CONTROL: u32 = 0x0002_0000;
+    const WRITE_DAC: u32 = 0x0004_0000;
+    const WRITE_OWNER: u32 = 0x0008_0000;
+    // Generic rights (object-type independent).
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const GENERIC_EXECUTE: u32 = 0x2000_0000;
+    const GENERIC_ALL: u32 = 0x1000_0000;
+
+    let standard_write = DELETE | WRITE_DAC | WRITE_OWNER;
+
+    let (read_bits, write_bits, execute_bits) = if is_registry {
+        // Registry key-specific rights (winnt.h KEY_*).
+        const KEY_QUERY_VALUE: u32 = 0x0001;
+        const KEY_SET_VALUE: u32 = 0x0002;
+        const KEY_CREATE_SUB_KEY: u32 = 0x0004;
+        const KEY_ENUMERATE_SUB_KEYS: u32 = 0x0008;
+        const KEY_NOTIFY: u32 = 0x0010;
+        const KEY_CREATE_LINK: u32 = 0x0020;
+        (
+            KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY | READ_CONTROL | GENERIC_READ,
+            KEY_SET_VALUE
+                | KEY_CREATE_SUB_KEY
+                | KEY_CREATE_LINK
+                | standard_write
+                | GENERIC_WRITE
+                | GENERIC_ALL,
+            // Registry has no execute concept (KEY_EXECUTE aliases KEY_READ).
+            GENERIC_EXECUTE,
+        )
+    } else {
+        // File/directory-specific rights (winnt.h FILE_*).
+        const FILE_READ_DATA: u32 = 0x0001; // a.k.a. FILE_LIST_DIRECTORY
+        const FILE_WRITE_DATA: u32 = 0x0002; // a.k.a. FILE_ADD_FILE
+        const FILE_APPEND_DATA: u32 = 0x0004; // a.k.a. FILE_ADD_SUBDIRECTORY
+        const FILE_READ_EA: u32 = 0x0008;
+        const FILE_WRITE_EA: u32 = 0x0010;
+        const FILE_EXECUTE: u32 = 0x0020; // a.k.a. FILE_TRAVERSE
+        const FILE_READ_ATTRIBUTES: u32 = 0x0080;
+        const FILE_WRITE_ATTRIBUTES: u32 = 0x0100;
+        (
+            FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | GENERIC_READ,
+            FILE_WRITE_DATA
+                | FILE_APPEND_DATA
+                | FILE_WRITE_EA
+                | FILE_WRITE_ATTRIBUTES
+                | standard_write
+                | GENERIC_WRITE
+                | GENERIC_ALL,
+            FILE_EXECUTE | GENERIC_EXECUTE,
+        )
+    };
+
+    if mask & write_bits != 0 {
+        AccessType::Write
+    } else if mask & execute_bits != 0 {
+        AccessType::Execute
+    } else if mask & read_bits != 0 {
+        AccessType::Read
+    } else {
+        AccessType::Unknown
+    }
+}
+
+fn find_prop<'a>(props: &'a [(String, String)], name: &str) -> Option<&'a String> {
+    props.iter().find(|(k, _)| k == name).map(|(_, v)| v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXED_FILETIME: u64 = 132_847_890_123_456_789;
+
+    fn parts(event_id: u16, kv: &[(&str, &str)]) -> DecodedEventParts {
+        DecodedEventParts {
+            event_id,
+            props: kv
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect(),
+        }
+    }
+
+    // ---- event 14 / 4907 access check -------------------------------------
+
+    #[test]
+    fn access_check_file_denial_read_mask() {
+        let p = parts(
+            14,
+            &[
+                ("Mode", "\"Normal\""),
+                ("ObjectType", "\"File\""),
+                (
+                    "ObjectName",
+                    "\"\\Device\\HarddiskVolume3\\Users\\x\\f.txt\"",
+                ),
+                // FILE_GENERIC_READ (0x120089).
+                ("AccessMask", "0x120089"),
+            ],
+        );
+        let ev = extract_denial(&p, 7777, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.event_id, 14);
+        assert_eq!(ev.pid, 7777);
+        assert_eq!(ev.resource_type, ResourceType::File);
+        assert_eq!(ev.object_name, r"\Device\HarddiskVolume3\Users\x\f.txt");
+        assert_eq!(ev.access_type, AccessType::Read);
+        assert_eq!(ev.filetime, FIXED_FILETIME);
+    }
+
+    #[test]
+    fn access_check_event_4907_still_routed() {
+        let p = parts(
+            4907,
+            &[
+                ("ObjectType", "\"File\""),
+                ("ObjectName", "\"c:\\x\""),
+                ("AccessMask", "0x1"),
+            ],
+        );
+        let ev = extract_denial(&p, 1, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.resource_type, ResourceType::File);
+        assert_eq!(ev.access_type, AccessType::Read);
+    }
+
+    #[test]
+    fn access_check_write_mask_classified_write() {
+        let p = parts(
+            14,
+            &[
+                ("ObjectType", "\"File\""),
+                ("ObjectName", "\"c:\\x\""),
+                // DELETE | FILE_READ_DATA (0x10001) — write wins.
+                ("AccessMask", "0x10001"),
+            ],
+        );
+        let ev = extract_denial(&p, 1, FIXED_FILETIME).unwrap();
+        assert_eq!(ev.access_type, AccessType::Write);
+    }
+
+    #[test]
+    fn access_check_key_denial_uses_registry_vocabulary() {
+        let p = parts(
+            14,
+            &[
+                ("ObjectType", "\"Key\""),
+                ("ObjectName", "\"\\REGISTRY\\USER\\.DEFAULT\\Console\""),
+                // KEY_READ (0x20019): READ_CONTROL | KEY_QUERY_VALUE |
+                // KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY -> Read.
+                ("AccessMask", "0x20019"),
+            ],
+        );
+        let ev = extract_denial(&p, 1, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.resource_type, ResourceType::Other);
+        assert_eq!(ev.access_type, AccessType::Read);
+    }
+
+    #[test]
+    fn access_check_empty_object_type_is_capability() {
+        // Permissive-mode capability check: present-but-empty ObjectType,
+        // empty ObjectName, mask 0x1 (not a file read verb here).
+        let p = parts(
+            14,
+            &[
+                ("Mode", "\"Permissive\""),
+                ("ObjectType", "\"\""),
+                ("ObjectName", "\"\""),
+                ("AccessMask", "0x1"),
+            ],
+        );
+        let ev = extract_denial(&p, 5900, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.resource_type, ResourceType::Capability);
+        assert_eq!(ev.access_type, AccessType::Unknown);
+        assert_eq!(ev.object_name, "");
+    }
+
+    #[test]
+    fn access_check_missing_mask_defaults_to_unknown() {
+        let p = parts(
+            4907,
+            &[("ObjectType", "\"File\""), ("ObjectName", "\"c:\\x\"")],
+        );
+        let ev = extract_denial(&p, 1, FIXED_FILETIME).unwrap();
+        assert_eq!(ev.access_type, AccessType::Unknown);
+    }
+
+    #[test]
+    fn access_check_unknown_object_type_dropped() {
+        let p = parts(14, &[("ObjectType", "\"Section\"")]);
+        assert!(extract_denial(&p, 1, FIXED_FILETIME).is_none());
+    }
+
+    #[test]
+    fn access_check_absent_object_type_dropped() {
+        let p = parts(14, &[("ObjectName", "\"x\"")]);
+        assert!(extract_denial(&p, 1, FIXED_FILETIME).is_none());
+    }
+
+    // ---- event 27 UI ------------------------------------------------------
+
+    #[test]
+    fn learning_mode_violation_extracted_as_ui() {
+        let p = parts(27, &[("ObjectName", "\"Clipboard\"")]);
+        let ev = extract_denial(&p, 9999, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.event_id, 27);
+        assert_eq!(ev.resource_type, ResourceType::Ui);
+        assert_eq!(ev.access_type, AccessType::Unknown);
+        assert_eq!(ev.object_name, "Clipboard");
+    }
+
+    // ---- event 28 capability denial ---------------------------------------
+
+    #[test]
+    fn capability_denial_event_28_extracted() {
+        // Real block-and-log shape: image name + hex ProcessId + Denied.
+        let p = parts(
+            28,
+            &[
+                ("ProcessName", "\"conhost.exe\""),
+                ("ProcessId", "0x1acc"),
+                ("Category", "1"),
+                ("Denied", "true"),
+            ],
+        );
+        let ev = extract_denial(&p, 42, FIXED_FILETIME).expect("should extract");
+        assert_eq!(ev.resource_type, ResourceType::Capability);
+        assert_eq!(ev.access_type, AccessType::Unknown);
+        // pid comes from the payload ProcessId (0x1acc), not the header.
+        assert_eq!(ev.pid, 0x1acc);
+        assert_eq!(ev.object_name, "");
+    }
+
+    #[test]
+    fn capability_denial_not_denied_is_dropped() {
+        let p = parts(28, &[("ProcessId", "0x10"), ("Denied", "false")]);
+        assert!(extract_denial(&p, 1, FIXED_FILETIME).is_none());
+    }
+
+    #[test]
+    fn capability_denial_falls_back_to_header_pid() {
+        let p = parts(28, &[("Denied", "true")]);
+        let ev = extract_denial(&p, 555, FIXED_FILETIME).unwrap();
+        assert_eq!(ev.pid, 555);
+    }
+
+    #[test]
+    fn unrelated_event_ignored() {
+        let p = parts(9999, &[("Foo", "\"bar\"")]);
+        assert!(extract_denial(&p, 1, FIXED_FILETIME).is_none());
+    }
+
+    // ---- parse_u32 --------------------------------------------------------
+
+    #[test]
+    fn parse_u32_reads_hex_prefixed() {
+        assert_eq!(parse_u32("0x120089"), Some(0x0012_0089));
+        assert_eq!(parse_u32("0X1"), Some(1));
+        assert_eq!(parse_u32("0x1acc"), Some(0x1acc));
+        // TDH could conceivably wrap or pad the value; be tolerant.
+        assert_eq!(parse_u32(" \"0x2\" "), Some(2));
+    }
+
+    #[test]
+    fn parse_u32_reads_bare_forms_and_rejects_garbage() {
+        assert_eq!(parse_u32("32"), Some(32));
+        // Bare hex fallback (no 0x prefix, not valid decimal).
+        assert_eq!(parse_u32("ff"), Some(0xff));
+        assert_eq!(parse_u32(""), None);
+        assert_eq!(parse_u32("<no data>"), None);
+        // Larger than u32.
+        assert_eq!(parse_u32("0x100000000"), None);
+    }
+
+    // ---- access_type_from_mask (files) ------------------------------------
+
+    #[test]
+    fn file_mask_read_write_execute_priority() {
+        // Pure reads.
+        assert_eq!(access_type_from_mask(0x0001, false), AccessType::Read); // FILE_READ_DATA
+        assert_eq!(access_type_from_mask(0x0012_0089, false), AccessType::Read); // FILE_GENERIC_READ
+                                                                                 // Pure execute / traverse.
+        assert_eq!(access_type_from_mask(0x0020, false), AccessType::Execute); // FILE_EXECUTE
+        assert_eq!(
+            access_type_from_mask(0x2000_0000, false),
+            AccessType::Execute
+        ); // GENERIC_EXECUTE
+           // Writes (incl. delete / take-ownership fold into Write).
+        assert_eq!(access_type_from_mask(0x0002, false), AccessType::Write); // FILE_WRITE_DATA
+        assert_eq!(access_type_from_mask(0x0001_0000, false), AccessType::Write); // DELETE
+        assert_eq!(access_type_from_mask(0x4000_0000, false), AccessType::Write); // GENERIC_WRITE
+        assert_eq!(access_type_from_mask(0x1000_0000, false), AccessType::Write); // GENERIC_ALL
+                                                                                  // Priority: write beats execute beats read when several are set.
+        assert_eq!(
+            access_type_from_mask(0x0001 | 0x0020 | 0x0002, false),
+            AccessType::Write
+        );
+        assert_eq!(
+            access_type_from_mask(0x0001 | 0x0020, false),
+            AccessType::Execute
+        );
+    }
+
+    #[test]
+    fn file_mask_no_recognised_right_is_unknown() {
+        // SYNCHRONIZE (0x100000) alone and MAXIMUM_ALLOWED (0x02000000) alone.
+        assert_eq!(
+            access_type_from_mask(0x0010_0000, false),
+            AccessType::Unknown
+        );
+        assert_eq!(
+            access_type_from_mask(0x0200_0000, false),
+            AccessType::Unknown
+        );
+        assert_eq!(access_type_from_mask(0, false), AccessType::Unknown);
+    }
+
+    // ---- access_type_from_mask (registry) ---------------------------------
+
+    #[test]
+    fn key_mask_uses_registry_vocabulary() {
+        // KEY_QUERY_VALUE / ENUMERATE / NOTIFY are reads.
+        assert_eq!(access_type_from_mask(0x0001, true), AccessType::Read); // KEY_QUERY_VALUE
+        assert_eq!(access_type_from_mask(0x0010, true), AccessType::Read); // KEY_NOTIFY (write for files!)
+                                                                           // KEY_SET_VALUE / CREATE_SUB_KEY / CREATE_LINK are writes.
+        assert_eq!(access_type_from_mask(0x0002, true), AccessType::Write); // KEY_SET_VALUE
+        assert_eq!(access_type_from_mask(0x0020, true), AccessType::Write); // KEY_CREATE_LINK (execute for files!)
+                                                                            // Registry has no execute concept: 0x20 is a write here, not execute.
+        assert_ne!(access_type_from_mask(0x0020, true), AccessType::Execute);
+    }
+}

--- a/src/backends/learning_mode/windows/src/extractors.rs
+++ b/src/backends/learning_mode/windows/src/extractors.rs
@@ -24,14 +24,14 @@
 //!   object type (Section, Process, Thread, ...) is dropped (not actionable
 //!   via sandbox policy). The [`AccessType`] is derived from the
 //!   `AccessMask` field (see [`access_type_from_mask`]). Emitted under both
-//!   learning modes (`block-and-log` → `Mode="Normal"`, `allow-and-log` →
+//!   learning modes (`block` → `Mode="Normal"`, `allow` →
 //!   `Mode="Permissive"`).
 //! - **27 — `LearningModeViolation`** — UI-surface denials →
 //!   [`ResourceType::Ui`]. Carries no usable access mask, so the access type
 //!   stays [`AccessType::Unknown`].
 //! - **28 — capability denial** — a compact capability-access-manager
 //!   record (`Denied` / `PackageSid` / `ProcessId`), emitted under
-//!   `block-and-log`; `allow-and-log` folds the same information into the
+//!   `block`; `allow` folds the same information into the
 //!   empty-`ObjectType` event 14 above. Mapped to [`ResourceType::Capability`].
 //!   The capability *name* is carried in the `PackageSid` blob and is not
 //!   yet decoded, so the resource path is left empty for now (see the crate
@@ -175,7 +175,7 @@ pub fn build_denial_from_learning_mode(
 
 /// Builds a [`RawDenial`] from a capability-denial (event 28) payload.
 ///
-/// Emitted under `block-and-log`. The record reports a `Denied` boolean; we
+/// Emitted under `block`. The record reports a `Denied` boolean; we
 /// only surface actual denials. The originating process is taken from the
 /// payload `ProcessId` (which is more precise than the ETW header pid for
 /// brokered checks) when present, else the header pid. The capability name
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn capability_denial_event_28_extracted() {
-        // Real block-and-log shape: image name + hex ProcessId + Denied.
+        // Real block shape: image name + hex ProcessId + Denied.
         let p = parts(
             28,
             &[

--- a/src/backends/learning_mode/windows/src/extractors.rs
+++ b/src/backends/learning_mode/windows/src/extractors.rs
@@ -152,10 +152,7 @@ pub fn build_denial_from_access_check(
 
     let object_name = find_prop(&parts.props, "ObjectName")
         .map(|v| v.trim_matches('"').to_string())
-        .unwrap_or_default();
-    if resource_type == ResourceType::Capability && object_name.is_empty() {
-        return None;
-    }
+        .filter(|name| !name.is_empty())?;
 
     let access_type = if resource_type == ResourceType::Capability {
         // Capability checks report a mask (often 0x1) that is not a
@@ -330,7 +327,12 @@ fn access_type_from_mask(mask: u32, is_registry: bool) -> AccessType {
         const KEY_NOTIFY: u32 = 0x0010;
         const KEY_CREATE_LINK: u32 = 0x0020;
         (
-            KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY | READ_CONTROL | GENERIC_READ,
+            KEY_QUERY_VALUE
+                | KEY_ENUMERATE_SUB_KEYS
+                | KEY_NOTIFY
+                | READ_CONTROL
+                | GENERIC_READ
+                | GENERIC_EXECUTE,
             KEY_SET_VALUE
                 | KEY_CREATE_SUB_KEY
                 | KEY_CREATE_LINK
@@ -338,7 +340,7 @@ fn access_type_from_mask(mask: u32, is_registry: bool) -> AccessType {
                 | GENERIC_WRITE
                 | GENERIC_ALL,
             // Registry has no execute concept (KEY_EXECUTE aliases KEY_READ).
-            GENERIC_EXECUTE,
+            0,
         )
     } else {
         // File/directory-specific rights (winnt.h FILE_*).
@@ -348,6 +350,7 @@ fn access_type_from_mask(mask: u32, is_registry: bool) -> AccessType {
         const FILE_READ_EA: u32 = 0x0008;
         const FILE_WRITE_EA: u32 = 0x0010;
         const FILE_EXECUTE: u32 = 0x0020; // a.k.a. FILE_TRAVERSE
+        const FILE_DELETE_CHILD: u32 = 0x0040;
         const FILE_READ_ATTRIBUTES: u32 = 0x0080;
         const FILE_WRITE_ATTRIBUTES: u32 = 0x0100;
         (
@@ -355,6 +358,7 @@ fn access_type_from_mask(mask: u32, is_registry: bool) -> AccessType {
             FILE_WRITE_DATA
                 | FILE_APPEND_DATA
                 | FILE_WRITE_EA
+                | FILE_DELETE_CHILD
                 | FILE_WRITE_ATTRIBUTES
                 | standard_write
                 | GENERIC_WRITE
@@ -498,6 +502,21 @@ mod tests {
     }
 
     #[test]
+    fn access_check_empty_file_and_registry_identifiers_are_dropped() {
+        for object_type in ["File", "Key"] {
+            let p = parts(
+                14,
+                &[
+                    ("ObjectType", object_type),
+                    ("ObjectName", "\"\""),
+                    ("AccessMask", "0x1"),
+                ],
+            );
+            assert!(extract_denial(&p, 5900, FIXED_FILETIME).is_none());
+        }
+    }
+
+    #[test]
     fn access_check_missing_mask_defaults_to_unknown() {
         let p = parts(
             4907,
@@ -627,6 +646,7 @@ mod tests {
         ); // GENERIC_EXECUTE
            // Writes (incl. delete / take-ownership fold into Write).
         assert_eq!(access_type_from_mask(0x0002, false), AccessType::Write); // FILE_WRITE_DATA
+        assert_eq!(access_type_from_mask(0x0040, false), AccessType::Write); // FILE_DELETE_CHILD
         assert_eq!(access_type_from_mask(0x0001_0000, false), AccessType::Write); // DELETE
         assert_eq!(access_type_from_mask(0x4000_0000, false), AccessType::Write); // GENERIC_WRITE
         assert_eq!(access_type_from_mask(0x1000_0000, false), AccessType::Write); // GENERIC_ALL
@@ -662,7 +682,8 @@ mod tests {
         // KEY_QUERY_VALUE / ENUMERATE / NOTIFY are reads.
         assert_eq!(access_type_from_mask(0x0001, true), AccessType::Read); // KEY_QUERY_VALUE
         assert_eq!(access_type_from_mask(0x0010, true), AccessType::Read); // KEY_NOTIFY (write for files!)
-                                                                           // KEY_SET_VALUE / CREATE_SUB_KEY / CREATE_LINK are writes.
+        assert_eq!(access_type_from_mask(0x2000_0000, true), AccessType::Read); // GENERIC_EXECUTE maps to KEY_READ
+                                                                                // KEY_SET_VALUE / CREATE_SUB_KEY / CREATE_LINK are writes.
         assert_eq!(access_type_from_mask(0x0002, true), AccessType::Write); // KEY_SET_VALUE
         assert_eq!(access_type_from_mask(0x0020, true), AccessType::Write); // KEY_CREATE_LINK (execute for files!)
                                                                             // Registry has no execute concept: 0x20 is a write here, not execute.

--- a/src/backends/learning_mode/windows/src/extractors.rs
+++ b/src/backends/learning_mode/windows/src/extractors.rs
@@ -33,11 +33,28 @@
 //!   record (`Denied` / `PackageSid` / `ProcessId`), emitted under
 //!   `block`; `allow` folds the same information into the
 //!   empty-`ObjectType` event 14 above. Mapped to [`ResourceType::Capability`].
-//!   The capability *name* is carried in the `PackageSid` blob and is not
-//!   yet decoded, so the resource path is left empty for now (see the crate
-//!   mode caveat).
+//!   Records are emitted only when TDH surfaces a decoded capability
+//!   identifier; otherwise they are omitted until SID/ACE decoding is
+//!   available.
 
 use learning_mode_core::{AccessType, ResourceType};
+use windows::core::GUID;
+
+/// Microsoft-Windows-Kernel-General provider.
+pub(crate) const KERNEL_GENERAL_PROVIDER: GUID = GUID {
+    data1: 0xa68c_a8b7,
+    data2: 0x004f,
+    data3: 0xd7b6,
+    data4: [0xa6, 0x98, 0x07, 0xe2, 0xde, 0x0f, 0x1f, 0x5d],
+};
+
+/// Microsoft-Windows-Privacy-Auditing-PermissiveLearningMode provider.
+pub(crate) const PRIVACY_LEARNING_MODE_PROVIDER: GUID = GUID {
+    data1: 0x811a_1ddb,
+    data2: 0x2e69,
+    data3: 0x5f25,
+    data4: [0xad, 0xc0, 0x4b, 0x18, 0x61, 0x70, 0xe7, 0x60],
+};
 
 /// Pre-decoded event payload handed to the extractors.
 ///
@@ -46,6 +63,8 @@ use learning_mode_core::{AccessType, ResourceType};
 /// extractors take only this representation so they stay unit-testable.
 #[derive(Debug, Clone)]
 pub struct DecodedEventParts {
+    /// Provider that emitted the event. Event IDs are provider-scoped.
+    pub provider: GUID,
     /// Originating ETW event ID.
     pub event_id: u16,
     /// `(name, value)` pairs from the decoded payload. String values are
@@ -79,11 +98,25 @@ pub struct RawDenial {
 /// Returns `None` for events that are not learning-mode denials or that
 /// carry an object type we don't surface.
 pub fn extract_denial(parts: &DecodedEventParts, pid: u32, filetime: u64) -> Option<RawDenial> {
+    if !is_learning_mode_event(parts.provider, parts.event_id) {
+        return None;
+    }
     match parts.event_id {
         14 | 4907 => build_denial_from_access_check(parts, pid, filetime),
         27 => build_denial_from_learning_mode(parts, pid, filetime),
         28 => build_denial_from_capability(parts, pid, filetime),
         _ => None,
+    }
+}
+
+/// Whether a provider/event pair belongs to the Learning Mode capture schema.
+pub(crate) fn is_learning_mode_event(provider: GUID, event_id: u16) -> bool {
+    if provider == KERNEL_GENERAL_PROVIDER {
+        matches!(event_id, 14 | 27 | 28)
+    } else if provider == PRIVACY_LEARNING_MODE_PROVIDER {
+        matches!(event_id, 14 | 27 | 4907)
+    } else {
+        false
     }
 }
 
@@ -120,6 +153,9 @@ pub fn build_denial_from_access_check(
     let object_name = find_prop(&parts.props, "ObjectName")
         .map(|v| v.trim_matches('"').to_string())
         .unwrap_or_default();
+    if resource_type == ResourceType::Capability && object_name.is_empty() {
+        return None;
+    }
 
     let access_type = if resource_type == ResourceType::Capability {
         // Capability checks report a mask (often 0x1) that is not a
@@ -149,19 +185,26 @@ pub fn build_denial_from_access_check(
 
 /// Builds a [`RawDenial`] from a `LearningModeViolation` (event 27) payload.
 ///
-/// These represent UI-surface denials; the resource identifier is taken
-/// from the first UI-ish field present. The event carries no usable access
-/// mask, so the access type stays [`AccessType::Unknown`].
+/// These represent UI-surface denials. `Category` identifies the class and
+/// `Detail` identifies the concrete UI operation; `ProcessName` is the caller
+/// and must not be emitted as the denied resource.
 pub fn build_denial_from_learning_mode(
     parts: &DecodedEventParts,
     pid: u32,
     filetime: u64,
 ) -> Option<RawDenial> {
-    let object_name = find_prop(&parts.props, "ObjectName")
-        .or_else(|| find_prop(&parts.props, "ResourceName"))
-        .or_else(|| find_prop(&parts.props, "ProcessName"))
-        .map(|v| v.trim_matches('"').to_string())
-        .unwrap_or_default();
+    let category = find_prop(&parts.props, "Category")?
+        .trim_matches('"')
+        .to_string();
+    let detail = find_prop(&parts.props, "Detail")?.trim_matches('"');
+    let object_name = match category.as_str() {
+        "1" => "ConvertToGui".to_string(),
+        "2" => parse_u32(detail)
+            .and_then(ui_operation_name)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("UiOperation({detail})")),
+        _ => format!("Category({category})/Detail({detail})"),
+    };
 
     Some(RawDenial {
         pid,
@@ -178,9 +221,8 @@ pub fn build_denial_from_learning_mode(
 /// Emitted under `block`. The record reports a `Denied` boolean; we
 /// only surface actual denials. The originating process is taken from the
 /// payload `ProcessId` (which is more precise than the ETW header pid for
-/// brokered checks) when present, else the header pid. The capability name
-/// is carried in the `PackageSid` blob and is not yet decoded, so the
-/// resource name is left empty for now.
+/// brokered checks) when present, else the header pid. Records without a
+/// decoded capability identifier are omitted.
 pub fn build_denial_from_capability(
     parts: &DecodedEventParts,
     pid: u32,
@@ -198,12 +240,13 @@ pub fn build_denial_from_capability(
         .and_then(|v| parse_u32(v))
         .unwrap_or(pid);
 
-    // Prefer a decoded capability name if a future decoder surfaces one;
-    // otherwise leave the name empty until the PackageSid blob is decoded.
+    // Emit only when the decoder has surfaced a usable identifier. Empty
+    // capability records collapse during dedup and cannot guide policy fixes.
     let object_name = find_prop(&parts.props, "CapabilityName")
         .or_else(|| find_prop(&parts.props, "Capability"))
+        .or_else(|| find_prop(&parts.props, "PackageSid"))
         .map(|v| v.trim_matches('"').to_string())
-        .unwrap_or_default();
+        .filter(|name| !name.is_empty() && name != "<unsupported>" && name != "<invalid SID>")?;
 
     Some(RawDenial {
         pid,
@@ -213,6 +256,22 @@ pub fn build_denial_from_capability(
         filetime,
         event_id: parts.event_id,
     })
+}
+
+fn ui_operation_name(value: u32) -> Option<&'static str> {
+    match value {
+        0x001 => Some("Handles"),
+        0x002 => Some("ReadClipboard"),
+        0x004 => Some("WriteClipboard"),
+        0x008 => Some("SystemParameters"),
+        0x010 => Some("DisplaySettings"),
+        0x020 => Some("GlobalAtoms"),
+        0x040 => Some("Desktop"),
+        0x080 => Some("ExitWindows"),
+        0x100 => Some("IME"),
+        0x200 => Some("Injection"),
+        _ => None,
+    }
 }
 
 /// Parses a `"0x…"` / decimal / bare-hex property value into a `u32`.
@@ -326,7 +385,21 @@ mod tests {
     const FIXED_FILETIME: u64 = 132_847_890_123_456_789;
 
     fn parts(event_id: u16, kv: &[(&str, &str)]) -> DecodedEventParts {
+        let provider = if event_id == 4907 {
+            PRIVACY_LEARNING_MODE_PROVIDER
+        } else {
+            KERNEL_GENERAL_PROVIDER
+        };
+        parts_with_provider(provider, event_id, kv)
+    }
+
+    fn parts_with_provider(
+        provider: GUID,
+        event_id: u16,
+        kv: &[(&str, &str)],
+    ) -> DecodedEventParts {
         DecodedEventParts {
+            provider,
             event_id,
             props: kv
                 .iter()
@@ -409,7 +482,7 @@ mod tests {
     }
 
     #[test]
-    fn access_check_empty_object_type_is_capability() {
+    fn access_check_empty_capability_identifier_is_dropped() {
         // Permissive-mode capability check: present-but-empty ObjectType,
         // empty ObjectName, mask 0x1 (not a file read verb here).
         let p = parts(
@@ -421,10 +494,7 @@ mod tests {
                 ("AccessMask", "0x1"),
             ],
         );
-        let ev = extract_denial(&p, 5900, FIXED_FILETIME).expect("should extract");
-        assert_eq!(ev.resource_type, ResourceType::Capability);
-        assert_eq!(ev.access_type, AccessType::Unknown);
-        assert_eq!(ev.object_name, "");
+        assert!(extract_denial(&p, 5900, FIXED_FILETIME).is_none());
     }
 
     #[test]
@@ -453,12 +523,19 @@ mod tests {
 
     #[test]
     fn learning_mode_violation_extracted_as_ui() {
-        let p = parts(27, &[("ObjectName", "\"Clipboard\"")]);
+        let p = parts(
+            27,
+            &[
+                ("ProcessName", "\"caller.exe\""),
+                ("Category", "2"),
+                ("Detail", "4"),
+            ],
+        );
         let ev = extract_denial(&p, 9999, FIXED_FILETIME).expect("should extract");
         assert_eq!(ev.event_id, 27);
         assert_eq!(ev.resource_type, ResourceType::Ui);
         assert_eq!(ev.access_type, AccessType::Unknown);
-        assert_eq!(ev.object_name, "Clipboard");
+        assert_eq!(ev.object_name, "WriteClipboard");
     }
 
     // ---- event 28 capability denial ---------------------------------------
@@ -473,6 +550,7 @@ mod tests {
                 ("ProcessId", "0x1acc"),
                 ("Category", "1"),
                 ("Denied", "true"),
+                ("PackageSid", "S-1-15-3-1"),
             ],
         );
         let ev = extract_denial(&p, 42, FIXED_FILETIME).expect("should extract");
@@ -480,7 +558,7 @@ mod tests {
         assert_eq!(ev.access_type, AccessType::Unknown);
         // pid comes from the payload ProcessId (0x1acc), not the header.
         assert_eq!(ev.pid, 0x1acc);
-        assert_eq!(ev.object_name, "");
+        assert_eq!(ev.object_name, "S-1-15-3-1");
     }
 
     #[test]
@@ -490,8 +568,18 @@ mod tests {
     }
 
     #[test]
+    fn unrelated_provider_event_id_is_dropped() {
+        let p = parts_with_provider(
+            GUID::from_u128(0x12345678_1234_1234_1234_1234567890ab),
+            27,
+            &[("Category", "2"), ("Detail", "4")],
+        );
+        assert!(extract_denial(&p, 1, FIXED_FILETIME).is_none());
+    }
+
+    #[test]
     fn capability_denial_falls_back_to_header_pid() {
-        let p = parts(28, &[("Denied", "true")]);
+        let p = parts(28, &[("Denied", "true"), ("PackageSid", "S-1-15-3-1")]);
         let ev = extract_denial(&p, 555, FIXED_FILETIME).unwrap();
         assert_eq!(ev.pid, 555);
     }

--- a/src/backends/learning_mode/windows/src/extractors.rs
+++ b/src/backends/learning_mode/windows/src/extractors.rs
@@ -10,6 +10,12 @@
 //! de-duplicates them into the public
 //! [`learning_mode_core::DeniedResource`].
 //!
+//! These policy-oriented extractors intentionally do not reuse the diagnostic
+//! console's display mapping. The console accepts broad real-time provider
+//! traffic and formats it for humans; this module accepts only the
+//! learning-mode providers and produces the stable cross-platform denial
+//! model used for policy generation.
+//!
 //! ## Event vocabulary
 //!
 //! The learning-mode ETL carries a set of event IDs that map onto the

--- a/src/backends/learning_mode/windows/src/lib.rs
+++ b/src/backends/learning_mode/windows/src/lib.rs
@@ -36,6 +36,17 @@ mod lifecycle;
 mod secenv;
 
 #[cfg(target_os = "windows")]
+mod etl_decode;
+#[cfg(target_os = "windows")]
+mod extractors;
+#[cfg(target_os = "windows")]
+mod path_norm;
+#[cfg(target_os = "windows")]
+mod tdh_decode;
+
+#[cfg(target_os = "windows")]
+pub use etl_decode::{decode_raw_events, EtlDenialAnalyzer};
+#[cfg(target_os = "windows")]
 pub use ffi::{is_learning_mode_api_available, LearningModeApi, LearningModeTraceHandle};
 #[cfg(target_os = "windows")]
 pub use lifecycle::CaptureSession;

--- a/src/backends/learning_mode/windows/src/lib.rs
+++ b/src/backends/learning_mode/windows/src/lib.rs
@@ -45,7 +45,9 @@ mod path_norm;
 mod tdh_decode;
 
 #[cfg(target_os = "windows")]
-pub use etl_decode::{decode_raw_events, EtlDenialAnalyzer};
+pub use etl_decode::{visit_raw_events, EtlDenialAnalyzer};
+#[cfg(target_os = "windows")]
+pub use extractors::DecodedEventParts;
 #[cfg(target_os = "windows")]
 pub use ffi::{is_learning_mode_api_available, LearningModeApi, LearningModeTraceHandle};
 #[cfg(target_os = "windows")]

--- a/src/backends/learning_mode/windows/src/path_norm.rs
+++ b/src/backends/learning_mode/windows/src/path_norm.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Kernel-form -> user-visible path normalization.
+//!
+//! ETW emits filesystem paths in two kernel forms:
+//!
+//! - the NT object-manager DOS-devices form `\??\C:\Users\foo\file.txt`
+//!   (and `\??\UNC\server\share` for network paths), and
+//! - the device form `\Device\HarddiskVolume3\Users\foo\file.txt`.
+//!
+//! User-visible paths use drive letters (`C:\Users\foo\file.txt`). This
+//! module owns both mappings.
+//!
+//! The `\??\` form is a pure textual prefix strip. For the `\Device\` form
+//! we walk `A:` through `Z:` calling `QueryDosDeviceW` to discover each
+//! drive's kernel mount (`\Device\HarddiskVolumeN`), then check the input
+//! path for a prefix match. The device map is cached for the lifetime of
+//! the process -- the mapping is stable in practice (drive-letter changes
+//! during a single workload run are vanishingly rare).
+//!
+//! Non-file paths (registry `\REGISTRY\Machine\...`, MUP / network shares,
+//! etc.) are returned unchanged.
+
+use std::sync::OnceLock;
+
+use windows::core::PCWSTR;
+use windows::Win32::Storage::FileSystem::QueryDosDeviceW;
+
+/// Cached `(drive_letter, kernel_prefix)` table, e.g.
+/// `[("C:", "\\Device\\HarddiskVolume3"), ...]`.
+static DRIVE_MAP: OnceLock<Vec<(String, String)>> = OnceLock::new();
+
+/// Maps a kernel-form path to its user-visible drive-letter form.
+///
+/// Returns `Some(canonical)` when the input starts with the NT
+/// object-manager DOS-devices prefix (`\??\C:\...`, `\??\UNC\...`) or a
+/// known `\Device\HarddiskVolumeN\...` prefix. Returns `None` when the path
+/// is not a filesystem path that can be canonicalized (registry, MUP,
+/// unknown device). Callers should fall back to the original input on
+/// `None`.
+pub fn to_user_visible(kernel_path: &str) -> Option<String> {
+    // NT object-manager DOS-devices prefix: `\??\C:\...` is exactly
+    // `C:\...`, and `\??\UNC\server\share` is `\\server\share`. This is a
+    // pure textual mapping that needs no device lookup.
+    if let Some(rest) = kernel_path.strip_prefix(r"\??\") {
+        if let Some(unc) = rest.strip_prefix(r"UNC\") {
+            return Some(format!(r"\\{unc}"));
+        }
+        return Some(rest.to_string());
+    }
+
+    if !kernel_path.starts_with(r"\Device\") {
+        return None;
+    }
+
+    let map = DRIVE_MAP.get_or_init(load_drive_map);
+
+    for (letter, prefix) in map {
+        if let Some(rest) = kernel_path.strip_prefix(prefix.as_str()) {
+            return Some(format!("{letter}{rest}"));
+        }
+    }
+    None
+}
+
+/// Test-only: rebuilds the drive map without consulting the cache.
+#[cfg(test)]
+pub(crate) fn rebuild_drive_map_for_tests() -> Vec<(String, String)> {
+    load_drive_map()
+}
+
+fn load_drive_map() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    let mut buf = [0u16; 260];
+
+    for c in b'A'..=b'Z' {
+        let letter = format!("{}:", c as char);
+        let wide: Vec<u16> = letter.encode_utf16().chain(std::iter::once(0)).collect();
+
+        // SAFETY: `wide` is a valid null-terminated wide string; `buf` is a
+        // valid mutable slice. The function writes at most `buf.len()` u16s.
+        let n = unsafe { QueryDosDeviceW(PCWSTR(wide.as_ptr()), Some(&mut buf)) };
+        if n == 0 {
+            continue;
+        }
+
+        // Result is a sequence of null-terminated strings ending in a double
+        // null. We only care about the first entry.
+        let end = buf
+            .iter()
+            .take(n as usize)
+            .position(|&w| w == 0)
+            .unwrap_or(n as usize);
+        let device = String::from_utf16_lossy(&buf[..end]);
+
+        // Common shapes: `\Device\HarddiskVolume3`, `\Device\Mup`, etc.
+        // Only canonicalize filesystem volumes; skip non-Harddisk entries.
+        if device.starts_with(r"\Device\HarddiskVolume") {
+            out.push((letter, device));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_device_path_returns_none() {
+        assert!(to_user_visible(r"C:\already\user\form").is_none());
+        assert!(to_user_visible(r"\REGISTRY\Machine\SOFTWARE\Foo").is_none());
+        assert!(to_user_visible("").is_none());
+    }
+
+    #[test]
+    fn dos_devices_prefix_is_stripped() {
+        assert_eq!(
+            to_user_visible(r"\??\C:\data\test\bin\").as_deref(),
+            Some(r"C:\data\test\bin\")
+        );
+        assert_eq!(to_user_visible(r"\??\C:\").as_deref(), Some(r"C:\"));
+    }
+
+    #[test]
+    fn dos_devices_unc_prefix_becomes_unc_path() {
+        assert_eq!(
+            to_user_visible(r"\??\UNC\server\share\file.txt").as_deref(),
+            Some(r"\\server\share\file.txt")
+        );
+    }
+
+    #[test]
+    fn drive_map_populates() {
+        // On any Windows machine running tests there is at least one volume
+        // (the system drive). Verifies QueryDosDeviceW works and our parser
+        // accepts at least one entry.
+        let map = rebuild_drive_map_for_tests();
+        assert!(
+            !map.is_empty(),
+            "drive map should have at least one HarddiskVolume entry"
+        );
+    }
+
+    #[test]
+    fn canonicalizes_system_drive_paths() {
+        let map = rebuild_drive_map_for_tests();
+        if let Some((letter, kernel_prefix)) = map.first() {
+            let synthetic = format!(r"{kernel_prefix}\Windows\System32\drivers\etc\hosts");
+            let canon = to_user_visible(&synthetic).expect("should canonicalize");
+            assert_eq!(
+                canon,
+                format!(r"{letter}\Windows\System32\drivers\etc\hosts")
+            );
+        }
+    }
+}

--- a/src/backends/learning_mode/windows/src/path_norm.rs
+++ b/src/backends/learning_mode/windows/src/path_norm.rs
@@ -58,7 +58,9 @@ pub fn to_user_visible(kernel_path: &str) -> Option<String> {
 
     for (letter, prefix) in map {
         if let Some(rest) = kernel_path.strip_prefix(prefix.as_str()) {
-            return Some(format!("{letter}{rest}"));
+            if rest.is_empty() || rest.starts_with('\\') {
+                return Some(format!("{letter}{rest}"));
+            }
         }
     }
     None
@@ -153,6 +155,18 @@ mod tests {
             assert_eq!(
                 canon,
                 format!(r"{letter}\Windows\System32\drivers\etc\hosts")
+            );
+        }
+    }
+
+    #[test]
+    fn device_prefix_requires_component_boundary() {
+        let map = rebuild_drive_map_for_tests();
+        if let Some((_, kernel_prefix)) = map.first() {
+            let false_prefix = format!("{kernel_prefix}0\\Windows");
+            assert!(
+                to_user_visible(&false_prefix).is_none(),
+                "{kernel_prefix} must not match {false_prefix}"
             );
         }
     }

--- a/src/backends/learning_mode/windows/src/path_norm.rs
+++ b/src/backends/learning_mode/windows/src/path_norm.rs
@@ -5,15 +5,15 @@
 //!
 //! ETW emits filesystem paths in two kernel forms:
 //!
-//! - the NT object-manager DOS-devices form `\??\C:\Users\foo\file.txt`
-//!   (and `\??\UNC\server\share` for network paths), and
+//! - DOS-device forms (`\??\`, `\\?\`, or `\\.\`) followed by a drive
+//!   path or `UNC\server\share`, and
 //! - the device form `\Device\HarddiskVolume3\Users\foo\file.txt`.
 //!
 //! User-visible paths use drive letters (`C:\Users\foo\file.txt`). This
 //! module owns both mappings.
 //!
-//! The `\??\` form is a pure textual prefix strip. For the `\Device\` form
-//! we walk `A:` through `Z:` calling `QueryDosDeviceW` to discover each
+//! The DOS-device forms are pure textual prefix strips. For the `\Device\`
+//! form we walk `A:` through `Z:` calling `QueryDosDeviceW` to discover each
 //! drive's kernel mount (`\Device\HarddiskVolumeN`), then check the input
 //! path for a prefix match. The device map is cached for the lifetime of
 //! the process -- the mapping is stable in practice (drive-letter changes
@@ -34,17 +34,24 @@ static DRIVE_MAP: OnceLock<Vec<(String, String)>> = OnceLock::new();
 /// Maps a kernel-form path to its user-visible drive-letter form.
 ///
 /// Returns `Some(canonical)` when the input starts with the NT
-/// object-manager DOS-devices prefix (`\??\C:\...`, `\??\UNC\...`) or a
+/// DOS-devices prefix (`\??\`, `\\?\`, or `\\.\`) or a
 /// known `\Device\HarddiskVolumeN\...` prefix. Returns `None` when the path
 /// is not a filesystem path that can be canonicalized (registry, MUP,
 /// unknown device). Callers should fall back to the original input on
 /// `None`.
 pub fn to_user_visible(kernel_path: &str) -> Option<String> {
-    // NT object-manager DOS-devices prefix: `\??\C:\...` is exactly
-    // `C:\...`, and `\??\UNC\server\share` is `\\server\share`. This is a
-    // pure textual mapping that needs no device lookup.
-    if let Some(rest) = kernel_path.strip_prefix(r"\??\") {
-        if let Some(unc) = rest.strip_prefix(r"UNC\") {
+    // DOS-device prefixes map directly to the path that follows. The UNC
+    // spelling retains its network-path leading slashes.
+    if let Some(rest) = kernel_path
+        .strip_prefix(r"\??\")
+        .or_else(|| kernel_path.strip_prefix(r"\\?\"))
+        .or_else(|| kernel_path.strip_prefix(r"\\.\"))
+    {
+        if let Some(prefix) = rest
+            .get(..4)
+            .filter(|prefix| prefix.eq_ignore_ascii_case(r"UNC\"))
+        {
+            let unc = &rest[prefix.len()..];
             return Some(format!(r"\\{unc}"));
         }
         return Some(rest.to_string());
@@ -132,6 +139,23 @@ mod tests {
             to_user_visible(r"\??\UNC\server\share\file.txt").as_deref(),
             Some(r"\\server\share\file.txt")
         );
+    }
+
+    #[test]
+    fn win32_device_prefixes_are_normalized() {
+        for path in [r"\\?\C:\data\file.txt", r"\\.\C:\data\file.txt"] {
+            assert_eq!(to_user_visible(path).as_deref(), Some(r"C:\data\file.txt"));
+        }
+        for path in [
+            r"\\?\UNC\server\share\file.txt",
+            r"\\?\unc\server\share\file.txt",
+            r"\\.\UNC\server\share\file.txt",
+        ] {
+            assert_eq!(
+                to_user_visible(path).as_deref(),
+                Some(r"\\server\share\file.txt")
+            );
+        }
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/path_norm.rs
+++ b/src/backends/learning_mode/windows/src/path_norm.rs
@@ -14,13 +14,14 @@
 //!
 //! The DOS-device forms are pure textual prefix strips. For the `\Device\`
 //! form we walk `A:` through `Z:` calling `QueryDosDeviceW` to discover each
-//! drive's kernel mount (`\Device\HarddiskVolumeN`), then check the input
+//! drive's kernel mount (`\Device\HarddiskVolumeN`, `\Device\CdRomN`, etc.),
+//! then check the input
 //! path for a prefix match. The device map is cached for the lifetime of
 //! the process -- the mapping is stable in practice (drive-letter changes
 //! during a single workload run are vanishingly rare).
 //!
-//! Non-file paths (registry `\REGISTRY\Machine\...`, MUP / network shares,
-//! etc.) are returned unchanged.
+//! MUP redirector paths are converted to UNC paths. Non-file paths such as
+//! registry `\REGISTRY\Machine\...` are not recognized.
 
 use std::sync::OnceLock;
 
@@ -35,10 +36,9 @@ static DRIVE_MAP: OnceLock<Vec<(String, String)>> = OnceLock::new();
 ///
 /// Returns `Some(canonical)` when the input starts with the NT
 /// DOS-devices prefix (`\??\`, `\\?\`, or `\\.\`) or a
-/// known `\Device\HarddiskVolumeN\...` prefix. Returns `None` when the path
-/// is not a filesystem path that can be canonicalized (registry, MUP,
-/// unknown device). Callers should fall back to the original input on
-/// `None`.
+/// known `\Device\HarddiskVolumeN\...` prefix, or the MUP redirector prefix.
+/// Returns `None` when the path is not a filesystem path that can be
+/// canonicalized (registry or unknown device).
 pub fn to_user_visible(kernel_path: &str) -> Option<String> {
     // DOS-device prefixes map directly to the path that follows. The UNC
     // spelling retains its network-path leading slashes.
@@ -57,12 +57,41 @@ pub fn to_user_visible(kernel_path: &str) -> Option<String> {
         return Some(rest.to_string());
     }
 
+    if let Some(rest) = kernel_path.strip_prefix(r"\Device\Mup\") {
+        let rest = if let Some(after_dfs) = rest.strip_prefix(r"DfsClient\") {
+            if after_dfs.starts_with(';') {
+                let (_, after_connection) = after_dfs.split_once('\\')?;
+                after_connection
+            } else {
+                after_dfs
+            }
+        } else if rest.starts_with(';') {
+            let (_, after_redirector) = rest.split_once('\\')?;
+            if after_redirector.starts_with(';') {
+                let (_, after_connection) = after_redirector.split_once('\\')?;
+                after_connection
+            } else {
+                after_redirector
+            }
+        } else {
+            rest
+        };
+        if !rest.is_empty() {
+            return Some(format!(r"\\{rest}"));
+        }
+        return None;
+    }
+
     if !kernel_path.starts_with(r"\Device\") {
         return None;
     }
 
     let map = DRIVE_MAP.get_or_init(load_drive_map);
 
+    map_device_path(kernel_path, map)
+}
+
+fn map_device_path(kernel_path: &str, map: &[(String, String)]) -> Option<String> {
     for (letter, prefix) in map {
         if let Some(rest) = kernel_path.strip_prefix(prefix.as_str()) {
             if rest.is_empty() || rest.starts_with('\\') {
@@ -71,6 +100,27 @@ pub fn to_user_visible(kernel_path: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Returns whether `path` is already an absolute user-visible DOS or UNC path.
+pub fn is_user_visible_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    (bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'\\' | b'/'))
+        || (path.starts_with(r"\\")
+            && !path.starts_with(r"\\?\")
+            && !path.starts_with(r"\\.\")
+            && !is_unc_named_pipe(path))
+}
+
+fn is_unc_named_pipe(path: &str) -> bool {
+    let mut components = path.trim_start_matches('\\').split('\\');
+    let _server = components.next();
+    components
+        .next()
+        .is_some_and(|share| share.eq_ignore_ascii_case("pipe"))
 }
 
 /// Test-only: rebuilds the drive map without consulting the cache.
@@ -103,9 +153,10 @@ fn load_drive_map() -> Vec<(String, String)> {
             .unwrap_or(n as usize);
         let device = String::from_utf16_lossy(&buf[..end]);
 
-        // Common shapes: `\Device\HarddiskVolume3`, `\Device\Mup`, etc.
-        // Only canonicalize filesystem volumes; skip non-Harddisk entries.
-        if device.starts_with(r"\Device\HarddiskVolume") {
+        // QueryDosDeviceW was invoked for a DOS drive letter, so every
+        // returned target is a drive-backed namespace worth mapping (for
+        // example HarddiskVolume, CdRom, or a redirector-backed drive).
+        if !device.is_empty() {
             out.push((letter, device));
         }
     }
@@ -146,6 +197,7 @@ mod tests {
         for path in [r"\\?\C:\data\file.txt", r"\\.\C:\data\file.txt"] {
             assert_eq!(to_user_visible(path).as_deref(), Some(r"C:\data\file.txt"));
         }
+
         for path in [
             r"\\?\UNC\server\share\file.txt",
             r"\\?\unc\server\share\file.txt",
@@ -159,6 +211,39 @@ mod tests {
     }
 
     #[test]
+    fn mup_path_becomes_unc_path() {
+        assert_eq!(
+            to_user_visible(r"\Device\Mup\server\share\file.txt").as_deref(),
+            Some(r"\\server\share\file.txt")
+        );
+        assert_eq!(
+            to_user_visible(r"\Device\Mup\;LanmanRedirector\server\share\file.txt").as_deref(),
+            Some(r"\\server\share\file.txt")
+        );
+        assert_eq!(
+            to_user_visible(
+                r"\Device\Mup\;LanmanRedirector\;Z:0000000000001234\server\share\file.txt"
+            )
+            .as_deref(),
+            Some(r"\\server\share\file.txt")
+        );
+        assert_eq!(
+            to_user_visible(r"\Device\Mup\DfsClient\;N:0000000000001234\server\share\file.txt")
+                .as_deref(),
+            Some(r"\\server\share\file.txt")
+        );
+    }
+
+    #[test]
+    fn recognizes_absolute_user_visible_paths() {
+        assert!(is_user_visible_absolute(r"C:\data\file.txt"));
+        assert!(is_user_visible_absolute(r"\\server\share\file.txt"));
+        assert!(!is_user_visible_absolute(r"\\server\pipe\name"));
+        assert!(!is_user_visible_absolute(r"\Device\Unknown\file.txt"));
+        assert!(!is_user_visible_absolute(r"relative\file.txt"));
+    }
+
+    #[test]
     fn drive_map_populates() {
         // On any Windows machine running tests there is at least one volume
         // (the system drive). Verifies QueryDosDeviceW works and our parser
@@ -166,7 +251,16 @@ mod tests {
         let map = rebuild_drive_map_for_tests();
         assert!(
             !map.is_empty(),
-            "drive map should have at least one HarddiskVolume entry"
+            "drive map should have at least one DOS drive entry"
+        );
+    }
+
+    #[test]
+    fn maps_non_hard_disk_drive_devices() {
+        let map = vec![("D:".to_string(), r"\Device\CdRom0".to_string())];
+        assert_eq!(
+            map_device_path(r"\Device\CdRom0\setup.exe", &map).as_deref(),
+            Some(r"D:\setup.exe")
         );
     }
 

--- a/src/backends/learning_mode/windows/src/tdh_decode.rs
+++ b/src/backends/learning_mode/windows/src/tdh_decode.rs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! ETW event-record TDH decoder + property formatter.
+//!
+//! Turns raw `EVENT_RECORD` payloads into [`DecodedEventParts`] (a flat
+//! `(name, value)` list) that the [`crate::extractors`] operate on. Only
+//! the `InType`s we need for the learning-mode denial events are wired up;
+//! the rest fall back to a textual placeholder so offset arithmetic stays
+//! consistent without wasting cycles on unsupported encodings.
+
+use windows::Win32::System::Diagnostics::Etw::{
+    TdhGetEventInformation, EVENT_PROPERTY_INFO, EVENT_RECORD, TRACE_EVENT_INFO,
+};
+
+use crate::extractors::DecodedEventParts;
+
+// TDH InType constants from evntrace.h / tdh.h.
+const TDH_INTYPE_UNICODESTRING: u16 = 1;
+const TDH_INTYPE_ANSISTRING: u16 = 2;
+const TDH_INTYPE_INT8: u16 = 3;
+const TDH_INTYPE_UINT8: u16 = 4;
+const TDH_INTYPE_INT16: u16 = 5;
+const TDH_INTYPE_UINT16: u16 = 6;
+const TDH_INTYPE_INT32: u16 = 7;
+const TDH_INTYPE_UINT32: u16 = 8;
+const TDH_INTYPE_INT64: u16 = 9;
+const TDH_INTYPE_UINT64: u16 = 10;
+const TDH_INTYPE_BOOLEAN: u16 = 13;
+const TDH_INTYPE_POINTER: u16 = 16;
+const TDH_INTYPE_HEXINT32: u16 = 20;
+const TDH_INTYPE_HEXINT64: u16 = 21;
+
+/// Decodes an `EVENT_RECORD` into `DecodedEventParts`.
+///
+/// Returns `None` when TDH can't describe the event (rare — usually
+/// indicates a corrupted or unknown event).
+///
+/// # Safety
+/// `event_record` must point to a valid `EVENT_RECORD` provided by the
+/// ETW callback; the caller must not retain references to its fields
+/// after the callback returns.
+pub unsafe fn decode_event_parts(event_record: *mut EVENT_RECORD) -> Option<DecodedEventParts> {
+    let mut buf_size: u32 = 0;
+    // First call: discover required buffer size. ERROR_INSUFFICIENT_BUFFER = 122.
+    let status = unsafe { TdhGetEventInformation(event_record, None, None, &mut buf_size) };
+    if status != 122 {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; buf_size as usize];
+    let info_ptr = buffer.as_mut_ptr().cast::<TRACE_EVENT_INFO>();
+    let status =
+        unsafe { TdhGetEventInformation(event_record, None, Some(info_ptr), &mut buf_size) };
+    if status != 0 {
+        return None;
+    }
+
+    let info = unsafe { &*info_ptr };
+
+    let event_id = unsafe { (*event_record).EventHeader.EventDescriptor.Id };
+    let props = decode_properties(&buffer, info, event_record);
+
+    Some(DecodedEventParts { event_id, props })
+}
+
+fn decode_properties(
+    info_buf: &[u8],
+    info: &TRACE_EVENT_INFO,
+    event_record: *mut EVENT_RECORD,
+) -> Vec<(String, String)> {
+    // SAFETY: caller passes a valid EVENT_RECORD; the field accesses
+    // are reads of POD fields.
+    let event = unsafe { &*event_record };
+    let user_data = event.UserData as *const u8;
+    let user_data_len = event.UserDataLength as usize;
+
+    if user_data.is_null() || user_data_len == 0 {
+        return Vec::new();
+    }
+
+    let prop_count = info.TopLevelPropertyCount as usize;
+    let mut results = Vec::with_capacity(prop_count);
+    let mut offset: usize = 0;
+
+    for i in 0..prop_count {
+        // SAFETY: EventPropertyInfoArray is a flexible-length array of
+        // EVENT_PROPERTY_INFO; TopLevelPropertyCount bounds the index.
+        let prop_info = unsafe {
+            let base =
+                std::ptr::addr_of!(info.EventPropertyInfoArray) as *const EVENT_PROPERTY_INFO;
+            &*base.add(i)
+        };
+
+        let prop_name =
+            wide_str_at(info_buf, prop_info.NameOffset).unwrap_or_else(|| format!("prop{i}"));
+
+        // PROPERTY_FLAGS::PropertyStruct = 1 — skip structured nested
+        // properties (not needed for the learning-mode denial events).
+        if prop_info.Flags.0 & 1 != 0 {
+            results.push((prop_name, "<struct>".to_string()));
+            continue;
+        }
+
+        // SAFETY: nonStructType is valid when PropertyStruct flag is unset.
+        let in_type = unsafe { prop_info.Anonymous1.nonStructType.InType };
+        // SAFETY: Anonymous3.length is always valid (a u16).
+        let declared_length = unsafe { prop_info.Anonymous3.length } as usize;
+
+        let remaining = user_data_len.saturating_sub(offset);
+        let data_ptr = if remaining > 0 {
+            // SAFETY: user_data is valid for user_data_len bytes; offset <= user_data_len.
+            unsafe { user_data.add(offset) }
+        } else {
+            std::ptr::null()
+        };
+
+        let (value_str, consumed) =
+            format_property_value(in_type, declared_length, data_ptr, remaining);
+
+        offset += consumed;
+        results.push((prop_name, value_str));
+    }
+
+    results
+}
+
+fn format_property_value(
+    in_type: u16,
+    declared_length: usize,
+    data: *const u8,
+    available: usize,
+) -> (String, usize) {
+    if data.is_null() || available == 0 {
+        return ("<no data>".to_string(), 0);
+    }
+
+    match in_type {
+        TDH_INTYPE_UNICODESTRING => {
+            let max_wchars = available / 2;
+            // SAFETY: data is valid for `available` bytes; max_wchars
+            // bounds the slice.
+            let wchars = unsafe { std::slice::from_raw_parts(data.cast::<u16>(), max_wchars) };
+            let len = wchars.iter().position(|&c| c == 0).unwrap_or(max_wchars);
+            let s = String::from_utf16_lossy(&wchars[..len]);
+            // Include the null terminator in consumed bytes when present.
+            let consumed = ((len + 1).min(max_wchars)) * 2;
+            (format!("\"{s}\""), consumed)
+        }
+        TDH_INTYPE_ANSISTRING => {
+            // SAFETY: data is valid for `available` bytes.
+            let bytes = unsafe { std::slice::from_raw_parts(data, available) };
+            let len = bytes.iter().position(|&b| b == 0).unwrap_or(available);
+            let s = String::from_utf8_lossy(&bytes[..len]);
+            let consumed = (len + 1).min(available);
+            (format!("\"{s}\""), consumed)
+        }
+        TDH_INTYPE_INT8 if available >= 1 => {
+            let v = unsafe { *data } as i8;
+            (v.to_string(), 1)
+        }
+        TDH_INTYPE_UINT8 if available >= 1 => {
+            let v = unsafe { *data };
+            (v.to_string(), 1)
+        }
+        TDH_INTYPE_BOOLEAN if available >= 4 => {
+            // SAFETY: data points to >=4 valid bytes; read_unaligned because
+            // ETW payload alignment is not guaranteed.
+            let v = unsafe { (data.cast::<u32>()).read_unaligned() };
+            (if v != 0 { "true" } else { "false" }.to_string(), 4)
+        }
+        TDH_INTYPE_INT16 if available >= 2 => (
+            unsafe { (data.cast::<i16>()).read_unaligned() }.to_string(),
+            2,
+        ),
+        TDH_INTYPE_UINT16 if available >= 2 => (
+            unsafe { (data.cast::<u16>()).read_unaligned() }.to_string(),
+            2,
+        ),
+        TDH_INTYPE_INT32 if available >= 4 => (
+            unsafe { (data.cast::<i32>()).read_unaligned() }.to_string(),
+            4,
+        ),
+        TDH_INTYPE_UINT32 if available >= 4 => (
+            unsafe { (data.cast::<u32>()).read_unaligned() }.to_string(),
+            4,
+        ),
+        TDH_INTYPE_HEXINT32 if available >= 4 => (
+            format!("{:#x}", unsafe { (data.cast::<u32>()).read_unaligned() }),
+            4,
+        ),
+        TDH_INTYPE_INT64 if available >= 8 => (
+            unsafe { (data.cast::<i64>()).read_unaligned() }.to_string(),
+            8,
+        ),
+        TDH_INTYPE_UINT64 if available >= 8 => (
+            unsafe { (data.cast::<u64>()).read_unaligned() }.to_string(),
+            8,
+        ),
+        TDH_INTYPE_HEXINT64 if available >= 8 => (
+            format!("{:#x}", unsafe { (data.cast::<u64>()).read_unaligned() }),
+            8,
+        ),
+        TDH_INTYPE_POINTER if available >= 8 => (
+            // 64-bit pointer; on 32-bit hosts this would be 4 bytes but
+            // we only target x64. Unaligned read because ETW payload
+            // alignment is not guaranteed.
+            format!("{:#x}", unsafe { (data.cast::<u64>()).read_unaligned() }),
+            8,
+        ),
+        // Unknown / unsupported InType: emit a placeholder. Consume the
+        // declared length when one is given so offset arithmetic stays
+        // consistent; otherwise consume zero.
+        _ => ("<unsupported>".to_string(), declared_length.min(available)),
+    }
+}
+
+fn wide_str_at(buf: &[u8], offset: u32) -> Option<String> {
+    let offset = offset as usize;
+    if offset == 0 || offset >= buf.len() {
+        return None;
+    }
+    let slice = &buf[offset..];
+    // The buffer is u8-aligned but the names are u16-aligned by
+    // construction (TDH places them at even offsets). Iterate u16
+    // pairs until null terminator or end of buffer.
+    let mut end = slice.len();
+    let mut i = 0;
+    while i + 1 < slice.len() {
+        let lo = slice[i] as u16;
+        let hi = slice[i + 1] as u16;
+        let wchar = lo | (hi << 8);
+        if wchar == 0 {
+            end = i;
+            break;
+        }
+        i += 2;
+    }
+    let trimmed = &slice[..end];
+    // Build a Vec<u16> from byte pairs.
+    let wchars: Vec<u16> = trimmed
+        .chunks_exact(2)
+        .map(|p| (p[0] as u16) | ((p[1] as u16) << 8))
+        .collect();
+    if wchars.is_empty() {
+        None
+    } else {
+        Some(String::from_utf16_lossy(&wchars))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wide_str_at_reads_utf16_until_null() {
+        // "hi\0extra" as UTF-16 LE: 68 00 69 00 00 00 65 00 78 00 74 00 72 00 61 00
+        let buf = [
+            0u8, 0, // padding at offset 0
+            b'h', 0, b'i', 0, 0, 0, b'e', 0, b'x', 0,
+        ];
+        assert_eq!(wide_str_at(&buf, 2).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn wide_str_at_out_of_bounds_returns_none() {
+        let buf = [0u8; 4];
+        assert!(wide_str_at(&buf, 100).is_none());
+        assert!(wide_str_at(&buf, 0).is_none());
+    }
+
+    #[test]
+    fn format_property_value_unicode_string_extracts_content() {
+        let s = "hello";
+        let mut bytes: Vec<u8> = s.encode_utf16().flat_map(|w| w.to_le_bytes()).collect();
+        bytes.extend_from_slice(&[0, 0]); // null terminator
+        let (val, consumed) =
+            format_property_value(TDH_INTYPE_UNICODESTRING, 0, bytes.as_ptr(), bytes.len());
+        assert_eq!(val, "\"hello\"");
+        assert_eq!(consumed, bytes.len()); // 5 chars + null = 12 bytes
+    }
+
+    #[test]
+    fn format_property_value_uint32_reads_little_endian() {
+        let bytes = 0xCAFE_BABEu32.to_le_bytes();
+        let (val, consumed) =
+            format_property_value(TDH_INTYPE_UINT32, 4, bytes.as_ptr(), bytes.len());
+        assert_eq!(val, "3405691582");
+        assert_eq!(consumed, 4);
+    }
+
+    #[test]
+    fn format_property_value_unsupported_consumes_declared_length() {
+        let bytes = [0u8; 4];
+        let (val, consumed) = format_property_value(0xFFFF, 4, bytes.as_ptr(), bytes.len());
+        assert_eq!(val, "<unsupported>");
+        assert_eq!(consumed, 4);
+    }
+
+    #[test]
+    fn format_property_value_null_data_returns_no_data() {
+        let (val, consumed) = format_property_value(TDH_INTYPE_UINT32, 4, std::ptr::null(), 0);
+        assert_eq!(val, "<no data>");
+        assert_eq!(consumed, 0);
+    }
+}

--- a/src/backends/learning_mode/windows/src/tdh_decode.rs
+++ b/src/backends/learning_mode/windows/src/tdh_decode.rs
@@ -36,6 +36,37 @@ const PROPERTY_PARAM_LENGTH: i32 = 0x2;
 const PROPERTY_PARAM_COUNT: i32 = 0x4;
 const MAX_PROPERTY_ELEMENTS: usize = 4096;
 
+struct TdhInfoBuffer {
+    storage: Vec<std::mem::MaybeUninit<TRACE_EVENT_INFO>>,
+    len: usize,
+}
+
+impl TdhInfoBuffer {
+    fn new(len: usize) -> Self {
+        let element_size = std::mem::size_of::<TRACE_EVENT_INFO>();
+        let element_count = len.div_ceil(element_size).max(1);
+        let mut storage = Vec::with_capacity(element_count);
+        storage.resize_with(element_count, std::mem::MaybeUninit::uninit);
+        // SAFETY: `storage` owns `element_count` writable elements. Zeroing
+        // them makes the complete byte view initialized before TDH fills it.
+        unsafe {
+            std::ptr::write_bytes(storage.as_mut_ptr(), 0, element_count);
+        }
+        Self { storage, len }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut TRACE_EVENT_INFO {
+        self.storage.as_mut_ptr().cast()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: `new` zero-initializes the allocation, and `len` never
+        // exceeds its capacity in bytes. The storage alignment is that of
+        // `TRACE_EVENT_INFO`, while this view is used only for byte offsets.
+        unsafe { std::slice::from_raw_parts(self.storage.as_ptr().cast(), self.len) }
+    }
+}
+
 /// Decodes an `EVENT_RECORD` into `DecodedEventParts`.
 ///
 /// Returns `None` when TDH can't describe the event (rare — usually
@@ -57,8 +88,8 @@ pub unsafe fn decode_event_parts(
         ));
     }
 
-    let mut buffer = vec![0u8; buf_size as usize];
-    let info_ptr = buffer.as_mut_ptr().cast::<TRACE_EVENT_INFO>();
+    let mut buffer = TdhInfoBuffer::new(buf_size as usize);
+    let info_ptr = buffer.as_mut_ptr();
     let status =
         unsafe { TdhGetEventInformation(event_record, None, Some(info_ptr), &mut buf_size) };
     if status != 0 {
@@ -71,7 +102,7 @@ pub unsafe fn decode_event_parts(
 
     let header = unsafe { (*event_record).EventHeader };
     let event_id = header.EventDescriptor.Id;
-    let props = decode_properties(&buffer, info, event_record)?;
+    let props = decode_properties(buffer.as_bytes(), info, event_record)?;
 
     Ok(DecodedEventParts {
         provider: header.ProviderId,
@@ -282,16 +313,26 @@ fn format_property_value(
                 available
             };
             let max_wchars = byte_len / 2;
-            // SAFETY: data is valid for `available` bytes; max_wchars
-            // bounds the slice.
-            let wchars = unsafe { std::slice::from_raw_parts(data.cast::<u16>(), max_wchars) };
-            let len = wchars.iter().position(|&c| c == 0).unwrap_or(max_wchars);
-            let s = String::from_utf16_lossy(&wchars[..len]);
+            // SAFETY: data is valid for `available` bytes; byte_len is bounded
+            // by available. Decode from byte pairs because ETW does not
+            // guarantee payload alignment.
+            let bytes = unsafe { std::slice::from_raw_parts(data, byte_len) };
+            let mut wchars = Vec::with_capacity(max_wchars);
+            let mut terminator_index = None;
+            for (index, chunk) in bytes.chunks_exact(2).enumerate() {
+                let wchar = u16::from_le_bytes([chunk[0], chunk[1]]);
+                if wchar == 0 {
+                    terminator_index = Some(index);
+                    break;
+                }
+                wchars.push(wchar);
+            }
+            let s = String::from_utf16_lossy(&wchars);
             // Include the null terminator in consumed bytes when present.
             let consumed = if declared_length > 0 {
                 byte_len
             } else {
-                ((len + 1).min(max_wchars)) * 2
+                terminator_index.map_or(max_wchars * 2, |index| (index + 1) * 2)
             };
             (format!("\"{s}\""), consumed)
         }
@@ -439,6 +480,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tdh_info_buffer_is_aligned_and_initialized() {
+        let mut buffer = TdhInfoBuffer::new(std::mem::size_of::<TRACE_EVENT_INFO>() + 7);
+
+        assert_eq!(
+            buffer
+                .as_mut_ptr()
+                .align_offset(std::mem::align_of::<TRACE_EVENT_INFO>()),
+            0
+        );
+        assert!(buffer.as_bytes().iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
     fn wide_str_at_reads_utf16_until_null() {
         // "hi\0extra" as UTF-16 LE: 68 00 69 00 00 00 65 00 78 00 74 00 72 00 61 00
         let buf = [
@@ -464,6 +518,27 @@ mod tests {
             format_property_value(TDH_INTYPE_UNICODESTRING, 0, bytes.as_ptr(), bytes.len());
         assert_eq!(val, "\"hello\"");
         assert_eq!(consumed, bytes.len()); // 5 chars + null = 12 bytes
+    }
+
+    #[test]
+    fn format_property_value_unicode_string_accepts_unaligned_data() {
+        let encoded: Vec<u8> = "hello"
+            .encode_utf16()
+            .flat_map(|wchar| wchar.to_le_bytes())
+            .chain([0, 0])
+            .collect();
+        let mut storage = vec![0u8; encoded.len() + 1];
+        let base = storage.as_ptr() as usize;
+        let offset = usize::from(base.is_multiple_of(std::mem::align_of::<u16>()));
+        storage[offset..offset + encoded.len()].copy_from_slice(&encoded);
+        let data = unsafe { storage.as_ptr().add(offset) };
+        assert_ne!((data as usize) % std::mem::align_of::<u16>(), 0);
+
+        let (value, consumed) =
+            format_property_value(TDH_INTYPE_UNICODESTRING, 0, data, encoded.len());
+
+        assert_eq!(value, "\"hello\"");
+        assert_eq!(consumed, encoded.len());
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/tdh_decode.rs
+++ b/src/backends/learning_mode/windows/src/tdh_decode.rs
@@ -28,8 +28,13 @@ const TDH_INTYPE_INT64: u16 = 9;
 const TDH_INTYPE_UINT64: u16 = 10;
 const TDH_INTYPE_BOOLEAN: u16 = 13;
 const TDH_INTYPE_POINTER: u16 = 16;
+const TDH_INTYPE_SID: u16 = 19;
 const TDH_INTYPE_HEXINT32: u16 = 20;
 const TDH_INTYPE_HEXINT64: u16 = 21;
+const PROPERTY_STRUCT: i32 = 0x1;
+const PROPERTY_PARAM_LENGTH: i32 = 0x2;
+const PROPERTY_PARAM_COUNT: i32 = 0x4;
+const MAX_PROPERTY_ELEMENTS: usize = 4096;
 
 /// Decodes an `EVENT_RECORD` into `DecodedEventParts`.
 ///
@@ -40,12 +45,16 @@ const TDH_INTYPE_HEXINT64: u16 = 21;
 /// `event_record` must point to a valid `EVENT_RECORD` provided by the
 /// ETW callback; the caller must not retain references to its fields
 /// after the callback returns.
-pub unsafe fn decode_event_parts(event_record: *mut EVENT_RECORD) -> Option<DecodedEventParts> {
+pub unsafe fn decode_event_parts(
+    event_record: *mut EVENT_RECORD,
+) -> Result<DecodedEventParts, String> {
     let mut buf_size: u32 = 0;
     // First call: discover required buffer size. ERROR_INSUFFICIENT_BUFFER = 122.
     let status = unsafe { TdhGetEventInformation(event_record, None, None, &mut buf_size) };
     if status != 122 {
-        return None;
+        return Err(format!(
+            "TdhGetEventInformation(size) failed with Win32 error {status}"
+        ));
     }
 
     let mut buffer = vec![0u8; buf_size as usize];
@@ -53,22 +62,29 @@ pub unsafe fn decode_event_parts(event_record: *mut EVENT_RECORD) -> Option<Deco
     let status =
         unsafe { TdhGetEventInformation(event_record, None, Some(info_ptr), &mut buf_size) };
     if status != 0 {
-        return None;
+        return Err(format!(
+            "TdhGetEventInformation(data) failed with Win32 error {status}"
+        ));
     }
 
     let info = unsafe { &*info_ptr };
 
-    let event_id = unsafe { (*event_record).EventHeader.EventDescriptor.Id };
-    let props = decode_properties(&buffer, info, event_record);
+    let header = unsafe { (*event_record).EventHeader };
+    let event_id = header.EventDescriptor.Id;
+    let props = decode_properties(&buffer, info, event_record)?;
 
-    Some(DecodedEventParts { event_id, props })
+    Ok(DecodedEventParts {
+        provider: header.ProviderId,
+        event_id,
+        props,
+    })
 }
 
 fn decode_properties(
     info_buf: &[u8],
     info: &TRACE_EVENT_INFO,
     event_record: *mut EVENT_RECORD,
-) -> Vec<(String, String)> {
+) -> Result<Vec<(String, String)>, String> {
     // SAFETY: caller passes a valid EVENT_RECORD; the field accesses
     // are reads of POD fields.
     let event = unsafe { &*event_record };
@@ -76,53 +92,176 @@ fn decode_properties(
     let user_data_len = event.UserDataLength as usize;
 
     if user_data.is_null() || user_data_len == 0 {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
+    let property_count = info.PropertyCount as usize;
     let prop_count = info.TopLevelPropertyCount as usize;
     let mut results = Vec::with_capacity(prop_count);
+    let mut numeric_values = vec![None; property_count];
     let mut offset: usize = 0;
 
     for i in 0..prop_count {
-        // SAFETY: EventPropertyInfoArray is a flexible-length array of
-        // EVENT_PROPERTY_INFO; TopLevelPropertyCount bounds the index.
-        let prop_info = unsafe {
-            let base =
-                std::ptr::addr_of!(info.EventPropertyInfoArray) as *const EVENT_PROPERTY_INFO;
-            &*base.add(i)
-        };
+        let value = decode_property(
+            i,
+            info_buf,
+            info,
+            user_data,
+            user_data_len,
+            &mut offset,
+            &mut numeric_values,
+        )?;
+        results.push(value);
+    }
 
-        let prop_name =
-            wide_str_at(info_buf, prop_info.NameOffset).unwrap_or_else(|| format!("prop{i}"));
+    Ok(results)
+}
 
-        // PROPERTY_FLAGS::PropertyStruct = 1 — skip structured nested
-        // properties (not needed for the learning-mode denial events).
-        if prop_info.Flags.0 & 1 != 0 {
-            results.push((prop_name, "<struct>".to_string()));
-            continue;
+fn decode_property(
+    index: usize,
+    info_buf: &[u8],
+    info: &TRACE_EVENT_INFO,
+    user_data: *const u8,
+    user_data_len: usize,
+    offset: &mut usize,
+    numeric_values: &mut [Option<usize>],
+) -> Result<(String, String), String> {
+    if index >= info.PropertyCount as usize {
+        return Err(format!("property index {index} is out of range"));
+    }
+    let prop_info = event_property_info(info, index);
+    let prop_name =
+        wide_str_at(info_buf, prop_info.NameOffset).unwrap_or_else(|| format!("prop{index}"));
+    let flags = prop_info.Flags.0;
+    let count = resolve_property_count(prop_info, flags, numeric_values, index)?;
+    if count > MAX_PROPERTY_ELEMENTS {
+        return Err(format!(
+            "property '{prop_name}' count {count} exceeds limit {MAX_PROPERTY_ELEMENTS}"
+        ));
+    }
+
+    if flags & PROPERTY_STRUCT != 0 {
+        let start_index = unsafe { prop_info.Anonymous1.structType.StructStartIndex } as usize;
+        let member_count = unsafe { prop_info.Anonymous1.structType.NumOfStructMembers } as usize;
+        for _ in 0..count {
+            for child_index in start_index..start_index + member_count {
+                let _ = decode_property(
+                    child_index,
+                    info_buf,
+                    info,
+                    user_data,
+                    user_data_len,
+                    offset,
+                    numeric_values,
+                )?;
+            }
         }
+        return Ok((prop_name, "<struct>".to_string()));
+    }
 
-        // SAFETY: nonStructType is valid when PropertyStruct flag is unset.
-        let in_type = unsafe { prop_info.Anonymous1.nonStructType.InType };
-        // SAFETY: Anonymous3.length is always valid (a u16).
-        let declared_length = unsafe { prop_info.Anonymous3.length } as usize;
+    let in_type = unsafe { prop_info.Anonymous1.nonStructType.InType };
+    let declared_length = if flags & PROPERTY_PARAM_LENGTH != 0 {
+        let length_index = unsafe { prop_info.Anonymous3.lengthPropertyIndex } as usize;
+        resolved_metadata(numeric_values, length_index, "length", index)?
+    } else {
+        (unsafe { prop_info.Anonymous3.length }) as usize
+    };
 
-        let remaining = user_data_len.saturating_sub(offset);
+    let mut values = Vec::with_capacity(count.min(available_element_bound(
+        in_type,
+        user_data_len.saturating_sub(*offset),
+    )));
+    let mut numeric_value = None;
+    for _ in 0..count {
+        let remaining = user_data_len.saturating_sub(*offset);
+        if remaining == 0 {
+            return Err(format!("property '{prop_name}' exceeds the event payload"));
+        }
         let data_ptr = if remaining > 0 {
-            // SAFETY: user_data is valid for user_data_len bytes; offset <= user_data_len.
-            unsafe { user_data.add(offset) }
+            unsafe { user_data.add(*offset) }
         } else {
             std::ptr::null()
         };
-
-        let (value_str, consumed) =
+        let (value, consumed) =
             format_property_value(in_type, declared_length, data_ptr, remaining);
+        if consumed == 0 && remaining > 0 {
+            return Err(format!(
+                "property '{prop_name}' has unsupported variable length"
+            ));
+        }
 
-        offset += consumed;
-        results.push((prop_name, value_str));
+        *offset = offset.saturating_add(consumed);
+        if count == 1 {
+            numeric_value = parse_numeric_metadata(&value);
+        }
+        values.push(value);
     }
+    numeric_values[index] = numeric_value;
 
-    results
+    let rendered = if values.len() == 1 {
+        values.pop().unwrap_or_default()
+    } else {
+        format!("[{}]", values.join(", "))
+    };
+    Ok((prop_name, rendered))
+}
+
+fn resolve_property_count(
+    prop_info: &EVENT_PROPERTY_INFO,
+    flags: i32,
+    numeric_values: &[Option<usize>],
+    property_index: usize,
+) -> Result<usize, String> {
+    if flags & PROPERTY_PARAM_COUNT != 0 {
+        let count_index = unsafe { prop_info.Anonymous2.countPropertyIndex } as usize;
+        resolved_metadata(numeric_values, count_index, "count", property_index)
+    } else {
+        let count = unsafe { prop_info.Anonymous2.count } as usize;
+        Ok(count.max(1))
+    }
+}
+
+fn available_element_bound(in_type: u16, available: usize) -> usize {
+    let element_size = match in_type {
+        TDH_INTYPE_INT8 | TDH_INTYPE_UINT8 => 1,
+        TDH_INTYPE_INT16 | TDH_INTYPE_UINT16 => 2,
+        TDH_INTYPE_INT32 | TDH_INTYPE_UINT32 | TDH_INTYPE_BOOLEAN | TDH_INTYPE_HEXINT32 => 4,
+        TDH_INTYPE_INT64 | TDH_INTYPE_UINT64 | TDH_INTYPE_POINTER | TDH_INTYPE_HEXINT64 => 8,
+        _ => 1,
+    };
+    (available / element_size).max(1)
+}
+
+fn event_property_info(info: &TRACE_EVENT_INFO, index: usize) -> &EVENT_PROPERTY_INFO {
+    unsafe {
+        let base = std::ptr::addr_of!(info.EventPropertyInfoArray) as *const EVENT_PROPERTY_INFO;
+        &*base.add(index)
+    }
+}
+
+fn resolved_metadata(
+    numeric_values: &[Option<usize>],
+    metadata_index: usize,
+    kind: &str,
+    property_index: usize,
+) -> Result<usize, String> {
+    numeric_values
+        .get(metadata_index)
+        .and_then(|value| *value)
+        .ok_or_else(|| {
+            format!(
+                "property {property_index} references unresolved {kind} property {metadata_index}"
+            )
+        })
+}
+
+fn parse_numeric_metadata(value: &str) -> Option<usize> {
+    let value = value.trim().trim_matches('"');
+    value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .and_then(|hex| usize::from_str_radix(hex, 16).ok())
+        .or_else(|| value.parse().ok())
 }
 
 fn format_property_value(
@@ -137,22 +276,39 @@ fn format_property_value(
 
     match in_type {
         TDH_INTYPE_UNICODESTRING => {
-            let max_wchars = available / 2;
+            let byte_len = if declared_length > 0 {
+                declared_length.min(available)
+            } else {
+                available
+            };
+            let max_wchars = byte_len / 2;
             // SAFETY: data is valid for `available` bytes; max_wchars
             // bounds the slice.
             let wchars = unsafe { std::slice::from_raw_parts(data.cast::<u16>(), max_wchars) };
             let len = wchars.iter().position(|&c| c == 0).unwrap_or(max_wchars);
             let s = String::from_utf16_lossy(&wchars[..len]);
             // Include the null terminator in consumed bytes when present.
-            let consumed = ((len + 1).min(max_wchars)) * 2;
+            let consumed = if declared_length > 0 {
+                byte_len
+            } else {
+                ((len + 1).min(max_wchars)) * 2
+            };
             (format!("\"{s}\""), consumed)
         }
         TDH_INTYPE_ANSISTRING => {
-            // SAFETY: data is valid for `available` bytes.
-            let bytes = unsafe { std::slice::from_raw_parts(data, available) };
-            let len = bytes.iter().position(|&b| b == 0).unwrap_or(available);
+            let byte_len = if declared_length > 0 {
+                declared_length.min(available)
+            } else {
+                available
+            };
+            let bytes = unsafe { std::slice::from_raw_parts(data, byte_len) };
+            let len = bytes.iter().position(|&b| b == 0).unwrap_or(byte_len);
             let s = String::from_utf8_lossy(&bytes[..len]);
-            let consumed = (len + 1).min(available);
+            let consumed = if declared_length > 0 {
+                byte_len
+            } else {
+                (len + 1).min(available)
+            };
             (format!("\"{s}\""), consumed)
         }
         TDH_INTYPE_INT8 if available >= 1 => {
@@ -208,11 +364,40 @@ fn format_property_value(
             format!("{:#x}", unsafe { (data.cast::<u64>()).read_unaligned() }),
             8,
         ),
+        TDH_INTYPE_SID if available >= 8 => format_sid(data, available),
         // Unknown / unsupported InType: emit a placeholder. Consume the
         // declared length when one is given so offset arithmetic stays
         // consistent; otherwise consume zero.
         _ => ("<unsupported>".to_string(), declared_length.min(available)),
     }
+}
+
+fn format_sid(data: *const u8, available: usize) -> (String, usize) {
+    let header = unsafe { std::slice::from_raw_parts(data, available.min(8)) };
+    if header.len() < 8 {
+        return ("<invalid SID>".to_string(), available);
+    }
+    let sub_authority_count = header[1] as usize;
+    let length = 8usize.saturating_add(sub_authority_count.saturating_mul(4));
+    if length > available {
+        return ("<invalid SID>".to_string(), available);
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(data, length) };
+    let authority = bytes[2..8]
+        .iter()
+        .fold(0u64, |value, byte| (value << 8) | u64::from(*byte));
+    let mut sid = format!("S-{}-{authority}", bytes[0]);
+    for index in 0..sub_authority_count {
+        let start = 8 + index * 4;
+        let value = u32::from_le_bytes([
+            bytes[start],
+            bytes[start + 1],
+            bytes[start + 2],
+            bytes[start + 3],
+        ]);
+        sid.push_str(&format!("-{value}"));
+    }
+    (sid, length)
 }
 
 fn wide_str_at(buf: &[u8], offset: u32) -> Option<String> {
@@ -282,6 +467,15 @@ mod tests {
     }
 
     #[test]
+    fn format_property_value_unicode_string_honors_fixed_length() {
+        let bytes: Vec<u8> = "abc".encode_utf16().flat_map(|w| w.to_le_bytes()).collect();
+        let (val, consumed) =
+            format_property_value(TDH_INTYPE_UNICODESTRING, 4, bytes.as_ptr(), bytes.len());
+        assert_eq!(val, "\"ab\"");
+        assert_eq!(consumed, 4);
+    }
+
+    #[test]
     fn format_property_value_uint32_reads_little_endian() {
         let bytes = 0xCAFE_BABEu32.to_le_bytes();
         let (val, consumed) =
@@ -303,5 +497,28 @@ mod tests {
         let (val, consumed) = format_property_value(TDH_INTYPE_UINT32, 4, std::ptr::null(), 0);
         assert_eq!(val, "<no data>");
         assert_eq!(consumed, 0);
+    }
+
+    #[test]
+    fn numeric_metadata_parses_decimal_and_hex() {
+        assert_eq!(parse_numeric_metadata("12"), Some(12));
+        assert_eq!(parse_numeric_metadata("0x10"), Some(16));
+        assert_eq!(parse_numeric_metadata("\"7\""), Some(7));
+        assert_eq!(parse_numeric_metadata("not-a-number"), None);
+    }
+
+    #[test]
+    fn format_property_value_sid_decodes_identifier() {
+        // S-1-15-3-1
+        let bytes = [
+            1, 2, // revision, sub-authority count
+            0, 0, 0, 0, 0, 15, // identifier authority
+            3, 0, 0, 0, // sub-authority 0
+            1, 0, 0, 0, // sub-authority 1
+        ];
+        let (value, consumed) =
+            format_property_value(TDH_INTYPE_SID, 0, bytes.as_ptr(), bytes.len());
+        assert_eq!(value, "S-1-15-3-1");
+        assert_eq!(consumed, bytes.len());
     }
 }

--- a/src/backends/learning_mode/windows/src/tdh_decode.rs
+++ b/src/backends/learning_mode/windows/src/tdh_decode.rs
@@ -35,6 +35,7 @@ const PROPERTY_STRUCT: i32 = 0x1;
 const PROPERTY_PARAM_LENGTH: i32 = 0x2;
 const PROPERTY_PARAM_COUNT: i32 = 0x4;
 const MAX_PROPERTY_ELEMENTS: usize = 4096;
+const EVENT_HEADER_FLAG_32_BIT_HEADER: u16 = 0x20;
 
 struct TdhInfoBuffer {
     storage: Vec<std::mem::MaybeUninit<TRACE_EVENT_INFO>>,
@@ -102,7 +103,8 @@ pub unsafe fn decode_event_parts(
 
     let header = unsafe { (*event_record).EventHeader };
     let event_id = header.EventDescriptor.Id;
-    let props = decode_properties(buffer.as_bytes(), info, event_record)?;
+    let pointer_size = pointer_size_from_header_flags(header.Flags);
+    let props = decode_properties(buffer.as_bytes(), info, event_record, pointer_size)?;
 
     Ok(DecodedEventParts {
         provider: header.ProviderId,
@@ -115,6 +117,7 @@ fn decode_properties(
     info_buf: &[u8],
     info: &TRACE_EVENT_INFO,
     event_record: *mut EVENT_RECORD,
+    pointer_size: usize,
 ) -> Result<Vec<(String, String)>, String> {
     // SAFETY: caller passes a valid EVENT_RECORD; the field accesses
     // are reads of POD fields.
@@ -131,38 +134,42 @@ fn decode_properties(
     let mut results = Vec::with_capacity(prop_count);
     let mut numeric_values = vec![None; property_count];
     let mut offset: usize = 0;
+    let context = PropertyDecodeContext {
+        info_buf,
+        info,
+        user_data,
+        user_data_len,
+        pointer_size,
+    };
 
     for i in 0..prop_count {
-        let value = decode_property(
-            i,
-            info_buf,
-            info,
-            user_data,
-            user_data_len,
-            &mut offset,
-            &mut numeric_values,
-        )?;
+        let value = decode_property(i, &context, &mut offset, &mut numeric_values)?;
         results.push(value);
     }
 
     Ok(results)
 }
 
-fn decode_property(
-    index: usize,
-    info_buf: &[u8],
-    info: &TRACE_EVENT_INFO,
+struct PropertyDecodeContext<'a> {
+    info_buf: &'a [u8],
+    info: &'a TRACE_EVENT_INFO,
     user_data: *const u8,
     user_data_len: usize,
+    pointer_size: usize,
+}
+
+fn decode_property(
+    index: usize,
+    context: &PropertyDecodeContext<'_>,
     offset: &mut usize,
     numeric_values: &mut [Option<usize>],
 ) -> Result<(String, String), String> {
-    if index >= info.PropertyCount as usize {
+    if index >= context.info.PropertyCount as usize {
         return Err(format!("property index {index} is out of range"));
     }
-    let prop_info = event_property_info(info, index);
-    let prop_name =
-        wide_str_at(info_buf, prop_info.NameOffset).unwrap_or_else(|| format!("prop{index}"));
+    let prop_info = event_property_info(context.info, index);
+    let prop_name = wide_str_at(context.info_buf, prop_info.NameOffset)
+        .unwrap_or_else(|| format!("prop{index}"));
     let flags = prop_info.Flags.0;
     let count = resolve_property_count(prop_info, flags, numeric_values, index)?;
     if count > MAX_PROPERTY_ELEMENTS {
@@ -176,15 +183,7 @@ fn decode_property(
         let member_count = unsafe { prop_info.Anonymous1.structType.NumOfStructMembers } as usize;
         for _ in 0..count {
             for child_index in start_index..start_index + member_count {
-                let _ = decode_property(
-                    child_index,
-                    info_buf,
-                    info,
-                    user_data,
-                    user_data_len,
-                    offset,
-                    numeric_values,
-                )?;
+                let _ = decode_property(child_index, context, offset, numeric_values)?;
             }
         }
         return Ok((prop_name, "<struct>".to_string()));
@@ -200,21 +199,27 @@ fn decode_property(
 
     let mut values = Vec::with_capacity(count.min(available_element_bound(
         in_type,
-        user_data_len.saturating_sub(*offset),
+        context.user_data_len.saturating_sub(*offset),
+        context.pointer_size,
     )));
     let mut numeric_value = None;
     for _ in 0..count {
-        let remaining = user_data_len.saturating_sub(*offset);
+        let remaining = context.user_data_len.saturating_sub(*offset);
         if remaining == 0 {
             return Err(format!("property '{prop_name}' exceeds the event payload"));
         }
         let data_ptr = if remaining > 0 {
-            unsafe { user_data.add(*offset) }
+            unsafe { context.user_data.add(*offset) }
         } else {
             std::ptr::null()
         };
-        let (value, consumed) =
-            format_property_value(in_type, declared_length, data_ptr, remaining);
+        let (value, consumed) = format_property_value_with_pointer_size(
+            in_type,
+            declared_length,
+            data_ptr,
+            remaining,
+            context.pointer_size,
+        );
         if consumed == 0 && remaining > 0 {
             return Err(format!(
                 "property '{prop_name}' has unsupported variable length"
@@ -252,12 +257,21 @@ fn resolve_property_count(
     }
 }
 
-fn available_element_bound(in_type: u16, available: usize) -> usize {
+fn pointer_size_from_header_flags(flags: u16) -> usize {
+    if flags & EVENT_HEADER_FLAG_32_BIT_HEADER != 0 {
+        4
+    } else {
+        8
+    }
+}
+
+fn available_element_bound(in_type: u16, available: usize, pointer_size: usize) -> usize {
     let element_size = match in_type {
         TDH_INTYPE_INT8 | TDH_INTYPE_UINT8 => 1,
         TDH_INTYPE_INT16 | TDH_INTYPE_UINT16 => 2,
         TDH_INTYPE_INT32 | TDH_INTYPE_UINT32 | TDH_INTYPE_BOOLEAN | TDH_INTYPE_HEXINT32 => 4,
-        TDH_INTYPE_INT64 | TDH_INTYPE_UINT64 | TDH_INTYPE_POINTER | TDH_INTYPE_HEXINT64 => 8,
+        TDH_INTYPE_POINTER => pointer_size,
+        TDH_INTYPE_INT64 | TDH_INTYPE_UINT64 | TDH_INTYPE_HEXINT64 => 8,
         _ => 1,
     };
     (available / element_size).max(1)
@@ -295,11 +309,12 @@ fn parse_numeric_metadata(value: &str) -> Option<usize> {
         .or_else(|| value.parse().ok())
 }
 
-fn format_property_value(
+fn format_property_value_with_pointer_size(
     in_type: u16,
     declared_length: usize,
     data: *const u8,
     available: usize,
+    pointer_size: usize,
 ) -> (String, usize) {
     if data.is_null() || available == 0 {
         return ("<no data>".to_string(), 0);
@@ -398,10 +413,11 @@ fn format_property_value(
             format!("{:#x}", unsafe { (data.cast::<u64>()).read_unaligned() }),
             8,
         ),
-        TDH_INTYPE_POINTER if available >= 8 => (
-            // 64-bit pointer; on 32-bit hosts this would be 4 bytes but
-            // we only target x64. Unaligned read because ETW payload
-            // alignment is not guaranteed.
+        TDH_INTYPE_POINTER if pointer_size == 4 && available >= 4 => (
+            format!("{:#x}", unsafe { (data.cast::<u32>()).read_unaligned() }),
+            4,
+        ),
+        TDH_INTYPE_POINTER if pointer_size == 8 && available >= 8 => (
             format!("{:#x}", unsafe { (data.cast::<u64>()).read_unaligned() }),
             8,
         ),
@@ -411,6 +427,16 @@ fn format_property_value(
         // consistent; otherwise consume zero.
         _ => ("<unsupported>".to_string(), declared_length.min(available)),
     }
+}
+
+#[cfg(test)]
+fn format_property_value(
+    in_type: u16,
+    declared_length: usize,
+    data: *const u8,
+    available: usize,
+) -> (String, usize) {
+    format_property_value_with_pointer_size(in_type, declared_length, data, available, 8)
 }
 
 fn format_sid(data: *const u8, available: usize) -> (String, usize) {
@@ -557,6 +583,40 @@ mod tests {
             format_property_value(TDH_INTYPE_UINT32, 4, bytes.as_ptr(), bytes.len());
         assert_eq!(val, "3405691582");
         assert_eq!(consumed, 4);
+    }
+
+    #[test]
+    fn pointer_width_follows_event_header_flags() {
+        assert_eq!(pointer_size_from_header_flags(0), 8);
+        assert_eq!(
+            pointer_size_from_header_flags(EVENT_HEADER_FLAG_32_BIT_HEADER),
+            4
+        );
+    }
+
+    #[test]
+    fn format_property_value_pointer_supports_32_and_64_bit_events() {
+        let pointer32 = 0xCAFE_BABEu32.to_le_bytes();
+        let (value, consumed) = format_property_value_with_pointer_size(
+            TDH_INTYPE_POINTER,
+            0,
+            pointer32.as_ptr(),
+            pointer32.len(),
+            4,
+        );
+        assert_eq!(value, "0xcafebabe");
+        assert_eq!(consumed, 4);
+
+        let pointer64 = 0xCAFE_BABE_DEAD_BEEFu64.to_le_bytes();
+        let (value, consumed) = format_property_value_with_pointer_size(
+            TDH_INTYPE_POINTER,
+            0,
+            pointer64.as_ptr(),
+            pointer64.len(),
+            8,
+        );
+        assert_eq!(value, "0xcafebabedeadbeef");
+        assert_eq!(consumed, 8);
     }
 
     #[test]

--- a/src/core/learning_mode_core/Cargo.toml
+++ b/src/core/learning_mode_core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "learning_mode_core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/src/core/learning_mode_core/src/analyze.rs
+++ b/src/core/learning_mode_core/src/analyze.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! The decode abstraction: turn a platform-native capture source into the
+//! cross-platform [`DeniedResource`] model.
+//!
+//! Each backend implements [`DenialAnalyzer`] over its own capture format.
+//! The Windows backend (`learning_mode_windows`) implements it over a
+//! sealed ETW trace (`.etl`); a future Linux backend would implement it
+//! over its own source. Keeping the trait in this cross-platform crate
+//! lets the runner and tests depend on the abstraction rather than any
+//! one OS decoder, and lets tests substitute a fake.
+
+use std::path::Path;
+
+use thiserror::Error;
+
+use crate::model::DeniedResource;
+
+/// Failure modes when analysing a capture source into denials.
+#[derive(Debug, Error)]
+pub enum AnalyzeError {
+    /// The capture source could not be opened (missing file, permissions).
+    #[error("failed to open capture source '{path}': {source}")]
+    Open {
+        /// The source path that could not be opened.
+        path: String,
+        /// The underlying I/O error.
+        source: std::io::Error,
+    },
+
+    /// The source was opened but could not be decoded into denials.
+    #[error("failed to decode capture source: {0}")]
+    Decode(String),
+
+    /// Analysis is not available on this platform / build (e.g. the
+    /// decoder is Windows-only and this is a non-Windows target).
+    #[error("capture analysis is not supported on this platform")]
+    Unsupported,
+}
+
+/// Decodes a platform-native capture source into de-duplicated denials.
+///
+/// Implementors return the unique `(path, accessType)` observations found
+/// in `source_path`; the caller wraps them with a
+/// [`crate::summary::DenialSummary`] and emits an NDJSON stream via
+/// [`crate::emit`].
+pub trait DenialAnalyzer {
+    /// Analyses the capture at `source_path`, returning the denials it
+    /// contains.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnalyzeError`] if the source cannot be opened, cannot be
+    /// decoded, or analysis is unsupported on this platform.
+    fn analyze(&self, source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AccessType, ResourceType};
+
+    /// A trivial analyzer returning a fixed set, proving the trait is
+    /// object-safe and usable behind a `dyn` reference.
+    struct FakeAnalyzer(Vec<DeniedResource>);
+
+    impl DenialAnalyzer for FakeAnalyzer {
+        fn analyze(&self, _source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[test]
+    fn analyzer_is_object_safe_and_returns_denials() {
+        let denials = vec![DeniedResource {
+            path: r"C:\a".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 1,
+            filetime: 2,
+        }];
+        let analyzer: Box<dyn DenialAnalyzer> = Box::new(FakeAnalyzer(denials.clone()));
+        let got = analyzer.analyze(Path::new("ignored.etl")).unwrap();
+        assert_eq!(got, denials);
+    }
+
+    #[test]
+    fn analyze_error_messages_are_meaningful() {
+        let err = AnalyzeError::Open {
+            path: "x.etl".to_string(),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "nope"),
+        };
+        assert!(err.to_string().contains("x.etl"));
+        assert!(AnalyzeError::Unsupported
+            .to_string()
+            .contains("not supported"));
+    }
+}

--- a/src/core/learning_mode_core/src/analyze.rs
+++ b/src/core/learning_mode_core/src/analyze.rs
@@ -64,7 +64,7 @@ pub enum AnalyzeError {
 ///
 /// Implementors return bounded unique `(path, accessType)` observations and
 /// whether additional unique records were truncated; the caller wraps them with a
-/// [`crate::summary::DenialSummary`] and emits an NDJSON stream via
+/// [`crate::summary::DenialSummary`] and emits an RFC 7464 JSON text sequence via
 /// [`crate::emit`].
 pub trait DenialAnalyzer {
     /// Analyses the capture at `source_path`, returning its bounded denial

--- a/src/core/learning_mode_core/src/analyze.rs
+++ b/src/core/learning_mode_core/src/analyze.rs
@@ -17,6 +17,27 @@ use thiserror::Error;
 
 use crate::model::DeniedResource;
 
+/// Result of decoding a capture source into bounded, de-duplicated denials.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalysisResult {
+    /// Unique denials retained by the analyzer in first-seen order.
+    pub denials: Vec<DeniedResource>,
+    /// Whether additional unique denials were observed after the result bound
+    /// was reached.
+    pub denied_resources_truncated: bool,
+}
+
+impl AnalysisResult {
+    /// Creates a complete, non-truncated result.
+    #[must_use]
+    pub fn complete(denials: Vec<DeniedResource>) -> Self {
+        Self {
+            denials,
+            denied_resources_truncated: false,
+        }
+    }
+}
+
 /// Failure modes when analysing a capture source into denials.
 #[derive(Debug, Error)]
 pub enum AnalyzeError {
@@ -41,19 +62,19 @@ pub enum AnalyzeError {
 
 /// Decodes a platform-native capture source into de-duplicated denials.
 ///
-/// Implementors return the unique `(path, accessType)` observations found
-/// in `source_path`; the caller wraps them with a
+/// Implementors return bounded unique `(path, accessType)` observations and
+/// whether additional unique records were truncated; the caller wraps them with a
 /// [`crate::summary::DenialSummary`] and emits an NDJSON stream via
 /// [`crate::emit`].
 pub trait DenialAnalyzer {
-    /// Analyses the capture at `source_path`, returning the denials it
-    /// contains.
+    /// Analyses the capture at `source_path`, returning its bounded denial
+    /// result.
     ///
     /// # Errors
     ///
     /// Returns [`AnalyzeError`] if the source cannot be opened, cannot be
     /// decoded, or analysis is unsupported on this platform.
-    fn analyze(&self, source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError>;
+    fn analyze(&self, source_path: &Path) -> Result<AnalysisResult, AnalyzeError>;
 }
 
 #[cfg(test)]
@@ -66,8 +87,8 @@ mod tests {
     struct FakeAnalyzer(Vec<DeniedResource>);
 
     impl DenialAnalyzer for FakeAnalyzer {
-        fn analyze(&self, _source_path: &Path) -> Result<Vec<DeniedResource>, AnalyzeError> {
-            Ok(self.0.clone())
+        fn analyze(&self, _source_path: &Path) -> Result<AnalysisResult, AnalyzeError> {
+            Ok(AnalysisResult::complete(self.0.clone()))
         }
     }
 
@@ -82,7 +103,8 @@ mod tests {
         }];
         let analyzer: Box<dyn DenialAnalyzer> = Box::new(FakeAnalyzer(denials.clone()));
         let got = analyzer.analyze(Path::new("ignored.etl")).unwrap();
-        assert_eq!(got, denials);
+        assert_eq!(got.denials, denials);
+        assert!(!got.denied_resources_truncated);
     }
 
     #[test]

--- a/src/core/learning_mode_core/src/emit.rs
+++ b/src/core/learning_mode_core/src/emit.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Framed NDJSON emitter for captureDenials output files.
+//!
+//! The output file follows the [RFC 7464] "JSON Text Sequences" framing:
+//! every record is preceded by an ASCII Record Separator (`0x1E`) and
+//! terminated by a line feed (`0x0A`):
+//!
+//! ```text
+//! <RS>{"type":"denial", ...}<LF>
+//! <RS>{"type":"denial", ...}<LF>
+//! <RS>{"type":"summary", ...}<LF>
+//! ```
+//!
+//! The `0x1E` prefix is load-bearing: it effectively never appears in
+//! legitimate workload output, so a consumer can split on it to reliably
+//! separate MXC envelopes from any interleaved bytes. The summary frame
+//! terminates the stream for one `wxc-exec` invocation.
+//!
+//! This module is transport-agnostic — it writes to any [`io::Write`],
+//! so the same code path serves the on-disk output file and in-memory
+//! test buffers.
+//!
+//! [RFC 7464]: https://www.rfc-editor.org/rfc/rfc7464
+
+use std::io::{self, Write};
+
+use crate::frame::DenialFrame;
+use crate::model::DeniedResource;
+use crate::summary::DenialSummary;
+
+/// ASCII Record Separator (`0x1E`), prefixed to every framed record.
+pub const RECORD_SEPARATOR: u8 = 0x1E;
+
+/// Writes one framed record: `RS` + compact JSON + `LF`.
+///
+/// # Errors
+///
+/// Returns any [`io::Error`] from the underlying writer, or a
+/// serialisation error surfaced as [`io::ErrorKind::InvalidData`].
+pub fn write_frame<W: Write>(writer: &mut W, frame: &DenialFrame) -> io::Result<()> {
+    let json = serde_json::to_vec(frame).map_err(io::Error::other)?;
+    writer.write_all(&[RECORD_SEPARATOR])?;
+    writer.write_all(&json)?;
+    writer.write_all(b"\n")
+}
+
+/// Writes a complete captureDenials stream: one `denial` frame per
+/// resource, followed by exactly one terminating `summary` frame, then
+/// flushes the writer.
+///
+/// The caller is responsible for having already de-duplicated
+/// `resources`; `summary.total_denials` should equal `resources.len()`
+/// for a non-truncated capture.
+///
+/// # Errors
+///
+/// Returns the first [`io::Error`] encountered while writing or flushing.
+pub fn write_stream<W: Write>(
+    writer: &mut W,
+    resources: &[DeniedResource],
+    summary: &DenialSummary,
+) -> io::Result<()> {
+    for resource in resources {
+        let frame = DenialFrame::Denial(resource.clone());
+        write_frame(writer, &frame)?;
+    }
+    write_frame(writer, &DenialFrame::Summary(*summary))?;
+    writer.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AccessType, ResourceType};
+
+    fn sample(path: &str) -> DeniedResource {
+        DeniedResource {
+            path: path.to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 100,
+            filetime: 200,
+        }
+    }
+
+    #[test]
+    fn write_frame_prefixes_rs_and_terminates_lf() {
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &DenialFrame::Denial(sample(r"C:\a"))).unwrap();
+        assert_eq!(buf[0], RECORD_SEPARATOR);
+        assert_eq!(*buf.last().unwrap(), b'\n');
+        // Exactly one RS and one LF for a single record.
+        assert_eq!(buf.iter().filter(|&&b| b == RECORD_SEPARATOR).count(), 1);
+        assert_eq!(buf.iter().filter(|&&b| b == b'\n').count(), 1);
+    }
+
+    #[test]
+    fn write_stream_emits_denials_then_single_summary() {
+        let resources = vec![sample(r"C:\a"), sample(r"C:\b")];
+        let summary = DenialSummary::new(0, 2, false);
+        let mut buf = Vec::new();
+        write_stream(&mut buf, &resources, &summary).unwrap();
+
+        let text = String::from_utf8(buf).unwrap();
+        let records: Vec<&str> = text
+            .split(RECORD_SEPARATOR as char)
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(records.len(), 3, "2 denials + 1 summary");
+        assert!(records[0].contains("\"type\":\"denial\""));
+        assert!(records[1].contains("\"type\":\"denial\""));
+        assert!(records[2].contains("\"type\":\"summary\""));
+        assert!(records[2].contains("\"totalDenials\":2"));
+    }
+
+    #[test]
+    fn written_stream_round_trips_by_splitting_on_rs() {
+        let resources = vec![sample(r"C:\a")];
+        let summary = DenialSummary::new(7, 1, true);
+        let mut buf = Vec::new();
+        write_stream(&mut buf, &resources, &summary).unwrap();
+
+        let text = String::from_utf8(buf).unwrap();
+        let frames: Vec<DenialFrame> = text
+            .split(RECORD_SEPARATOR as char)
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| serde_json::from_str(s.trim()).unwrap())
+            .collect();
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0], DenialFrame::Denial(sample(r"C:\a")));
+        assert_eq!(frames[1], DenialFrame::Summary(summary));
+    }
+
+    #[test]
+    fn empty_capture_still_writes_summary() {
+        let summary = DenialSummary::new(0, 0, false);
+        let mut buf = Vec::new();
+        write_stream(&mut buf, &[], &summary).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+        assert!(text.contains("\"type\":\"summary\""));
+        assert_eq!(text.matches('\n').count(), 1);
+    }
+}

--- a/src/core/learning_mode_core/src/emit.rs
+++ b/src/core/learning_mode_core/src/emit.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-//! Framed NDJSON emitter for captureDenials output files.
+//! RFC 7464 JSON text sequence emitter for captureDenials output files.
 //!
 //! The output file follows the [RFC 7464] "JSON Text Sequences" framing:
 //! every record is preceded by an ASCII Record Separator (`0x1E`) and

--- a/src/core/learning_mode_core/src/frame.rs
+++ b/src/core/learning_mode_core/src/frame.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! The self-describing wire records that make up a captureDenials output
+//! stream.
+//!
+//! A captureDenials output file is a sequence of JSON records, each
+//! tagged with a `type` discriminator so a consumer can dispatch without
+//! positional assumptions:
+//!
+//! ```text
+//! {"type":"denial","path":"...","resourceType":"file","accessType":"read","pid":123,"filetime":...}
+//! {"type":"denial", ...}
+//! {"type":"summary","exitCode":0,"totalDenials":2,"deniedResourcesTruncated":false}
+//! ```
+//!
+//! [`DenialFrame`] is an internally-tagged enum over the two record
+//! kinds, so `serde` handles the `type` field and consumers get an
+//! exhaustive match. The framing bytes (RFC 7464 record separators) are
+//! added by [`crate::emit`]; this module only defines the JSON objects.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::DeniedResource;
+use crate::summary::DenialSummary;
+
+/// One record in a captureDenials output stream.
+///
+/// Serialises with an internal `type` tag (`"denial"` / `"summary"`)
+/// flattened alongside the payload fields, matching the on-disk NDJSON
+/// contract consumers parse.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum DenialFrame {
+    /// A single denied resource observation.
+    Denial(DeniedResource),
+    /// The terminating summary; exactly one per stream, written last.
+    Summary(DenialSummary),
+}
+
+impl From<DeniedResource> for DenialFrame {
+    fn from(resource: DeniedResource) -> Self {
+        DenialFrame::Denial(resource)
+    }
+}
+
+impl From<DenialSummary> for DenialFrame {
+    fn from(summary: DenialSummary) -> Self {
+        DenialFrame::Summary(summary)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AccessType, ResourceType};
+
+    #[test]
+    fn denial_frame_carries_type_tag() {
+        let frame = DenialFrame::from(DeniedResource {
+            path: r"C:\x".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 7,
+            filetime: 9,
+        });
+        let json = serde_json::to_string(&frame).unwrap();
+        assert!(json.starts_with("{\"type\":\"denial\""), "got {json}");
+        assert!(json.contains("\"path\":\"C:\\\\x\""), "got {json}");
+    }
+
+    #[test]
+    fn summary_frame_carries_type_tag() {
+        let frame = DenialFrame::from(DenialSummary::new(0, 1, false));
+        let json = serde_json::to_string(&frame).unwrap();
+        assert!(json.starts_with("{\"type\":\"summary\""), "got {json}");
+        assert!(json.contains("\"totalDenials\":1"), "got {json}");
+    }
+
+    #[test]
+    fn frame_round_trips_through_json() {
+        let denial = DenialFrame::from(DeniedResource {
+            path: r"C:\y".to_string(),
+            resource_type: ResourceType::Capability,
+            access_type: AccessType::Unknown,
+            pid: 3,
+            filetime: 4,
+        });
+        let parsed: DenialFrame =
+            serde_json::from_str(&serde_json::to_string(&denial).unwrap()).unwrap();
+        assert_eq!(denial, parsed);
+
+        let summary = DenialFrame::from(DenialSummary::new(2, 5, true));
+        let parsed: DenialFrame =
+            serde_json::from_str(&serde_json::to_string(&summary).unwrap()).unwrap();
+        assert_eq!(summary, parsed);
+    }
+}

--- a/src/core/learning_mode_core/src/frame.rs
+++ b/src/core/learning_mode_core/src/frame.rs
@@ -27,7 +27,7 @@ use crate::summary::DenialSummary;
 /// One record in a captureDenials output stream.
 ///
 /// Serialises with an internal `type` tag (`"denial"` / `"summary"`)
-/// flattened alongside the payload fields, matching the on-disk NDJSON
+/// flattened alongside the payload fields, matching the on-disk JSON sequence
 /// contract consumers parse.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]

--- a/src/core/learning_mode_core/src/frame.rs
+++ b/src/core/learning_mode_core/src/frame.rs
@@ -9,7 +9,7 @@
 //! positional assumptions:
 //!
 //! ```text
-//! {"type":"denial","path":"...","resourceType":"file","accessType":"read","pid":123,"filetime":...}
+//! {"type":"denial","path":"...","resourceType":"file","accessType":"read","pid":123,"filetime":"..."}
 //! {"type":"denial", ...}
 //! {"type":"summary","exitCode":0,"totalDenials":2,"deniedResourcesTruncated":false}
 //! ```

--- a/src/core/learning_mode_core/src/lib.rs
+++ b/src/core/learning_mode_core/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Cross-platform core for the captureDenials / learning-mode pipeline.
+//!
+//! MXC's learning-mode capture flow has three stages:
+//!
+//! 1. **Capture** — a backend runs the workload under an OS learning mode
+//!    and seals a native trace (on Windows, an ETW `.etl`). This lives in
+//!    the per-OS backend crates.
+//! 2. **Analyse** — the trace is decoded into cross-platform
+//!    [`DeniedResource`] records. The per-OS decoder implements
+//!    [`DenialAnalyzer`]; this crate owns the trait and the model.
+//! 3. **Emit** — the records plus a terminating [`DenialSummary`] are
+//!    written to an NDJSON output file that host applications read to
+//!    regenerate their sandbox policy. See [`emit`].
+//!
+//! This crate is the cross-platform hinge between stages 2 and 3: it
+//! defines the public [`DeniedResource`] model, the [`DenialSummary`]
+//! terminator, the self-describing [`DenialFrame`] wire records, the
+//! RFC 7464 NDJSON [`emit`]ter, and the [`DenialAnalyzer`] decode trait.
+//! It carries no OS-specific code so the wire format never encodes a
+//! platform assumption.
+//!
+//! ## Mode caveat
+//!
+//! What a capture contains depends on the active OS learning mode.
+//! File/path and UI denials are recorded under both `learningMode`
+//! (block-and-log) and `permissiveLearningMode` (allow-and-log), but
+//! **capability** ([`ResourceType::Capability`]) denials are currently
+//! only recorded under permissive learning mode. Consumers must not
+//! assume capability records are present under plain `learningMode`.
+
+#![deny(missing_docs)]
+
+pub mod analyze;
+pub mod emit;
+pub mod frame;
+pub mod model;
+pub mod summary;
+
+pub use analyze::{AnalyzeError, DenialAnalyzer};
+pub use emit::{write_frame, write_stream, RECORD_SEPARATOR};
+pub use frame::DenialFrame;
+pub use model::{AccessType, DedupKey, DeniedResource, ResourceType};
+pub use summary::DenialSummary;

--- a/src/core/learning_mode_core/src/lib.rs
+++ b/src/core/learning_mode_core/src/lib.rs
@@ -12,13 +12,13 @@
 //!    [`DeniedResource`] records. The per-OS decoder implements
 //!    [`DenialAnalyzer`]; this crate owns the trait and the model.
 //! 3. **Emit** — the records plus a terminating [`DenialSummary`] are
-//!    written to an NDJSON output file that host applications read to
+//!    written to an RFC 7464 JSON text sequence that host applications read to
 //!    regenerate their sandbox policy. See [`emit`].
 //!
 //! This crate is the cross-platform hinge between stages 2 and 3: it
 //! defines the public [`DeniedResource`] model, the [`DenialSummary`]
 //! terminator, the self-describing [`DenialFrame`] wire records, the
-//! RFC 7464 NDJSON [`emit`]ter, and the [`DenialAnalyzer`] decode trait.
+//! RFC 7464 JSON text sequence [`emit`]ter, and the [`DenialAnalyzer`] decode trait.
 //! It carries no OS-specific code so the wire format never encodes a
 //! platform assumption.
 //!

--- a/src/core/learning_mode_core/src/lib.rs
+++ b/src/core/learning_mode_core/src/lib.rs
@@ -25,11 +25,10 @@
 //! ## Mode caveat
 //!
 //! What a capture contains depends on the active OS learning mode.
-//! File/path and UI denials are recorded under both `learningMode`
-//! (`block`) and `permissiveLearningMode` (`allow`), but
-//! **capability** ([`ResourceType::Capability`]) denials are currently
-//! only recorded under permissive learning mode. Consumers must not
-//! assume capability records are present under plain `learningMode`.
+//! File/path, UI, and capability denials may be recorded under both
+//! `learningMode` (`block`) and `permissiveLearningMode` (`allow`). The
+//! concrete ETW event shape differs by mode, and records without a decoded
+//! resource identifier are omitted rather than emitted as empty resources.
 
 #![deny(missing_docs)]
 
@@ -39,7 +38,7 @@ pub mod frame;
 pub mod model;
 pub mod summary;
 
-pub use analyze::{AnalyzeError, DenialAnalyzer};
+pub use analyze::{AnalysisResult, AnalyzeError, DenialAnalyzer};
 pub use emit::{write_frame, write_stream, RECORD_SEPARATOR};
 pub use frame::DenialFrame;
 pub use model::{AccessType, DedupKey, DeniedResource, ResourceType};

--- a/src/core/learning_mode_core/src/lib.rs
+++ b/src/core/learning_mode_core/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! What a capture contains depends on the active OS learning mode.
 //! File/path and UI denials are recorded under both `learningMode`
-//! (block-and-log) and `permissiveLearningMode` (allow-and-log), but
+//! (`block`) and `permissiveLearningMode` (`allow`), but
 //! **capability** ([`ResourceType::Capability`]) denials are currently
 //! only recorded under permissive learning mode. Consumers must not
 //! assume capability records are present under plain `learningMode`.

--- a/src/core/learning_mode_core/src/model.rs
+++ b/src/core/learning_mode_core/src/model.rs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Public data model for the captureDenials / learning-mode pipeline.
+//!
+//! [`DeniedResource`] is the shape every backend decoder emits, every
+//! transport carries, and every SDK consumer parses. New OS backends
+//! produce it from their native sources (Windows ETW today; Linux/macOS
+//! later); the NDJSON output file (see [`crate::emit`]) is just a framed
+//! stream of these records plus a trailing [`crate::summary::DenialSummary`].
+//!
+//! The types stay tiny and cross-platform so the wire format never
+//! accidentally encodes a Windows-only assumption. The Windows ETL
+//! decoder lives in the `learning_mode_windows` backend crate and maps
+//! its ETW-intermediate events into these types.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of resource an access denial was recorded against.
+///
+/// The variant set is deliberately closed and cross-platform. The
+/// Windows decoder classifies ETW events into these buckets; other
+/// backends map their native sources onto the same vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResourceType {
+    /// Filesystem path (file or directory).
+    File,
+    /// User-interface resource (clipboard, window handle, input, etc.).
+    Ui,
+    /// Network endpoint. Reserved for future network/WFP capture; the
+    /// current Windows backend does not yet produce this variant.
+    Network,
+    /// A named OS capability (AppContainer / brokered capability) the
+    /// workload was denied. Only produced under permissive learning
+    /// mode today — see the mode caveat in the crate docs.
+    Capability,
+    /// Unclassified denial (registry, COM, IPC, section object, etc.).
+    Other,
+}
+
+/// The kind of access that was attempted and denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessType {
+    /// Read / query access.
+    Read,
+    /// Write / create / modify / delete access.
+    Write,
+    /// Execute / traverse access.
+    Execute,
+    /// Access kind could not be determined from the source event.
+    Unknown,
+}
+
+/// One denied `(path, accessType)` observation surfaced to consumers.
+///
+/// A `DeniedResource` describes a single resource the sandboxed workload
+/// was denied access to. Per-`(path, accessType)` de-duplication happens
+/// in the decoder, so consumers can treat the emitted stream as already
+/// unique.
+///
+/// # Examples
+///
+/// ```
+/// use learning_mode_core::{AccessType, DeniedResource, ResourceType};
+///
+/// let denial = DeniedResource {
+///     path: r"C:\Users\test\secret.txt".to_string(),
+///     resource_type: ResourceType::File,
+///     access_type: AccessType::Read,
+///     pid: 1234,
+///     filetime: 132_847_890_123_456_789,
+/// };
+/// let json = serde_json::to_string(&denial)?;
+/// assert!(json.contains("\"resourceType\":\"file\""));
+/// # Ok::<(), serde_json::Error>(())
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeniedResource {
+    /// User-visible canonicalised resource identifier. On Windows this is
+    /// drive-letter form (`C:\Users\...`) with NT-device-namespace
+    /// prefixes (`\??\`, `\Device\HarddiskVolumeN\`) already stripped by
+    /// the decoder. Network endpoints (when implemented) use `host:port`.
+    pub path: String,
+
+    /// Type of resource (see [`ResourceType`]).
+    pub resource_type: ResourceType,
+
+    /// Access type the workload was attempting (see [`AccessType`]).
+    pub access_type: AccessType,
+
+    /// Process ID inside the sandbox that triggered the denial.
+    pub pid: u32,
+
+    /// Kernel timestamp of the denial. On Windows this is `FILETIME`
+    /// (100-nanosecond intervals since 1601-01-01 UTC), copied from
+    /// `EVENT_RECORD.EventHeader.TimeStamp`. Other backends normalise
+    /// their native clocks onto the same epoch so consumers can treat
+    /// the field uniformly.
+    pub filetime: u64,
+}
+
+/// De-duplication key for a denial: the `(path, accessType)` pair.
+///
+/// Decoders collapse the many raw kernel access-check events a workload
+/// generates (locale code re-reading the same key on every `printf`,
+/// etc.) down to one record per unique pair.
+pub type DedupKey = (String, AccessType);
+
+impl DeniedResource {
+    /// Returns the `(path, accessType)` de-duplication key for this
+    /// denial. Cloning the path is intentional so the key can outlive a
+    /// borrow of `self` while a decoder accumulates into a set.
+    #[must_use]
+    pub fn dedup_key(&self) -> DedupKey {
+        (self.path.clone(), self.access_type)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn denied_resource_serialises_camel_case() {
+        // Guards the wire-format contract: SDK consumers depend on the
+        // camelCase keys and lowercased enum strings. A future serde
+        // rename would silently break every downstream parser.
+        let r = DeniedResource {
+            path: r"C:\Users\test\file.txt".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 1234,
+            filetime: 132_847_890_123_456_789,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(json.contains("\"resourceType\":\"file\""), "got {json}");
+        assert!(json.contains("\"accessType\":\"read\""), "got {json}");
+        assert!(
+            json.contains("\"filetime\":132847890123456789"),
+            "got {json}"
+        );
+    }
+
+    #[test]
+    fn denied_resource_round_trips_through_json() {
+        let r = DeniedResource {
+            path: r"C:\foo\bar.txt".to_string(),
+            resource_type: ResourceType::Capability,
+            access_type: AccessType::Write,
+            pid: 9999,
+            filetime: 42,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let parsed: DeniedResource = serde_json::from_str(&json).unwrap();
+        assert_eq!(r, parsed);
+    }
+
+    #[test]
+    fn resource_type_serialises_each_variant_to_lowercase() {
+        for (variant, expected) in [
+            (ResourceType::File, "\"file\""),
+            (ResourceType::Ui, "\"ui\""),
+            (ResourceType::Network, "\"network\""),
+            (ResourceType::Capability, "\"capability\""),
+            (ResourceType::Other, "\"other\""),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn access_type_serialises_each_variant_to_lowercase() {
+        for (variant, expected) in [
+            (AccessType::Read, "\"read\""),
+            (AccessType::Write, "\"write\""),
+            (AccessType::Execute, "\"execute\""),
+            (AccessType::Unknown, "\"unknown\""),
+        ] {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn dedup_key_pairs_path_and_access_type() {
+        let r = DeniedResource {
+            path: r"C:\a".to_string(),
+            resource_type: ResourceType::File,
+            access_type: AccessType::Read,
+            pid: 1,
+            filetime: 1,
+        };
+        assert_eq!(r.dedup_key(), (r"C:\a".to_string(), AccessType::Read));
+    }
+}

--- a/src/core/learning_mode_core/src/model.rs
+++ b/src/core/learning_mode_core/src/model.rs
@@ -6,7 +6,7 @@
 //! [`DeniedResource`] is the shape every backend decoder emits, every
 //! transport carries, and every SDK consumer parses. New OS backends
 //! produce it from their native sources (Windows ETW today; Linux/macOS
-//! later); the NDJSON output file (see [`crate::emit`]) is just a framed
+//! later); the JSON text sequence (see [`crate::emit`]) is a framed
 //! stream of these records plus a trailing [`crate::summary::DenialSummary`].
 //!
 //! The types stay tiny and cross-platform so the wire format never

--- a/src/core/learning_mode_core/src/model.rs
+++ b/src/core/learning_mode_core/src/model.rs
@@ -32,8 +32,8 @@ pub enum ResourceType {
     /// current Windows backend does not yet produce this variant.
     Network,
     /// A named OS capability (AppContainer / brokered capability) the
-    /// workload was denied. Only produced under permissive learning
-    /// mode today — see the mode caveat in the crate docs.
+    /// workload was denied. Capability records may be produced under either
+    /// learning mode when the source event contains a decoded identifier.
     Capability,
     /// Unclassified denial (registry, COM, IPC, section object, etc.).
     Other,

--- a/src/core/learning_mode_core/src/model.rs
+++ b/src/core/learning_mode_core/src/model.rs
@@ -16,6 +16,28 @@
 
 use serde::{Deserialize, Serialize};
 
+mod decimal_u64 {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Repr {
+        Decimal(String),
+        LegacyNumber(u64),
+    }
+
+    pub fn serialize<S: Serializer>(value: &u64, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&value.to_string())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u64, D::Error> {
+        match Repr::deserialize(deserializer)? {
+            Repr::Decimal(value) => value.parse().map_err(serde::de::Error::custom),
+            Repr::LegacyNumber(value) => Ok(value),
+        }
+    }
+}
+
 /// The kind of resource an access denial was recorded against.
 ///
 /// The variant set is deliberately closed and cross-platform. The
@@ -98,7 +120,9 @@ pub struct DeniedResource {
     /// (100-nanosecond intervals since 1601-01-01 UTC), copied from
     /// `EVENT_RECORD.EventHeader.TimeStamp`. Other backends normalise
     /// their native clocks onto the same epoch so consumers can treat
-    /// the field uniformly.
+    /// the field uniformly. The JSON wire format uses a decimal string so
+    /// JavaScript consumers do not lose precision.
+    #[serde(with = "decimal_u64")]
     pub filetime: u64,
 }
 
@@ -139,7 +163,7 @@ mod tests {
         assert!(json.contains("\"resourceType\":\"file\""), "got {json}");
         assert!(json.contains("\"accessType\":\"read\""), "got {json}");
         assert!(
-            json.contains("\"filetime\":132847890123456789"),
+            json.contains("\"filetime\":\"132847890123456789\""),
             "got {json}"
         );
     }
@@ -156,6 +180,15 @@ mod tests {
         let json = serde_json::to_string(&r).unwrap();
         let parsed: DeniedResource = serde_json::from_str(&json).unwrap();
         assert_eq!(r, parsed);
+    }
+
+    #[test]
+    fn denied_resource_accepts_legacy_numeric_filetime() {
+        let parsed: DeniedResource = serde_json::from_str(
+            r#"{"path":"C:\\foo","resourceType":"file","accessType":"read","pid":1,"filetime":42}"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.filetime, 42);
     }
 
     #[test]

--- a/src/core/learning_mode_core/src/summary.rs
+++ b/src/core/learning_mode_core/src/summary.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Terminating summary frame for a captureDenials output stream.
+//!
+//! Exactly one [`DenialSummary`] is written after the last
+//! [`crate::model::DeniedResource`] in an NDJSON output file. It gives
+//! consumers the child's exit code, the count of unique denials, and a
+//! flag indicating whether the decoder had to truncate the set (so a UX
+//! can tell the user "showing N of many").
+
+use serde::{Deserialize, Serialize};
+
+/// The final frame in a captureDenials output stream.
+///
+/// `total_denials` is the number of *unique* `(path, accessType)` pairs,
+/// which matches the number of `denial` frames that preceded this one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DenialSummary {
+    /// Exit code of the sandboxed child process.
+    pub exit_code: i32,
+
+    /// Count of unique `(path, accessType)` denials emitted (equals the
+    /// number of `denial` frames preceding this summary).
+    pub total_denials: usize,
+
+    /// `true` when the decoder capped the emitted set and additional
+    /// denials were observed but not written. Consumers should surface
+    /// this so the user knows the list is partial.
+    pub denied_resources_truncated: bool,
+}
+
+impl DenialSummary {
+    /// Builds a summary for a completed capture.
+    #[must_use]
+    pub fn new(exit_code: i32, total_denials: usize, denied_resources_truncated: bool) -> Self {
+        Self {
+            exit_code,
+            total_denials,
+            denied_resources_truncated,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn summary_serialises_camel_case() {
+        let s = DenialSummary::new(0, 3, false);
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"exitCode\":0"), "got {json}");
+        assert!(json.contains("\"totalDenials\":3"), "got {json}");
+        assert!(
+            json.contains("\"deniedResourcesTruncated\":false"),
+            "got {json}"
+        );
+    }
+
+    #[test]
+    fn summary_round_trips_through_json() {
+        let s = DenialSummary::new(255, 42, true);
+        let json = serde_json::to_string(&s).unwrap();
+        let parsed: DenialSummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, parsed);
+    }
+}

--- a/src/core/learning_mode_core/src/summary.rs
+++ b/src/core/learning_mode_core/src/summary.rs
@@ -4,7 +4,7 @@
 //! Terminating summary frame for a captureDenials output stream.
 //!
 //! Exactly one [`DenialSummary`] is written after the last
-//! [`crate::model::DeniedResource`] in an NDJSON output file. It gives
+//! [`crate::model::DeniedResource`] in an RFC 7464 JSON text sequence. It gives
 //! consumers the child's exit code, the count of unique denials, and a
 //! flag indicating whether the decoder had to truncate the set (so a UX
 //! can tell the user "showing N of many").


### PR DESCRIPTION
## 📖 Description

Adds the denial-analysis layer on top of Integration PR #696.

- Introduces the cross-platform `learning_mode_core` denial model, summary, analysis, framing, and emission primitives.
- Adds the Windows sealed-ETL decoder using OpenTrace/ProcessTrace and TDH metadata.
- Decodes file, registry, UI, and capability-related Learning Mode events into normalized denial resources.
- Adds path normalization, typed property extraction, and composition tests using representative real event shapes.
- Adds `lm_analyze` for manually validating captured ETL files.

This PR is intentionally stacked on #696 and should merge after it.

## 🔗 References

- #696
- #661

## 🔍 Validation

- `cargo test -p learning_mode_core`
- `cargo test -p learning_mode_windows --all-targets`
- `cargo clippy -p learning_mode_core -p learning_mode_windows --all-targets -- -D warnings`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/699)