### PR TITLE
Fix playground build by pointing at the real SDK package directory

### DIFF
--- a/tests/playground/package-lock.json
+++ b/tests/playground/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mxc-playground",
       "version": "0.1.0-alpha.1",
       "dependencies": {
-        "@microsoft/mxc-sdk": "file:../../sdk",
+        "@microsoft/mxc-sdk": "file:../../sdk/node",
         "node-pty": "^1.0.0"
       },
       "devDependencies": {
@@ -22,7 +22,7 @@
         "node": ">=22.12.0"
       }
     },
-    "../../sdk": {
+    "../../sdk/node": {
       "name": "@microsoft/mxc-sdk",
       "version": "0.7.0",
       "license": "MIT",
@@ -580,7 +580,7 @@
       }
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "resolved": "../../sdk",
+      "resolved": "../../sdk/node",
       "link": true
     },
     "node_modules/@sindresorhus/is": {

--- a/tests/playground/package.json
+++ b/tests/playground/package.json
@@ -100,7 +100,7 @@
     "typescript": "^5.4.0"
   },
   "dependencies": {
-    "@microsoft/mxc-sdk": "file:../../sdk",
+    "@microsoft/mxc-sdk": "file:../../sdk/node",
     "node-pty": "^1.0.0"
   }
 }


### PR DESCRIPTION
## 📖 Description

Fixes the `tests/playground` build, which failed for every developer because its
`@microsoft/mxc-sdk` dependency pointed at a directory that contains no package.

`tests/playground/package.json` declared `"@microsoft/mxc-sdk": "file:../../sdk"`,
but `sdk/` only holds the `node/` and `dotnet/` subdirectories and has no
`package.json` of its own. The real package is `sdk/node`.

npm still created `node_modules/@microsoft/mxc-sdk` as a symlink to the bare
`sdk/` directory, so `npm install` reported success and the breakage only
surfaced at compile time as a missing-module error.

This PR repoints the dependency at `file:../../sdk/node` and refreshes the three
corresponding `package-lock.json` entries. The lockfile was updated with
`npm install --package-lock-only` so the caret ranges were not re-resolved — the
diff is 4 lines and contains no incidental dependency upgrades.

## 🔍 Validation

- Before the fix, `npm run build` in `tests/playground` failed with:
  `src/main/main.ts(68,35): error TS2307: Cannot find module '@microsoft/mxc-sdk' or its corresponding type declarations.`
- After the fix, a clean `npm ci` followed by `npm run build` succeeds for both
  the main and renderer TypeScript projects.
- Verified standalone on this branch (no other dependency changes present).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/704)