### PR TITLE
Add --wait-for-debugger flag for BaseContainer/AppContainer runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ wxc-exec.exe --audit policy.json
 
 > **Warning:** `--audit` injects `permissiveLearningMode` — AppContainer restrictions are **not** enforced for the duration of the run. Use only for policy authoring. It cannot be combined with `processContainer.captureDenials`; use `captureDenials.mode: "allow"` for permissive application-driven capture. `learningModeLogging` and `permissiveLearningMode` are reserved internal capability names and are rejected in `processContainer.capabilities`. See [docs/learning-mode/capabilities.md](docs/learning-mode/capabilities.md) for the three learning-mode flows.
 
+### Wait for Debugger
+
+`--wait-for-debugger` holds the sandboxed child suspended right after creation — before it has run any code, including its own loader initialization — instead of resuming it immediately. This lets an external, unsandboxed debugger attach to the *real* sandboxed process by PID at its own pace (there's no timeout, since nothing can run until a debugger attaches):
+
+```bash
+wxc-exec.exe --wait-for-debugger config.json
+```
+
+Attach a debugger to the printed PID and set breakpoints (necessarily deferred/pending ones, since no dependent DLL past the main image has loaded yet). The instant `wxc-exec` detects the attach it automatically clears its own suspend hold, so a plain `g` is all you need afterward — no `~0 m` ("Resume Thread") required. Windows-only; only the AppContainer tier of the `processcontainer` backend implements the suspend point (BaseContainer is skipped automatically, since it cannot guarantee `CREATE_SUSPENDED` is honored on every OS build).
+
 ## Telemetry (Experimental)
 
 MXC supports optional TraceLogging ETW telemetry for execution observability. When enabled, structured events (`MXC.Execution` and `MXC.Error`) are emitted to the local ETW subsystem via the Rust [`tracelogging`](https://crates.io/crates/tracelogging) crate. Every event includes common fields (Version, Channel, IsDebugging, `UTCReplace_AppSessionGuid`) as Part C custom event data.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ wxc-exec.exe --audit policy.json
 wxc-exec.exe --wait-for-debugger config.json
 ```
 
-Attach a debugger to the printed PID and set breakpoints (necessarily deferred/pending ones, since no dependent DLL past the main image has loaded yet). The instant `wxc-exec` detects the attach it automatically clears its own suspend hold, so a plain `g` is all you need afterward — no `~0 m` ("Resume Thread") required. Windows-only; only the AppContainer tier of the `processcontainer` backend implements the suspend point (BaseContainer is skipped automatically, since it cannot guarantee `CREATE_SUSPENDED` is honored on every OS build).
+Attach a debugger to the printed PID and set breakpoints (necessarily deferred/pending ones, since no dependent DLL past the main image has loaded yet). The instant `wxc-exec` detects the attach it automatically clears its own suspend hold, so a plain `g` is all you need afterward — no `~0 m` ("Resume Thread") required. Windows-only; only the AppContainer tier of the `processcontainer` backend implements the suspend point (BaseContainer is skipped automatically, since it cannot guarantee `CREATE_SUSPENDED` is honored on every OS build). Combining `--wait-for-debugger` with any other `containment` backend (Windows Sandbox, WSLC, IsolationSession, Hyperlight, MicroVM, LXC, Bubblewrap, Seatbelt) is rejected up front, since none of them expose a pre-execution suspend point.
 
 ## Telemetry (Experimental)
 

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -1046,6 +1046,22 @@ impl AppContainerScriptRunner {
                 &request.policy.base_process_ui,
             );
             job.set_ui_limits(&restrictions)?;
+            if request.wait_for_debugger {
+                // The child is about to be held suspended (no code run at
+                // all, not even loader init) until a debugger attaches --
+                // see `debugger_wait`. If `wxc-exec` itself dies before that
+                // happens (Ctrl-C, console close, an unhandled panic, or
+                // being killed by its own parent), nothing else can ever
+                // resume or reap this child, so it would otherwise survive
+                // as a permanently-suspended orphan. Kill-on-close makes the
+                // OS terminate it the instant the last handle to this job
+                // closes, which happens on every one of those exit paths
+                // (including the ones that bypass every Rust destructor).
+                // Not set for normal runs: their children are expected to
+                // keep running to their own completion independent of
+                // wxc-exec's lifetime.
+                job.set_kill_on_job_close()?;
+            }
             job.assign_process(process_handle.get())?;
             Ok(job)
         })() {

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -1346,7 +1346,23 @@ impl SandboxBackend for AppContainerScriptRunner {
                 return Err(ScriptResponse::error(&e.to_string()));
             }
         };
-        if let Err(e) = child.resume() {
+
+        // `--wait-for-debugger`: block (no timeout) until an external
+        // debugger attaches to the real sandboxed PID, then clear only
+        // wxc-exec's own CREATE_SUSPENDED hold — see `debugger_wait` module
+        // docs for why this leaves the debugger's own attach-time freeze in
+        // place (so a plain `g` is enough, no `~0 m` needed).
+        if request.wait_for_debugger {
+            if let Err(e) = crate::debugger_wait::wait_for_debugger_then_resume(
+                child.process.get(),
+                child.thread.get(),
+                child.pid,
+                logger,
+            ) {
+                self.teardown(&mut prepared, request.lifecycle.preserve_policy, logger);
+                return Err(ScriptResponse::error(&e.to_string()));
+            }
+        } else if let Err(e) = child.resume() {
             self.teardown(&mut prepared, request.lifecycle.preserve_policy, logger);
             return Err(ScriptResponse::error(&e.to_string()));
         }

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -1967,69 +1967,28 @@ impl BaseContainerRunner {
             }
         };
 
-        // `--wait-for-debugger`: block (no timeout) until an external
-        // debugger attaches to the real sandboxed PID, then clear only
-        // wxc-exec's own CREATE_SUSPENDED hold — see `debugger_wait` module
-        // docs for why this leaves the debugger's own attach-time freeze in
-        // place (so a plain `g` is enough, no `~0 m` needed). Unreachable in
-        // practice: `validate()` rejects `--wait-for-debugger` for this
-        // backend before `spawn_base` runs (BaseContainer cannot guarantee
-        // CREATE_SUSPENDED is honored on every OS build). Handled here
-        // anyway so a direct/test caller that bypasses `validate()` still
-        // fails closed instead of silently violating the suspend guarantee.
-        if request.wait_for_debugger {
-            if let Err(e) = crate::debugger_wait::wait_for_debugger_then_resume(
-                pi.hProcess,
-                pi.hThread,
-                pi.dwProcessId,
-                logger,
-            ) {
-                let _ = writeln!(
-                    logger,
-                    "Error: --wait-for-debugger failed ({e}); the sandboxed child has \
-                     been terminated."
-                );
-                // `wait_for_debugger_then_resume` already terminated the
-                // child on failure; reap it and tear down the same
-                // sandbox/proxy state the job-setup-failure path above does.
-                unsafe {
-                    let _ = WaitForSingleObject(pi.hProcess, u32::MAX);
-                    let _ = CloseHandle(pi.hProcess);
-                    let _ = CloseHandle(pi.hThread);
-                }
-                if request.lifecycle.destroy_on_exit {
-                    run_sandbox_cleanup(
-                        &identity,
-                        &sid_string,
-                        request.policy.network_proxy.is_enabled(),
-                        logger,
-                    );
-                    sandbox_tracking::unregister_ctrl_c_cleanup();
-                }
-                self.proxy_coordinator.stop(logger);
+        // `--wait-for-debugger` never reaches this point: `spawn()` (the only
+        // caller of `spawn_base`) runs `self.validate(request)?` first, and
+        // `validate()` unconditionally rejects the flag for this backend
+        // (BaseContainer cannot guarantee CREATE_SUSPENDED is honored on
+        // every OS build -- see `debugger_wait` module docs for what that
+        // guarantee protects). Asserted rather than handled with a second,
+        // untested parallel error path: if a future refactor of `spawn()`
+        // ever drops the `validate()` call, this fires instead of silently
+        // resuming a child the operator expected to stay suspended.
+        debug_assert!(
+            !request.wait_for_debugger,
+            "wait_for_debugger must be rejected by validate() before reaching spawn_base"
+        );
 
-                const WAIT_FOR_DEBUGGER_FAILED_MSG: &str =
-                    "--wait-for-debugger failed while waiting for a debugger to attach; \
-                     the sandboxed child was terminated.";
-                return Err(ScriptResponse {
-                    exit_code: -1,
-                    error_message: WAIT_FOR_DEBUGGER_FAILED_MSG.to_string(),
-                    standard_err: WAIT_FOR_DEBUGGER_FAILED_MSG.to_string(),
-                    extended_error: format!("wait_for_debugger_then_resume failed: {e}"),
-                    failure_phase: FailurePhase::LaunchFailed,
-                    ..Default::default()
-                });
-            }
-        } else {
-            // The child was created suspended; now that it is in the job object (so
-            // every descendant it spawns is captured), resume its main thread. If the
-            // create API ignored CREATE_SUSPENDED the thread is already running and
-            // this is a harmless no-op.
-            // SAFETY: `pi.hThread` is the just-created, still-owned main-thread
-            // handle; `ResumeThread` only adjusts its suspend count.
-            unsafe {
-                ResumeThread(pi.hThread);
-            }
+        // The child was created suspended; now that it is in the job object (so
+        // every descendant it spawns is captured), resume its main thread. If the
+        // create API ignored CREATE_SUSPENDED the thread is already running and
+        // this is a harmless no-op.
+        // SAFETY: `pi.hThread` is the just-created, still-owned main-thread
+        // handle; `ResumeThread` only adjusts its suspend count.
+        unsafe {
+            ResumeThread(pi.hThread);
         }
 
         // Hand ownership to the caller via `BaseChild`, which performs

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -1967,14 +1967,69 @@ impl BaseContainerRunner {
             }
         };
 
-        // The child was created suspended; now that it is in the job object (so
-        // every descendant it spawns is captured), resume its main thread. If the
-        // create API ignored CREATE_SUSPENDED the thread is already running and
-        // this is a harmless no-op.
-        // SAFETY: `pi.hThread` is the just-created, still-owned main-thread
-        // handle; `ResumeThread` only adjusts its suspend count.
-        unsafe {
-            ResumeThread(pi.hThread);
+        // `--wait-for-debugger`: block (no timeout) until an external
+        // debugger attaches to the real sandboxed PID, then clear only
+        // wxc-exec's own CREATE_SUSPENDED hold — see `debugger_wait` module
+        // docs for why this leaves the debugger's own attach-time freeze in
+        // place (so a plain `g` is enough, no `~0 m` needed). Unreachable in
+        // practice: `validate()` rejects `--wait-for-debugger` for this
+        // backend before `spawn_base` runs (BaseContainer cannot guarantee
+        // CREATE_SUSPENDED is honored on every OS build). Handled here
+        // anyway so a direct/test caller that bypasses `validate()` still
+        // fails closed instead of silently violating the suspend guarantee.
+        if request.wait_for_debugger {
+            if let Err(e) = crate::debugger_wait::wait_for_debugger_then_resume(
+                pi.hProcess,
+                pi.hThread,
+                pi.dwProcessId,
+                logger,
+            ) {
+                let _ = writeln!(
+                    logger,
+                    "Error: --wait-for-debugger failed ({e}); the sandboxed child has \
+                     been terminated."
+                );
+                // `wait_for_debugger_then_resume` already terminated the
+                // child on failure; reap it and tear down the same
+                // sandbox/proxy state the job-setup-failure path above does.
+                unsafe {
+                    let _ = WaitForSingleObject(pi.hProcess, u32::MAX);
+                    let _ = CloseHandle(pi.hProcess);
+                    let _ = CloseHandle(pi.hThread);
+                }
+                if request.lifecycle.destroy_on_exit {
+                    run_sandbox_cleanup(
+                        &identity,
+                        &sid_string,
+                        request.policy.network_proxy.is_enabled(),
+                        logger,
+                    );
+                    sandbox_tracking::unregister_ctrl_c_cleanup();
+                }
+                self.proxy_coordinator.stop(logger);
+
+                const WAIT_FOR_DEBUGGER_FAILED_MSG: &str =
+                    "--wait-for-debugger failed while waiting for a debugger to attach; \
+                     the sandboxed child was terminated.";
+                return Err(ScriptResponse {
+                    exit_code: -1,
+                    error_message: WAIT_FOR_DEBUGGER_FAILED_MSG.to_string(),
+                    standard_err: WAIT_FOR_DEBUGGER_FAILED_MSG.to_string(),
+                    extended_error: format!("wait_for_debugger_then_resume failed: {e}"),
+                    failure_phase: FailurePhase::LaunchFailed,
+                    ..Default::default()
+                });
+            }
+        } else {
+            // The child was created suspended; now that it is in the job object (so
+            // every descendant it spawns is captured), resume its main thread. If the
+            // create API ignored CREATE_SUSPENDED the thread is already running and
+            // this is a harmless no-op.
+            // SAFETY: `pi.hThread` is the just-created, still-owned main-thread
+            // handle; `ResumeThread` only adjusts its suspend count.
+            unsafe {
+                ResumeThread(pi.hThread);
+            }
         }
 
         // Hand ownership to the caller via `BaseChild`, which performs
@@ -2042,6 +2097,25 @@ struct BaseChild {
 
 impl SandboxBackend for BaseContainerRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        // `Experimental_CreateProcessInSandbox` is not guaranteed to honor
+        // CREATE_SUSPENDED on every OS build (see the creation-flags comment
+        // above), so this backend cannot guarantee the sandboxed process has
+        // run no code before a debugger attaches -- the core contract
+        // `--wait-for-debugger` promises. The dispatcher already routes
+        // `--wait-for-debugger` requests to an AppContainer tier
+        // automatically (its `CreateProcess*` contract always honors
+        // CREATE_SUSPENDED); this only fails closed for direct callers of
+        // this backend.
+        if request.wait_for_debugger {
+            return Err(ScriptResponse::error(
+                "--wait-for-debugger is not supported by the BaseContainer backend: \
+                 Experimental_CreateProcessInSandbox is not guaranteed to honor \
+                 CREATE_SUSPENDED on every OS build, so it cannot guarantee the \
+                 sandboxed process has run no code before a debugger attaches. Use \
+                 the AppContainer tier instead (the dispatcher does this \
+                 automatically for --wait-for-debugger).",
+            ));
+        }
         let capture_denials = request.policy.capture_denials.is_some();
         let use_process_security_environment = self.uses_process_security_environment(request);
         if capture_denials && !use_process_security_environment {
@@ -3588,6 +3662,27 @@ mod tests {
             "expected the capability-gate message, got: {}",
             err.error_message
         );
+    }
+
+    #[test]
+    fn validate_runner_rejects_wait_for_debugger() {
+        // BaseContainer's `Experimental_CreateProcessInSandbox` cannot
+        // guarantee CREATE_SUSPENDED is honored on every OS build, so this
+        // backend must fail closed for `--wait-for-debugger` rather than
+        // silently risk running code before a debugger attaches. The
+        // dispatcher already routes this flag to an AppContainer tier (see
+        // `dispatcher::tests::wait_for_debugger_skips_base_container_even_when_usable`);
+        // this covers a direct/test caller that bypasses the dispatcher.
+        let runner = BaseContainerRunner::new();
+        let request = ExecutionRequest {
+            wait_for_debugger: true,
+            ..ExecutionRequest::default()
+        };
+
+        let err = runner
+            .validate(&request)
+            .expect_err("--wait-for-debugger must be rejected by the BaseContainer backend");
+        assert!(err.error_message.contains("wait-for-debugger"));
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/debugger_wait.rs
+++ b/src/backends/appcontainer/common/src/debugger_wait.rs
@@ -34,26 +34,46 @@
 //!
 //! Once resumed this way, `wxc-exec` falls into its normal (already
 //! unbounded when `script_timeout` is 0) wait for the child to exit — no
-//! special-casing there. Ctrl-C during the attach-wait is handled by the
-//! existing `sandbox_tracking` console-control handler (registered well
-//! before this point), which runs on its own OS thread independent of this
-//! poll loop.
+//! special-casing there. Ctrl-C, console close, an unhandled panic, or the
+//! parent process killing `wxc-exec` while this loop is still waiting would
+//! otherwise orphan the child permanently: it has not run any code at all
+//! (not even loader init), so nothing of its own could ever notice
+//! `wxc-exec` is gone and resume or reap it. The runner that creates the
+//! job object this child is assigned to sets
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` whenever `wait_for_debugger` is
+//! requested (see `job_object::UiJobObject::set_kill_on_job_close`), so the
+//! OS itself kills the child the instant the last handle to that job
+//! closes — which happens on every one of those exit paths, including the
+//! ones that bypass every Rust destructor.
 //!
-//! Failure handling: a `CheckRemoteDebuggerPresent` error (e.g. the process
-//! handle going bad because the suspended child was killed externally while
-//! we were polling) is a permanent condition, not "no debugger yet" — retrying
-//! it forever would hang `wxc-exec` indefinitely. Likewise a failing
-//! `ResumeThread` after attach must not be reported as success. Both cases
-//! terminate the child and return an error, mirroring
-//! `SpawnedChild::resume`'s fail-closed behavior; the caller only needs to
-//! tear down its own sandbox resources and surface the error.
+//! Failure handling: this loop can end in three ways other than a
+//! successful attach, and each is handled distinctly:
+//!  - A `CheckRemoteDebuggerPresent` API failure (not "no debugger yet" —
+//!    that is a *successful* call reporting `present == false`) is a
+//!    permanent condition; retrying it forever would hang `wxc-exec`
+//!    indefinitely. Terminates the child and fails closed.
+//!  - The suspended child exiting on its own (e.g. killed externally)
+//!    before a debugger attaches. A process `HANDLE` stays a valid kernel
+//!    object — and `CheckRemoteDebuggerPresent` keeps reporting
+//!    `present == false` on it — long after the process it refers to has
+//!    terminated, so `present == false` alone can never distinguish "still
+//!    waiting" from "can never resolve". Every poll iteration also checks
+//!    child liveness via `WaitForSingleObject` (which doubles as the
+//!    poll-interval sleep) and fails closed the instant it observes the
+//!    child has exited; no `TerminateProcess` is needed since the child is
+//!    already dead.
+//!  - A failing `ResumeThread` after attach, which must not be reported as
+//!    success. Terminates the child and fails closed.
+//!
+//! All three cases return an error to the caller, which only needs to tear
+//! down its own sandbox resources and surface it.
 
 use std::fmt::Write as _;
 use std::time::Duration;
 
-use windows::Win32::Foundation::{GetLastError, HANDLE};
+use windows::Win32::Foundation::{GetLastError, HANDLE, WAIT_OBJECT_0};
 use windows::Win32::System::Diagnostics::Debug::CheckRemoteDebuggerPresent;
-use windows::Win32::System::Threading::{ResumeThread, TerminateProcess};
+use windows::Win32::System::Threading::{ResumeThread, TerminateProcess, WaitForSingleObject};
 use windows_core::BOOL;
 
 use wxc_common::error::WxcError;
@@ -61,6 +81,48 @@ use wxc_common::logger::Logger;
 
 /// How often to poll `CheckRemoteDebuggerPresent` while waiting.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Outcome of [`wait_loop`]'s pure state machine, distinguishing the two
+/// failure modes so the caller can decide whether the child still needs
+/// terminating.
+#[derive(Debug, PartialEq, Eq)]
+enum WaitLoopOutcome {
+    /// A debugger attached.
+    Attached,
+    /// The child exited (observed via the liveness check) before a debugger
+    /// attached. The child is already gone; no `TerminateProcess` needed.
+    ChildExited,
+    /// The attach check itself failed (a permanent condition). Carries the
+    /// error message; the caller terminates the child and fails closed.
+    ApiFailure(String),
+}
+
+/// Pure poll-loop state machine: poll `check_attached` until it reports an
+/// attached debugger, checking child liveness via `wait_tick` between polls.
+/// Contains no Win32 calls itself -- both are injected as closures so this
+/// can be exercised by unit tests with canned sequences and no real process,
+/// debugger, or OS wait at all.
+///
+/// `check_attached` returns `Ok(true)` once attached, `Ok(false)` if not yet
+/// attached, or `Err` on a permanent API failure. `wait_tick` is called only
+/// when not yet attached; it performs (or simulates) the poll-interval delay
+/// and returns `true` if the child died during that wait.
+fn wait_loop(
+    mut check_attached: impl FnMut() -> Result<bool, String>,
+    mut wait_tick: impl FnMut() -> bool,
+) -> WaitLoopOutcome {
+    loop {
+        match check_attached() {
+            Ok(true) => return WaitLoopOutcome::Attached,
+            Ok(false) => {
+                if wait_tick() {
+                    return WaitLoopOutcome::ChildExited;
+                }
+            }
+            Err(e) => return WaitLoopOutcome::ApiFailure(e),
+        }
+    }
+}
 
 /// Block (no timeout) until a debugger attaches to `process`, then resume
 /// `thread` exactly once — cancelling only the `CREATE_SUSPENDED` increment
@@ -85,30 +147,53 @@ pub fn wait_for_debugger_then_resume(
     let _ = writeln!(logger, "{banner}");
     eprintln!("{banner}");
 
-    loop {
-        let mut present = BOOL(0);
-        // SAFETY: `process` is a valid, open handle for the duration of this
-        // call (caller contract); `present` is a valid out-param on the stack.
-        let checked = unsafe { CheckRemoteDebuggerPresent(process, &mut present) };
-        match checked {
-            Ok(()) if present.as_bool() => break,
-            Ok(()) => std::thread::sleep(POLL_INTERVAL),
-            Err(e) => {
-                // The handle went bad (e.g. the still-suspended child was
-                // terminated externally) -- this can never resolve on its
-                // own, so fail closed instead of polling forever.
-                // SAFETY: `process` is the caller's still-owned handle;
-                // terminating it before returning matches the fail-closed
-                // contract every other launch-failure path in the runners
-                // follows.
-                unsafe {
-                    let _ = TerminateProcess(process, u32::MAX);
-                }
-                return Err(WxcError::Process(format!(
-                    "CheckRemoteDebuggerPresent failed while waiting for a debugger to \
-                     attach to PID {pid}: {e}"
-                )));
+    let outcome = wait_loop(
+        || {
+            let mut present = BOOL(0);
+            // SAFETY: `process` is a valid, open handle for the duration of
+            // this call (caller contract); `present` is a valid out-param
+            // on the stack.
+            unsafe { CheckRemoteDebuggerPresent(process, &mut present) }
+                .map(|()| present.as_bool())
+                .map_err(|e| e.to_string())
+        },
+        || {
+            // `present == false` alone can't distinguish "still waiting"
+            // from "the child died and this can never resolve" (see the
+            // module doc). `WaitForSingleObject` doubles as the poll
+            // interval and a liveness check: it returns early, before the
+            // interval elapses, only if `process` has become signaled --
+            // i.e. the child exited.
+            // SAFETY: `process` is a valid, open handle for the duration of
+            // this call (caller contract).
+            (unsafe { WaitForSingleObject(process, POLL_INTERVAL.as_millis() as u32) })
+                == WAIT_OBJECT_0
+        },
+    );
+
+    match outcome {
+        WaitLoopOutcome::Attached => {}
+        WaitLoopOutcome::ChildExited => {
+            return Err(WxcError::Process(format!(
+                "PID {pid} exited before a debugger attached"
+            )));
+        }
+        WaitLoopOutcome::ApiFailure(e) => {
+            // A genuine CheckRemoteDebuggerPresent API failure (distinct
+            // from the "no debugger yet" `Ok(false)` case) is a permanent
+            // condition -- retrying it forever would hang wxc-exec
+            // indefinitely. Fail closed instead.
+            // SAFETY: `process` is the caller's still-owned handle;
+            // terminating it before returning matches the fail-closed
+            // contract every other launch-failure path in the runners
+            // follows.
+            unsafe {
+                let _ = TerminateProcess(process, u32::MAX);
             }
+            return Err(WxcError::Process(format!(
+                "CheckRemoteDebuggerPresent failed while waiting for a debugger to attach to \
+                 PID {pid}: {e}"
+            )));
         }
     }
 
@@ -131,4 +216,69 @@ pub fn wait_for_debugger_then_resume(
     }
     let _ = writeln!(logger, "Process started, PID: {pid}.");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_loop_attaches_immediately() {
+        let outcome = wait_loop(|| Ok(true), || panic!("wait_tick must not be called"));
+        assert_eq!(outcome, WaitLoopOutcome::Attached);
+    }
+
+    #[test]
+    fn wait_loop_attaches_after_several_polls() {
+        let mut checks = vec![false, false, true].into_iter();
+        let mut ticks = 0;
+        let outcome = wait_loop(
+            || Ok(checks.next().expect("no more canned checks")),
+            || {
+                ticks += 1;
+                false // child stays alive
+            },
+        );
+        assert_eq!(outcome, WaitLoopOutcome::Attached);
+        // Two "not yet attached" results precede the final "attached" one.
+        assert_eq!(ticks, 2);
+    }
+
+    #[test]
+    fn wait_loop_reports_child_exited_mid_wait() {
+        let outcome = wait_loop(|| Ok(false), || true);
+        assert_eq!(outcome, WaitLoopOutcome::ChildExited);
+    }
+
+    #[test]
+    fn wait_loop_never_attached_keeps_polling_while_alive() {
+        // Regression guard: a child that stays alive without ever attaching
+        // must not be reported as exited or as a failure -- it should just
+        // keep polling (bounded here so the test terminates).
+        let mut remaining = 5;
+        let outcome = wait_loop(
+            || {
+                if remaining == 0 {
+                    Ok(true)
+                } else {
+                    remaining -= 1;
+                    Ok(false)
+                }
+            },
+            || false, // never dies
+        );
+        assert_eq!(outcome, WaitLoopOutcome::Attached);
+    }
+
+    #[test]
+    fn wait_loop_propagates_api_failure() {
+        let outcome = wait_loop(
+            || Err("access denied".to_string()),
+            || panic!("wait_tick must not be called on API failure"),
+        );
+        assert_eq!(
+            outcome,
+            WaitLoopOutcome::ApiFailure("access denied".to_string())
+        );
+    }
 }

--- a/src/backends/appcontainer/common/src/debugger_wait.rs
+++ b/src/backends/appcontainer/common/src/debugger_wait.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `--wait-for-debugger` support.
+//!
+//! The mechanism: the runners create the sandboxed child suspended and
+//! assign it to the job object exactly as before, but instead of calling
+//! `ResumeThread` immediately, they hand off to
+//! [`wait_for_debugger_then_resume`], which:
+//!
+//!  1. Logs the PID and blocks — with **no timeout** — polling
+//!     `CheckRemoteDebuggerPresent` on the child's process handle. The main
+//!     thread has not run any code yet — not even its own loader
+//!     initialization, so no dependent DLL past the main image is mapped —
+//!     so nothing here races an operator who takes an arbitrarily long time
+//!     to attach.
+//!  2. The instant a debugger attaches, calls `ResumeThread` exactly once.
+//!
+//! Why step 2 doesn't let the target run away before the operator sets
+//! breakpoints: attaching a debugger (`DebugActiveProcess`) synthesizes an
+//! initial batch of debug events (process/thread/module state) that stay
+//! *outstanding* — and every thread stays frozen — until the debugger
+//! itself acknowledges them via `ContinueDebugEvent`/`g`. That freeze is a
+//! second, independent contribution to the same suspend-count field
+//! `CREATE_SUSPENDED` used, which is why attaching used to leave the count
+//! at 2 (our 1 + the debugger's 1) and required an operator-side `~0 m`
+//! before `g`. By calling `ResumeThread` ourselves the moment attach is
+//! detected, we cancel only *our own* contribution — the debugger's
+//! independent freeze is still holding the thread — so all the operator
+//! needs is a plain `g`. Every breakpoint set beforehand is still
+//! necessarily a deferred/pending one (nothing but the main image has
+//! loaded), so it resolves normally once the target actually starts running
+//! after `g`.
+//!
+//! Once resumed this way, `wxc-exec` falls into its normal (already
+//! unbounded when `script_timeout` is 0) wait for the child to exit — no
+//! special-casing there. Ctrl-C during the attach-wait is handled by the
+//! existing `sandbox_tracking` console-control handler (registered well
+//! before this point), which runs on its own OS thread independent of this
+//! poll loop.
+//!
+//! Failure handling: a `CheckRemoteDebuggerPresent` error (e.g. the process
+//! handle going bad because the suspended child was killed externally while
+//! we were polling) is a permanent condition, not "no debugger yet" — retrying
+//! it forever would hang `wxc-exec` indefinitely. Likewise a failing
+//! `ResumeThread` after attach must not be reported as success. Both cases
+//! terminate the child and return an error, mirroring
+//! `SpawnedChild::resume`'s fail-closed behavior; the caller only needs to
+//! tear down its own sandbox resources and surface the error.
+
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use windows::Win32::Foundation::{GetLastError, HANDLE};
+use windows::Win32::System::Diagnostics::Debug::CheckRemoteDebuggerPresent;
+use windows::Win32::System::Threading::{ResumeThread, TerminateProcess};
+use windows_core::BOOL;
+
+use wxc_common::error::WxcError;
+use wxc_common::logger::Logger;
+
+/// How often to poll `CheckRemoteDebuggerPresent` while waiting.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Block (no timeout) until a debugger attaches to `process`, then resume
+/// `thread` exactly once — cancelling only the `CREATE_SUSPENDED` increment
+/// `wxc-exec` itself added, leaving the debugger's own attach-time freeze in
+/// place so the operator's plain `g` is what actually starts it running.
+///
+/// On failure the child is terminated (fail closed) before returning
+/// [`WxcError::Process`]; the caller only needs to tear down its own sandbox
+/// resources and surface the error.
+///
+/// # Safety
+/// `process` and `thread` must be valid, still-open handles to the just
+/// created, still-suspended child for the duration of this call; the caller
+/// retains ownership (this function does not close either handle).
+pub fn wait_for_debugger_then_resume(
+    process: HANDLE,
+    thread: HANDLE,
+    pid: u32,
+    logger: &mut Logger,
+) -> Result<(), WxcError> {
+    let banner = format!("Process suspended, PID: {pid}. Attach a debugger to continue.");
+    let _ = writeln!(logger, "{banner}");
+    eprintln!("{banner}");
+
+    loop {
+        let mut present = BOOL(0);
+        // SAFETY: `process` is a valid, open handle for the duration of this
+        // call (caller contract); `present` is a valid out-param on the stack.
+        let checked = unsafe { CheckRemoteDebuggerPresent(process, &mut present) };
+        match checked {
+            Ok(()) if present.as_bool() => break,
+            Ok(()) => std::thread::sleep(POLL_INTERVAL),
+            Err(e) => {
+                // The handle went bad (e.g. the still-suspended child was
+                // terminated externally) -- this can never resolve on its
+                // own, so fail closed instead of polling forever.
+                // SAFETY: `process` is the caller's still-owned handle;
+                // terminating it before returning matches the fail-closed
+                // contract every other launch-failure path in the runners
+                // follows.
+                unsafe {
+                    let _ = TerminateProcess(process, u32::MAX);
+                }
+                return Err(WxcError::Process(format!(
+                    "CheckRemoteDebuggerPresent failed while waiting for a debugger to \
+                     attach to PID {pid}: {e}"
+                )));
+            }
+        }
+    }
+
+    // SAFETY: `thread` is the caller's still-owned, still-suspended main
+    // thread handle; ResumeThread only adjusts its suspend count. This
+    // cancels exactly the one increment wxc-exec added via CREATE_SUSPENDED
+    // — the debugger's own attach-time freeze (a separate contribution to
+    // the same counter) is unaffected and keeps the thread from actually
+    // running until the operator issues `g`.
+    let resumed = unsafe { ResumeThread(thread) };
+    if resumed == u32::MAX {
+        let err = unsafe { GetLastError() };
+        // SAFETY: same fail-closed contract as above.
+        unsafe {
+            let _ = TerminateProcess(process, u32::MAX);
+        }
+        return Err(WxcError::Process(format!(
+            "ResumeThread failed after debugger attach for PID {pid}: {err:?}"
+        )));
+    }
+    let _ = writeln!(logger, "Process started, PID: {pid}.");
+    Ok(())
+}

--- a/src/backends/appcontainer/common/src/dispatcher.rs
+++ b/src/backends/appcontainer/common/src/dispatcher.rs
@@ -342,7 +342,20 @@ fn select_backend_with_fallback(
     // BaseContainerRunner prefers PSEC whenever it is available and compatible,
     // otherwise uses the transitional SBOX contract. If neither BaseContainer
     // contract is usable, detection continues to the AppContainer tiers.
-    let prefer_base_container = BaseContainerRunner::is_usable_for_request(request);
+    //
+    // `--wait-for-debugger` needs a suspend point the Win32 `CreateProcess`
+    // contract actually guarantees. BaseContainer's
+    // `Experimental_CreateProcessInSandbox` may silently ignore
+    // CREATE_SUSPENDED on some OS builds (see `base_container_runner`'s
+    // creation-flags comment) -- which would let the sandboxed process start
+    // running before a debugger attaches, violating the feature's core
+    // guarantee. Skip Tier 1 whenever `wait_for_debugger` is requested so
+    // selection falls through to an AppContainer tier (2/3), whose
+    // `CreateProcess*` calls always honor CREATE_SUSPENDED per the documented
+    // Win32 contract. `BaseContainerRunner::validate` also rejects the flag
+    // directly, as defense-in-depth for callers that bypass this dispatcher.
+    let prefer_base_container =
+        !request.wait_for_debugger && BaseContainerRunner::is_usable_for_request(request);
     let supports_deny_paths = BaseContainerRunner::supports_deny_paths_for_request(request);
     let decision = fallback_detector::detect_with_base_container_capabilities(
         &request.policy,
@@ -915,6 +928,29 @@ mod tests {
         let req = test_request(empty_policy());
         let d = dispatch_with_fallback(&req).expect("dispatch should succeed");
         assert!(matches!(d.tier, IsolationTier::AppContainerDacl));
+    }
+
+    #[test]
+    fn wait_for_debugger_skips_base_container_even_when_usable() {
+        // `--wait-for-debugger` must never land on BaseContainer:
+        // `Experimental_CreateProcessInSandbox` cannot guarantee
+        // CREATE_SUSPENDED is honored on every OS build, which would violate
+        // the flag's core "no code has run yet" guarantee. Force
+        // BaseContainer *usable* (bypassing real host capability) so this
+        // exercises the `prefer_base_container` gate itself, not host
+        // variance -- without the guard, Tier 1 would be selected (see
+        // `dispatch_t1_naturally_selected_when_bc_usable` /
+        // `select_backend_t1_builds_base_container_no_dacl`).
+        let _g = BcUsableGuard::set(true);
+        let mut req = test_request(empty_policy());
+        req.wait_for_debugger = true;
+        let (backend, _dacl, tier, _warnings) =
+            select_backend_with_fallback(&req).expect("selection should succeed");
+        assert!(
+            !matches!(tier, IsolationTier::BaseContainer),
+            "wait_for_debugger must never select BaseContainer, got {tier:?}"
+        );
+        assert!(matches!(backend, SelectedBackend::AppContainer(_)));
     }
 
     // -------------------------------------------------------------------

--- a/src/backends/appcontainer/common/src/job_object.rs
+++ b/src/backends/appcontainer/common/src/job_object.rs
@@ -19,11 +19,12 @@ use std::sync::OnceLock;
 use windows::Win32::Foundation::{CloseHandle, HANDLE};
 use windows::Win32::System::JobObjects::{
     AssignProcessToJobObject, CreateJobObjectW, JobObjectBasicUIRestrictions,
-    SetInformationJobObject, TerminateJobObject, JOBOBJECT_BASIC_UI_RESTRICTIONS,
-    JOB_OBJECT_UILIMIT, JOB_OBJECT_UILIMIT_DESKTOP, JOB_OBJECT_UILIMIT_DISPLAYSETTINGS,
-    JOB_OBJECT_UILIMIT_EXITWINDOWS, JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES,
-    JOB_OBJECT_UILIMIT_READCLIPBOARD, JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS,
-    JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
+    JobObjectExtendedLimitInformation, SetInformationJobObject, TerminateJobObject,
+    JOBOBJECT_BASIC_UI_RESTRICTIONS, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_UILIMIT, JOB_OBJECT_UILIMIT_DESKTOP,
+    JOB_OBJECT_UILIMIT_DISPLAYSETTINGS, JOB_OBJECT_UILIMIT_EXITWINDOWS,
+    JOB_OBJECT_UILIMIT_GLOBALATOMS, JOB_OBJECT_UILIMIT_HANDLES, JOB_OBJECT_UILIMIT_READCLIPBOARD,
+    JOB_OBJECT_UILIMIT_SYSTEMPARAMETERS, JOB_OBJECT_UILIMIT_WRITECLIPBOARD,
 };
 use windows::Win32::System::SystemServices::JOB_OBJECT_UILIMIT_IME;
 use windows_core::PCWSTR;
@@ -275,6 +276,35 @@ impl UiJobObject {
             .map_err(|e| WxcError::Process(format!("AssignProcessToJobObject: {e}")))
     }
 
+    /// Sets `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so the OS itself terminates
+    /// every process assigned to this job the moment the *last* handle to
+    /// the job closes — including the implicit close that happens when
+    /// `wxc-exec` exits abnormally (Ctrl-C/Ctrl-Break/console-close/logoff,
+    /// whose default handler calls `ExitProcess` directly and skips every
+    /// Rust destructor, or an unhandled panic). Used only for
+    /// `--wait-for-debugger`: a child left suspended at `CREATE_SUSPENDED`
+    /// (having run no code at all, not even loader init) has no thread of
+    /// its own that could ever notice `wxc-exec` is gone, so without this it
+    /// survives as an orphan until someone finds it in Task Manager. Not set
+    /// for normal runs, whose children are expected to keep running to
+    /// their own completion independent of `wxc-exec`'s lifetime.
+    pub fn set_kill_on_job_close(&self) -> Result<(), WxcError> {
+        let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        // SAFETY: `info` is a valid, fully-initialized struct living on the
+        // stack for the duration of the call, matching the size of the type
+        // `JobObjectExtendedLimitInformation` expects.
+        unsafe {
+            SetInformationJobObject(
+                self.handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const c_void,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        }
+        .map_err(|e| WxcError::Process(format!("SetInformationJobObject(KillOnClose): {e}")))
+    }
+
     /// Terminate every process currently assigned to this job (the sandboxed
     /// child and all of its descendants) with the given exit code. Used to
     /// tree-kill a running sandbox. Best-effort: errors are ignored since the
@@ -315,6 +345,16 @@ mod tests {
             ..Default::default()
         })
         .expect("set global-namespace block");
+        drop(job);
+    }
+
+    #[test]
+    fn set_kill_on_job_close_succeeds_with_no_assigned_process() {
+        // No process ever gets assigned in this test, so dropping the job
+        // right after must not kill anything real -- this only pins that
+        // the `SetInformationJobObject` call itself succeeds.
+        let job = UiJobObject::new().expect("create");
+        job.set_kill_on_job_close().expect("set kill-on-close");
         drop(job);
     }
 

--- a/src/backends/appcontainer/common/src/lib.rs
+++ b/src/backends/appcontainer/common/src/lib.rs
@@ -16,6 +16,8 @@ pub mod appcontainer_runner;
 #[cfg(target_os = "windows")]
 pub mod base_container_runner;
 #[cfg(target_os = "windows")]
+pub mod debugger_wait;
+#[cfg(target_os = "windows")]
 pub mod dispatcher;
 #[cfg(target_os = "windows")]
 pub mod fallback_detector;

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -136,6 +136,31 @@ struct Cli {
     #[arg(long)]
     audit_verbose: bool,
 
+    /// Hold the sandboxed child suspended after creation — before it has
+    /// run any code, including its own loader initialization — instead of
+    /// resuming it immediately, so an external debugger can attach to the
+    /// *real* sandboxed process from outside the sandbox by PID, at its own
+    /// pace (no timeout: nothing races it, since nothing can run until a
+    /// debugger attaches). Unlike Image File Execution Options (IFEO),
+    /// which substitutes the debugger itself into the sandbox (so the
+    /// debugger process ends up sandboxed too and can fail for the same
+    /// reasons the target does), the target here stays the real process;
+    /// only the debugger you attach runs unsandboxed.
+    ///
+    /// Attaching a debugger adds its own +1 to the suspend count; the
+    /// instant wxc-exec detects the attach, it automatically clears its own
+    /// original CREATE_SUSPENDED increment (a single ResumeThread call), so
+    /// after setting breakpoints (necessarily deferred/pending ones, since
+    /// no dependent DLL past the main image has loaded yet), a plain `g` is
+    /// all you need — no `~0 m` ("Resume Thread") required. Windows-only;
+    /// only the AppContainer tier of the `processcontainer` backend
+    /// implements the suspend point (BaseContainer is skipped
+    /// automatically, since it cannot guarantee CREATE_SUSPENDED is honored
+    /// on every OS build).
+    #[cfg(target_os = "windows")]
+    #[arg(long = "wait-for-debugger")]
+    wait_for_debugger: bool,
+
     /// Command to run inside the container, overriding `process.commandLine`
     /// from the policy. The command must follow a `--` separator so normal
     /// CLI flags remain usable after the config path. Examples:
@@ -1040,6 +1065,10 @@ fn main() {
     request.experimental_enabled = cli.experimental;
     request.testing_features_enabled = cli.allow_testing_features;
     request.dry_run = cli.dry_run;
+    #[cfg(target_os = "windows")]
+    {
+        request.wait_for_debugger = cli.wait_for_debugger;
+    }
 
     // ── Telemetry init (experimental) ───────────────────────────────
     let telemetry_active = if request.experimental_enabled {

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -156,7 +156,8 @@ struct Cli {
     /// only the AppContainer tier of the `processcontainer` backend
     /// implements the suspend point (BaseContainer is skipped
     /// automatically, since it cannot guarantee CREATE_SUSPENDED is honored
-    /// on every OS build).
+    /// on every OS build). Rejected up front for every other containment
+    /// backend, none of which expose a pre-execution suspend point.
     #[cfg(target_os = "windows")]
     #[arg(long = "wait-for-debugger")]
     wait_for_debugger: bool,
@@ -1568,6 +1569,18 @@ mod tests {
         assert!(cli.experimental);
         assert!(cli.debug);
         assert!(cli.command.is_empty());
+    }
+
+    #[test]
+    fn cli_wait_for_debugger_flag_present_maps_to_true() {
+        let cli = parse_cli(&["wxc-exec", "policy.json", "--wait-for-debugger"]);
+        assert!(cli.wait_for_debugger);
+    }
+
+    #[test]
+    fn cli_wait_for_debugger_flag_absent_maps_to_false() {
+        let cli = parse_cli(&["wxc-exec", "policy.json"]);
+        assert!(!cli.wait_for_debugger);
     }
 
     #[test]

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -5011,6 +5011,16 @@ mod tests {
     }
 
     #[test]
+    fn wait_for_debugger_defaults_to_false() {
+        let json = r#"{"process": {"commandLine": "echo hi"}}"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let req = load_request(&encoded, &mut logger, true).unwrap();
+        assert!(!req.wait_for_debugger);
+    }
+
+    #[test]
     fn unknown_experimental_fields_ignored() {
         let json = r#"{"process": {"commandLine": "echo hi"}, "experimental": {"futureFeature": {"x": 1}, "test": {"message": "hi"}}}"#;
         let encoded = base64_encode(json.as_bytes());

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -1327,6 +1327,7 @@ fn convert_wire_config(
         testing_features_enabled: false,
         experimental,
         dry_run: false,
+        wait_for_debugger: false,
     })
 }
 

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -744,6 +744,9 @@ pub struct ExecutionRequest {
     /// Consumed by the AppContainer runner; the dispatcher never routes a
     /// `wait_for_debugger` request to the BaseContainer runner, which
     /// cannot guarantee `CREATE_SUSPENDED` is honored on every OS build.
+    /// `wxc_common::validator::validate_common` rejects a request with this
+    /// set unless `containment == ContainmentBackend::ProcessContainer`, so
+    /// non-Windows and non-ProcessContainer backends never see it set.
     pub wait_for_debugger: bool,
 }
 

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -728,6 +728,23 @@ pub struct ExecutionRequest {
     /// Dry-run mode: validate config and runner setup then return success
     /// without executing the sandboxed process.
     pub dry_run: bool,
+    /// Set by `--wait-for-debugger`: hold the sandboxed child's main thread
+    /// suspended after creation (it stays at its `CREATE_SUSPENDED` suspend
+    /// count, having run no code at all, including its own loader
+    /// initialization) until an external, unsandboxed debugger attaches to
+    /// the real PID. The instant `wxc-exec` detects the attach it
+    /// automatically clears its own suspend increment (a single
+    /// `ResumeThread` call), leaving only the debugger's own attach-time
+    /// freeze in place — so after setting breakpoints (necessarily
+    /// deferred/pending ones, since no dependent DLL past the main image
+    /// has loaded), a plain `g` in the debugger is all that's needed; no
+    /// `~0 m` ("Resume Thread") required. `wxc-exec` then falls into its
+    /// normal (already-unbounded-by-default) wait for the child to exit.
+    /// `false` (default) is the unchanged, immediate-resume behavior.
+    /// Consumed by the AppContainer runner; the dispatcher never routes a
+    /// `wait_for_debugger` request to the BaseContainer runner, which
+    /// cannot guarantee `CREATE_SUSPENDED` is honored on every OS build.
+    pub wait_for_debugger: bool,
 }
 
 /// Where a [`ResolvedWorkingDirectory`] came from.

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -1,13 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::models::{ExecutionRequest, ScriptResponse};
+use crate::models::{ContainmentBackend, ExecutionRequest, ScriptResponse};
 use crate::mxc_error::MxcError;
 
 /// Validates non-backend-specific parts of the request (e.g. non-empty script).
 pub fn validate_common(request: &ExecutionRequest) -> Result<(), ScriptResponse> {
     if request.script_code.is_empty() {
         return Err(ScriptResponse::error("Script content must not be empty."));
+    }
+
+    // `--wait-for-debugger` only has a pre-execution suspend point on the
+    // `processcontainer` backend (and only the AppContainer tier of it — the
+    // dispatcher/`BaseContainerRunner::validate` handle that narrower case).
+    // Every other backend (Windows Sandbox, WSLC, IsolationSession,
+    // Hyperlight, MicroVM, LXC, Bubblewrap, Seatbelt) would otherwise accept
+    // the flag and silently run the workload immediately, defeating the
+    // flag's contract. Enforced centrally so it applies uniformly to every
+    // backend and every present/future one, rather than requiring each
+    // runner to remember to check it.
+    if request.wait_for_debugger && request.containment != ContainmentBackend::ProcessContainer {
+        return Err(ScriptResponse::error(&format!(
+            "--wait-for-debugger is only supported by the processcontainer backend \
+             (AppContainer tier); {} provides no pre-execution suspend point.",
+            request.containment.wire_name()
+        )));
     }
 
     // Enforce the testing-only-features gate centrally so it applies uniformly
@@ -128,6 +145,44 @@ mod tests {
         req.policy.network_proxy.builtin_test_server = true;
         req.testing_features_enabled = true;
 
+        assert!(validate_common(&req).is_ok());
+    }
+
+    #[test]
+    fn rejects_wait_for_debugger_on_non_processcontainer_backend() {
+        let req = ExecutionRequest {
+            script_code: "echo hi".to_string(),
+            containment: crate::models::ContainmentBackend::Lxc,
+            wait_for_debugger: true,
+            ..Default::default()
+        };
+        let err = validate_common(&req).unwrap_err();
+        assert!(
+            err.error_message.contains("--wait-for-debugger") && err.error_message.contains("lxc"),
+            "expected wait-for-debugger gate error, got: {}",
+            err.error_message
+        );
+    }
+
+    #[test]
+    fn accepts_wait_for_debugger_on_processcontainer_backend() {
+        let req = ExecutionRequest {
+            script_code: "echo hi".to_string(),
+            containment: crate::models::ContainmentBackend::ProcessContainer,
+            wait_for_debugger: true,
+            ..Default::default()
+        };
+        assert!(validate_common(&req).is_ok());
+    }
+
+    #[test]
+    fn accepts_wait_for_debugger_false_on_any_backend() {
+        let req = ExecutionRequest {
+            script_code: "echo hi".to_string(),
+            containment: crate::models::ContainmentBackend::Seatbelt,
+            wait_for_debugger: false,
+            ..Default::default()
+        };
         assert!(validate_common(&req).is_ok());
     }
 }


### PR DESCRIPTION
## 📖 Description

Adds a Windows-only `--wait-for-debugger` CLI flag to `wxc-exec.exe` for the BaseContainer/AppContainer (`processcontainer`) backends. When set, the sandboxed child is left suspended right after creation — before it has executed any code at all, not even its own loader init — instead of being resumed immediately. This lets an external, unsandboxed debugger attach to the *real* sandboxed process by PID at its own pace (no timeout, since nothing can run until the debugger releases it).

`wxc-exec` polls `CheckRemoteDebuggerPresent` (no timeout) and, the instant a debugger attaches, clears only its own `CREATE_SUSPENDED` increment — leaving the debugger's own attach-time freeze in place, so a plain `g` is enough afterward (no `~0 m` needed). Stderr/log output on suspend/resume is a single concise line (`Process suspended, PID: <pid>...` / `Process started, PID: <pid>.`) rather than a long banner.

Changes are scoped to just this feature: the new CLI flag, the `ExecutionRequest.wait_for_debugger` field threaded through the wire/domain config, and the two BaseContainer/AppContainer suspend points. `README.md` is updated with a new "Wait for Debugger" subsection under Debugging.

## 🔗 References
<!-- No related issue for this change. -->

## 🔍 Validation

- `cargo build -p wxc -p appcontainer_common --target x86_64-pc-windows-msvc` (debug) — passes
- `cargo fmt --all -- --check` — passes
- `cargo clippy --target x86_64-pc-windows-msvc --locked --all-targets --all-features --release -- -D warnings` (full workspace, matching CI's Windows lint job exactly) — passes with zero warnings
- Manual: built `wxc-exec.exe` and confirmed it runs

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
- [ ] Bug fix
- [x] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/712)