### PR TITLE
[Bubblewrap] Gate platform detection on a minimum bwrap version

### DIFF
--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -22,8 +22,11 @@ requiring root privileges or a container runtime.
   apk add bubblewrap
   ```
   The deny-by-default baseline (see [How It Works](#how-it-works)) emits its
-  read-only mounts via `--ro-bind-try`, which requires **bwrap 0.3.0+**
-  (released 2017; every currently-supported distro ships a newer version).
+  read-only mounts via `--ro-bind-try` (bwrap 0.3.1+) and the sandbox
+  environment is built with `--clearenv` (bwrap 0.5.0+), so **bwrap 0.5.0 or
+  newer** is required. Platform detection probes `bwrap --version` and reports
+  the backend as unavailable — with the detected version — when the host is
+  below that floor.
 - User namespaces must be enabled:
   ```bash
   # Check: should print "1"

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { execSync, execFileSync } from 'child_process';
 import { fileURLToPath } from 'node:url';
 import { ContainmentBackend, IsolationTier, PlatformSupport, UiCapabilitySupport } from './types.js';
+import { diagLog } from './diagnostic.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -276,8 +277,15 @@ function computeSupport(): PlatformSupport {
     const bubblewrap = _probeBubblewrap();
     if (bubblewrap.available) {
       methods.push('bubblewrap');
-    } else if (methods.length === 0) {
-      support.reason = `Neither LXC nor Bubblewrap is available on this system (${bubblewrap.reason})`;
+    } else {
+      // Always surface why bwrap is unavailable. When LXC is present the
+      // platform is still supported, so `reason` — documented as why the
+      // platform is *not* supported — must stay unset, and the detail would
+      // otherwise be dropped with no way to diagnose the missing backend.
+      diagLog(`getPlatformSupport: bubblewrap unavailable — ${bubblewrap.reason}`);
+      if (methods.length === 0) {
+        support.reason = `Neither LXC nor Bubblewrap is available on this system (${bubblewrap.reason})`;
+      }
     }
     if (methods.length > 0) {
       support.isSupported = true;
@@ -359,6 +367,16 @@ function bwrapExistsOnPath(): boolean {
 }
 
 /**
+ * How long to wait for `bwrap --version` before giving up.
+ *
+ * `getPlatformSupport()` is synchronous, so without a bound a `bwrap` that
+ * hangs — a wrapper script on PATH, a binary on a stalled network mount —
+ * would block the caller indefinitely. Printing a version string is
+ * near-instant, so this is generous.
+ */
+const BWRAP_VERSION_TIMEOUT_MS = 5000;
+
+/**
  * Default runner for `bwrap --version`. Uses `execFileSync` rather than a
  * shell so a missing binary surfaces as `ENOENT` instead of the shell's
  * indistinguishable exit code 127 — that separation is what lets us report
@@ -370,15 +388,31 @@ function defaultBwrapVersionRunner(): BwrapVersionResult {
   try {
     return {
       kind: 'output',
-      stdout: execFileSync('bwrap', ['--version'], { encoding: 'utf-8', stdio: 'pipe' }),
+      stdout: execFileSync('bwrap', ['--version'], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        timeout: BWRAP_VERSION_TIMEOUT_MS,
+      }),
     };
   } catch (err) {
-    const e = err as NodeJS.ErrnoException & { status?: number | null; stderr?: Buffer | string };
+    const e = err as NodeJS.ErrnoException & {
+      status?: number | null;
+      stderr?: Buffer | string;
+      killed?: boolean;
+    };
     // `ENOENT` covers both an absent binary and a present-but-unusable one
     // (missing ELF interpreter / shebang target), so confirm the binary is
     // really absent before blaming the package manager.
     if (e.code === 'ENOENT' && !bwrapExistsOnPath()) {
       return { kind: 'notFound' };
+    }
+    // Timed out: the child was killed, so there is no meaningful exit status.
+    if (e.code === 'ETIMEDOUT' || e.killed) {
+      return {
+        kind: 'failed',
+        status: null,
+        detail: `timed out after ${BWRAP_VERSION_TIMEOUT_MS}ms`,
+      };
     }
     return {
       kind: 'failed',

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -360,11 +360,10 @@ function defaultBwrapVersionRunner(): BwrapVersionResult {
     if (e.code === 'ENOENT') {
       return { kind: 'notFound' };
     }
-    const stderr = typeof e.stderr === 'string' ? e.stderr : (e.stderr?.toString() ?? '');
     return {
       kind: 'failed',
       status: e.status ?? null,
-      detail: stderr.trim() || e.message,
+      detail: e.stderr?.toString().trim() || e.message,
     };
   }
 }
@@ -395,20 +394,15 @@ export function _setBwrapVersionRunner(fn: (() => BwrapVersionResult) | null): v
 export function _parseBwrapVersion(output: string): [number, number, number] | null {
   const token = output.split(/\s+/).find((t) => /^\d/.test(t));
   if (!token) return null;
-  const parts = token.split('.');
   const components: number[] = [];
-  for (let i = 0; i < 3; i++) {
-    if (i >= parts.length) {
-      // Genuinely absent component (e.g. a two-component "0.6") defaults to 0.
-      components.push(0);
-      continue;
-    }
-    const digits = /^\d+/.exec(parts[i]);
+  for (const part of token.split('.').slice(0, 3)) {
+    const digits = /^\d+/.exec(part);
     // Present but non-numeric: fail closed rather than guessing 0.
     if (!digits) return null;
     components.push(parseInt(digits[0], 10));
   }
-  return [components[0], components[1], components[2]];
+  // Only a genuinely absent component defaults to 0, so "0.6" is 0.6.0.
+  return [components[0], components[1] ?? 0, components[2] ?? 0];
 }
 
 /** Compare two `[major, minor, patch]` tuples lexicographically. */
@@ -449,7 +443,8 @@ export function _probeBubblewrap(): BubblewrapProbe {
   if (result.kind === 'failed') {
     // Present but broken: do not send the user to their package manager for a
     // package they already have.
-    const where = result.status === null ? 'could not be executed' : `exited with status ${result.status}`;
+    const where =
+      result.status === null ? 'could not be executed' : `exited with status ${result.status}`;
     const detail = result.detail ? `: ${result.detail}` : '';
     return {
       available: false,

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -427,7 +427,11 @@ export function _parseBwrapVersion(output: string): [number, number, number] | n
   const marker = tokens[1].lastIndexOf('+really');
   const token = marker === -1 ? tokens[1] : tokens[1].slice(marker + '+really'.length);
   const components: number[] = [];
-  for (const part of token.split('.').slice(0, 3)) {
+  // Every component must be numeric, including ones past the patch: they are
+  // not significant, but `0.5.0.invalid` is an unrecognized banner rather than
+  // 0.5.0. Validating (rather than rejecting on count) keeps a distro
+  // four-part build such as `0.6.0.1` working.
+  for (const part of token.split('.')) {
     const digits = /^\d+/.exec(part);
     // Present but non-numeric: fail closed rather than guessing 0.
     if (!digits) return null;

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -342,6 +342,23 @@ type BwrapVersionResult =
   | { kind: 'failed'; status: number | null; detail: string };
 
 /**
+ * Whether a `bwrap` candidate exists anywhere on `PATH`.
+ *
+ * Linux reports `ENOENT` both for a genuinely absent binary and for one that
+ * exists but cannot be executed (a missing ELF interpreter or script shebang
+ * target), so the spawn error alone cannot tell `notFound` from `failed`. A
+ * candidate on `PATH` means the package is installed and the failure is a
+ * broken install.
+ */
+function bwrapExistsOnPath(): boolean {
+  const pathVar = process.env.PATH;
+  if (!pathVar) return false;
+  return pathVar
+    .split(path.delimiter)
+    .some((dir) => dir !== '' && fs.existsSync(path.join(dir, 'bwrap')));
+}
+
+/**
  * Default runner for `bwrap --version`. Uses `execFileSync` rather than a
  * shell so a missing binary surfaces as `ENOENT` instead of the shell's
  * indistinguishable exit code 127 — that separation is what lets us report
@@ -357,7 +374,10 @@ function defaultBwrapVersionRunner(): BwrapVersionResult {
     };
   } catch (err) {
     const e = err as NodeJS.ErrnoException & { status?: number | null; stderr?: Buffer | string };
-    if (e.code === 'ENOENT') {
+    // `ENOENT` covers both an absent binary and a present-but-unusable one
+    // (missing ELF interpreter / shebang target), so confirm the binary is
+    // really absent before blaming the package manager.
+    if (e.code === 'ENOENT' && !bwrapExistsOnPath()) {
       return { kind: 'notFound' };
     }
     return {
@@ -385,9 +405,9 @@ export function _setBwrapVersionRunner(fn: (() => BwrapVersionResult) | null): v
  * minimum-version gate.
  *
  * Lenient about what *surrounds* each number so distro-patched version strings
- * (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the version
- * token is split on `.` and each of the (up to three) components contributes
- * its leading digits.
+ * (`0.4.1-1`, a bare `0.6`) still resolve: the version token is split on `.`
+ * and each of the (up to three) components contributes its leading digits.
+ * Debian's `+really` marker is honored rather than ignored — see below.
  *
  * Strict about components that are *present but not numeric*: only a component
  * that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
@@ -401,8 +421,13 @@ export function _parseBwrapVersion(output: string): [number, number, number] | n
   // has been stable since 0.1.0.
   const tokens = output.trim().split(/\s+/);
   if (tokens[0]?.toLowerCase() !== 'bubblewrap' || !tokens[1]) return null;
+  // Debian's `+really` marker means the package ships the version that FOLLOWS
+  // it, so `0.5.0+really0.4.1` is really 0.4.1 — which predates `--clearenv`
+  // and must not clear the gate.
+  const marker = tokens[1].lastIndexOf('+really');
+  const token = marker === -1 ? tokens[1] : tokens[1].slice(marker + '+really'.length);
   const components: number[] = [];
-  for (const part of tokens[1].split('.').slice(0, 3)) {
+  for (const part of token.split('.').slice(0, 3)) {
     const digits = /^\d+/.exec(part);
     // Present but non-numeric: fail closed rather than guessing 0.
     if (!digits) return null;

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -435,7 +435,12 @@ export function _parseBwrapVersion(output: string): [number, number, number] | n
     const digits = /^\d+/.exec(part);
     // Present but non-numeric: fail closed rather than guessing 0.
     if (!digits) return null;
-    components.push(parseInt(digits[0], 10));
+    const value = parseInt(digits[0], 10);
+    // Mirror the Rust parser's `u32`: a larger value is not something bwrap
+    // could print, and accepting it would let this gate admit a banner the
+    // backend's gate rejects.
+    if (value > 0xffffffff) return null;
+    components.push(value);
   }
   // Only a genuinely absent component defaults to 0, so "0.6" is 0.6.0.
   return [components[0], components[1] ?? 0, components[2] ?? 0];

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -379,10 +379,15 @@ export function _setBwrapVersionRunner(fn: (() => BwrapVersionResult) | null): v
  * Parse the version out of a `bwrap --version` line such as
  * `"bubblewrap 0.11.2"`.
  *
+ * Anchored on the `bubblewrap` package name, which is what makes unrecognized
+ * output fail closed: without it any numeric token in arbitrary output (say
+ * `"some other tool 999"`) would be read as a version and clear the
+ * minimum-version gate.
+ *
  * Lenient about what *surrounds* each number so distro-patched version strings
- * (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the first
- * whitespace-separated token starting with a digit is taken, split on `.`, and
- * each of the (up to three) components contributes its leading digits.
+ * (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the version
+ * token is split on `.` and each of the (up to three) components contributes
+ * its leading digits.
  *
  * Strict about components that are *present but not numeric*: only a component
  * that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
@@ -392,10 +397,12 @@ export function _setBwrapVersionRunner(fn: (() => BwrapVersionResult) | null): v
  * @returns `[major, minor, patch]`, or `null` when the version cannot be determined.
  */
 export function _parseBwrapVersion(output: string): [number, number, number] | null {
-  const token = output.split(/\s+/).find((t) => /^\d/.test(t));
-  if (!token) return null;
+  // bwrap prints its PACKAGE_STRING, "bubblewrap <version>"; that leading name
+  // has been stable since 0.1.0.
+  const tokens = output.trim().split(/\s+/);
+  if (tokens[0]?.toLowerCase() !== 'bubblewrap' || !tokens[1]) return null;
   const components: number[] = [];
-  for (const part of token.split('.').slice(0, 3)) {
+  for (const part of tokens[1].split('.').slice(0, 3)) {
     const digits = /^\d+/.exec(part);
     // Present but non-numeric: fail closed rather than guessing 0.
     if (!digits) return null;
@@ -443,8 +450,10 @@ export function _probeBubblewrap(): BubblewrapProbe {
   if (result.kind === 'failed') {
     // Present but broken: do not send the user to their package manager for a
     // package they already have.
+    // Covers both a spawn failure and termination by a signal, neither of
+    // which yields an exit code.
     const where =
-      result.status === null ? 'could not be executed' : `exited with status ${result.status}`;
+      result.status === null ? 'failed without an exit status' : `exited with status ${result.status}`;
     const detail = result.detail ? `: ${result.detail}` : '';
     return {
       available: false,

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -273,12 +273,15 @@ function computeSupport(): PlatformSupport {
     // are installed; callers pick via the containment field.
     const methods: ContainmentBackend[] = [];
     if (isLxcAvailable()) methods.push('lxc');
-    if (isBubblewrapAvailable()) methods.push('bubblewrap');
+    const bubblewrap = probeBubblewrap();
+    if (bubblewrap.available) {
+      methods.push('bubblewrap');
+    } else if (methods.length === 0) {
+      support.reason = `Neither LXC nor Bubblewrap is available on this system (${bubblewrap.reason})`;
+    }
     if (methods.length > 0) {
       support.isSupported = true;
       support.availableMethods = methods;
-    } else {
-      support.reason = 'Neither LXC nor Bubblewrap is available on this system';
     }
     return support;
   }
@@ -313,15 +316,90 @@ function isLxcAvailable(): boolean {
 }
 
 /**
- * Check if Bubblewrap (bwrap) is available on the system
+ * Minimum `bwrap` version the Bubblewrap backend supports, as
+ * `[major, minor, patch]`.
+ *
+ * This is the oldest release that has **every** flag the Rust argument builder
+ * emits. `--ro-bind-try` (deny-by-default baseline mounts) landed in bwrap
+ * 0.3.1 and `--clearenv` (minimal sandbox environment) in 0.5.0, so
+ * `--clearenv` sets the floor.
+ *
+ * Mirrors `MIN_BWRAP_VERSION` in
+ * `src/backends/bubblewrap/common/src/bwrap_version.rs` — keep both in sync.
  */
-function isBubblewrapAvailable(): boolean {
-  try {
-    execSync('bwrap --version', { encoding: 'utf-8', stdio: 'pipe' });
-    return true;
-  } catch {
-    return false;
+const MIN_BWRAP_VERSION: readonly [number, number, number] = [0, 5, 0];
+
+/** Outcome of the Bubblewrap probe: available, or unavailable with a reason. */
+type BubblewrapProbe = { available: true } | { available: false; reason: string };
+
+/**
+ * Parse the version out of a `bwrap --version` line such as
+ * `"bubblewrap 0.11.2"`.
+ *
+ * Deliberately lenient about what surrounds the number so distro-patched
+ * version strings (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still
+ * resolve: the first whitespace-separated token starting with a digit is
+ * taken, split on `.`, and each of the (up to three) components contributes
+ * its leading digits.
+ *
+ * @internal Exported for unit tests.
+ * @returns `[major, minor, patch]`, or `null` when no version token is present.
+ */
+export function _parseBwrapVersion(output: string): [number, number, number] | null {
+  const token = output.split(/\s+/).find((t) => /^\d/.test(t));
+  if (!token) return null;
+  const components = token.split('.').map((component) => {
+    const digits = /^\d+/.exec(component);
+    return digits ? parseInt(digits[0], 10) : 0;
+  });
+  return [components[0], components[1] ?? 0, components[2] ?? 0];
+}
+
+/** Compare two `[major, minor, patch]` tuples lexicographically. */
+function compareVersions(
+  a: readonly [number, number, number],
+  b: readonly [number, number, number],
+): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
   }
+  return 0;
+}
+
+/**
+ * Check whether Bubblewrap (bwrap) is installed *and* new enough.
+ *
+ * Presence on PATH is not sufficient: a `bwrap` older than
+ * {@link MIN_BWRAP_VERSION} would reject flags the backend always emits and
+ * fail at spawn time with an opaque "unknown option" error. Unparsable output
+ * fails closed — without a version we cannot assert the required flags exist.
+ */
+function probeBubblewrap(): BubblewrapProbe {
+  const minVersion = MIN_BWRAP_VERSION.join('.');
+  let output: string;
+  try {
+    output = execSync('bwrap --version', { encoding: 'utf-8', stdio: 'pipe' });
+  } catch {
+    return {
+      available: false,
+      reason: `Bubblewrap (bwrap) is not installed or not on PATH; version ${minVersion} or newer is required`,
+    };
+  }
+
+  const version = _parseBwrapVersion(output);
+  if (!version) {
+    return {
+      available: false,
+      reason: `could not determine the Bubblewrap (bwrap) version from ${JSON.stringify(output.trim())}; version ${minVersion} or newer is required`,
+    };
+  }
+  if (compareVersions(version, MIN_BWRAP_VERSION) < 0) {
+    return {
+      available: false,
+      reason: `Bubblewrap (bwrap) ${version.join('.')} is too old; version ${minVersion} or newer is required`,
+    };
+  }
+  return { available: true };
 }
 
 /**

--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -273,7 +273,7 @@ function computeSupport(): PlatformSupport {
     // are installed; callers pick via the containment field.
     const methods: ContainmentBackend[] = [];
     if (isLxcAvailable()) methods.push('lxc');
-    const bubblewrap = probeBubblewrap();
+    const bubblewrap = _probeBubblewrap();
     if (bubblewrap.available) {
       methods.push('bubblewrap');
     } else if (methods.length === 0) {
@@ -333,26 +333,82 @@ const MIN_BWRAP_VERSION: readonly [number, number, number] = [0, 5, 0];
 type BubblewrapProbe = { available: true } | { available: false; reason: string };
 
 /**
+ * Raw result of running `bwrap --version`, normalized across the ways the call
+ * can fail. Mirrors the cases the Rust `probe_bwrap` distinguishes.
+ */
+type BwrapVersionResult =
+  | { kind: 'output'; stdout: string }
+  | { kind: 'notFound' }
+  | { kind: 'failed'; status: number | null; detail: string };
+
+/**
+ * Default runner for `bwrap --version`. Uses `execFileSync` rather than a
+ * shell so a missing binary surfaces as `ENOENT` instead of the shell's
+ * indistinguishable exit code 127 — that separation is what lets us report
+ * "not installed" and "installed but broken" differently.
+ *
+ * Replaceable in unit tests via {@link _setBwrapVersionRunner}.
+ */
+function defaultBwrapVersionRunner(): BwrapVersionResult {
+  try {
+    return {
+      kind: 'output',
+      stdout: execFileSync('bwrap', ['--version'], { encoding: 'utf-8', stdio: 'pipe' }),
+    };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & { status?: number | null; stderr?: Buffer | string };
+    if (e.code === 'ENOENT') {
+      return { kind: 'notFound' };
+    }
+    const stderr = typeof e.stderr === 'string' ? e.stderr : (e.stderr?.toString() ?? '');
+    return {
+      kind: 'failed',
+      status: e.status ?? null,
+      detail: stderr.trim() || e.message,
+    };
+  }
+}
+
+let bwrapVersionRunner: () => BwrapVersionResult = defaultBwrapVersionRunner;
+
+/** @internal Test-only: override the `bwrap --version` runner. */
+export function _setBwrapVersionRunner(fn: (() => BwrapVersionResult) | null): void {
+  bwrapVersionRunner = fn ?? defaultBwrapVersionRunner;
+}
+
+/**
  * Parse the version out of a `bwrap --version` line such as
  * `"bubblewrap 0.11.2"`.
  *
- * Deliberately lenient about what surrounds the number so distro-patched
- * version strings (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still
- * resolve: the first whitespace-separated token starting with a digit is
- * taken, split on `.`, and each of the (up to three) components contributes
- * its leading digits.
+ * Lenient about what *surrounds* each number so distro-patched version strings
+ * (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the first
+ * whitespace-separated token starting with a digit is taken, split on `.`, and
+ * each of the (up to three) components contributes its leading digits.
+ *
+ * Strict about components that are *present but not numeric*: only a component
+ * that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
+ * rather than silently read as `0.6.0`.
  *
  * @internal Exported for unit tests.
- * @returns `[major, minor, patch]`, or `null` when no version token is present.
+ * @returns `[major, minor, patch]`, or `null` when the version cannot be determined.
  */
 export function _parseBwrapVersion(output: string): [number, number, number] | null {
   const token = output.split(/\s+/).find((t) => /^\d/.test(t));
   if (!token) return null;
-  const components = token.split('.').map((component) => {
-    const digits = /^\d+/.exec(component);
-    return digits ? parseInt(digits[0], 10) : 0;
-  });
-  return [components[0], components[1] ?? 0, components[2] ?? 0];
+  const parts = token.split('.');
+  const components: number[] = [];
+  for (let i = 0; i < 3; i++) {
+    if (i >= parts.length) {
+      // Genuinely absent component (e.g. a two-component "0.6") defaults to 0.
+      components.push(0);
+      continue;
+    }
+    const digits = /^\d+/.exec(parts[i]);
+    // Present but non-numeric: fail closed rather than guessing 0.
+    if (!digits) return null;
+    components.push(parseInt(digits[0], 10));
+  }
+  return [components[0], components[1], components[2]];
 }
 
 /** Compare two `[major, minor, patch]` tuples lexicographically. */
@@ -373,24 +429,39 @@ function compareVersions(
  * {@link MIN_BWRAP_VERSION} would reject flags the backend always emits and
  * fail at spawn time with an opaque "unknown option" error. Unparsable output
  * fails closed — without a version we cannot assert the required flags exist.
+ *
+ * Mirrors `probe_bwrap` in
+ * `src/backends/bubblewrap/common/src/bwrap_version.rs`, including the
+ * distinction between a missing binary and a present-but-broken one.
+ *
+ * @internal Exported for unit tests.
  */
-function probeBubblewrap(): BubblewrapProbe {
+export function _probeBubblewrap(): BubblewrapProbe {
   const minVersion = MIN_BWRAP_VERSION.join('.');
-  let output: string;
-  try {
-    output = execSync('bwrap --version', { encoding: 'utf-8', stdio: 'pipe' });
-  } catch {
+  const result = bwrapVersionRunner();
+
+  if (result.kind === 'notFound') {
     return {
       available: false,
       reason: `Bubblewrap (bwrap) is not installed or not on PATH; version ${minVersion} or newer is required`,
     };
   }
+  if (result.kind === 'failed') {
+    // Present but broken: do not send the user to their package manager for a
+    // package they already have.
+    const where = result.status === null ? 'could not be executed' : `exited with status ${result.status}`;
+    const detail = result.detail ? `: ${result.detail}` : '';
+    return {
+      available: false,
+      reason: `Bubblewrap (bwrap) is present but \`bwrap --version\` ${where}${detail}; version ${minVersion} or newer is required`,
+    };
+  }
 
-  const version = _parseBwrapVersion(output);
+  const version = _parseBwrapVersion(result.stdout);
   if (!version) {
     return {
       available: false,
-      reason: `could not determine the Bubblewrap (bwrap) version from ${JSON.stringify(output.trim())}; version ${minVersion} or newer is required`,
+      reason: `could not determine the Bubblewrap (bwrap) version from ${JSON.stringify(result.stdout.trim())}; version ${minVersion} or newer is required`,
     };
   }
   if (compareVersions(version, MIN_BWRAP_VERSION) < 0) {

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -526,6 +526,19 @@ describe('bwrap minimum-version gate', () => {
     assert.doesNotMatch(probe.reason, /not installed/);
   });
 
+  it('reports a timed-out probe as a failure rather than hanging', () => {
+    // `getPlatformSupport()` is synchronous, so a hung `bwrap --version` must
+    // surface as a bounded failure with the timeout named.
+    _setBwrapVersionRunner(() => ({
+      kind: 'failed',
+      status: null,
+      detail: 'timed out after 5000ms',
+    }));
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /timed out after 5000ms/);
+  });
+
   it('describes a failure that has no exit status without claiming it never ran', () => {
     // A signal-terminated run also has a null status, so the wording must not
     // assert the process could not be executed.

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -395,8 +395,13 @@ describe('bwrap version parsing', () => {
 
   it('parses distro-patched and short version strings', () => {
     assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.4.1-1'), [0, 4, 1]);
-    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.11.0+really0.10.0'), [0, 11, 0]);
     assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.6'), [0, 6, 0]);
+  });
+
+  it('honors the Debian `+really` marker', () => {
+    // `X+reallyY` ships upstream Y, not X, so Y is the effective version.
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.11.0+really0.10.0'), [0, 10, 0]);
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.11.0+really0.10.0-1'), [0, 10, 0]);
   });
 
   it('returns null when no version token is present', () => {
@@ -456,6 +461,15 @@ describe('bwrap minimum-version gate', () => {
   it('rejects the release immediately below the floor', () => {
     withVersion('bubblewrap 0.4.99\n');
     assert.strictEqual(_probeBubblewrap().available, false);
+  });
+
+  it('does not let a `+really` version smuggle a below-floor bwrap past the gate', () => {
+    // Regression: reading the leading version accepted this as 0.5.0, even
+    // though the installed bwrap is 0.4.1 and has no `--clearenv`.
+    withVersion('bubblewrap 0.5.0+really0.4.1\n');
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /0\.4\.1 is too old/);
   });
 
   it('fails closed on unparsable probe output', () => {

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -10,6 +10,7 @@ import {
   _resetPlatformSupportCache,
   _setProbeRunner,
   _setWindowsBuildQuery,
+  _parseBwrapVersion,
   findWxcExecutable,
 } from '../../src/platform.js';
 
@@ -378,5 +379,26 @@ describe('isolation_session availability gate', () => {
     const support = getPlatformSupport();
     assert.ok(support.isSupported);
     assert.strictEqual(support.availableMethods[0], 'processcontainer');
+  });
+});
+
+// The Bubblewrap probe gates on version, not just presence: `--clearenv`
+// (emitted unconditionally by the Rust argument builder) only exists in
+// bwrap 0.5.0+. Mirrors the Rust tests in
+// `src/backends/bubblewrap/common/src/bwrap_version.rs`.
+describe('bwrap version parsing', () => {
+  it('parses the standard `bwrap --version` output', () => {
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.11.2\n'), [0, 11, 2]);
+  });
+
+  it('parses distro-patched and short version strings', () => {
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.4.1-1'), [0, 4, 1]);
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.11.0+really0.10.0'), [0, 11, 0]);
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.6'), [0, 6, 0]);
+  });
+
+  it('returns null when no version token is present', () => {
+    assert.strictEqual(_parseBwrapVersion(''), null);
+    assert.strictEqual(_parseBwrapVersion('bwrap: command not found'), null);
   });
 });

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -11,6 +11,8 @@ import {
   _setProbeRunner,
   _setWindowsBuildQuery,
   _parseBwrapVersion,
+  _probeBubblewrap,
+  _setBwrapVersionRunner,
   findWxcExecutable,
 } from '../../src/platform.js';
 
@@ -400,5 +402,104 @@ describe('bwrap version parsing', () => {
   it('returns null when no version token is present', () => {
     assert.strictEqual(_parseBwrapVersion(''), null);
     assert.strictEqual(_parseBwrapVersion('bwrap: command not found'), null);
+  });
+
+  it('fails closed on a present but non-numeric component', () => {
+    // "0.6.invalid" must not be read as 0.6.0 — only an absent component
+    // defaults to 0.
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 0.6.invalid'), null);
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 0.beta.1'), null);
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 0.6.'), null);
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 1'), [1, 0, 0]);
+  });
+});
+
+// The minimum-version comparison itself, driven through the injectable
+// runner. Without these the SDK gate could drift from the Rust gate in
+// `src/backends/bubblewrap/common/src/bwrap_version.rs` unnoticed.
+describe('bwrap minimum-version gate', () => {
+  afterEach(() => {
+    _setBwrapVersionRunner(null);
+    _resetPlatformSupportCache();
+  });
+
+  const withVersion = (stdout: string) =>
+    _setBwrapVersionRunner(() => ({ kind: 'output', stdout }));
+
+  it('accepts a version exactly at the floor', () => {
+    withVersion('bubblewrap 0.5.0\n');
+    assert.deepStrictEqual(_probeBubblewrap(), { available: true });
+  });
+
+  it('accepts a version above the floor', () => {
+    withVersion('bubblewrap 0.11.2\n');
+    assert.deepStrictEqual(_probeBubblewrap(), { available: true });
+  });
+
+  it('rejects a version below the floor and names it', () => {
+    // 0.4.1 has --ro-bind-try but not --clearenv.
+    withVersion('bubblewrap 0.4.1\n');
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /0\.4\.1 is too old/);
+    assert.match(probe.reason, /0\.5\.0 or newer/);
+  });
+
+  it('rejects the release immediately below the floor', () => {
+    withVersion('bubblewrap 0.4.99\n');
+    assert.strictEqual(_probeBubblewrap().available, false);
+  });
+
+  it('fails closed on unparsable probe output', () => {
+    withVersion('something else entirely\n');
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /could not determine/);
+  });
+
+  it('reports a missing binary as not installed', () => {
+    _setBwrapVersionRunner(() => ({ kind: 'notFound' }));
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /not installed or not on PATH/);
+  });
+
+  it('reports a present but broken binary distinctly from a missing one', () => {
+    // A permissions/loader failure must not tell the user to install a
+    // package they already have; the status and stderr must survive.
+    _setBwrapVersionRunner(() => ({
+      kind: 'failed',
+      status: 126,
+      detail: 'bwrap: permission denied',
+    }));
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /is present but/);
+    assert.match(probe.reason, /126/);
+    assert.match(probe.reason, /permission denied/);
+    assert.doesNotMatch(probe.reason, /not installed/);
+  });
+
+  it('describes a spawn failure that has no exit status', () => {
+    _setBwrapVersionRunner(() => ({
+      kind: 'failed',
+      status: null,
+      detail: 'EACCES: permission denied',
+    }));
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /could not be executed/);
+  });
+
+  it('omits bubblewrap from getPlatformSupport below the floor', { skip: os.platform() !== 'linux' }, () => {
+    withVersion('bubblewrap 0.4.1\n');
+    _resetPlatformSupportCache();
+    assert.ok(!getPlatformSupport().availableMethods.includes('bubblewrap'));
+  });
+
+  it('includes bubblewrap in getPlatformSupport at the floor', { skip: os.platform() !== 'linux' }, () => {
+    withVersion('bubblewrap 0.5.0\n');
+    _resetPlatformSupportCache();
+    assert.ok(getPlatformSupport().availableMethods.includes('bubblewrap'));
   });
 });

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -417,6 +417,14 @@ describe('bwrap version parsing', () => {
     assert.strictEqual(_parseBwrapVersion('bwrap 0.11.2'), null);
   });
 
+  it('rejects junk after the patch component', () => {
+    // Regression: components past the patch were dropped unchecked, so
+    // "0.5.0.invalid" cleared the gate as 0.5.0.
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 0.5.0.invalid'), null);
+    // A numeric fourth component is a plausible distro build, not junk.
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 0.6.0.1'), [0, 6, 0]);
+  });
+
   it('fails closed on a present but non-numeric component', () => {
     // "0.6.invalid" must not be read as 0.6.0 — only an absent component
     // defaults to 0.

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -417,6 +417,15 @@ describe('bwrap version parsing', () => {
     assert.strictEqual(_parseBwrapVersion('bwrap 0.11.2'), null);
   });
 
+  it('rejects components that overflow the Rust parser\'s u32', () => {
+    // Shared contract with `bwrap_version.rs`: an out-of-range component is a
+    // malformed banner, not a very new bwrap. Without this the SDK gate would
+    // admit a banner the backend's gate rejects.
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 99999999999999999999.0.0'), null);
+    assert.strictEqual(_parseBwrapVersion('bubblewrap 0.4294967296.0'), null);
+    assert.deepStrictEqual(_parseBwrapVersion('bubblewrap 4294967295.0.0'), [4294967295, 0, 0]);
+  });
+
   it('rejects junk after the patch component', () => {
     // Regression: components past the patch were dropped unchecked, so
     // "0.5.0.invalid" cleared the gate as 0.5.0.

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -404,6 +404,14 @@ describe('bwrap version parsing', () => {
     assert.strictEqual(_parseBwrapVersion('bwrap: command not found'), null);
   });
 
+  it('fails closed on a stray number in unrelated output', () => {
+    // Regression: searching for any numeric token let unrelated output clear
+    // the gate — "some other tool 999" parsed as 999.0.0. Anchoring on the
+    // `bubblewrap` package name is what keeps this fail-closed.
+    assert.strictEqual(_parseBwrapVersion('some other tool 999'), null);
+    assert.strictEqual(_parseBwrapVersion('bwrap 0.11.2'), null);
+  });
+
   it('fails closed on a present but non-numeric component', () => {
     // "0.6.invalid" must not be read as 0.6.0 — only an absent component
     // defaults to 0.
@@ -457,6 +465,13 @@ describe('bwrap minimum-version gate', () => {
     assert.match(probe.reason, /could not determine/);
   });
 
+  it('fails closed when unrelated output contains a number', () => {
+    withVersion('some other tool 999\n');
+    const probe = _probeBubblewrap();
+    assert.strictEqual(probe.available, false);
+    assert.match(probe.reason, /could not determine/);
+  });
+
   it('reports a missing binary as not installed', () => {
     _setBwrapVersionRunner(() => ({ kind: 'notFound' }));
     const probe = _probeBubblewrap();
@@ -480,7 +495,9 @@ describe('bwrap minimum-version gate', () => {
     assert.doesNotMatch(probe.reason, /not installed/);
   });
 
-  it('describes a spawn failure that has no exit status', () => {
+  it('describes a failure that has no exit status without claiming it never ran', () => {
+    // A signal-terminated run also has a null status, so the wording must not
+    // assert the process could not be executed.
     _setBwrapVersionRunner(() => ({
       kind: 'failed',
       status: null,
@@ -488,7 +505,7 @@ describe('bwrap minimum-version gate', () => {
     }));
     const probe = _probeBubblewrap();
     assert.strictEqual(probe.available, false);
-    assert.match(probe.reason, /could not be executed/);
+    assert.match(probe.reason, /failed without an exit status/);
   });
 
   it('omits bubblewrap from getPlatformSupport below the floor', { skip: os.platform() !== 'linux' }, () => {

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3152,6 +3152,7 @@ name = "wxc_e2e_tests"
 version = "0.7.0"
 dependencies = [
  "base64",
+ "bwrap_common",
  "serde",
  "serde_json",
 ]

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -44,7 +44,7 @@ use wxc_common::sandbox_process::{
 use wxc_common::unix_proxy_coordinator::UnixProxyCoordinator;
 use wxc_common::validator::validate_common;
 
-use crate::bwrap_command;
+use crate::{bwrap_command, bwrap_version};
 
 /// Bubblewrap sandbox runner. Uses only shared `ContainerPolicy` fields —
 /// no backend-specific config struct required.
@@ -54,17 +54,6 @@ pub struct BubblewrapScriptRunner;
 impl BubblewrapScriptRunner {
     pub fn new() -> Self {
         Self
-    }
-
-    /// Check whether `bwrap` is available on PATH.
-    fn is_bwrap_available() -> bool {
-        Command::new("bwrap")
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false)
     }
 }
 
@@ -83,11 +72,11 @@ impl SandboxBackend for BubblewrapScriptRunner {
         // `validate_common` (ahead of every `ScriptRunner::run`), so no
         // backend-local check is needed here.
 
-        if !Self::is_bwrap_available() {
-            return Err(ScriptResponse::error(
-                "Bubblewrap (bwrap) is not installed or not on PATH. \
-                 Install it via your package manager (e.g., apt install bubblewrap).",
-            ));
+        // `bwrap` must be present *and* new enough for every flag the argument
+        // builder emits — an old binary would otherwise fail at spawn time with
+        // an opaque "unknown option" error.
+        if let Err(err) = bwrap_version::probe_bwrap() {
+            return Err(ScriptResponse::error(&err.to_string()));
         }
 
         Ok(())

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -214,6 +214,14 @@ fn parse_version(output: &str) -> Option<BwrapVersion> {
     let major = leading_number(components.next()?)?;
     let minor = components.next().map_or(Some(0), leading_number)?;
     let patch = components.next().map_or(Some(0), leading_number)?;
+
+    // Components past the patch are not significant, but they must still look
+    // like a version: `0.5.0.invalid` is an unrecognized banner, not 0.5.0.
+    // Checking them (rather than rejecting on count) keeps a distro four-part
+    // build such as `0.6.0.1` working.
+    if !components.all(|extra| leading_number(extra).is_some()) {
+        return None;
+    }
     Some(BwrapVersion::new(major, minor, patch))
 }
 
@@ -304,6 +312,24 @@ mod tests {
         assert_eq!(
             parse_version("bubblewrap 1"),
             Some(BwrapVersion::new(1, 0, 0))
+        );
+    }
+
+    #[test]
+    fn rejects_junk_after_the_patch_component() {
+        // Regression: components past the patch were dropped unchecked, so
+        // "0.5.0.invalid" cleared the gate as 0.5.0.
+        assert_eq!(parse_version("bubblewrap 0.5.0.invalid"), None);
+        assert_eq!(
+            check_version_output("bubblewrap 0.5.0.invalid"),
+            Err(BwrapUnavailable::UnrecognizedVersion(
+                "bubblewrap 0.5.0.invalid".to_string()
+            ))
+        );
+        // A numeric fourth component is a plausible distro build, not junk.
+        assert_eq!(
+            parse_version("bubblewrap 0.6.0.1"),
+            Some(BwrapVersion::new(0, 6, 0))
         );
     }
 

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -99,7 +99,9 @@ impl fmt::Display for BwrapUnavailable {
                 write!(f, "Bubblewrap (bwrap) is present but `bwrap --version` ")?;
                 match status {
                     Some(code) => write!(f, "exited with status {code}")?,
-                    None => write!(f, "could not be executed")?,
+                    // Covers both a spawn failure and termination by a signal,
+                    // neither of which yields an exit code.
+                    None => write!(f, "failed without an exit status")?,
                 }
                 if !detail.is_empty() {
                     write!(f, ": {detail}")?;
@@ -154,8 +156,7 @@ pub fn probe_bwrap() -> Result<BwrapVersion, BwrapUnavailable> {
         });
     }
 
-    // bwrap prints its autotools/meson `PACKAGE_STRING` (e.g. "bubblewrap
-    // 0.11.2") on stdout; the leading name has been stable since 0.1.0.
+    // The version banner goes to stdout; `parse_version` owns its format.
     let stdout = String::from_utf8_lossy(&output.stdout);
     check_version_output(&stdout)
 }
@@ -176,23 +177,31 @@ fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailable> 
 /// Parse the version out of a `bwrap --version` line such as
 /// `"bubblewrap 0.11.2"`.
 ///
+/// Anchored on the `bubblewrap` package name, which is what makes unrecognized
+/// output fail closed: without it any numeric token in arbitrary output (say
+/// `"some other tool 999"`) would be read as a version and clear the
+/// minimum-version gate.
+///
 /// Lenient about what *surrounds* each number so distro-patched version strings
-/// (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the first
-/// whitespace-separated token starting with a digit is taken, split on `.`, and
-/// each of the (up to three) components contributes its leading digits.
+/// (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the version
+/// token is split on `.` and each of the (up to three) components contributes
+/// its leading digits.
 ///
 /// Strict about components that are *present but not numeric*: only a component
 /// that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
 /// rather than silently read as `0.6.0`. Returns `None` whenever the version
 /// cannot be determined, which callers treat as fail-closed.
 fn parse_version(output: &str) -> Option<BwrapVersion> {
-    let token = output
-        .split_whitespace()
-        .find(|token| token.starts_with(|c: char| c.is_ascii_digit()))?;
+    // bwrap prints its autotools/meson `PACKAGE_STRING` — "bubblewrap <version>"
+    // — and that leading name has been stable since 0.1.0.
+    let mut tokens = output.split_whitespace();
+    if !tokens.next()?.eq_ignore_ascii_case("bubblewrap") {
+        return None;
+    }
 
     // `map_or(Some(0), ..)` is the absent-vs-unreadable split: an exhausted
     // iterator yields 0, a component `leading_number` rejects fails the parse.
-    let mut components = token.split('.');
+    let mut components = tokens.next()?.split('.');
     let major = leading_number(components.next()?)?;
     let minor = components.next().map_or(Some(0), leading_number)?;
     let patch = components.next().map_or(Some(0), leading_number)?;
@@ -298,6 +307,21 @@ mod tests {
     }
 
     #[test]
+    fn fails_closed_on_a_stray_number_in_unrelated_output() {
+        // Regression: searching for any numeric token let unrelated output
+        // clear the gate — "some other tool 999" parsed as 999.0.0. Anchoring
+        // on the `bubblewrap` package name is what keeps this fail-closed.
+        assert_eq!(parse_version("some other tool 999"), None);
+        assert_eq!(parse_version("bwrap 0.11.2"), None);
+        assert_eq!(
+            check_version_output("some other tool 999"),
+            Err(BwrapUnavailable::UnrecognizedVersion(
+                "some other tool 999".to_string()
+            ))
+        );
+    }
+
+    #[test]
     fn messages_name_the_required_version() {
         for err in [
             BwrapUnavailable::NotFound,
@@ -340,15 +364,16 @@ mod tests {
     #[test]
     fn probe_failure_message_handles_a_missing_status() {
         // Spawn failures that are not `NotFound` (permissions, loader errors)
-        // have no exit status, only an OS error string.
+        // and signal-terminated runs both lack an exit status, so the wording
+        // must not claim the process never ran.
         let message = BwrapUnavailable::ProbeFailed {
             status: None,
             detail: "Permission denied (os error 13)".to_string(),
         }
         .to_string();
         assert!(
-            message.contains("could not be executed"),
-            "should describe the spawn failure: {message}"
+            message.contains("failed without an exit status"),
+            "should describe the missing status: {message}"
         );
         assert!(
             message.contains("os error 13"),

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -334,6 +334,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_components_that_overflow_u32() {
+        // Shared contract with the SDK parser: an out-of-range component is a
+        // malformed banner, not a very new bwrap. Both sides must fail closed
+        // so the SDK gate cannot admit what this one rejects.
+        assert_eq!(parse_version("bubblewrap 99999999999999999999.0.0"), None);
+        assert_eq!(parse_version("bubblewrap 0.4294967296.0"), None);
+        assert_eq!(
+            parse_version("bubblewrap 4294967295.0.0"),
+            Some(BwrapVersion::new(4_294_967_295, 0, 0))
+        );
+    }
+
+    #[test]
     fn ordering_is_semantic() {
         assert!(BwrapVersion::new(0, 4, 9) < BwrapVersion::new(0, 5, 0));
         assert!(BwrapVersion::new(0, 11, 0) > BwrapVersion::new(0, 9, 9));

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -140,9 +140,10 @@ pub fn probe_bwrap() -> Result<BwrapVersion, BwrapUnavailable> {
         .stdin(Stdio::null())
         .output()
         .map_err(|err| match err.kind() {
-            // Only a genuinely missing binary is "not installed"; anything else
-            // (permissions, loader errors) is a broken install, not a missing one.
-            std::io::ErrorKind::NotFound => BwrapUnavailable::NotFound,
+            // `ENOENT` covers both an absent binary and a present-but-unusable
+            // one (missing ELF interpreter / shebang target), so confirm the
+            // binary is really absent before blaming the package manager.
+            std::io::ErrorKind::NotFound if !bwrap_exists_on_path() => BwrapUnavailable::NotFound,
             _ => BwrapUnavailable::ProbeFailed {
                 status: None,
                 detail: err.to_string(),
@@ -183,9 +184,9 @@ fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailable> 
 /// minimum-version gate.
 ///
 /// Lenient about what *surrounds* each number so distro-patched version strings
-/// (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the version
-/// token is split on `.` and each of the (up to three) components contributes
-/// its leading digits.
+/// (`0.4.1-1`, a bare `0.6`) still resolve: the version token is split on `.`
+/// and each of the (up to three) components contributes its leading digits.
+/// Debian's `+really` marker is honored rather than ignored — see below.
 ///
 /// Strict about components that are *present but not numeric*: only a component
 /// that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
@@ -198,14 +199,34 @@ fn parse_version(output: &str) -> Option<BwrapVersion> {
     if !tokens.next()?.eq_ignore_ascii_case("bubblewrap") {
         return None;
     }
+    let token = tokens.next()?;
+
+    // Debian's `+really` marker means the package ships the version that
+    // FOLLOWS it (used when a maintainer must ship an older upstream without
+    // decreasing the package version). Reading the leading version would
+    // over-report: `0.5.0+really0.4.1` is really 0.4.1, which predates
+    // `--clearenv` and must not clear the gate.
+    let token = token.rsplit_once("+really").map_or(token, |(_, real)| real);
 
     // `map_or(Some(0), ..)` is the absent-vs-unreadable split: an exhausted
     // iterator yields 0, a component `leading_number` rejects fails the parse.
-    let mut components = tokens.next()?.split('.');
+    let mut components = token.split('.');
     let major = leading_number(components.next()?)?;
     let minor = components.next().map_or(Some(0), leading_number)?;
     let patch = components.next().map_or(Some(0), leading_number)?;
     Some(BwrapVersion::new(major, minor, patch))
+}
+
+/// Whether a `bwrap` candidate exists anywhere on `PATH`.
+///
+/// Linux returns `ENOENT` both for a genuinely absent binary and for one that
+/// exists but cannot be executed (a missing ELF interpreter or script shebang
+/// target), so the spawn error alone cannot tell [`BwrapUnavailable::NotFound`]
+/// from [`BwrapUnavailable::ProbeFailed`]. A candidate on `PATH` means the
+/// package is installed and the failure is a broken install.
+fn bwrap_exists_on_path() -> bool {
+    std::env::var_os("PATH")
+        .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join("bwrap").exists()))
 }
 
 /// Parse the leading run of ASCII digits of `component`, ignoring any suffix
@@ -232,19 +253,37 @@ mod tests {
 
     #[test]
     fn parses_distro_patched_and_short_versions() {
-        // Debian-style revision suffix, a "+really" epoch fixup, and a
-        // two-component version must all resolve.
+        // Debian-style revision suffix and a two-component version.
         assert_eq!(
             parse_version("bubblewrap 0.4.1-1"),
             Some(BwrapVersion::new(0, 4, 1))
         );
         assert_eq!(
-            parse_version("bubblewrap 0.11.0+really0.10.0"),
-            Some(BwrapVersion::new(0, 11, 0))
-        );
-        assert_eq!(
             parse_version("bubblewrap 0.6"),
             Some(BwrapVersion::new(0, 6, 0))
+        );
+    }
+
+    #[test]
+    fn honors_the_debian_really_marker() {
+        // `X+reallyY` ships upstream Y, not X, so Y is the effective version.
+        assert_eq!(
+            parse_version("bubblewrap 0.11.0+really0.10.0"),
+            Some(BwrapVersion::new(0, 10, 0))
+        );
+        assert_eq!(
+            parse_version("bubblewrap 0.11.0+really0.10.0-1"),
+            Some(BwrapVersion::new(0, 10, 0))
+        );
+    }
+
+    #[test]
+    fn really_marker_cannot_smuggle_a_below_floor_version_past_the_gate() {
+        // Regression: reading the leading version accepted this as 0.5.0, even
+        // though the installed bwrap is 0.4.1 and has no `--clearenv`.
+        assert_eq!(
+            check_version_output("bubblewrap 0.5.0+really0.4.1"),
+            Err(BwrapUnavailable::TooOld(BwrapVersion::new(0, 4, 1)))
         );
     }
 

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -1,0 +1,269 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Bubblewrap availability + version probing.
+//!
+//! Presence of `bwrap` on PATH is not sufficient: the argument vector built by
+//! [`crate::bwrap_command`] uses flags that were added over the life of the
+//! project, so an old `bwrap` would fail at spawn time with an opaque
+//! "unknown option" error. This module probes `bwrap --version` once and
+//! reports a precise, actionable reason when the host cannot run the backend.
+//!
+//! The parsing half is pure (no I/O), so it is unit-tested on every host; only
+//! [`probe_bwrap`] shells out.
+
+use std::fmt;
+use std::process::{Command, Stdio};
+
+/// The minimum `bwrap` version the Bubblewrap backend supports.
+///
+/// This is the oldest release that has **every** flag
+/// [`crate::bwrap_command::build_args_classified`] emits. The binding
+/// constraints, in order of introduction:
+///
+/// | Flag         | First `bwrap` release |
+/// |--------------|-----------------------|
+/// | `--bind`, `--ro-bind`, `--dev`, `--proc`, `--tmpfs`, `--symlink`, `--chdir`, `--setenv`, `--unshare-*` | 0.1.0 |
+/// | `--ro-bind-try` (deny-by-default baseline mounts) | 0.3.1 |
+/// | `--clearenv` (minimal sandbox environment) | **0.5.0** |
+///
+/// `--clearenv` is therefore the flag that sets the floor. If the argument
+/// builder ever adopts a newer flag, raise this constant in the same change.
+pub const MIN_BWRAP_VERSION: BwrapVersion = BwrapVersion::new(0, 5, 0);
+
+/// A `major.minor.patch` Bubblewrap version.
+///
+/// Ordering is the derived field order (major, then minor, then patch), which
+/// is exactly the semantic precedence bwrap releases use.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BwrapVersion {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl BwrapVersion {
+    /// Construct a version from its components.
+    pub const fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// The major component.
+    pub const fn major(&self) -> u32 {
+        self.major
+    }
+
+    /// The minor component.
+    pub const fn minor(&self) -> u32 {
+        self.minor
+    }
+
+    /// The patch component.
+    pub const fn patch(&self) -> u32 {
+        self.patch
+    }
+}
+
+impl fmt::Display for BwrapVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Why the Bubblewrap backend cannot run on this host.
+///
+/// [`fmt::Display`] renders the user-facing reason, so callers (the runner's
+/// `validate` and the engine's platform probe) share one message source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BwrapUnavailable {
+    /// `bwrap --version` could not be executed, or exited non-zero.
+    NotFound,
+    /// `bwrap --version` ran but printed something we could not parse. We fail
+    /// closed here: without a version we cannot assert the required flags exist.
+    UnrecognizedVersion(String),
+    /// `bwrap` is present but predates [`MIN_BWRAP_VERSION`].
+    TooOld(BwrapVersion),
+}
+
+impl fmt::Display for BwrapUnavailable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotFound => write!(
+                f,
+                "Bubblewrap (bwrap) is not installed or not on PATH. \
+                 Install it via your package manager (e.g., apt install bubblewrap). \
+                 Version {MIN_BWRAP_VERSION} or newer is required."
+            ),
+            Self::UnrecognizedVersion(output) => write!(
+                f,
+                "Could not determine the Bubblewrap (bwrap) version: \
+                 `bwrap --version` printed {output:?}. \
+                 Version {MIN_BWRAP_VERSION} or newer is required."
+            ),
+            Self::TooOld(found) => write!(
+                f,
+                "Bubblewrap (bwrap) {found} is too old: version {MIN_BWRAP_VERSION} or newer is \
+                 required (the sandbox uses `--clearenv`, added in bwrap 0.5.0). \
+                 Upgrade the bubblewrap package."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BwrapUnavailable {}
+
+/// Probe the host for a usable `bwrap`.
+///
+/// Runs `bwrap --version` and validates the reported version against
+/// [`MIN_BWRAP_VERSION`]. Returns the detected version on success.
+pub fn probe_bwrap() -> Result<BwrapVersion, BwrapUnavailable> {
+    let output = Command::new("bwrap")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .output()
+        .map_err(|_| BwrapUnavailable::NotFound)?;
+
+    if !output.status.success() {
+        return Err(BwrapUnavailable::NotFound);
+    }
+
+    // bwrap prints its autotools/meson `PACKAGE_STRING` (e.g. "bubblewrap
+    // 0.11.2") on stdout; the leading name has been stable since 0.1.0.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    check_version_output(&stdout)
+}
+
+/// Validate a raw `bwrap --version` output string against
+/// [`MIN_BWRAP_VERSION`]. Split out from [`probe_bwrap`] so the decision logic
+/// is testable without a `bwrap` binary on the host.
+pub fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailable> {
+    let version = parse_version(output)
+        .ok_or_else(|| BwrapUnavailable::UnrecognizedVersion(output.trim().to_string()))?;
+
+    if version < MIN_BWRAP_VERSION {
+        return Err(BwrapUnavailable::TooOld(version));
+    }
+    Ok(version)
+}
+
+/// Parse the version out of a `bwrap --version` line such as
+/// `"bubblewrap 0.11.2"`.
+///
+/// Deliberately lenient about what surrounds the number so distro-patched
+/// version strings (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still
+/// resolve: the first whitespace-separated token starting with a digit is
+/// taken, split on `.`, and each of the (up to three) components contributes
+/// its leading digits. Returns `None` when no such token exists.
+pub fn parse_version(output: &str) -> Option<BwrapVersion> {
+    let token = output
+        .split_whitespace()
+        .find(|token| token.starts_with(|c: char| c.is_ascii_digit()))?;
+
+    let mut components = token.split('.').map(leading_number);
+    let major = components.next().flatten()?;
+    let minor = components.next().flatten().unwrap_or(0);
+    let patch = components.next().flatten().unwrap_or(0);
+    Some(BwrapVersion::new(major, minor, patch))
+}
+
+/// Parse the leading run of ASCII digits of `component`, ignoring any suffix
+/// (so `"1-1"` yields `1`). Returns `None` when there is no leading digit or
+/// the number overflows.
+fn leading_number(component: &str) -> Option<u32> {
+    let digits: String = component.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_standard_version_output() {
+        assert_eq!(
+            parse_version("bubblewrap 0.11.2\n"),
+            Some(BwrapVersion::new(0, 11, 2))
+        );
+    }
+
+    #[test]
+    fn parses_distro_patched_and_short_versions() {
+        // Debian-style revision suffix, a "+really" epoch fixup, and a
+        // two-component version must all resolve.
+        assert_eq!(
+            parse_version("bubblewrap 0.4.1-1"),
+            Some(BwrapVersion::new(0, 4, 1))
+        );
+        assert_eq!(
+            parse_version("bubblewrap 0.11.0+really0.10.0"),
+            Some(BwrapVersion::new(0, 11, 0))
+        );
+        assert_eq!(
+            parse_version("bubblewrap 0.6"),
+            Some(BwrapVersion::new(0, 6, 0))
+        );
+    }
+
+    #[test]
+    fn rejects_output_without_a_version() {
+        assert_eq!(parse_version(""), None);
+        assert_eq!(parse_version("bwrap: command not found"), None);
+    }
+
+    #[test]
+    fn ordering_is_semantic() {
+        assert!(BwrapVersion::new(0, 4, 9) < BwrapVersion::new(0, 5, 0));
+        assert!(BwrapVersion::new(0, 11, 0) > BwrapVersion::new(0, 9, 9));
+        assert!(BwrapVersion::new(1, 0, 0) > BwrapVersion::new(0, 99, 99));
+    }
+
+    #[test]
+    fn accepts_minimum_and_newer_versions() {
+        assert_eq!(
+            check_version_output("bubblewrap 0.5.0"),
+            Ok(MIN_BWRAP_VERSION)
+        );
+        assert_eq!(
+            check_version_output("bubblewrap 0.11.2"),
+            Ok(BwrapVersion::new(0, 11, 2))
+        );
+    }
+
+    #[test]
+    fn rejects_versions_below_the_minimum() {
+        // 0.4.1 has `--ro-bind-try` but not `--clearenv`.
+        assert_eq!(
+            check_version_output("bubblewrap 0.4.1"),
+            Err(BwrapUnavailable::TooOld(BwrapVersion::new(0, 4, 1)))
+        );
+    }
+
+    #[test]
+    fn fails_closed_on_unparsable_output() {
+        assert_eq!(
+            check_version_output("some other tool\n"),
+            Err(BwrapUnavailable::UnrecognizedVersion(
+                "some other tool".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn messages_name_the_required_version() {
+        for err in [
+            BwrapUnavailable::NotFound,
+            BwrapUnavailable::UnrecognizedVersion("junk".to_string()),
+            BwrapUnavailable::TooOld(BwrapVersion::new(0, 4, 1)),
+        ] {
+            let message = err.to_string();
+            assert!(
+                message.contains(&MIN_BWRAP_VERSION.to_string()),
+                "message should name the minimum version: {message}"
+            );
+        }
+    }
+}

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -35,7 +35,7 @@ pub const MIN_BWRAP_VERSION: BwrapVersion = BwrapVersion::new(0, 5, 0);
 ///
 /// Ordering is the derived field order (major, then minor, then patch), which
 /// is exactly the semantic precedence bwrap releases use.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct BwrapVersion {
     major: u32,
     minor: u32,
@@ -50,21 +50,6 @@ impl BwrapVersion {
             minor,
             patch,
         }
-    }
-
-    /// The major component.
-    pub const fn major(&self) -> u32 {
-        self.major
-    }
-
-    /// The minor component.
-    pub const fn minor(&self) -> u32 {
-        self.minor
-    }
-
-    /// The patch component.
-    pub const fn patch(&self) -> u32 {
-        self.patch
     }
 }
 
@@ -178,7 +163,7 @@ pub fn probe_bwrap() -> Result<BwrapVersion, BwrapUnavailable> {
 /// Validate a raw `bwrap --version` output string against
 /// [`MIN_BWRAP_VERSION`]. Split out from [`probe_bwrap`] so the decision logic
 /// is testable without a `bwrap` binary on the host.
-pub fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailable> {
+fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailable> {
     let version = parse_version(output)
         .ok_or_else(|| BwrapUnavailable::UnrecognizedVersion(output.trim().to_string()))?;
 
@@ -200,34 +185,28 @@ pub fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailab
 /// that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
 /// rather than silently read as `0.6.0`. Returns `None` whenever the version
 /// cannot be determined, which callers treat as fail-closed.
-pub fn parse_version(output: &str) -> Option<BwrapVersion> {
+fn parse_version(output: &str) -> Option<BwrapVersion> {
     let token = output
         .split_whitespace()
         .find(|token| token.starts_with(|c: char| c.is_ascii_digit()))?;
 
+    // `map_or(Some(0), ..)` is the absent-vs-unreadable split: an exhausted
+    // iterator yields 0, a component `leading_number` rejects fails the parse.
     let mut components = token.split('.');
     let major = leading_number(components.next()?)?;
-    let minor = next_component(&mut components)?;
-    let patch = next_component(&mut components)?;
+    let minor = components.next().map_or(Some(0), leading_number)?;
+    let patch = components.next().map_or(Some(0), leading_number)?;
     Some(BwrapVersion::new(major, minor, patch))
-}
-
-/// Take the next version component: `0` when the iterator is exhausted (a
-/// two-component version such as `0.6` is fine), `None` when a component is
-/// present but has no leading digits (fail closed).
-fn next_component<'a>(components: &mut impl Iterator<Item = &'a str>) -> Option<u32> {
-    match components.next() {
-        Some(component) => leading_number(component),
-        None => Some(0),
-    }
 }
 
 /// Parse the leading run of ASCII digits of `component`, ignoring any suffix
 /// (so `"1-1"` yields `1`). Returns `None` when there is no leading digit or
 /// the number overflows.
 fn leading_number(component: &str) -> Option<u32> {
-    let digits: String = component.chars().take_while(char::is_ascii_digit).collect();
-    digits.parse().ok()
+    let end = component
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(component.len());
+    component[..end].parse().ok()
 }
 
 #[cfg(test)]

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -80,8 +80,20 @@ impl fmt::Display for BwrapVersion {
 /// `validate` and the engine's platform probe) share one message source.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BwrapUnavailable {
-    /// `bwrap --version` could not be executed, or exited non-zero.
+    /// `bwrap` could not be found — the spawn failed with
+    /// [`std::io::ErrorKind::NotFound`].
     NotFound,
+    /// `bwrap` was found but `bwrap --version` did not complete successfully
+    /// (e.g. a permissions problem, a dynamic-loader failure, or a non-zero
+    /// exit). Distinct from [`Self::NotFound`] so the reported remediation is
+    /// not the misleading "install the package", and so the underlying cause is
+    /// preserved rather than discarded.
+    ProbeFailed {
+        /// Exit status of `bwrap --version`, when the process ran at all.
+        status: Option<i32>,
+        /// Captured stderr, or the OS error when the process could not start.
+        detail: String,
+    },
     /// `bwrap --version` ran but printed something we could not parse. We fail
     /// closed here: without a version we cannot assert the required flags exist.
     UnrecognizedVersion(String),
@@ -98,6 +110,21 @@ impl fmt::Display for BwrapUnavailable {
                  Install it via your package manager (e.g., apt install bubblewrap). \
                  Version {MIN_BWRAP_VERSION} or newer is required."
             ),
+            Self::ProbeFailed { status, detail } => {
+                write!(f, "Bubblewrap (bwrap) is present but `bwrap --version` ")?;
+                match status {
+                    Some(code) => write!(f, "exited with status {code}")?,
+                    None => write!(f, "could not be executed")?,
+                }
+                if !detail.is_empty() {
+                    write!(f, ": {detail}")?;
+                }
+                write!(
+                    f,
+                    ". Version {MIN_BWRAP_VERSION} or newer is required; fix the \
+                     installation before using the Bubblewrap backend."
+                )
+            }
             Self::UnrecognizedVersion(output) => write!(
                 f,
                 "Could not determine the Bubblewrap (bwrap) version: \
@@ -125,10 +152,21 @@ pub fn probe_bwrap() -> Result<BwrapVersion, BwrapUnavailable> {
         .arg("--version")
         .stdin(Stdio::null())
         .output()
-        .map_err(|_| BwrapUnavailable::NotFound)?;
+        .map_err(|err| match err.kind() {
+            // Only a genuinely missing binary is "not installed"; anything else
+            // (permissions, loader errors) is a broken install, not a missing one.
+            std::io::ErrorKind::NotFound => BwrapUnavailable::NotFound,
+            _ => BwrapUnavailable::ProbeFailed {
+                status: None,
+                detail: err.to_string(),
+            },
+        })?;
 
     if !output.status.success() {
-        return Err(BwrapUnavailable::NotFound);
+        return Err(BwrapUnavailable::ProbeFailed {
+            status: output.status.code(),
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        });
     }
 
     // bwrap prints its autotools/meson `PACKAGE_STRING` (e.g. "bubblewrap
@@ -153,21 +191,35 @@ pub fn check_version_output(output: &str) -> Result<BwrapVersion, BwrapUnavailab
 /// Parse the version out of a `bwrap --version` line such as
 /// `"bubblewrap 0.11.2"`.
 ///
-/// Deliberately lenient about what surrounds the number so distro-patched
-/// version strings (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still
-/// resolve: the first whitespace-separated token starting with a digit is
-/// taken, split on `.`, and each of the (up to three) components contributes
-/// its leading digits. Returns `None` when no such token exists.
+/// Lenient about what *surrounds* each number so distro-patched version strings
+/// (`0.4.1-1`, `0.11.0+really0.10.0`, a bare `0.6`) still resolve: the first
+/// whitespace-separated token starting with a digit is taken, split on `.`, and
+/// each of the (up to three) components contributes its leading digits.
+///
+/// Strict about components that are *present but not numeric*: only a component
+/// that is genuinely absent defaults to `0`, so `"0.6.invalid"` is rejected
+/// rather than silently read as `0.6.0`. Returns `None` whenever the version
+/// cannot be determined, which callers treat as fail-closed.
 pub fn parse_version(output: &str) -> Option<BwrapVersion> {
     let token = output
         .split_whitespace()
         .find(|token| token.starts_with(|c: char| c.is_ascii_digit()))?;
 
-    let mut components = token.split('.').map(leading_number);
-    let major = components.next().flatten()?;
-    let minor = components.next().flatten().unwrap_or(0);
-    let patch = components.next().flatten().unwrap_or(0);
+    let mut components = token.split('.');
+    let major = leading_number(components.next()?)?;
+    let minor = next_component(&mut components)?;
+    let patch = next_component(&mut components)?;
     Some(BwrapVersion::new(major, minor, patch))
+}
+
+/// Take the next version component: `0` when the iterator is exhausted (a
+/// two-component version such as `0.6` is fine), `None` when a component is
+/// present but has no leading digits (fail closed).
+fn next_component<'a>(components: &mut impl Iterator<Item = &'a str>) -> Option<u32> {
+    match components.next() {
+        Some(component) => leading_number(component),
+        None => Some(0),
+    }
 }
 
 /// Parse the leading run of ASCII digits of `component`, ignoring any suffix
@@ -215,6 +267,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_present_but_nonnumeric_components() {
+        // A component that exists but has no leading digit must fail closed
+        // rather than silently defaulting to 0 — "0.6.invalid" is not 0.6.0.
+        assert_eq!(parse_version("bubblewrap 0.6.invalid"), None);
+        assert_eq!(parse_version("bubblewrap 0.beta.1"), None);
+        assert_eq!(parse_version("bubblewrap 0.6."), None);
+        // ...but a genuinely absent component still defaults to 0.
+        assert_eq!(
+            parse_version("bubblewrap 1"),
+            Some(BwrapVersion::new(1, 0, 0))
+        );
+    }
+
+    #[test]
     fn ordering_is_semantic() {
         assert!(BwrapVersion::new(0, 4, 9) < BwrapVersion::new(0, 5, 0));
         assert!(BwrapVersion::new(0, 11, 0) > BwrapVersion::new(0, 9, 9));
@@ -256,6 +322,10 @@ mod tests {
     fn messages_name_the_required_version() {
         for err in [
             BwrapUnavailable::NotFound,
+            BwrapUnavailable::ProbeFailed {
+                status: Some(126),
+                detail: "permission denied".to_string(),
+            },
             BwrapUnavailable::UnrecognizedVersion("junk".to_string()),
             BwrapUnavailable::TooOld(BwrapVersion::new(0, 4, 1)),
         ] {
@@ -265,5 +335,45 @@ mod tests {
                 "message should name the minimum version: {message}"
             );
         }
+    }
+
+    #[test]
+    fn probe_failure_message_preserves_status_and_stderr() {
+        // A broken-but-present bwrap must not be reported as "not installed":
+        // that remediation would send the user to their package manager for a
+        // package they already have.
+        let message = BwrapUnavailable::ProbeFailed {
+            status: Some(126),
+            detail: "bwrap: permission denied".to_string(),
+        }
+        .to_string();
+        assert!(message.contains("126"), "status should survive: {message}");
+        assert!(
+            message.contains("bwrap: permission denied"),
+            "stderr should survive: {message}"
+        );
+        assert!(
+            !message.contains("not installed"),
+            "must not claim the package is missing: {message}"
+        );
+    }
+
+    #[test]
+    fn probe_failure_message_handles_a_missing_status() {
+        // Spawn failures that are not `NotFound` (permissions, loader errors)
+        // have no exit status, only an OS error string.
+        let message = BwrapUnavailable::ProbeFailed {
+            status: None,
+            detail: "Permission denied (os error 13)".to_string(),
+        }
+        .to_string();
+        assert!(
+            message.contains("could not be executed"),
+            "should describe the spawn failure: {message}"
+        );
+        assert!(
+            message.contains("os error 13"),
+            "OS error should survive: {message}"
+        );
     }
 }

--- a/src/backends/bubblewrap/common/src/lib.rs
+++ b/src/backends/bubblewrap/common/src/lib.rs
@@ -7,9 +7,13 @@
 //!   [`ExecutionRequest`](wxc_common::models::ExecutionRequest). It is
 //!   platform-agnostic (pure argument generation) so it compiles and is
 //!   fully unit-tested on every host.
+//! - [`bwrap_version`] probes the host `bwrap` and checks it is new enough to
+//!   understand every flag [`bwrap_command`] emits. Shared by the runner's
+//!   `validate` and the engine's platform-support probe.
 //! - [`bwrap_runner`] is gated to `target_os = "linux"` since it actually
 //!   spawns the `bwrap` binary.
 
 pub mod bwrap_command;
 #[cfg(target_os = "linux")]
 pub mod bwrap_runner;
+pub mod bwrap_version;

--- a/src/core/mxc_engine/src/platform.rs
+++ b/src/core/mxc_engine/src/platform.rs
@@ -52,17 +52,19 @@ pub fn platform_support() -> PlatformSupport {
 
     #[cfg(target_os = "linux")]
     {
-        if command_succeeds("bwrap", &["--version"]) {
-            PlatformSupport {
+        // Presence alone is not enough: `bwrap` must also be new enough for
+        // every flag the argument builder emits (see
+        // `bwrap_common::bwrap_version::MIN_BWRAP_VERSION`).
+        match bwrap_common::bwrap_version::probe_bwrap() {
+            Ok(_) => PlatformSupport {
                 is_supported: true,
                 available_methods: vec!["bubblewrap".to_string()],
                 ..Default::default()
-            }
-        } else {
-            PlatformSupport {
-                reason: Some("Bubblewrap is not available on this system".to_string()),
+            },
+            Err(err) => PlatformSupport {
+                reason: Some(err.to_string()),
                 ..Default::default()
-            }
+            },
         }
     }
 
@@ -82,19 +84,4 @@ pub fn platform_support() -> PlatformSupport {
             ..Default::default()
         }
     }
-}
-
-/// Returns true when `program args...` exits successfully — used to probe for
-/// the presence of `bwrap` on Linux.
-#[cfg(target_os = "linux")]
-fn command_succeeds(program: &str, args: &[&str]) -> bool {
-    use std::process::{Command, Stdio};
-    Command::new(program)
-        .args(args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
 }

--- a/src/testing/wxc_e2e_tests/Cargo.toml
+++ b/src/testing/wxc_e2e_tests/Cargo.toml
@@ -10,3 +10,8 @@ description = "End-to-end integration tests for MXC"
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+# Bubblewrap characterization tests reuse the backend's own version probe so
+# their skip condition cannot drift from what the runner accepts.
+[target.'cfg(target_os = "linux")'.dependencies]
+bwrap_common.workspace = true

--- a/src/testing/wxc_e2e_tests/src/lib.rs
+++ b/src/testing/wxc_e2e_tests/src/lib.rs
@@ -540,19 +540,28 @@ pub fn has_platform_exec() -> bool {
     }
 }
 
-/// Whether `bwrap` (Bubblewrap) is installed and runnable on this Linux host.
-/// Bubblewrap characterization tests skip cleanly when it is absent (e.g. a CI
-/// runner without `bubblewrap` installed).
+/// Whether `bwrap` (Bubblewrap) is installed, runnable, and new enough on this
+/// Linux host. Bubblewrap characterization tests skip cleanly otherwise (e.g. a
+/// CI runner without `bubblewrap` installed, or one shipping a release older
+/// than [`bwrap_common::bwrap_version::MIN_BWRAP_VERSION`]) — the backend
+/// rejects such hosts up front, so the tests would have nothing to exercise.
 pub fn has_bwrap() -> bool {
-    let available = Command::new("bwrap")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !available {
-        println!("SKIPPED: bwrap not found on PATH — install `bubblewrap` to run these tests");
+    #[cfg(target_os = "linux")]
+    {
+        match bwrap_common::bwrap_version::probe_bwrap() {
+            Ok(_) => true,
+            Err(err) => {
+                println!("SKIPPED: {err}");
+                false
+            }
+        }
     }
-    available
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        println!("SKIPPED: Bubblewrap is only available on Linux");
+        false
+    }
 }
 
 /// Opt-in switch for the Windows ProcessContainer characterization tests.


### PR DESCRIPTION
## 📖 Description

Bubblewrap platform detection only checked that `bwrap --version` exited
successfully. Presence on PATH is not the same as usability: a host with an old
`bubblewrap` was reported as **supported**, and the failure only surfaced later
at spawn time as an opaque `bwrap: unknown option` error.

This PR gates detection on a **minimum version**, derived from the flags
`bwrap_command::build_args_classified` actually emits (verified against the
bubblewrap git history):

| Flag | First `bwrap` release |
|------|-----------------------|
| `--bind`, `--ro-bind`, `--dev`, `--proc`, `--tmpfs`, `--symlink`, `--chdir`, `--setenv`, `--unshare-*` | 0.1.0 |
| `--ro-bind-try` (deny-by-default baseline mounts) | 0.3.1 |
| `--clearenv` (minimal sandbox environment) | **0.5.0** |

`--clearenv` sets the floor, so **bwrap 0.5.0** is the minimum. The docs
previously claimed `0.3.0+`, which was both wrong for `--ro-bind-try` (0.3.1)
and predated the `--clearenv` requirement.

### Changes

- **New** `src/backends/bubblewrap/common/src/bwrap_version.rs`:
  - `MIN_BWRAP_VERSION` with a table documenting *why* each component is the
    floor, so a future flag adoption has an obvious place to bump.
  - `BwrapVersion` (ordered `major.minor.patch`) and a parser that is:
    - **anchored** on the `bubblewrap` package name, so unrecognized output
      actually fails closed — a stray number in unrelated output (`some other
      tool 999`) can't be read as a version and clear the gate;
    - **lenient** about what *surrounds* each number, so distro-patched strings
      (`0.4.1-1`, a bare `0.6`) resolve;
    - **strict** about components that are *present and non-numeric*, so
      `0.6.invalid` is rejected rather than silently read as `0.6.0`;
    - correct about Debian's `+really` marker, which names the version the
      package *actually* ships — `0.5.0+really0.4.1` is 0.4.1, and is rejected
      rather than admitted as 0.5.0;
    - strict about trailing components and overflow, so `0.5.0.invalid` and an
      out-of-`u32` component are rejected instead of being read as 0.5.0 /
      admitted as very new, while a numeric `0.6.0.1` distro build still works.
  - `probe_bwrap()` returning `Result<BwrapVersion, BwrapUnavailable>`, where
    `BwrapUnavailable` renders the user-facing reason via `Display` — one
    message source for every caller. Its variants separate the four distinct
    outcomes:
    - `NotFound` — spawn failed with `io::ErrorKind::NotFound`; the binary is
      genuinely absent, so "install the package" is the right remediation.
    - `ProbeFailed { status, detail }` — the binary exists but `bwrap --version`
      failed (permissions, dynamic-loader problems, non-zero exit). Keeps the
      exit status and stderr instead of discarding them, and does **not** tell
      the user to install a package they already have.
    - `UnrecognizedVersion` — ran, but printed something unparsable. Fails
      **closed**: without a version we cannot assert the required flags exist.
    - `TooOld` — names the detected version and the required floor.
- `mxc_engine::platform_support` and `BubblewrapScriptRunner::validate` both now
  call the single probe, replacing their two independent presence-only checks,
  so the platform report and the runner can no longer disagree.
- `wxc_e2e_tests::has_bwrap()` reuses the same probe, so the Bubblewrap
  characterization tests skip cleanly on a too-old host instead of red-failing
  on an error the backend now rejects up front.
- `sdk/node/src/platform.ts` mirrors the gate (`MIN_BWRAP_VERSION`,
  `_parseBwrapVersion`, `_probeBubblewrap`), including the missing/broken
  distinction. The probe uses `execFileSync` rather than `execSync` because
  running through a shell collapses a missing binary into an indistinguishable
  exit code 127, whereas `execFileSync` surfaces `ENOENT` directly. The Linux
  `reason` now says *why* rather than reporting a bare "not available".
- `docs/bwrap-support/bubblewrap-backend.md` prerequisites corrected to 0.5.0.

`src/Cargo.lock` changes by exactly one line — `wxc_e2e_tests` gains the
**internal workspace crate** `bwrap_common` (Linux-only target dependency). No
new external dependency is introduced, and `dependency-feed-check` passes.

## 🔗 References

No existing issue — found while reviewing Bubblewrap host detection.

Minimum-version claims were verified directly against
[containers/bubblewrap](https://github.com/containers/bubblewrap) release tags
(`--clearenv` added by `8f72ceb`, first released in `v0.5.0`; `--bind-try`
family added by `d3515d8`, first released in `v0.3.1`).

`main` has since been merged in. That merge included a refactor of
`bwrap_command.rs` (proxy env keys moved into the shared
`wxc_common::proxy_env`), so the emitted flag set was re-checked afterwards —
it is unchanged, and `--clearenv` remains the binding constraint.

## 🔍 Validation

Automated coverage added:

- **16 Rust unit tests** in `bwrap_version.rs` — standard / distro-patched /
  short version parsing, rejection of non-version output, rejection of
  present-but-non-numeric components, semantic ordering, acceptance at exactly
  `MIN_BWRAP_VERSION`, rejection of `0.4.1`, fail-closed on unparsable output
  (including a stray number in unrelated output), rejection of trailing junk
  and of components that overflow `u32`, `+really` resolving to the shipped
  version and not smuggling a below-floor bwrap past the gate, every error
  message naming the required version, and the probe-failure message preserving
  exit status and stderr (with and without a status).
- **21 SDK unit tests** in `sdk/node/tests/unit/platform.test.ts` — the parser
  cases plus the minimum-version comparison itself, driven through a new
  `_setBwrapVersionRunner` hook (matching the existing `_setProbeRunner` /
  `_setWindowsBuildQuery` convention): below-floor, exactly-at-floor,
  above-floor, unparsable, missing, and present-but-broken outcomes, and the
  resulting `getPlatformSupport()` methods on Linux. This keeps the duplicated
  SDK gate from drifting from the Rust gate unnoticed.

Commands run locally (macOS host):

```
cargo fmt --all -- --check                                   # clean
cargo clippy -p bwrap_common -p mxc_engine -p wxc_e2e_tests \
    -p wxc_common --all-targets -- -D warnings               # clean
cargo clippy -p bwrap_common -p mxc_engine -p wxc_e2e_tests \
    -p wxc_common --all-targets \
    --target x86_64-unknown-linux-gnu -- -D warnings         # clean (covers the Linux-gated runner)
cargo test -p bwrap_common -p mxc_engine -p wxc_common       # 539 passed, 0 failed
cd sdk/node && npm run build && npm test                     # 195 passed, 3 failed
```

The 3 SDK failures are **pre-existing and unrelated** — Windows-only
`availableTools` policy assertions (`pwsh.exe` / `PSReadLine` / system root)
that cannot pass on a macOS host. Confirmed identical on a stashed baseline
before any change, and the `SDK Unit Tests (windows)` CI lane passes.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task



