### PR TITLE
[Bubblewrap] Fix proxy tests by using non-rate-limited origin

### DIFF
--- a/sdk/node/tests/integration/linux-bubblewrap.test.ts
+++ b/sdk/node/tests/integration/linux-bubblewrap.test.ts
@@ -14,6 +14,7 @@ import {
   debugSpawnOptions,
   spawnFromConfigAsync,
   startUnixTestProxy,
+  NETWORK_TEST_URL,
 } from './test-helpers.js';
 import type { ChildProcess } from 'node:child_process';
 
@@ -111,8 +112,9 @@ describe('Linux Bubblewrap network proxy (schema 0.6.0-alpha)', {
       'bubblewrap',
       'bwrap-external-proxy',
     );
+    // Azure Artifacts feed (NETWORK_TEST_URL)
     config.process!.commandLine =
-      'curl -fsSL https://api.github.com/zen > /dev/null && echo PROXY_OK';
+      `curl -fsSL '${NETWORK_TEST_URL}' > /dev/null && echo PROXY_OK`;
     config.network = {
       ...(config.network ?? {}),
       defaultPolicy: 'allow',
@@ -131,7 +133,7 @@ describe('Linux Bubblewrap network proxy (schema 0.6.0-alpha)', {
       'bwrap-builtin-proxy',
     );
     config.process!.commandLine =
-      'curl -fsSL https://api.github.com/zen > /dev/null && echo BUILTIN_OK';
+      `curl -fsSL '${NETWORK_TEST_URL}' > /dev/null && echo BUILTIN_OK`;
     config.network = {
       ...(config.network ?? {}),
       defaultPolicy: 'allow',
@@ -154,7 +156,7 @@ describe('Linux Bubblewrap network proxy (schema 0.6.0-alpha)', {
     // prints BLOCKED_OK so we can assert both signals are present.
     config.process!.commandLine =
       'set -e; ' +
-      'curl -fsSL https://api.github.com/zen > /dev/null && echo SENTINEL_OK; ' +
+      `curl -fsSL '${NETWORK_TEST_URL}' > /dev/null && echo SENTINEL_OK; ` +
       'if curl -fsS --max-time 5 https://example.com > /dev/null 2>&1; then ' +
       '  echo SENTINEL_BAD_LEAK; exit 1; ' +
       'else ' +
@@ -164,7 +166,7 @@ describe('Linux Bubblewrap network proxy (schema 0.6.0-alpha)', {
       ...(config.network ?? {}),
       defaultPolicy: 'allow',
       proxy: { builtinTestServer: true },
-      allowedHosts: ['api.github.com'],
+      allowedHosts: ['pkgs.dev.azure.com'],
     };
 
     const result = await spawnFromConfigAsync(config, { ...debugSpawnOptions, experimental: true, allowTestingFeatures: true });


### PR DESCRIPTION
## 📖 Description
The three "Linux Bubblewrap network proxy" integration tests curled https://api.github.com/zen through the proxy tunnel and asserted the command exited 0. GitHub's anonymous REST API is rate-limited to 60 req/hr per source IP; on shared CI NAT egress that quota is routinely exhausted, so the API returns 403. With curl -f that surfaces as exit 22 (CURLE_HTTP_RETURNED_ERROR) and the test fails with "22 !== 0"

Switch all three tests to the shared NETWORK_TEST_URL Azure Artifacts feed already used by the LXC and Seatbelt network suites: reachable on locked-down ADO agents (Azure feeds are allowed) and not rate-limited. Align the allowedHosts test to pkgs.dev.azure.com.

Validated the tests are green with the fix.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/719)