### PR TITLE
Fix VPack CodeSign validation for test bundle

### DIFF
--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -89,6 +89,10 @@ extends:
             ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
             ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
 
+            # MXC Vpack only used for testing purposes.
+            ob_sdl_codeSignValidation_excludes: -|**\*.exe;-|**\*.dll;-|**\*.js
+            ob_symbolsPublishing_enabled: false     
+
           steps:
             - task: PowerShell@2
               displayName: Set vpack version

--- a/.azure-pipelines/templates/Vpack.Package.Job.yml
+++ b/.azure-pipelines/templates/Vpack.Package.Job.yml
@@ -88,10 +88,9 @@ extends:
             ob_createvpack_patchVer: $(SdkPatch)         # set by 'Set vpack version' step
             ob_createvpack_prereleaseVer: $(VersionDate).$(VersionCounter)
             ob_createvpack_metadata: $(Build.SourceBranchName).$(Build.BuildNumber).$(Build.SourceVersion)
-
-            # MXC Vpack only used for testing purposes.
-            ob_sdl_codeSignValidation_excludes: -|**\*.exe;-|**\*.dll;-|**\*.js
-            ob_symbolsPublishing_enabled: false     
+            # IsolationSession collateral is test-only; continue validating the
+            # production x64 and arm64 payloads outside this subtree.
+            ob_sdl_codeSignValidation_excludes: '-|**\isolation_session_test_bundle\**'
 
           steps:
             - task: PowerShell@2
@@ -147,13 +146,13 @@ extends:
                   # per-arch SBOMs are identical source-wise, so promote x64's.
                   Copy-Item -Recurse -Force "$(ob_outputDirectory)\x64\_manifest" "$(ob_outputDirectory)\_manifest"
 
-                  # Stage isolation_session test collateral into the vpack under isolation_session/
+                  # Stage isolation_session test collateral under isolation_session_test_bundle/.
                   $isoSrcMain = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-main-x64"
-                  $isoDestMain = "$(ob_outputDirectory)\isolation_session\main"
+                  $isoDestMain = "$(ob_outputDirectory)\isolation_session_test_bundle\main"
                   New-Item -ItemType Directory -Force -Path $isoDestMain | Out-Null
                   Copy-Item -Recurse -Force "$isoSrcMain\*" $isoDestMain
                   
                   $isoSrcFeature = "$(Pipeline.Workspace)\IsoSession-TestPackage\mxc-iso-test-bundle-feature-x64"
-                  $isoDestFeature = "$(ob_outputDirectory)\isolation_session\feature"
+                  $isoDestFeature = "$(ob_outputDirectory)\isolation_session_test_bundle\feature"
                   New-Item -ItemType Directory -Force -Path $isoDestFeature | Out-Null
                   Copy-Item -Recurse -Force "$isoSrcFeature\*" $isoDestFeature


### PR DESCRIPTION
## 📖 Description

Exclude the test-only IsolationSession bundle from Windows Undocked CodeSign Validation while continuing to validate the production x64 and arm64 payloads. Rename the VPack subtree to make its test-only purpose explicit.

## 🔗 References

## 🔍 Validation
- validation will happen after running vpack pipeline when change checked in.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/720)