### PR TITLE
Document the trust model and the outer-clamp design

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -472,7 +472,7 @@ what the user should do (upgrade OS, enable feature, change the config).
 MXC's authorization model and the platform-dependent external bounds that can
 constrain what a config relaxes.
 
-### Authorization model: one principal, secure-and-loud defaults
+### Authorization model: one principal, secure defaults and diagnostics
 
 For the agent/SDK consumers MXC is built for, the same principal authors **both**
 the config JSON and the command line. There is no second, more-privileged channel
@@ -493,15 +493,19 @@ Given that precondition, safety rests on three in-repo mechanisms:
    is `block`, `ui.disable` is `true`, clipboard/injection off, etc. (see
    [the schema reference](schema.md) for each field's default). A minimal config
    is a tight sandbox.
-2. **Explicit + loud relaxation.** Fields that open a network, UI, capability,
-   or Seatbelt boundary beyond their secure default are logged at parse time as
-   `SECURITY: boundary relaxed: …`, making them auditable in the diagnostic log.
-   Filesystem path grants and the Seatbelt pty baseline are deliberately out of
-   this audit's scope, being the request's primary purpose rather than a
-   relaxation. One known gap is `network.blockedHosts`: Hyperlight and NanVix
-   currently interpret a non-empty blocklist as allow-all-except even when
-   `network.defaultPolicy=block`, while the generic audit assumes blocklists only
-   subtract connectivity and does not log them. The backend fixes are tracked in
+2. **Diagnostic relaxation audit.** Fields that open a network, UI, capability,
+   or Seatbelt boundary beyond their secure default are recorded at parse time as
+   `SECURITY: boundary relaxed: …`. They are immediately visible with `--debug`
+   or a configured diagnostic log sink, and the default CLIs print the buffer on
+   configuration and infrastructure error paths. A successful default non-debug
+   run does not currently print the buffer, so this audit is not yet loud or
+   externally auditable in that mode. Filesystem path grants and the Seatbelt
+   pty baseline are deliberately out of this audit's scope, being the request's
+   primary purpose rather than a relaxation. One known gap is
+   `network.blockedHosts`: Hyperlight and NanVix currently interpret a non-empty
+   blocklist as allow-all-except even when `network.defaultPolicy=block`, while
+   the generic audit assumes blocklists only subtract connectivity and does not
+   log them. The backend fixes are tracked in
    [#786](https://github.com/microsoft/mxc/issues/786) and
    [#787](https://github.com/microsoft/mxc/issues/787).
 3. **Catastrophic capabilities are removed from shipped builds.** A capability
@@ -513,27 +517,29 @@ Given that precondition, safety rests on three in-repo mechanisms:
 
 ### The outer clamp (optional, platform-asymmetric)
 
-The mechanisms above bound what the *config* requests. An **outer clamp** is a
-separate, optional upper bound enforced *below* the config — an unbypassable
-ceiling a host operator can impose so that even a fully-relaxed config cannot
-exceed it. Whether such a clamp can be made truly unbypassable is
-**platform-asymmetric**, because it depends on an OS primitive MXC does not own:
+The mechanisms above initialize safe defaults, record requested relaxations, and
+reject selected catastrophic capabilities; they do not generally cap what the
+config may request. An **outer clamp** would be a separate, optional upper bound
+enforced *below* the config — a ceiling a host operator can impose so that even a
+fully-relaxed config cannot exceed it. Whether such a clamp can be made truly
+unbypassable is **platform-asymmetric**, because it depends on an OS primitive
+MXC does not own:
 
 | Platform | Clamp mechanism | Unbypassable? | Status |
 |---|---|---|---|
-| Windows — BaseContainer tier | OS sandbox broker enforces the policy inside `Experimental_CreateProcessInSandbox` | Yes — the broker is the kernel-side authority | OS-infra (outside this repo) |
-| Windows — AppContainer fallback tiers (BFS / DACL) | AppContainer + `bfscfg.exe` BFS or host-side DACL ACEs; used when the BaseContainer API is absent | Partial — enforcement is partly host-side, not a single kernel broker | Existing backend behavior: BFS is absent from a stock build and requires the non-default `tier2_bfs` feature plus `bfscfg.exe`; the DACL path is the default stock fallback, enabled unless `fallback.allowDaclMutation=false` |
+| Windows — BaseContainer tier | None separate: the OS broker enforces the caller-authored sandbox spec | No independent ceiling | Current behavior; a fully relaxed config is passed to `Experimental_CreateProcessInSandbox` |
+| Windows — AppContainer fallback tiers (BFS / DACL) | None separate: AppContainer, BFS, and DACL ACEs enforce the caller-authored paths | No independent ceiling | Current behavior; BFS is absent from a stock build and requires the non-default `tier2_bfs` feature plus `bfscfg.exe`, while DACL is the default stock fallback unless `fallback.allowDaclMutation=false` |
 | Linux (LXC) | Host LSM (AppArmor / SELinux) profile + root-owned policy file | Yes, with a host LSM; otherwise advisory | OS-infra / host config |
 | Linux (Bubblewrap) | LSM, or compile-time capability removal | Partial — bwrap is unprivileged by design | OS-infra / build |
 | macOS (Seatbelt) | Root-owned policy file + codesign / SIP | Yes, with SIP + signed binary; otherwise advisory | OS-infra (outside this repo) |
-| All platforms | Root/admin-owned **clamp-policy file** read at the trust boundary, capping the boundary relaxations that the parse-time audit logs | No — a trust-boundary gate, bypassable by a local admin, not a kernel guarantee | Deferred (in-repo candidate) |
+| All platforms | Root/admin-owned **clamp-policy file** read at the trust boundary, capping the boundary relaxations the parser accepts | No — a trust-boundary gate, bypassable by a local admin, not a kernel guarantee | Deferred (in-repo candidate) |
 
-The truly unbypassable rows (broker, LSM, SIP) live in OS infrastructure outside
-this repository and are intentionally **out of scope here**. The one piece that
-*could* live in-repo — a root-owned clamp-policy file the parser enforces as a
-ceiling on relaxations — is a meaningful additional gate but is **not a kernel
-guarantee** (a local admin can edit the file), so it is tracked as a follow-up
-rather than shipped as if it were unbypassable. Catastrophic, un-clampable
+The potential unbypassable clamps above (LSM and SIP) live in OS infrastructure
+outside this repository and are intentionally **out of scope here**. The one
+piece that *could* live in-repo — a root-owned clamp-policy file the parser
+enforces as a ceiling on relaxations — is a meaningful additional gate but is
+**not a kernel guarantee** (a local admin can edit the file), so it is tracked as
+a follow-up rather than shipped as if it were unbypassable. Catastrophic
 capabilities are handled instead by compile-time removal (above), which needs no
 OS primitive.
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -469,8 +469,8 @@ what the user should do (upgrade OS, enable feature, change the config).
 
 ## Trust model and the outer clamp
 
-MXC's authorization model and the (optional) unbypassable upper bound on what a
-config can relax.
+MXC's authorization model and the platform-dependent external bounds that can
+constrain what a config relaxes.
 
 ### Authorization model: one principal, secure-and-loud defaults
 
@@ -487,8 +487,7 @@ authorization for boundary-relaxing fields.
 > passing it in. See [the outer clamp](#the-outer-clamp-optional-platform-asymmetric)
 > for the mechanism that would enforce a ceiling independently of the config.
 
-Given that precondition, safety rests on three in-repo mechanisms, all
-implemented:
+Given that precondition, safety rests on three in-repo mechanisms:
 
 1. **Secure defaults.** Every boundary defaults closed: `network.defaultPolicy`
    is `block`, `ui.disable` is `true`, clipboard/injection off, etc. (see
@@ -496,10 +495,15 @@ implemented:
    is a tight sandbox.
 2. **Explicit + loud relaxation.** Fields that open a network, UI, capability,
    or Seatbelt boundary beyond their secure default are logged at parse time as
-   `SECURITY: boundary relaxed: …`, so those relaxations are never silent — they
-   are auditable in the diagnostic log. Filesystem path grants and the Seatbelt
-   pty baseline are deliberately out of this audit's scope, being the request's
-   primary purpose rather than a relaxation.
+   `SECURITY: boundary relaxed: …`, making them auditable in the diagnostic log.
+   Filesystem path grants and the Seatbelt pty baseline are deliberately out of
+   this audit's scope, being the request's primary purpose rather than a
+   relaxation. One known gap is `network.blockedHosts`: Hyperlight and NanVix
+   currently interpret a non-empty blocklist as allow-all-except even when
+   `network.defaultPolicy=block`, while the generic audit assumes blocklists only
+   subtract connectivity and does not log them. The backend fixes are tracked in
+   [#786](https://github.com/microsoft/mxc/issues/786) and
+   [#787](https://github.com/microsoft/mxc/issues/787).
 3. **Catastrophic capabilities are removed from shipped builds.** A capability
    that would defeat the sandbox wholesale rather than merely widen it —
    currently `seatbelt.profileOverride`, which replaces the entire generated
@@ -518,7 +522,7 @@ exceed it. Whether such a clamp can be made truly unbypassable is
 | Platform | Clamp mechanism | Unbypassable? | Status |
 |---|---|---|---|
 | Windows — BaseContainer tier | OS sandbox broker enforces the policy inside `Experimental_CreateProcessInSandbox` | Yes — the broker is the kernel-side authority | OS-infra (outside this repo) |
-| Windows — AppContainer fallback tiers (BFS / DACL) | AppContainer + `bfscfg.exe` BFS or host-side DACL ACEs; used when the BaseContainer API is absent | Partial — enforcement is partly host-side, not a single kernel broker | Existing backend behavior, but **not present in a stock build**: BFS requires the non-default `tier2_bfs` feature plus `bfscfg.exe` on the host, and the DACL path requires explicit config opt-in |
+| Windows — AppContainer fallback tiers (BFS / DACL) | AppContainer + `bfscfg.exe` BFS or host-side DACL ACEs; used when the BaseContainer API is absent | Partial — enforcement is partly host-side, not a single kernel broker | Existing backend behavior: BFS is absent from a stock build and requires the non-default `tier2_bfs` feature plus `bfscfg.exe`; the DACL path is the default stock fallback, enabled unless `fallback.allowDaclMutation=false` |
 | Linux (LXC) | Host LSM (AppArmor / SELinux) profile + root-owned policy file | Yes, with a host LSM; otherwise advisory | OS-infra / host config |
 | Linux (Bubblewrap) | LSM, or compile-time capability removal | Partial — bwrap is unprivileged by design | OS-infra / build |
 | macOS (Seatbelt) | Root-owned policy file + codesign / SIP | Yes, with SIP + signed binary; otherwise advisory | OS-infra (outside this repo) |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -467,6 +467,72 @@ The MXC ↔ OS contract therefore reports: which feature failed, whether it was 
 version mismatch or a runtime/capability unavailability (e.g. Hyper-V off), and
 what the user should do (upgrade OS, enable feature, change the config).
 
+## Trust model and the outer clamp
+
+MXC's authorization model and the (optional) unbypassable upper bound on what a
+config can relax.
+
+### Authorization model: one principal, secure-and-loud defaults
+
+For the agent/SDK consumers MXC is built for, the same principal authors **both**
+the config JSON and the command line. There is no second, more-privileged channel
+to grant capabilities from, so MXC does **not** require a mandatory second-channel
+authorization for boundary-relaxing fields.
+
+> **Precondition.** This holds only where the invoker and the config author are
+> the same trust principal. MXC does not enforce that. An embedder that runs
+> `wxc-exec` with a config derived from lower-trust input (an end user, a remote
+> service, model output) has two principals, and the model above does not apply
+> to it — such an embedder must validate or constrain the config itself before
+> passing it in. See [the outer clamp](#the-outer-clamp-optional-platform-asymmetric)
+> for the mechanism that would enforce a ceiling independently of the config.
+
+Given that precondition, safety rests on three in-repo mechanisms, all
+implemented:
+
+1. **Secure defaults.** Every boundary defaults closed: `network.defaultPolicy`
+   is `block`, `ui.disable` is `true`, clipboard/injection off, etc. (see
+   [the schema reference](schema.md) for each field's default). A minimal config
+   is a tight sandbox.
+2. **Explicit + loud relaxation.** Fields that open a network, UI, capability,
+   or Seatbelt boundary beyond their secure default are logged at parse time as
+   `SECURITY: boundary relaxed: …`, so those relaxations are never silent — they
+   are auditable in the diagnostic log. Filesystem path grants and the Seatbelt
+   pty baseline are deliberately out of this audit's scope, being the request's
+   primary purpose rather than a relaxation.
+3. **Catastrophic capabilities are removed from shipped builds.** A capability
+   that would defeat the sandbox wholesale rather than merely widen it —
+   currently `seatbelt.profileOverride`, which replaces the entire generated
+   deny-default profile — is **rejected by release/shipped binaries** (the parser
+   returns a config error, and the builder branch is compiled out), so it cannot
+   be honored in production at all.
+
+### The outer clamp (optional, platform-asymmetric)
+
+The mechanisms above bound what the *config* requests. An **outer clamp** is a
+separate, optional upper bound enforced *below* the config — an unbypassable
+ceiling a host operator can impose so that even a fully-relaxed config cannot
+exceed it. Whether such a clamp can be made truly unbypassable is
+**platform-asymmetric**, because it depends on an OS primitive MXC does not own:
+
+| Platform | Clamp mechanism | Unbypassable? | Status |
+|---|---|---|---|
+| Windows — BaseContainer tier | OS sandbox broker enforces the policy inside `Experimental_CreateProcessInSandbox` | Yes — the broker is the kernel-side authority | OS-infra (outside this repo) |
+| Windows — AppContainer fallback tiers (BFS / DACL) | AppContainer + `bfscfg.exe` BFS or host-side DACL ACEs; used when the BaseContainer API is absent | Partial — enforcement is partly host-side, not a single kernel broker | Existing backend behavior, but **not present in a stock build**: BFS requires the non-default `tier2_bfs` feature plus `bfscfg.exe` on the host, and the DACL path requires explicit config opt-in |
+| Linux (LXC) | Host LSM (AppArmor / SELinux) profile + root-owned policy file | Yes, with a host LSM; otherwise advisory | OS-infra / host config |
+| Linux (Bubblewrap) | LSM, or compile-time capability removal | Partial — bwrap is unprivileged by design | OS-infra / build |
+| macOS (Seatbelt) | Root-owned policy file + codesign / SIP | Yes, with SIP + signed binary; otherwise advisory | OS-infra (outside this repo) |
+| All platforms | Root/admin-owned **clamp-policy file** read at the trust boundary, capping the boundary relaxations that the parse-time audit logs | No — a trust-boundary gate, bypassable by a local admin, not a kernel guarantee | Deferred (in-repo candidate) |
+
+The truly unbypassable rows (broker, LSM, SIP) live in OS infrastructure outside
+this repository and are intentionally **out of scope here**. The one piece that
+*could* live in-repo — a root-owned clamp-policy file the parser enforces as a
+ceiling on relaxations — is a meaningful additional gate but is **not a kernel
+guarantee** (a local admin can edit the file), so it is tracked as a follow-up
+rather than shipped as if it were unbypassable. Catastrophic, un-clampable
+capabilities are handled instead by compile-time removal (above), which needs no
+OS primitive.
+
 ## Experimental Features — Clarifications
 
 **Shipping model:** The shipped schema contains **only** non-experimental 


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

This PR documents MXC's authorization model and the platform-dependent external bounds that can constrain it. It is documentation only: genuinely unbypassable clamps require OS or host infrastructure outside this repository, so the document states the current guarantees and gaps without implying an in-repo enforcement boundary that does not exist.

## Details

* Describe the one-principal model and its precondition: the invoker and config author must be the same trust principal; embedders accepting lower-trust config input must impose their own constraints.
* Distinguish secure defaults, buffered relaxation diagnostics, and targeted catastrophic-capability rejection from a general authority ceiling. Diagnostic entries are visible with `--debug`, a configured sink, or relevant error paths, but not after a successful default non-debug CLI run.
* Classify the Windows execution tiers as enforcing the caller-authored policy rather than supplying an independent clamp. BFS is absent from stock builds; DACL mutation is the default fallback unless `fallback.allowDaclMutation=false`.
* Record the Hyperlight and NanVix `blockedHosts` audit/enforcement gaps and the corresponding follow-up issues.
* Survey the external Windows broker, Linux LSM/root policy, macOS SIP/root policy, and a possible in-repo clamp-policy file, clearly separating OS guarantees from deferred repository work.

## Tests

* `git diff --check`

## Related Issues

- #786
- #787

## Stack

Merge bottom-up; this document depends on the mechanisms introduced by the earlier PRs.

1. #726 — boundary-relaxation diagnostics
2. #727 — reject `seatbelt.profileOverride` in shipped builds
3. **This PR** — document the trust model and outer-clamp design
