### PR TITLE
Fix cross-compile on Windows hosts

### DIFF
--- a/src/core/mxc_build_common/src/lib.rs
+++ b/src/core/mxc_build_common/src/lib.rs
@@ -13,9 +13,10 @@ use std::process::Command;
 
 /// Embed Windows VersionInfo resource metadata into the binary being compiled.
 ///
-/// On non-Windows targets this is a no-op.  The `ProductVersion` field is set
-/// to `<cargo-pkg-version>+<short-git-hash>` so that every build encodes the
-/// exact source commit.
+/// On non-Windows hosts and when building non-Windows targets on a Windows host
+/// this is a no-op.
+/// The `ProductVersion` field is set to `<cargo-pkg-version>+<short-git-hash>`
+/// so that every build encodes the exact source commit.
 pub fn embed_version_info(file_description: &str, original_filename: &str) {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=Cargo.toml");
@@ -24,7 +25,11 @@ pub fn embed_version_info(file_description: &str, original_filename: &str) {
     track_git_head();
 
     #[cfg(windows)]
-    embed_version_info_windows(file_description, original_filename);
+    {
+        if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("windows") {
+            embed_version_info_windows(file_description, original_filename);
+        }
+    }
 
     // Suppress unused-variable warnings on non-Windows.
     #[cfg(not(windows))]


### PR DESCRIPTION
This change updates the embed_version_info function to correctly handle cross-compilation on Windows hosts. When building macOS or Linux targets on a Windows host, the function becomes a no-op.

* Details
    - When running on a Windows Host check that the target OS is also Windows before embedding version info.

* Tests
    - cargo check -p lxc --target x86_64-unknown-linux-gnu
    - cargo check -p mxc_darwin --target aarch64-apple-darwin
    - build.bat --all

Addresses Issue #735
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/736)