### PR TITLE
test: 1ES runner connectivity smoke (do not merge)

### DIFF
--- a/.github/workflows/1es-smoke.yml
+++ b/.github/workflows/1es-smoke.yml
@@ -1,0 +1,57 @@
+# ============================================================================
+# 1ES connectivity smoke test — proves microsoft/mxc can dispatch a job to the
+# 1ES Hosted GitHub Runner pool and that runner group 145 grants this repo.
+#
+# THROWAWAY / PROOF workflow. Not part of the real CI matrix (Build.yml).
+# Nested-virt/WHP checks intentionally omitted — this ONLY verifies pickup.
+#
+# Pool values from the created pool:
+#   1ES.Pool          = 1es-mxc-e2e-windows-25h2-pro-x64
+#   1ES.ImageOverride = windows-25h2-pro-x64
+# ============================================================================
+name: 1ES Connectivity Smoke
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: 1ES pickup
+    runs-on:
+      - self-hosted
+      - "1ES.Pool=1es-mxc-e2e-windows-25h2-pro-x64"
+      - "1ES.ImageOverride=windows-25h2-pro-x64"
+    timeout-minutes: 15
+
+    steps:
+      - name: Hello from the 1ES runner
+        shell: pwsh
+        run: |
+          Write-Host "=== Job picked up on the 1ES pool ==="
+          Write-Host "Hostname   : $(hostname)"
+          Write-Host "User       : $(whoami)"
+          Write-Host "OS         : $([System.Environment]::OSVersion.VersionString)"
+          Write-Host "RUNNER_NAME: $env:RUNNER_NAME"
+          Write-Host "Cores      : $env:NUMBER_OF_PROCESSORS"
+
+      - name: Confirm this is the expected Azure pool VM (IMDS)
+        shell: pwsh
+        run: |
+          try {
+            $c = (Invoke-RestMethod -Headers @{Metadata="true"} -NoProxy `
+              -Uri "http://169.254.169.254/metadata/instance?api-version=2021-02-01").compute
+            Write-Host "vmSize   : $($c.vmSize)"
+            Write-Host "location : $($c.location)"
+            Write-Host "vmId     : $($c.vmId)"
+            if ($env:GITHUB_STEP_SUMMARY) {
+              "## 1ES runner picked up`n- **vmSize**: $($c.vmSize)`n- **location**: $($c.location)`n- **host**: $(hostname)" |
+                Add-Content -Path $env:GITHUB_STEP_SUMMARY
+            }
+          } catch {
+            Write-Host "::warning::IMDS unreachable: $($_.Exception.Message)"
+          }


### PR DESCRIPTION
## Summary
Throwaway proof workflow to verify **microsoft/mxc can dispatch a job to the 1ES Hosted GitHub Runner pool** `1es-mxc-e2e-windows-25h2-pro-x64` (org-level bind to `microsoft`, runner group 145).

Pickup-only — nested-virt/WHP checks intentionally omitted. If the `1ES pickup` job runs, the org↔pool wiring and runner-group grant for this repo are confirmed. If it stays queued, runner group 145 does not grant mxc.

Do not merge — this is an E2E connectivity test.

- [x] This pull request is related to 1ES runner onboarding for MXC.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/737)