### PR TITLE
[WSLC] State-aware lifecycle (PR 1/3): persistent daemon + named-pipe IPC control plane

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -52,6 +52,7 @@ jobs:
             winhttp-proxy-shim.exe
             wxc-windows-sandbox-daemon.exe
             wxc-windows-sandbox-guest.exe
+            wxc-wslc-daemon.exe
             wxc-test-proxy.exe
             mxc-diagnostic-console.exe
 

--- a/.github/workflows/Build.Windows.Job.yml
+++ b/.github/workflows/Build.Windows.Job.yml
@@ -81,6 +81,7 @@ jobs:
             src/target/${{ matrix.target }}/release/winhttp-proxy-shim.exe
             src/target/${{ matrix.target }}/release/wxc-windows-sandbox-daemon.exe
             src/target/${{ matrix.target }}/release/wxc-windows-sandbox-guest.exe
+            src/target/${{ matrix.target }}/release/wxc-wslc-daemon.exe
             src/target/${{ matrix.target }}/release/wxc-test-proxy.exe
             src/target/${{ matrix.target }}/release/mxc-diagnostic-console.exe
             src/target/${{ matrix.target }}/release/wslcsdk.dll

--- a/build.bat
+++ b/build.bat
@@ -140,6 +140,10 @@ for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
             )
         )
         if "%WITH_WSLC%"=="1" (
+            if exist "!BIN_DIR!\wxc-wslc-daemon.exe" (
+                copy /Y "!BIN_DIR!\wxc-wslc-daemon.exe" "sdk\node\bin\!SDK_ARCH!\" >nul
+                echo   Copied !SDK_ARCH!\wxc-wslc-daemon.exe
+            )
             if exist "!BIN_DIR!\wslcsdk.dll" (
                 copy /Y "!BIN_DIR!\wslcsdk.dll" "sdk\node\bin\!SDK_ARCH!\" >nul
                 echo   Copied !SDK_ARCH!\wslcsdk.dll

--- a/sdk/node/tests/integration/test-helpers.ts
+++ b/sdk/node/tests/integration/test-helpers.ts
@@ -68,7 +68,8 @@ export const EXPECTED_MACOS_BINARIES = [
 // Binaries that are optional (feature-gated or only present in certain builds)
 // but still legitimate if found in the package.
 const OPTIONAL_BINARIES = [
-  'wslcsdk.dll',   // Only built with --with-wslc
+  'wslcsdk.dll',          // Only built with --with-wslc
+  'wxc-wslc-daemon.exe',  // Only built with --with-wslc
   'plm.exe',       // Permissive Learning Mode helper (Windows-only); staged
                    // only when the plm crate is included in the build.
 ];

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -3105,10 +3105,14 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 name = "wslc_common"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "libloading",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "tar",
  "tempfile",
+ "uuid",
  "windows",
  "wxc_common",
  "zip",
@@ -3249,6 +3253,22 @@ dependencies = [
  "mxc_build_common",
  "windows",
  "windows-core",
+ "wxc_common",
+]
+
+[[package]]
+name = "wxc_wslc_daemon"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "mxc_build_common",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+ "windows",
+ "wslc_common",
  "wxc_common",
 ]
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "backends/lxc/common",
     "backends/bubblewrap/common",
     "backends/wslc/common",
+    "backends/wslc/daemon",
     "backends/seatbelt/common",
     "host/wxc_host_prep",
     "host/wxc_winhttp_proxy_shim",

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -62,6 +62,23 @@ pub(crate) fn sdk_error(context: &str, hr: HRESULT, sdk_msg: &str) -> ScriptResp
     ScriptResponse::error(&msg)
 }
 
+/// NUL-terminate `value` for a C string the WSLc SDK will read, rejecting an
+/// interior NUL instead of letting the SDK silently observe a truncated value.
+///
+/// The daemon protocol accepts arbitrary JSON strings, so a command, env entry,
+/// image, or container path can contain `\u{0}`. Rust keeps such a string whole,
+/// but the SDK stops at the first NUL — so validation/logging and execution
+/// would disagree about what actually ran. Reject at the marshalling boundary.
+fn cstr_bytes(field: &str, value: &str) -> Result<Vec<u8>, ScriptResponse> {
+    std::ffi::CString::new(value)
+        .map(|c| c.into_bytes_with_nul())
+        .map_err(|_| {
+            ScriptResponse::error(&format!(
+                "{field} contains an interior NUL byte, which is not a valid C string"
+            ))
+        })
+}
+
 // ---------------------------------------------------------------------------
 // Process I/O capture plumbing
 // ---------------------------------------------------------------------------
@@ -323,7 +340,7 @@ impl ProcessSettings {
         // script heaps; all are owned by the returned struct.
         let sh = b"/bin/sh\0".to_vec();
         let dash_c = b"-c\0".to_vec();
-        let script_cstr = format!("{}\0", script_code).into_bytes();
+        let script_cstr = cstr_bytes("command", script_code)?;
         let argv: Vec<PCSTR> = vec![
             sh.as_ptr() as PCSTR,
             dash_c.as_ptr() as PCSTR,
@@ -341,8 +358,8 @@ impl ProcessSettings {
         if !env.is_empty() {
             env_cstrings = env
                 .iter()
-                .map(|e| format!("{}\0", e).into_bytes())
-                .collect();
+                .map(|e| cstr_bytes("environment variable", e))
+                .collect::<Result<Vec<_>, _>>()?;
             env_ptrs = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
             let hr =
                 sdk.WslcSetProcessSettingsEnvVariables(&mut raw, env_ptrs.as_ptr(), env_ptrs.len());
@@ -365,7 +382,7 @@ impl ProcessSettings {
                     "working_directory must be an absolute in-container path (got {working_directory:?})"
                 )));
             }
-            let c = format!("{}\0", working_directory).into_bytes();
+            let c = cstr_bytes("working_directory", working_directory)?;
             let hr = sdk.WslcSetProcessSettingsWorkingDirectory(&mut raw, c.as_ptr() as PCSTR);
             if hr != S_OK {
                 return Err(sdk_error(
@@ -452,7 +469,7 @@ impl ContainerSettings {
         flags: WslcContainerFlags,
         logger: &mut Logger,
     ) -> Result<Self, ScriptResponse> {
-        let image_cstr = format!("{}\0", image).into_bytes();
+        let image_cstr = cstr_bytes("image", image)?;
         let mut raw = std::mem::zeroed::<WslcContainerSettings>();
         let hr = sdk.WslcInitContainerSettings(image_cstr.as_ptr() as PCSTR, &mut raw);
         if hr != S_OK {
@@ -503,10 +520,10 @@ impl ContainerSettings {
             .iter()
             .map(|m| {
                 let win: Vec<u16> = to_wide(&m.windows_path);
-                let ctr: Vec<u8> = format!("{}\0", m.container_path).into_bytes();
-                (win, ctr)
+                let ctr: Vec<u8> = cstr_bytes("mount container_path", &m.container_path)?;
+                Ok((win, ctr))
             })
-            .collect();
+            .collect::<Result<Vec<_>, ScriptResponse>>()?;
 
         let mut volumes: Vec<WslcContainerVolume> = Vec::new();
         if !mounts.is_empty() {
@@ -1063,4 +1080,33 @@ pub unsafe fn delete_daemon_container(
     }
     let _ = writeln!(logger, "[WSLC][daemon] Container deleted");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cstr_bytes_nul_terminates_a_plain_value() {
+        let bytes = cstr_bytes("command", "echo hi").expect("plain value is a valid C string");
+        assert_eq!(bytes, b"echo hi\0");
+    }
+
+    #[test]
+    fn cstr_bytes_accepts_empty() {
+        let bytes = cstr_bytes("working_directory", "").expect("empty value is a valid C string");
+        assert_eq!(bytes, b"\0");
+    }
+
+    #[test]
+    fn cstr_bytes_rejects_interior_nul() {
+        let err = cstr_bytes("command", "echo\0rm -rf /")
+            .expect_err("an interior NUL must be rejected, not silently truncated");
+        let msg = format!("{:?}", err);
+        assert!(msg.contains("command"), "error names the field: {msg}");
+        assert!(
+            msg.contains("interior NUL"),
+            "error explains the cause: {msg}"
+        );
+    }
 }

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -140,6 +140,11 @@ unsafe extern "C" fn exit_callback(_exit_code: i32, context: *mut c_void) {
 pub struct ProcessSettings {
     raw: WslcProcessSettings,
     io_ctx: Arc<IoContext>,
+    // Reclaims the SDK's `IoContext` reference if settings build or process
+    // creation fails before a live process adopts it. Disarmed by
+    // `mark_process_created` once a process is created, after which
+    // `exit_callback` (or a deliberate leak on kill) owns reclamation.
+    sdk_io_ref: SdkIoRef,
     _sh: Vec<u8>,
     _dash_c: Vec<u8>,
     _script_cstr: Vec<u8>,
@@ -147,6 +152,38 @@ pub struct ProcessSettings {
     _env_cstrings: Vec<Vec<u8>>,
     _env_ptrs: Vec<PCSTR>,
     _cwd_cstr: Option<Vec<u8>>,
+}
+
+/// Owns an `Arc<IoContext>` reference handed to the SDK and reclaims it on drop
+/// unless disarmed. Used both as a local guard while building settings and as
+/// the stored owner inside [`ProcessSettings`], so any error path before a live
+/// process adopts the reference frees it instead of leaking.
+struct SdkIoRef(Option<*const IoContext>);
+
+impl SdkIoRef {
+    fn none() -> Self {
+        Self(None)
+    }
+
+    /// Disarm reclamation, returning the raw pointer (dropped on the floor by the
+    /// caller so ownership passes to `exit_callback`).
+    fn disarm(&mut self) -> Option<*const IoContext> {
+        self.0.take()
+    }
+}
+
+impl Drop for SdkIoRef {
+    fn drop(&mut self) {
+        if let Some(p) = self.0.take() {
+            // SAFETY: `p` came from `Arc::into_raw`. This runs only when no live
+            // process ever adopted the SDK reference (settings build or process /
+            // container creation failed), so the SDK will never invoke
+            // `exit_callback` for it and reclaiming here is sound.
+            unsafe {
+                drop(Arc::from_raw(p));
+            }
+        }
+    }
 }
 
 impl ProcessSettings {
@@ -206,6 +243,9 @@ impl ProcessSettings {
         // SDK's reference is reclaimed inside `exit_callback`, so a process that
         // is killed without its exit callback firing deliberately leaks the
         // reference rather than freeing it while the SDK may still call back.
+        // Until a process actually adopts the reference, `sdk_io_ref` guards it
+        // so any early return below frees it instead of leaking.
+        let mut sdk_io_ref = SdkIoRef::none();
         if register_callbacks {
             let io_ctx_raw = Arc::into_raw(Arc::clone(&io_ctx)) as *mut c_void;
             let callbacks = WslcProcessCallbacks {
@@ -219,6 +259,7 @@ impl ProcessSettings {
                 drop(Arc::from_raw(io_ctx_raw as *const IoContext));
                 return Err(sdk_error("WslcSetProcessSettingsCallbacks failed", hr, ""));
             }
+            sdk_io_ref = SdkIoRef(Some(io_ctx_raw as *const IoContext));
         }
 
         // Command line: /bin/sh -c <script>. argv points into the sh/dash_c/
@@ -279,6 +320,7 @@ impl ProcessSettings {
         Ok(ProcessSettings {
             raw,
             io_ctx,
+            sdk_io_ref,
             _sh: sh,
             _dash_c: dash_c,
             _script_cstr: script_cstr,
@@ -287,6 +329,21 @@ impl ProcessSettings {
             _env_ptrs: env_ptrs,
             _cwd_cstr: cwd_cstr,
         })
+    }
+
+    /// Transfer ownership of the SDK's `IoContext` reference to the newly-created
+    /// process. After this, `Drop` will not reclaim it — `exit_callback` (or a
+    /// deliberate leak on kill) owns reclamation, preserving the invariant that
+    /// the reference is never freed while the SDK may still call back.
+    ///
+    /// # Safety
+    /// Call exactly once, immediately after a process has been successfully
+    /// created from these settings (`WslcCreateContainerProcess`, or
+    /// `WslcCreateContainer` + `WslcStartContainer` when used as a container
+    /// init). Skipping this after a successful create would let `Drop` free a
+    /// reference the SDK still owns.
+    pub unsafe fn mark_process_created(&mut self) {
+        let _ = self.sdk_io_ref.disarm();
     }
 
     /// The I/O-capture context shared with the SDK callbacks.
@@ -746,6 +803,9 @@ pub unsafe fn exec_in_container(
         return Err(sdk_error("WslcCreateContainerProcess failed", hr, &msg));
     }
     let process_guard = WslcProcessGuard::from_raw(process, sdk.release_process_fn());
+    // The process now owns the SDK's IoContext reference; `exit_callback` will
+    // reclaim it. Disarm the settings guard so it is not freed underneath the SDK.
+    process_settings.mark_process_created();
 
     let mut exit_event: HANDLE = ptr::null_mut();
     let hr = sdk.WslcGetProcessExitEvent(process_guard.as_raw(), &mut exit_event);
@@ -768,7 +828,14 @@ pub unsafe fn exec_in_container(
                 wait_ms
             );
             // Kill only this process; the keepalive init keeps the container up.
-            let _ = sdk.WslcSignalProcess(process_guard.as_raw(), WslcSignal::WSLC_SIGNAL_SIGKILL);
+            let kill_hr =
+                sdk.WslcSignalProcess(process_guard.as_raw(), WslcSignal::WSLC_SIGNAL_SIGKILL);
+            if kill_hr != S_OK {
+                let _ = writeln!(
+                    logger,
+                    "[WSLC][daemon] Warning: WslcSignalProcess(SIGKILL) failed (hr={kill_hr:?}); process may still be running"
+                );
+            }
         }
     }
 

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -75,36 +75,14 @@ pub struct IoContext {
     pub(crate) exited: Arc<(Mutex<bool>, Condvar)>,
 }
 
-/// RAII guard that reclaims an `Arc<IoContext>` from a raw pointer on drop.
-/// Prevents leaking the `Arc` reference count on early returns.
-pub(crate) struct IoCtxRawGuard {
-    ptr: *mut c_void,
-}
-
-impl IoCtxRawGuard {
-    fn new(ptr: *mut c_void) -> Self {
-        Self { ptr }
-    }
-}
-
-impl Drop for IoCtxRawGuard {
-    fn drop(&mut self) {
-        if !self.ptr.is_null() {
-            unsafe {
-                eprintln!("[WSLC][debug] IoCtxRawGuard dropped -- reclaiming Arc<IoContext>");
-                let _ = Arc::from_raw(self.ptr as *const IoContext);
-            }
-        }
-    }
-}
-
 /// Callback invoked by the WSLc SDK for stdout/stderr data.
 ///
 /// # Safety
 /// `context` must be a valid pointer obtained from `Arc::into_raw(Arc<IoContext>)`.
-/// The `Arc` is kept alive by the owning [`ProcessSettings`] (via [`IoCtxRawGuard`],
-/// which reclaims it on drop), so the pointer remains valid for the duration of
-/// all callbacks. The SDK guarantees `data` is valid for `data_size` bytes.
+/// The `Arc` reference handed to the SDK is released inside [`exit_callback`]; the
+/// SDK guarantees no I/O callback fires after exit, and the owning
+/// [`ProcessSettings`] holds an independent reference, so the pointer stays valid
+/// for every callback. The SDK guarantees `data` is valid for `data_size` bytes.
 unsafe extern "C" fn io_callback(
     io_handle: WslcProcessIOHandle,
     data: *const BYTE,
@@ -131,15 +109,21 @@ unsafe extern "C" fn io_callback(
 
 /// Callback invoked when the process exits and all I/O has been flushed.
 /// Per SDK docs: "Once this callback is invoked, any registered IO callbacks
-/// will no longer be called." This guarantees buffers are complete.
+/// will no longer be called." This guarantees buffers are complete and that the
+/// SDK will not touch `context` again, so this reclaims the `Arc` reference the
+/// SDK was handed.
 ///
 /// # Safety
-/// Same lifetime requirements as [`io_callback`].
+/// `context` must be the pointer handed to `WslcSetProcessSettingsCallbacks`,
+/// obtained from `Arc::into_raw(Arc<IoContext>)`, and must be invoked at most
+/// once.
 unsafe extern "C" fn exit_callback(_exit_code: i32, context: *mut c_void) {
     if context.is_null() {
         return;
     }
-    let ctx = &*(context as *const IoContext);
+    // Reclaim the SDK's reference. The owning `ProcessSettings` holds its own
+    // reference, so the `IoContext` stays alive for the waiting thread.
+    let ctx = Arc::from_raw(context as *const IoContext);
     let mut exited = ctx.exited.0.lock().unwrap_or_else(|e| e.into_inner());
     *exited = true;
     ctx.exited.1.notify_all();
@@ -156,7 +140,6 @@ unsafe extern "C" fn exit_callback(_exit_code: i32, context: *mut c_void) {
 pub struct ProcessSettings {
     raw: WslcProcessSettings,
     io_ctx: Arc<IoContext>,
-    _io_guard: IoCtxRawGuard,
     _sh: Vec<u8>,
     _dash_c: Vec<u8>,
     _script_cstr: Vec<u8>,
@@ -212,21 +195,19 @@ impl ProcessSettings {
             return Err(sdk_error("WslcInitProcessSettings failed", hr, ""));
         }
 
-        // Register I/O callbacks to capture stdout/stderr. We hand the SDK an
-        // Arc reference via raw pointer; IoCtxRawGuard reconstructs it on drop
-        // so the reference count is not leaked, and the memory stays alive while
-        // the SDK may still invoke callbacks on its internal threads.
         let io_ctx = Arc::new(IoContext {
             stdout: Arc::new(Mutex::new(Vec::new())),
             stderr: Arc::new(Mutex::new(Vec::new())),
             exited: Arc::new((Mutex::new(false), Condvar::new())),
         });
-        let io_ctx_raw = Arc::into_raw(Arc::clone(&io_ctx)) as *mut c_void;
-        let io_guard = IoCtxRawGuard::new(io_ctx_raw);
 
         // Callbacks are registered only for the streamed path; a detached init
-        // shares no IoContext with the SDK.
+        // shares no IoContext with the SDK and mints no extra reference. The
+        // SDK's reference is reclaimed inside `exit_callback`, so a process that
+        // is killed without its exit callback firing deliberately leaks the
+        // reference rather than freeing it while the SDK may still call back.
         if register_callbacks {
+            let io_ctx_raw = Arc::into_raw(Arc::clone(&io_ctx)) as *mut c_void;
             let callbacks = WslcProcessCallbacks {
                 onStdOut: Some(io_callback),
                 onStdErr: Some(io_callback),
@@ -234,6 +215,8 @@ impl ProcessSettings {
             };
             let hr = sdk.WslcSetProcessSettingsCallbacks(&mut raw, &callbacks, io_ctx_raw);
             if hr != S_OK {
+                // The SDK never took ownership; reclaim the reference now.
+                drop(Arc::from_raw(io_ctx_raw as *const IoContext));
                 return Err(sdk_error("WslcSetProcessSettingsCallbacks failed", hr, ""));
             }
         }
@@ -296,7 +279,6 @@ impl ProcessSettings {
         Ok(ProcessSettings {
             raw,
             io_ctx,
-            _io_guard: io_guard,
             _sh: sh,
             _dash_c: dash_c,
             _script_cstr: script_cstr,

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -43,7 +43,7 @@ use wxc_common::logger::Logger;
 use wxc_common::models::{PortMapping, ScriptResponse};
 use wxc_common::string_util::{to_wide, CoTaskMemPWSTR};
 
-use crate::policy_mapping::{self, VolumeMount};
+use crate::policy_mapping::VolumeMount;
 use crate::wsl_container_runner::{wslc_prerequisite_error, WSLContainerRunner};
 use crate::wslc_bindings::*;
 
@@ -65,6 +65,32 @@ pub(crate) fn sdk_error(context: &str, hr: HRESULT, sdk_msg: &str) -> ScriptResp
 // ---------------------------------------------------------------------------
 // Process I/O capture plumbing
 // ---------------------------------------------------------------------------
+//
+// # IoContext reference lifecycle (why a kill deliberately leaks)
+//
+// The SDK's stdout/stderr/exit callbacks each receive a raw `*IoContext`. We
+// hand the SDK one `Arc<IoContext>` reference (`Arc::into_raw`) and keep an
+// independent `Arc` inside `ProcessSettings`, so the context outlives every
+// callback. Reclaiming the SDK's reference safely hinges on exactly one rule:
+// **it is freed only from `exit_callback`, and the SDK guarantees no callback
+// fires after exit.** That yields three reachable end-states:
+//
+//   build settings ──fail before create──▶ SdkIoRef::drop frees the ref
+//        │                                  (no process exists to call back)
+//        ▼
+//   process created ──▶ mark_process_created() disarms SdkIoRef
+//        │
+//        ├── process exits ──▶ exit_callback fires ──▶ frees the SDK ref
+//        │
+//        └── process killed, exit_callback never fires ──▶ ref is LEAKED
+//            on purpose: freeing it while the SDK might still call back would
+//            be use-after-free. A confirmed-unkillable container is quarantined
+//            (see `exec_in_container` / session_manager), bounding the leak to
+//            that one compromised sandbox.
+//
+// So `SdkIoRef` guards the pre-adoption window (frees on early failure), and
+// after adoption ownership passes to `exit_callback`; the kill path trades a
+// bounded, one-time leak for memory safety.
 
 /// Shared buffer for capturing process I/O via SDK callbacks. Fields are
 /// `pub(crate)` so the one-shot runner's wait/collect helpers can read the
@@ -73,6 +99,33 @@ pub struct IoContext {
     pub(crate) stdout: Arc<Mutex<Vec<u8>>>,
     pub(crate) stderr: Arc<Mutex<Vec<u8>>>,
     pub(crate) exited: Arc<(Mutex<bool>, Condvar)>,
+}
+
+/// Per-stream cap on captured stdout/stderr, in bytes. The WSLc SDK streams
+/// output from untrusted in-container code straight into these buffers; without
+/// a ceiling one exec could grow them without bound and OOM the persistent
+/// daemon, taking down every sandbox it owns. When a stream reaches the cap the
+/// tail is dropped and a one-time truncation marker is appended.
+const MAX_CAPTURED_STREAM_BYTES: usize = 8 * 1024 * 1024;
+
+/// Appended once to a captured stream when it first hits the cap, so a consumer
+/// can tell the output was truncated rather than genuinely ending there.
+const STREAM_TRUNCATION_MARKER: &[u8] = b"\n[output truncated: stream exceeded capture cap]\n";
+
+/// Append `bytes` to a captured stream buffer, enforcing
+/// [`MAX_CAPTURED_STREAM_BYTES`]. Once the cap is reached the buffer stops
+/// growing; the marker is appended exactly once, on the call that crosses it.
+fn append_capped(buf: &mut Vec<u8>, bytes: &[u8]) {
+    if buf.len() >= MAX_CAPTURED_STREAM_BYTES {
+        return;
+    }
+    let remaining = MAX_CAPTURED_STREAM_BYTES - buf.len();
+    if bytes.len() <= remaining {
+        buf.extend_from_slice(bytes);
+    } else {
+        buf.extend_from_slice(&bytes[..remaining]);
+        buf.extend_from_slice(STREAM_TRUNCATION_MARKER);
+    }
 }
 
 /// Callback invoked by the WSLc SDK for stdout/stderr data.
@@ -97,11 +150,11 @@ unsafe extern "C" fn io_callback(
     match io_handle {
         WslcProcessIOHandle::WSLC_PROCESS_IO_HANDLE_STDOUT => {
             let mut buf = ctx.stdout.lock().unwrap_or_else(|e| e.into_inner());
-            buf.extend_from_slice(bytes);
+            append_capped(&mut buf, bytes);
         }
         WslcProcessIOHandle::WSLC_PROCESS_IO_HANDLE_STDERR => {
             let mut buf = ctx.stderr.lock().unwrap_or_else(|e| e.into_inner());
-            buf.extend_from_slice(bytes);
+            append_capped(&mut buf, bytes);
         }
         _ => {}
     }
@@ -145,6 +198,10 @@ pub struct ProcessSettings {
     // `mark_process_created` once a process is created, after which
     // `exit_callback` (or a deliberate leak on kill) owns reclamation.
     sdk_io_ref: SdkIoRef,
+    // Backing buffers the SDK stored raw pointers into (it does not copy them)
+    // and dereferences at `WslcCreateContainerProcess` time. They must outlive
+    // the create call, so the struct owns them; the `_` prefix marks them as
+    // held purely to anchor those lifetimes, never read directly.
     _sh: Vec<u8>,
     _dash_c: Vec<u8>,
     _script_cstr: Vec<u8>,
@@ -189,7 +246,7 @@ impl Drop for SdkIoRef {
 impl ProcessSettings {
     /// Build process settings that run `script_code` under `/bin/sh -c`, with
     /// the given `env` (already proxy-adjusted by the caller) and
-    /// `working_directory` (a Windows path mapped to its container path; empty =
+    /// `working_directory` (an absolute in-container path, e.g. `/work`; empty =
     /// container default). Registers stdout/stderr/exit capture callbacks.
     ///
     /// # Safety
@@ -298,23 +355,26 @@ impl ProcessSettings {
             }
         }
 
-        // Working directory (mapped Windows -> container path; skip if unmapped).
+        // Working directory (an absolute in-container path, e.g. `/work`; empty =
+        // container default). It is passed straight to the SDK; a non-absolute
+        // value is rejected rather than silently ignored.
         let mut cwd_cstr: Option<Vec<u8>> = None;
         if !working_directory.is_empty() {
-            if let Some(container_cwd) =
-                policy_mapping::windows_path_to_container_path(working_directory)
-            {
-                let c = format!("{}\0", container_cwd).into_bytes();
-                let hr = sdk.WslcSetProcessSettingsWorkingDirectory(&mut raw, c.as_ptr() as PCSTR);
-                if hr != S_OK {
-                    return Err(sdk_error(
-                        "WslcSetProcessSettingsWorkingDirectory failed",
-                        hr,
-                        "",
-                    ));
-                }
-                cwd_cstr = Some(c);
+            if !working_directory.starts_with('/') {
+                return Err(ScriptResponse::error(&format!(
+                    "working_directory must be an absolute in-container path (got {working_directory:?})"
+                )));
             }
+            let c = format!("{}\0", working_directory).into_bytes();
+            let hr = sdk.WslcSetProcessSettingsWorkingDirectory(&mut raw, c.as_ptr() as PCSTR);
+            if hr != S_OK {
+                return Err(sdk_error(
+                    "WslcSetProcessSettingsWorkingDirectory failed",
+                    hr,
+                    "",
+                ));
+            }
+            cwd_cstr = Some(c);
         }
 
         Ok(ProcessSettings {
@@ -764,6 +824,11 @@ pub unsafe fn start_daemon_container(
 pub struct ExecOutcome {
     pub exit_code: i32,
     pub timed_out: bool,
+    /// Set when the process could not be positively confirmed to have ended:
+    /// no exit event and no exit callback, or a timeout `SIGKILL` that did not
+    /// land. The container is then in an unknown state and the caller must
+    /// quarantine it rather than reuse it for a later exec.
+    pub terminated_unconfirmed: bool,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
 }
@@ -814,13 +879,26 @@ pub unsafe fn exec_in_container(
     }
 
     let wait_ms = if timeout_ms > 0 { timeout_ms } else { u32::MAX };
+
+    // Positive-confirmation tracking. Reporting a clean exit requires proof the
+    // process actually ended — either the exit event signalling or the SDK's
+    // exit callback firing. Without either, `WslcGetProcessExitCode` returns
+    // `STILL_ACTIVE` for a process that is very much still running, so it must
+    // never be reported as an exit code.
     let mut timed_out = false;
+    let mut exit_signalled = false;
+    // Set when the process cannot be confirmed terminated (no exit proof, or a
+    // timeout SIGKILL that did not land); the container is then compromised.
+    let mut terminated_unconfirmed = false;
+
     if !exit_event.is_null() {
         let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
             windows::Win32::Foundation::HANDLE(exit_event),
             wait_ms,
         );
-        if wait_result == windows::Win32::Foundation::WAIT_TIMEOUT {
+        if wait_result == windows::Win32::Foundation::WAIT_OBJECT_0 {
+            exit_signalled = true;
+        } else if wait_result == windows::Win32::Foundation::WAIT_TIMEOUT {
             timed_out = true;
             let _ = writeln!(
                 logger,
@@ -833,14 +911,30 @@ pub unsafe fn exec_in_container(
             if kill_hr != S_OK {
                 let _ = writeln!(
                     logger,
-                    "[WSLC][daemon] Warning: WslcSignalProcess(SIGKILL) failed (hr={kill_hr:?}); process may still be running"
+                    "[WSLC][daemon] Warning: WslcSignalProcess(SIGKILL) failed (hr=0x{:08X}); \
+                     process may still be running",
+                    kill_hr as u32
                 );
             }
+        } else {
+            // WAIT_FAILED / WAIT_ABANDONED / anything else: the wait told us
+            // nothing about the process, so it cannot be claimed exited or
+            // killed. Treat the container as compromised.
+            let last_error = windows::Win32::Foundation::GetLastError();
+            let _ = writeln!(
+                logger,
+                "[WSLC][daemon] Warning: waiting on the exec exit event failed: \
+                 WaitForSingleObject returned 0x{:08X} (GetLastError 0x{:08X}); \
+                 container state is unknown",
+                wait_result.0, last_error.0
+            );
+            terminated_unconfirmed = true;
         }
     }
 
-    // Wait for the exit callback to fire — guarantees all I/O is flushed.
-    {
+    // Wait for the exit callback — the only proof the process is actually gone
+    // and that all captured I/O has been flushed.
+    let wait_for_exit_callback = || {
         let (lock, cvar) = &*process_settings.io_ctx().exited;
         let mut exited = lock.lock().unwrap_or_else(|e| e.into_inner());
         if !*exited {
@@ -848,14 +942,23 @@ pub unsafe fn exec_in_container(
                 .wait_timeout(exited, Duration::from_secs(30))
                 .unwrap_or_else(|e| e.into_inner());
             exited = result.0;
-            if !*exited {
-                let _ = writeln!(
-                    logger,
-                    "[WSLC][daemon] Warning: exit callback did not fire within 30s"
-                );
-            }
         }
-        drop(exited);
+        *exited
+    };
+
+    let mut confirmed = wait_for_exit_callback();
+    if timed_out && !confirmed {
+        // The SIGKILL was only a request and plainly has not landed yet; give
+        // the callback one more bounded chance before declaring the outcome
+        // unconfirmed.
+        confirmed = wait_for_exit_callback();
+        if !confirmed {
+            let _ = writeln!(
+                logger,
+                "[WSLC][daemon] Warning: exit callback did not fire after the timeout SIGKILL; \
+                 process may still be running"
+            );
+        }
     }
 
     let mut exit_code: i32 = -1;
@@ -877,19 +980,38 @@ pub unsafe fn exec_in_container(
         .unwrap_or_else(|e| e.into_inner())
         .clone();
 
+    // Resolve the reported outcome from positive evidence only.
     if timed_out {
-        let _ = writeln!(logger, "[WSLC][daemon] Process killed after timeout");
-    } else {
+        if confirmed {
+            let _ = writeln!(logger, "[WSLC][daemon] Process killed after timeout");
+        } else {
+            terminated_unconfirmed = true;
+        }
+    } else if exit_signalled || confirmed {
         let _ = writeln!(
             logger,
             "[WSLC][daemon] Process exited with code {}",
             exit_code
         );
+    } else {
+        // Neither timed out nor confirmed exited: nothing proves the process
+        // ended, so its exit code is meaningless.
+        let _ = writeln!(
+            logger,
+            "[WSLC][daemon] Warning: exec never reported an exit (no exit event, no exit \
+             callback); container state is unknown"
+        );
+        terminated_unconfirmed = true;
     }
 
     Ok(ExecOutcome {
-        exit_code: if timed_out { -1 } else { exit_code },
+        exit_code: if timed_out || terminated_unconfirmed {
+            -1
+        } else {
+            exit_code
+        },
         timed_out,
+        terminated_unconfirmed,
         stdout,
         stderr,
     })

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -1,0 +1,895 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Reusable WSLc SDK building blocks shared by the one-shot `ScriptRunner`
+//! ([`crate::wsl_container_runner`]) and the state-aware daemon
+//! (`wxc_wslc_daemon::session_manager`).
+//!
+//! # Why this module exists
+//! The one-shot runner builds a `WslcProcessSettings` and a
+//! `WslcContainerSettings` inline, then creates the container in a single
+//! function whose stack locals keep the backing string/pointer buffers alive.
+//! The WSLc SDK **stores raw pointers into those caller buffers** (it does not
+//! copy them) and dereferences them at `WslcCreateContainer` /
+//! `WslcCreateContainerProcess` time, so the buffers must outlive the create
+//! call. In the one-shot path that "outlives" is expressed by stack scope.
+//!
+//! The state-aware daemon needs the *same* marshalling but across separate
+//! phase calls, so the lifetime contract cannot be expressed by a single
+//! function's stack. This module reifies each settings blob as a
+//! **buffer-owning struct** ([`ProcessSettings`] / [`ContainerSettings`]) that
+//! bundles the `Wslc*Settings` value together with every heap buffer its
+//! pointers reference. Both callers hold the struct for as long as the SDK
+//! needs the pointers valid.
+//!
+//! # Move safety
+//! Every buffer a settings pointer references is heap-allocated (`Vec`, `Arc`)
+//! or `'static`. Moving one of these structs copies only the owning headers —
+//! the referenced heap allocations do not relocate — so the raw pointers the
+//! SDK stored remain valid across a move. The one rule callers must honor:
+//! **do not move the struct after handing a `&raw` (or a settings value that
+//! embeds a pointer to it, e.g. an init-process settings) to the SDK.** In
+//! practice the builders return the fully-populated struct by value (a single
+//! move that happens *before* any `&raw` is taken), after which callers keep it
+//! as a stationary local.
+
+use std::ffi::c_void;
+use std::fmt::Write;
+use std::ptr;
+use std::sync::{Arc, Condvar, Mutex};
+use std::time::Duration;
+
+use wxc_common::logger::Logger;
+use wxc_common::models::{PortMapping, ScriptResponse};
+use wxc_common::string_util::{to_wide, CoTaskMemPWSTR};
+
+use crate::policy_mapping::{self, VolumeMount};
+use crate::wsl_container_runner::{wslc_prerequisite_error, WSLContainerRunner};
+use crate::wslc_bindings::*;
+
+// ---------------------------------------------------------------------------
+// Shared error helper
+// ---------------------------------------------------------------------------
+
+/// Build a `ScriptResponse` error from an HRESULT failure with an optional
+/// SDK-provided message.
+pub(crate) fn sdk_error(context: &str, hr: HRESULT, sdk_msg: &str) -> ScriptResponse {
+    let msg = if sdk_msg.is_empty() {
+        format!("{}: HRESULT 0x{:08X}", context, hr as u32)
+    } else {
+        format!("{}: {} (HRESULT 0x{:08X})", context, sdk_msg, hr as u32)
+    };
+    ScriptResponse::error(&msg)
+}
+
+// ---------------------------------------------------------------------------
+// Process I/O capture plumbing
+// ---------------------------------------------------------------------------
+
+/// Shared buffer for capturing process I/O via SDK callbacks. Fields are
+/// `pub(crate)` so the one-shot runner's wait/collect helpers can read the
+/// captured bytes and exit signal.
+pub struct IoContext {
+    pub(crate) stdout: Arc<Mutex<Vec<u8>>>,
+    pub(crate) stderr: Arc<Mutex<Vec<u8>>>,
+    pub(crate) exited: Arc<(Mutex<bool>, Condvar)>,
+}
+
+/// RAII guard that reclaims an `Arc<IoContext>` from a raw pointer on drop.
+/// Prevents leaking the `Arc` reference count on early returns.
+pub(crate) struct IoCtxRawGuard {
+    ptr: *mut c_void,
+}
+
+impl IoCtxRawGuard {
+    fn new(ptr: *mut c_void) -> Self {
+        Self { ptr }
+    }
+}
+
+impl Drop for IoCtxRawGuard {
+    fn drop(&mut self) {
+        if !self.ptr.is_null() {
+            unsafe {
+                eprintln!("[WSLC][debug] IoCtxRawGuard dropped -- reclaiming Arc<IoContext>");
+                let _ = Arc::from_raw(self.ptr as *const IoContext);
+            }
+        }
+    }
+}
+
+/// Callback invoked by the WSLc SDK for stdout/stderr data.
+///
+/// # Safety
+/// `context` must be a valid pointer obtained from `Arc::into_raw(Arc<IoContext>)`.
+/// The `Arc` is kept alive by the owning [`ProcessSettings`] (via [`IoCtxRawGuard`],
+/// which reclaims it on drop), so the pointer remains valid for the duration of
+/// all callbacks. The SDK guarantees `data` is valid for `data_size` bytes.
+unsafe extern "C" fn io_callback(
+    io_handle: WslcProcessIOHandle,
+    data: *const BYTE,
+    data_size: u32,
+    context: *mut c_void,
+) {
+    if context.is_null() || data.is_null() || data_size == 0 {
+        return;
+    }
+    let ctx = &*(context as *const IoContext);
+    let bytes = std::slice::from_raw_parts(data, data_size as usize);
+    match io_handle {
+        WslcProcessIOHandle::WSLC_PROCESS_IO_HANDLE_STDOUT => {
+            let mut buf = ctx.stdout.lock().unwrap_or_else(|e| e.into_inner());
+            buf.extend_from_slice(bytes);
+        }
+        WslcProcessIOHandle::WSLC_PROCESS_IO_HANDLE_STDERR => {
+            let mut buf = ctx.stderr.lock().unwrap_or_else(|e| e.into_inner());
+            buf.extend_from_slice(bytes);
+        }
+        _ => {}
+    }
+}
+
+/// Callback invoked when the process exits and all I/O has been flushed.
+/// Per SDK docs: "Once this callback is invoked, any registered IO callbacks
+/// will no longer be called." This guarantees buffers are complete.
+///
+/// # Safety
+/// Same lifetime requirements as [`io_callback`].
+unsafe extern "C" fn exit_callback(_exit_code: i32, context: *mut c_void) {
+    if context.is_null() {
+        return;
+    }
+    let ctx = &*(context as *const IoContext);
+    let mut exited = ctx.exited.0.lock().unwrap_or_else(|e| e.into_inner());
+    *exited = true;
+    ctx.exited.1.notify_all();
+}
+
+// ---------------------------------------------------------------------------
+// ProcessSettings builder
+// ---------------------------------------------------------------------------
+
+/// A fully-populated `WslcProcessSettings` together with every heap buffer its
+/// pointers reference (cmdline argv, env, working dir) and the I/O-capture
+/// context. Safe to move (all referenced data is heap/`'static`); do not move
+/// after taking `&raw`.
+pub struct ProcessSettings {
+    raw: WslcProcessSettings,
+    io_ctx: Arc<IoContext>,
+    _io_guard: IoCtxRawGuard,
+    _sh: Vec<u8>,
+    _dash_c: Vec<u8>,
+    _script_cstr: Vec<u8>,
+    _argv: Vec<PCSTR>,
+    _env_cstrings: Vec<Vec<u8>>,
+    _env_ptrs: Vec<PCSTR>,
+    _cwd_cstr: Option<Vec<u8>>,
+}
+
+impl ProcessSettings {
+    /// Build process settings that run `script_code` under `/bin/sh -c`, with
+    /// the given `env` (already proxy-adjusted by the caller) and
+    /// `working_directory` (a Windows path mapped to its container path; empty =
+    /// container default). Registers stdout/stderr/exit capture callbacks.
+    ///
+    /// # Safety
+    /// `sdk` must hold valid, currently-loaded function pointers and COM must be
+    /// initialized on the calling thread.
+    pub unsafe fn build(
+        sdk: &WslcSdk,
+        script_code: &str,
+        env: &[String],
+        working_directory: &str,
+    ) -> Result<Self, ScriptResponse> {
+        Self::build_inner(sdk, script_code, env, working_directory, true)
+    }
+
+    /// Like [`build`](Self::build) but registers no stdio callbacks and shares no
+    /// `IoContext` with the SDK, for a detached init whose output is never
+    /// streamed. [`io_ctx`](Self::io_ctx) is inert for the returned value.
+    ///
+    /// # Safety
+    /// Same contract as [`build`](Self::build).
+    pub unsafe fn build_detached(
+        sdk: &WslcSdk,
+        script_code: &str,
+        env: &[String],
+        working_directory: &str,
+    ) -> Result<Self, ScriptResponse> {
+        Self::build_inner(sdk, script_code, env, working_directory, false)
+    }
+
+    unsafe fn build_inner(
+        sdk: &WslcSdk,
+        script_code: &str,
+        env: &[String],
+        working_directory: &str,
+        register_callbacks: bool,
+    ) -> Result<Self, ScriptResponse> {
+        let mut raw = std::mem::zeroed::<WslcProcessSettings>();
+        let hr = sdk.WslcInitProcessSettings(&mut raw);
+        if hr != S_OK {
+            return Err(sdk_error("WslcInitProcessSettings failed", hr, ""));
+        }
+
+        // Register I/O callbacks to capture stdout/stderr. We hand the SDK an
+        // Arc reference via raw pointer; IoCtxRawGuard reconstructs it on drop
+        // so the reference count is not leaked, and the memory stays alive while
+        // the SDK may still invoke callbacks on its internal threads.
+        let io_ctx = Arc::new(IoContext {
+            stdout: Arc::new(Mutex::new(Vec::new())),
+            stderr: Arc::new(Mutex::new(Vec::new())),
+            exited: Arc::new((Mutex::new(false), Condvar::new())),
+        });
+        let io_ctx_raw = Arc::into_raw(Arc::clone(&io_ctx)) as *mut c_void;
+        let io_guard = IoCtxRawGuard::new(io_ctx_raw);
+
+        // Callbacks are registered only for the streamed path; a detached init
+        // shares no IoContext with the SDK.
+        if register_callbacks {
+            let callbacks = WslcProcessCallbacks {
+                onStdOut: Some(io_callback),
+                onStdErr: Some(io_callback),
+                onExit: Some(exit_callback),
+            };
+            let hr = sdk.WslcSetProcessSettingsCallbacks(&mut raw, &callbacks, io_ctx_raw);
+            if hr != S_OK {
+                return Err(sdk_error("WslcSetProcessSettingsCallbacks failed", hr, ""));
+            }
+        }
+
+        // Command line: /bin/sh -c <script>. argv points into the sh/dash_c/
+        // script heaps; all are owned by the returned struct.
+        let sh = b"/bin/sh\0".to_vec();
+        let dash_c = b"-c\0".to_vec();
+        let script_cstr = format!("{}\0", script_code).into_bytes();
+        let argv: Vec<PCSTR> = vec![
+            sh.as_ptr() as PCSTR,
+            dash_c.as_ptr() as PCSTR,
+            script_cstr.as_ptr() as PCSTR,
+        ];
+        let hr = sdk.WslcSetProcessSettingsCmdLine(&mut raw, argv.as_ptr(), argv.len());
+        if hr != S_OK {
+            return Err(sdk_error("WslcSetProcessSettingsCmdLine failed", hr, ""));
+        }
+
+        // Environment variables (only when non-empty, matching the one-shot
+        // path). env_ptrs point into env_cstrings; both are owned below.
+        let mut env_cstrings: Vec<Vec<u8>> = Vec::new();
+        let mut env_ptrs: Vec<PCSTR> = Vec::new();
+        if !env.is_empty() {
+            env_cstrings = env
+                .iter()
+                .map(|e| format!("{}\0", e).into_bytes())
+                .collect();
+            env_ptrs = env_cstrings.iter().map(|e| e.as_ptr() as PCSTR).collect();
+            let hr =
+                sdk.WslcSetProcessSettingsEnvVariables(&mut raw, env_ptrs.as_ptr(), env_ptrs.len());
+            if hr != S_OK {
+                return Err(sdk_error(
+                    "WslcSetProcessSettingsEnvVariables failed",
+                    hr,
+                    "",
+                ));
+            }
+        }
+
+        // Working directory (mapped Windows -> container path; skip if unmapped).
+        let mut cwd_cstr: Option<Vec<u8>> = None;
+        if !working_directory.is_empty() {
+            if let Some(container_cwd) =
+                policy_mapping::windows_path_to_container_path(working_directory)
+            {
+                let c = format!("{}\0", container_cwd).into_bytes();
+                let hr = sdk.WslcSetProcessSettingsWorkingDirectory(&mut raw, c.as_ptr() as PCSTR);
+                if hr != S_OK {
+                    return Err(sdk_error(
+                        "WslcSetProcessSettingsWorkingDirectory failed",
+                        hr,
+                        "",
+                    ));
+                }
+                cwd_cstr = Some(c);
+            }
+        }
+
+        Ok(ProcessSettings {
+            raw,
+            io_ctx,
+            _io_guard: io_guard,
+            _sh: sh,
+            _dash_c: dash_c,
+            _script_cstr: script_cstr,
+            _argv: argv,
+            _env_cstrings: env_cstrings,
+            _env_ptrs: env_ptrs,
+            _cwd_cstr: cwd_cstr,
+        })
+    }
+
+    /// The I/O-capture context shared with the SDK callbacks.
+    pub fn io_ctx(&self) -> &IoContext {
+        &self.io_ctx
+    }
+
+    /// Mutable raw settings pointer for `WslcSetContainerSettingsInitProcess` /
+    /// `WslcCreateContainerProcess`. Do not move `self` after calling this.
+    pub fn raw_mut(&mut self) -> &mut WslcProcessSettings {
+        &mut self.raw
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContainerSettings builder
+// ---------------------------------------------------------------------------
+
+/// A fully-populated `WslcContainerSettings` together with every heap buffer its
+/// pointers reference (image name, volume paths, port mappings). The init
+/// process is intentionally NOT set here — that is caller-specific (the one-shot
+/// path bakes the script as init; the daemon uses a keepalive init) and is
+/// applied by the caller before `WslcCreateContainer`.
+pub struct ContainerSettings {
+    raw: WslcContainerSettings,
+    _image_cstr: Vec<u8>,
+    _wide_paths: Vec<(Vec<u16>, Vec<u8>)>,
+    _volumes: Vec<WslcContainerVolume>,
+    _port_mappings: Vec<WslcContainerPortMapping>,
+}
+
+impl ContainerSettings {
+    /// Build container settings for `image` with the given volume `mounts`,
+    /// `port_mappings`, networking `net_mode`, and container `flags`. The caller
+    /// computes `net_mode`/`flags`/`mounts` from policy (identical to the
+    /// one-shot path) and applies the init process afterward.
+    ///
+    /// # Safety
+    /// `sdk` must hold valid, currently-loaded function pointers.
+    pub unsafe fn build(
+        sdk: &WslcSdk,
+        image: &str,
+        mounts: &[VolumeMount],
+        port_mappings: &[PortMapping],
+        net_mode: WslcContainerNetworkingMode,
+        flags: WslcContainerFlags,
+        logger: &mut Logger,
+    ) -> Result<Self, ScriptResponse> {
+        let image_cstr = format!("{}\0", image).into_bytes();
+        let mut raw = std::mem::zeroed::<WslcContainerSettings>();
+        let hr = sdk.WslcInitContainerSettings(image_cstr.as_ptr() as PCSTR, &mut raw);
+        if hr != S_OK {
+            return Err(sdk_error("WslcInitContainerSettings failed", hr, ""));
+        }
+
+        // Port mappings (host<->container). Empty list = no forwarding. The
+        // parser rejects UDP up front today; the explicit branch is retained so
+        // this keeps compiling if UDP is enabled after an SDK update.
+        let mut port_vec: Vec<WslcContainerPortMapping> = Vec::new();
+        if !port_mappings.is_empty() {
+            port_vec = port_mappings
+                .iter()
+                .map(|pm| WslcContainerPortMapping {
+                    windowsPort: pm.windows_port,
+                    containerPort: pm.container_port,
+                    protocol: if pm.protocol == "udp" {
+                        WslcPortProtocol::WSLC_PORT_PROTOCOL_UDP
+                    } else {
+                        WslcPortProtocol::WSLC_PORT_PROTOCOL_TCP
+                    },
+                    windowsAddress: ptr::null_mut(),
+                })
+                .collect();
+
+            let hr = sdk.WslcSetContainerSettingsPortMappings(
+                &mut raw,
+                port_vec.as_ptr(),
+                port_vec.len() as u32,
+            );
+            if hr != S_OK {
+                return Err(sdk_error(
+                    "WslcSetContainerSettingsPortMappings failed",
+                    hr,
+                    "",
+                ));
+            }
+            let _ = writeln!(
+                logger,
+                "[WSLC] {} port mapping(s) configured",
+                port_vec.len()
+            );
+        }
+
+        // Volume mounts. wide_paths owns the widened Windows paths + NUL-
+        // terminated container paths the volume pointers reference.
+        let wide_paths: Vec<(Vec<u16>, Vec<u8>)> = mounts
+            .iter()
+            .map(|m| {
+                let win: Vec<u16> = to_wide(&m.windows_path);
+                let ctr: Vec<u8> = format!("{}\0", m.container_path).into_bytes();
+                (win, ctr)
+            })
+            .collect();
+
+        let mut volumes: Vec<WslcContainerVolume> = Vec::new();
+        if !mounts.is_empty() {
+            volumes = wide_paths
+                .iter()
+                .zip(mounts.iter())
+                .map(|((win, ctr), m)| WslcContainerVolume {
+                    windowsPath: win.as_ptr(),
+                    containerPath: ctr.as_ptr() as PCSTR,
+                    readOnly: if m.read_only { 1 } else { 0 },
+                })
+                .collect();
+
+            let hr = sdk.WslcSetContainerSettingsVolumes(
+                &mut raw,
+                volumes.as_ptr(),
+                volumes.len() as u32,
+            );
+            if hr != S_OK {
+                return Err(sdk_error("WslcSetContainerSettingsVolumes failed", hr, ""));
+            }
+            let _ = writeln!(
+                logger,
+                "[WSLC] {} volume mount(s) configured",
+                volumes.len()
+            );
+        }
+
+        let hr = sdk.WslcSetContainerSettingsNetworkingMode(&mut raw, net_mode);
+        if hr != S_OK {
+            return Err(sdk_error(
+                "WslcSetContainerSettingsNetworkingMode failed",
+                hr,
+                "",
+            ));
+        }
+        let _ = writeln!(logger, "[WSLC] Networking mode: {:?}", net_mode);
+
+        let hr = sdk.WslcSetContainerSettingsFlags(&mut raw, flags);
+        if hr != S_OK {
+            return Err(sdk_error("WslcSetContainerSettingsFlags failed", hr, ""));
+        }
+
+        Ok(ContainerSettings {
+            raw,
+            _image_cstr: image_cstr,
+            _wide_paths: wide_paths,
+            _volumes: volumes,
+            _port_mappings: port_vec,
+        })
+    }
+
+    /// Mutable raw settings for `WslcSetContainerSettingsInitProcess`.
+    /// Do not move `self` after calling this.
+    pub fn raw_mut(&mut self) -> &mut WslcContainerSettings {
+        &mut self.raw
+    }
+
+    /// Shared raw settings for `WslcCreateContainer`.
+    pub fn raw(&self) -> &WslcContainerSettings {
+        &self.raw
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State-aware daemon steps
+// ---------------------------------------------------------------------------
+//
+// The one-shot runner expresses each phase (session → image → container →
+// process → wait) as stack scope inside `run_internal`. The state-aware daemon
+// (`wxc_wslc_daemon::session_manager`) drives the *same* SDK sequence but across
+// separate provision/start/exec/stop/deprovision calls, so each step is reified
+// as a standalone `pub unsafe fn` here. These wrappers keep every raw
+// [`IoContext`] / SDK-buffer access inside `wslc_common` (the daemon is a
+// separate crate and only holds the returned RAII guards + `WslcSdk`).
+//
+// COM affinity: unlike the one-shot path these do NOT call `CoInitializeEx` —
+// the daemon worker thread joins the MTA for its whole lifetime before invoking
+// any of them.
+
+/// Long-lived container init command for daemon-owned containers. Unlike the
+/// one-shot path (which bakes the caller's script as PID 1), the daemon needs an
+/// init process that keeps the container alive across repeated `exec` calls.
+/// `while true; do sleep 86400; done` is portable across busybox (`alpine`) and
+/// coreutils (`mariner`/`fedora`/`python`) shells.
+pub const KEEPALIVE_SCRIPT: &str = "while true; do sleep 86400; done";
+
+/// Load the WSLc SDK and verify its runtime prerequisites, WITHOUT initialising
+/// COM (the caller — the daemon worker thread — is already in the MTA).
+///
+/// # Safety
+/// COM must already be initialised on the calling thread and the SDK DLL must be
+/// resolvable. The returned [`WslcSdk`] holds raw function pointers; keep it
+/// alive for the duration of all SDK use.
+pub unsafe fn load_sdk_checked(logger: &mut Logger) -> Result<WslcSdk, ScriptResponse> {
+    let sdk = WslcSdk::load().map_err(|e| ScriptResponse::error(&e))?;
+
+    let mut missing = WslcComponentFlags::WSLC_COMPONENT_FLAG_NONE;
+    let hr = sdk.WslcGetMissingComponents(&mut missing);
+    if hr != S_OK {
+        return Err(sdk_error("WslcGetMissingComponents failed", hr, ""));
+    }
+    if missing.any_missing() {
+        return Err(ScriptResponse::error(&wslc_prerequisite_error(missing)));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Runtime check passed");
+    Ok(sdk)
+}
+
+/// Create the shared daemon session (the WSL2 utility VM). Minimal by design —
+/// no per-request cpu/memory/timeout/gpu tuning (those are one-shot `WslcConfig`
+/// knobs; the daemon amortises a single session across sandboxes).
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and COM must be initialised on this
+/// thread.
+pub unsafe fn create_daemon_session(
+    sdk: &WslcSdk,
+    session_name: &str,
+    storage_path: &str,
+    logger: &mut Logger,
+) -> Result<WslcSessionGuard, ScriptResponse> {
+    // Both wide buffers must outlive `WslcCreateSession` (the SDK stores pointers
+    // into them at `WslcInitSessionSettings` time); they are function locals held
+    // through the create call below.
+    let name_wide: Vec<u16> = to_wide(session_name);
+    let storage_wide: Vec<u16> = to_wide(storage_path);
+
+    let mut settings = std::mem::zeroed::<WslcSessionSettings>();
+    let hr = sdk.WslcInitSessionSettings(name_wide.as_ptr(), storage_wide.as_ptr(), &mut settings);
+    if hr != S_OK {
+        return Err(sdk_error("WslcInitSessionSettings failed", hr, ""));
+    }
+
+    let mut session: WslcSession = ptr::null_mut();
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcCreateSession(&mut settings, &mut session, err_msg.as_mut_ptr());
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcCreateSession failed", hr, &msg));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Session created");
+
+    Ok(WslcSessionGuard::from_raw(
+        session,
+        sdk.terminate_session_fn(),
+        sdk.release_session_fn(),
+    ))
+}
+
+/// Ensure `image` is available in the session's local cache: use it if already
+/// present, import it from `image_tar_path` if provided, otherwise fail with the
+/// same pre-pull guidance as the one-shot path (MXC never pulls at run time).
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `session` must be a live handle.
+pub unsafe fn resolve_image(
+    sdk: &WslcSdk,
+    session: WslcSession,
+    image: &str,
+    image_tar_path: Option<&str>,
+    storage_path: Option<&str>,
+    logger: &mut Logger,
+) -> Result<(), ScriptResponse> {
+    let mut images: *mut WslcImageInfo = ptr::null_mut();
+    let mut image_count: u32 = 0;
+    let hr = sdk.WslcListSessionImages(session, &mut images, &mut image_count);
+    if hr != S_OK {
+        return Err(sdk_error("WslcListSessionImages failed", hr, ""));
+    }
+
+    let mut image_found = false;
+    if !images.is_null() {
+        let images_slice = std::slice::from_raw_parts(images, image_count as usize);
+        for info in images_slice {
+            let name_bytes =
+                std::slice::from_raw_parts(info.name.as_ptr().cast::<u8>(), info.name.len());
+            let end = name_bytes
+                .iter()
+                .position(|&b| b == 0)
+                .unwrap_or(name_bytes.len());
+            if let Ok(name) = std::str::from_utf8(&name_bytes[..end]) {
+                if name == image {
+                    image_found = true;
+                    break;
+                }
+            }
+        }
+        windows::Win32::System::Com::CoTaskMemFree(Some(images as *const c_void));
+    }
+
+    if image_found {
+        if image_tar_path.is_some() {
+            let _ = writeln!(
+                logger,
+                "[WSLC][daemon] Image '{}' already cached, skipping tar import",
+                image
+            );
+        } else {
+            let _ = writeln!(logger, "[WSLC][daemon] Image '{}' found", image);
+        }
+        return Ok(());
+    }
+
+    if let Some(tar_path) = image_tar_path {
+        return WSLContainerRunner::import_image_from_tar(sdk, session, image, tar_path, logger);
+    }
+
+    // MXC is an execution layer; image management is out of band. Mirror the
+    // one-shot runner's pre-pull guidance so operators get the same actionable
+    // command.
+    let (storage_arg_wxc, storage_arg_ps) = match storage_path {
+        Some(sp) => (
+            format!(" --storage-path \"{}\"", sp),
+            format!(" -StoragePath \"{}\"", sp),
+        ),
+        None => (String::new(), String::new()),
+    };
+    Err(ScriptResponse::error(&format!(
+        "WSLC image '{}' not found locally. Pre-pull it with: \
+         wxc-exec.exe --setup-wslc --image {}{} \
+         (or scripts\\setup-wslc.ps1 -Image {}{}). \
+         MXC does not pull images at run time; \
+         see docs/wsl/wsl-container-support-plan.md.",
+        image, image, storage_arg_wxc, image, storage_arg_ps,
+    )))
+}
+
+/// Create a daemon-owned container with `keepalive` as its init process, so it
+/// stays alive across repeated `exec` calls. The caller keeps `keepalive`
+/// stationary until this returns (the SDK reads its buffers at
+/// `WslcCreateContainer` time).
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `session` must be a live handle.
+pub unsafe fn create_daemon_container(
+    sdk: &WslcSdk,
+    session: WslcSession,
+    image: &str,
+    mounts: &[VolumeMount],
+    net_mode: WslcContainerNetworkingMode,
+    keepalive: &mut ProcessSettings,
+    logger: &mut Logger,
+) -> Result<WslcContainerGuard, ScriptResponse> {
+    // Daemon containers never forward ports (no state-aware port-mapping config)
+    // and set no container flags (auto-remove/gpu/privileged are one-shot-only).
+    let mut container_settings = ContainerSettings::build(
+        sdk,
+        image,
+        mounts,
+        &[],
+        net_mode,
+        WslcContainerFlags::WSLC_CONTAINER_FLAG_NONE,
+        logger,
+    )?;
+
+    let hr =
+        sdk.WslcSetContainerSettingsInitProcess(container_settings.raw_mut(), keepalive.raw_mut());
+    if hr != S_OK {
+        return Err(sdk_error(
+            "WslcSetContainerSettingsInitProcess failed",
+            hr,
+            "",
+        ));
+    }
+
+    let mut container: WslcContainer = ptr::null_mut();
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcCreateContainer(
+        session,
+        container_settings.raw(),
+        &mut container,
+        err_msg.as_mut_ptr(),
+    );
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcCreateContainer failed", hr, &msg));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Container created");
+
+    Ok(WslcContainerGuard::from_raw(
+        container,
+        sdk.release_container_fn(),
+    ))
+}
+
+/// Boot a created daemon container. Uses `START_FLAG_NONE` (not `ATTACH`): the
+/// keepalive init's stdio is never streamed — per-`exec` processes carry the
+/// user-visible I/O.
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `container` must be a live handle.
+pub unsafe fn start_daemon_container(
+    sdk: &WslcSdk,
+    container: WslcContainer,
+    logger: &mut Logger,
+) -> Result<(), ScriptResponse> {
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcStartContainer(
+        container,
+        WslcContainerStartFlags::WSLC_CONTAINER_START_FLAG_NONE,
+        err_msg.as_mut_ptr(),
+    );
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcStartContainer failed", hr, &msg));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Container started");
+    Ok(())
+}
+
+/// Captured result of a daemon `exec`. Live bidirectional streaming is a later
+/// fill-in; for now the whole stdout/stderr is captured and the exit code
+/// returned once the process completes.
+pub struct ExecOutcome {
+    pub exit_code: i32,
+    pub timed_out: bool,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+/// Run `script_code` (under `/bin/sh -c`) as a fresh process inside a started
+/// daemon container and wait for it to complete. On timeout the *process* is
+/// killed (SIGKILL) — NOT the container — so the keepalive init survives for
+/// subsequent execs.
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `container` must be a live,
+/// started handle.
+pub unsafe fn exec_in_container(
+    sdk: &WslcSdk,
+    container: WslcContainer,
+    script_code: &str,
+    env: &[String],
+    working_directory: &str,
+    timeout_ms: u32,
+    logger: &mut Logger,
+) -> Result<ExecOutcome, ScriptResponse> {
+    // `process_settings` owns every buffer the SDK reads at
+    // `WslcCreateContainerProcess` time plus the I/O-capture context; it is held
+    // as a stationary local until after the process exits below.
+    let mut process_settings = ProcessSettings::build(sdk, script_code, env, working_directory)?;
+
+    let mut process: WslcProcess = ptr::null_mut();
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcCreateContainerProcess(
+        container,
+        process_settings.raw_mut(),
+        &mut process,
+        err_msg.as_mut_ptr(),
+    );
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcCreateContainerProcess failed", hr, &msg));
+    }
+    let process_guard = WslcProcessGuard::from_raw(process, sdk.release_process_fn());
+
+    let mut exit_event: HANDLE = ptr::null_mut();
+    let hr = sdk.WslcGetProcessExitEvent(process_guard.as_raw(), &mut exit_event);
+    if hr != S_OK {
+        return Err(sdk_error("WslcGetProcessExitEvent failed", hr, ""));
+    }
+
+    let wait_ms = if timeout_ms > 0 { timeout_ms } else { u32::MAX };
+    let mut timed_out = false;
+    if !exit_event.is_null() {
+        let wait_result = windows::Win32::System::Threading::WaitForSingleObject(
+            windows::Win32::Foundation::HANDLE(exit_event),
+            wait_ms,
+        );
+        if wait_result == windows::Win32::Foundation::WAIT_TIMEOUT {
+            timed_out = true;
+            let _ = writeln!(
+                logger,
+                "[WSLC][daemon] exec timeout ({}ms) reached — killing process",
+                wait_ms
+            );
+            // Kill only this process; the keepalive init keeps the container up.
+            let _ = sdk.WslcSignalProcess(process_guard.as_raw(), WslcSignal::WSLC_SIGNAL_SIGKILL);
+        }
+    }
+
+    // Wait for the exit callback to fire — guarantees all I/O is flushed.
+    {
+        let (lock, cvar) = &*process_settings.io_ctx().exited;
+        let mut exited = lock.lock().unwrap_or_else(|e| e.into_inner());
+        if !*exited {
+            let result = cvar
+                .wait_timeout(exited, Duration::from_secs(30))
+                .unwrap_or_else(|e| e.into_inner());
+            exited = result.0;
+            if !*exited {
+                let _ = writeln!(
+                    logger,
+                    "[WSLC][daemon] Warning: exit callback did not fire within 30s"
+                );
+            }
+        }
+        drop(exited);
+    }
+
+    let mut exit_code: i32 = -1;
+    let hr = sdk.WslcGetProcessExitCode(process_guard.as_raw(), &mut exit_code);
+    if hr != S_OK && !timed_out {
+        return Err(sdk_error("WslcGetProcessExitCode failed", hr, ""));
+    }
+
+    let stdout = process_settings
+        .io_ctx()
+        .stdout
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let stderr = process_settings
+        .io_ctx()
+        .stderr
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+
+    if timed_out {
+        let _ = writeln!(logger, "[WSLC][daemon] Process killed after timeout");
+    } else {
+        let _ = writeln!(
+            logger,
+            "[WSLC][daemon] Process exited with code {}",
+            exit_code
+        );
+    }
+
+    Ok(ExecOutcome {
+        exit_code: if timed_out { -1 } else { exit_code },
+        timed_out,
+        stdout,
+        stderr,
+    })
+}
+
+/// Stop a running daemon container (SIGTERM), keeping it created for a later
+/// `start`.
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `container` must be a live handle.
+pub unsafe fn stop_daemon_container(
+    sdk: &WslcSdk,
+    container: WslcContainer,
+    logger: &mut Logger,
+) -> Result<(), ScriptResponse> {
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcStopContainer(
+        container,
+        WslcSignal::WSLC_SIGNAL_SIGTERM,
+        10,
+        err_msg.as_mut_ptr(),
+    );
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcStopContainer failed", hr, &msg));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Container stopped");
+    Ok(())
+}
+
+/// Delete a daemon container (forcefully).
+///
+/// # Safety
+/// `sdk` must hold valid function pointers and `container` must be a live handle.
+pub unsafe fn delete_daemon_container(
+    sdk: &WslcSdk,
+    container: WslcContainer,
+    logger: &mut Logger,
+) -> Result<(), ScriptResponse> {
+    let mut err_msg = CoTaskMemPWSTR::null();
+    let hr = sdk.WslcDeleteContainer(
+        container,
+        WslcDeleteContainerFlags::WSLC_DELETE_CONTAINER_FLAG_FORCE,
+        err_msg.as_mut_ptr(),
+    );
+    if hr != S_OK {
+        let msg = err_msg.to_string_lossy();
+        return Err(sdk_error("WslcDeleteContainer failed", hr, &msg));
+    }
+    let _ = writeln!(logger, "[WSLC][daemon] Container deleted");
+    Ok(())
+}

--- a/src/backends/wslc/common/src/daemon_client.rs
+++ b/src/backends/wslc/common/src/daemon_client.rs
@@ -80,10 +80,20 @@ pub struct ExecResult {
 }
 
 /// A connected handle to the live daemon. Cheap to hold: it caches only the
-/// resolved pipe name and opens a fresh pipe connection per request (one request
-/// per connection, matching the server).
+/// resolved pipe name plus the daemon's trusted identity (PID + creation time
+/// from the discovery record), and opens a fresh pipe connection per request
+/// (one request per connection, matching the server).
 pub struct DaemonClient {
     pipe_name: String,
+    /// PID of the daemon process this client trusts, from the discovery record.
+    /// Every opened pipe is authenticated against this so a hostile same-user
+    /// pipe squatter cannot impersonate the daemon.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    server_pid: u32,
+    /// Creation time of `server_pid` from the record, to defeat PID reuse: the
+    /// connected server must be the exact process the record identified.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    server_pid_creation_time: u64,
 }
 
 impl DaemonClient {
@@ -137,6 +147,8 @@ impl DaemonClient {
     fn from_record(record: &DaemonRecord) -> Self {
         Self {
             pipe_name: record.pipe_name.clone(),
+            server_pid: record.pid,
+            server_pid_creation_time: record.pid_creation_time,
         }
     }
 
@@ -215,15 +227,18 @@ impl DaemonClient {
 
     /// Open a fresh synchronous connection to the daemon pipe, retrying past the
     /// brief windows where every instance is momentarily busy or being recreated.
+    ///
+    /// SECURITY: the handle is opened with `SECURITY_SQOS_PRESENT |
+    /// SECURITY_IDENTIFICATION` so a pipe server can only *identify* this
+    /// (possibly elevated) phase process, never impersonate it; and once
+    /// connected the server's PID/creation time is authenticated against the
+    /// trusted discovery record before any request is sent, so a hostile
+    /// same-user pipe squatter cannot pose as the daemon.
     fn open_pipe(&self) -> Result<File> {
         let deadline = Instant::now() + OPEN_TIMEOUT;
-        loop {
-            match OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(&self.pipe_name)
-            {
-                Ok(file) => return Ok(file),
+        let file = loop {
+            match open_pipe_handle(&self.pipe_name) {
+                Ok(file) => break file,
                 Err(e) => {
                     let retryable = matches!(
                         e.raw_os_error(),
@@ -236,8 +251,84 @@ impl DaemonClient {
                     return Err(e).with_context(|| format!("open daemon pipe {}", self.pipe_name));
                 }
             }
+        };
+        self.verify_server_identity(&file)?;
+        Ok(file)
+    }
+
+    /// Authenticate the connected pipe server against the trusted discovery
+    /// record. A mismatch means something other than the recorded daemon is
+    /// answering on this pipe name — refuse to send it anything.
+    #[cfg(windows)]
+    fn verify_server_identity(&self, pipe: &File) -> Result<()> {
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Foundation::HANDLE;
+        use windows::Win32::System::Pipes::GetNamedPipeServerProcessId;
+
+        let handle = HANDLE(pipe.as_raw_handle());
+        let mut server_pid: u32 = 0;
+        // SAFETY: `handle` is a live pipe handle owned by `pipe`; `server_pid`
+        // is a valid out pointer.
+        unsafe { GetNamedPipeServerProcessId(handle, &mut server_pid) }
+            .map_err(|e| anyhow::anyhow!("GetNamedPipeServerProcessId failed: {e}"))?;
+
+        if server_pid != self.server_pid {
+            bail!(
+                "refusing to talk to daemon pipe {}: connected server pid {} does not match the \
+                 trusted discovery record pid {} (possible pipe-squatting attempt)",
+                self.pipe_name,
+                server_pid,
+                self.server_pid
+            );
+        }
+        // Defeat PID reuse: the server must be the exact process the record
+        // identified, not a new process that recycled the PID.
+        match crate::daemon_record::process_creation_time(server_pid) {
+            Some(ct) if ct == self.server_pid_creation_time => Ok(()),
+            Some(ct) => bail!(
+                "refusing to talk to daemon pipe {}: server pid {} creation time {} does not \
+                 match the trusted record {} (pid reuse or spoofed server)",
+                self.pipe_name,
+                server_pid,
+                ct,
+                self.server_pid_creation_time
+            ),
+            None => bail!(
+                "refusing to talk to daemon pipe {}: could not read the creation time of server \
+                 pid {} to authenticate it",
+                self.pipe_name,
+                server_pid
+            ),
         }
     }
+
+    /// Non-Windows stub: there is no daemon (and no named-pipe transport) off
+    /// Windows, so nothing to authenticate.
+    #[cfg(not(windows))]
+    fn verify_server_identity(&self, _pipe: &File) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Open the daemon pipe as an ordinary synchronous file handle.
+///
+/// On Windows the handle carries `SECURITY_SQOS_PRESENT |
+/// SECURITY_IDENTIFICATION` so the pipe server is capped at the Identification
+/// impersonation level and cannot act as this process.
+fn open_pipe_handle(pipe_name: &str) -> std::io::Result<File> {
+    let mut opts = OpenOptions::new();
+    opts.read(true).write(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // Security quality-of-service flags for CreateFile: present bit plus the
+        // Identification level (SecurityIdentification == 1, shifted into the
+        // high word).
+        const SECURITY_SQOS_PRESENT: u32 = 0x0010_0000;
+        const SECURITY_IDENTIFICATION: u32 = 0x0001_0000;
+        opts.custom_flags(SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION);
+    }
+    opts.open(pipe_name)
 }
 
 /// The live daemon iff it is ready and speaks this build's protocol version.
@@ -366,5 +457,24 @@ mod tests {
         let text = err.to_string();
         assert!(text.contains("Busy"));
         assert!(text.contains("single-flight slot held"));
+    }
+
+    #[test]
+    fn from_record_captures_server_identity() {
+        use crate::daemon_record::RECORD_SCHEMA_VERSION;
+        let record = DaemonRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            pid: 4321,
+            pid_creation_time: 0xABCD,
+            pipe_name: r"\\.\pipe\mxc-wslc-test".to_string(),
+            ready: true,
+            protocol_version: PROTOCOL_VERSION,
+        };
+        let client = DaemonClient::from_record(&record);
+        // The pipe server is authenticated against this identity in open_pipe;
+        // losing it would silently disable the anti-squatting check.
+        assert_eq!(client.pipe_name, record.pipe_name);
+        assert_eq!(client.server_pid, 4321);
+        assert_eq!(client.server_pid_creation_time, 0xABCD);
     }
 }

--- a/src/backends/wslc/common/src/daemon_client.rs
+++ b/src/backends/wslc/common/src/daemon_client.rs
@@ -1,0 +1,366 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Phase-process side of the state-aware WSLc control protocol.
+//!
+//! Each state-aware lifecycle phase (`provision` / `start` / `exec` / `stop` /
+//! `deprovision`) runs as a short-lived process that drives the long-lived
+//! `wxc-wslc-daemon` over an owner-only named pipe. This module is the client
+//! half: it discovers (or spawns) the daemon, then issues one
+//! [`DaemonRequest`] per connection and decodes the [`DaemonResponse`] (and, for
+//! exec, the [`StreamFrame`] data phase).
+//!
+//! # Sync by design
+//! The daemon server is async (tokio), but the client is deliberately
+//! **blocking**: a phase process is otherwise synchronous, `wslc_common` has no
+//! tokio dependency, and the framing (`[len: u32 LE][json]`) is trivial over
+//! blocking `std::io`. A Windows named pipe opens as an ordinary synchronous
+//! file handle, so `std::fs::File` read/write is all that is needed.
+//!
+//! # Discovery / spawn
+//! [`DaemonClient::connect`] fast-paths onto a live, ready, protocol-compatible
+//! daemon. Otherwise it takes the cross-process [`TransitionLock`] (so two phase
+//! processes cannot both spawn a daemon), re-checks, spawns
+//! `wxc-wslc-daemon.exe` (detached, co-located with the current executable) if
+//! none exists, and waits for it to publish a `ready` record.
+//!
+//! Windows-only: the daemon and its named-pipe transport are a Windows feature
+//! (`daemon_record` provides non-Windows stubs, but there is no daemon there).
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::daemon_protocol::{
+    encode_frame, DaemonRequest, DaemonResponse, DeprovisionConfig, ErrKind, ExecConfig,
+    ProvisionConfig, StartConfig, StopConfig, StreamFrame, MAX_FRAME_SIZE, PROTOCOL_VERSION,
+};
+use crate::daemon_record::{live_daemon, DaemonRecord, TransitionLock};
+
+/// Max wait to acquire the daemon spawn/teardown transition lock.
+const SPAWN_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Max wait for a freshly spawned (or concurrently starting) daemon to publish a
+/// `ready` record.
+const READY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Poll cadence while waiting for the `ready` record.
+const READY_POLL: Duration = Duration::from_millis(100);
+
+/// Max wait when opening the daemon pipe, to ride out the brief window between
+/// the server accepting one client and re-creating the next listening instance.
+const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Retry cadence for a transiently busy/absent pipe instance.
+const OPEN_RETRY: Duration = Duration::from_millis(20);
+
+// Win32 error codes for the transient pipe-open conditions worth retrying.
+const ERROR_FILE_NOT_FOUND: i32 = 2;
+const ERROR_PIPE_BUSY: i32 = 231;
+
+/// The captured result of an exec run. Live stdout/stderr framing is a daemon
+/// fill-in; today the daemon returns only the terminal exit code, so these
+/// buffers are usually empty, but the client already accumulates any
+/// [`StreamFrame::Stdout`] / [`StreamFrame::Stderr`] the daemon sends.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+/// A connected handle to the live daemon. Cheap to hold: it caches only the
+/// resolved pipe name and opens a fresh pipe connection per request (one request
+/// per connection, matching the server).
+pub struct DaemonClient {
+    pipe_name: String,
+}
+
+impl DaemonClient {
+    /// Discover the live daemon, spawning it if necessary, and return a client
+    /// bound to its pipe.
+    pub fn connect() -> Result<Self> {
+        // Fast path: a live, ready, compatible daemon already exists.
+        if let Some(record) = ready_daemon()? {
+            return Ok(Self::from_record(&record));
+        }
+
+        // Slow path: serialise spawn/teardown so two phase processes cannot both
+        // spawn a daemon (or race a spawn against a teardown).
+        let _lock = TransitionLock::acquire(SPAWN_LOCK_TIMEOUT)
+            .context("acquire daemon spawn transition lock")?;
+
+        let deadline = Instant::now() + READY_TIMEOUT;
+        let mut spawned = false;
+        loop {
+            match live_daemon()? {
+                Some(record) if !record.protocol_compatible() => {
+                    bail!(
+                        "a running wslc daemon speaks control protocol v{} but this build speaks \
+                         v{}; refusing to drive it (stop the stale daemon and retry)",
+                        record.protocol_version,
+                        PROTOCOL_VERSION
+                    );
+                }
+                Some(record) if record.ready => return Ok(Self::from_record(&record)),
+                // A daemon is alive but still starting up: keep waiting for it to
+                // flip `ready` rather than spawning a duplicate.
+                Some(_) => {}
+                None => {
+                    if !spawned {
+                        spawn_daemon()?;
+                        spawned = true;
+                    }
+                    // Otherwise we already spawned; keep polling for its record.
+                }
+            }
+
+            if Instant::now() >= deadline {
+                bail!(
+                    "timed out after {READY_TIMEOUT:?} waiting for the wslc daemon to become ready"
+                );
+            }
+            std::thread::sleep(READY_POLL);
+        }
+    }
+
+    fn from_record(record: &DaemonRecord) -> Self {
+        Self {
+            pipe_name: record.pipe_name.clone(),
+        }
+    }
+
+    /// Liveness probe. Returns `Ok(())` iff the daemon answers with `Pong`.
+    pub fn ping(&self) -> Result<()> {
+        match self.call(&DaemonRequest::Ping)? {
+            DaemonResponse::Pong => Ok(()),
+            other => bail!("unexpected reply to ping: {other:?}"),
+        }
+    }
+
+    /// Provision a container; returns the daemon-minted sandbox id.
+    pub fn provision(&self, config: ProvisionConfig) -> Result<String> {
+        match self.call(&DaemonRequest::Provision(config))? {
+            DaemonResponse::Provisioned { sandbox_id } => Ok(sandbox_id),
+            DaemonResponse::Err { kind, message } => Err(daemon_err(kind, &message)),
+            other => bail!("unexpected reply to provision: {other:?}"),
+        }
+    }
+
+    /// Start a provisioned container.
+    pub fn start(&self, config: StartConfig) -> Result<()> {
+        expect_ok(self.call(&DaemonRequest::Start(config))?)
+    }
+
+    /// Stop a running container (keeps it created for a later `start`).
+    pub fn stop(&self, config: StopConfig) -> Result<()> {
+        expect_ok(self.call(&DaemonRequest::Stop(config))?)
+    }
+
+    /// Deprovision (delete) a container.
+    pub fn deprovision(&self, config: DeprovisionConfig) -> Result<()> {
+        expect_ok(self.call(&DaemonRequest::Deprovision(config))?)
+    }
+
+    /// Run a command in a started container to completion, returning its exit
+    /// code and any streamed output.
+    ///
+    /// After the daemon admits the exec with `Ok`, this reads the
+    /// [`StreamFrame`] data phase — accumulating stdout/stderr — until the
+    /// terminal [`StreamFrame::Exit`] (or [`StreamFrame::Error`]).
+    pub fn exec(&self, config: ExecConfig) -> Result<ExecResult> {
+        let mut pipe = self.open_pipe()?;
+        write_frame(&mut pipe, &DaemonRequest::Exec(config))?;
+
+        match read_frame::<DaemonResponse>(&mut pipe)? {
+            DaemonResponse::Ok => {}
+            DaemonResponse::Err { kind, message } => return Err(daemon_err(kind, &message)),
+            other => bail!("unexpected exec admission reply: {other:?}"),
+        }
+
+        let mut result = ExecResult::default();
+        loop {
+            match read_frame::<StreamFrame>(&mut pipe)? {
+                StreamFrame::Stdout { data } => result.stdout.extend_from_slice(&data),
+                StreamFrame::Stderr { data } => result.stderr.extend_from_slice(&data),
+                StreamFrame::Exit { code } => {
+                    result.exit_code = code;
+                    return Ok(result);
+                }
+                StreamFrame::Error { message } => bail!("exec failed: {message}"),
+                StreamFrame::Stdin { .. } => {
+                    bail!("protocol error: daemon sent a Stdin frame to the client")
+                }
+            }
+        }
+    }
+
+    /// Issue a single non-streaming request on a fresh connection and return the
+    /// daemon's reply.
+    fn call(&self, request: &DaemonRequest) -> Result<DaemonResponse> {
+        let mut pipe = self.open_pipe()?;
+        write_frame(&mut pipe, request)?;
+        read_frame(&mut pipe)
+    }
+
+    /// Open a fresh synchronous connection to the daemon pipe, retrying past the
+    /// brief windows where every instance is momentarily busy or being recreated.
+    fn open_pipe(&self) -> Result<File> {
+        let deadline = Instant::now() + OPEN_TIMEOUT;
+        loop {
+            match OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&self.pipe_name)
+            {
+                Ok(file) => return Ok(file),
+                Err(e) => {
+                    let retryable = matches!(
+                        e.raw_os_error(),
+                        Some(ERROR_PIPE_BUSY) | Some(ERROR_FILE_NOT_FOUND)
+                    );
+                    if retryable && Instant::now() < deadline {
+                        std::thread::sleep(OPEN_RETRY);
+                        continue;
+                    }
+                    return Err(e).with_context(|| format!("open daemon pipe {}", self.pipe_name));
+                }
+            }
+        }
+    }
+}
+
+/// The live daemon iff it is ready and speaks this build's protocol version.
+fn ready_daemon() -> Result<Option<DaemonRecord>> {
+    match live_daemon()? {
+        Some(record) if record.ready && record.protocol_compatible() => Ok(Some(record)),
+        _ => Ok(None),
+    }
+}
+
+/// Spawn `wxc-wslc-daemon.exe` (co-located with the current executable) as a
+/// detached background process. It publishes its own discovery record; we do not
+/// hold a handle to it.
+fn spawn_daemon() -> Result<()> {
+    let exe = daemon_exe_path()?;
+
+    let mut cmd = Command::new(&exe);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP: the daemon must outlive
+        // this phase process and not share its console.
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+        cmd.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+    }
+
+    cmd.spawn()
+        .with_context(|| format!("spawn wslc daemon {}", exe.display()))?;
+    Ok(())
+}
+
+/// Resolve the daemon executable path: `wxc-wslc-daemon.exe` next to the current
+/// executable (the build scripts stage it alongside `wxc-exec.exe`).
+fn daemon_exe_path() -> Result<PathBuf> {
+    let current = std::env::current_exe().context("resolve current executable path")?;
+    let dir = current
+        .parent()
+        .context("current executable has no parent directory")?;
+    let name = if cfg!(windows) {
+        "wxc-wslc-daemon.exe"
+    } else {
+        "wxc-wslc-daemon"
+    };
+    Ok(dir.join(name))
+}
+
+/// Map a `DaemonResponse` expected to be a bare success into `Result<()>`.
+fn expect_ok(response: DaemonResponse) -> Result<()> {
+    match response {
+        DaemonResponse::Ok => Ok(()),
+        DaemonResponse::Err { kind, message } => Err(daemon_err(kind, &message)),
+        other => bail!("unexpected reply (expected ok): {other:?}"),
+    }
+}
+
+/// Build an error carrying the daemon's stable [`ErrKind`] token plus detail.
+fn daemon_err(kind: ErrKind, message: &str) -> anyhow::Error {
+    anyhow::anyhow!("daemon error [{kind:?}]: {message}")
+}
+
+/// Serialise `msg` and write it as one length-prefixed frame.
+fn write_frame<T: Serialize>(pipe: &mut File, msg: &T) -> Result<()> {
+    let frame = encode_frame(msg).context("encode frame")?;
+    pipe.write_all(&frame).context("write frame")?;
+    pipe.flush().context("flush frame")?;
+    Ok(())
+}
+
+/// Read exactly one length-prefixed frame and deserialise it.
+fn read_frame<T: DeserializeOwned>(pipe: &mut File) -> Result<T> {
+    let mut len_buf = [0u8; 4];
+    pipe.read_exact(&mut len_buf)
+        .context("read frame length prefix")?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        bail!("incoming frame length {len} exceeds maximum {MAX_FRAME_SIZE}");
+    }
+    let mut body = vec![0u8; len];
+    pipe.read_exact(&mut body).context("read frame body")?;
+    serde_json::from_slice(&body).context("deserialise frame body")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn daemon_exe_is_resolved_next_to_current_exe() {
+        let path = daemon_exe_path().unwrap();
+        let expected_dir = std::env::current_exe()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        assert_eq!(path.parent().unwrap(), expected_dir);
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("wxc-wslc-daemon"));
+    }
+
+    #[test]
+    fn expect_ok_maps_variants() {
+        assert!(expect_ok(DaemonResponse::Ok).is_ok());
+
+        let err = expect_ok(DaemonResponse::Err {
+            kind: ErrKind::NotStarted,
+            message: "sandbox not started".to_string(),
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("NotStarted"));
+        assert!(err.to_string().contains("sandbox not started"));
+
+        assert!(expect_ok(DaemonResponse::Pong).is_err());
+    }
+
+    #[test]
+    fn daemon_err_carries_kind_and_message() {
+        let err = daemon_err(ErrKind::Busy, "single-flight slot held");
+        let text = err.to_string();
+        assert!(text.contains("Busy"));
+        assert!(text.contains("single-flight slot held"));
+    }
+}

--- a/src/backends/wslc/common/src/daemon_client.rs
+++ b/src/backends/wslc/common/src/daemon_client.rs
@@ -43,12 +43,16 @@ use crate::daemon_protocol::{
 };
 use crate::daemon_record::{live_daemon, DaemonRecord, TransitionLock};
 
-/// Max wait to acquire the daemon spawn/teardown transition lock.
-const SPAWN_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
-
 /// Max wait for a freshly spawned (or concurrently starting) daemon to publish a
 /// `ready` record.
 const READY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Max wait to acquire the daemon spawn/teardown transition lock. Must exceed
+/// [`READY_TIMEOUT`]: the lock holder retains it for the whole readiness wait, so
+/// a second client has to be willing to wait at least that long — otherwise it
+/// would give up while the first daemon is still validly starting and report a
+/// spurious failure.
+const SPAWN_LOCK_TIMEOUT: Duration = Duration::from_secs(75);
 
 /// Poll cadence while waiting for the `ready` record.
 const READY_POLL: Duration = Duration::from_millis(100);

--- a/src/backends/wslc/common/src/daemon_protocol.rs
+++ b/src/backends/wslc/common/src/daemon_protocol.rs
@@ -1,0 +1,441 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Control protocol between a `wxc-exec` phase process and the long-lived
+//! `wxc-wslc-daemon`.
+//!
+//! State-aware WSLc runs each lifecycle phase (provision / start / exec / stop /
+//! deprovision) as a **separate** short-lived `wxc-exec` process, but the WSLc
+//! SDK has no cross-process re-attach: `WslcSession` / `WslcContainer` handles
+//! are obtainable only via `WslcCreate*` and are in-process. A persistent
+//! per-user daemon therefore owns the handles, and the phase processes drive it
+//! over this protocol.
+//!
+//! # Framing
+//! Every message is length-prefixed: a 4-byte little-endian `u32` frame length
+//! followed by that many bytes of JSON ([`serde_json`]). The same framing
+//! carries both the control frames ([`DaemonRequest`] / [`DaemonResponse`]) and
+//! the exec data-phase [`StreamFrame`]s, so the wire has a single, trivially
+//! testable structure.
+//!
+//! # Layering
+//! These are the daemon's **own internal** config structs, deliberately
+//! separate from the public `experimental.wslc.*` wire schema. The state-aware
+//! backend (a later PR) is the translator between the public wire model and
+//! this protocol; keeping them decoupled lets the daemon + IPC ship and be
+//! fully tested without touching the wire schema or its CI gates.
+
+use serde::de::DeserializeOwned;
+use serde::ser::Error as _;
+use serde::{Deserialize, Serialize};
+
+/// Upper bound on a single decoded frame (16 MiB). Guards the decoder against a
+/// hostile or corrupt length prefix demanding an unbounded allocation.
+pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
+
+/// Control-channel wire-protocol version. The daemon and client are shipped
+/// from the same build, so in normal operation both sides always match; the
+/// version guards against a stale daemon left running by a different mxc
+/// install. Bump only for incompatible changes to framing or message shape.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Per-phase config structs (daemon-internal; NOT the public wire schema)
+// ---------------------------------------------------------------------------
+
+/// One host→container directory mount, mirroring the one-shot runner's volume
+/// handling. Paths are host-absolute; `container` is the in-container mount
+/// point.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VolumeMount {
+    pub host: String,
+    pub container: String,
+    pub read_only: bool,
+}
+
+/// Container network mode. Mirrors exactly what the one-shot WSLc runner
+/// supports — no host-filtering / egress allow-deny (the SDK grants no
+/// `CAP_NET_ADMIN` and cannot give VM-level enforcement without breaking other
+/// security promises, so there is no iptables path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkMode {
+    /// Isolated: no container networking.
+    #[default]
+    None,
+    /// Bridged (NAT) networking.
+    Bridged,
+}
+
+/// Inputs to `provision`: ensure the shared session (booting the WSL2 utility VM
+/// on first provision), resolve the image, and create the container. Mirrors the
+/// session/container-level fields of the one-shot `WslcConfig` plus the
+/// container's volume and network policy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProvisionConfig {
+    /// Container image reference (e.g. `alpine:latest`).
+    pub image: String,
+    /// Optional local tar to import as the image instead of pulling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_tar_path: Option<String>,
+    /// Host↔container directory mounts.
+    #[serde(default)]
+    pub volumes: Vec<VolumeMount>,
+    /// Container network mode.
+    #[serde(default)]
+    pub network: NetworkMode,
+}
+
+/// Inputs to `start`: the container was created at provision; start boots it.
+/// Carries only the sandbox id — network/volume policy is immutable post-provision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartConfig {
+    pub sandbox_id: String,
+}
+
+/// Inputs to `exec`: run one command in the started container and stream its
+/// stdio back over the pipe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecConfig {
+    pub sandbox_id: String,
+    /// Command line to run inside the container (shell-interpreted, mirroring
+    /// the one-shot runner's `script_code`).
+    pub script_code: String,
+    /// Working directory inside the container (empty = container default).
+    #[serde(default)]
+    pub working_directory: String,
+    /// Environment variables applied to the process, as `(name, value)` pairs.
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+    /// Timeout in milliseconds (0 = no timeout).
+    #[serde(default)]
+    pub timeout_ms: u32,
+}
+
+/// Inputs to `stop`: stop the running container, keeping it created for a later
+/// `start`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StopConfig {
+    pub sandbox_id: String,
+}
+
+/// Inputs to `deprovision`: delete the container and drop its refcount; the
+/// daemon releases the shared session once the last container is gone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeprovisionConfig {
+    pub sandbox_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Control frames
+// ---------------------------------------------------------------------------
+
+/// A control request sent by a phase process to the daemon.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum DaemonRequest {
+    /// Ensure session + create container. Replies [`DaemonResponse::Provisioned`].
+    Provision(ProvisionConfig),
+    /// Boot the created container. Replies [`DaemonResponse::Ok`].
+    Start(StartConfig),
+    /// Run a command and stream its stdio. After an [`DaemonResponse::Ok`]
+    /// admission, both sides exchange [`StreamFrame`]s until [`StreamFrame::Exit`].
+    Exec(ExecConfig),
+    /// Stop the running container. Replies [`DaemonResponse::Ok`].
+    Stop(StopConfig),
+    /// Delete the container (refcount--). Replies [`DaemonResponse::Ok`].
+    Deprovision(DeprovisionConfig),
+    /// Liveness probe. Replies [`DaemonResponse::Pong`].
+    Ping,
+}
+
+/// The daemon's reply to a [`DaemonRequest`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum DaemonResponse {
+    /// `provision` succeeded; carries the minted sandbox id (the addressable
+    /// handle a later phase presents).
+    Provisioned { sandbox_id: String },
+    /// Generic success (start / stop / deprovision, and exec admission).
+    Ok,
+    /// Reply to [`DaemonRequest::Ping`].
+    Pong,
+    /// The request failed or was refused. `kind` is a stable machine-readable
+    /// token (see [`ErrKind`]); `message` is human-readable detail.
+    Err { kind: ErrKind, message: String },
+}
+
+/// Stable, machine-readable classification of a [`DaemonResponse::Err`], so the
+/// client can map daemon failures onto the appropriate `MxcError` variant
+/// without string-matching.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrKind {
+    /// The referenced sandbox id is unknown to the daemon.
+    NotProvisioned,
+    /// The sandbox exists but is not in a state that permits the request
+    /// (e.g. exec before start).
+    NotStarted,
+    /// Another exec already holds the container's single-flight slot.
+    Busy,
+    /// The container/session is still coming up.
+    NotReady,
+    /// The client speaks a different protocol version than this daemon.
+    Protocol,
+    /// A backend/SDK-level failure while servicing the request.
+    Backend,
+}
+
+// ---------------------------------------------------------------------------
+// Exec data-phase stream frames
+// ---------------------------------------------------------------------------
+
+/// A frame exchanged during the exec data phase (after an admitted
+/// [`DaemonRequest::Exec`]). Client→daemon carries [`StreamFrame::Stdin`];
+/// daemon→client carries [`StreamFrame::Stdout`] / [`StreamFrame::Stderr`] and
+/// a terminal [`StreamFrame::Exit`] (or [`StreamFrame::Error`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StreamFrame {
+    /// Client→daemon: bytes to write to the process stdin. An empty payload
+    /// signals stdin EOF.
+    Stdin { data: Vec<u8> },
+    /// Daemon→client: bytes read from the process stdout.
+    Stdout { data: Vec<u8> },
+    /// Daemon→client: bytes read from the process stderr.
+    Stderr { data: Vec<u8> },
+    /// Daemon→client: terminal frame; the process exited with `code`. No more
+    /// stream frames follow.
+    Exit { code: i32 },
+    /// Daemon→client: terminal frame; the exec failed before or during the run.
+    Error { message: String },
+}
+
+// ---------------------------------------------------------------------------
+// Framing helpers (generic over any serde message type)
+// ---------------------------------------------------------------------------
+
+/// Serialize `msg` into a length-prefixed frame: `[len: u32 LE][json: len bytes]`.
+pub fn encode_frame<T: Serialize>(msg: &T) -> Result<Vec<u8>, serde_json::Error> {
+    let json = serde_json::to_vec(msg)?;
+    if json.len() > MAX_FRAME_SIZE {
+        return Err(serde_json::Error::custom(
+            "message too large for protocol framing",
+        ));
+    }
+    let len = json.len() as u32;
+    let mut frame = Vec::with_capacity(4 + json.len());
+    frame.extend_from_slice(&len.to_le_bytes());
+    frame.extend_from_slice(&json);
+    Ok(frame)
+}
+
+/// Result of attempting to decode one frame from the front of a byte buffer.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DecodeResult<T> {
+    /// A complete message was decoded; drain `consumed` bytes from the front of
+    /// the buffer before decoding again.
+    Message { message: T, consumed: usize },
+    /// The buffer does not yet hold a full frame; read more bytes and retry.
+    Incomplete,
+}
+
+/// Try to decode one message of type `T` from the front of `buf`.
+///
+/// Returns [`DecodeResult::Incomplete`] when fewer than `4 + len` bytes are
+/// present. A length prefix exceeding [`MAX_FRAME_SIZE`] is a hard error rather
+/// than an unbounded wait.
+pub fn decode_frame<T: DeserializeOwned>(buf: &[u8]) -> Result<DecodeResult<T>, serde_json::Error> {
+    if buf.len() < 4 {
+        return Ok(DecodeResult::Incomplete);
+    }
+    let len = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+    if len > MAX_FRAME_SIZE {
+        return Err(serde_json::Error::custom("frame length exceeds maximum"));
+    }
+    let total = 4 + len;
+    if buf.len() < total {
+        return Ok(DecodeResult::Incomplete);
+    }
+    let message: T = serde_json::from_slice(&buf[4..total])?;
+    Ok(DecodeResult::Message {
+        message,
+        consumed: total,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip<T>(msg: T)
+    where
+        T: Serialize + DeserializeOwned + PartialEq + std::fmt::Debug,
+    {
+        let frame = encode_frame(&msg).unwrap();
+        match decode_frame::<T>(&frame).unwrap() {
+            DecodeResult::Message { message, consumed } => {
+                assert_eq!(message, msg);
+                assert_eq!(consumed, frame.len());
+            }
+            DecodeResult::Incomplete => panic!("expected a complete message"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_provision() {
+        roundtrip(DaemonRequest::Provision(ProvisionConfig {
+            image: "alpine:latest".to_string(),
+            image_tar_path: Some(r"C:\images\alpine.tar".to_string()),
+            volumes: vec![VolumeMount {
+                host: r"C:\work".to_string(),
+                container: "/work".to_string(),
+                read_only: true,
+            }],
+            network: NetworkMode::Bridged,
+        }));
+    }
+
+    #[test]
+    fn roundtrip_each_request_variant() {
+        roundtrip(DaemonRequest::Start(StartConfig {
+            sandbox_id: "wslc:abc123".to_string(),
+        }));
+        roundtrip(DaemonRequest::Exec(ExecConfig {
+            sandbox_id: "wslc:abc123".to_string(),
+            script_code: "echo hi".to_string(),
+            working_directory: "/work".to_string(),
+            env: vec![("PATH".to_string(), "/usr/bin".to_string())],
+            timeout_ms: 30_000,
+        }));
+        roundtrip(DaemonRequest::Stop(StopConfig {
+            sandbox_id: "wslc:abc123".to_string(),
+        }));
+        roundtrip(DaemonRequest::Deprovision(DeprovisionConfig {
+            sandbox_id: "wslc:abc123".to_string(),
+        }));
+        roundtrip(DaemonRequest::Ping);
+    }
+
+    #[test]
+    fn roundtrip_each_response_variant() {
+        roundtrip(DaemonResponse::Provisioned {
+            sandbox_id: "wslc:abc123".to_string(),
+        });
+        roundtrip(DaemonResponse::Ok);
+        roundtrip(DaemonResponse::Pong);
+        for kind in [
+            ErrKind::NotProvisioned,
+            ErrKind::NotStarted,
+            ErrKind::Busy,
+            ErrKind::NotReady,
+            ErrKind::Protocol,
+            ErrKind::Backend,
+        ] {
+            roundtrip(DaemonResponse::Err {
+                kind,
+                message: "detail".to_string(),
+            });
+        }
+    }
+
+    #[test]
+    fn roundtrip_stream_frames() {
+        roundtrip(StreamFrame::Stdin {
+            data: b"input".to_vec(),
+        });
+        roundtrip(StreamFrame::Stdout {
+            data: b"out".to_vec(),
+        });
+        roundtrip(StreamFrame::Stderr {
+            data: b"err".to_vec(),
+        });
+        roundtrip(StreamFrame::Exit { code: 42 });
+        roundtrip(StreamFrame::Error {
+            message: "spawn failed".to_string(),
+        });
+    }
+
+    #[test]
+    fn network_mode_defaults_to_none() {
+        assert_eq!(NetworkMode::default(), NetworkMode::None);
+    }
+
+    #[test]
+    fn decode_incomplete_header() {
+        let r: DecodeResult<DaemonRequest> = decode_frame(&[0u8; 3]).unwrap();
+        assert_eq!(r, DecodeResult::Incomplete);
+    }
+
+    #[test]
+    fn decode_incomplete_body() {
+        // Header claims 100 bytes; only 10 present.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&100u32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 10]);
+        let r: DecodeResult<DaemonRequest> = decode_frame(&buf).unwrap();
+        assert_eq!(r, DecodeResult::Incomplete);
+    }
+
+    #[test]
+    fn decode_empty_buffer_is_incomplete() {
+        let r: DecodeResult<DaemonRequest> = decode_frame(&[]).unwrap();
+        assert_eq!(r, DecodeResult::Incomplete);
+    }
+
+    #[test]
+    fn decode_rejects_oversized_length_prefix() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&(MAX_FRAME_SIZE as u32 + 1).to_le_bytes());
+        let r: Result<DecodeResult<DaemonRequest>, _> = decode_frame(&buf);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn frame_length_prefix_matches_payload() {
+        let frame = encode_frame(&DaemonRequest::Ping).unwrap();
+        let declared = u32::from_le_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+        assert_eq!(declared, frame.len() - 4);
+    }
+
+    #[test]
+    fn two_frames_decode_sequentially() {
+        let f1 = encode_frame(&DaemonRequest::Ping).unwrap();
+        let f2 = encode_frame(&DaemonResponse::Pong).unwrap();
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&f1);
+        buf.extend_from_slice(&f2);
+
+        let consumed = match decode_frame::<DaemonRequest>(&buf).unwrap() {
+            DecodeResult::Message { message, consumed } => {
+                assert_eq!(message, DaemonRequest::Ping);
+                consumed
+            }
+            DecodeResult::Incomplete => panic!("expected first frame"),
+        };
+        match decode_frame::<DaemonResponse>(&buf[consumed..]).unwrap() {
+            DecodeResult::Message {
+                message,
+                consumed: c2,
+            } => {
+                assert_eq!(message, DaemonResponse::Pong);
+                assert_eq!(consumed + c2, buf.len());
+            }
+            DecodeResult::Incomplete => panic!("expected second frame"),
+        }
+    }
+
+    #[test]
+    fn decode_rejects_malformed_json_body() {
+        let mut buf = Vec::new();
+        let body = b"{ not json";
+        buf.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        buf.extend_from_slice(body);
+        let r: Result<DecodeResult<DaemonRequest>, _> = decode_frame(&buf);
+        assert!(r.is_err());
+    }
+}

--- a/src/backends/wslc/common/src/daemon_record.rs
+++ b/src/backends/wslc/common/src/daemon_record.rs
@@ -72,6 +72,12 @@ impl DaemonRecord {
 // Record root + path derivation
 // ---------------------------------------------------------------------------
 
+/// Environment variable that overrides [`state_aware_root`] at runtime. Set by
+/// cross-process integration tests — and inherited by the daemon they spawn —
+/// to isolate the discovery record from a developer's real per-user daemon.
+/// Unset in production.
+pub const STATE_ROOT_ENV_VAR: &str = "MXC_WSLC_STATE_ROOT";
+
 /// Root directory for state-aware WSLc records. `temp_dir()` is per-user on
 /// Windows (`%TEMP%`), giving the per-user isolation the design requires.
 pub fn state_aware_root() -> PathBuf {
@@ -79,6 +85,14 @@ pub fn state_aware_root() -> PathBuf {
     {
         if let Some(p) = test_root::get() {
             return p;
+        }
+    }
+    // Runtime override, honored by both the phase process and the daemon it
+    // spawns (which inherits the environment). Lets cross-process integration
+    // tests point discovery at a throwaway root. Unset in production.
+    if let Some(dir) = std::env::var_os(STATE_ROOT_ENV_VAR) {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
         }
     }
     std::env::temp_dir().join("mxc-wslc").join("state-aware")

--- a/src/backends/wslc/common/src/daemon_record.rs
+++ b/src/backends/wslc/common/src/daemon_record.rs
@@ -94,11 +94,15 @@ pub fn secure_record_root() -> Result<()> {
     ensure_secure_dir(&state_aware_root())
 }
 
+/// Required prefix for a daemon control pipe. A trusted record must name a pipe
+/// with this prefix; anything else is treated as a planted/hostile record.
+pub const PIPE_NAME_PREFIX: &str = r"\\.\pipe\mxc-wslc-";
+
 /// Derive a fresh, unique named-pipe path for a daemon instance. The pipe's ACL
 /// (not the name) enforces access control, so uniqueness only needs to avoid
 /// collision with a concurrent stale-but-not-yet-reaped daemon.
 pub fn mint_pipe_name() -> String {
-    format!(r"\\.\pipe\mxc-wslc-{}", uuid::Uuid::new_v4().simple())
+    format!("{PIPE_NAME_PREFIX}{}", uuid::Uuid::new_v4().simple())
 }
 
 // ---------------------------------------------------------------------------
@@ -111,11 +115,12 @@ pub fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     let parent = path
         .parent()
         .context("record path has no parent directory")?;
-    std::fs::create_dir_all(parent).with_context(|| format!("create record dir {parent:?}"))?;
 
-    // Secure the directory before creating the temp file. A later DACL change
-    // would not revoke an attacker's already-open handle.
-    set_owner_only_dir(parent).with_context(|| format!("secure record dir {parent:?}"))?;
+    // Secure every directory we introduce (not just the leaf) before creating
+    // the temp file: an attacker owning an intermediate dir could otherwise swap
+    // the leaf via a rename, and a later DACL change would not revoke an
+    // attacker's already-open handle.
+    ensure_secure_dir(parent).with_context(|| format!("secure record dir {parent:?}"))?;
 
     let json = serde_json::to_vec_pretty(value).context("serialise record")?;
     let tmp = parent.join(format!("{}.tmp", uuid::Uuid::new_v4()));
@@ -164,11 +169,26 @@ pub fn check_schema(found: u32) -> Result<()> {
 /// Read the global daemon record, validating its schema. Returns `Ok(None)` if
 /// the record does not exist.
 pub fn read_daemon_record() -> Result<Option<DaemonRecord>> {
-    let Some(record) = read_json::<DaemonRecord>(&daemon_record_path())? else {
+    let path = daemon_record_path();
+    // Verify the record file and its directory chain are owned by the current
+    // user before trusting the contents; a shared-`%TEMP%` attacker could
+    // otherwise plant a record redirecting us to a hostile pipe.
+    verify_record_trust(&path)?;
+    let Some(record) = read_json::<DaemonRecord>(&path)? else {
         return Ok(None);
     };
     check_schema(record.schema_version)?;
+    validate_pipe_name(&record.pipe_name)?;
     Ok(Some(record))
+}
+
+/// Reject a record naming any pipe outside the daemon's namespace, so a planted
+/// record cannot redirect a phase process to an arbitrary endpoint.
+fn validate_pipe_name(name: &str) -> Result<()> {
+    if !name.starts_with(PIPE_NAME_PREFIX) {
+        anyhow::bail!("daemon record names an unexpected pipe {name:?}; refusing to connect");
+    }
+    Ok(())
 }
 
 /// Read the daemon record only if it describes a process that is still alive. A
@@ -228,17 +248,75 @@ pub fn set_owner_only_dir(_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Create and secure a directory before reading trusted state from it.
+/// Create and owner-secure a directory and every component we introduce beneath
+/// the system temp dir (not just the leaf), then verify current-user ownership.
 #[cfg(windows)]
 pub fn ensure_secure_dir(dir: &Path) -> Result<()> {
-    std::fs::create_dir_all(dir).with_context(|| format!("create dir {dir:?}"))?;
-    set_owner_only_dir(dir)
+    for component in dirs_to_secure(dir) {
+        std::fs::create_dir_all(&component).with_context(|| format!("create dir {component:?}"))?;
+        set_owner_only_dir(&component)?;
+    }
+    Ok(())
 }
 
 /// Non-Windows directory creation.
 #[cfg(not(windows))]
 pub fn ensure_secure_dir(dir: &Path) -> Result<()> {
     std::fs::create_dir_all(dir).with_context(|| format!("create dir {dir:?}"))
+}
+
+/// The directory components to secure for `dir`, shallowest first: every strict
+/// descendant of the system temp dir up to and including `dir`. If `dir` is not
+/// under the temp dir, only `dir` itself is secured.
+#[cfg(windows)]
+fn dirs_to_secure(dir: &Path) -> Vec<PathBuf> {
+    let base = std::env::temp_dir();
+    if !dir.starts_with(&base) {
+        return vec![dir.to_path_buf()];
+    }
+    let mut chain = Vec::new();
+    let mut cur = Some(dir);
+    while let Some(p) = cur {
+        if p == base {
+            break;
+        }
+        chain.push(p.to_path_buf());
+        cur = p.parent();
+    }
+    chain.reverse();
+    chain
+}
+
+/// Verify `path` and its securable directory chain are owned by the current
+/// user before their contents are trusted. Absent files (and dirs) pass, since
+/// there is then nothing to trust.
+#[cfg(windows)]
+fn verify_record_trust(path: &Path) -> Result<()> {
+    let check = |p: &Path| -> Result<()> {
+        if !p.exists() {
+            return Ok(());
+        }
+        let owned = wxc_common::filesystem_dacl::owner_is_self(p)
+            .map_err(|e| anyhow::Error::new(e).context(format!("read owner of {p:?}")))?;
+        if !owned {
+            anyhow::bail!(
+                "refusing to trust {p:?}: it is owned by another user (cross-user tampering risk)"
+            );
+        }
+        Ok(())
+    };
+    if let Some(parent) = path.parent() {
+        for component in dirs_to_secure(parent) {
+            check(&component)?;
+        }
+    }
+    check(path)
+}
+
+/// Non-Windows no-op.
+#[cfg(not(windows))]
+fn verify_record_trust(_path: &Path) -> Result<()> {
+    Ok(())
 }
 
 /// Apply an owner-only DACL to an existing file.
@@ -486,6 +564,23 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         set_state_aware_root_for_test(Some(dir.path().to_path_buf()));
         assert!(read_daemon_record().unwrap().is_none());
+        set_state_aware_root_for_test(None);
+    }
+
+    #[test]
+    fn read_rejects_record_with_foreign_pipe_name() {
+        let _guard = STATE_AWARE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        set_state_aware_root_for_test(Some(dir.path().to_path_buf()));
+
+        let json = format!(
+            r#"{{"schema_version":{RECORD_SCHEMA_VERSION},"pid":1,"pid_creation_time":2,
+               "pipe_name":"\\\\.\\pipe\\evil","ready":true,"protocol_version":{}}}"#,
+            crate::daemon_protocol::PROTOCOL_VERSION
+        );
+        std::fs::write(daemon_record_path(), json).unwrap();
+        assert!(read_daemon_record().is_err());
+
         set_state_aware_root_for_test(None);
     }
 

--- a/src/backends/wslc/common/src/daemon_record.rs
+++ b/src/backends/wslc/common/src/daemon_record.rs
@@ -1,0 +1,588 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! On-disk daemon discovery record, process-liveness helpers, and the
+//! phase-transition lock for state-aware WSLc.
+//!
+//! Unlike Windows Sandbox — where `provision` is pure bookkeeping and a daemon
+//! is spawned lazily at `start`, so per-sandbox state must persist on disk — the
+//! WSLc daemon *is* the source of truth for sandbox state: `provision` boots the
+//! shared session and creates the container inside the daemon, and the WSLc SDK
+//! has no cross-process re-attach. If the daemon dies, every container dies with
+//! it and clients re-provision. Consequently the only durable artifact is the
+//! [`DaemonRecord`] (how to find and authenticate the live daemon); per-sandbox
+//! Provisioned/Started/Stopped state lives in the daemon's in-memory refcounted
+//! `sandbox_id -> container` map, never on disk.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Schema version of the on-disk [`DaemonRecord`]. Bump on any incompatible
+/// change to the record shape.
+pub const RECORD_SCHEMA_VERSION: u32 = 1;
+
+/// Named mutex serialising daemon spawn + teardown across phase processes, so
+/// two concurrent phase processes cannot both spawn a daemon (or race a spawn
+/// against a teardown). `Local\` scope: these unelevated per-user processes lack
+/// `SeCreateGlobalPrivilege`, and cross-session sharing is unsupported by design.
+#[cfg(windows)]
+const TRANSITION_MUTEX_NAME: &str = r"Local\mxc-wslc-stateaware-transition";
+
+// ---------------------------------------------------------------------------
+// Daemon discovery record
+// ---------------------------------------------------------------------------
+
+/// Global per-user daemon record (`daemon.json`). Present iff a daemon is (or
+/// recently was) alive. A present record does **not** imply the daemon is alive
+/// — pair with [`daemon_alive`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonRecord {
+    pub schema_version: u32,
+    /// Daemon process id.
+    pub pid: u32,
+    /// Daemon process creation time (Win32 `FILETIME`, 100ns ticks). Paired with
+    /// `pid` to defeat PID reuse: a recycled PID will not match.
+    pub pid_creation_time: u64,
+    /// Named-pipe path the daemon serves its control protocol on
+    /// (e.g. `\\.\pipe\mxc-wslc-<unique>`). The pipe's SDDL restricts access to
+    /// the owning user, so no separate auth secret is required.
+    pub pipe_name: String,
+    /// `false` while the daemon is booting the session; `true` once it is ready
+    /// to accept requests.
+    pub ready: bool,
+    /// Control-protocol wire version this daemon speaks
+    /// (see [`crate::daemon_protocol::PROTOCOL_VERSION`]). Absent (pre-versioning)
+    /// records default to `0`, i.e. incompatible.
+    #[serde(default)]
+    pub protocol_version: u32,
+}
+
+impl DaemonRecord {
+    /// True iff this daemon speaks this build's control-protocol version. A
+    /// mismatch means a different mxc install left it running: it must not be
+    /// driven with mismatched framing.
+    pub fn protocol_compatible(&self) -> bool {
+        self.protocol_version == crate::daemon_protocol::PROTOCOL_VERSION
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Record root + path derivation
+// ---------------------------------------------------------------------------
+
+/// Root directory for state-aware WSLc records. `temp_dir()` is per-user on
+/// Windows (`%TEMP%`), giving the per-user isolation the design requires.
+pub fn state_aware_root() -> PathBuf {
+    #[cfg(test)]
+    {
+        if let Some(p) = test_root::get() {
+            return p;
+        }
+    }
+    std::env::temp_dir().join("mxc-wslc").join("state-aware")
+}
+
+/// Global daemon record file: `<root>\daemon.json`.
+pub fn daemon_record_path() -> PathBuf {
+    state_aware_root().join("daemon.json")
+}
+
+/// Create and secure the record root before reading trusted state from it.
+pub fn secure_record_root() -> Result<()> {
+    ensure_secure_dir(&state_aware_root())
+}
+
+/// Derive a fresh, unique named-pipe path for a daemon instance. The pipe's ACL
+/// (not the name) enforces access control, so uniqueness only needs to avoid
+/// collision with a concurrent stale-but-not-yet-reaped daemon.
+pub fn mint_pipe_name() -> String {
+    format!(r"\\.\pipe\mxc-wslc-{}", uuid::Uuid::new_v4().simple())
+}
+
+// ---------------------------------------------------------------------------
+// Atomic, owner-only JSON record IO
+// ---------------------------------------------------------------------------
+
+/// Serialise a JSON record through an atomic same-directory rename, securing the
+/// parent directory and the temp file owner-only before publishing.
+pub fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("record path has no parent directory")?;
+    std::fs::create_dir_all(parent).with_context(|| format!("create record dir {parent:?}"))?;
+
+    // Secure the directory before creating the temp file. A later DACL change
+    // would not revoke an attacker's already-open handle.
+    set_owner_only_dir(parent).with_context(|| format!("secure record dir {parent:?}"))?;
+
+    let json = serde_json::to_vec_pretty(value).context("serialise record")?;
+    let tmp = parent.join(format!("{}.tmp", uuid::Uuid::new_v4()));
+    std::fs::write(&tmp, &json).with_context(|| format!("write temp record {tmp:?}"))?;
+
+    if let Err(e) = set_owner_only_file(&tmp) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("secure record DACL {tmp:?}"));
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e).with_context(|| format!("rename {tmp:?} -> {path:?}"));
+    }
+    Ok(())
+}
+
+/// Read and deserialise a JSON record. Returns `Ok(None)` if the file does not
+/// exist; `Err` for a present-but-unreadable / unparseable file.
+pub fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<Option<T>> {
+    match std::fs::read_to_string(path) {
+        Ok(s) => {
+            let value =
+                serde_json::from_str(&s).with_context(|| format!("parse record {path:?}"))?;
+            Ok(Some(value))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e).with_context(|| format!("read record {path:?}")),
+    }
+}
+
+/// Reject a record whose schema does not match what this build understands.
+pub fn check_schema(found: u32) -> Result<()> {
+    if found != RECORD_SCHEMA_VERSION {
+        anyhow::bail!(
+            "daemon record schema {found} is incompatible with supported schema {RECORD_SCHEMA_VERSION}"
+        );
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Daemon record convenience readers / writers
+// ---------------------------------------------------------------------------
+
+/// Read the global daemon record, validating its schema. Returns `Ok(None)` if
+/// the record does not exist.
+pub fn read_daemon_record() -> Result<Option<DaemonRecord>> {
+    let Some(record) = read_json::<DaemonRecord>(&daemon_record_path())? else {
+        return Ok(None);
+    };
+    check_schema(record.schema_version)?;
+    Ok(Some(record))
+}
+
+/// Read the daemon record only if it describes a process that is still alive. A
+/// present-but-dead record (daemon crashed without cleanup) yields `None`.
+pub fn live_daemon() -> Result<Option<DaemonRecord>> {
+    match read_daemon_record()? {
+        Some(record) if daemon_alive(&record) => Ok(Some(record)),
+        _ => Ok(None),
+    }
+}
+
+/// Atomically write the global daemon record.
+pub fn write_daemon_record(record: &DaemonRecord) -> Result<()> {
+    atomic_write_json(&daemon_record_path(), record)
+}
+
+/// Remove the global daemon record, treating `NotFound` as success.
+pub fn remove_daemon_record() -> std::io::Result<()> {
+    match std::fs::remove_file(daemon_record_path()) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// True iff the daemon described by `record` is still the live process it claims
+/// to be: a process with its PID is currently running AND its creation time
+/// matches the recorded one.
+pub fn daemon_alive(record: &DaemonRecord) -> bool {
+    running_process_creation_time(record.pid) == Some(record.pid_creation_time)
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem DACL helpers (owner-only), Windows + portable stub
+// ---------------------------------------------------------------------------
+
+/// Apply an inheritable owner-only DACL to `dir`, and reject a directory owned
+/// by another user (who would retain implicit `WRITE_DAC`).
+#[cfg(windows)]
+pub fn set_owner_only_dir(dir: &Path) -> Result<()> {
+    wxc_common::filesystem_dacl::set_owner_only_dacl(dir, true)
+        .map_err(|e| anyhow::Error::new(e).context(format!("secure dir {dir:?}")))?;
+    let owned = wxc_common::filesystem_dacl::owner_is_self(dir)
+        .map_err(|e| anyhow::Error::new(e).context(format!("read owner of {dir:?}")))?;
+    if !owned {
+        anyhow::bail!(
+            "refusing to use {dir:?}: it is owned by another user (cross-user tampering risk). \
+             Remove it and retry."
+        );
+    }
+    Ok(())
+}
+
+/// Non-Windows no-op.
+#[cfg(not(windows))]
+pub fn set_owner_only_dir(_dir: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// Create and secure a directory before reading trusted state from it.
+#[cfg(windows)]
+pub fn ensure_secure_dir(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("create dir {dir:?}"))?;
+    set_owner_only_dir(dir)
+}
+
+/// Non-Windows directory creation.
+#[cfg(not(windows))]
+pub fn ensure_secure_dir(dir: &Path) -> Result<()> {
+    std::fs::create_dir_all(dir).with_context(|| format!("create dir {dir:?}"))
+}
+
+/// Apply an owner-only DACL to an existing file.
+#[cfg(windows)]
+fn set_owner_only_file(path: &Path) -> Result<()> {
+    wxc_common::filesystem_dacl::set_owner_only_dacl(path, false)
+        .map_err(|e| anyhow::Error::new(e).context(format!("secure file {path:?}")))
+}
+
+/// Non-Windows no-op.
+#[cfg(not(windows))]
+fn set_owner_only_file(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Process creation-time liveness, Windows + portable stub
+// ---------------------------------------------------------------------------
+
+/// Creation time of `pid` while the process is still running. A retained handle
+/// keeps an exited process queryable, so this also checks the handle's signalled
+/// state and returns `None` for an exited-but-retained process.
+#[cfg(windows)]
+pub fn running_process_creation_time(pid: u32) -> Option<u64> {
+    use windows::Win32::Foundation::{CloseHandle, FILETIME, WAIT_OBJECT_0};
+    use windows::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_SYNCHRONIZE,
+    };
+
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: `pid` is a plain integer; the handle is closed on every path and
+    // the FILETIME out-params are fully initialised before use.
+    unsafe {
+        let handle = OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+            false,
+            pid,
+        )
+        .ok()?;
+        let exited = WaitForSingleObject(handle, 0) == WAIT_OBJECT_0;
+        let mut creation = FILETIME::default();
+        let mut exit = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        let ok = GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user).is_ok();
+        let _ = CloseHandle(handle);
+        if !ok || exited {
+            return None;
+        }
+        Some(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
+    }
+}
+
+/// Non-Windows stub.
+#[cfg(not(windows))]
+pub fn running_process_creation_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+/// Creation time of `pid` regardless of running state (used at daemon startup to
+/// stamp its own record). Returns `None` for pid 0 or a query failure.
+#[cfg(windows)]
+pub fn process_creation_time(pid: u32) -> Option<u64> {
+    use windows::Win32::Foundation::{CloseHandle, FILETIME};
+    use windows::Win32::System::Threading::{
+        GetProcessTimes, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    if pid == 0 {
+        return None;
+    }
+    // SAFETY: `pid` is a plain integer; the handle is closed on every path and
+    // the FILETIME out-params are fully initialised before use.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid).ok()?;
+        let mut creation = FILETIME::default();
+        let mut exit = FILETIME::default();
+        let mut kernel = FILETIME::default();
+        let mut user = FILETIME::default();
+        let ok = GetProcessTimes(handle, &mut creation, &mut exit, &mut kernel, &mut user).is_ok();
+        let _ = CloseHandle(handle);
+        if !ok {
+            return None;
+        }
+        Some(((creation.dwHighDateTime as u64) << 32) | creation.dwLowDateTime as u64)
+    }
+}
+
+/// Non-Windows stub.
+#[cfg(not(windows))]
+pub fn process_creation_time(_pid: u32) -> Option<u64> {
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Transition lock (named mutex), Windows + portable stub
+// ---------------------------------------------------------------------------
+
+/// RAII guard over the named transition mutex. While held, no other phase
+/// process can spawn or tear down the daemon, which prevents double-spawn and
+/// spawn/teardown races. Released on drop.
+#[cfg(windows)]
+pub struct TransitionLock {
+    handle: windows::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl TransitionLock {
+    /// Acquire the transition mutex, waiting up to `timeout`. `Err` on either
+    /// contention (timeout) or a real create/wait failure.
+    pub fn acquire(timeout: std::time::Duration) -> Result<Self> {
+        use windows::core::PCWSTR;
+        use windows::Win32::Foundation::{
+            CloseHandle, WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT,
+        };
+        use windows::Win32::System::Threading::{CreateMutexW, WaitForSingleObject};
+
+        let wide: Vec<u16> = TRANSITION_MUTEX_NAME
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+
+        // SAFETY: `wide` is a valid null-terminated UTF-16 buffer that outlives
+        // the call; the returned handle is owned by `self` and closed on drop.
+        let handle = unsafe { CreateMutexW(None, false, PCWSTR(wide.as_ptr())) }
+            .context("create transition mutex")?;
+
+        let ms = timeout.as_millis().min(u32::MAX as u128) as u32;
+        // SAFETY: `handle` is a valid mutex handle from `CreateMutexW`.
+        let wait = unsafe { WaitForSingleObject(handle, ms) };
+        if wait == WAIT_OBJECT_0 || wait == WAIT_ABANDONED {
+            // WAIT_ABANDONED: a prior holder died without releasing. We now own
+            // the mutex; protected state is reconciled separately via the daemon
+            // record + process-identity liveness, so taking ownership is correct.
+            Ok(Self { handle })
+        } else {
+            // SAFETY: closing the handle we just created; we do not own the mutex.
+            unsafe {
+                let _ = CloseHandle(handle);
+            }
+            if wait == WAIT_TIMEOUT {
+                anyhow::bail!(
+                    "timed out acquiring transition lock after {timeout:?} (another phase process \
+                     is spawning or tearing down the daemon)"
+                );
+            }
+            anyhow::bail!("waiting on transition mutex failed (wait result {wait:?})");
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for TransitionLock {
+    fn drop(&mut self) {
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::Threading::ReleaseMutex;
+        // SAFETY: `handle` is a valid mutex handle owned by `self`.
+        unsafe {
+            let _ = ReleaseMutex(self.handle);
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+/// Non-Windows stub: the transition mutex is a Windows-only concept.
+#[cfg(not(windows))]
+pub struct TransitionLock;
+
+#[cfg(not(windows))]
+impl TransitionLock {
+    pub fn acquire(_timeout: std::time::Duration) -> Result<Self> {
+        Ok(Self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test-only record-root override
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test_root {
+    use std::path::PathBuf;
+    use std::sync::{Mutex, OnceLock};
+
+    static OVERRIDE: OnceLock<Mutex<Option<PathBuf>>> = OnceLock::new();
+    fn slot() -> &'static Mutex<Option<PathBuf>> {
+        OVERRIDE.get_or_init(|| Mutex::new(None))
+    }
+    pub fn set(p: Option<PathBuf>) {
+        *slot().lock().expect("test_root mutex poisoned") = p;
+    }
+    pub fn get() -> Option<PathBuf> {
+        slot().lock().expect("test_root mutex poisoned").clone()
+    }
+}
+
+/// Redirect [`state_aware_root`] for a test.
+#[cfg(test)]
+pub fn set_state_aware_root_for_test(path: Option<PathBuf>) {
+    test_root::set(path);
+}
+
+/// Serialises tests that override [`state_aware_root`].
+#[cfg(test)]
+pub static STATE_AWARE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record() -> DaemonRecord {
+        DaemonRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            pid: std::process::id(),
+            pid_creation_time: 123,
+            pipe_name: mint_pipe_name(),
+            ready: true,
+            protocol_version: crate::daemon_protocol::PROTOCOL_VERSION,
+        }
+    }
+
+    #[test]
+    fn daemon_record_roundtrips_on_disk() {
+        let _guard = STATE_AWARE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        set_state_aware_root_for_test(Some(dir.path().to_path_buf()));
+
+        let record = sample_record();
+        write_daemon_record(&record).unwrap();
+        let read = read_daemon_record().unwrap().unwrap();
+        assert_eq!(read, record);
+
+        remove_daemon_record().unwrap();
+        assert!(read_daemon_record().unwrap().is_none());
+
+        set_state_aware_root_for_test(None);
+    }
+
+    #[test]
+    fn read_missing_daemon_record_is_none() {
+        let _guard = STATE_AWARE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        set_state_aware_root_for_test(Some(dir.path().to_path_buf()));
+        assert!(read_daemon_record().unwrap().is_none());
+        set_state_aware_root_for_test(None);
+    }
+
+    #[test]
+    fn check_schema_rejects_mismatch() {
+        assert!(check_schema(RECORD_SCHEMA_VERSION).is_ok());
+        assert!(check_schema(RECORD_SCHEMA_VERSION + 1).is_err());
+    }
+
+    #[test]
+    fn protocol_compatible_matches_current_and_rejects_others() {
+        let mut record = sample_record();
+        assert!(record.protocol_compatible());
+        record.protocol_version = crate::daemon_protocol::PROTOCOL_VERSION + 1;
+        assert!(!record.protocol_compatible());
+    }
+
+    #[test]
+    fn daemon_record_without_protocol_version_reads_as_incompatible() {
+        // A pre-versioning record omits `protocol_version`; serde `default` makes
+        // it 0, which is never the current version.
+        let json = format!(
+            r#"{{"schema_version":{RECORD_SCHEMA_VERSION},"pid":1,"pid_creation_time":2,
+               "pipe_name":"\\\\.\\pipe\\x","ready":true}}"#
+        );
+        let record: DaemonRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(record.protocol_version, 0);
+        assert!(!record.protocol_compatible());
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing() {
+        let _guard = STATE_AWARE_TEST_LOCK.lock().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        set_state_aware_root_for_test(Some(dir.path().to_path_buf()));
+
+        let mut record = sample_record();
+        write_daemon_record(&record).unwrap();
+        record.ready = false;
+        write_daemon_record(&record).unwrap();
+        assert!(!read_daemon_record().unwrap().unwrap().ready);
+
+        set_state_aware_root_for_test(None);
+    }
+
+    #[test]
+    fn mint_pipe_name_is_unique_and_well_formed() {
+        let a = mint_pipe_name();
+        let b = mint_pipe_name();
+        assert_ne!(a, b);
+        assert!(a.starts_with(r"\\.\pipe\mxc-wslc-"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn current_process_is_alive_with_matching_creation_time() {
+        let pid = std::process::id();
+        let ct = process_creation_time(pid).expect("own creation time");
+        let record = DaemonRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            pid,
+            pid_creation_time: ct,
+            pipe_name: mint_pipe_name(),
+            ready: true,
+            protocol_version: crate::daemon_protocol::PROTOCOL_VERSION,
+        };
+        assert!(daemon_alive(&record));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn wrong_creation_time_is_not_alive() {
+        let pid = std::process::id();
+        let record = DaemonRecord {
+            schema_version: RECORD_SCHEMA_VERSION,
+            pid,
+            pid_creation_time: 0xDEAD_BEEF,
+            pipe_name: mint_pipe_name(),
+            ready: true,
+            protocol_version: crate::daemon_protocol::PROTOCOL_VERSION,
+        };
+        assert!(!daemon_alive(&record));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn dead_pid_has_no_running_creation_time() {
+        // PID 0 is never a valid queryable user process.
+        assert_eq!(running_process_creation_time(0), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn transition_lock_acquire_release_reacquire() {
+        let lock = TransitionLock::acquire(std::time::Duration::from_secs(1)).unwrap();
+        drop(lock);
+        // Re-acquire after release must succeed.
+        let _lock = TransitionLock::acquire(std::time::Duration::from_secs(1)).unwrap();
+    }
+}

--- a/src/backends/wslc/common/src/lib.rs
+++ b/src/backends/wslc/common/src/lib.rs
@@ -13,6 +13,10 @@
 //! `wxc-exec`) and streaming (`SandboxBackend`, in [`sandbox`], used by the
 //! Rust SDK).
 
+pub mod container_steps;
+pub mod daemon_client;
+pub mod daemon_protocol;
+pub mod daemon_record;
 pub mod policy_mapping;
 pub mod sandbox;
 mod stream_buffer;

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -468,8 +468,8 @@ impl WSLContainerRunner {
     /// Supports both rootfs tars (`docker export`) and Docker image archives
     /// (`docker save`). The format is auto-detected via `detect_tar_format`.
     /// Returns `Ok(())` on success or `Err(ScriptResponse)` on failure.
-    unsafe fn import_image_from_tar(
-        sdk: &'static WslcSdk,
+    pub(crate) unsafe fn import_image_from_tar(
+        sdk: &WslcSdk,
         session: WslcSession,
         image_name: &str,
         tar_path: &str,
@@ -607,7 +607,7 @@ fn sdk_error(context: &str, hr: HRESULT, sdk_msg: &str) -> ScriptResponse {
 /// reports as missing. `missing` may combine multiple bits, and the guidance is branched
 /// per-component so a user missing only `VirtualMachinePlatform` isn't told to update WSL
 /// (which doesn't enable that Windows optional feature), and vice versa.
-fn wslc_prerequisite_error(missing: WslcComponentFlags) -> String {
+pub(crate) fn wslc_prerequisite_error(missing: WslcComponentFlags) -> String {
     let needs_vmp =
         missing.0 & WslcComponentFlags::WSLC_COMPONENT_FLAG_VIRTUAL_MACHINE_PLATFORM.0 != 0;
     let needs_wsl_package = missing.0 & WslcComponentFlags::WSLC_COMPONENT_FLAG_WSL_PACKAGE.0 != 0;

--- a/src/backends/wslc/common/src/wslc_bindings.rs
+++ b/src/backends/wslc/common/src/wslc_bindings.rs
@@ -147,6 +147,7 @@ impl WslcSdk {
             WslcSetContainerSettingsPortMappings,
             WslcSetContainerSettingsVolumes,
             WslcCreateContainerProcess,
+            WslcSignalProcess,
             WslcReleaseContainer,
             WslcGetContainerInitProcess,
             WslcStopContainer,

--- a/src/backends/wslc/daemon/Cargo.toml
+++ b/src/backends/wslc/daemon/Cargo.toml
@@ -9,6 +9,8 @@ name = "wxc-wslc-daemon"
 path = "src/main.rs"
 
 [dependencies]
+
+[target.'cfg(windows)'.dependencies]
 wxc_common = { workspace = true }
 wslc_common = { workspace = true }
 windows = { workspace = true }
@@ -18,7 +20,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 uuid = { workspace = true }
 
-[dev-dependencies]
+[target.'cfg(windows)'.dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/src/backends/wslc/daemon/Cargo.toml
+++ b/src/backends/wslc/daemon/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
-name = "wslc_common"
+name = "wxc_wslc_daemon"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[features]
-default = []
-link-wslcsdk = []
+[[bin]]
+name = "wxc-wslc-daemon"
+path = "src/main.rs"
 
 [dependencies]
 wxc_common = { workspace = true }
+wslc_common = { workspace = true }
 windows = { workspace = true }
+tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 uuid = { workspace = true }
-tar = "0.4"
-libloading = "0.8"
 
 [dev-dependencies]
 tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
-zip = { version = "2", default-features = false, features = ["deflate"] }
-sha2 = "0.10"
+mxc_build_common.workspace = true

--- a/src/backends/wslc/daemon/build.rs
+++ b/src/backends/wslc/daemon/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+fn main() {
+    mxc_build_common::embed_version_info("WSL Container integration daemon", "wxc-wslc-daemon.exe");
+}

--- a/src/backends/wslc/daemon/src/control_server.rs
+++ b/src/backends/wslc/daemon/src/control_server.rs
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Named-pipe control server: accepts phase-process connections, decodes one
+//! [`DaemonRequest`] per connection, dispatches it to the WSLc worker via a
+//! [`SessionHandle`], and writes back a [`DaemonResponse`] (plus a
+//! [`StreamFrame`] stream for exec).
+//!
+//! One request per connection keeps the framing trivial and matches how the
+//! state-aware client drives each lifecycle phase as a discrete call. Exec is
+//! the exception: after an `Ok` admission it enters the [`StreamFrame`] data
+//! phase (live stdio) until a terminal `Exit` / `Error`.
+//!
+//! SECURITY: every pipe instance is created with a protected DACL that grants
+//! access to only the current user and Local SYSTEM (mirroring the owner-only
+//! DACL stamped on the daemon's on-disk record), so no other Windows user can
+//! connect to the control plane.
+
+use std::ffi::c_void;
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use tokio::sync::Notify;
+use windows::core::{PCWSTR, PWSTR};
+use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+use windows::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+use windows::Win32::Security::{
+    GetTokenInformation, TokenUser, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES, TOKEN_QUERY,
+    TOKEN_USER,
+};
+use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+use wslc_common::daemon_protocol::{
+    encode_frame, DaemonRequest, DaemonResponse, ErrKind, StreamFrame, MAX_FRAME_SIZE,
+};
+
+use crate::session_manager::SessionHandle;
+
+/// Run the accept loop until `shutdown` is notified.
+///
+/// Uses the standard tokio overlapped-pipe pattern: keep one un-connected
+/// server instance listening; when it connects, hand it to a task and create the
+/// next instance so the next client is never refused.
+pub async fn run(session: SessionHandle, pipe_name: String, shutdown: Arc<Notify>) -> Result<()> {
+    let security = OwnerOnlySecurity::new().context("build owner-only pipe security")?;
+    let mut server = create_secured_instance(&pipe_name, &security, true)?;
+
+    loop {
+        tokio::select! {
+            connect = server.connect() => {
+                connect?;
+                let connected = server;
+                // Create the next instance before servicing this one.
+                server = create_secured_instance(&pipe_name, &security, false)?;
+                let session = session.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_client(connected, session).await {
+                        eprintln!("[wslc-daemon] client connection error: {e:#}");
+                    }
+                });
+            }
+            _ = shutdown.notified() => break,
+        }
+    }
+    Ok(())
+}
+
+/// Create one named-pipe server instance carrying the owner-only DACL.
+fn create_secured_instance(
+    pipe_name: &str,
+    security: &OwnerOnlySecurity,
+    first: bool,
+) -> Result<NamedPipeServer> {
+    let mut attrs = security.attributes();
+    // SAFETY: `attrs` is a valid SECURITY_ATTRIBUTES whose security descriptor
+    // is owned by `security` and outlives this call.
+    let server = unsafe {
+        ServerOptions::new()
+            .first_pipe_instance(first)
+            .create_with_security_attributes_raw(
+                pipe_name,
+                &mut attrs as *mut SECURITY_ATTRIBUTES as *mut c_void,
+            )
+    }?;
+    Ok(server)
+}
+
+/// Owns a `PSECURITY_DESCRIPTOR` describing a protected DACL that grants the
+/// current user and Local SYSTEM full access, and nothing else.
+struct OwnerOnlySecurity {
+    psd: PSECURITY_DESCRIPTOR,
+}
+
+// SAFETY: `psd` is a self-contained LocalAlloc'd security descriptor with no
+// thread affinity; ownership can move across threads freely.
+unsafe impl Send for OwnerOnlySecurity {}
+
+impl OwnerOnlySecurity {
+    fn new() -> Result<Self> {
+        let sid = current_user_sid_string()?;
+        let sddl = format!("D:P(A;;FA;;;{sid})(A;;FA;;;SY)");
+        let mut wide: Vec<u16> = sddl.encode_utf16().collect();
+        wide.push(0);
+
+        let mut psd = PSECURITY_DESCRIPTOR(std::ptr::null_mut());
+        // SAFETY: `wide` is a NUL-terminated UTF-16 SDDL string; `psd` receives a
+        // LocalAlloc'd descriptor freed in `Drop`.
+        unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                PCWSTR(wide.as_ptr()),
+                SDDL_REVISION_1,
+                &mut psd,
+                None,
+            )
+        }
+        .context("ConvertStringSecurityDescriptorToSecurityDescriptorW")?;
+        if psd.0.is_null() {
+            bail!("ConvertStringSecurityDescriptorToSecurityDescriptorW returned NULL");
+        }
+        Ok(Self { psd })
+    }
+
+    /// A `SECURITY_ATTRIBUTES` referencing the owned descriptor. The returned
+    /// value borrows `self`; keep `self` alive while it is in use.
+    fn attributes(&self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: self.psd.0,
+            bInheritHandle: false.into(),
+        }
+    }
+}
+
+impl Drop for OwnerOnlySecurity {
+    fn drop(&mut self) {
+        if !self.psd.0.is_null() {
+            // SAFETY: `psd` was allocated by
+            // `ConvertStringSecurityDescriptorToSecurityDescriptorW`, which
+            // documents `LocalFree` as the matching deallocator.
+            unsafe {
+                let _ = LocalFree(Some(HLOCAL(self.psd.0)));
+            }
+        }
+    }
+}
+
+/// Resolve the current process token's user SID as an SDDL string (e.g. `S-1-5-...`).
+fn current_user_sid_string() -> Result<String> {
+    // SAFETY: standard token-query sequence; every raw pointer is backed by a
+    // live local, and both the token handle and the LocalAlloc'd SID string are
+    // released before returning.
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token)
+            .context("OpenProcessToken")?;
+
+        // First call sizes the buffer (expected to fail with insufficient buffer).
+        let mut len = 0u32;
+        let _ = GetTokenInformation(token, TokenUser, None, 0, &mut len);
+        let mut buf = vec![0u8; len as usize];
+        let info = GetTokenInformation(
+            token,
+            TokenUser,
+            Some(buf.as_mut_ptr() as *mut c_void),
+            len,
+            &mut len,
+        );
+        let _ = CloseHandle(token);
+        info.context("GetTokenInformation(TokenUser)")?;
+
+        let token_user = &*(buf.as_ptr() as *const TOKEN_USER);
+        let mut sid_wstr = PWSTR::null();
+        ConvertSidToStringSidW(token_user.User.Sid, &mut sid_wstr)
+            .context("ConvertSidToStringSidW")?;
+        let sid = sid_wstr
+            .to_string()
+            .context("SID string was not valid UTF-16")?;
+        let _ = LocalFree(Some(HLOCAL(sid_wstr.0 as *mut c_void)));
+        Ok(sid)
+    }
+}
+
+/// Service exactly one request on a freshly-connected pipe instance.
+async fn handle_client(mut pipe: NamedPipeServer, session: SessionHandle) -> Result<()> {
+    let request: DaemonRequest = read_frame(&mut pipe).await?;
+    match request {
+        DaemonRequest::Ping => {
+            write_frame(&mut pipe, &DaemonResponse::Pong).await?;
+        }
+        DaemonRequest::Provision(config) => {
+            let resp = match session.provision(config).await {
+                Ok(sandbox_id) => DaemonResponse::Provisioned { sandbox_id },
+                Err(e) => err_response(ErrKind::Backend, e),
+            };
+            write_frame(&mut pipe, &resp).await?;
+        }
+        DaemonRequest::Start(config) => {
+            let resp = ok_or_err(session.start(config).await);
+            write_frame(&mut pipe, &resp).await?;
+        }
+        DaemonRequest::Stop(config) => {
+            let resp = ok_or_err(session.stop(config).await);
+            write_frame(&mut pipe, &resp).await?;
+        }
+        DaemonRequest::Deprovision(config) => {
+            let resp = ok_or_err(session.deprovision(config).await);
+            write_frame(&mut pipe, &resp).await?;
+        }
+        DaemonRequest::Exec(config) => {
+            handle_exec(pipe, session, config).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Exec: admit with `Ok`, then stream the run's outcome as [`StreamFrame`]s.
+///
+/// TODO(fill-in): bidirectional live stdio (client `Stdin` frames -> process,
+/// process stdout/stderr -> `Stdout`/`Stderr` frames). The skeleton runs the
+/// command to completion and emits only the terminal frame.
+async fn handle_exec(
+    mut pipe: NamedPipeServer,
+    session: SessionHandle,
+    config: wslc_common::daemon_protocol::ExecConfig,
+) -> Result<()> {
+    write_frame(&mut pipe, &DaemonResponse::Ok).await?;
+    let terminal = match session.exec(config).await {
+        Ok(code) => StreamFrame::Exit { code },
+        Err(e) => StreamFrame::Error {
+            message: format!("{e:#}"),
+        },
+    };
+    write_frame(&mut pipe, &terminal).await?;
+    Ok(())
+}
+
+/// Map a `Result<()>` to `Ok` / `Err` response.
+fn ok_or_err(result: Result<()>) -> DaemonResponse {
+    match result {
+        Ok(()) => DaemonResponse::Ok,
+        Err(e) => err_response(ErrKind::Backend, e),
+    }
+}
+
+fn err_response(kind: ErrKind, e: anyhow::Error) -> DaemonResponse {
+    DaemonResponse::Err {
+        kind,
+        message: format!("{e:#}"),
+    }
+}
+
+/// Read one length-prefixed frame and deserialise it.
+async fn read_frame<T: DeserializeOwned>(pipe: &mut NamedPipeServer) -> Result<T> {
+    let mut len_buf = [0u8; 4];
+    pipe.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_SIZE {
+        bail!("incoming frame length {len} exceeds maximum {MAX_FRAME_SIZE}");
+    }
+    let mut body = vec![0u8; len];
+    pipe.read_exact(&mut body).await?;
+    Ok(serde_json::from_slice(&body)?)
+}
+
+/// Serialise `msg` and write it as a length-prefixed frame.
+async fn write_frame<T: Serialize>(pipe: &mut NamedPipeServer, msg: &T) -> Result<()> {
+    let frame = encode_frame(msg)?;
+    pipe.write_all(&frame).await?;
+    pipe.flush().await?;
+    Ok(())
+}

--- a/src/backends/wslc/daemon/src/control_server.rs
+++ b/src/backends/wslc/daemon/src/control_server.rs
@@ -17,6 +17,7 @@
 //! connect to the control plane.
 
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use anyhow::{bail, Context, Result};
@@ -42,27 +43,51 @@ use wslc_common::daemon_protocol::{
 
 use crate::session_manager::SessionHandle;
 
+/// Bind the first pipe instance and build the owner-only security descriptor.
+///
+/// Called synchronously before the daemon record is published so a client never
+/// discovers a `ready` record for a pipe that is not yet listening.
+pub fn bind(pipe_name: &str) -> Result<(OwnerOnlySecurity, NamedPipeServer)> {
+    let security = OwnerOnlySecurity::new().context("build owner-only pipe security")?;
+    let first = create_secured_instance(pipe_name, &security, true)?;
+    Ok((security, first))
+}
+
 /// Run the accept loop until `shutdown` is notified.
 ///
-/// Uses the standard tokio overlapped-pipe pattern: keep one un-connected
-/// server instance listening; when it connects, hand it to a task and create the
-/// next instance so the next client is never refused.
-pub async fn run(session: SessionHandle, pipe_name: String, shutdown: Arc<Notify>) -> Result<()> {
-    let security = OwnerOnlySecurity::new().context("build owner-only pipe security")?;
-    let mut server = create_secured_instance(&pipe_name, &security, true)?;
+/// Keeps one un-connected server instance listening; when it connects, hand it
+/// to a task and create the next instance so the next client is never refused.
+/// `active_clients` tracks in-flight requests so the idle watchdog does not tear
+/// the daemon down mid-request.
+pub async fn run(
+    session: SessionHandle,
+    pipe_name: String,
+    security: OwnerOnlySecurity,
+    first_instance: NamedPipeServer,
+    active_clients: Arc<AtomicUsize>,
+    shutdown: Arc<Notify>,
+) -> Result<()> {
+    let mut server = first_instance;
 
     loop {
         tokio::select! {
             connect = server.connect() => {
-                connect?;
+                if let Err(e) = connect {
+                    eprintln!("[wslc-daemon] pipe connect error: {e}");
+                    server = create_secured_instance(&pipe_name, &security, false)?;
+                    continue;
+                }
                 let connected = server;
                 // Create the next instance before servicing this one.
                 server = create_secured_instance(&pipe_name, &security, false)?;
                 let session = session.clone();
+                let active = active_clients.clone();
+                active.fetch_add(1, Ordering::SeqCst);
                 tokio::spawn(async move {
                     if let Err(e) = handle_client(connected, session).await {
                         eprintln!("[wslc-daemon] client connection error: {e:#}");
                     }
+                    active.fetch_sub(1, Ordering::SeqCst);
                 });
             }
             _ = shutdown.notified() => break,
@@ -93,7 +118,7 @@ fn create_secured_instance(
 
 /// Owns a `PSECURITY_DESCRIPTOR` describing a protected DACL that grants the
 /// current user and Local SYSTEM full access, and nothing else.
-struct OwnerOnlySecurity {
+pub(crate) struct OwnerOnlySecurity {
     psd: PSECURITY_DESCRIPTOR,
 }
 

--- a/src/backends/wslc/daemon/src/control_server.rs
+++ b/src/backends/wslc/daemon/src/control_server.rs
@@ -60,6 +60,14 @@ const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(30);
 /// abandoning them, so a wedged handler cannot block daemon exit forever.
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Bounded-backoff retry budget for recreating a control-pipe instance after a
+/// transient create failure (handle/resource exhaustion). A single transient
+/// hiccup must not tear the daemon — and every live sandbox — down; only a
+/// failure that persists past the whole budget is treated as fatal.
+const INSTANCE_RETRY_ATTEMPTS: u32 = 5;
+const INSTANCE_RETRY_BACKOFF: Duration = Duration::from_millis(50);
+const INSTANCE_RETRY_MAX_BACKOFF: Duration = Duration::from_millis(500);
+
 /// Bind the first pipe instance and build the owner-only security descriptor.
 ///
 /// Called synchronously before the daemon record is published so a client never
@@ -90,36 +98,52 @@ pub async fn run(
     let limiter = Arc::new(Semaphore::new(MAX_CONCURRENT_CLIENTS));
     let mut clients: JoinSet<()> = JoinSet::new();
 
+    // A create-instance failure that persists past its retry budget is fatal:
+    // we can no longer listen for new clients. Record it, break, then drain and
+    // surface it after in-flight handlers finish — never mid-loop, so an already
+    // accepted client is not abandoned.
+    let mut fatal: Option<anyhow::Error> = None;
+
     loop {
         tokio::select! {
             connect = server.connect() => {
                 if let Err(e) = connect {
                     eprintln!("[wslc-daemon] pipe connect error: {e}");
-                    server = create_secured_instance(&pipe_name, &security, false)?;
+                    match create_secured_instance_retry(&pipe_name, &security).await {
+                        Ok(next) => server = next,
+                        Err(e) => {
+                            fatal = Some(e.context("recreate control pipe after connect error"));
+                            break;
+                        }
+                    }
                     continue;
                 }
                 let connected = server;
-                // Create the next instance before servicing this one.
-                server = create_secured_instance(&pipe_name, &security, false)?;
+                // Recreate the next listening instance before servicing this one
+                // so the next client is not refused. Transient failures are
+                // retried with bounded backoff rather than tearing the whole
+                // daemon down on a single accept-capacity hiccup.
+                let next = create_secured_instance_retry(&pipe_name, &security).await;
 
-                // Bound concurrency: acquire a slot before spawning. At capacity
-                // this awaits a free slot (backpressure) rather than spawning an
-                // unbounded task. The semaphore is never closed, so acquire
-                // cannot fail.
-                let permit = Semaphore::acquire_owned(limiter.clone())
-                    .await
-                    .expect("client semaphore is never closed");
+                // Service the accepted client regardless of whether we managed to
+                // recreate the next instance, so a fatal recreate failure below
+                // does not abandon a connection we already accepted.
+                spawn_client_handler(
+                    &mut clients,
+                    &limiter,
+                    &session,
+                    &active_clients,
+                    connected,
+                )
+                .await;
 
-                let session = session.clone();
-                let active = active_clients.clone();
-                active.fetch_add(1, Ordering::SeqCst);
-                clients.spawn(async move {
-                    let _permit = permit;
-                    if let Err(e) = handle_client(connected, session).await {
-                        eprintln!("[wslc-daemon] client connection error: {e:#}");
+                match next {
+                    Ok(n) => server = n,
+                    Err(e) => {
+                        fatal = Some(e.context("recreate control pipe instance"));
+                        break;
                     }
-                    active.fetch_sub(1, Ordering::SeqCst);
-                });
+                }
             }
             // Reap finished handlers so the JoinSet does not accumulate.
             Some(_) = clients.join_next() => {}
@@ -140,7 +164,65 @@ pub async fn run(
         clients.shutdown().await;
     }
 
-    Ok(())
+    match fatal {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Acquire a concurrency slot (backpressure at capacity) and spawn a task to
+/// service one accepted client connection, tracking it in `active_clients` for
+/// the idle watchdog.
+async fn spawn_client_handler(
+    clients: &mut JoinSet<()>,
+    limiter: &Arc<Semaphore>,
+    session: &SessionHandle,
+    active_clients: &Arc<AtomicUsize>,
+    connected: NamedPipeServer,
+) {
+    // Bound concurrency: acquire a slot before spawning. At capacity this awaits
+    // a free slot (backpressure) rather than spawning an unbounded task. The
+    // semaphore is never closed, so acquire cannot fail.
+    let permit = Semaphore::acquire_owned(limiter.clone())
+        .await
+        .expect("client semaphore is never closed");
+
+    let session = session.clone();
+    let active = active_clients.clone();
+    active.fetch_add(1, Ordering::SeqCst);
+    clients.spawn(async move {
+        let _permit = permit;
+        if let Err(e) = handle_client(connected, session).await {
+            eprintln!("[wslc-daemon] client connection error: {e:#}");
+        }
+        active.fetch_sub(1, Ordering::SeqCst);
+    });
+}
+
+/// Recreate a listening pipe instance, retrying transient failures with bounded
+/// backoff so one accept-capacity/handle-exhaustion hiccup does not tear the
+/// daemon — and every live sandbox — down. Only a failure that persists past the
+/// whole budget is returned as an error.
+async fn create_secured_instance_retry(
+    pipe_name: &str,
+    security: &OwnerOnlySecurity,
+) -> Result<NamedPipeServer> {
+    let mut backoff = INSTANCE_RETRY_BACKOFF;
+    for attempt in 1..=INSTANCE_RETRY_ATTEMPTS {
+        match create_secured_instance(pipe_name, security, false) {
+            Ok(server) => return Ok(server),
+            Err(e) if attempt < INSTANCE_RETRY_ATTEMPTS => {
+                eprintln!(
+                    "[wslc-daemon] pipe instance create failed \
+                     (attempt {attempt}/{INSTANCE_RETRY_ATTEMPTS}): {e:#}; retrying in {backoff:?}"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(INSTANCE_RETRY_MAX_BACKOFF);
+            }
+            Err(e) => return Err(e).context("pipe instance create exhausted retries"),
+        }
+    }
+    unreachable!("the loop returns on the final attempt")
 }
 
 /// Create one named-pipe server instance carrying the owner-only DACL.
@@ -172,6 +254,13 @@ pub(crate) struct OwnerOnlySecurity {
 // SAFETY: `psd` is a self-contained LocalAlloc'd security descriptor with no
 // thread affinity; ownership can move across threads freely.
 unsafe impl Send for OwnerOnlySecurity {}
+
+// SAFETY: the descriptor is immutable after construction — `attributes()` only
+// copies the pointer into a `SECURITY_ATTRIBUTES` and the OS reads (never
+// mutates) it, and the sole `LocalFree` happens in `Drop` on the owning thread.
+// Shared `&OwnerOnlySecurity` access across threads (e.g. held across an await
+// in the accept loop) is therefore race-free.
+unsafe impl Sync for OwnerOnlySecurity {}
 
 impl OwnerOnlySecurity {
     fn new() -> Result<Self> {

--- a/src/backends/wslc/daemon/src/control_server.rs
+++ b/src/backends/wslc/daemon/src/control_server.rs
@@ -19,13 +19,16 @@
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, Semaphore};
+use tokio::task::JoinSet;
+use tokio::time::timeout;
 use windows::core::{PCWSTR, PWSTR};
 use windows::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
 use windows::Win32::Security::Authorization::{
@@ -43,6 +46,20 @@ use wslc_common::daemon_protocol::{
 
 use crate::session_manager::SessionHandle;
 
+/// Upper bound on concurrently-serviced client connections. At capacity the
+/// accept loop applies backpressure (a new connection waits for a slot) instead
+/// of spawning an unbounded number of handler tasks.
+const MAX_CONCURRENT_CLIENTS: usize = 128;
+
+/// Deadline for a freshly-connected client to send its first (request) frame. A
+/// client that connects and then stalls must not pin a handler task — and a
+/// concurrency slot — indefinitely.
+const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Bound on how long shutdown waits for in-flight handlers to finish before
+/// abandoning them, so a wedged handler cannot block daemon exit forever.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Bind the first pipe instance and build the owner-only security descriptor.
 ///
 /// Called synchronously before the daemon record is published so a client never
@@ -58,7 +75,9 @@ pub fn bind(pipe_name: &str) -> Result<(OwnerOnlySecurity, NamedPipeServer)> {
 /// Keeps one un-connected server instance listening; when it connects, hand it
 /// to a task and create the next instance so the next client is never refused.
 /// `active_clients` tracks in-flight requests so the idle watchdog does not tear
-/// the daemon down mid-request.
+/// the daemon down mid-request. Concurrency is bounded by a semaphore, and on
+/// shutdown all in-flight handlers are drained before returning so the caller
+/// can release the WSLc session without racing a live handler.
 pub async fn run(
     session: SessionHandle,
     pipe_name: String,
@@ -68,6 +87,8 @@ pub async fn run(
     shutdown: Arc<Notify>,
 ) -> Result<()> {
     let mut server = first_instance;
+    let limiter = Arc::new(Semaphore::new(MAX_CONCURRENT_CLIENTS));
+    let mut clients: JoinSet<()> = JoinSet::new();
 
     loop {
         tokio::select! {
@@ -80,19 +101,45 @@ pub async fn run(
                 let connected = server;
                 // Create the next instance before servicing this one.
                 server = create_secured_instance(&pipe_name, &security, false)?;
+
+                // Bound concurrency: acquire a slot before spawning. At capacity
+                // this awaits a free slot (backpressure) rather than spawning an
+                // unbounded task. The semaphore is never closed, so acquire
+                // cannot fail.
+                let permit = Semaphore::acquire_owned(limiter.clone())
+                    .await
+                    .expect("client semaphore is never closed");
+
                 let session = session.clone();
                 let active = active_clients.clone();
                 active.fetch_add(1, Ordering::SeqCst);
-                tokio::spawn(async move {
+                clients.spawn(async move {
+                    let _permit = permit;
                     if let Err(e) = handle_client(connected, session).await {
                         eprintln!("[wslc-daemon] client connection error: {e:#}");
                     }
                     active.fetch_sub(1, Ordering::SeqCst);
                 });
             }
+            // Reap finished handlers so the JoinSet does not accumulate.
+            Some(_) = clients.join_next() => {}
             _ = shutdown.notified() => break,
         }
     }
+
+    // Drain in-flight handlers so the caller never releases the session/worker
+    // while a handler is still using it. Abandon anything past the deadline so a
+    // wedged handler cannot block daemon exit forever.
+    if timeout(DRAIN_TIMEOUT, async {
+        while clients.join_next().await.is_some() {}
+    })
+    .await
+    .is_err()
+    {
+        eprintln!("[wslc-daemon] drain timed out; abandoning in-flight client handlers");
+        clients.shutdown().await;
+    }
+
     Ok(())
 }
 
@@ -213,7 +260,11 @@ fn current_user_sid_string() -> Result<String> {
 
 /// Service exactly one request on a freshly-connected pipe instance.
 async fn handle_client(mut pipe: NamedPipeServer, session: SessionHandle) -> Result<()> {
-    let request: DaemonRequest = read_frame(&mut pipe).await?;
+    // Bound the wait for the request frame so a client that connects and then
+    // stalls cannot pin this handler (and its concurrency slot) indefinitely.
+    let request: DaemonRequest = timeout(FIRST_FRAME_TIMEOUT, read_frame(&mut pipe))
+        .await
+        .context("timed out waiting for the client's first frame")??;
     match request {
         DaemonRequest::Ping => {
             write_frame(&mut pipe, &DaemonResponse::Pong).await?;

--- a/src/backends/wslc/daemon/src/main.rs
+++ b/src/backends/wslc/daemon/src/main.rs
@@ -155,6 +155,14 @@ async fn run() -> Result<()> {
 
 /// Poll the live-container count; once it has been zero for `IDLE_TIMEOUT` with
 /// no in-flight requests, notify shutdown.
+///
+/// The signal is delivered with [`Notify::notify_one`], not `notify_waiters`:
+/// the control server only awaits `shutdown.notified()` inside its `select!`, so
+/// a wakeup raised while it is executing another branch (accepting or spawning a
+/// handler) would be dropped by `notify_waiters` (it retains no permit when no
+/// task is parked). `notify_one` stores a permit, so the server's next
+/// `notified()` completes regardless of when the signal was raised — the
+/// watchdog can then return without leaving the daemon alive forever.
 #[cfg(windows)]
 async fn idle_watchdog(
     session: session_manager::SessionHandle,
@@ -170,16 +178,41 @@ async fn idle_watchdog(
             Ok(0) if active_clients.load(Ordering::SeqCst) == 0 => {
                 idle_for += IDLE_POLL;
                 if idle_for >= IDLE_TIMEOUT {
-                    shutdown.notify_waiters();
+                    shutdown.notify_one();
                     return;
                 }
             }
             Ok(_) => idle_for = Duration::ZERO,
             Err(_) => {
                 // Worker gone: nothing left to serve.
-                shutdown.notify_waiters();
+                shutdown.notify_one();
                 return;
             }
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::Notify;
+
+    /// Regression for the lost idle-shutdown wakeup: the watchdog may fire while
+    /// the control server is executing a non-`notified()` `select!` branch. With
+    /// `notify_one` the signal is retained as a permit, so the server's *next*
+    /// `notified()` still completes. (`notify_waiters` would drop it here and
+    /// hang the daemon alive forever.)
+    #[tokio::test]
+    async fn notify_one_is_observed_when_raised_before_the_waiter_parks() {
+        let shutdown = Notify::new();
+
+        // Signal raised while no task is parked (server busy elsewhere).
+        shutdown.notify_one();
+
+        // The server later reaches its `notified()`; it must complete promptly.
+        tokio::time::timeout(Duration::from_secs(5), shutdown.notified())
+            .await
+            .expect("a permit raised before the waiter parked must not be lost");
     }
 }

--- a/src/backends/wslc/daemon/src/main.rs
+++ b/src/backends/wslc/daemon/src/main.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! `wxc-wslc-daemon` — the long-lived per-user daemon that owns the WSLc SDK
+//! session + container handles across state-aware lifecycle phases.
+//!
+//! Each state-aware phase (`provision` / `start` / `exec` / `stop` /
+//! `deprovision`) runs as a separate short-lived `wxc-exec` process, but the
+//! WSLc SDK has no cross-process re-attach for its `WslcSession` /
+//! `WslcContainer` handles. This daemon holds those handles on a single worker
+//! thread ([`session_manager`]) and serves the phase processes over an
+//! owner-only named pipe ([`control_server`]).
+//!
+//! Boot sequence:
+//! 1. Secure the record root and mint a unique pipe name.
+//! 2. Spawn the WSLc worker thread.
+//! 3. Publish a `daemon.json` record with `ready = false` so a racing client can
+//!    discover us but knows not to send work yet.
+//! 4. Start the control server; once it is listening, flip the record to
+//!    `ready = true`.
+//! 5. Run an idle watchdog: when the live-container count stays at zero past the
+//!    idle timeout, shut down.
+//! 6. On exit, remove the record.
+
+mod control_server;
+mod session_manager;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::sync::Notify;
+
+use wslc_common::daemon_protocol::PROTOCOL_VERSION;
+use wslc_common::daemon_record::{
+    mint_pipe_name, process_creation_time, remove_daemon_record, secure_record_root,
+    write_daemon_record, DaemonRecord, RECORD_SCHEMA_VERSION,
+};
+
+/// How long the live-container count must stay at zero before the daemon exits.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Poll cadence for the idle watchdog.
+const IDLE_POLL: Duration = Duration::from_secs(15);
+
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build tokio runtime")?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
+    secure_record_root().context("secure state-aware record root")?;
+
+    let pid = std::process::id();
+    let pid_creation_time = process_creation_time(pid).unwrap_or(0);
+    let pipe_name = mint_pipe_name();
+
+    let session = session_manager::spawn().context("spawn WSLc session worker")?;
+
+    // Publish a not-yet-ready record so a racing client can find us but waits.
+    let mut record = DaemonRecord {
+        schema_version: RECORD_SCHEMA_VERSION,
+        pid,
+        pid_creation_time,
+        pipe_name: pipe_name.clone(),
+        ready: false,
+        protocol_version: PROTOCOL_VERSION,
+    };
+    write_daemon_record(&record).context("publish initial daemon record")?;
+
+    let shutdown = Arc::new(Notify::new());
+
+    // Start the control server. It creates the first pipe instance eagerly, so
+    // once `spawn` returns the pipe exists and clients can connect.
+    let server = tokio::spawn(control_server::run(
+        session.clone(),
+        pipe_name.clone(),
+        shutdown.clone(),
+    ));
+
+    // Flip the record to ready now that the pipe is being served.
+    record.ready = true;
+    write_daemon_record(&record).context("publish ready daemon record")?;
+
+    // Idle watchdog: exit after IDLE_TIMEOUT with no live containers.
+    let watchdog = tokio::spawn(idle_watchdog(session.clone(), shutdown.clone()));
+
+    // Wait for the control server to finish (it stops when `shutdown` fires).
+    let server_result = server.await;
+
+    // Ensure the watchdog and worker are torn down.
+    shutdown.notify_waiters();
+    watchdog.abort();
+    let _ = session.shutdown().await;
+
+    // Best-effort record cleanup so a later client does not find a stale record.
+    let _ = remove_daemon_record();
+
+    server_result
+        .context("control server task panicked")?
+        .context("control server failed")
+}
+
+/// Poll the live-container count; once it has been zero for `IDLE_TIMEOUT`,
+/// notify shutdown.
+async fn idle_watchdog(session: session_manager::SessionHandle, shutdown: Arc<Notify>) {
+    let mut idle_for = Duration::ZERO;
+    loop {
+        tokio::time::sleep(IDLE_POLL).await;
+        match session.container_count().await {
+            Ok(0) => {
+                idle_for += IDLE_POLL;
+                if idle_for >= IDLE_TIMEOUT {
+                    shutdown.notify_waiters();
+                    return;
+                }
+            }
+            Ok(_) => idle_for = Duration::ZERO,
+            Err(_) => {
+                // Worker gone: nothing left to serve.
+                shutdown.notify_waiters();
+                return;
+            }
+        }
+    }
+}

--- a/src/backends/wslc/daemon/src/main.rs
+++ b/src/backends/wslc/daemon/src/main.rs
@@ -20,28 +20,55 @@
 //!    in-flight requests past the idle timeout, shut down.
 //! 5. On exit, remove the record.
 
+#[cfg(windows)]
 mod control_server;
+#[cfg(windows)]
 mod session_manager;
 
+#[cfg(windows)]
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(windows)]
 use std::sync::Arc;
+#[cfg(windows)]
 use std::time::Duration;
 
+#[cfg(windows)]
 use anyhow::{Context, Result};
+#[cfg(windows)]
 use tokio::sync::Notify;
 
+#[cfg(windows)]
 use wslc_common::daemon_protocol::PROTOCOL_VERSION;
+#[cfg(windows)]
 use wslc_common::daemon_record::{
     mint_pipe_name, process_creation_time, remove_daemon_record, secure_record_root,
-    write_daemon_record, DaemonRecord, RECORD_SCHEMA_VERSION,
+    write_daemon_record, DaemonRecord, TransitionLock, RECORD_SCHEMA_VERSION,
 };
 
 /// How long the live-container count must stay at zero before the daemon exits.
+#[cfg(windows)]
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Poll cadence for the idle watchdog.
+#[cfg(windows)]
 const IDLE_POLL: Duration = Duration::from_secs(15);
 
+/// Bound on how long shutdown waits for the transition lock before tearing down
+/// without it, so a phase process holding the lock cannot hang daemon exit.
+#[cfg(windows)]
+const SHUTDOWN_LOCK_TIMEOUT: Duration = Duration::from_secs(10);
+
+// The daemon owns the WSLc SDK's live session/container handles, which only
+// exist on Windows. The Windows-only dependencies are target-gated in
+// Cargo.toml so non-Windows workspace commands (`cargo build/test --workspace`)
+// still resolve and compile this crate down to the stub below.
+#[cfg(not(windows))]
+fn main() {
+    eprintln!("wxc-wslc-daemon is Windows-only.");
+    std::process::exit(64);
+}
+
+#[cfg(windows)]
 fn main() -> Result<()> {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -50,6 +77,7 @@ fn main() -> Result<()> {
     runtime.block_on(run())
 }
 
+#[cfg(windows)]
 async fn run() -> Result<()> {
     secure_record_root().context("secure state-aware record root")?;
 
@@ -97,16 +125,28 @@ async fn run() -> Result<()> {
         shutdown.clone(),
     ));
 
-    // Wait for the control server to finish (it stops when `shutdown` fires).
+    // Wait for the control server to finish: it stops accepting when `shutdown`
+    // fires and then drains its in-flight handlers, so once this returns no
+    // handler is still using the session.
     let server_result = server.await;
 
-    // Ensure the watchdog and worker are torn down.
-    shutdown.notify_waiters();
+    // Stop the idle watchdog (it may still be sleeping between polls).
     watchdog.abort();
-    let _ = session.shutdown().await;
 
-    // Best-effort record cleanup so a later client does not find a stale record.
-    let _ = remove_daemon_record();
+    // Teardown order matters. Take the transition lock so a concurrent phase
+    // process's spawn/discovery serialises against us, then remove the discovery
+    // record BEFORE releasing the session — a client must never find a `ready`
+    // record for a daemon whose session is being torn down; with the record
+    // gone it spawns a fresh daemon once we release the lock. If the lock cannot
+    // be taken promptly (a phase process holds it mid-spawn), proceed anyway:
+    // record removal and session release are still correct on their own.
+    {
+        let _lock = TransitionLock::acquire(SHUTDOWN_LOCK_TIMEOUT)
+            .map_err(|e| eprintln!("[wslc-daemon] shutdown: {e:#}; proceeding without the lock"))
+            .ok();
+        let _ = remove_daemon_record();
+        let _ = session.shutdown().await;
+    }
 
     server_result
         .context("control server task panicked")?
@@ -115,6 +155,7 @@ async fn run() -> Result<()> {
 
 /// Poll the live-container count; once it has been zero for `IDLE_TIMEOUT` with
 /// no in-flight requests, notify shutdown.
+#[cfg(windows)]
 async fn idle_watchdog(
     session: session_manager::SessionHandle,
     active_clients: Arc<AtomicUsize>,

--- a/src/backends/wslc/daemon/src/main.rs
+++ b/src/backends/wslc/daemon/src/main.rs
@@ -54,7 +54,12 @@ async fn run() -> Result<()> {
     secure_record_root().context("secure state-aware record root")?;
 
     let pid = std::process::id();
-    let pid_creation_time = process_creation_time(pid).unwrap_or(0);
+    // Stamp the record with our own verifiable identity. If we cannot read our
+    // creation time, fail startup rather than publish an unverifiable record: a
+    // record with a bogus creation time fails its own `daemon_alive` liveness
+    // check, so discovery clients would treat this daemon as dead and spawn a
+    // duplicate while it is still serving.
+    let pid_creation_time = process_creation_time(pid).context("read own process creation time")?;
     let pipe_name = mint_pipe_name();
 
     let session = session_manager::spawn().context("spawn WSLc session worker")?;

--- a/src/backends/wslc/daemon/src/main.rs
+++ b/src/backends/wslc/daemon/src/main.rs
@@ -14,17 +14,16 @@
 //! Boot sequence:
 //! 1. Secure the record root and mint a unique pipe name.
 //! 2. Spawn the WSLc worker thread.
-//! 3. Publish a `daemon.json` record with `ready = false` so a racing client can
-//!    discover us but knows not to send work yet.
-//! 4. Start the control server; once it is listening, flip the record to
-//!    `ready = true`.
-//! 5. Run an idle watchdog: when the live-container count stays at zero past the
-//!    idle timeout, shut down.
-//! 6. On exit, remove the record.
+//! 3. Bind the first control-pipe instance, then publish a `ready` `daemon.json`
+//!    record — the pipe is listening before any client can discover it.
+//! 4. Run an idle watchdog: when the live-container count stays at zero with no
+//!    in-flight requests past the idle timeout, shut down.
+//! 5. On exit, remove the record.
 
 mod control_server;
 mod session_manager;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -60,33 +59,38 @@ async fn run() -> Result<()> {
 
     let session = session_manager::spawn().context("spawn WSLc session worker")?;
 
-    // Publish a not-yet-ready record so a racing client can find us but waits.
-    let mut record = DaemonRecord {
+    // Bind the first pipe instance before advertising the record, so a client
+    // never discovers a ready record for a pipe that is not yet listening.
+    let (security, first_instance) =
+        control_server::bind(&pipe_name).context("bind control pipe")?;
+
+    let record = DaemonRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         pid,
         pid_creation_time,
         pipe_name: pipe_name.clone(),
-        ready: false,
+        ready: true,
         protocol_version: PROTOCOL_VERSION,
     };
-    write_daemon_record(&record).context("publish initial daemon record")?;
+    write_daemon_record(&record).context("publish daemon record")?;
 
     let shutdown = Arc::new(Notify::new());
+    let active_clients = Arc::new(AtomicUsize::new(0));
 
-    // Start the control server. It creates the first pipe instance eagerly, so
-    // once `spawn` returns the pipe exists and clients can connect.
     let server = tokio::spawn(control_server::run(
         session.clone(),
         pipe_name.clone(),
+        security,
+        first_instance,
+        active_clients.clone(),
         shutdown.clone(),
     ));
 
-    // Flip the record to ready now that the pipe is being served.
-    record.ready = true;
-    write_daemon_record(&record).context("publish ready daemon record")?;
-
-    // Idle watchdog: exit after IDLE_TIMEOUT with no live containers.
-    let watchdog = tokio::spawn(idle_watchdog(session.clone(), shutdown.clone()));
+    let watchdog = tokio::spawn(idle_watchdog(
+        session.clone(),
+        active_clients,
+        shutdown.clone(),
+    ));
 
     // Wait for the control server to finish (it stops when `shutdown` fires).
     let server_result = server.await;
@@ -104,14 +108,20 @@ async fn run() -> Result<()> {
         .context("control server failed")
 }
 
-/// Poll the live-container count; once it has been zero for `IDLE_TIMEOUT`,
-/// notify shutdown.
-async fn idle_watchdog(session: session_manager::SessionHandle, shutdown: Arc<Notify>) {
+/// Poll the live-container count; once it has been zero for `IDLE_TIMEOUT` with
+/// no in-flight requests, notify shutdown.
+async fn idle_watchdog(
+    session: session_manager::SessionHandle,
+    active_clients: Arc<AtomicUsize>,
+    shutdown: Arc<Notify>,
+) {
     let mut idle_for = Duration::ZERO;
     loop {
         tokio::time::sleep(IDLE_POLL).await;
         match session.container_count().await {
-            Ok(0) => {
+            // A provision holds the count at zero while it runs, so also require
+            // no in-flight client requests before counting as idle.
+            Ok(0) if active_clients.load(Ordering::SeqCst) == 0 => {
                 idle_for += IDLE_POLL;
                 if idle_for >= IDLE_TIMEOUT {
                     shutdown.notify_waiters();

--- a/src/backends/wslc/daemon/src/session_manager.rs
+++ b/src/backends/wslc/daemon/src/session_manager.rs
@@ -172,9 +172,12 @@ struct ContainerEntry {
 /// only [`WorkerCommand`]s cross the channel.
 struct Worker {
     logger: Logger,
-    sdk: Option<WslcSdk>,
-    session: Option<WslcSessionGuard>,
+    // Field order is load-bearing on implicit drop: `containers` and `session`
+    // hold handles whose Drop calls into the SDK, so they must drop before `sdk`
+    // unloads `wslcsdk.dll`.
     containers: HashMap<String, ContainerEntry>,
+    session: Option<WslcSessionGuard>,
+    sdk: Option<WslcSdk>,
 }
 
 impl Worker {
@@ -363,37 +366,29 @@ impl Worker {
     }
 
     fn deprovision(&mut self, config: DeprovisionConfig) -> Result<()> {
-        let entry = self
-            .containers
-            .remove(&config.sandbox_id)
-            .ok_or_else(|| anyhow::anyhow!("unknown sandbox {}", config.sandbox_id))?;
-
-        let result = if let Some(sdk) = self.sdk.as_ref() {
-            // SAFETY: `sdk` is valid and `entry.container` is a live handle.
-            unsafe {
-                container_steps::delete_daemon_container(
-                    sdk,
-                    entry.container.as_raw(),
-                    &mut self.logger,
-                )
-            }
-            .map_err(sr_err)
-        } else {
-            Ok(())
+        let container_raw = match self.containers.get(&config.sandbox_id) {
+            Some(e) => e.container.as_raw(),
+            None => anyhow::bail!("unknown sandbox {}", config.sandbox_id),
         };
 
-        // Release the container handle regardless of delete success. Must happen
-        // before the SDK/session are torn down below (their DLL must stay loaded).
-        drop(entry);
+        if let Some(sdk) = self.sdk.as_ref() {
+            // SAFETY: `sdk` is valid and `container_raw` is a live handle.
+            unsafe {
+                container_steps::delete_daemon_container(sdk, container_raw, &mut self.logger)
+            }
+            .map_err(sr_err)?;
+        }
 
-        // Release the shared session (and unload the SDK) once idle. Ordering is
-        // load-bearing: the session guard's Drop uses SDK fn pointers, so it must
-        // drop before the SDK unloads the DLL.
+        // Delete succeeded (or no SDK loaded): drop the handle now. Keeping the
+        // entry on failure above leaves it retryable.
+        self.containers.remove(&config.sandbox_id);
+
+        // Release the shared session (and unload the SDK) once idle.
         if self.containers.is_empty() {
             self.session = None;
             self.sdk = None;
         }
-        result
+        Ok(())
     }
 
     fn shutdown(&mut self) {

--- a/src/backends/wslc/daemon/src/session_manager.rs
+++ b/src/backends/wslc/daemon/src/session_manager.rs
@@ -383,11 +383,10 @@ impl Worker {
         // entry on failure above leaves it retryable.
         self.containers.remove(&config.sandbox_id);
 
-        // Release the shared session (and unload the SDK) once idle.
-        if self.containers.is_empty() {
-            self.session = None;
-            self.sdk = None;
-        }
+        // The shared session (and SDK) stay loaded so a subsequent provision
+        // reuses the already-booted WSL2 VM. The idle watchdog releases them via
+        // `shutdown` once the container count has stayed at zero for the idle
+        // timeout.
         Ok(())
     }
 
@@ -432,7 +431,13 @@ pub fn spawn() -> Result<SessionHandle> {
         .name("wslc-session-worker".to_string())
         .spawn(move || {
             #[cfg(windows)]
-            let _com = ComApartment::enter();
+            let _com = match ComApartment::enter() {
+                Ok(com) => com,
+                Err(e) => {
+                    eprintln!("[wslc-daemon] worker COM initialisation failed: {e:#}");
+                    return;
+                }
+            };
 
             let mut worker = Worker::new();
             while let Some(cmd) = rx.blocking_recv() {
@@ -474,14 +479,16 @@ struct ComApartment;
 
 #[cfg(windows)]
 impl ComApartment {
-    fn enter() -> Self {
+    fn enter() -> Result<Self> {
         use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
-        // SAFETY: called once at worker-thread startup; balanced by CoUninitialize
-        // in Drop. A non-success HRESULT (e.g. already-initialised) is benign here.
-        unsafe {
-            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+        // SAFETY: called once at worker-thread startup. On success the matching
+        // `CoUninitialize` runs in `Drop`; on failure no guard is produced, so
+        // `CoUninitialize` is never called for an apartment we did not enter.
+        let hr = unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) };
+        if hr.is_err() {
+            anyhow::bail!("CoInitializeEx(MTA) failed: {hr:?}");
         }
-        Self
+        Ok(Self)
     }
 }
 

--- a/src/backends/wslc/daemon/src/session_manager.rs
+++ b/src/backends/wslc/daemon/src/session_manager.rs
@@ -335,6 +335,25 @@ impl Worker {
         }
         .map_err(sr_err)?;
 
+        if outcome.terminated_unconfirmed {
+            // The process could not be confirmed dead, so the container may
+            // still be running untrusted work and must not be reused for a
+            // later exec. Quarantine it: best-effort delete, then drop the
+            // handle so a subsequent exec fails with "unknown sandbox".
+            if let Some(sdk) = self.sdk.as_ref() {
+                // SAFETY: `sdk` is valid and `container` is a live handle.
+                let _ = unsafe {
+                    container_steps::delete_daemon_container(sdk, container, &mut self.logger)
+                };
+            }
+            self.containers.remove(&config.sandbox_id);
+            anyhow::bail!(
+                "exec on sandbox {} could not be confirmed terminated; the container was \
+                 quarantined",
+                config.sandbox_id
+            );
+        }
+
         if outcome.timed_out {
             anyhow::bail!("exec timed out after {}ms", config.timeout_ms);
         }

--- a/src/backends/wslc/daemon/src/session_manager.rs
+++ b/src/backends/wslc/daemon/src/session_manager.rs
@@ -1,0 +1,630 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Owns the WSLc SDK session and containers on a single dedicated worker
+//! thread.
+//!
+//! The WSLc SDK's `WslcSession` / `WslcContainer` / `WslcProcess` handles are
+//! thread-affine and must all be created and used from one apartment. This
+//! module confines every SDK call to a single long-lived worker thread that
+//! joins the MTA for its whole lifetime; async pipe handlers dispatch typed
+//! [`WorkerCommand`]s to it over a channel and await the reply.
+//!
+//! State-aware topology (decided): **one** shared `WslcSession` (the WSL2
+//! utility VM, booted lazily on first provision and amortised across all
+//! sandboxes) and a refcounted `sandbox_id -> container` map. The session is
+//! released when the last container is deprovisioned and the idle timeout
+//! elapses.
+//!
+//! Each phase drives the real WSLc SDK via the reusable steps in
+//! [`wslc_common::container_steps`]: `provision` ensures the session + resolves
+//! the image + creates a container with a keepalive init process; `start` boots
+//! it; `exec` runs a fresh `WslcCreateContainerProcess` to completion; `stop` /
+//! `deprovision` stop + delete. Live bidirectional stdio streaming over the
+//! control pipe is still a later fill-in — `exec` currently returns the exit
+//! code only.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use tokio::sync::{mpsc, oneshot};
+
+use wslc_common::container_steps::{self, ProcessSettings};
+use wslc_common::daemon_protocol::{
+    DeprovisionConfig, ExecConfig, NetworkMode, ProvisionConfig, StartConfig, StopConfig,
+};
+use wslc_common::policy_mapping;
+use wslc_common::wslc_bindings::{
+    WslcContainerGuard, WslcContainerNetworkingMode, WslcSdk, WslcSessionGuard,
+};
+use wxc_common::logger::{Logger, Mode};
+use wxc_common::models::ScriptResponse;
+
+/// Fixed name of the single WSL2 utility-VM session the daemon owns.
+const SESSION_NAME: &str = "mxc-wslc-daemon";
+
+/// Default on-disk WSLc image/session store. Matches the one-shot runner's
+/// default so images pre-pulled via `setup-wslc.ps1` are found by the daemon.
+fn default_storage_path() -> String {
+    std::env::temp_dir()
+        .join("mxc-wslc-sessions")
+        .to_string_lossy()
+        .to_string()
+}
+
+/// Map a step helper's `ScriptResponse` error into the daemon's `anyhow` error.
+fn sr_err(resp: ScriptResponse) -> anyhow::Error {
+    anyhow::anyhow!(resp.error_message)
+}
+
+/// A unit of work dispatched from an async pipe handler to the WSLc worker
+/// thread. Each variant carries a `oneshot` reply channel the worker fulfils.
+pub enum WorkerCommand {
+    Provision {
+        config: ProvisionConfig,
+        reply: oneshot::Sender<Result<String>>,
+    },
+    Start {
+        config: StartConfig,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Run a command to completion, returning its exit code. Live stdio
+    /// streaming is layered on in the fill-in phase; for now this is
+    /// request/response only.
+    Exec {
+        config: ExecConfig,
+        reply: oneshot::Sender<Result<i32>>,
+    },
+    Stop {
+        config: StopConfig,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    Deprovision {
+        config: DeprovisionConfig,
+        reply: oneshot::Sender<Result<()>>,
+    },
+    /// Report the current live-container count (drives the idle watchdog).
+    ContainerCount { reply: oneshot::Sender<usize> },
+    /// Release all containers + the session and stop the worker thread.
+    Shutdown { reply: oneshot::Sender<()> },
+}
+
+/// A cheap, clonable handle async tasks use to drive the worker thread.
+#[derive(Clone)]
+pub struct SessionHandle {
+    tx: mpsc::UnboundedSender<WorkerCommand>,
+}
+
+impl SessionHandle {
+    /// Provision a container, returning its minted `sandbox_id`.
+    pub async fn provision(&self, config: ProvisionConfig) -> Result<String> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Provision { config, reply })?;
+        rx.await.map_err(worker_gone)?
+    }
+
+    /// Start a provisioned container.
+    pub async fn start(&self, config: StartConfig) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Start { config, reply })?;
+        rx.await.map_err(worker_gone)?
+    }
+
+    /// Run a command in a started container to completion.
+    pub async fn exec(&self, config: ExecConfig) -> Result<i32> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Exec { config, reply })?;
+        rx.await.map_err(worker_gone)?
+    }
+
+    /// Stop a running container.
+    pub async fn stop(&self, config: StopConfig) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Stop { config, reply })?;
+        rx.await.map_err(worker_gone)?
+    }
+
+    /// Deprovision (delete) a container.
+    pub async fn deprovision(&self, config: DeprovisionConfig) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Deprovision { config, reply })?;
+        rx.await.map_err(worker_gone)?
+    }
+
+    /// Current number of live containers (0 means the daemon is idle).
+    pub async fn container_count(&self) -> Result<usize> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::ContainerCount { reply })?;
+        rx.await.map_err(worker_gone)
+    }
+
+    /// Ask the worker to release everything and stop. Awaits confirmation.
+    pub async fn shutdown(&self) -> Result<()> {
+        let (reply, rx) = oneshot::channel();
+        self.send(WorkerCommand::Shutdown { reply })?;
+        rx.await.map_err(worker_gone)
+    }
+
+    fn send(&self, cmd: WorkerCommand) -> Result<()> {
+        self.tx
+            .send(cmd)
+            .map_err(|_| anyhow::anyhow!("WSLc worker thread is gone"))
+    }
+}
+
+fn worker_gone(_e: oneshot::error::RecvError) -> anyhow::Error {
+    anyhow::anyhow!("WSLc worker dropped the reply channel")
+}
+
+/// Per-container bookkeeping held by the worker: whether the container is
+/// currently started and the live `WslcContainer` handle (kept alive across
+/// phases so repeated `exec`s hit a warm container). The sandbox id is the
+/// map key.
+struct ContainerEntry {
+    started: bool,
+    container: WslcContainerGuard,
+}
+
+/// The single-threaded WSLc session owner. Constructed and run entirely on the
+/// worker thread. Holds the lazily-loaded SDK and the one shared session (the
+/// WSL2 utility VM), plus the `sandbox_id -> container` map. The SDK/session/
+/// guard handles are `!Send` raw pointers, but they never leave this thread —
+/// only [`WorkerCommand`]s cross the channel.
+struct Worker {
+    logger: Logger,
+    sdk: Option<WslcSdk>,
+    session: Option<WslcSessionGuard>,
+    containers: HashMap<String, ContainerEntry>,
+}
+
+impl Worker {
+    fn new() -> Self {
+        Self {
+            logger: Logger::new(Mode::Console),
+            sdk: None,
+            session: None,
+            containers: HashMap::new(),
+        }
+    }
+
+    /// Lazily load the SDK and boot the shared session on first use. Idempotent.
+    fn ensure_session(&mut self) -> Result<()> {
+        if self.sdk.is_none() {
+            // SAFETY: the worker thread is already in the MTA (see `ComApartment`).
+            let sdk =
+                unsafe { container_steps::load_sdk_checked(&mut self.logger) }.map_err(sr_err)?;
+            self.sdk = Some(sdk);
+        }
+        if self.session.is_none() {
+            let storage = default_storage_path();
+            let sdk = self.sdk.as_ref().expect("sdk loaded above");
+            // SAFETY: `sdk` holds valid pointers and COM is initialised.
+            let session = unsafe {
+                container_steps::create_daemon_session(
+                    sdk,
+                    SESSION_NAME,
+                    &storage,
+                    &mut self.logger,
+                )
+            }
+            .map_err(sr_err)?;
+            self.session = Some(session);
+        }
+        Ok(())
+    }
+
+    fn provision(&mut self, config: ProvisionConfig) -> Result<String> {
+        self.ensure_session()?;
+
+        let sdk = self.sdk.as_ref().expect("session ensured");
+        let session = self.session.as_ref().expect("session ensured").as_raw();
+
+        let mounts: Vec<policy_mapping::VolumeMount> = config
+            .volumes
+            .iter()
+            .map(|v| policy_mapping::VolumeMount {
+                windows_path: v.host.clone(),
+                container_path: v.container.clone(),
+                read_only: v.read_only,
+            })
+            .collect();
+        let net_mode = match config.network {
+            NetworkMode::None => WslcContainerNetworkingMode::WSLC_CONTAINER_NETWORKING_MODE_NONE,
+            NetworkMode::Bridged => {
+                WslcContainerNetworkingMode::WSLC_CONTAINER_NETWORKING_MODE_BRIDGED
+            }
+        };
+
+        // SAFETY: `sdk`/`session` are valid; every buffer the SDK stores pointers
+        // into is owned by a stationary local (`keepalive`) until create returns.
+        let container = unsafe {
+            container_steps::resolve_image(
+                sdk,
+                session,
+                &config.image,
+                config.image_tar_path.as_deref(),
+                None,
+                &mut self.logger,
+            )
+            .map_err(sr_err)?;
+
+            let mut keepalive =
+                ProcessSettings::build_detached(sdk, container_steps::KEEPALIVE_SCRIPT, &[], "")
+                    .map_err(sr_err)?;
+
+            container_steps::create_daemon_container(
+                sdk,
+                session,
+                &config.image,
+                &mounts,
+                net_mode,
+                &mut keepalive,
+                &mut self.logger,
+            )
+            .map_err(sr_err)?
+        };
+
+        let sandbox_id = format!("wslc:{}", uuid::Uuid::new_v4().simple());
+        self.containers.insert(
+            sandbox_id.clone(),
+            ContainerEntry {
+                started: false,
+                container,
+            },
+        );
+        Ok(sandbox_id)
+    }
+
+    fn start(&mut self, config: StartConfig) -> Result<()> {
+        // Existence check first, so an unknown sandbox errors without needing the
+        // SDK (keeps the no-WSL unit tests self-contained).
+        if !self.containers.contains_key(&config.sandbox_id) {
+            anyhow::bail!("unknown sandbox {}", config.sandbox_id);
+        }
+        let sdk = self
+            .sdk
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no active WSLc session"))?;
+        let entry = self
+            .containers
+            .get_mut(&config.sandbox_id)
+            .expect("checked above");
+        // SAFETY: `sdk` is valid and `entry.container` is a live handle.
+        unsafe {
+            container_steps::start_daemon_container(sdk, entry.container.as_raw(), &mut self.logger)
+        }
+        .map_err(sr_err)?;
+        entry.started = true;
+        Ok(())
+    }
+
+    fn exec(&mut self, config: ExecConfig) -> Result<i32> {
+        let (container, started) = match self.containers.get(&config.sandbox_id) {
+            Some(e) => (e.container.as_raw(), e.started),
+            None => anyhow::bail!("unknown sandbox {}", config.sandbox_id),
+        };
+        if !started {
+            anyhow::bail!("sandbox {} is not started", config.sandbox_id);
+        }
+        let sdk = self
+            .sdk
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no active WSLc session"))?;
+
+        // ProcessSettings::build expects `NAME=VALUE` env entries.
+        let env: Vec<String> = config
+            .env
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+
+        // SAFETY: `sdk` is valid and `container` is a live, started handle.
+        let outcome = unsafe {
+            container_steps::exec_in_container(
+                sdk,
+                container,
+                &config.script_code,
+                &env,
+                &config.working_directory,
+                config.timeout_ms,
+                &mut self.logger,
+            )
+        }
+        .map_err(sr_err)?;
+
+        if outcome.timed_out {
+            anyhow::bail!("exec timed out after {}ms", config.timeout_ms);
+        }
+        // NOTE: outcome.stdout/stderr are captured but not yet forwarded — live
+        // stdio streaming over the control pipe is a later fill-in; the PR1
+        // contract returns the exit code only.
+        Ok(outcome.exit_code)
+    }
+
+    fn stop(&mut self, config: StopConfig) -> Result<()> {
+        if !self.containers.contains_key(&config.sandbox_id) {
+            anyhow::bail!("unknown sandbox {}", config.sandbox_id);
+        }
+        let sdk = self
+            .sdk
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("no active WSLc session"))?;
+        let entry = self
+            .containers
+            .get_mut(&config.sandbox_id)
+            .expect("checked above");
+        // SAFETY: `sdk` is valid and `entry.container` is a live handle.
+        unsafe {
+            container_steps::stop_daemon_container(sdk, entry.container.as_raw(), &mut self.logger)
+        }
+        .map_err(sr_err)?;
+        entry.started = false;
+        Ok(())
+    }
+
+    fn deprovision(&mut self, config: DeprovisionConfig) -> Result<()> {
+        let entry = self
+            .containers
+            .remove(&config.sandbox_id)
+            .ok_or_else(|| anyhow::anyhow!("unknown sandbox {}", config.sandbox_id))?;
+
+        let result = if let Some(sdk) = self.sdk.as_ref() {
+            // SAFETY: `sdk` is valid and `entry.container` is a live handle.
+            unsafe {
+                container_steps::delete_daemon_container(
+                    sdk,
+                    entry.container.as_raw(),
+                    &mut self.logger,
+                )
+            }
+            .map_err(sr_err)
+        } else {
+            Ok(())
+        };
+
+        // Release the container handle regardless of delete success. Must happen
+        // before the SDK/session are torn down below (their DLL must stay loaded).
+        drop(entry);
+
+        // Release the shared session (and unload the SDK) once idle. Ordering is
+        // load-bearing: the session guard's Drop uses SDK fn pointers, so it must
+        // drop before the SDK unloads the DLL.
+        if self.containers.is_empty() {
+            self.session = None;
+            self.sdk = None;
+        }
+        result
+    }
+
+    fn shutdown(&mut self) {
+        if let Some(sdk) = self.sdk.as_ref() {
+            for (_, entry) in self.containers.drain() {
+                // SAFETY: `sdk` is valid and `entry.container` is a live handle.
+                unsafe {
+                    if entry.started {
+                        let _ = container_steps::stop_daemon_container(
+                            sdk,
+                            entry.container.as_raw(),
+                            &mut self.logger,
+                        );
+                    }
+                    let _ = container_steps::delete_daemon_container(
+                        sdk,
+                        entry.container.as_raw(),
+                        &mut self.logger,
+                    );
+                }
+                // entry (WslcContainerGuard) drops here, releasing the handle.
+            }
+        } else {
+            self.containers.clear();
+        }
+        // Session guard drops before the SDK unloads the DLL.
+        self.session = None;
+        self.sdk = None;
+    }
+}
+
+/// Spawn the WSLc worker thread and return a handle to it.
+///
+/// The thread joins the MTA for its entire lifetime (WSLc SDK apartment
+/// affinity) and processes [`WorkerCommand`]s until a [`WorkerCommand::Shutdown`]
+/// is received or the command channel closes.
+pub fn spawn() -> Result<SessionHandle> {
+    let (tx, mut rx) = mpsc::unbounded_channel::<WorkerCommand>();
+
+    std::thread::Builder::new()
+        .name("wslc-session-worker".to_string())
+        .spawn(move || {
+            #[cfg(windows)]
+            let _com = ComApartment::enter();
+
+            let mut worker = Worker::new();
+            while let Some(cmd) = rx.blocking_recv() {
+                match cmd {
+                    WorkerCommand::Provision { config, reply } => {
+                        let _ = reply.send(worker.provision(config));
+                    }
+                    WorkerCommand::Start { config, reply } => {
+                        let _ = reply.send(worker.start(config));
+                    }
+                    WorkerCommand::Exec { config, reply } => {
+                        let _ = reply.send(worker.exec(config));
+                    }
+                    WorkerCommand::Stop { config, reply } => {
+                        let _ = reply.send(worker.stop(config));
+                    }
+                    WorkerCommand::Deprovision { config, reply } => {
+                        let _ = reply.send(worker.deprovision(config));
+                    }
+                    WorkerCommand::ContainerCount { reply } => {
+                        let _ = reply.send(worker.containers.len());
+                    }
+                    WorkerCommand::Shutdown { reply } => {
+                        worker.shutdown();
+                        let _ = reply.send(());
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|e| anyhow::anyhow!("spawn WSLc worker thread: {e}"))?;
+
+    Ok(SessionHandle { tx })
+}
+
+/// RAII guard that keeps the calling thread in the COM MTA for the WSLc SDK.
+#[cfg(windows)]
+struct ComApartment;
+
+#[cfg(windows)]
+impl ComApartment {
+    fn enter() -> Self {
+        use windows::Win32::System::Com::{CoInitializeEx, COINIT_MULTITHREADED};
+        // SAFETY: called once at worker-thread startup; balanced by CoUninitialize
+        // in Drop. A non-success HRESULT (e.g. already-initialised) is benign here.
+        unsafe {
+            let _ = CoInitializeEx(None, COINIT_MULTITHREADED);
+        }
+        Self
+    }
+}
+
+#[cfg(windows)]
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        use windows::Win32::System::Com::CoUninitialize;
+        // SAFETY: balances the CoInitializeEx in `enter`, on the same thread.
+        unsafe {
+            CoUninitialize();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn count(handle: &SessionHandle) -> usize {
+        handle.container_count().await.unwrap()
+    }
+
+    // ---- No-WSL unit tests (run everywhere, never touch the SDK) ----
+
+    #[tokio::test]
+    async fn start_unknown_sandbox_errors() {
+        let handle = spawn().unwrap();
+        let err = handle
+            .start(StartConfig {
+                sandbox_id: "wslc:does-not-exist".to_string(),
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown sandbox"));
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn exec_unknown_sandbox_errors() {
+        let handle = spawn().unwrap();
+        let err = handle
+            .exec(ExecConfig {
+                sandbox_id: "wslc:does-not-exist".to_string(),
+                script_code: "echo hi".to_string(),
+                working_directory: String::new(),
+                env: Vec::new(),
+                timeout_ms: 0,
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown sandbox"));
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stop_unknown_sandbox_errors() {
+        let handle = spawn().unwrap();
+        let err = handle
+            .stop(StopConfig {
+                sandbox_id: "wslc:does-not-exist".to_string(),
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown sandbox"));
+        handle.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn deprovision_unknown_sandbox_errors() {
+        let handle = spawn().unwrap();
+        let err = handle
+            .deprovision(DeprovisionConfig {
+                sandbox_id: "wslc:does-not-exist".to_string(),
+            })
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown sandbox"));
+        assert_eq!(count(&handle).await, 0);
+        handle.shutdown().await.unwrap();
+    }
+
+    // ---- Full lifecycle integration test (WSL2 host only) ----
+    //
+    // Exercises the real SDK path end to end: provision (boot VM + create
+    // container) → start → exec → stop → deprovision → refcount back to 0. It
+    // needs a WSL2 host with `alpine:latest` pre-pulled into the daemon session
+    // cache (`%TEMP%\mxc-wslc-sessions`, e.g. via `scripts\setup-wslc.ps1
+    // -Image alpine:latest`), so it is `#[ignore]`d and run explicitly with
+    // `cargo test -p wxc_wslc_daemon -- --ignored`.
+    #[tokio::test]
+    #[ignore = "requires a WSL2 host with alpine:latest pre-pulled into the daemon session cache"]
+    async fn full_lifecycle_on_wsl_host() {
+        let handle = spawn().unwrap();
+        assert_eq!(count(&handle).await, 0);
+
+        let id = handle
+            .provision(ProvisionConfig {
+                image: "alpine:latest".to_string(),
+                image_tar_path: None,
+                volumes: Vec::new(),
+                network: Default::default(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(count(&handle).await, 1);
+
+        handle
+            .start(StartConfig {
+                sandbox_id: id.clone(),
+            })
+            .await
+            .unwrap();
+
+        let code = handle
+            .exec(ExecConfig {
+                sandbox_id: id.clone(),
+                script_code: "echo hi".to_string(),
+                working_directory: String::new(),
+                env: Vec::new(),
+                timeout_ms: 30_000,
+            })
+            .await
+            .unwrap();
+        assert_eq!(code, 0);
+
+        handle
+            .stop(StopConfig {
+                sandbox_id: id.clone(),
+            })
+            .await
+            .unwrap();
+
+        handle
+            .deprovision(DeprovisionConfig { sandbox_id: id })
+            .await
+            .unwrap();
+        assert_eq!(count(&handle).await, 0);
+
+        handle.shutdown().await.unwrap();
+    }
+}

--- a/src/backends/wslc/daemon/tests/daemon_ipc.rs
+++ b/src/backends/wslc/daemon/tests/daemon_ipc.rs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! End-to-end IPC tests that drive the real `wxc-wslc-daemon` binary through the
+//! [`DaemonClient`] over a live named pipe.
+//!
+//! [`ping_round_trip_over_pipe`] needs no WSL: `Ping` is served entirely by the
+//! control server without touching the WSLc SDK, so it exercises spawn/discovery,
+//! the ready-record rendezvous, pipe connect, and frame round-tripping on any
+//! Windows host. The full lifecycle test is `#[ignore]`d because it boots a WSL2
+//! utility VM.
+//!
+//! NOTE: both tests spawn a daemon that publishes the single global daemon
+//! record, so running the ignored test alongside the default test requires
+//! `--test-threads=1` to avoid the two daemons clobbering each other's record.
+
+#![cfg(windows)]
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use wslc_common::daemon_client::DaemonClient;
+use wslc_common::daemon_record::{read_daemon_record, remove_daemon_record};
+
+/// Owns a spawned daemon process and guarantees teardown (kill + record cleanup)
+/// even if a test assertion panics.
+struct DaemonProcess {
+    child: Child,
+}
+
+impl DaemonProcess {
+    /// Spawn the daemon binary and wait until it publishes a `ready` record that
+    /// names this process, so a subsequent [`DaemonClient::connect`] fast-paths.
+    fn spawn_ready() -> Self {
+        let exe = env!("CARGO_BIN_EXE_wxc-wslc-daemon");
+        let child = Command::new(exe)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::inherit())
+            .spawn()
+            .expect("spawn wxc-wslc-daemon");
+        let this = Self { child };
+
+        let pid = this.child.id();
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            if let Ok(Some(record)) = read_daemon_record() {
+                if record.pid == pid && record.ready {
+                    return this;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "daemon (pid {pid}) did not publish a ready record in time"
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for DaemonProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        // The daemon was killed before it could clean up; drop the stale record
+        // so it does not confuse a later run.
+        let _ = remove_daemon_record();
+    }
+}
+
+#[test]
+fn ping_round_trip_over_pipe() {
+    let _daemon = DaemonProcess::spawn_ready();
+
+    let client = DaemonClient::connect().expect("connect to daemon");
+    client.ping().expect("ping should return Pong");
+
+    // A second connection proves the server re-armed the next pipe instance.
+    client.ping().expect("second ping should also succeed");
+}
+
+/// Full state-aware lifecycle over the pipe: provision -> start -> exec -> stop
+/// -> deprovision. Requires a WSL2 host with `alpine:latest` pre-pulled into the
+/// daemon session cache (`%TEMP%\mxc-wslc-sessions`, e.g. via
+/// `scripts\setup-wslc.ps1 -Image alpine:latest`). Run explicitly with
+/// `cargo test -p wxc_wslc_daemon --test daemon_ipc -- --ignored`.
+#[test]
+#[ignore = "requires a WSL2 host with alpine:latest pre-pulled into the daemon session cache"]
+fn full_lifecycle_over_pipe() {
+    use wslc_common::daemon_protocol::{
+        DeprovisionConfig, ExecConfig, ProvisionConfig, StartConfig, StopConfig,
+    };
+
+    let _daemon = DaemonProcess::spawn_ready();
+    let client = DaemonClient::connect().expect("connect to daemon");
+
+    let sandbox_id = client
+        .provision(ProvisionConfig {
+            image: "alpine:latest".to_string(),
+            image_tar_path: None,
+            volumes: Vec::new(),
+            network: Default::default(),
+        })
+        .expect("provision");
+
+    client
+        .start(StartConfig {
+            sandbox_id: sandbox_id.clone(),
+        })
+        .expect("start");
+
+    let result = client
+        .exec(ExecConfig {
+            sandbox_id: sandbox_id.clone(),
+            script_code: "echo hi".to_string(),
+            working_directory: String::new(),
+            env: Vec::new(),
+            timeout_ms: 30_000,
+        })
+        .expect("first exec");
+    assert_eq!(result.exit_code, 0, "echo hi should exit 0");
+
+    // A second exec against the same started container proves the keepalive init
+    // keeps it warm for repeated `WslcCreateContainerProcess` calls.
+    let result = client
+        .exec(ExecConfig {
+            sandbox_id: sandbox_id.clone(),
+            script_code: "exit 7".to_string(),
+            working_directory: String::new(),
+            env: Vec::new(),
+            timeout_ms: 30_000,
+        })
+        .expect("second exec");
+    assert_eq!(result.exit_code, 7, "exit 7 should propagate its exit code");
+
+    client
+        .stop(StopConfig {
+            sandbox_id: sandbox_id.clone(),
+        })
+        .expect("stop");
+
+    client
+        .deprovision(DeprovisionConfig { sandbox_id })
+        .expect("deprovision");
+}

--- a/src/backends/wslc/daemon/tests/daemon_ipc.rs
+++ b/src/backends/wslc/daemon/tests/daemon_ipc.rs
@@ -10,9 +10,11 @@
 //! Windows host. The full lifecycle test is `#[ignore]`d because it boots a WSL2
 //! utility VM.
 //!
-//! NOTE: both tests spawn a daemon that publishes the single global daemon
-//! record, so running the ignored test alongside the default test requires
-//! `--test-threads=1` to avoid the two daemons clobbering each other's record.
+//! NOTE: each spawned daemon uses an isolated, throwaway record root (via
+//! `MXC_WSLC_STATE_ROOT`) so it never touches a developer's real per-user
+//! daemon. The override is process-wide, so running the ignored test alongside
+//! the default one still requires `--test-threads=1` so the two harnesses do
+//! not clobber each other's `MXC_WSLC_STATE_ROOT`.
 
 #![cfg(windows)]
 
@@ -20,26 +22,36 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use wslc_common::daemon_client::DaemonClient;
-use wslc_common::daemon_record::{read_daemon_record, remove_daemon_record};
+use wslc_common::daemon_record::{read_daemon_record, STATE_ROOT_ENV_VAR};
 
-/// Owns a spawned daemon process and guarantees teardown (kill + record cleanup)
-/// even if a test assertion panics.
+/// Owns a spawned daemon process and guarantees teardown (kill + isolated
+/// record cleanup) even if a test assertion panics.
 struct DaemonProcess {
     child: Child,
+    // Drops after `child` (declaration order), removing the isolated record
+    // tree only once the daemon that writes into it has been killed.
+    _root: tempfile::TempDir,
 }
 
 impl DaemonProcess {
     /// Spawn the daemon binary and wait until it publishes a `ready` record that
     /// names this process, so a subsequent [`DaemonClient::connect`] fast-paths.
     fn spawn_ready() -> Self {
+        // Isolate discovery from the developer's real per-user daemon: point the
+        // record root at a throwaway dir, set both in-process (for the in-proc
+        // `read_daemon_record` / `DaemonClient` below) and on the spawned daemon.
+        let root = tempfile::tempdir().expect("create temp state root");
+        std::env::set_var(STATE_ROOT_ENV_VAR, root.path());
+
         let exe = env!("CARGO_BIN_EXE_wxc-wslc-daemon");
         let child = Command::new(exe)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::inherit())
+            .env(STATE_ROOT_ENV_VAR, root.path())
             .spawn()
             .expect("spawn wxc-wslc-daemon");
-        let this = Self { child };
+        let this = Self { child, _root: root };
 
         let pid = this.child.id();
         let deadline = Instant::now() + Duration::from_secs(30);
@@ -62,9 +74,9 @@ impl Drop for DaemonProcess {
     fn drop(&mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
-        // The daemon was killed before it could clean up; drop the stale record
-        // so it does not confuse a later run.
-        let _ = remove_daemon_record();
+        // `_root` (a TempDir) removes the isolated record tree on drop; clear the
+        // override so a later test in this binary falls back to the default root.
+        std::env::remove_var(STATE_ROOT_ENV_VAR);
     }
 }
 


### PR DESCRIPTION
## 📖 Description
First of three PRs delivering the **state-aware WSLc lifecycle**. The WSLc SDK (2.9.3) has **no cross-process re-attach** — `WslcSession`/`WslcContainer`/`WslcProcess` handles are in-process only — so a persistent, per-Windows-user **daemon**
must hold the handles across the separate `provision`/`start`/`exec`/`stop`/`deprovision` phase processes. This PR lands that daemon and its IPC control plane. It has **no product-visible surface** (no `wire.rs`/schema changes; nothing invokes the daemon yet), so it merges independently.

### What's included
- **New `wxc-wslc-daemon` crate** (`src/backends/wslc/daemon/`):
  - `main.rs` — bootstrap, bind-before-publish daemon record, dedicated WSLc worker thread/COM apartment, idle watchdog (teardown on no live containers + no in-flight clients).
  - `control_server.rs` — owner-only-SDDL named pipe, length-prefixed JSON frame dispatch
    (`PROVISION`/`START`/`EXEC`/`STOP`/`DEPROVISION`/`PING`).
  - `session_manager.rs` — real `WslcSession`/container/process lifecycle over `container_steps`, holding the refcounted `sandbox_id -> WslcContainer` map on a thread-affine worker.
- **`wslc_common` additions**: `daemon_protocol.rs` (control frames + internal per-phase config structs, deliberately separate from the public wire schema), `daemon_record.rs` (discovery record, pid+creation-time liveness, owner-only DACL hardening, transition lock), `daemon_client.rs` (spawn/poll, connect, exec result accumulation — live bidirectional stdio bridge deferred to PR 2).
- **New `container_steps.rs`**: daemon-side WSLc step primitives (create session/container, exec, stop, delete) adapted for a warm keepalive-init session. The one-shot `wsl_container_runner.rs` is unchanged except two visibility relaxations so the daemon steps can reuse its `import_image_from_tar` + `wslc_prerequisite_error`.
- **Build wiring**: `build.bat` stages the daemon exe next to `wxc-exec` + SDK bin.
- **Tests**: Rust integration test drives the daemon directly over the pipe (real container + 2× exec on a warm container); the full-lifecycle test is `#[ignore]`d (requires a WSL2 host with `alpine:latest` pre-pulled). Unit tests for framing, refcount, idle-teardown, transition lock, and record trust run by default.

### Coming in the pipeline
- **PR 2/3 — state-aware backend + wire/schema + E2E**: `wslc/common/state_aware.rs` (`StatefulSandboxBackend`, prefix `wslc`) translating the public `experimental.wslc.*` wire schema into daemon protocol frames; `mxc_engine` state-aware arm + config-parser wiring; regenerated dev schema + generated TS wire types; multi-invocation E2E script with warm-reuse + idle-teardown assertions;
- **PR 3/3 — TypeScript SDK**: `Wslc*Config`/`*Result` types + branded `SandboxId<'wslc'>` and helper prefix wiring, mirroring the LXC state-aware SDK surface.

## 🔗 References
<!-- Link related issues, PRs, or docs. Use "Resolves #1234" to auto-close. -->

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [x] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/745)