### PR TITLE
fix(seatbelt): allow AF_UNIX sockets and resolve symlinked root paths

### DIFF
--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -196,6 +196,14 @@ Policy paths are rewritten before they are emitted into the profile:
    `/etc`, `/tmp`, `/var` → `/private/…`, and `/home` →
    `/System/Volumes/Data/home`.
 
+After resolution, the most-restrictive-wins precedence (`deny` > `readonly` >
+`readwrite`) is re-applied to the **resolved** paths. The shared config parser
+already applies it, but only to the raw strings, so two spellings of the same
+path (`readonlyPaths: ["/private/tmp/x"]` and `readwritePaths: ["/tmp/x"]`)
+survive it and collide only here. Seatbelt is last-match-wins and the read-write
+rule is emitted second, so without this the weaker grant would win and silently
+make a read-only path writable.
+
 Steps 2 and 3 are mandatory, not cosmetic. Those root entries are symlinks on macOS,
 and the kernel fully resolves a path before matching it against a profile
 filter — so a rule written against the unresolved path never matches and is

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -187,11 +187,16 @@ matches MXC's `denied_paths` contract on every other backend.
 Policy paths are rewritten before they are emitted into the profile:
 
 1. A leading `~` / `~/…` is expanded against `$HOME`.
-2. A leading symlinked root path segment is rewritten to its real target:
+2. Redundant lexical segments are collapsed: repeated separators (`//tmp`),
+   `.` segments (`/./tmp`), and a trailing `/`. A `..` segment is **rejected**
+   as a config error rather than resolved — macOS resolves `..` physically,
+   after following symlinks (`/tmp/..` is `/private`, not `/`), so resolving it
+   lexically could silently point the rule somewhere else.
+3. A leading symlinked root path segment is rewritten to its real target:
    `/etc`, `/tmp`, `/var` → `/private/…`, and `/home` →
    `/System/Volumes/Data/home`.
 
-Step 2 is mandatory, not cosmetic. Those root entries are symlinks on macOS,
+Steps 2 and 3 are mandatory, not cosmetic. Those root entries are symlinks on macOS,
 and the kernel fully resolves a path before matching it against a profile
 filter — so a rule written against the unresolved path never matches and is
 silently dead. This applies to the automatic `$TMPDIR` grant too, which
@@ -218,12 +223,13 @@ Two asymmetries are intentional:
 
 - `readonlyPaths` grants **neither** operation. A socket is a bidirectional
   channel, not a read.
-- `deniedPaths` denies `network-outbound` even though no path-scoped
-  `network-outbound` allow can reach it. `defaultPolicy: "allow"` (and the
-  remote-proxy fallback) emit an *unfiltered* `(allow network-outbound)`, so
-  without the deny the sandbox could `connect()` to a pre-existing socket
-  inside a denied subtree — a Docker, `ssh-agent` or `gpg-agent` socket is a
-  control plane, so that would be an escape.
+- `deniedPaths` denies `network-outbound`, overriding **both** kinds of allow
+  that can reach it: a broader `readwritePaths` subtree containing the denied
+  path, and the *unfiltered* `(allow network-outbound)` emitted by
+  `defaultPolicy: "allow"` and the remote-proxy fallback. Without the deny the
+  sandbox could `connect()` to a pre-existing socket inside a denied subtree —
+  a Docker, `ssh-agent` or `gpg-agent` socket is a control plane, so that would
+  be an escape.
 
 A baseline of read-only system paths (`/usr/lib`, `/usr/libexec`,
 `/usr/share`, `/System`, `/Library`, `/private/var/db/timezone`,

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -175,12 +175,55 @@ settings live under a top-level `seatbelt` key:
 | Policy field | Generated rule | Effect |
 |---|---|---|
 | `readonlyPaths` | `(allow file-read* (subpath …))` | Script can read these subtrees |
-| `readwritePaths` | `(allow file-read* file-write* (subpath …))` | Script can read and write |
-| `deniedPaths` | `(deny file-read* file-write* (subpath …))` emitted **last** | Overrides any broader allow above |
+| `readwritePaths` | `(allow file-read* file-write* network-bind network-outbound (subpath …))` | Script can read and write, and bind/connect AF_UNIX sockets under these subtrees |
+| `deniedPaths` | `(deny file-read* file-write* network-bind network-outbound (subpath …))` emitted **last** | Overrides any broader allow above |
 
 Apple's Seatbelt evaluates rules with last-match-wins semantics within an
 operation, so denies emitted after allows correctly override them. This
 matches MXC's `denied_paths` contract on every other backend.
+
+#### Path resolution
+
+Policy paths are rewritten before they are emitted into the profile:
+
+1. A leading `~` / `~/…` is expanded against `$HOME`.
+2. A leading symlinked root path segment is rewritten to its real target:
+   `/etc`, `/tmp`, `/var` → `/private/…`, and `/home` →
+   `/System/Volumes/Data/home`.
+
+Step 2 is mandatory, not cosmetic. Those root entries are symlinks on macOS,
+and the kernel fully resolves a path before matching it against a profile
+filter — so a rule written against the unresolved path never matches and is
+silently dead. This applies to the automatic `$TMPDIR` grant too, which
+resolves to `/var/folders/…`. `/Users` needs no rewriting: it is a *firmlink*,
+not a symlink, so it is already the canonical path.
+
+#### UNIX-domain sockets
+
+Seatbelt matches AF_UNIX sockets by **path** — `bind()` under `network-bind`
+and `connect()` under `network-outbound` — while the `(local ip)` / `(remote
+ip)` filters used by the network policy cover IP sockets only. MXC therefore
+governs AF_UNIX sockets with the **filesystem** policy, not the network policy:
+both halves are permitted anywhere the sandbox may already create files.
+
+This is deliberate. The socket is a filesystem object reachable only by
+processes that can traverse to its path, so using one where writes are already
+permitted grants no new capability — and Node toolchains (tsx, vite, esbuild,
+jest workers) need it for their IPC pipes. Gating it behind `allowLocalNetwork`
+would force real network ingress on just to run a build. Because the rules are
+path-scoped they never widen IP binding or IP egress, which stay governed by
+`defaultPolicy` and `allowLocalNetwork`.
+
+Two asymmetries are intentional:
+
+- `readonlyPaths` grants **neither** operation. A socket is a bidirectional
+  channel, not a read.
+- `deniedPaths` denies `network-outbound` even though no path-scoped
+  `network-outbound` allow can reach it. `defaultPolicy: "allow"` (and the
+  remote-proxy fallback) emit an *unfiltered* `(allow network-outbound)`, so
+  without the deny the sandbox could `connect()` to a pre-existing socket
+  inside a denied subtree — a Docker, `ssh-agent` or `gpg-agent` socket is a
+  control plane, so that would be an escape.
 
 A baseline of read-only system paths (`/usr/lib`, `/usr/libexec`,
 `/usr/share`, `/System`, `/Library`, `/private/var/db/timezone`,
@@ -194,8 +237,9 @@ independently of the profile.
 
 | Policy | Generated rule |
 |---|---|
-| `defaultPolicy: "block"` | No `(allow network-outbound)` is emitted; the baseline `(deny default)` then blocks all sockets. |
+| `defaultPolicy: "block"` | No `(allow network-outbound)` is emitted; the baseline `(deny default)` then blocks all IP sockets. |
 | `defaultPolicy: "allow"` (no host list) | `(allow network-outbound)` plus `(allow network-bind (local ip))` and `(allow system-socket)`. |
+| `allowLocalNetwork: true` | `(allow network-inbound (local ip))` — required in addition to `network-bind` before the kernel will accept `listen()` on an IP socket. Independent of `defaultPolicy`, and unrelated to AF_UNIX sockets (see above). |
 | `allowedHosts` | Accepted for SDK compatibility, but Seatbelt cannot filter DNS names; the profile degrades to allow-all outbound as best-effort. |
 | `blockedHosts` | Rejected during validation because Seatbelt cannot enforce hostname blocks. |
 | `proxy` (loopback: `localhost` / `builtinTestServer`) | Under `defaultPolicy: "block"`, allows only the resolved `localhost:<proxy-port>`. Other loopback services and the wider network remain blocked. Under `allow`, the existing allow-all covers it. |

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -179,9 +179,11 @@ settings live under a top-level `seatbelt` key:
 | `readonlyPaths` (nested under a read-write path) | `(deny file-write* network-bind network-outbound (subpath …))` | Removes write and socket authority a shallower read-write rule would otherwise grant |
 | `deniedPaths` | `(deny file-read* file-write* network-bind network-outbound (subpath …))` emitted **last** | Overrides any broader allow above |
 
-Apple's Seatbelt evaluates rules with last-match-wins semantics within an
-operation, so denies emitted after allows correctly override them. This
-matches MXC's `denied_paths` contract on every other backend.
+Apple's Seatbelt evaluates rules with last-match-wins semantics between rules
+that carry a **filter**, so denies emitted after allows correctly override them.
+This matches MXC's `denied_paths` contract on every other backend. An
+*unfiltered* rule does not participate: a later `(allow network-outbound)` with
+no filter will not override an earlier path-scoped deny.
 
 `readonlyPaths` and `readwritePaths` are emitted **shallow-to-deep**, one rule
 per path, using the same ordering the Linux backends apply

--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -176,11 +176,24 @@ settings live under a top-level `seatbelt` key:
 |---|---|---|
 | `readonlyPaths` | `(allow file-read* (subpath …))` | Script can read these subtrees |
 | `readwritePaths` | `(allow file-read* file-write* network-bind network-outbound (subpath …))` | Script can read and write, and bind/connect AF_UNIX sockets under these subtrees |
+| `readonlyPaths` (nested under a read-write path) | `(deny file-write* network-bind network-outbound (subpath …))` | Removes write and socket authority a shallower read-write rule would otherwise grant |
 | `deniedPaths` | `(deny file-read* file-write* network-bind network-outbound (subpath …))` emitted **last** | Overrides any broader allow above |
 
 Apple's Seatbelt evaluates rules with last-match-wins semantics within an
 operation, so denies emitted after allows correctly override them. This
 matches MXC's `denied_paths` contract on every other backend.
+
+`readonlyPaths` and `readwritePaths` are emitted **shallow-to-deep**, one rule
+per path, using the same ordering the Linux backends apply
+(`wxc_common::filesystem_resolve`). Last-match-wins then makes the *deepest*
+intent win at every path, so a read-only entry nested inside a broader
+read-write subtree stays read-only. Because an `allow` can never take authority
+back from an earlier rule, each read-only path also emits an explicit
+`(deny file-write* network-bind network-outbound …)`.
+
+`deniedPaths` is not part of that plan — it is emitted after the network rules
+so it also overrides the unfiltered `(allow network-outbound)`, which makes it
+win outright regardless of depth.
 
 #### Path resolution
 
@@ -195,6 +208,14 @@ Policy paths are rewritten before they are emitted into the profile:
 3. A leading symlinked root path segment is rewritten to its real target:
    `/etc`, `/tmp`, `/var` → `/private/…`, and `/home` →
    `/System/Volumes/Data/home`.
+
+A `..` segment is rejected on this backend only. The shared config parser
+accepts it, so a cross-backend policy using `..` will fail on macOS and run
+elsewhere. That is intentional: the alternative is the failure mode this whole
+section exists to remove — the rule would be emitted, match nothing, and for
+`deniedPaths` fail open. Resolving `..` correctly needs `std::fs::canonicalize`
+against the live filesystem, which the profile builder deliberately avoids so it
+stays pure string generation, unit-testable on any host.
 
 After resolution, the most-restrictive-wins precedence (`deny` > `readonly` >
 `readwrite`) is re-applied to the **resolved** paths. The shared config parser
@@ -219,13 +240,19 @@ ip)` filters used by the network policy cover IP sockets only. MXC therefore
 governs AF_UNIX sockets with the **filesystem** policy, not the network policy:
 both halves are permitted anywhere the sandbox may already create files.
 
-This is deliberate. The socket is a filesystem object reachable only by
-processes that can traverse to its path, so using one where writes are already
-permitted grants no new capability — and Node toolchains (tsx, vite, esbuild,
-jest workers) need it for their IPC pipes. Gating it behind `allowLocalNetwork`
-would force real network ingress on just to run a build. Because the rules are
-path-scoped they never widen IP binding or IP egress, which stay governed by
-`defaultPolicy` and `allowLocalNetwork`.
+This is deliberate. A socket is a filesystem object reachable only by processes
+that can traverse to its path, and Node toolchains (tsx, vite, esbuild, jest
+workers) need both halves for their IPC pipes. Gating them behind
+`allowLocalNetwork` would force real network ingress on just to run a build.
+Because the rules are path-scoped they never widen IP binding or IP egress,
+which stay governed by `defaultPolicy` and `allowLocalNetwork`.
+
+There is a real tradeoff to be aware of, though: `connect()` is a capability
+that `file-write*` alone did not grant. A sandbox with a broad `readwritePaths`
+root can now talk to any **pre-existing** listener underneath it, and a control
+socket (Docker, `ssh-agent`, `gpg-agent`) is a meaningful target. Prefer a
+narrow read-write root, and put any sensitive socket in `deniedPaths`, which
+overrides this grant.
 
 Two asymmetries are intentional:
 

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -152,22 +152,26 @@ fn write_filesystem_allow(out: &mut String, request: &ExecutionRequest) -> Resul
 
     if !policy.readonly_paths.is_empty() {
         out.push_str(";; --- policy.readonlyPaths ---\n");
-        out.push_str("(allow file-read*\n");
-        for p in &policy.readonly_paths {
-            let expanded = expand_tilde(p)?;
-            let _ = writeln!(out, "    (subpath {})", quote_scheme(&expanded));
-        }
-        out.push_str(")\n");
+        write_path_rule(out, "allow file-read*", &policy.readonly_paths)?;
     }
 
     if !policy.readwrite_paths.is_empty() {
-        out.push_str(";; --- policy.readwritePaths ---\n");
-        out.push_str("(allow file-read* file-write*\n");
-        for p in &policy.readwrite_paths {
-            let expanded = expand_tilde(p)?;
-            let _ = writeln!(out, "    (subpath {})", quote_scheme(&expanded));
-        }
-        out.push_str(")\n");
+        // `network-bind` / `network-outbound` under a *path* filter match only
+        // AF_UNIX sockets — Seatbelt matches IP sockets with `(local ip)` /
+        // `(remote ip)` — so this widens nothing on the IP side. A UNIX socket
+        // is a filesystem object reachable only by processes that can traverse
+        // to its path, so `readwritePaths` (not the network policy) governs it:
+        // binding or connecting where the sandbox may already create files
+        // grants no capability it lacks. Both halves are needed — Node
+        // toolchains (tsx, vite, esbuild, jest) bind an IPC pipe and then
+        // connect to it. `readonlyPaths` deliberately gets neither: a socket is
+        // a bidirectional channel, not a read.
+        out.push_str(";; --- policy.readwritePaths (+ AF_UNIX socket bind/connect) ---\n");
+        write_path_rule(
+            out,
+            "allow file-read* file-write* network-bind network-outbound",
+            &policy.readwrite_paths,
+        )?;
     }
 
     Ok(())
@@ -177,15 +181,34 @@ fn write_filesystem_deny(out: &mut String, request: &ExecutionRequest) -> Result
     let policy = &request.policy;
 
     if !policy.denied_paths.is_empty() {
+        // `network-outbound` must be denied here even though it is never
+        // allowed per-path above: `write_outbound_allow_rules` emits an
+        // *unfiltered* `(allow network-outbound)`, which would otherwise let
+        // the sandbox `connect()` to a UNIX socket inside a denied subtree and
+        // talk to whatever listens there. A Docker / ssh-agent / gpg-agent
+        // socket is a control plane, so that would be an escape.
         out.push_str(";; --- policy.deniedPaths (override broader allow rules) ---\n");
-        out.push_str("(deny file-read* file-write*\n");
-        for p in &policy.denied_paths {
-            let expanded = expand_tilde(p)?;
-            let _ = writeln!(out, "    (subpath {})", quote_scheme(&expanded));
-        }
-        out.push_str(")\n");
+        write_path_rule(
+            out,
+            "deny file-read* file-write* network-bind network-outbound",
+            &policy.denied_paths,
+        )?;
     }
 
+    Ok(())
+}
+
+/// Emit a single `(<ops> (subpath …)…)` rule over resolved policy paths.
+fn write_path_rule(out: &mut String, ops: &str, paths: &[String]) -> Result<(), String> {
+    let _ = writeln!(out, "({ops}");
+    for p in paths {
+        let _ = writeln!(
+            out,
+            "    (subpath {})",
+            quote_scheme(&resolve_policy_path(p)?)
+        );
+    }
+    out.push_str(")\n");
     Ok(())
 }
 
@@ -466,6 +489,51 @@ fn write_extra_seatbelt_rules(out: &mut String, request: &ExecutionRequest) {
     out.push_str(")\n");
 }
 
+/// Resolve a caller-supplied policy path into the form Seatbelt matches:
+/// expand a leading `~`, then rewrite the symlinked macOS root directories.
+///
+/// Both steps are required. See [`expand_tilde`] and
+/// [`resolve_macos_root_symlinks`].
+pub(crate) fn resolve_policy_path(path: &str) -> Result<String, String> {
+    Ok(resolve_macos_root_symlinks(&expand_tilde(path)?))
+}
+
+/// The macOS root directories that are symlinks, and their targets.
+///
+/// `/etc`, `/tmp`, and `/var` point into `/private`; `/home` points at the
+/// data volume. `/Users` is deliberately absent — it is a *firmlink*, not a
+/// symlink, so `/Users/...` is already the canonical path the kernel matches.
+const MACOS_SYMLINKED_ROOTS: [(&str, &str); 4] = [
+    ("/etc", "/private/etc"),
+    ("/tmp", "/private/tmp"),
+    ("/var", "/private/var"),
+    ("/home", "/System/Volumes/Data/home"),
+];
+
+/// Rewrite a leading symlinked macOS root directory to its real target.
+///
+/// The kernel resolves a path fully before matching it against a profile's
+/// `subpath` / `literal` filters, so a rule written against the unresolved
+/// path is dead: `(subpath "/tmp/work")` never matches, because the kernel
+/// only ever sees `/private/tmp/work`. That silently voided every policy path
+/// under these roots — including the automatic `$TMPDIR` grant, which resolves
+/// to `/var/folders/...` on macOS.
+///
+/// Only a whole leading path segment is rewritten, so `/variable` is left
+/// alone. Paths already written against the real target pass through
+/// unchanged, because none of the targets is itself under a symlinked root.
+fn resolve_macos_root_symlinks(path: &str) -> String {
+    for (root, target) in MACOS_SYMLINKED_ROOTS {
+        let Some(rest) = path.strip_prefix(root) else {
+            continue;
+        };
+        if rest.is_empty() || rest.starts_with('/') {
+            return format!("{target}{rest}");
+        }
+    }
+    path.to_string()
+}
+
 /// Expand a leading `~` or `~/` to the current user's home directory.
 /// Returns an error if `HOME` is not set and the path requires expansion.
 pub(crate) fn expand_tilde(path: &str) -> Result<String, String> {
@@ -543,7 +611,7 @@ mod tests {
         assert!(p.contains("policy.readonlyPaths"));
         assert!(p.contains("(allow file-read*"));
         assert!(p.contains("(subpath \"/opt/tools\")"));
-        assert!(p.contains("(subpath \"/var/data\")"));
+        assert!(p.contains("(subpath \"/private/var/data\")"));
         assert!(!p.contains("file-write* (subpath \"/opt/tools\")"));
     }
 
@@ -553,7 +621,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["/tmp/output".into()];
         let p = build_profile(&r).unwrap();
         assert!(p.contains("(allow file-read* file-write*"));
-        assert!(p.contains("(subpath \"/tmp/output\")"));
+        assert!(p.contains("(subpath \"/private/tmp/output\")"));
     }
 
     #[test]
@@ -568,7 +636,7 @@ mod tests {
             deny_idx > allow_idx,
             "deny rules must come after allow rules so they win on last-match"
         );
-        assert!(p.contains("(subpath \"/tmp/secret\")"));
+        assert!(p.contains("(subpath \"/private/tmp/secret\")"));
     }
 
     #[test]
@@ -795,7 +863,113 @@ mod tests {
         // of the quoted string and inject Scheme.
         r.policy.readonly_paths = vec!["/tmp/a\"b\\c".into()];
         let p = build_profile(&r).unwrap();
-        assert!(p.contains("(subpath \"/tmp/a\\\"b\\\\c\")"));
+        assert!(p.contains("(subpath \"/private/tmp/a\\\"b\\\\c\")"));
+    }
+
+    const RW_RULE: &str = "(allow file-read* file-write* network-bind network-outbound\n";
+    const DENY_RULE: &str = "(deny file-read* file-write* network-bind network-outbound\n";
+
+    #[test]
+    fn readwrite_paths_emit_unix_socket_ops() {
+        let mut r = req();
+        r.policy.readwrite_paths = vec!["/tmp/output".into()];
+        let p = build_profile(&r).unwrap();
+        let idx = p.find(RW_RULE).expect("readwrite rule");
+        assert!(p[idx..].contains("(subpath \"/private/tmp/output\")"));
+    }
+
+    #[test]
+    fn readwrite_unix_socket_ops_are_independent_of_network_policy() {
+        // AF_UNIX bind/connect follow the filesystem policy, so a default-deny
+        // network policy with allowLocalNetwork off must still permit them.
+        let mut r = req();
+        r.policy.readwrite_paths = vec!["/tmp/output".into()];
+        r.policy.default_network_policy = NetworkPolicy::Block;
+        r.policy.allow_local_network = false;
+        let p = build_profile(&r).unwrap();
+        assert!(p.contains(RW_RULE));
+        assert!(!p.contains("network-inbound"));
+        assert!(!p.contains("(allow network-outbound)"));
+    }
+
+    #[test]
+    fn denied_paths_deny_outbound_after_unfiltered_allow() {
+        // `defaultPolicy: allow` emits a bare `(allow network-outbound)`; the
+        // deny must come after it or a denied subtree's UNIX sockets stay
+        // connectable.
+        let mut r = req();
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        r.policy.denied_paths = vec!["/tmp/secret".into()];
+        let p = build_profile(&r).unwrap();
+        let allow_idx = p
+            .find("(allow network-outbound)")
+            .expect("unfiltered outbound allow");
+        let deny_idx = p.find(DENY_RULE).expect("deny must cover network-outbound");
+        assert!(deny_idx > allow_idx);
+    }
+
+    #[test]
+    fn readonly_paths_do_not_get_unix_socket_ops() {
+        let mut r = req();
+        r.policy.readonly_paths = vec!["/tmp/input".into()];
+        let p = build_profile(&r).unwrap();
+        assert!(!p.contains(RW_RULE));
+        assert!(!p.contains("network-bind"));
+    }
+
+    #[test]
+    fn denied_paths_deny_unix_socket_ops_after_allows() {
+        let mut r = req();
+        r.policy.readwrite_paths = vec!["/tmp".into()];
+        r.policy.denied_paths = vec!["/tmp/secret".into()];
+        let p = build_profile(&r).unwrap();
+        let deny_idx = p.find(DENY_RULE).expect("deny must cover socket ops");
+        let allow_idx = p.find(RW_RULE).expect("allow rule");
+        assert!(
+            deny_idx > allow_idx,
+            "deny must follow allow so last-match-wins re-denies the socket path"
+        );
+        assert!(p[deny_idx..].contains("(subpath \"/private/tmp/secret\")"));
+    }
+
+    #[test]
+    fn macos_root_symlinks_are_resolved() {
+        assert_eq!(resolve_macos_root_symlinks("/tmp"), "/private/tmp");
+        assert_eq!(resolve_macos_root_symlinks("/var"), "/private/var");
+        assert_eq!(resolve_macos_root_symlinks("/etc"), "/private/etc");
+        assert_eq!(
+            resolve_macos_root_symlinks("/var/folders/qj/T"),
+            "/private/var/folders/qj/T"
+        );
+        assert_eq!(
+            resolve_macos_root_symlinks("/home/me"),
+            "/System/Volumes/Data/home/me"
+        );
+    }
+
+    #[test]
+    fn macos_root_resolution_only_matches_whole_segments() {
+        // A prefix that merely starts with the same letters is not a match.
+        assert_eq!(resolve_macos_root_symlinks("/variable"), "/variable");
+        assert_eq!(resolve_macos_root_symlinks("/tmpfs/x"), "/tmpfs/x");
+        assert_eq!(resolve_macos_root_symlinks("/etcd"), "/etcd");
+        assert_eq!(resolve_macos_root_symlinks("/homebrew"), "/homebrew");
+        // Already-resolved and unrelated paths pass through untouched.
+        assert_eq!(
+            resolve_macos_root_symlinks("/private/tmp/x"),
+            "/private/tmp/x"
+        );
+        assert_eq!(resolve_macos_root_symlinks("/Users/me/w"), "/Users/me/w");
+        assert_eq!(resolve_macos_root_symlinks(""), "");
+    }
+
+    #[test]
+    fn macos_root_resolution_is_idempotent() {
+        // Re-resolving a resolved path must be a no-op — no target is itself
+        // under a symlinked root.
+        for (_, target) in MACOS_SYMLINKED_ROOTS {
+            assert_eq!(resolve_macos_root_symlinks(target), target);
+        }
     }
 
     #[test]

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -1132,6 +1132,28 @@ mod tests {
     }
 
     #[test]
+    fn readonly_socket_strip_survives_a_default_allow_outbound() {
+        // `defaultPolicy: "allow"` emits an unfiltered `(allow
+        // network-outbound)` *after* the filesystem section. Seatbelt does not
+        // let an unfiltered rule override a path-filtered one, so the
+        // read-only strip still governs AF_UNIX `connect()` under that
+        // subtree. Verified against `sandbox-exec`: with both rules present in
+        // this order, connecting to a pre-existing socket there is EPERM,
+        // while the same profile without the strip connects fine.
+        let mut r = req();
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        r.policy.readonly_paths = vec!["/tmp/ro".into()];
+        let p = build_profile(&r).unwrap();
+
+        let strip_idx = p.find(RO_STRIP).expect("read-only strip");
+        assert!(p[strip_idx..].contains("(subpath \"/private/tmp/ro\")"));
+        assert!(
+            p.find("(allow network-outbound)\n").expect("default allow") > strip_idx,
+            "this test is only meaningful while the unfiltered allow comes last, profile:\n{p}"
+        );
+    }
+
+    #[test]
     fn readonly_wins_over_readwrite_for_aliased_spellings() {
         // The parser's most-restrictive-wins pass compares raw strings, so
         // these two spellings both survive it and only collide once resolved.

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -181,12 +181,14 @@ fn write_filesystem_deny(out: &mut String, request: &ExecutionRequest) -> Result
     let policy = &request.policy;
 
     if !policy.denied_paths.is_empty() {
-        // `network-outbound` must be denied here even though it is never
-        // allowed per-path above: `write_outbound_allow_rules` emits an
-        // *unfiltered* `(allow network-outbound)`, which would otherwise let
-        // the sandbox `connect()` to a UNIX socket inside a denied subtree and
-        // talk to whatever listens there. A Docker / ssh-agent / gpg-agent
-        // socket is a control plane, so that would be an escape.
+        // `network-outbound` is denied here for two reasons. A denied path can
+        // sit inside a broader `readwritePaths` subtree, whose allow covers it;
+        // and `write_outbound_allow_rules` emits an *unfiltered* `(allow
+        // network-outbound)` under `defaultPolicy: "allow"` and the
+        // remote-proxy fallback. Either would otherwise let the sandbox
+        // `connect()` to a UNIX socket inside a denied subtree and talk to
+        // whatever listens there. A Docker / ssh-agent / gpg-agent socket is a
+        // control plane, so that would be an escape.
         out.push_str(";; --- policy.deniedPaths (override broader allow rules) ---\n");
         write_path_rule(
             out,
@@ -490,12 +492,51 @@ fn write_extra_seatbelt_rules(out: &mut String, request: &ExecutionRequest) {
 }
 
 /// Resolve a caller-supplied policy path into the form Seatbelt matches:
-/// expand a leading `~`, then rewrite the symlinked macOS root directories.
+/// expand a leading `~`, normalize redundant lexical segments, then rewrite the
+/// symlinked macOS root directories.
 ///
-/// Both steps are required. See [`expand_tilde`] and
-/// [`resolve_macos_root_symlinks`].
+/// All three steps are required. See [`expand_tilde`], [`normalize_lexical`]
+/// and [`resolve_macos_root_symlinks`].
 pub(crate) fn resolve_policy_path(path: &str) -> Result<String, String> {
-    Ok(resolve_macos_root_symlinks(&expand_tilde(path)?))
+    let expanded = expand_tilde(path)?;
+    Ok(resolve_macos_root_symlinks(&normalize_lexical(&expanded)?))
+}
+
+/// Collapse the lexical spellings of a path that leave a Seatbelt rule dead:
+/// repeated separators (`//tmp`), `.` segments (`/./tmp`), and a trailing `/`.
+///
+/// The kernel canonicalizes an accessed path before matching it against a
+/// profile filter, but it does not canonicalize the filter, so `(subpath
+/// "//tmp/secret")` never matches anything. For `deniedPaths` that fails
+/// **open**, so these spellings have to be folded away rather than passed
+/// through.
+///
+/// A `..` segment is rejected instead of being resolved. macOS resolves `..`
+/// *physically* — after following symlinks — so resolving it lexically can move
+/// the rule somewhere else entirely: `/tmp/..` is `/private`, not `/`. Silently
+/// widening an allow rule to `/` would be worse than the dead rule, and leaving
+/// it in place keeps the deny fail-open, so an unresolvable path is a config
+/// error the caller must fix by passing the resolved path.
+fn normalize_lexical(path: &str) -> Result<String, String> {
+    if path.split('/').any(|seg| seg == "..") {
+        return Err(format!(
+            "Filesystem path '{path}' contains a '..' segment. macOS resolves '..' after \
+             following symlinks, so the generated sandbox rule could not be matched \
+             reliably; specify the fully resolved path instead."
+        ));
+    }
+
+    let joined = path
+        .split('/')
+        .filter(|seg| !seg.is_empty() && *seg != ".")
+        .collect::<Vec<_>>()
+        .join("/");
+
+    Ok(if path.starts_with('/') {
+        format!("/{joined}")
+    } else {
+        joined
+    })
 }
 
 /// The macOS root directories that are symlinks, and their targets.
@@ -929,6 +970,60 @@ mod tests {
             deny_idx > allow_idx,
             "deny must follow allow so last-match-wins re-denies the socket path"
         );
+        assert!(p[deny_idx..].contains("(subpath \"/private/tmp/secret\")"));
+    }
+
+    #[test]
+    fn lexical_spellings_normalize_to_the_same_rule() {
+        // Each of these accesses `/private/tmp/secret` at the kernel level, so
+        // each must produce the same filter — otherwise a deny written with a
+        // redundant spelling is dead and fails open.
+        for spelling in [
+            "/tmp/secret",
+            "//tmp/secret",
+            "/./tmp/secret",
+            "/tmp//secret",
+            "/tmp/./secret/",
+            "///tmp/secret//",
+        ] {
+            assert_eq!(
+                resolve_policy_path(spelling).unwrap(),
+                "/private/tmp/secret",
+                "spelling {spelling} must normalize"
+            );
+        }
+    }
+
+    #[test]
+    fn lexical_normalization_is_idempotent_and_preserves_root() {
+        assert_eq!(resolve_policy_path("/").unwrap(), "/");
+        assert_eq!(resolve_policy_path("//").unwrap(), "/");
+        let once = resolve_policy_path("//tmp/./secret/").unwrap();
+        assert_eq!(resolve_policy_path(&once).unwrap(), once);
+    }
+
+    #[test]
+    fn parent_segments_are_rejected_rather_than_resolved() {
+        // `/tmp/..` is `/private` on macOS, not `/`, so resolving lexically
+        // would silently widen an allow and leave a deny dead.
+        for path in ["/private/var/../tmp", "/tmp/..", "/..", "/a/b/../c"] {
+            let err = resolve_policy_path(path).unwrap_err();
+            assert!(err.contains(".."), "{path} must be rejected, got {err}");
+        }
+        // A path merely *containing* dots in a segment name is fine.
+        assert_eq!(
+            resolve_policy_path("/tmp/..secret").unwrap(),
+            "/private/tmp/..secret"
+        );
+    }
+
+    #[test]
+    fn denied_path_with_redundant_spelling_still_denies() {
+        let mut r = req();
+        r.policy.readwrite_paths = vec!["/tmp".into()];
+        r.policy.denied_paths = vec!["//tmp/./secret/".into()];
+        let p = build_profile(&r).unwrap();
+        let deny_idx = p.find(DENY_RULE).expect("deny rule");
         assert!(p[deny_idx..].contains("(subpath \"/private/tmp/secret\")"));
     }
 

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -27,7 +27,9 @@
 
 use std::fmt::Write as _;
 
-use wxc_common::models::{ClipboardPolicy, ExecutionRequest, NetworkPolicy, ProxyAddress};
+use wxc_common::models::{
+    ClipboardPolicy, ContainerPolicy, ExecutionRequest, NetworkPolicy, ProxyAddress,
+};
 
 /// Build a complete Seatbelt sandbox profile, scoping cooperative proxy
 /// reachability to the resolved address supplied by the runner.
@@ -71,7 +73,8 @@ pub fn build_profile_with_proxy(
     out.push_str(TTY_ALLOW);
 
     // Policy-derived allow rules.
-    write_filesystem_allow(&mut out, request)?;
+    let resolved = ResolvedPaths::from_policy(&request.policy)?;
+    write_filesystem_allow(&mut out, &resolved);
     write_network_rules(&mut out, request, proxy_address);
     write_nested_pty_rules(&mut out, request);
     write_keychain_rules(&mut out, request)?;
@@ -79,7 +82,7 @@ pub fn build_profile_with_proxy(
     write_ui_rules(&mut out, request);
 
     // Policy-derived deny rules go LAST so they win on conflict.
-    write_filesystem_deny(&mut out, request)?;
+    write_filesystem_deny(&mut out, &resolved);
 
     Ok(out)
 }
@@ -147,15 +150,55 @@ const TTY_ALLOW: &str = "\
 (allow file-read* (subpath \"/dev/fd\"))
 ";
 
-fn write_filesystem_allow(out: &mut String, request: &ExecutionRequest) -> Result<(), String> {
-    let policy = &request.policy;
+/// The policy path lists resolved into the form Seatbelt matches, with the
+/// most-restrictive-wins precedence (`deny` > `readonly` > `readwrite`)
+/// re-applied.
+///
+/// The shared parser applies that precedence to the *raw* strings, which is not
+/// enough once paths are resolved: two spellings of the same path
+/// (`readonlyPaths: ["/private/tmp/x"]` and `readwritePaths: ["/tmp/x"]`)
+/// differ as strings, so both survive the parser, then resolve to the same
+/// filter here. Seatbelt is last-match-wins and the read-write rule is emitted
+/// after the read-only one, so without this the *weaker* grant would win and
+/// silently make a read-only path writable.
+struct ResolvedPaths {
+    readonly: Vec<String>,
+    readwrite: Vec<String>,
+    denied: Vec<String>,
+}
 
-    if !policy.readonly_paths.is_empty() {
+impl ResolvedPaths {
+    fn from_policy(policy: &ContainerPolicy) -> Result<Self, String> {
+        let denied = resolve_all(&policy.denied_paths)?;
+        let readonly = resolve_all(&policy.readonly_paths)?;
+        let mut readwrite = resolve_all(&policy.readwrite_paths)?;
+
+        // `denied` is emitted last and would override either allow anyway, but
+        // dropping the path keeps the emitted profile an honest description of
+        // the effective policy.
+        let mut readonly: Vec<String> = readonly;
+        readonly.retain(|p| !denied.contains(p));
+        readwrite.retain(|p| !denied.contains(p) && !readonly.contains(p));
+
+        Ok(Self {
+            readonly,
+            readwrite,
+            denied,
+        })
+    }
+}
+
+fn resolve_all(paths: &[String]) -> Result<Vec<String>, String> {
+    paths.iter().map(|p| resolve_policy_path(p)).collect()
+}
+
+fn write_filesystem_allow(out: &mut String, paths: &ResolvedPaths) {
+    if !paths.readonly.is_empty() {
         out.push_str(";; --- policy.readonlyPaths ---\n");
-        write_path_rule(out, "allow file-read*", &policy.readonly_paths)?;
+        write_path_rule(out, "allow file-read*", &paths.readonly);
     }
 
-    if !policy.readwrite_paths.is_empty() {
+    if !paths.readwrite.is_empty() {
         // `network-bind` / `network-outbound` under a *path* filter match only
         // AF_UNIX sockets — Seatbelt matches IP sockets with `(local ip)` /
         // `(remote ip)` — so this widens nothing on the IP side. A UNIX socket
@@ -170,17 +213,13 @@ fn write_filesystem_allow(out: &mut String, request: &ExecutionRequest) -> Resul
         write_path_rule(
             out,
             "allow file-read* file-write* network-bind network-outbound",
-            &policy.readwrite_paths,
-        )?;
+            &paths.readwrite,
+        );
     }
-
-    Ok(())
 }
 
-fn write_filesystem_deny(out: &mut String, request: &ExecutionRequest) -> Result<(), String> {
-    let policy = &request.policy;
-
-    if !policy.denied_paths.is_empty() {
+fn write_filesystem_deny(out: &mut String, paths: &ResolvedPaths) {
+    if !paths.denied.is_empty() {
         // `network-outbound` is denied here for two reasons. A denied path can
         // sit inside a broader `readwritePaths` subtree, whose allow covers it;
         // and `write_outbound_allow_rules` emits an *unfiltered* `(allow
@@ -193,25 +232,18 @@ fn write_filesystem_deny(out: &mut String, request: &ExecutionRequest) -> Result
         write_path_rule(
             out,
             "deny file-read* file-write* network-bind network-outbound",
-            &policy.denied_paths,
-        )?;
-    }
-
-    Ok(())
-}
-
-/// Emit a single `(<ops> (subpath …)…)` rule over resolved policy paths.
-fn write_path_rule(out: &mut String, ops: &str, paths: &[String]) -> Result<(), String> {
-    let _ = writeln!(out, "({ops}");
-    for p in paths {
-        let _ = writeln!(
-            out,
-            "    (subpath {})",
-            quote_scheme(&resolve_policy_path(p)?)
+            &paths.denied,
         );
     }
+}
+
+/// Emit a single `(<ops> (subpath …)…)` rule over already-resolved paths.
+fn write_path_rule(out: &mut String, ops: &str, paths: &[String]) {
+    let _ = writeln!(out, "({ops}");
+    for p in paths {
+        let _ = writeln!(out, "    (subpath {})", quote_scheme(p));
+    }
     out.push_str(")\n");
-    Ok(())
 }
 
 fn write_network_rules(
@@ -907,6 +939,7 @@ mod tests {
         assert!(p.contains("(subpath \"/private/tmp/a\\\"b\\\\c\")"));
     }
 
+    const RO_SECTION: &str = ";; --- policy.readonlyPaths ---";
     const RW_RULE: &str = "(allow file-read* file-write* network-bind network-outbound\n";
     const DENY_RULE: &str = "(deny file-read* file-write* network-bind network-outbound\n";
 
@@ -1025,6 +1058,52 @@ mod tests {
         let p = build_profile(&r).unwrap();
         let deny_idx = p.find(DENY_RULE).expect("deny rule");
         assert!(p[deny_idx..].contains("(subpath \"/private/tmp/secret\")"));
+    }
+
+    #[test]
+    fn readonly_wins_over_readwrite_for_aliased_spellings() {
+        // The parser's most-restrictive-wins pass compares raw strings, so
+        // these two spellings both survive it and only collide once resolved.
+        // Seatbelt is last-match-wins and readwrite is emitted second, so
+        // without resolved-path precedence the read-only intent would be lost.
+        let mut r = req();
+        r.policy.readonly_paths = vec!["/private/tmp/x".into()];
+        r.policy.readwrite_paths = vec!["/tmp/x".into()];
+        let p = build_profile(&r).unwrap();
+
+        let ro_idx = p.find(RO_SECTION).expect("readonly section");
+        assert!(p[ro_idx..].contains("(subpath \"/private/tmp/x\")"));
+        assert!(
+            !p.contains(RW_RULE),
+            "aliased readwrite entry must be dropped, profile was:\n{p}"
+        );
+    }
+
+    #[test]
+    fn denied_wins_over_aliased_readonly_and_readwrite() {
+        let mut r = req();
+        r.policy.denied_paths = vec!["/private/tmp/x".into()];
+        r.policy.readonly_paths = vec!["/tmp/x".into()];
+        r.policy.readwrite_paths = vec!["//tmp/./x".into()];
+        let p = build_profile(&r).unwrap();
+
+        assert!(!p.contains(RO_SECTION), "profile:\n{p}");
+        assert!(!p.contains(RW_RULE), "profile:\n{p}");
+        let deny_idx = p.find(DENY_RULE).expect("deny rule");
+        assert!(p[deny_idx..].contains("(subpath \"/private/tmp/x\")"));
+    }
+
+    #[test]
+    fn distinct_paths_survive_resolved_precedence() {
+        let mut r = req();
+        r.policy.readonly_paths = vec!["/tmp/ro".into()];
+        r.policy.readwrite_paths = vec!["/tmp/rw".into()];
+        let p = build_profile(&r).unwrap();
+
+        let ro_idx = p.find(RO_SECTION).expect("readonly section");
+        assert!(p[ro_idx..].contains("(subpath \"/private/tmp/ro\")"));
+        let rw_idx = p.find(RW_RULE).expect("readwrite rule");
+        assert!(p[rw_idx..].contains("(subpath \"/private/tmp/rw\")"));
     }
 
     #[test]

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -27,6 +27,7 @@
 
 use std::fmt::Write as _;
 
+use wxc_common::filesystem_resolve::{resolve_path_plan, FsIntent};
 use wxc_common::models::{
     ClipboardPolicy, ContainerPolicy, ExecutionRequest, NetworkPolicy, ProxyAddress,
 };
@@ -193,28 +194,47 @@ fn resolve_all(paths: &[String]) -> Result<Vec<String>, String> {
 }
 
 fn write_filesystem_allow(out: &mut String, paths: &ResolvedPaths) {
-    if !paths.readonly.is_empty() {
-        out.push_str(";; --- policy.readonlyPaths ---\n");
-        write_path_rule(out, "allow file-read*", &paths.readonly);
+    if paths.readonly.is_empty() && paths.readwrite.is_empty() {
+        return;
     }
 
-    if !paths.readwrite.is_empty() {
-        // `network-bind` / `network-outbound` under a *path* filter match only
-        // AF_UNIX sockets — Seatbelt matches IP sockets with `(local ip)` /
-        // `(remote ip)` — so this widens nothing on the IP side. A UNIX socket
-        // is a filesystem object reachable only by processes that can traverse
-        // to its path, so `readwritePaths` (not the network policy) governs it:
-        // binding or connecting where the sandbox may already create files
-        // grants no capability it lacks. Both halves are needed — Node
-        // toolchains (tsx, vite, esbuild, jest) bind an IPC pipe and then
-        // connect to it. `readonlyPaths` deliberately gets neither: a socket is
-        // a bidirectional channel, not a read.
-        out.push_str(";; --- policy.readwritePaths (+ AF_UNIX socket bind/connect) ---\n");
-        write_path_rule(
-            out,
-            "allow file-read* file-write* network-bind network-outbound",
-            &paths.readwrite,
-        );
+    // Emit shallow-to-deep, one rule per path, using the same ordering the
+    // Linux backends apply (`wxc_common::filesystem_resolve`). Seatbelt is
+    // last-match-wins, so ordering by depth makes the *deepest* intent win at
+    // every path — a `readonlyPaths` entry nested inside a broader
+    // `readwritePaths` subtree stays read-only rather than inheriting the
+    // parent's write grant. `deniedPaths` is deliberately not part of this
+    // plan: it is emitted after the network rules so it also overrides the
+    // unfiltered `(allow network-outbound)`, which makes it win outright.
+    out.push_str(";; --- policy.readonlyPaths / policy.readwritePaths (shallow-to-deep) ---\n");
+    for mount in resolve_path_plan(&paths.readwrite, &paths.readonly, &[]) {
+        let subpath = [mount.path.clone()];
+        match mount.intent {
+            FsIntent::ReadWrite => {
+                // `network-bind` / `network-outbound` under a *path* filter
+                // match only AF_UNIX sockets — Seatbelt matches IP sockets with
+                // `(local ip)` / `(remote ip)` — so this widens nothing on the
+                // IP side. Both halves are needed: Node toolchains (tsx, vite,
+                // esbuild, jest) bind an IPC pipe and then connect to it.
+                write_path_rule(
+                    out,
+                    "allow file-read* file-write* network-bind network-outbound",
+                    &subpath,
+                );
+            }
+            FsIntent::ReadOnly => {
+                write_path_rule(out, "allow file-read*", &subpath);
+                // The read allow alone cannot take write or socket authority
+                // back from a shallower read-write rule — an `allow` never
+                // denies — so the removal has to be explicit.
+                write_path_rule(
+                    out,
+                    "deny file-write* network-bind network-outbound",
+                    &subpath,
+                );
+            }
+            FsIntent::Denied => unreachable!("denied paths are not part of this plan"),
+        }
     }
 }
 
@@ -939,7 +959,18 @@ mod tests {
         assert!(p.contains("(subpath \"/private/tmp/a\\\"b\\\\c\")"));
     }
 
-    const RO_SECTION: &str = ";; --- policy.readonlyPaths ---";
+    const FS_SECTION: &str =
+        ";; --- policy.readonlyPaths / policy.readwritePaths (shallow-to-deep) ---";
+    const RO_STRIP: &str = "(deny file-write* network-bind network-outbound\n";
+
+    /// The policy-derived filesystem section, excluding the always-emitted
+    /// baseline rules that also start with `(allow file-read*`.
+    fn fs_section(profile: &str) -> &str {
+        profile
+            .find(FS_SECTION)
+            .map(|i| &profile[i..])
+            .unwrap_or("")
+    }
     const RW_RULE: &str = "(allow file-read* file-write* network-bind network-outbound\n";
     const DENY_RULE: &str = "(deny file-read* file-write* network-bind network-outbound\n";
 
@@ -988,7 +1019,9 @@ mod tests {
         r.policy.readonly_paths = vec!["/tmp/input".into()];
         let p = build_profile(&r).unwrap();
         assert!(!p.contains(RW_RULE));
-        assert!(!p.contains("network-bind"));
+        // The only socket mention for a read-only path is the explicit removal.
+        assert!(!p.contains("allow network-bind"));
+        assert!(fs_section(&p).contains(RO_STRIP));
     }
 
     #[test]
@@ -1061,6 +1094,44 @@ mod tests {
     }
 
     #[test]
+    fn nested_readonly_keeps_write_away_from_broader_readwrite() {
+        // `/tmp` resolves to `/private/tmp`, which is an ancestor of the
+        // read-only entry. An `allow` cannot take authority back, so the
+        // read-only path must emit an explicit removal *after* the broader
+        // read-write allow.
+        let mut r = req();
+        r.policy.readwrite_paths = vec!["/tmp".into()];
+        r.policy.readonly_paths = vec!["/private/tmp/secret".into()];
+        let p = build_profile(&r).unwrap();
+
+        let rw_idx = p.find(RW_RULE).expect("readwrite rule");
+        let strip_idx = p.find(RO_STRIP).expect("read-only must strip write");
+        assert!(
+            strip_idx > rw_idx,
+            "deepest intent must be emitted last, profile:\n{p}"
+        );
+        assert!(p[strip_idx..].contains("(subpath \"/private/tmp/secret\")"));
+    }
+
+    #[test]
+    fn nested_readwrite_still_wins_inside_broader_readonly() {
+        // The mirror case: the deeper read-write entry must survive, otherwise
+        // depth ordering would have simply inverted the bug.
+        let mut r = req();
+        r.policy.readonly_paths = vec!["/tmp".into()];
+        r.policy.readwrite_paths = vec!["/private/tmp/build".into()];
+        let p = build_profile(&r).unwrap();
+
+        let strip_idx = p.find(RO_STRIP).expect("read-only strip");
+        let rw_idx = p.find(RW_RULE).expect("readwrite rule");
+        assert!(
+            rw_idx > strip_idx,
+            "deeper readwrite must win, profile:\n{p}"
+        );
+        assert!(p[rw_idx..].contains("(subpath \"/private/tmp/build\")"));
+    }
+
+    #[test]
     fn readonly_wins_over_readwrite_for_aliased_spellings() {
         // The parser's most-restrictive-wins pass compares raw strings, so
         // these two spellings both survive it and only collide once resolved.
@@ -1071,8 +1142,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["/tmp/x".into()];
         let p = build_profile(&r).unwrap();
 
-        let ro_idx = p.find(RO_SECTION).expect("readonly section");
-        assert!(p[ro_idx..].contains("(subpath \"/private/tmp/x\")"));
+        assert!(fs_section(&p).contains("(subpath \"/private/tmp/x\")"));
         assert!(
             !p.contains(RW_RULE),
             "aliased readwrite entry must be dropped, profile was:\n{p}"
@@ -1087,7 +1157,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["//tmp/./x".into()];
         let p = build_profile(&r).unwrap();
 
-        assert!(!p.contains(RO_SECTION), "profile:\n{p}");
+        assert!(!p.contains(FS_SECTION), "profile:\n{p}");
         assert!(!p.contains(RW_RULE), "profile:\n{p}");
         let deny_idx = p.find(DENY_RULE).expect("deny rule");
         assert!(p[deny_idx..].contains("(subpath \"/private/tmp/x\")"));
@@ -1100,8 +1170,7 @@ mod tests {
         r.policy.readwrite_paths = vec!["/tmp/rw".into()];
         let p = build_profile(&r).unwrap();
 
-        let ro_idx = p.find(RO_SECTION).expect("readonly section");
-        assert!(p[ro_idx..].contains("(subpath \"/private/tmp/ro\")"));
+        assert!(fs_section(&p).contains("(subpath \"/private/tmp/ro\")"));
         let rw_idx = p.find(RW_RULE).expect("readwrite rule");
         assert!(p[rw_idx..].contains("(subpath \"/private/tmp/rw\")"));
     }


### PR DESCRIPTION
## 📖 Description

Fixes two bugs in the macOS Seatbelt backend that made UNIX-domain sockets unusable and silently dropped most filesystem policy rules.

### 1. AF_UNIX sockets were never permitted

Seatbelt matches AF_UNIX sockets by **path** — `bind()` under `network-bind`, `connect()` under `network-outbound` — while `allowLocalNetwork` only emits `network-inbound (local ip)`, which covers IP sockets. Any Node toolchain that uses an IPC pipe (tsx, vite, esbuild, jest workers) failed with:

```
Error: listen EPERM: operation not permitted /var/folders/…/T/tsx-501/51325.pipe
```

Both operations are now granted on `readwritePaths`. A UNIX socket is a filesystem object reachable only by processes that can traverse to its path, so using one where writes are already permitted grants no new capability. This is why the **filesystem** policy governs it rather than the network policy — gating it behind `allowLocalNetwork` would force real network ingress on just to run a build.

Because the rules are path-scoped they never widen IP binding or IP egress, which stay governed by `defaultPolicy` and `allowLocalNetwork`. Verified empirically: with only a `(subpath …)` filter present, TCP `bind()` and TCP `connect()` both still return `EPERM`.

`readonlyPaths` deliberately gets neither operation — a socket is a bidirectional channel, not a read.

### 2. Policy paths were emitted verbatim

`/etc`, `/tmp`, `/var` and `/home` are symlinks on macOS, and the kernel fully canonicalizes a path *before* matching it against a profile filter. A rule written against the unresolved path therefore never matches and is **silently dead** — no error, no diagnostic.

This also killed the automatic `$TMPDIR` grant, which resolves to `/var/folders/…`. Policy paths are now rewritten to their real targets before emission (`/etc`, `/tmp`, `/var` → `/private/…`; `/home` → `/System/Volumes/Data/home`). `/Users` needs no rewriting — it is a *firmlink*, not a symlink.

### Escape closed as a side effect

Fixing (2) turns dead **deny** rules live as well as dead allow rules. While auditing that, an actual bypass was found and closed: `deniedPaths` now also denies `network-outbound`. `defaultPolicy: "allow"` and the remote-proxy fallback emit an *unfiltered* `(allow network-outbound)`, which previously let the sandbox `connect()` to a pre-existing socket inside a denied subtree. A Docker, `ssh-agent` or `gpg-agent` socket is a control plane, so that was an escape.

Reproduced end to end — a listener planted in a `deniedPaths` subtree, with the sandbox connecting to it:

| | Result |
|---|---|
| before | `ESCAPE: PWNED` |
| after | `BLOCKED EPERM` |

### Path normalization

Policy paths are also folded to a single canonical spelling before emission: redundant separators (`//tmp`), `.` segments (`/./tmp`) and a trailing `/` are collapsed. Seatbelt canonicalizes only the *accessed* path, not the filter, so a rule written with a redundant spelling is dead — and for `deniedPaths` that fails **open**. Confirmed with `sandbox-exec`: a deny on `(subpath "//private/tmp/x/secret/")` lets a write through, while the normalized spelling denies it.

A `..` segment is **rejected** as a config error rather than resolved. macOS resolves `..` physically, after following symlinks, so `/tmp/..` is `/private`, not `/` — resolving it lexically could silently widen an allow rule to `/`, which is worse than the dead rule it replaces.

All of this is pure string work, so `profile_builder` stays platform-agnostic and unit-testable on Linux CI.

### Path precedence

Most-restrictive-wins (`deny` > `readonly` > `readwrite`) is re-applied to the **resolved** paths. The shared config parser already applies it, but only to the raw strings — so `readonlyPaths: ["/private/tmp/x"]` and `readwritePaths: ["/tmp/x"]` survive it as distinct entries and collide only at emission. Seatbelt is last-match-wins and the read-write rule is emitted second, so without this the read-only intent would be silently lost.

### Rule ordering

`readonlyPaths` and `readwritePaths` are emitted **shallow-to-deep**, one rule per path, reusing `wxc_common::filesystem_resolve::resolve_path_plan` — the same plan the Bubblewrap and LXC backends use. Last-match-wins then gives deepest-intent-wins, so a read-only entry nested inside a broader read-write subtree stays read-only. Since an `allow` can never take authority back, each read-only path also emits an explicit `(deny file-write* network-bind network-outbound …)`.

`deniedPaths` stays outside that plan and is emitted after the network rules, so it still overrides the unfiltered `(allow network-outbound)`.

### Security tradeoff

AF_UNIX `connect()` is a capability that `file-write*` alone did not grant. A sandbox with a broad `readwritePaths` root can now reach any **pre-existing** listener underneath it, and a control socket (Docker, `ssh-agent`, `gpg-agent`) is a meaningful target. Documented in the backend guide: prefer a narrow read-write root, and put sensitive sockets in `deniedPaths`, which overrides the grant.

### Known limitation

`..` is rejected on this backend only, while the shared parser accepts it — a cross-backend policy using `..` will fail on macOS and run elsewhere. That is intentional: the alternative is the silently-dead rule this PR exists to remove. Resolving it correctly needs `std::fs::canonicalize` against the live filesystem.

For the same reason, only *root* symlinks are resolved. A policy path that traverses a **non-root** symlink still produces a rule that never matches; for `deniedPaths` that fails **open**. Fixing it needs `std::fs::canonicalize`, which would break `profile_builder`'s platform-agnostic purity (it is pure string generation, unit-tested on every host including Linux CI). Left as a separate change — Bubblewrap already solves the equivalent problem with `resolve_through_symlinks` in `bwrap_runner.rs`.

## 🔗 References

- `docs/macos-support/seatbelt-backend.md` — updated with the new rule tables, a `#### Path resolution` section, and a `#### UNIX-domain sockets` section explaining the rationale and the two intentional asymmetries.

## 🔍 Validation

**Automated**

- `cargo test -p seatbelt_common` → **62 passed**, 0 failed (was 45 before; 17 new tests cover socket ops, readonly exclusion, deny ordering vs. the unfiltered outbound allow, root-symlink resolution incl. whole-segment matching and idempotence, lexical spelling normalization / `..` rejection, resolved-path precedence for aliased spellings, and depth ordering in both nesting directions)
- `cargo clippy -p seatbelt_common --all-targets -- -D warnings` → clean
- `cargo test -p seatbelt_common -p wxc_common -p mxc_engine -p mxc-sdk -p mxc_darwin` → all green, 0 failed

**Manual, with a real `mxc-exec-mac` build**

| Scenario | Result |
|---|---|
| `defaultPolicy: "block"`, raw `$TMPDIR` in `readwritePaths`, bind + connect on a `.pipe` (the reported failure) | `LISTEN_OK` / `CONNECT_OK` / `SERVER_GOT ping` |
| same scenario on `main` | `LISTEN_FAIL EPERM` |
| bind inside a `deniedPaths` subtree | `EPERM` |
| connect to a pre-existing socket inside a `deniedPaths` subtree | `EPERM` (`ESCAPE: PWNED` before) |
| deny written as `//private/tmp/x/secret/` | denied (write went through before normalization) |
| `readonlyPaths: ["/private/tmp/x"]` + `readwritePaths: ["/tmp/x"]` | `EPERM` on write (was writable before resolved-path precedence) |
| `readonlyPaths: ["/private/tmp/x/secret"]` nested in `readwritePaths: ["/tmp/x"]` | `EPERM` on write (was writable before depth ordering) |
| `readwritePaths: ["/private/tmp/x/build"]` nested in `readonlyPaths: ["/tmp/x"]` | write succeeds — deeper intent still wins |
| TCP `listen()` under `block`, no `allowLocalNetwork` | `EPERM` — no IP-bind leak |
| TCP `listen()` under `block` with `allowLocalNetwork: true` | `TCP_LISTEN_OK` — existing behavior preserved |
| TCP `connect()` with only path-scoped outbound rules | `EPERM` — no IP-egress leak |

**Bypass probes** — `..`, `//`, trailing slash, and the `/tmp` → `/private/tmp` alias were each attempted against a denied subtree; all correctly denied (the kernel canonicalizes before rule evaluation).

Pre-existing, unrelated build breakage on macOS (`nanvix_common` `E0425`, `windows-future`) was confirmed present on `main`, hence the targeted `-p` crate selection above rather than `--workspace`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/749)


