### PR TITLE
fix(bwrap): surface allowLocalNetwork settings the Bubblewrap backend cannot honor

### DIFF
--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -164,9 +164,10 @@ Example:
 Bubblewrap supports two network modes:
 
 **Full block** (`defaultPolicy: "block"`, no host lists) — uses
-`--unshare-net` for complete network namespace isolation. No network stack
-is available inside the sandbox (including loopback). Runs fully
-unprivileged.
+`--unshare-net` for complete network namespace isolation. The sandbox gets a
+private network stack with only its own loopback (bwrap brings `lo` up), so
+nothing outside the sandbox is reachable and nothing outside can reach in.
+Runs fully unprivileged.
 
 ```json
 {
@@ -200,6 +201,30 @@ iptables.
 
 **Full allow** (`defaultPolicy: "allow"`, no host lists) — the sandbox
 shares the host network namespace with no restrictions.
+
+#### `allowLocalNetwork` is not independently enforceable
+
+`network.allowLocalNetwork` controls whether the sandboxed process may
+`bind()`/`listen()` on local IPs and accept **inbound** connections. It says
+nothing about *outbound* reachability of loopback or RFC1918 addresses —
+that is governed by `defaultPolicy` / `allowedHosts` / `blockedHosts`.
+
+Bubblewrap has no inbound-only primitive. Unprivileged bwrap has no veth
+interface to scope iptables to, and seccomp cannot dereference the `sockaddr`
+passed to `bind()`, so an AF_INET-only filter is not expressible. The
+namespace choice alone decides the outcome:
+
+| `allowLocalNetwork` | Namespace | Result |
+|---------------------|-----------|--------|
+| `false` (default) | private (`--unshare-net`) | Honored at the sandbox boundary — nothing outside can reach in. `bind()`/`listen()` still succeed on the sandbox's own loopback, so its processes can talk to each other; that is already inside the caller's trust boundary |
+| `false` | shared with host | **Not honored** — the process can bind/listen on host-local addresses |
+| `true` | private (`--unshare-net`) | **Partially honored** — the listener is reachable only from inside the sandbox |
+| `true` | shared with host | Honored |
+
+Rows 2 and 3 emit a `WARNING:` line to the runner log at preflight rather
+than failing silently. Windows (AppContainer's `privateNetworkClientServer`
+capability) and macOS (Seatbelt's `(allow network-inbound (local ip))`)
+enforce the field at the syscall level; this divergence is Linux-specific.
 
 ### Process Settings
 

--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -163,11 +163,11 @@ Example:
 
 Bubblewrap supports two network modes:
 
-**Full block** (`defaultPolicy: "block"`, no host lists) — uses
-`--unshare-net` for complete network namespace isolation. The sandbox gets a
-private network stack with only its own loopback (bwrap brings `lo` up), so
-nothing outside the sandbox is reachable and nothing outside can reach in.
-Runs fully unprivileged.
+**Full block** (`defaultPolicy: "block"`, no host lists, no `network.proxy`)
+— uses `--unshare-net` for complete network namespace isolation. The sandbox
+gets a private network stack with only its own loopback (bwrap brings `lo`
+up), so nothing outside the sandbox is reachable and nothing outside can
+reach in. Runs fully unprivileged.
 
 ```json
 {

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -101,6 +101,63 @@ const BASELINE_RO_BIND_PATHS: &[&str] = &[
     "/mnt/wsl/resolv.conf",
 ];
 
+/// Whether the sandbox gets its own network namespace (`--unshare-net`) rather
+/// than sharing the host's.
+///
+/// Full isolation applies only when the default policy denies outbound, no
+/// per-host rules need iptables on the shared namespace, and no loopback proxy
+/// has to stay reachable.
+fn uses_private_netns(request: &ExecutionRequest, proxy_address: Option<&ProxyAddress>) -> bool {
+    request.policy.default_network_policy == NetworkPolicy::Block
+        && request.policy.allowed_hosts.is_empty()
+        && request.policy.blocked_hosts.is_empty()
+        && proxy_address.is_none()
+}
+
+/// Describe an `network.allowLocalNetwork` setting Bubblewrap cannot honor, or
+/// `None` when the sandbox's namespace already matches the request.
+///
+/// `allowLocalNetwork` governs whether the sandboxed process may bind/listen on
+/// local IPs and accept **inbound** connections (it says nothing about outbound
+/// reachability of local addresses — that is `defaultPolicy`/`allowedHosts`).
+/// Bubblewrap has no inbound-only primitive: the sandbox either gets a private
+/// network namespace or shares the host's, and neither can be narrowed further.
+/// Unprivileged bwrap has no veth to scope iptables to, and seccomp cannot
+/// dereference the `sockaddr` passed to `bind`, so an AF_INET-only filter is not
+/// expressible. The namespace choice therefore decides the outcome, and this
+/// returns the mismatch so the runner can say so out loud rather than dropping
+/// the field silently.
+///
+/// The private-namespace arm satisfies `false` only at the sandbox boundary:
+/// bwrap brings `lo` up inside the new namespace, so sandbox processes can still
+/// bind and connect to each other over their own loopback. That stays inside the
+/// caller's trust boundary — those processes already share pipes, files and the
+/// mount namespace — so it is not warned about.
+pub fn local_network_diagnostic(
+    request: &ExecutionRequest,
+    proxy_address: Option<&ProxyAddress>,
+) -> Option<&'static str> {
+    match (
+        request.policy.allow_local_network,
+        uses_private_netns(request, proxy_address),
+    ) {
+        (false, false) => Some(
+            "WARNING: Bubblewrap: network.allowLocalNetwork=false is not enforced while the \
+             sandbox shares the host network namespace (defaultPolicy='allow', allowedHosts / \
+             blockedHosts, or network.proxy). The sandboxed process can still bind, listen and \
+             accept on host-local addresses. For an unreachable sandbox use defaultPolicy='block' \
+             with no host lists and no proxy, which applies --unshare-net.",
+        ),
+        (true, true) => Some(
+            "WARNING: Bubblewrap: network.allowLocalNetwork=true is confined to the sandbox's own \
+             network namespace. defaultPolicy='block' with no host lists and no proxy applies \
+             --unshare-net, so a listener inside the sandbox is reachable only from within it, \
+             never from the host. Use defaultPolicy='allow' to share the host network namespace.",
+        ),
+        _ => None,
+    }
+}
+
 /// Build the complete `bwrap` argument list, masking **every** denied path as a
 /// directory (`--tmpfs`).
 ///
@@ -154,12 +211,7 @@ pub fn build_args_classified(
     // applies iptables rules separately. When a network proxy is active we
     // also keep the host network namespace so the sandbox can reach the
     // loopback proxy.
-    let has_host_rules =
-        !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty();
-    let full_block = request.policy.default_network_policy == NetworkPolicy::Block
-        && !has_host_rules
-        && proxy_address.is_none();
-    if full_block {
+    if uses_private_netns(request, proxy_address) {
         args.push("--unshare-net".into());
     }
 
@@ -323,6 +375,56 @@ mod tests {
             !args.contains(&"--unshare-net".to_string()),
             "should omit --unshare-net when host rules require iptables"
         );
+    }
+
+    // ------- allowLocalNetwork diagnostic tests -------------------------
+
+    #[test]
+    fn local_network_denied_under_private_netns_is_not_warned() {
+        // Default policy (block, no host lists, no proxy) applies
+        // --unshare-net: nothing outside can reach in, so allowLocalNetwork=false
+        // is satisfied at the sandbox boundary and needs no warning.
+        let r = base_request();
+        assert!(!r.policy.allow_local_network);
+        assert!(local_network_diagnostic(&r, None).is_none());
+    }
+
+    #[test]
+    fn local_network_denied_on_shared_netns_warns() {
+        let mut r = base_request();
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        let msg = local_network_diagnostic(&r, None).expect("shared netns cannot honor the deny");
+        assert!(msg.contains("allowLocalNetwork=false"));
+    }
+
+    #[test]
+    fn local_network_denied_with_host_rules_warns() {
+        let mut r = base_request();
+        r.policy.blocked_hosts = vec!["evil.example.com".into()];
+        assert!(local_network_diagnostic(&r, None).is_some());
+    }
+
+    #[test]
+    fn local_network_denied_with_proxy_warns() {
+        let r = base_request();
+        let addr = ProxyAddress::new("127.0.0.1".into(), 8080);
+        assert!(local_network_diagnostic(&r, Some(&addr)).is_some());
+    }
+
+    #[test]
+    fn local_network_allowed_under_private_netns_warns() {
+        let mut r = base_request();
+        r.policy.allow_local_network = true;
+        let msg = local_network_diagnostic(&r, None).expect("--unshare-net isolates the listener");
+        assert!(msg.contains("allowLocalNetwork=true"));
+    }
+
+    #[test]
+    fn local_network_allowed_on_shared_netns_is_honored() {
+        let mut r = base_request();
+        r.policy.allow_local_network = true;
+        r.policy.default_network_policy = NetworkPolicy::Allow;
+        assert!(local_network_diagnostic(&r, None).is_none());
     }
 
     #[test]

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -143,16 +143,16 @@ pub fn local_network_diagnostic(
     ) {
         (false, false) => Some(
             "WARNING: Bubblewrap: network.allowLocalNetwork=false is not enforced while the \
-             sandbox shares the host network namespace (defaultPolicy='allow', allowedHosts / \
-             blockedHosts, or network.proxy). The sandboxed process can still bind, listen and \
-             accept on host-local addresses. For an unreachable sandbox use defaultPolicy='block' \
-             with no host lists and no proxy, which applies --unshare-net.",
+             sandbox shares the host network namespace (defaultPolicy='allow' or network.proxy). \
+             The sandboxed process can still bind, listen and accept on host-local addresses. For \
+             an unreachable sandbox use defaultPolicy='block' with no proxy, which applies \
+             --unshare-net.",
         ),
         (true, true) => Some(
             "WARNING: Bubblewrap: network.allowLocalNetwork=true is confined to the sandbox's own \
-             network namespace. defaultPolicy='block' with no host lists and no proxy applies \
-             --unshare-net, so a listener inside the sandbox is reachable only from within it, \
-             never from the host. Use defaultPolicy='allow' to share the host network namespace.",
+             network namespace. defaultPolicy='block' with no proxy applies --unshare-net, so a \
+             listener inside the sandbox is reachable only from within it, never from the host. \
+             Use defaultPolicy='allow' to share the host network namespace.",
         ),
         _ => None,
     }

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -114,7 +114,7 @@ fn uses_private_netns(request: &ExecutionRequest, proxy_address: Option<&ProxyAd
         && proxy_address.is_none()
 }
 
-/// Describe an `network.allowLocalNetwork` setting Bubblewrap cannot honor, or
+/// Describe a `network.allowLocalNetwork` setting Bubblewrap cannot honor, or
 /// `None` when the sandbox's namespace already matches the request.
 ///
 /// `allowLocalNetwork` governs whether the sandboxed process may bind/listen on

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -191,6 +191,9 @@ impl BubblewrapScriptRunner {
         // 2. Build the bwrap argument vector. `denied_files` is the file-mask
         //    subset classified during symlink resolution (see
         //    [`resolve_denied_paths`]).
+        if let Some(warning) = bwrap_command::local_network_diagnostic(request, proxy.address()) {
+            let _ = writeln!(logger, "{}", warning);
+        }
         let args = bwrap_command::build_args_classified(request, proxy.address(), denied_files);
         let _ = writeln!(
             logger,


### PR DESCRIPTION
## 📖 Description

`network.allowLocalNetwork` — "the sandboxed process may `bind()`/`listen()` on local IPs and accept **inbound** connections" — is a first-class part of the policy surface. It is declared in `ContainerPolicy` (`src/core/wxc_common/src/models.rs`), parsed by `config_parser.rs`, carried on the wire (`src/core/wxc_common/src/wire.rs`), and honored by two of the three backends:

- **Windows** maps it to the AppContainer `privateNetworkClientServer` capability (`src/core/mxc_engine/src/policy.rs`).
- **Seatbelt** emits `(allow network-inbound (local ip))` (`src/backends/seatbelt/common/src/profile_builder.rs`).

`grep -rn "allow_local_network" src/backends/bubblewrap/` returned **zero** hits. On Linux the value was validated, transported to the backend, and then dropped on the floor — a silent no-op in a security-relevant control, which is worse than an outright rejection because the policy readback still shows the field as requested.

### Why this isn't enforced instead

Bubblewrap has no inbound-only primitive:

- Unprivileged bwrap shares the host network namespace and has **no veth interface**, so iptables rules cannot be scoped to the sandbox. `NetworkIptablesManager` already skips its `FORWARD` hook when there is no veth, precisely to avoid applying host-wide rules.
- seccomp **cannot dereference** the `sockaddr` argument to `bind()`, so an AF_INET-only filter is not expressible. Blocking `bind` outright would also kill AF_UNIX sockets; blocking `listen` would still miss UDP servers.

The namespace choice alone therefore decides the outcome, which leaves two mismatches — note the second is in the *restrictive* direction and was not previously identified:

| `allowLocalNetwork` | Namespace | Outcome before this PR |
|---|---|---|
| `false` (default) | private (`--unshare-net`) | Satisfied at the sandbox boundary |
| `false` | shared with host (`defaultPolicy: allow`, host lists, or `network.proxy`) | **Restriction silently dropped** — the process can bind/listen on host-local addresses |
| `true` | private (`--unshare-net`) | **Silently useless** — the listener sits in a namespace nothing outside can reach |
| `true` | shared with host | Honored |

### Change

- New pure `local_network_diagnostic()` in `bwrap_command.rs` returns the mismatch for the two unhonorable rows; `bwrap_runner::spawn_bwrap` logs it as a `WARNING:` at preflight, so the failure is loud rather than silent.
- Extracted the `--unshare-net` predicate into `uses_private_netns()`, shared with `build_args_classified`, so the diagnostic and the argument builder cannot drift apart.
- Documented the per-platform divergence in `docs/bwrap-support/bubblewrap-backend.md`.

**Deliberately a warning, not a rejection.** `false` is the default, so rejecting the shared-namespace case would break every `defaultPolicy: "allow"` run. And `true` + `--unshare-net` is legitimate when a sandbox both serves and connects to its own loopback.

### Incidental doc fix

The backend doc claimed `--unshare-net` leaves "no network stack ... (including loopback)". That is wrong: bubblewrap calls `loopback_setup()` when unsharing the network namespace, so `lo` is up inside the sandbox. The doc now says so, and the truth table depends on it being accurate.

### Limitations

This does not make Bubblewrap enforce the field — it makes the gap observable. Enforcement would need a privileged network namespace with a veth pair (i.e. the LXC model), which is out of scope for an unprivileged backend.

## 🔗 References

- Prior art on the same backend for this class of fix (surface an unhonorable policy loudly at preflight instead of failing quietly): #507
- Related but distinct, and already closed: #479 "Bubblewrap network firewall mode rejects IPv6-resolved hosts"
- `loopback_setup()` on `--unshare-net`: [containers/bubblewrap `bubblewrap.c`](https://github.com/containers/bubblewrap/blob/main/bubblewrap.c)

## 🔍 Validation

Automated (run from `src/`; the Bubblewrap runner is `#[cfg(target_os = "linux")]`, so the Linux target was cross-checked from a macOS host):

```
cargo fmt -p bwrap_common -- --check
cargo test -p bwrap_common                        # 35 passed (was 29)
cargo clippy -p bwrap_common --all-targets -- -D warnings
cargo clippy --target x86_64-unknown-linux-gnu -p bwrap_common --all-targets -- -D warnings
```

All four pass, with the same results captured as a baseline before the change (no regressions).

Six new unit tests cover the truth table exhaustively. They live in `bwrap_command`, which is deliberately platform-agnostic, so they execute on every host:

- `local_network_denied_under_private_netns_is_not_warned`
- `local_network_denied_on_shared_netns_warns`
- `local_network_denied_with_host_rules_warns`
- `local_network_denied_with_proxy_warns`
- `local_network_allowed_under_private_netns_warns`
- `local_network_allowed_on_shared_netns_is_honored`

Not yet run: `tests/scripts/run_bwrap_all_tests.sh` on a Linux host with `bwrap` installed, to observe the warning end-to-end. The logged line itself is compile-verified for the Linux target but not executed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)) — no dependency changes

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/750)