### PR TITLE
Remove check_refs_volumes from basecontainer and appcontainer

### DIFF
--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -999,19 +999,6 @@ impl AppContainerScriptRunner {
         //   which handles the child can access.
         let mut pi = PROCESS_INFORMATION::default();
 
-        // Pre-launch check: abort if policy paths are on ReFS (Dev Drive) volumes
-        // where BFS cannot enforce filesystem policy.
-        if let Some(diag) = crate::launch_diagnostics::check_refs_volumes(
-            &request.policy.readonly_paths,
-            &request.policy.readwrite_paths,
-        ) {
-            logger.log_line(&format!(
-                "Error: Pre-launch diagnostic [{}]: {}",
-                diag.kind, diag.message
-            ));
-            return Err(WxcError::Process(diag.message));
-        }
-
         unsafe {
             CreateProcessW(
                 PCWSTR::null(),

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -1222,26 +1222,6 @@ impl BaseContainerRunner {
         let ac_sid_str = derive_sid_string_from_name(&identity);
         let _ = writeln!(logger, "AppContainerSID: {ac_sid_str}");
 
-        // Pre-launch check: abort if policy paths are on ReFS (Dev Drive) volumes
-        // where BFS cannot enforce filesystem policy.
-        if let Some(diag) = crate::launch_diagnostics::check_refs_volumes(
-            &request.policy.readonly_paths,
-            &request.policy.readwrite_paths,
-        ) {
-            let _ = writeln!(
-                logger,
-                "Error: Pre-launch diagnostic [{}]: {}",
-                diag.kind, diag.message
-            );
-            return Err(ScriptResponse {
-                exit_code: -1,
-                error_message: diag.message.clone(),
-                standard_err: diag.message,
-                failure_phase: FailurePhase::LaunchFailed,
-                ..Default::default()
-            });
-        }
-
         // 4. Call Experimental_CreateProcessInSandbox.
         //    If the OS returns ERROR_NOT_SUPPORTED (0x32) and we passed a non-null
         //    environment block, this is a downlevel build that doesn't support the

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -84,7 +84,7 @@ pub fn diagnose_environment_not_supported() -> LaunchDiagnostic {
 pub fn diagnose_process_exit(
     command_line: &str,
     readonly_paths: &[String],
-    readwrite_paths: &[String],
+    _readwrite_paths: &[String],
     exit_code: u32,
 ) -> Option<LaunchDiagnostic> {
     let bare_exe = Path::new(extract_exe_from_command_line(command_line));
@@ -92,7 +92,7 @@ pub fn diagnose_process_exit(
     if let Some(diag) = check_exe_heuristics(&resolved_exe, readonly_paths, Some(exit_code)) {
         return Some(diag);
     }
-    check_refs_volumes(readonly_paths, readwrite_paths)
+    None
 }
 
 // -- Constants ---------------------------------------------------------------
@@ -232,114 +232,6 @@ fn check_velocity_keys() -> Vec<(u32, bool)> {
     {
         Vec::new()
     }
-}
-
-/// Pre-launch check: detect if any sandbox policy paths reference ReFS volumes
-/// (e.g. Dev Drives). BFS (Bind Filter) does not work correctly on ReFS, so
-/// filesystem policy will not be enforced on those volumes.
-///
-/// Call this **before** launching the sandboxed process. If it returns `Some`,
-/// the caller should abort launch and surface the diagnostic to the user.
-pub fn check_refs_volumes(
-    readonly_paths: &[String],
-    readwrite_paths: &[String],
-) -> Option<LaunchDiagnostic> {
-    #[cfg(target_os = "windows")]
-    {
-        let system_drive = std::env::var("SystemDrive")
-            .unwrap_or_else(|_| "C:".to_string())
-            .to_uppercase();
-
-        // Collect unique non-system drive letters from all policy paths.
-        let mut non_system_drives: Vec<char> = Vec::new();
-        for path in readonly_paths.iter().chain(readwrite_paths.iter()) {
-            if let Some(drive_letter) = extract_drive_letter(path) {
-                let upper = drive_letter.to_ascii_uppercase();
-                let drive_prefix = format!("{}:", upper);
-                if drive_prefix != system_drive && !non_system_drives.contains(&upper) {
-                    non_system_drives.push(upper);
-                }
-            }
-        }
-
-        if non_system_drives.is_empty() {
-            return None;
-        }
-
-        // Check which of these drives are ReFS.
-        let refs_drives: Vec<char> = non_system_drives
-            .into_iter()
-            .filter(|&d| is_refs_volume(d))
-            .collect();
-
-        if refs_drives.is_empty() {
-            return None;
-        }
-
-        let drive_list: String = refs_drives
-            .iter()
-            .map(|d| format!("{d}:"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        Some(LaunchDiagnostic {
-            kind: "refs_volume_unsupported",
-            message: format!(
-                "The sandbox policy references paths on ReFS volume(s) ({drive_list}) which \
-                 may be a Dev Drive. The Bind Filter (BFS) used to enforce filesystem policy \
-                 does not work correctly on ReFS volumes, so sandboxed processes may not be \
-                 able to access files on those paths. Move your working directory to an NTFS \
-                 volume, or remove those paths from readonlyPaths/readwritePaths."
-            ),
-        })
-    }
-    #[cfg(not(target_os = "windows"))]
-    {
-        let _ = (readonly_paths, readwrite_paths);
-        None
-    }
-}
-
-/// Extract the drive letter from a path like "D:\foo" or "d:/bar".
-fn extract_drive_letter(path: &str) -> Option<char> {
-    let bytes = path.as_bytes();
-    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
-        Some(bytes[0] as char)
-    } else {
-        None
-    }
-}
-
-/// Check if a volume uses ReFS by calling GetVolumeInformationW.
-#[cfg(target_os = "windows")]
-fn is_refs_volume(drive_letter: char) -> bool {
-    use windows::Win32::Storage::FileSystem::GetVolumeInformationW;
-
-    let root = format!("{}:\\", drive_letter);
-    let root_wide: Vec<u16> = root.encode_utf16().chain(std::iter::once(0)).collect();
-
-    let mut fs_name_buf = [0u16; 64];
-    let success = unsafe {
-        GetVolumeInformationW(
-            windows::core::PCWSTR(root_wide.as_ptr()),
-            None,                   // volume name (not needed)
-            None,                   // serial number
-            None,                   // max component length
-            None,                   // filesystem flags
-            Some(&mut fs_name_buf), // filesystem name
-        )
-    };
-
-    if success.is_err() {
-        return false;
-    }
-
-    let fs_name = String::from_utf16_lossy(
-        &fs_name_buf[..fs_name_buf
-            .iter()
-            .position(|&c| c == 0)
-            .unwrap_or(fs_name_buf.len())],
-    );
-    fs_name.eq_ignore_ascii_case("ReFS")
 }
 
 /// Attempt to resolve a potentially bare executable name (e.g. `pwsh.exe`)
@@ -589,23 +481,5 @@ mod tests {
             1,
         );
         assert!(diag.is_none());
-    }
-
-    // -- extract_drive_letter tests --
-
-    #[test]
-    fn extract_drive_letter_absolute() {
-        assert_eq!(extract_drive_letter(r"D:\myrepo"), Some('D'));
-        assert_eq!(extract_drive_letter(r"c:\users"), Some('c'));
-    }
-
-    #[test]
-    fn extract_drive_letter_none_for_unc() {
-        assert_eq!(extract_drive_letter(r"\\server\share"), None);
-    }
-
-    #[test]
-    fn extract_drive_letter_none_for_relative() {
-        assert_eq!(extract_drive_letter("relative/path"), None);
     }
 }


### PR DESCRIPTION
## 📖 Description
The OS added support for REFS volumes in a recent OS change, so the check_refs_volumes fast fail (and diagnostic) is no longer relevant for base container.  Additionally, as AppContainer doesn't use BFS at this point in time, it isn't limited by the REFS issues downlevel.

## 🔗 References
Resolves #474 
Resolves #734 


## 🔍 Validation
Ran cargo test -p wxc_e2e_tests -- --ignored for automated tests.
Ran the below JSON (with base container and appcontainer) and verified access to files that exist, and that if a process failed, it doesn't display a REFS error.  D:\\ is a DevDrive configured via settings.

{
  "version": "0.6.0-alpha",
  "containerId": "CLI-BFS-Tes2",
  "containment": "processcontainer",
  "process": {
    "commandLine": "python -c \"import os\nallowed_path = 'D:\\\\test\\\\wxc_test_allowed\\\\test_output.txt'\ndenied_path = 'D:\\\\test\\\\wxc_test_denied\\\\forbidden.txt'\nprint('Testing filesystem BFS enforcement...')\nf = open(allowed_path, 'w')\nf.write('SUCCESS: Write to allowed path worked!')\nf.close()\nprint(f'Successfully wrote to: {allowed_path}')\nprint('Now attempting to write to denied path...')\ntry:\n    f2 = open(denied_path, 'w')\n    f2.write('This should fail')\n    f2.close()\n    print('ERROR: Should not have been able to write to denied path!')\nexcept PermissionError:\n    print('SUCCESS: Access to denied path was blocked as expected')\"",
    "timeout": 30000
  },
  "filesystem": {
    "readwritePaths": [
      "D:\\test",
      "D:\\"
    ]
  },
  "ui": {
    "disable": false
  }
}




## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/756)