### PR TITLE
Add Copilot-Instructions label policy rule

### DIFF
--- a/.github/policies/labelManagement.issueOpened.yml
+++ b/.github/policies/labelManagement.issueOpened.yml
@@ -15,6 +15,23 @@ configuration:
               action: Opened
         then:
           - addCodeFlowLink
+      - description: Add Copilot-Instructions label to PRs modifying Copilot instruction files
+        if:
+          - payloadType: Pull_Request
+          - or:
+              - isAction:
+                  action: Opened
+              - isAction:
+                  action: Synchronize
+          - filesMatchPattern:
+              pattern: ^\.github/(copilot-instructions\.md|instructions/.+\.instructions\.md)$
+              matchAny: true
+          - not:
+              hasLabel:
+                label: Copilot-Instructions
+        then:
+          - addLabel:
+              label: Copilot-Instructions
       - description: Add Needs-Triage to new issues
         if:
           - payloadType: Issues


### PR DESCRIPTION
## 📖 Description

Adds a policy-bot rule to automatically apply a `Copilot-Instructions` label to pull requests that modify `.github/copilot-instructions.md` or any `.github/instructions/*.instructions.md` file, so reviewers get extra visibility when Copilot's guidance changes.

The rule triggers on PR Opened and Synchronize, matches files via regex, and is guarded with a 
ot: hasLabel check so it won't re-fire once the label is already applied.

Created with GitHub Copilot's assistance.

## 🔗 References

Closes #762

## 🔍 Validation

- Validated the YAML with PowerShell's powershell-yaml module (ConvertFrom-Yaml).
- Cross-checked all conditions/actions against the documented GitOps.PullRequestIssueManagement policy schema.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the dependency-feed-check check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/763)