### PR TITLE
Enable publishing the PSEC bindings crate

### DIFF
--- a/external/windows-sdk/ProcessSecurityEnvironment.provenance.toml
+++ b/external/windows-sdk/ProcessSecurityEnvironment.provenance.toml
@@ -12,8 +12,8 @@
 # then regenerate the bindings (see the crate README).
 
 [source]
-# The schema originates from the internal Microsoft Windows OS repository and is
-# not publicly redistributable. Only the schema text (not the OS tree) is vendored.
+# The schema originates from the Microsoft Windows OS repository. Only the
+# schema text (not the OS tree) is vendored.
 repository = "Windows OS (internal Azure DevOps)"
 # The PSEC schema is a Windows OS containment contract; there is no public OS
 # revision to cite. Instead of guessing a source path/revision, we record the

--- a/src/core/generated/process_security_environment_specification/Cargo.toml
+++ b/src/core/generated/process_security_environment_specification/Cargo.toml
@@ -7,7 +7,7 @@ name = "process_security_environment_spec"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-publish = false
+publish = true
 description = "Generated FlatBuffers bindings for ProcessSecurityEnvironment"
 
 [dependencies]

--- a/src/core/generated/process_security_environment_specification/README.md
+++ b/src/core/generated/process_security_environment_specification/README.md
@@ -12,10 +12,9 @@ by the FlatBuffers compiler (`flatc`).
 
 ## Provenance
 
-The vendored schema originates from the internal Microsoft Windows OS repository
-and is not publicly redistributable. Authoritative provenance — the source
-pull request, the schema SHA-256, and the exact `flatc` version used — is
-recorded in
+The vendored schema originates from the Microsoft Windows OS repository.
+Authoritative provenance — the validated Windows build, schema SHA-256, and
+exact `flatc` version used — is recorded in
 [`external/windows-sdk/ProcessSecurityEnvironment.provenance.toml`](../../../../external/windows-sdk/ProcessSecurityEnvironment.provenance.toml).
 That file is the single source of truth consumed by both the regeneration
 script and the CI drift gate.


### PR DESCRIPTION
## 📖 Description

Enables publication of the generated `process_security_environment_spec` crate by setting `publish = true`.

Also removes the unsupported statement that the PSEC schema is not publicly redistributable. The provenance documentation continues to record its Windows OS origin, validated Windows build, schema hash, and pinned `flatc` version.

## 🔗 References

Related to #739.

## 🔍 Validation

- `cargo package -p process_security_environment_spec --allow-dirty --no-verify`
- `cargo publish --dry-run -p process_security_environment_spec --allow-dirty --no-verify`
- `git diff --check`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)) — `Cargo.lock` is unchanged.

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/782)