### PR TITLE
[LXC] Hook the firewall chain onto the bridge port so it actually filters

### DIFF
--- a/src/backends/lxc/common/src/network_iptables.rs
+++ b/src/backends/lxc/common/src/network_iptables.rs
@@ -8,6 +8,7 @@
 //! interface.
 
 use std::net::{IpAddr, Ipv6Addr, ToSocketAddrs};
+use std::path::Path;
 use std::process::Command;
 
 use wxc_common::logger::Logger;
@@ -18,6 +19,16 @@ enum IpFamily {
     V4,
     V6,
 }
+
+/// Where the kernel reports per-interface attributes. Injectable in tests via
+/// the `_in` form of the lookup below.
+const SYSFS_NET_ROOT: &str = "/sys/class/net";
+
+/// Toggles that decide whether bridged packets are handed to iptables and
+/// ip6tables at all. A bridged container's chain is unreachable unless the
+/// matching one reads `1`.
+const BRIDGE_NF_CALL_IPTABLES: &str = "/proc/sys/net/bridge/bridge-nf-call-iptables";
+const BRIDGE_NF_CALL_IP6TABLES: &str = "/proc/sys/net/bridge/bridge-nf-call-ip6tables";
 
 /// Whether a host-list entry produces an ACCEPT or a DROP rule. Local to this
 /// backend: it distinguishes `allowedHosts` from `blockedHosts` and is not a
@@ -68,6 +79,8 @@ pub(crate) struct CreatedResources {
     v6_chain: bool,
     v4_hook: bool,
     v6_hook: bool,
+    v4_physdev_hook: bool,
+    v6_physdev_hook: bool,
 }
 
 /// Flush and delete the chain, reporting whether it is still owned afterward.
@@ -106,7 +119,12 @@ impl CreatedResources {
     /// compiled on every target so Windows and macOS CI still type-check it.
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn is_empty(&self) -> bool {
-        !self.v4_chain && !self.v6_chain && !self.v4_hook && !self.v6_hook
+        !self.v4_chain
+            && !self.v6_chain
+            && !self.v4_hook
+            && !self.v6_hook
+            && !self.v4_physdev_hook
+            && !self.v6_physdev_hook
     }
 
     /// Test-only constructor so `signal_cleanup`'s tests can build a
@@ -120,6 +138,8 @@ impl CreatedResources {
             v6_chain,
             v4_hook,
             v6_hook,
+            v4_physdev_hook: false,
+            v6_physdev_hook: false,
         }
     }
 }
@@ -238,6 +258,126 @@ impl NetworkIptablesManager {
     /// Set the veth interface name for the container.
     pub fn set_veth_interface(&mut self, iface: &str) {
         self.veth_interface = Some(iface.to_string());
+    }
+
+    /// Build one FORWARD hook rule matching the veth as the input interface.
+    ///
+    /// `op` is `-I` to install or `-D` to remove. Both come from this one
+    /// builder so a delete can never drift from the insert it has to match:
+    /// iptables deletes by full rule specification, and a spec that differs by
+    /// even one match leaves the hook in place.
+    fn build_forward_hook_iface_rule_args(op: &str, iface: &str, chain_name: &str) -> Vec<String> {
+        vec![
+            op.to_string(),
+            "FORWARD".to_string(),
+            "-i".to_string(),
+            iface.to_string(),
+            "-j".to_string(),
+            chain_name.to_string(),
+        ]
+    }
+
+    /// Build one FORWARD hook rule matching the veth as the *bridge port* the
+    /// packet entered on.
+    ///
+    /// This is the rule that does the work whenever the container is attached
+    /// to a bridge, which is the default LXC topology (`lxc.net.0.link` set to
+    /// `lxcbr0`). A packet leaving such a container is bridged onto `lxcbr0`
+    /// and then routed off it, so by the time FORWARD sees the packet its
+    /// input interface is the bridge and not the veth -- an `-i <veth>` rule
+    /// matches nothing at all. Measured on a live container: with both rules
+    /// present in FORWARD and the same traffic flowing, the `--physdev-in`
+    /// rule counted 11 packets while the `-i` rule counted zero.
+    ///
+    /// `--physdev-in` still names one specific bridge port, so the chain stays
+    /// scoped to a single container. Matching the bridge itself would apply
+    /// one container's policy to every container sharing it.
+    fn build_forward_hook_physdev_rule_args(
+        op: &str,
+        iface: &str,
+        chain_name: &str,
+    ) -> Vec<String> {
+        vec![
+            op.to_string(),
+            "FORWARD".to_string(),
+            "-m".to_string(),
+            "physdev".to_string(),
+            "--physdev-in".to_string(),
+            iface.to_string(),
+            "-j".to_string(),
+            chain_name.to_string(),
+        ]
+    }
+
+    /// Whether `iface` is enslaved to a bridge, looked up under an injectable
+    /// sysfs root so this is testable without a live interface.
+    ///
+    /// The kernel exposes `master` only for an enslaved interface, so its mere
+    /// presence is the answer.
+    fn veth_is_bridge_enslaved_in(sysfs_net_root: &Path, iface: &str) -> bool {
+        sysfs_net_root.join(iface).join("master").exists()
+    }
+
+    /// Whether bridged traffic is delivered to iptables at all, read from an
+    /// injectable path.
+    ///
+    /// The file exists only when `br_netfilter` is loaded, and a value of `1`
+    /// is what makes `--physdev-in` able to match. Absent or `0`, a bridged
+    /// container's packets bypass these chains entirely.
+    fn bridge_netfilter_active_at(path: &Path) -> bool {
+        std::fs::read_to_string(path)
+            .map(|contents| contents.trim() == "1")
+            .unwrap_or(false)
+    }
+
+    /// Production wrapper over [`Self::veth_is_bridge_enslaved_in`].
+    fn veth_is_bridge_enslaved(iface: &str) -> bool {
+        Self::veth_is_bridge_enslaved_in(Path::new(SYSFS_NET_ROOT), iface)
+    }
+
+    /// Production wrapper over [`Self::bridge_netfilter_active_at`].
+    fn bridge_netfilter_active(path: &str) -> bool {
+        Self::bridge_netfilter_active_at(Path::new(path))
+    }
+
+    /// Install the `--physdev-in` FORWARD hook for one family.
+    ///
+    /// Whether a failure here is fatal depends entirely on the topology, so
+    /// the decision lives in one place rather than being duplicated per
+    /// family. On a bridged veth this rule is the only one that can ever
+    /// match, so failing to install it means the policy is not enforced and
+    /// the caller must not be told otherwise. On a directly routed veth the
+    /// `-i` rule already carries the traffic and this one is redundant, so a
+    /// host whose kernel lacks the `physdev` match is still correctly
+    /// filtered and only warrants a warning.
+    fn install_physdev_hook(
+        run: fn(&[Vec<String>], &mut Logger) -> Result<(), String>,
+        iface: &str,
+        chain_name: &str,
+        bridged: bool,
+        tool: &str,
+        logger: &mut Logger,
+    ) -> Result<bool, String> {
+        let rule = Self::build_forward_hook_physdev_rule_args("-I", iface, chain_name);
+        match run(&[rule], logger) {
+            Ok(()) => Ok(true),
+            Err(err) if bridged => Err(format!(
+                "Failed to install the physdev FORWARD hook on bridged veth {} for chain {} \
+                 ({}): {}. That rule is the only one a bridged container's packets can match, \
+                 so the policy would not be enforced. Refusing to report success for an \
+                 unenforceable policy.",
+                iface, chain_name, tool, err
+            )),
+            Err(err) => {
+                logger.log_line(&format!(
+                    "Warning: could not install the physdev FORWARD hook on {} for chain {} \
+                     ({}): {}. The veth is not bridged, so the interface hook already carries \
+                     this container's traffic.",
+                    iface, chain_name, tool, err
+                ));
+                Ok(false)
+            }
+        }
     }
 
     /// Resolve a destination string to IPv4 and IPv6 firewall destinations.
@@ -1022,36 +1162,103 @@ impl NetworkIptablesManager {
         }
 
         // Hook the chains into FORWARD for the container's egress traffic.
-        // Packets originating in the container arrive at the host on the
-        // host-side veth, so they match FORWARD by input interface (`-i`);
-        // `-o` would instead match traffic flowing toward the container.
+        //
+        // Two rules per family, because the input interface FORWARD sees
+        // depends on how the veth is attached. A veth routed directly by the
+        // host arrives as `-i <veth>`. A veth enslaved to a bridge -- the
+        // default LXC topology -- arrives as `-i <bridge>`, and only
+        // `--physdev-in <veth>` still identifies the container. Installing
+        // only the first is what let a fully populated deny-all chain sit in
+        // the ruleset filtering nothing.
+        //
+        // The two are mutually exclusive for any given packet, so no packet is
+        // counted twice. `-o` would instead match traffic flowing toward the
+        // container.
         if let Some(ref iface) = self.veth_interface {
-            Self::run_iptables(
-                &["-I", "FORWARD", "-i", iface, "-j", &self.chain_name],
+            let bridged = Self::veth_is_bridge_enslaved(iface);
+            let chain_name = self.chain_name.clone();
+
+            // On a bridged veth the physdev rule is the only one that can
+            // match, and it can only match while br_netfilter is delivering
+            // bridged packets to iptables. Without that, both rules install
+            // cleanly and neither ever fires, which is the exact failure this
+            // change exists to remove: a chain that looks enforced and is not.
+            if bridged && !Self::bridge_netfilter_active(BRIDGE_NF_CALL_IPTABLES) {
+                return Err(format!(
+                    "Container veth {} is enslaved to a bridge but bridged packets are not \
+                     delivered to iptables ({} is absent or 0), so chain {} could never be \
+                     reached from FORWARD. Refusing to report success for an unenforceable \
+                     policy.",
+                    iface, BRIDGE_NF_CALL_IPTABLES, chain_name
+                ));
+            }
+
+            Self::run_iptables_rule_args(
+                &[Self::build_forward_hook_iface_rule_args(
+                    "-I",
+                    iface,
+                    &chain_name,
+                )],
                 logger,
             )?;
             created.v4_hook = true;
             Self::publish_created(created);
+
+            created.v4_physdev_hook = Self::install_physdev_hook(
+                Self::run_iptables_rule_args,
+                iface,
+                &chain_name,
+                bridged,
+                "iptables",
+                logger,
+            )?;
+            Self::publish_created(created);
             logger.log_line(&format!(
                 "FORWARD hook installed on {} for chain {} (iptables).",
-                iface, self.chain_name
+                iface, chain_name
             ));
             if ipv6_enabled {
-                Self::run_ip6tables(
-                    &["-I", "FORWARD", "-i", iface, "-j", &self.chain_name],
+                if bridged && !Self::bridge_netfilter_active(BRIDGE_NF_CALL_IP6TABLES) {
+                    return Err(format!(
+                        "Container veth {} is enslaved to a bridge but bridged packets are not \
+                         delivered to ip6tables ({} is absent or 0), so chain {} could never be \
+                         reached from FORWARD for IPv6. Refusing to report success for an \
+                         unenforceable policy.",
+                        iface, BRIDGE_NF_CALL_IP6TABLES, chain_name
+                    ));
+                }
+
+                Self::run_ip6tables_rule_args(
+                    &[Self::build_forward_hook_iface_rule_args(
+                        "-I",
+                        iface,
+                        &chain_name,
+                    )],
                     logger,
                 )?;
                 created.v6_hook = true;
                 Self::publish_created(created);
+
+                created.v6_physdev_hook = Self::install_physdev_hook(
+                    Self::run_ip6tables_rule_args,
+                    iface,
+                    &chain_name,
+                    bridged,
+                    "ip6tables",
+                    logger,
+                )?;
+                Self::publish_created(created);
+
                 logger.log_line(&format!(
                     "FORWARD hook installed on {} for chain {} (ip6tables).",
-                    iface, self.chain_name
+                    iface, chain_name
                 ));
             }
         } else {
             // Without a veth interface there is nothing to hook the chain to,
-            // and an unhooked chain is never traversed: FORWARD only reaches it
-            // via `-i <veth>`. Reporting success here would hand the caller a
+            // and an unhooked chain is never traversed: FORWARD reaches it only
+            // via a rule naming the veth, whether as the input interface or as
+            // the bridge port. Reporting success here would hand the caller a
             // fully populated deny-all chain that filters nothing, which is
             // strictly worse than no firewall at all because it looks enforced.
             //
@@ -1106,32 +1313,68 @@ impl NetworkIptablesManager {
     ) -> CreatedResources {
         let mut residual = *created;
 
-        // Remove from FORWARD only for families this attempt hooked. Must
-        // match the `-i` direction used at insertion so the delete finds the
-        // rule; a `-o` delete would leak the FORWARD hook.
+        // Remove from FORWARD only for families this attempt hooked, and only
+        // the hook forms it actually installed. Both specs come from the same
+        // builders used at insertion, because iptables deletes by full rule
+        // specification: a spec that differs by even one match -- `-o` instead
+        // of `-i`, or the interface rule standing in for the physdev one --
+        // finds nothing and leaks the hook.
         if let Some(iface) = veth_interface {
             if created.v4_hook
-                && Self::run_iptables(&["-D", "FORWARD", "-i", iface, "-j", chain_name], logger)
-                    .is_ok()
+                && Self::run_iptables_rule_args(
+                    &[Self::build_forward_hook_iface_rule_args(
+                        "-D", iface, chain_name,
+                    )],
+                    logger,
+                )
+                .is_ok()
             {
                 residual.v4_hook = false;
             }
+            if created.v4_physdev_hook
+                && Self::run_iptables_rule_args(
+                    &[Self::build_forward_hook_physdev_rule_args(
+                        "-D", iface, chain_name,
+                    )],
+                    logger,
+                )
+                .is_ok()
+            {
+                residual.v4_physdev_hook = false;
+            }
             if created.v6_hook
-                && Self::run_ip6tables(&["-D", "FORWARD", "-i", iface, "-j", chain_name], logger)
-                    .is_ok()
+                && Self::run_ip6tables_rule_args(
+                    &[Self::build_forward_hook_iface_rule_args(
+                        "-D", iface, chain_name,
+                    )],
+                    logger,
+                )
+                .is_ok()
             {
                 residual.v6_hook = false;
+            }
+            if created.v6_physdev_hook
+                && Self::run_ip6tables_rule_args(
+                    &[Self::build_forward_hook_physdev_rule_args(
+                        "-D", iface, chain_name,
+                    )],
+                    logger,
+                )
+                .is_ok()
+            {
+                residual.v6_physdev_hook = false;
             }
         }
 
         // Flush and delete only the chains this attempt created, and only once
-        // that family's FORWARD hook is confirmed gone. `-X` is the command
-        // that actually relinquishes the chain, so ownership is only cleared
-        // when it succeeds. The gate is per family because the two chains live
-        // in different tables and are referenced independently.
+        // every FORWARD hook for that family is confirmed gone. `-X` is the
+        // command that actually relinquishes the chain, so ownership is only
+        // cleared when it succeeds. Either surviving hook still references the
+        // chain, so both gate the delete. The gate is per family because the
+        // two chains live in different tables and are referenced independently.
         residual.v4_chain = teardown_chain(
             created.v4_chain,
-            residual.v4_hook,
+            residual.v4_hook || residual.v4_physdev_hook,
             logger,
             |logger| {
                 let _ = Self::run_iptables(&["-F", chain_name], logger);
@@ -1140,7 +1383,7 @@ impl NetworkIptablesManager {
         );
         residual.v6_chain = teardown_chain(
             created.v6_chain,
-            residual.v6_hook,
+            residual.v6_hook || residual.v6_physdev_hook,
             logger,
             |logger| {
                 let _ = Self::run_ip6tables(&["-F", chain_name], logger);
@@ -1250,6 +1493,12 @@ impl Drop for NetworkIptablesManager {
 #[cfg(test)]
 #[path = "network_iptables_veth_spec.rs"]
 mod veth_spec;
+
+/// Black-box specification for the FORWARD hook wiring, kept in its own file
+/// for the same reason as `veth_spec`.
+#[cfg(test)]
+#[path = "network_iptables_forward_hook_spec.rs"]
+mod forward_hook_spec;
 
 #[cfg(test)]
 mod test_firewall {

--- a/src/backends/lxc/common/src/network_iptables.rs
+++ b/src/backends/lxc/common/src/network_iptables.rs
@@ -1049,12 +1049,26 @@ impl NetworkIptablesManager {
                 ));
             }
         } else {
-            // Without a veth interface, we cannot safely scope rules to the container.
-            // Refuse to apply host-wide rules to avoid affecting all host traffic.
-            logger.log_line(
-                "Warning: No veth interface set for container. \
-                 Cannot scope iptables rules. Skipping FORWARD hook.",
-            );
+            // Without a veth interface there is nothing to hook the chain to,
+            // and an unhooked chain is never traversed: FORWARD only reaches it
+            // via `-i <veth>`. Reporting success here would hand the caller a
+            // fully populated deny-all chain that filters nothing, which is
+            // strictly worse than no firewall at all because it looks enforced.
+            //
+            // The alternative -- installing the rules host-wide so they do take
+            // effect -- is not acceptable either: unscoped they would apply to
+            // every container and to the host's own traffic.
+            //
+            // So the only honest outcome is to fail. `apply_firewall_rules_inner`
+            // rolls back the chains recorded in `created`, and `lxc_runner`
+            // destroys the container rather than starting a workload that
+            // believes it is confined.
+            return Err(format!(
+                "No veth interface for container; cannot scope iptables rules to chain {}. \
+                 The chain would never be reached from FORWARD, so the network policy would \
+                 not be enforced. Refusing to report success for an unenforceable policy.",
+                self.chain_name
+            ));
         }
 
         Ok(())
@@ -1228,6 +1242,15 @@ impl Drop for NetworkIptablesManager {
 /// because `cargo test` runs tests in parallel -- a process-global fake would
 /// have to be serialized behind a lock and would let one test observe
 /// another's commands.
+/// Spec for the fail-closed behavior when rules cannot be scoped to the
+/// container. Attached as a child module rather than a `tests/` integration
+/// test because the `test_firewall` seam below is `#[cfg(test)]`, which an
+/// integration test -- a separate crate -- can never see. Kept in its own file
+/// so this one does not grow further.
+#[cfg(test)]
+#[path = "network_iptables_veth_spec.rs"]
+mod veth_spec;
+
 #[cfg(test)]
 mod test_firewall {
     use std::cell::RefCell;

--- a/src/backends/lxc/common/src/network_iptables_forward_hook_spec.rs
+++ b/src/backends/lxc/common/src/network_iptables_forward_hook_spec.rs
@@ -6,3 +6,453 @@
 //!
 //! Written against the documented contract of the hook builders and the
 //! topology detectors, not against their bodies.
+
+use super::*;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Hand back a directory path under the OS temp root that no other test (or
+/// prior run) has used, so sysfs and netfilter fixtures never collide when
+/// tests run concurrently in the same process.
+fn fresh_fixture_dir(label: &str) -> PathBuf {
+    static SEQ: AtomicU32 = AtomicU32::new(0);
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("mxc-forward-hook-spec-{label}-{pid}-{seq}"))
+}
+
+// The op token controls whether this is an install or a removal, and
+// iptables reads the operation as the first word of the command; if it were
+// buried elsewhere the CLI invocation would not do what the caller asked.
+#[test]
+fn iface_hook_rule_args_start_with_the_requested_operation() {
+    let install =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", "veth10", "MXC-tenant10");
+    let delete =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-D", "veth10", "MXC-tenant10");
+
+    assert_eq!(install.first().map(String::as_str), Some("-I"));
+    assert_eq!(delete.first().map(String::as_str), Some("-D"));
+}
+
+// This rule must be installed into the kernel's FORWARD chain specifically;
+// any other chain would never see forwarded container traffic at all.
+#[test]
+fn iface_hook_rule_args_operate_on_the_forward_chain() {
+    let args =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", "veth11", "MXC-tenant11");
+
+    assert_eq!(
+        args.get(1).map(String::as_str),
+        Some("FORWARD"),
+        "expected the chain immediately after the operation to be FORWARD, got: {args:?}"
+    );
+}
+
+// The whole point of this builder is to match on the veth's own input
+// interface, naming the specific interface passed in.
+#[test]
+fn iface_hook_rule_args_match_on_the_named_input_interface() {
+    let iface = "veth12";
+    let args =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", iface, "MXC-tenant12");
+
+    let i_index = args
+        .iter()
+        .position(|a| a == "-i")
+        .expect("expected an -i input-interface match in the rule args");
+    assert_eq!(
+        args.get(i_index + 1).map(String::as_str),
+        Some(iface),
+        "expected the -i match to name {iface}, got: {args:?}"
+    );
+}
+
+// A rule that matches the right interface but jumps to the wrong chain (or
+// no chain) would never hook the container's own filtering.
+#[test]
+fn iface_hook_rule_args_jump_to_the_named_chain() {
+    let chain_name = "MXC-tenant13";
+    let args =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", "veth13", chain_name);
+
+    let j_index = args
+        .iter()
+        .position(|a| a == "-j")
+        .expect("expected a -j jump target in the rule args");
+    assert_eq!(
+        args.get(j_index + 1).map(String::as_str),
+        Some(chain_name),
+        "expected the -j target to be {chain_name}, got: {args:?}"
+    );
+}
+
+// If this builder ever picked up a physdev match too, it would silently
+// start behaving like the bridged-topology rule, defeating the reason the
+// two builders are separate functions.
+#[test]
+fn iface_hook_rule_args_never_carry_a_physdev_match() {
+    let args =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", "veth14", "MXC-tenant14");
+
+    assert!(
+        !args.iter().any(|a| a == "physdev" || a == "--physdev-in"),
+        "an input-interface rule must not also carry a physdev match, got: {args:?}"
+    );
+}
+
+// A delete that is not token-for-token identical to its insert (apart from
+// the operation) will not match anything in the kernel's rule table, and the
+// rule it was supposed to remove leaks.
+#[test]
+fn iface_hook_delete_spec_differs_from_its_insert_only_by_the_operation() {
+    let iface = "veth15";
+    let chain_name = "MXC-tenant15";
+    let install =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", iface, chain_name);
+    let delete =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-D", iface, chain_name);
+
+    assert_eq!(
+        install.len(),
+        delete.len(),
+        "install and delete rule specs must have the same number of tokens, install: {install:?}, delete: {delete:?}"
+    );
+    assert_ne!(
+        install[0], delete[0],
+        "the first token is the operation and must differ between install and delete"
+    );
+    assert_eq!(
+        &install[1..],
+        &delete[1..],
+        "every token besides the operation must match exactly, or the delete will not find the rule the install created"
+    );
+}
+
+// Same operation-placement guarantee as the interface builder, so an install
+// and a delete of a physdev rule both do what the caller asked.
+#[test]
+fn physdev_hook_rule_args_start_with_the_requested_operation() {
+    let install = NetworkIptablesManager::build_forward_hook_physdev_rule_args(
+        "-I",
+        "veth20",
+        "MXC-tenant20",
+    );
+    let delete = NetworkIptablesManager::build_forward_hook_physdev_rule_args(
+        "-D",
+        "veth20",
+        "MXC-tenant20",
+    );
+
+    assert_eq!(install.first().map(String::as_str), Some("-I"));
+    assert_eq!(delete.first().map(String::as_str), Some("-D"));
+}
+
+// This rule must also land in the kernel's FORWARD chain -- the physdev
+// match only changes what is matched within that chain, not which chain it
+// is installed into.
+#[test]
+fn physdev_hook_rule_args_operate_on_the_forward_chain() {
+    let args = NetworkIptablesManager::build_forward_hook_physdev_rule_args(
+        "-I",
+        "veth21",
+        "MXC-tenant21",
+    );
+
+    assert_eq!(
+        args.get(1).map(String::as_str),
+        Some("FORWARD"),
+        "expected the chain immediately after the operation to be FORWARD, got: {args:?}"
+    );
+}
+
+// Once a veth is bridge-enslaved, the bridge port it entered on is the only
+// thing that still identifies that one container, so the exact token
+// sequence iptables needs for the physdev match -- not just "physdev appears
+// somewhere" -- is the contract itself.
+#[test]
+fn physdev_hook_rule_args_match_the_named_physdev_in_port() {
+    let iface = "veth-c9f3";
+    let chain_name = "MXC-tenant-c9f3";
+    let args =
+        NetworkIptablesManager::build_forward_hook_physdev_rule_args("-I", iface, chain_name);
+
+    let expected: Vec<String> = ["-m", "physdev", "--physdev-in", iface]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    let found = args
+        .windows(expected.len())
+        .any(|w| w == expected.as_slice());
+
+    assert!(
+        found,
+        "expected the contiguous sequence {expected:?} in the physdev rule args, got: {args:?}"
+    );
+}
+
+// A physdev rule that matches the right bridge port but jumps to the wrong
+// chain would leave the container's own filtering unhooked, same as the
+// interface builder's equivalent guarantee.
+#[test]
+fn physdev_hook_rule_args_jump_to_the_named_chain() {
+    let chain_name = "MXC-tenant23";
+    let args =
+        NetworkIptablesManager::build_forward_hook_physdev_rule_args("-I", "veth23", chain_name);
+
+    let j_index = args
+        .iter()
+        .position(|a| a == "-j")
+        .expect("expected a -j jump target in the rule args");
+    assert_eq!(
+        args.get(j_index + 1).map(String::as_str),
+        Some(chain_name),
+        "expected the -j target to be {chain_name}, got: {args:?}"
+    );
+}
+
+// Once a veth is bridge-enslaved, FORWARD sees the bridge as the input
+// interface, not the veth; an -i match naming the veth would match nothing
+// at all, so this builder must not carry one.
+#[test]
+fn physdev_hook_rule_args_never_carry_an_input_interface_match() {
+    let args = NetworkIptablesManager::build_forward_hook_physdev_rule_args(
+        "-I",
+        "veth24",
+        "MXC-tenant24",
+    );
+
+    assert!(
+        !args.iter().any(|a| a == "-i"),
+        "a physdev-matched rule must not also carry an -i input-interface match, got: {args:?}"
+    );
+}
+
+// Same leak hazard as the interface builder's delete/insert invariant: a
+// physdev delete spec that drifts from its insert will not find the rule and
+// leaves it installed on the host forever.
+#[test]
+fn physdev_hook_delete_spec_differs_from_its_insert_only_by_the_operation() {
+    let iface = "veth25";
+    let chain_name = "MXC-tenant25";
+    let install =
+        NetworkIptablesManager::build_forward_hook_physdev_rule_args("-I", iface, chain_name);
+    let delete =
+        NetworkIptablesManager::build_forward_hook_physdev_rule_args("-D", iface, chain_name);
+
+    assert_eq!(
+        install.len(),
+        delete.len(),
+        "install and delete rule specs must have the same number of tokens, install: {install:?}, delete: {delete:?}"
+    );
+    assert_ne!(
+        install[0], delete[0],
+        "the first token is the operation and must differ between install and delete"
+    );
+    assert_eq!(
+        &install[1..],
+        &delete[1..],
+        "every token besides the operation must match exactly, or the delete will not find the rule the install created"
+    );
+}
+
+// The two builders exist because a directly routed veth and a
+// bridge-enslaved veth need different matches to see the same packets. If
+// they ever produced identical rule specs, one of those two topologies would
+// silently collapse onto the other's match, bringing back the bug this
+// change fixes.
+#[test]
+fn the_iface_and_physdev_hook_builders_never_produce_the_same_rule_specification() {
+    let iface = "veth26";
+    let chain_name = "MXC-tenant26";
+    let iface_rule =
+        NetworkIptablesManager::build_forward_hook_iface_rule_args("-I", iface, chain_name);
+    let physdev_rule =
+        NetworkIptablesManager::build_forward_hook_physdev_rule_args("-I", iface, chain_name);
+
+    assert_ne!(
+        iface_rule, physdev_rule,
+        "the input-interface rule and the physdev rule must differ, or bridged and directly \
+         routed containers would collapse onto the same match"
+    );
+}
+
+// The kernel only creates a `master` entry once an interface is enslaved to
+// a bridge, so its presence alone is what this function is allowed to trust.
+#[test]
+fn an_interface_with_a_master_entry_is_reported_as_bridge_enslaved() {
+    let root = fresh_fixture_dir("enslaved");
+    let iface_dir = root.join("veth-a1b2");
+    fs::create_dir_all(&iface_dir).expect("failed to create the fake sysfs interface directory");
+    fs::write(iface_dir.join("master"), "").expect("failed to create the fake master entry");
+
+    let result = NetworkIptablesManager::veth_is_bridge_enslaved_in(&root, "veth-a1b2");
+
+    fs::remove_dir_all(&root).expect("failed to clean up the fake sysfs root");
+    assert!(
+        result,
+        "an interface with a master entry must be reported as bridge-enslaved"
+    );
+}
+
+// A veth that is not enslaved has an interface directory but no `master`
+// entry inside it; this is the ordinary "routed directly" topology.
+#[test]
+fn an_interface_without_a_master_entry_is_not_bridge_enslaved() {
+    let root = fresh_fixture_dir("unenslaved");
+    let iface_dir = root.join("veth-d4e5");
+    fs::create_dir_all(&iface_dir).expect("failed to create the fake sysfs interface directory");
+
+    let result = NetworkIptablesManager::veth_is_bridge_enslaved_in(&root, "veth-d4e5");
+
+    fs::remove_dir_all(&root).expect("failed to clean up the fake sysfs root");
+    assert!(
+        !result,
+        "an interface directory with no master entry must not be reported as bridge-enslaved"
+    );
+}
+
+// If the interface itself has no sysfs directory at all -- for example a
+// name that does not exist on the host -- there is nothing to be enslaved,
+// and the function must say so rather than erroring.
+#[test]
+fn a_missing_interface_directory_is_not_bridge_enslaved() {
+    let root = fresh_fixture_dir("missing-iface");
+    fs::create_dir_all(&root).expect("failed to create the fake sysfs root");
+
+    let result = NetworkIptablesManager::veth_is_bridge_enslaved_in(&root, "veth-ghost");
+
+    fs::remove_dir_all(&root).expect("failed to clean up the fake sysfs root");
+    assert!(
+        !result,
+        "an interface with no sysfs directory at all must not be reported as bridge-enslaved"
+    );
+}
+
+// The toggle file's documented "on" value is exactly "1"; this is the
+// baseline positive case every other Function 4 test is a variation of.
+#[test]
+fn a_bridge_netfilter_toggle_of_1_is_reported_active() {
+    let dir = fresh_fixture_dir("nf-on");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "1").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        result,
+        "a toggle file containing exactly \"1\" must be reported as active"
+    );
+}
+
+// The real kernel file ends in a newline; a comparison that forgets to trim
+// would treat every real, active system as inactive.
+#[test]
+fn a_bridge_netfilter_toggle_of_1_with_a_trailing_newline_is_reported_active() {
+    let dir = fresh_fixture_dir("nf-on-newline");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "1\n").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        result,
+        "a toggle file containing \"1\\n\", matching the real kernel file's trailing newline, must be reported as active"
+    );
+}
+
+// "0" is the documented "off" value and must read as inactive, not merely as
+// "not 1 so default to something".
+#[test]
+fn a_bridge_netfilter_toggle_of_0_is_not_active() {
+    let dir = fresh_fixture_dir("nf-off");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "0").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        !result,
+        "a toggle file containing \"0\" must not be reported as active"
+    );
+}
+
+// Absence means the bridge-netfilter machinery is not loaded at all, which
+// is the unsafe case: it must never be mistaken for "on".
+#[test]
+fn a_missing_bridge_netfilter_toggle_is_not_active() {
+    let dir = fresh_fixture_dir("nf-missing");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        !result,
+        "a toggle file that does not exist at all must not be reported as active"
+    );
+}
+
+// Empty contents are neither "1" nor "0"; the function must not treat a
+// truncated or not-yet-written file as active.
+#[test]
+fn an_empty_bridge_netfilter_toggle_is_not_active() {
+    let dir = fresh_fixture_dir("nf-empty");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        !result,
+        "a toggle file with empty contents must not be reported as active"
+    );
+}
+
+// Whitespace-only contents must not survive trimming into an empty string
+// that somehow compares equal to "1"; it must compare as not-"1" and read as
+// inactive.
+#[test]
+fn a_whitespace_only_bridge_netfilter_toggle_is_not_active() {
+    let dir = fresh_fixture_dir("nf-whitespace");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "   \n\t  ").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        !result,
+        "a toggle file with only whitespace must not be reported as active"
+    );
+}
+
+// Any value that is not exactly "1" must read as inactive, not just values
+// that happen to be "0"; otherwise a fail-open bug could hide behind an
+// unexpected value like a stray "2".
+#[test]
+fn a_bridge_netfilter_toggle_with_an_unrecognized_value_is_not_active() {
+    let dir = fresh_fixture_dir("nf-unrecognized");
+    fs::create_dir_all(&dir).expect("failed to create the fake proc directory");
+    let toggle = dir.join("bridge-nf-call-iptables");
+    fs::write(&toggle, "2").expect("failed to write the fake netfilter toggle");
+
+    let result = NetworkIptablesManager::bridge_netfilter_active_at(&toggle);
+
+    fs::remove_dir_all(&dir).expect("failed to clean up the fake proc directory");
+    assert!(
+        !result,
+        "a toggle file containing a value other than \"1\" must not be reported as active"
+    );
+}

--- a/src/backends/lxc/common/src/network_iptables_forward_hook_spec.rs
+++ b/src/backends/lxc/common/src/network_iptables_forward_hook_spec.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Black-box specification for the FORWARD hook that steers a container's
+//! egress into its own chain.
+//!
+//! Written against the documented contract of the hook builders and the
+//! topology detectors, not against their bodies.

--- a/src/backends/lxc/common/src/network_iptables_veth_spec.rs
+++ b/src/backends/lxc/common/src/network_iptables_veth_spec.rs
@@ -5,3 +5,189 @@
 //!
 //! Attached to `network_iptables` as a child module via `#[path]`, so it can
 //! reach the `#[cfg(test)]` fake-firewall seam.
+
+use super::*;
+use wxc_common::logger::{Logger, Mode};
+use wxc_common::models::{ContainerPolicy, NetworkEnforcementMode};
+
+/// Build a policy that requests the given network enforcement mode, leaving
+/// every other field at its default.
+fn policy_requesting(mode: NetworkEnforcementMode) -> ContainerPolicy {
+    ContainerPolicy {
+        network_enforcement_mode: mode,
+        ..Default::default()
+    }
+}
+
+// A chain that is never hooked to the container's veth interface is a chain
+// no packet ever traverses. If the manager does not know which veth belongs
+// to the container, it must refuse rather than report success on a firewall
+// that filters nothing. This covers the `Firewall` half of R1; `Both` is
+// covered separately below so a fix scoped to only one enforcement mode
+// cannot pass the suite.
+#[test]
+fn apply_is_refused_when_the_container_interface_is_unknown_in_firewall_mode() {
+    let _fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("ctrl-firewall");
+    let policy = policy_requesting(NetworkEnforcementMode::Firewall);
+    let mut logger = Logger::new(Mode::Buffer);
+
+    let result = manager.apply_firewall_rules(&policy, &mut logger);
+
+    assert!(
+        result.is_err(),
+        "Firewall mode with no veth interface set must fail closed, got {:?}",
+        result
+    );
+}
+
+// Same hazard as above under `Both`, which also requests firewall
+// enforcement. A fix that only checks the interface in the `Firewall` arm
+// would leave `Both` silently unenforced, and only a dedicated test for this
+// mode would catch it.
+#[test]
+fn apply_is_refused_when_the_container_interface_is_unknown_in_both_mode() {
+    let _fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("ctrl-both");
+    let policy = policy_requesting(NetworkEnforcementMode::Both);
+    let mut logger = Logger::new(Mode::Buffer);
+
+    let result = manager.apply_firewall_rules(&policy, &mut logger);
+
+    assert!(
+        result.is_err(),
+        "Both mode with no veth interface set must fail closed, got {:?}",
+        result
+    );
+}
+
+// A caller who is told "firewall applied" while the interface was never known
+// deserves an error that says what to check. If the message drops the chain
+// name or the "will not be enforced" meaning, an operator debugging why a
+// container's traffic is unfiltered has nothing to search logs for.
+#[test]
+fn refusal_error_names_the_unenforced_chain() {
+    let _fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("acme-web");
+    let policy = policy_requesting(NetworkEnforcementMode::Firewall);
+    let mut logger = Logger::new(Mode::Buffer);
+
+    let err = manager
+        .apply_firewall_rules(&policy, &mut logger)
+        .expect_err("Firewall mode with no veth interface set must fail closed");
+
+    let chain = "MXC-acme-web";
+    assert!(
+        err.contains(chain),
+        "error must name the chain left unenforced ({chain}), got: {err}"
+    );
+
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("not") && lower.contains("enforc"),
+        "error must convey that the policy will not be enforced, got: {err}"
+    );
+}
+
+// Negative control for R1: the only thing that changes here is that the veth
+// interface is now known. Without this test, R1's failures would prove
+// nothing about the interface check specifically -- an `apply_firewall_rules`
+// that always returned `Err` would also pass every R1 test above.
+#[test]
+fn apply_succeeds_once_the_veth_interface_is_known() {
+    let fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("ctrl-negative");
+    manager.set_veth_interface("veth-ctrl0");
+    let policy = policy_requesting(NetworkEnforcementMode::Firewall);
+    let mut logger = Logger::new(Mode::Buffer);
+    let _ = fake.forget_issued();
+
+    let result = manager.apply_firewall_rules(&policy, &mut logger);
+
+    assert!(
+        result.is_ok(),
+        "the same Firewall policy that fails with no veth interface must succeed once one is set, got {:?}",
+        result
+    );
+    assert!(
+        !fake.issued().is_empty(),
+        "a successful Firewall apply must actually issue iptables commands, not just report success"
+    );
+}
+
+// A caller who is refused must not be left holding a chain on the host: an
+// unhooked-but-still-installed chain is inert today but becomes a liability
+// the moment anything later hooks a chain by that name. The failed apply
+// must tear down what it created, not merely stop short of hooking it up.
+#[test]
+fn apply_tears_down_the_chain_it_created_when_it_fails_closed() {
+    let fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("ctrl-teardown");
+    let policy = policy_requesting(NetworkEnforcementMode::Firewall);
+    let mut logger = Logger::new(Mode::Buffer);
+    let _ = fake.forget_issued();
+
+    let result = manager.apply_firewall_rules(&policy, &mut logger);
+    assert!(
+        result.is_err(),
+        "expected the apply to fail closed so the teardown path runs, got {:?}",
+        result
+    );
+
+    let issued = fake.issued();
+    let chain = "MXC-ctrl-teardown";
+    let creation_index = issued
+        .iter()
+        .position(|cmd| cmd.iter().any(|a| a == "-N") && cmd.iter().any(|a| a == chain))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a chain-creation (-N) command naming {chain} before the failure, issued: {:?}",
+                issued
+            )
+        });
+    let teardown_index = issued
+        .iter()
+        .position(|cmd| {
+            (cmd.iter().any(|a| a == "-F") || cmd.iter().any(|a| a == "-X"))
+                && cmd.iter().any(|a| a == chain)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a teardown (-F/-X) command naming {chain} after the failed apply, issued: {:?}",
+                issued
+            )
+        });
+
+    assert!(
+        teardown_index > creation_index,
+        "teardown of {chain} must be issued after its creation, issued: {:?}",
+        issued
+    );
+}
+
+// A container that never asked for a firewall (`Capabilities` is the default
+// enforcement mode) must not be punished for an interface the caller was
+// never required to set. Any firewall command touching the host here would
+// be an unrequested side effect on a container that opted out of firewalling
+// entirely.
+#[test]
+fn capabilities_only_container_is_unaffected_by_a_missing_veth_interface() {
+    let fake = super::test_firewall::install();
+    let mut manager = NetworkIptablesManager::new("ctrl-capsonly");
+    let policy = policy_requesting(NetworkEnforcementMode::Capabilities);
+    let mut logger = Logger::new(Mode::Buffer);
+    let _ = fake.forget_issued();
+
+    let result = manager.apply_firewall_rules(&policy, &mut logger);
+
+    assert!(
+        result.is_ok(),
+        "Capabilities mode must not fail just because the veth interface is unknown, got {:?}",
+        result
+    );
+    assert!(
+        fake.issued().is_empty(),
+        "Capabilities-only enforcement must not issue any iptables commands, issued: {:?}",
+        fake.issued()
+    );
+}

--- a/src/backends/lxc/common/src/network_iptables_veth_spec.rs
+++ b/src/backends/lxc/common/src/network_iptables_veth_spec.rs
@@ -1,0 +1,7 @@
+//! Spec for the fail-closed contract of `apply_firewall_rules`: when the
+//! firewall cannot be scoped to the container, the caller must be told the
+//! policy was not applied rather than being handed a chain that filters
+//! nothing.
+//!
+//! Attached to `network_iptables` as a child module via `#[path]`, so it can
+//! reach the `#[cfg(test)]` fake-firewall seam.

--- a/tests/configs/lxc_network_enforcement_allow.json
+++ b/tests/configs/lxc_network_enforcement_allow.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-LXC-Net-Allow",
+  "containment": "lxc",
+  "process": {
+    "commandLine": "sh -c \"wget -qO- --timeout=10 https://api.github.com/zen >/dev/null 2>&1 && echo MXC_NET_ALLOWED || echo MXC_NET_BLOCKED\""
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "lxc": {
+    "distribution": "alpine",
+    "release": "3.23"
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "firewall",
+    "allowedHosts": ["api.github.com"],
+    "blockedHosts": []
+  }
+}

--- a/tests/configs/lxc_network_enforcement_deny.json
+++ b/tests/configs/lxc_network_enforcement_deny.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-LXC-Net-Deny",
+  "containment": "lxc",
+  "process": {
+    "commandLine": "sh -c \"wget -qO- --timeout=8 https://api.github.com/zen >/dev/null 2>&1 && echo MXC_NET_ALLOWED || echo MXC_NET_BLOCKED\""
+  },
+  "lifecycle": {
+    "destroyOnExit": true
+  },
+  "lxc": {
+    "distribution": "alpine",
+    "release": "3.23"
+  },
+  "network": {
+    "defaultPolicy": "block",
+    "enforcementMode": "firewall",
+    "allowedHosts": [],
+    "blockedHosts": []
+  }
+}

--- a/tests/scripts/run_lxc_all_tests.sh
+++ b/tests/scripts/run_lxc_all_tests.sh
@@ -66,6 +66,7 @@ run_test "LXC Network IPv6+CIDR" "$SCRIPT_DIR/run_lxc_network_ipv6_cidr_test.sh"
 run_test "LXC Network Invalid CIDR" "$SCRIPT_DIR/run_lxc_network_invalid_cidr_test.sh"
 run_test "LXC Network Dual-Stack Hostname" "$SCRIPT_DIR/run_lxc_network_dualstack_test.sh"
 run_test "LXC Network CIDR Boundary" "$SCRIPT_DIR/run_lxc_network_cidr_boundary_test.sh"
+run_test "LXC Network Enforcement" "$SCRIPT_DIR/run_lxc_network_enforcement_test.sh"
 run_test "LXC Timeout" "$SCRIPT_DIR/run_lxc_timeout_test.sh"
 run_test "LXC Env+Cwd" "$SCRIPT_DIR/run_lxc_env_cwd_test.sh"
 

--- a/tests/scripts/run_lxc_network_enforcement_test.sh
+++ b/tests/scripts/run_lxc_network_enforcement_test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# LXC network policy enforcement test
+#
+# Every other network script asserts that the FORWARD hook was *installed*.
+# That is a log line, and a hook can install cleanly, name the right chain,
+# and still match no packet -- which is exactly how a fully populated deny-all
+# chain that filtered nothing once passed every script in this directory.
+#
+# This script asserts the guarantee itself rather than the log: a destination
+# the policy does not allow must be unreachable from inside the container.
+#
+# Both directions are required, and the allow case is not decoration. A
+# blocked-only assertion would also pass on a host with no working network at
+# all, or on a change that broke egress outright, so it proves nothing on its
+# own.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+# An honest skip for a missing prerequisite: exit 77 so run_lxc_all_tests.sh
+# records SKIPPED rather than PASS. A suite that could not run must not look green.
+SKIP_EXIT=77
+skip() {
+    echo "SKIP: $1"
+    exit "$SKIP_EXIT"
+}
+
+[ "$(id -u)" -eq 0 ] || skip "requires root for iptables/ip6tables and LXC."
+command -v iptables >/dev/null 2>&1 || skip "iptables is not installed."
+command -v ip6tables >/dev/null 2>&1 || skip "ip6tables is not installed."
+command -v lxc-create >/dev/null 2>&1 || skip "LXC (lxc-create) is not installed."
+[ -f "$LXC_EXEC" ] || skip "lxc-exec binary not built; run build.sh first."
+
+DENY_CONFIG="$REPO_DIR/tests/configs/lxc_network_enforcement_deny.json"
+ALLOW_CONFIG="$REPO_DIR/tests/configs/lxc_network_enforcement_allow.json"
+DENY_CHAIN="MXC-CLI-LXC-Net-Deny"
+ALLOW_CHAIN="MXC-CLI-LXC-Net-Allow"
+
+fail() {
+    echo "FAIL: $1"
+    exit 1
+}
+
+assert_firewall_chain_cleaned_up() {
+    if iptables -S "$1" >/dev/null 2>&1; then
+        fail "iptables chain '$1' was left behind after lxc-exec completed."
+    fi
+    if ip6tables -S "$1" >/dev/null 2>&1; then
+        fail "ip6tables chain '$1' was left behind after lxc-exec completed."
+    fi
+}
+
+# A hook that references the chain but survives teardown leaves the next
+# container's traffic running through a stale rule, so the reference count
+# matters as much as the chain itself.
+assert_no_forward_reference() {
+    if iptables -S FORWARD 2>/dev/null | grep -Fq -- "$1"; then
+        fail "a FORWARD rule still references chain '$1' after teardown."
+    fi
+}
+
+echo "Running LXC network policy enforcement test..."
+
+# The container reports the outcome itself rather than relying on its exit
+# code, so a wrapper that swallows or rewrites the status cannot turn a
+# reachable destination into an apparent block.
+echo "--- deny case: default policy blocks, nothing allowed ---"
+DENY_OUTPUT=$("$LXC_EXEC" --debug "$DENY_CONFIG" 2>&1 || true)
+echo "$DENY_OUTPUT"
+
+if echo "$DENY_OUTPUT" | grep -Fq "MXC_NET_ALLOWED"; then
+    fail "egress succeeded under a default-block policy with no allowed hosts. The chain is not filtering this container's traffic."
+fi
+if ! echo "$DENY_OUTPUT" | grep -Fq "MXC_NET_BLOCKED"; then
+    fail "the deny case produced no verdict at all; the container command did not run."
+fi
+
+assert_no_forward_reference "$DENY_CHAIN"
+assert_firewall_chain_cleaned_up "$DENY_CHAIN"
+
+echo "--- allow case: same default, destination explicitly allowed ---"
+ALLOW_OUTPUT=$("$LXC_EXEC" --debug "$ALLOW_CONFIG" 2>&1 || true)
+echo "$ALLOW_OUTPUT"
+
+if echo "$ALLOW_OUTPUT" | grep -Fq "MXC_NET_BLOCKED"; then
+    fail "an explicitly allowed destination was unreachable. The policy is over-blocking, so the deny case above proves nothing."
+fi
+if ! echo "$ALLOW_OUTPUT" | grep -Fq "MXC_NET_ALLOWED"; then
+    fail "the allow case produced no verdict at all; the container command did not run."
+fi
+
+assert_no_forward_reference "$ALLOW_CHAIN"
+assert_firewall_chain_cleaned_up "$ALLOW_CHAIN"
+
+echo "PASS: a disallowed destination was blocked and an allowed destination was reachable."
+echo "LXC network policy enforcement test complete."


### PR DESCRIPTION
## The problem

The per-container firewall chain was hooked into `FORWARD` with `-i <veth>`
only.  That matches nothing whenever the veth is enslaved to a bridge, which
is the default LXC topology: the packet is bridged onto `lxcbr0` and then
routed off it, so by the time `FORWARD` sees it the input interface is the
bridge, never the veth.

The chain was created correctly, populated correctly, hooked without error,
and traversed by zero packets.

Measured on a live container before this change, with `defaultPolicy: block`
and no allowed hosts:

```
Chain MXC-CLI-LXC-Net-Probe (1 references)
 pkts bytes target     prot opt in     out
    0     0 ACCEPT     0    --  lo     *
    0     0 ACCEPT     0    --  *      *      state RELATED,ESTABLISHED
    0     0 ACCEPT     17   --  *      *      udp dpt:53
    0     0 ACCEPT     6    --  *      *      tcp dpt:53
    0     0 DROP       0    --  *      *
```

Every counter zero, the closing DROP included, and a fetch from inside the
container succeeded anyway.  Adding a counting rule to the same `FORWARD`
chain on the same traffic separated the two cases cleanly:

| rule in FORWARD | packets |
|---|---|
| `-i lxcbr0 -j <counter>` | 11 |
| `-i <veth> -j MXC-…` (what the code installed) | 0 |

## The fix

Install a second hook per family matching `-m physdev --physdev-in <veth>`.
That match names the bridge port the packet entered on, so the chain stays
scoped to a single container -- matching the bridge itself would apply one
container's policy to every container sharing it.  The two rules are mutually
exclusive for any given packet, so a directly routed veth is still carried by
the `-i` rule and nothing is counted twice.

Fail closed on the two conditions that would leave the chain unreachable
again, in the same voice as the missing-veth refusal from #790:

- a bridged veth whose `bridge-nf-call-{ip,ip6}tables` toggle is absent or `0`,
  because bridged packets are then not delivered to iptables at all;
- a bridged veth whose physdev hook will not install, because that rule is the
  only one its packets can match.

On a directly routed veth the physdev rule is redundant, so a kernel without
the match warns rather than refusing a container that is in fact filtered
correctly.

Teardown removes both forms, built from the same builders used at insertion so
a delete cannot drift from the insert it has to match, and the chain delete now
waits on both hooks because either surviving one still references the chain.

## Why the diff is larger than the earlier slices in this series

A hook that installs cleanly and matches nothing is indistinguishable from a
working firewall in every test this repository had.  Shrinking the change to
match the shape of #788/#789/#790 would have meant shipping one half of it.

## Verification

Live containers, same binary, same configs, before and after:

| scenario | before | after |
|---|---|---|
| `block`, no allowed hosts | fetch succeeded | **blocked** |
| `block`, `api.github.com` allowed | — | **reachable** |
| all five existing network E2E scripts | pass | **pass** |
| FORWARD references / chains after teardown | 0 / 0 | **0 / 0** |

The positive control matters as much as the negative one: blocking everything
would also have produced a blocked result.

- `cargo test -p lxc_common --lib` — **144 passed, 0 failed** (121 before).
- `cargo clippy -p lxc_common --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Mutation testing over nine seeded defects, including the exact bug fixed
  here — **9 caught, 0 survivors**.

## Tests

The 23 unit specs were written against the documented contract by an author
who did not read the implementation, and live in their own file.

The new E2E script exists because unit tests cannot see this failure at all.
Every existing network script asserts that the FORWARD hook was *installed* --
a log line that printed correctly throughout.  The new one asserts the
guarantee: a destination the policy does not allow must be unreachable from
inside the container, and an explicitly allowed one must still be reachable.

It was checked in both directions.  Against this branch it passes.  Against
the implementation from the parent commit it fails on the deny case with
`egress succeeded under a default-block policy with no allowed hosts`, which
is the regression it exists to catch.

Note for reviewers: no CI workflow currently runs the LXC E2E scripts, which
is a large part of how this shipped unnoticed.

## Base

Targets `main` so CI runs: the `Build` workflow only triggers for pull requests
whose base is `main`, `feature/*`, or `user/*`, and `*` does not match `/`, so
a PR based on `user/dahoehna/...` gets no build at all.

It therefore carries #790's two commits as well as its own, because it rewrites
the hook block immediately adjacent to that PR's `else` branch in the same
function.  Once #790 merges this diff shrinks to its own two commits with no
action needed.  **Review commits `f51dc1b` and `b9946e3`;** the two below them
are #790, already reviewed there.

## Not in this PR

- **Deny-wins precedence** and **unresolvable-Deny fail-closed** move to the
  next slice.  Both rearrange or add rules *inside* the chain, which is
  cosmetic until the chain is reachable -- which is what this PR fixes.
- **The blanket port-53 hole** stays open for now.  Narrowing it requires
  knowing which resolver addresses are legitimate, and no schema field carries
  that today; it is also load-bearing, since containers resolve names through
  it.  It waits on the GA network schema alongside #634 and #627.

Refs AB#62830341.
