### PR TITLE
Add mxc_config_contract crate for version-specific config parsing

### DIFF
--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1490,6 +1490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mxc_config_contract"
+version = "0.7.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "mxc_darwin"
 version = "0.7.0"
 dependencies = [

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,46 +1,47 @@
 [workspace]
 members = [
-    "core/wxc",
-    "core/wxc_common",
-    "core/learning_mode_core",
-    "core/lxc",
-    "core/mxc_darwin",
-    "core/mxc-sdk",
-    "core/mxc_engine",
-    "core/mxc_pty",
-    "core/mxc_build_common",
-    "host/plm",
-    "core/generated/base_container_specification",
-    "core/generated/process_security_environment_specification",
     "backends/appcontainer/common",
-    "backends/windows_sandbox/daemon",
-    "backends/windows_sandbox/guest",
-    "backends/windows_sandbox/common",
-    "backends/windows_sandbox/lifecycle",
+    "backends/bubblewrap/common",
+    "backends/hyperlight/common",
     "backends/isolation_session/bindings",
     "backends/isolation_session/common",
-    "backends/hyperlight/common",
-    "backends/nanvix/common",
-    "backends/nanvix/build_common",
-    "backends/nanvix/binaries",
-    "backends/nanvix/runner",
     "backends/learning_mode/windows",
     "backends/lxc/common",
-    "backends/bubblewrap/common",
+    "backends/nanvix/binaries",
+    "backends/nanvix/build_common",
+    "backends/nanvix/common",
+    "backends/nanvix/runner",
+    "backends/seatbelt/common",
+    "backends/windows_sandbox/common",
+    "backends/windows_sandbox/daemon",
+    "backends/windows_sandbox/guest",
+    "backends/windows_sandbox/lifecycle",
     "backends/wslc/common",
     "backends/wslc/daemon",
-    "backends/seatbelt/common",
+    "core/generated/base_container_specification",
+    "core/generated/process_security_environment_specification",
+    "core/learning_mode_core",
+    "core/lxc",
+    "core/mxc_build_common",
+    "core/mxc_config_contract",
+    "core/mxc_darwin",
+    "core/mxc_engine",
+    "core/mxc_pty",
+    "core/mxc-sdk",
+    "core/wxc",
+    "core/wxc_common",
+    "ffi/mxc_ffi",
+    "host/plm",
     "host/wxc_host_prep",
     "host/wxc_winhttp_proxy_shim",
+    "mxc_telemetry",
+    "testing/unix_test_proxy",
     "testing/wxc_e2e_tests",
     "testing/wxc_test_driver",
     "testing/wxc_test_proxy",
-    "testing/unix_test_proxy",
     "testing/wxc_ui_probe",
     "tools/mxc_diagnostic_console",
     "tools/mxc_schema_gen",
-    "ffi/mxc_ffi",
-    "mxc_telemetry",
 ]
 exclude = ["testing/fuzz"]
 resolver = "3"
@@ -61,81 +62,81 @@ edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
+anyhow = "1"
+appcontainer_common = { path = "backends/appcontainer/common" }
+base64 = "0.22"
+bwrap_common = { path = "backends/bubblewrap/common" }
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+clap = { version = "4", features = ["derive"] }
+flatbuffers = "25"
+getrandom = "0.2"
+hyperlight_common = { path = "backends/hyperlight/common" }
+isolation_session_bindings = { path = "backends/isolation_session/bindings" }
+isolation_session_common = { path = "backends/isolation_session/common" }
+learning_mode_core = { path = "core/learning_mode_core" }
+learning_mode_windows = { path = "backends/learning_mode/windows" }
+libc = "0.2"
+lxc_common = { path = "backends/lxc/common" }
+mxc_build_common = { path = "core/mxc_build_common" }
+mxc_engine = { path = "core/mxc_engine" }
+mxc_pty = { path = "core/mxc_pty" }
+mxc-sdk = { path = "core/mxc-sdk" }
+mxc_telemetry = { path = "mxc_telemetry" }
+nanvix_runner = { path = "backends/nanvix/runner" }
+nix = { version = "0.29", features = ["fs", "mount", "sched", "signal", "net", "process", "user", "term"] }
+process_security_environment_spec = { path = "core/generated/process_security_environment_specification" }
+quick-xml = "0.41"
+sandbox_spec = { path = "core/generated/base_container_specification" }
+seatbelt_common = { path = "backends/seatbelt/common" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_path_to_error = "0.1"
+sha2 = "0.10"
+tempfile = "3"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
 # Pure-Rust ETW TraceLogging provider used by `mxc_telemetry` (Windows-only;
 # the crate compiles to no-ops on other targets). Pinned at the workspace
 # level so every consumer resolves the same version.
 tracelogging = "1.2"
+unicode-general-category = "1"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
+widestring = "1"
 windows = { version = "0.62", features = [
     "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_WindowsFirewall",
     "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Security_Credentials",
+    "Win32_Security_Isolation",
+    "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_Console",
-    "Win32_System_Environment",
-    "Win32_System_Ole",
-    "Win32_System_Threading",
-    "Win32_System_Pipes",
-    "Win32_Storage_FileSystem",
-    "Win32_System_IO",
-    "Win32_NetworkManagement_WindowsFirewall",
-    "Win32_Networking_WinSock",
-    "Win32_Security_Credentials",
-    "Win32_Security_Authorization",
-    "Win32_System_Memory",
     "Win32_System_Diagnostics_Debug",
-    "Win32_Security_Isolation",
-    "Win32_System_Variant",
-    "Win32_System_LibraryLoader",
-    "Win32_UI_Shell",
-    "Win32_System_Registry",
     "Win32_System_Diagnostics_Etw",
     "Win32_System_Diagnostics_ToolHelp",
-    "Win32_System_ProcessStatus",
-    "Win32_System_SystemInformation",
-    "Win32_System_Time",
-    "Win32_System_SystemServices",
-    "Win32_System_WindowsProgramming",
+    "Win32_System_Environment",
+    "Win32_System_IO",
     "Win32_System_JobObjects",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_Ole",
+    "Win32_System_Pipes",
+    "Win32_System_ProcessStatus",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_Time",
+    "Win32_System_Variant",
+    "Win32_System_WindowsProgramming",
+    "Win32_UI_Shell",
 ] }
 windows-core = "0.62"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_path_to_error = "0.1"
-unicode-general-category = "1"
-thiserror = "2"
-anyhow = "1"
-base64 = "0.22"
-sha2 = "0.10"
-clap = { version = "4", features = ["derive"] }
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
-quick-xml = "0.41"
-wxc_common = { path = "core/wxc_common" }
-mxc_engine = { path = "core/mxc_engine" }
-mxc-sdk = { path = "core/mxc-sdk" }
-appcontainer_common = { path = "backends/appcontainer/common" }
 windows_sandbox_common = { path = "backends/windows_sandbox/common" }
 windows_sandbox_lifecycle = { path = "backends/windows_sandbox/lifecycle" }
-isolation_session_common = { path = "backends/isolation_session/common" }
-hyperlight_common = { path = "backends/hyperlight/common" }
-learning_mode_windows = { path = "backends/learning_mode/windows" }
-learning_mode_core = { path = "core/learning_mode_core" }
-nanvix_runner = { path = "backends/nanvix/runner" }
-tokio = { version = "1", features = ["full"] }
-uuid = { version = "1", features = ["v4"] }
-getrandom = "0.2"
-libc = "0.2"
-nix = { version = "0.29", features = ["fs", "mount", "sched", "signal", "net", "process", "user", "term"] }
-lxc_common = { path = "backends/lxc/common" }
-bwrap_common = { path = "backends/bubblewrap/common" }
-seatbelt_common = { path = "backends/seatbelt/common" }
-wslc_common = { path = "backends/wslc/common" }
-isolation_session_bindings = { path = "backends/isolation_session/bindings" }
-mxc_pty = { path = "core/mxc_pty" }
-flatbuffers = "25"
-sandbox_spec = { path = "core/generated/base_container_specification" }
-process_security_environment_spec = { path = "core/generated/process_security_environment_specification" }
-mxc_telemetry = { path = "mxc_telemetry" }
-widestring = "1"
-url = "2"
 winreg = "0.55"
-tempfile = "3"
-mxc_build_common = { path = "core/mxc_build_common" }
+wslc_common = { path = "backends/wslc/common" }
+wxc_common = { path = "core/wxc_common" }

--- a/src/core/mxc_config_contract/Cargo.toml
+++ b/src/core/mxc_config_contract/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mxc_config_contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Represents the policy/configuration contract system containing multiple version contracts"
+
+[dependencies]
+serde.workspace = true
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/src/core/mxc_config_contract/src/lib.rs
+++ b/src/core/mxc_config_contract/src/lib.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Exact version identities and lifecycle metadata for MXC configuration
+//! contracts.
+//!
+//! This crate provides the dependency-light boundary used to select a
+//! configuration contract from raw JSON source. It owns exact version matching,
+//! contract lifecycle metadata, and version declaration probing.
+//!
+//! The version probe validates only the required `version` declaration. It does
+//! not validate the remainder of the selected configuration contract.
+//!
+//! This crate must not depend on MXC runtime, execution-engine, or containment
+//! backend crates. It is not yet consumed by the production configuration
+//! parser; version-specific request types and parser dispatch will be added in
+//! later phases.
+
+mod registry;
+mod version;
+
+pub use registry::{descriptor, supported_versions, ContractDescriptor, ContractStatus, CONTRACTS};
+pub use version::{probe_version, ContractVersion, ContractVersion::*, VersionProbeError};

--- a/src/core/mxc_config_contract/src/registry.rs
+++ b/src/core/mxc_config_contract/src/registry.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::ContractVersion;
+
+/// The publication lifecycle state of a configuration contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractStatus {
+    /// An immutable published contract.
+    Published,
+    /// A mutable development contract.
+    Development,
+}
+
+/// Lifecycle metadata for one registered configuration contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContractDescriptor {
+    version: ContractVersion,
+    status: ContractStatus,
+}
+
+impl ContractDescriptor {
+    /// Returns the contract version.
+    pub const fn version(&self) -> ContractVersion {
+        self.version
+    }
+
+    /// Returns the contract's lifecycle status.
+    pub const fn status(&self) -> ContractStatus {
+        self.status
+    }
+
+    /// Returns whether this is a mutable development contract.
+    pub const fn is_development(&self) -> bool {
+        matches!(self.status, ContractStatus::Development)
+    }
+}
+
+/// Metadata for every configuration contract currently registered by this
+/// crate.
+pub const CONTRACTS: &[ContractDescriptor] = &[
+    ContractDescriptor {
+        version: ContractVersion::V0_6_0Alpha,
+        status: ContractStatus::Published,
+    },
+    ContractDescriptor {
+        version: ContractVersion::V0_7_0Alpha,
+        status: ContractStatus::Published,
+    },
+    ContractDescriptor {
+        version: ContractVersion::V0_8_0Alpha,
+        status: ContractStatus::Development,
+    },
+];
+
+/// Returns the descriptor for a registered contract version.
+pub const fn descriptor(version: ContractVersion) -> ContractDescriptor {
+    match version {
+        ContractVersion::V0_6_0Alpha => CONTRACTS[0],
+        ContractVersion::V0_7_0Alpha => CONTRACTS[1],
+        ContractVersion::V0_8_0Alpha => CONTRACTS[2],
+    }
+}
+
+static SUPPORTED_VERSIONS: [ContractVersion; CONTRACTS.len()] = {
+    let mut result = [ContractVersion::V0_6_0Alpha; CONTRACTS.len()];
+    let mut i = 0;
+    while i < CONTRACTS.len() {
+        result[i] = CONTRACTS[i].version();
+        i += 1;
+    }
+    result
+};
+
+/// Returns all registered contract versions in registry order.
+pub fn supported_versions() -> &'static [ContractVersion] {
+    &SUPPORTED_VERSIONS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supported_versions() {
+        let versions = supported_versions();
+        assert_eq!(versions.len(), 3);
+        assert!(versions.contains(&ContractVersion::V0_6_0Alpha));
+        assert!(versions.contains(&ContractVersion::V0_7_0Alpha));
+        assert!(versions.contains(&ContractVersion::V0_8_0Alpha));
+    }
+
+    #[test]
+    fn test_supported_versions_round_trip() {
+        for desc in CONTRACTS {
+            let version = desc.version();
+            let round_trip_desc = descriptor(version);
+            assert_eq!(desc.version(), round_trip_desc.version());
+            assert_eq!(desc.is_development(), round_trip_desc.is_development());
+            assert_eq!(
+                version,
+                ContractVersion::parse_exact(version.as_str()).unwrap()
+            );
+        }
+    }
+}

--- a/src/core/mxc_config_contract/src/version.rs
+++ b/src/core/mxc_config_contract/src/version.rs
@@ -1,0 +1,231 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/// An exact MXC configuration contract version.
+///
+/// Versions are matched by their complete registered spelling. No semantic
+/// version ranges or normalization are applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContractVersion {
+    /// The `0.6.0-alpha` contract.
+    V0_6_0Alpha,
+    /// The `0.7.0-alpha` contract.
+    V0_7_0Alpha,
+    /// The `0.8.0-alpha` development contract.
+    V0_8_0Alpha,
+}
+
+impl ContractVersion {
+    /// Returns the exact registered spelling of this contract version.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ContractVersion::V0_6_0Alpha => "0.6.0-alpha",
+            ContractVersion::V0_7_0Alpha => "0.7.0-alpha",
+            ContractVersion::V0_8_0Alpha => "0.8.0-alpha",
+        }
+    }
+
+    /// Looks up an exact registered contract version.
+    ///
+    /// Returns `None` when `value` is not an exact supported spelling.
+    pub fn parse_exact(value: &str) -> Option<Self> {
+        match value {
+            "0.6.0-alpha" => Some(ContractVersion::V0_6_0Alpha),
+            "0.7.0-alpha" => Some(ContractVersion::V0_7_0Alpha),
+            "0.8.0-alpha" => Some(ContractVersion::V0_8_0Alpha),
+            _ => None,
+        }
+    }
+}
+
+/// An error encountered while probing a configuration's version declaration.
+#[derive(Debug, thiserror::Error)]
+pub enum VersionProbeError {
+    /// The document is malformed or does not contain exactly one string-valued
+    /// `version` field.
+    #[error("Invalid version declaration")]
+    InvalidDeclaration(#[source] serde_json::Error),
+    /// The document declares a syntactically valid but unsupported version.
+    ///
+    /// The contained string is decoded user input and must be escaped before
+    /// inclusion in terminal or log output.
+    #[error("Unsupported version")]
+    UnsupportedVersion(String),
+}
+
+use serde::Deserialize;
+use std::borrow::Cow;
+
+#[derive(Deserialize)]
+struct VersionProbe<'a> {
+    #[serde(borrow)]
+    version: Cow<'a, str>,
+}
+
+/// Reads the exact contract version declared by a raw JSON configuration.
+///
+/// Fields other than `version` are ignored. This function validates only the
+/// version declaration; it does not validate the selected contract's complete
+/// structure.
+///
+/// # Errors
+///
+/// Returns [`VersionProbeError::InvalidDeclaration`] when the input is invalid
+/// JSON, is not an object, omits `version`, supplies it more than once, or gives
+/// it a non-string value.
+///
+/// Returns [`VersionProbeError::UnsupportedVersion`] when `version` is a valid
+/// JSON string but is not an exact registered contract version.
+pub fn probe_version(json: &str) -> Result<ContractVersion, VersionProbeError> {
+    let probe: VersionProbe<'_> =
+        serde_json::from_str(json).map_err(VersionProbeError::InvalidDeclaration)?;
+    ContractVersion::parse_exact(&probe.version)
+        .ok_or_else(|| VersionProbeError::UnsupportedVersion(probe.version.into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_accepts_0_6_0_alpha() {
+        let json = r#"{"version": "0.6.0-alpha"}"#;
+        let version = probe_version(json).unwrap();
+        assert_eq!(version.as_str(), "0.6.0-alpha");
+    }
+
+    #[test]
+    fn probe_accepts_0_7_0_alpha() {
+        let json = r#"{"version": "0.7.0-alpha"}"#;
+        let version = probe_version(json).unwrap();
+        assert_eq!(version.as_str(), "0.7.0-alpha");
+    }
+
+    #[test]
+    fn probe_accepts_0_8_0_alpha() {
+        let json = r#"{"version": "0.8.0-alpha"}"#;
+        let version = probe_version(json).unwrap();
+        assert_eq!(version.as_str(), "0.8.0-alpha");
+    }
+
+    #[test]
+    fn probe_ignores_unrelated_fields() {
+        let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {"command": "echo"}
+    }"#;
+
+        assert_eq!(probe_version(json).unwrap(), ContractVersion::V0_6_0Alpha);
+    }
+
+    #[test]
+    fn probe_rejects_missing_field() {
+        let json = r#"{"not_version": "0.6.0-alpha"}"#;
+        let result = probe_version(json);
+        assert!(matches!(
+            result,
+            Err(VersionProbeError::InvalidDeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn probe_rejects_multiple_fields() {
+        let json = r#"{"version": "0.6.0-alpha", "version": "0.7.0-alpha"}"#;
+        let result = probe_version(json);
+        assert!(matches!(
+            result,
+            Err(VersionProbeError::InvalidDeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn probe_rejects_non_object_root() {
+        for json in [r#"[]"#, r#""0.6.0-alpha""#, "null", "42"] {
+            assert!(matches!(
+                probe_version(json),
+                Err(VersionProbeError::InvalidDeclaration(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn probe_rejects_trailing_json() {
+        let json = r#"{"version":"0.6.0-alpha"} {}"#;
+
+        assert!(matches!(
+            probe_version(json),
+            Err(VersionProbeError::InvalidDeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn probe_rejects_invalid_field_types() {
+        for json in [
+            r#"{"version": 0.6}"#,                      // number
+            r#"{"version": {"major": 0, "minor": 6}}"#, // object
+            r#"{"version": ["0.6.0-alpha"]}"#,          // array
+            r#"{"version": null}"#,                     // null
+            r#"{"version": true}"#,                     // boolean
+        ] {
+            assert!(matches!(
+                probe_version(json),
+                Err(VersionProbeError::InvalidDeclaration(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn probe_reports_unrecognized_0_6_2() {
+        let json = r#"{"version": "0.6.2"}"#;
+        let result = probe_version(json);
+        assert!(matches!(
+            result,
+            Err(VersionProbeError::UnsupportedVersion(_))
+        ));
+    }
+
+    #[test]
+    fn probe_reports_unsupported_0_6_0_dev() {
+        let json = r#"{"version": "0.6.0-dev"}"#;
+        let result = probe_version(json);
+        assert!(matches!(
+            result,
+            Err(VersionProbeError::UnsupportedVersion(_))
+        ));
+    }
+
+    #[test]
+    fn probe_rejects_invalid_json() {
+        let json = r#"{"version": "0.6.0-alpha""#; // Missing closing brace
+        let result = probe_version(json);
+        assert!(matches!(
+            result,
+            Err(VersionProbeError::InvalidDeclaration(_))
+        ));
+    }
+
+    #[test]
+    fn probe_accepts_unicode_escaped_hyphen() {
+        let json = r#"{"version":"0.6.0\u002dalpha"}"#;
+
+        assert_eq!(probe_version(json).unwrap(), ContractVersion::V0_6_0Alpha);
+    }
+
+    #[test]
+    fn probe_accepts_unicode_escaped_digit() {
+        let json = r#"{"version":"\u0030.7.0-alpha"}"#;
+
+        assert_eq!(probe_version(json).unwrap(), ContractVersion::V0_7_0Alpha);
+    }
+
+    #[test]
+    fn probe_reports_escaped_unsupported_version() {
+        let json = r#"{"version":"0.6.0-\u0062eta"}"#;
+
+        assert!(matches!(
+            probe_version(json),
+            Err(VersionProbeError::UnsupportedVersion(version))
+                if version == "0.6.0-beta"
+        ));
+    }
+}


### PR DESCRIPTION
This PR adds the mxc_config_contract crate, the first phase of moving MXC to
version-specific configuration parsers. It introduces a contract registry that
maps each supported schema version to its status, plus a probe that reads the
version field from a config document so a later change can dispatch to the
matching parser. Nothing consumes the crate yet.

* Details
    - ContractVersion enumerates the supported schema versions (0.6.0-alpha,
    0.7.0-alpha, 0.8.0-alpha) and matches them exactly rather than by semver
    range.
    - probe_version reads the version field and returns a typed
      VersionProbeError for invalid version declarations (malformed JSON, a
      missing field, duplicate fields, an incorrectly typed field) or an
      unsupported version.
    - CONTRACTS records each version's Published or Development status;
      supported_versions returns a &'static slice derived from it at compile
      time.
    - Sort the workspace members, dependencies, and windows feature list
      alphabetically, which accounts for most of the src/Cargo.toml diff.

* Tests
    - cargo test -p mxc_config_contract (17 tests, all pass)
    - cargo clippy -p mxc_config_contract --all-targets -- -D warnings
    - cargo fmt --all -- --check

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 95afc2f4-729a-480b-9b18-5f5f8736298a