### PR TITLE
Document process containers proxy packaging and deployment for developers

### DIFF
--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -49,7 +49,9 @@ Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required on ProcessContainer.
 
 The proxy must already be running. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient`
-for external destinations, and inbound firewall authorization.
+for external destinations, and inbound firewall authorization. The proxy must bind its listener only to the configured
+loopback address, never to wildcard addresses such as `0.0.0.0` or `[::]`; the loopback URL does not enforce the
+listener binding.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -91,7 +93,8 @@ for external destinations, and inbound firewall authorization.
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules">
       <desktop2:FirewallRules Executable="proxy.exe">
-        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all"
+          LocalPortMin="8080" LocalPortMax="8080" />
       </desktop2:FirewallRules>
     </desktop2:Extension>
   </Extensions>
@@ -101,7 +104,8 @@ for external destinations, and inbound firewall authorization.
 Replace the identity, publisher, architecture, executable, display strings,
 and logo. The publisher must match the signing certificate. `runFullTrust` is
 required by the firewall extension; `TrustLevel="appContainer"` still runs the
-proxy in an AppContainer.
+proxy in an AppContainer. Replace both firewall-rule port values with the port
+from `runtimeConfig.networkProxy`.
 
 See [Proxy identity and firewall authorization](../networking.md#proxy-identity-and-firewall-authorization)
 for Windows enforcement and firewall details.

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -51,7 +51,7 @@ port. The proxy-specific `network` block above is required on ProcessContainer.
 The proxy must already be running. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient`
 for external destinations, and inbound firewall authorization.
 
-### Minimal packaged-proxy manifest
+### Minimal packaged AppContainer proxy manifest
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -62,11 +62,7 @@ for external destinations, and inbound firewall authorization.
   xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   IgnorableNamespaces="uap uap10 desktop2 rescap">
-  <Identity
-    Name="Contoso.AgentProxy"
-    Publisher="CN=Contoso"
-    Version="1.0.0.0"
-    ProcessorArchitecture="x64" />
+  <Identity Name="Contoso.AgentProxy" Publisher="CN=Contoso" Version="1.0.0.0" ProcessorArchitecture="x64" />
   <Properties>
     <DisplayName>Agent Proxy</DisplayName>
     <PublisherDisplayName>Contoso</PublisherDisplayName>
@@ -76,10 +72,7 @@ for external destinations, and inbound firewall authorization.
     <Resource Language="en-us" />
   </Resources>
   <Dependencies>
-    <TargetDeviceFamily
-      Name="Windows.Desktop"
-      MinVersion="10.0.19041.0"
-      MaxVersionTested="10.0.26100.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
@@ -87,18 +80,11 @@ for external destinations, and inbound firewall authorization.
     <Capability Name="privateNetworkClientServer" />
   </Capabilities>
   <Applications>
-    <Application
-      Id="Proxy"
-      Executable="proxy.exe"
-      EntryPoint="Windows.PartialTrustApplication"
-      uap10:RuntimeBehavior="packagedClassicApp"
-      uap10:TrustLevel="appContainer">
-      <uap:VisualElements
-        DisplayName="Agent Proxy"
-        Description="HTTP proxy for contained workloads"
-        BackgroundColor="transparent"
-        Square150x150Logo="Assets\Logo.png"
-        Square44x44Logo="Assets\Logo.png"
+    <Application Id="Proxy" Executable="proxy.exe"
+      uap10:RuntimeBehavior="packagedClassicApp" uap10:TrustLevel="appContainer">
+      <uap:VisualElements DisplayName="Agent Proxy"
+        Description="HTTP proxy for contained workloads" BackgroundColor="transparent"
+        Square150x150Logo="Assets\Logo.png" Square44x44Logo="Assets\Logo.png"
         AppListEntry="none" />
     </Application>
   </Applications>
@@ -117,4 +103,5 @@ and logo. The publisher must match the signing certificate. `runFullTrust` is
 required by the firewall extension; `TrustLevel="appContainer"` still runs the
 proxy in an AppContainer.
 
-See [Process Container Networking Configuration](../networking.md) for Windows enforcement and firewall details.
+See [Proxy identity and firewall authorization](../networking.md#proxy-identity-and-firewall-authorization)
+for Windows enforcement and firewall details.

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -119,9 +119,8 @@ Get-AppxPackage -Name Contoso.AgentProxy |
   Select-Object -ExpandProperty PackageFamilyName
 ```
 
-Use that value verbatim for `allowedProxyPeer` for any packaged proxy. The Package Family Name is derived from the
-manifest identity name and publisher; it is not the display name or application ID. A bare profile name such as
-`agent-proxy` is valid only for an unpackaged AppContainer proxy.
+Use that value verbatim for `allowedProxyPeer` for any packaged proxy. For an unpackaged AppContainer proxy, use its
+AppContainer profile name instead.
 
 See [Proxy identity and firewall authorization](../networking.md#proxy-identity-and-firewall-authorization)
 for Windows enforcement and firewall details.

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -39,7 +39,7 @@ Package identity can scope a packaged proxy whether or not that proxy uses AppCo
 | Field | Value |
 |---|---|
 | `runtimeConfig.networkProxy` | HTTP/S loopback URL with an explicit port |
-| `processContainer.network.allowedProxyPeer` | Package family name or AppContainer profile name |
+| `processContainer.network.allowedProxyPeer` | Installed Package Family Name or AppContainer profile name |
 
 ProcessContainer requires `ingress.default: "allow"` for private-network communication with an identity-scoped proxy.
 Windows implements this with the bidirectional `privateNetworkClientServer` capability, so the setting also permits
@@ -81,6 +81,14 @@ listener binding.
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
   </Capabilities>
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules">
+      <desktop2:FirewallRules Executable="proxy.exe">
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all"
+          LocalPortMin="8080" LocalPortMax="8080" />
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
   <Applications>
     <Application Id="Proxy" Executable="proxy.exe"
       uap10:RuntimeBehavior="packagedClassicApp" uap10:TrustLevel="appContainer">
@@ -90,14 +98,6 @@ listener binding.
         AppListEntry="none" />
     </Application>
   </Applications>
-  <Extensions>
-    <desktop2:Extension Category="windows.firewallRules">
-      <desktop2:FirewallRules Executable="proxy.exe">
-        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all"
-          LocalPortMin="8080" LocalPortMax="8080" />
-      </desktop2:FirewallRules>
-    </desktop2:Extension>
-  </Extensions>
 </Package>
 ```
 
@@ -106,6 +106,18 @@ and logo. The publisher must match the signing certificate. `runFullTrust` is
 required by the firewall extension; `TrustLevel="appContainer"` still runs the
 proxy in an AppContainer. Replace both firewall-rule port values with the port
 from `runtimeConfig.networkProxy`.
+
+After installing the package, retrieve its exact Package Family Name:
+
+```powershell
+Get-AppxPackage -Name Contoso.AgentProxy |
+  Select-Object -ExpandProperty PackageFamilyName
+```
+
+Use that value verbatim for `allowedProxyPeer`. The Package Family Name is
+derived from the manifest identity name and publisher; it is not the display
+name or application ID. A bare profile name such as `agent-proxy` is valid
+only for an unpackaged AppContainer proxy.
 
 See [Proxy identity and firewall authorization](../networking.md#proxy-identity-and-firewall-authorization)
 for Windows enforcement and firewall details.

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -109,10 +109,8 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The manifest example uses a fixed port. Dynamic ports are supported, but a static manifest rule does not change when
-the deployment selects a different port at runtime. Before launching the client, the deployment must ensure that an
-equivalent inbound rule exists for the proxy identity, executable, and selected port. How the rule is provisioned and
-retired is deployment-owned. Do not use an unrestricted package firewall rule to accommodate an OS-assigned port.
+The manifest example uses port 8080. The proxy developer must ensure that its inbound firewall rule covers the port
+supplied to MXC in `runtimeConfig.networkProxy`.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -109,11 +109,10 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The static package firewall declaration is scoped to the configured port and cannot follow a dynamic port at runtime.
-A dynamic-port deployment must use an installer- or administrator-owned firewall API to replace the previous rule
-before launching the client. The replacement must be scoped to the package or AppContainer SID, proxy executable, and
-new port; the deployment must remove stale rules during replacement, teardown, and uninstall. Do not use an
-unrestricted package firewall rule to accommodate an OS-assigned port.
+The manifest example uses a fixed port. Dynamic ports are supported, but a static manifest rule does not change when
+the deployment selects a different port at runtime. Before launching the client, the deployment must ensure that an
+equivalent inbound rule exists for the proxy identity, executable, and selected port. How the rule is provisioned and
+retired is deployment-owned. Do not use an unrestricted package firewall rule to accommodate an OS-assigned port.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -48,10 +48,12 @@ private-network server traffic. `egress.default: "deny"` continues to block dire
 Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required on ProcessContainer.
 
-The proxy must already be running. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient`
-for external destinations, and inbound firewall authorization. The proxy must bind its listener only to the configured
-loopback address, never to wildcard addresses such as `0.0.0.0` or `[::]`; the loopback URL does not enforce the
-listener binding.
+The proxy must already be running and listening on the loopback address and
+port configured by `runtimeConfig.networkProxy`. MXC validates that the
+configured endpoint is loopback but does not constrain the proxy's other
+listeners. A packaged AppContainer proxy needs `privateNetworkClientServer`,
+`internetClient` for external destinations, and inbound firewall
+authorization.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -84,8 +86,7 @@ listener binding.
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules">
       <desktop2:FirewallRules Executable="proxy.exe">
-        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all"
-          LocalPortMin="8080" LocalPortMax="8080" />
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
       </desktop2:FirewallRules>
     </desktop2:Extension>
   </Extensions>
@@ -101,11 +102,17 @@ listener binding.
 </Package>
 ```
 
-Replace the identity, publisher, architecture, executable, display strings,
-and logo. The publisher must match the signing certificate. `runFullTrust` is
-required by the firewall extension; `TrustLevel="appContainer"` still runs the
-proxy in an AppContainer. Replace both firewall-rule port values with the port
-from `runtimeConfig.networkProxy`.
+See the Microsoft Learn
+[package manifest schema reference](https://learn.microsoft.com/uwp/schemas/appxpackage/uapmanifestschema/schema-root)
+for package identity, signing, assets, and application metadata.
+`runFullTrust` is required by the firewall extension;
+`TrustLevel="appContainer"` still runs the proxy in an AppContainer.
+
+The firewall declaration intentionally does not restrict the local port. The
+proxy may request an OS-assigned port, then provide the selected loopback
+address and port to the caller for `runtimeConfig.networkProxy`. A proxy that
+uses a fixed port can instead add matching `LocalPortMin` and `LocalPortMax`
+values.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -42,8 +42,9 @@ Package identity can scope a packaged proxy whether or not that proxy uses AppCo
 | `processContainer.network.allowedProxyPeer` | Installed Package Family Name or AppContainer profile name |
 
 ProcessContainer requires `ingress.default: "allow"` for private-network communication with an identity-scoped proxy.
-Windows implements this with the bidirectional `privateNetworkClientServer` capability, so the setting also permits
-private-network server traffic. `egress.default: "deny"` continues to block direct internet traffic.
+Windows implements this on the MXC client with the bidirectional `privateNetworkClientServer` capability, so the
+setting also permits private-network server traffic. `egress.default: "deny"` continues to block direct internet
+traffic.
 
 Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required for an identity-scoped ProcessContainer proxy and is

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -79,9 +79,9 @@ and inbound firewall authorization.
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.19041.0" MaxVersionTested="10.0.26100.0" />
   </Dependencies>
   <Capabilities>
-    <rescap:Capability Name="runFullTrust" />
     <Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer" />
+    <rescap:Capability Name="runFullTrust" />
   </Capabilities>
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules">

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -45,4 +45,76 @@ ProcessContainer requires `ingress.default: "allow"` for private-network communi
 Windows implements this with the bidirectional `privateNetworkClientServer` capability, so the setting also permits
 private-network server traffic. `egress.default: "deny"` continues to block direct internet traffic.
 
-See [Process Container Networking Configuration](../networking.md) for Windows enforcement details.
+Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
+port. The proxy-specific `network` block above is required on ProcessContainer.
+
+The proxy must already be running. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient`
+for external destinations, and inbound firewall authorization.
+
+### Minimal packaged-proxy manifest
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+  xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap uap10 desktop2 rescap">
+  <Identity
+    Name="Contoso.AgentProxy"
+    Publisher="CN=Contoso"
+    Version="1.0.0.0"
+    ProcessorArchitecture="x64" />
+  <Properties>
+    <DisplayName>Agent Proxy</DisplayName>
+    <PublisherDisplayName>Contoso</PublisherDisplayName>
+    <Logo>Assets\Logo.png</Logo>
+  </Properties>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Dependencies>
+    <TargetDeviceFamily
+      Name="Windows.Desktop"
+      MinVersion="10.0.19041.0"
+      MaxVersionTested="10.0.26100.0" />
+  </Dependencies>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+    <Capability Name="internetClient" />
+    <Capability Name="privateNetworkClientServer" />
+  </Capabilities>
+  <Applications>
+    <Application
+      Id="Proxy"
+      Executable="proxy.exe"
+      EntryPoint="Windows.PartialTrustApplication"
+      uap10:RuntimeBehavior="packagedClassicApp"
+      uap10:TrustLevel="appContainer">
+      <uap:VisualElements
+        DisplayName="Agent Proxy"
+        Description="HTTP proxy for contained workloads"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Logo.png"
+        Square44x44Logo="Assets\Logo.png"
+        AppListEntry="none" />
+    </Application>
+  </Applications>
+  <Extensions>
+    <desktop2:Extension Category="windows.firewallRules">
+      <desktop2:FirewallRules Executable="proxy.exe">
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
+      </desktop2:FirewallRules>
+    </desktop2:Extension>
+  </Extensions>
+</Package>
+```
+
+Replace the identity, publisher, architecture, executable, display strings,
+and logo. The publisher must match the signing certificate. `runFullTrust` is
+required by the firewall extension; `TrustLevel="appContainer"` still runs the
+proxy in an AppContainer.
+
+See [Process Container Networking Configuration](../networking.md) for Windows enforcement and firewall details.

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -46,12 +46,14 @@ Windows implements this with the bidirectional `privateNetworkClientServer` capa
 private-network server traffic. `egress.default: "deny"` continues to block direct internet traffic.
 
 Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
-port. The proxy-specific `network` block above is required on ProcessContainer.
+port. The proxy-specific `network` block above is required for an identity-scoped ProcessContainer proxy and is
+omitted for the identity-less host-loopback deployment.
 
 The proxy must already be running and listening on the loopback address and
-port configured by `runtimeConfig.networkProxy`. MXC's schema 0.8 implementation must validate that the configured
-endpoint is loopback. The proxy must bind only the configured loopback listener. A packaged AppContainer proxy needs
-`privateNetworkClientServer`, `internetClient` for external destinations, and inbound firewall authorization.
+port configured by `runtimeConfig.networkProxy`. See the canonical
+[proxy deployment requirements](../networking.md#proxy-deployment-choices) for endpoint validation and listener
+binding. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient` for external destinations,
+and inbound firewall authorization.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -107,8 +109,10 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The firewall declaration is scoped to the configured port. A deployment that uses a dynamic port must create or
-update an equivalently executable- and port-scoped firewall rule before launching the client. Do not use an
+The static package firewall declaration is scoped to the configured port and cannot follow a dynamic port at runtime.
+A dynamic-port deployment must use an installer- or administrator-owned firewall API to replace the previous rule
+before launching the client. The replacement must be scoped to the package or AppContainer SID, proxy executable, and
+new port; the deployment must remove stale rules during replacement, teardown, and uninstall. Do not use an
 unrestricted package firewall rule to accommodate an OS-assigned port.
 
 After installing the package, retrieve its exact Package Family Name:

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -49,11 +49,9 @@ Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required on ProcessContainer.
 
 The proxy must already be running and listening on the loopback address and
-port configured by `runtimeConfig.networkProxy`. MXC validates that the
-configured endpoint is loopback but does not constrain the proxy's other
-listeners. A packaged AppContainer proxy needs `privateNetworkClientServer`,
-`internetClient` for external destinations, and inbound firewall
-authorization.
+port configured by `runtimeConfig.networkProxy`. MXC's schema 0.8 implementation must validate that the configured
+endpoint is loopback. The proxy must bind only the configured loopback listener. A packaged AppContainer proxy needs
+`privateNetworkClientServer`, `internetClient` for external destinations, and inbound firewall authorization.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -86,7 +84,8 @@ authorization.
   <Extensions>
     <desktop2:Extension Category="windows.firewallRules">
       <desktop2:FirewallRules Executable="proxy.exe">
-        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all" />
+        <desktop2:Rule Direction="in" IPProtocol="TCP" Profile="all"
+          LocalPortMin="8080" LocalPortMax="8080" />
       </desktop2:FirewallRules>
     </desktop2:Extension>
   </Extensions>
@@ -108,11 +107,9 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The firewall declaration intentionally does not restrict the local port. The
-proxy may request an OS-assigned port, then provide the selected loopback
-address and port to the caller for `runtimeConfig.networkProxy`. A proxy that
-uses a fixed port can instead add matching `LocalPortMin` and `LocalPortMax`
-values.
+The firewall declaration is scoped to the configured port. A deployment that uses a dynamic port must create or
+update an equivalently executable- and port-scoped firewall rule before launching the client. Do not use an
+unrestricted package firewall rule to accommodate an OS-assigned port.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -118,10 +118,9 @@ Get-AppxPackage -Name Contoso.AgentProxy |
   Select-Object -ExpandProperty PackageFamilyName
 ```
 
-Use that value verbatim for `allowedProxyPeer`. The Package Family Name is
-derived from the manifest identity name and publisher; it is not the display
-name or application ID. A bare profile name such as `agent-proxy` is valid
-only for an unpackaged AppContainer proxy.
+Use that value verbatim for `allowedProxyPeer` for any packaged proxy. The Package Family Name is derived from the
+manifest identity name and publisher; it is not the display name or application ID. A bare profile name such as
+`agent-proxy` is valid only for an unpackaged AppContainer proxy.
 
 See [Proxy identity and firewall authorization](../networking.md#proxy-identity-and-firewall-authorization)
 for Windows enforcement and firewall details.

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -86,14 +86,18 @@ Model 2 involves two separate processes:
 - **Proxy process:** a caller-created process that is already running outside the MXC client container. It may be
   packaged or unpackaged, with or without AppContainer isolation.
 
+MXC must reject a `runtimeConfig.networkProxy` endpoint that is not loopback. The caller must configure the proxy to
+bind only the exact loopback address and port supplied to MXC.
+
 | External proxy | `allowedProxyPeer` | MXC client policy | Additional proxy identity |
 |---|---|---|---|
-| Packaged proxy | PFN | `default: "allow"`; `hostLoopback: "deny"` | Package identity |
+| Packaged proxy | Package Family Name | `default: "allow"`; `hostLoopback: "deny"` | Package identity |
 | Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | AppContainer profile |
 | Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
 
 All deployments retain the base Model 2 client policy. `allowedProxyPeer` adds proxy identity binding on top of the
-common WFP endpoint enforcement.
+common WFP endpoint enforcement. The packaged row covers both AppContainer and non-AppContainer proxies because their
+client policy and package identity are the same; the enforcement table below separates their additional protections.
 
 `ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
 opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
@@ -167,7 +171,8 @@ The caller must:
 #### Proxy identity and firewall authorization
 
 The WFP loopback-address-and-port restriction described above applies to every row. The table compares the additional
-OS enforcement provided for the external proxy. A packaged AppContainer proxy provides the best enforcement.
+OS enforcement provided for the external proxy. A packaged AppContainer proxy provides the best enforcement. The two
+middle rows provide different protections and are not ordered relative to each other.
 
 | Proxy deployment | `allowedProxyPeer` | Additional OS enforcement |
 |---|---|---|
@@ -180,7 +185,8 @@ The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall
 declaration shown in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
 `uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
-requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port.
+requires its installer or administrator to own an equivalent rule scoped to the AppContainer profile SID, proxy
+executable, and configured port.
 See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -83,32 +83,36 @@ Model 2 involves two separate processes:
 
 - **MXC client container:** the BaseContainer created by MXC, which runs the caller's workload and initiates HTTP/S
   connections to the proxy.
-- **Proxy process:** a caller-created process that is already running outside the MXC client container. It may run in an
-  AppContainer or without AppContainer isolation.
+- **Proxy process:** a caller-created process that is already running outside the MXC client container. It may be
+  packaged or unpackaged, with or without AppContainer isolation.
 
 | External proxy | `allowedProxyPeer` | MXC client policy | Proxy binding |
 |---|---|---|---|
-| AppContainer | Package family/profile | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
-| Non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | Host loopback and endpoint |
+| Packaged proxy | PFN | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
+| Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
+| Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | Host loopback and endpoint |
 
-Both deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
+All deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
 `privateNetworkClientServer`. This is a Windows capability requirement, not a statement that the proxy connection
 enters the MXC client container; the client initiates that connection. The capability is bidirectional, so it also
 permits private-network server traffic.
 
-`ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes the AppContainer peer without opening general
-host-loopback access, so that path keeps `hostLoopback: "deny"`. A non-AppContainer proxy has no peer identity, so its
-endpoint requires `hostLoopback: "allow"`. That also permits the MXC client container to reach other host-loopback
-services and permits host-loopback clients to reach listeners in the MXC client container.
+`ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
+opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
+non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. That also permits the MXC
+client container to reach other host-loopback services and permits host-loopback clients to reach listeners in the MXC
+client container.
 
-#### Contained AppContainer proxy
+#### Identity-scoped proxy
 
 Use the canonical [ProcessContainer schema 0.8 configuration](examples/0.8.0-schema.md), which shows
 `runtimeConfig.networkProxy`, `processContainer.network.allowedProxyPeer`, and their relationship in one place.
+Use the installed Package Family Name for a packaged proxy, regardless of whether it has AppContainer isolation. Use
+the AppContainer profile name for an unpackaged AppContainer proxy.
 
-#### Non-AppContainer proxy
+#### Unpackaged non-AppContainer proxy
 
-Packaged and unpackaged non-AppContainer proxies omit the AppContainer peer identity:
+An unpackaged non-AppContainer proxy has no package family or AppContainer profile identity:
 
 ```jsonc
 {
@@ -127,10 +131,9 @@ Packaged and unpackaged non-AppContainer proxies omit the AppContainer peer iden
 ```
 
 MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
-AppContainer proxy. The difference is that MXC identifies the proxy only by the configured endpoint, not by an
-AppContainer identity, and enables bidirectional host-loopback access. This weaker option is intended primarily for
-development and debugging. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged
-deployments require an installer- or administrator-owned rule.
+identity-scoped proxy. The difference is that MXC identifies this proxy only by the configured endpoint and enables
+bidirectional host-loopback access. This weaker option is intended primarily for development and debugging and requires
+an installer- or administrator-owned firewall rule.
 
 #### HTTP client guidance
 
@@ -150,11 +153,11 @@ apply when `runtimeConfig.networkProxy` is present.
 The proxy endpoint is runtime metadata, not shared network policy. MXC configures the per-container WinHTTP proxy,
 applies WFP endpoint scoping, and grants the private-network capability selected by `ingress.default`.
 
-The two proxy identity paths are mutually exclusive. When
-`allowedProxyPeer` is present, MXC resolves the peer and grants the private-network capability selected by
-`ingress.default`. When it is omitted, MXC uses the configured proxy endpoint without binding that endpoint to an
-AppContainer identity and requires bidirectional host-loopback access. MXC configures the per-container WinHTTP proxy
-for either path.
+The identity-scoped and host-loopback paths are
+mutually exclusive. When `allowedProxyPeer` is present, MXC resolves the package family or AppContainer profile and
+grants the private-network capability selected by `ingress.default`. When it is omitted, MXC uses the configured proxy
+endpoint without peer identity binding and requires bidirectional host-loopback access. MXC configures the per-container
+WinHTTP proxy for either path.
 
 The caller must:
 
@@ -171,7 +174,7 @@ An AppContainer proxy is recommended. Supported deployment options are:
 |---|---|---|
 | Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
-| Packaged non-AppContainer | Omit | Host-loopback access and package firewall rule |
+| Packaged non-AppContainer | Package family name | Package identity and package firewall rule |
 | Unpackaged non-AppContainer | Omit | Host-loopback access and administrator firewall rule |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -92,14 +92,8 @@ Model 2 involves two separate processes:
 | Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | AppContainer profile |
 | Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
 
-Regardless of proxy type, an enforcing BaseContainer path applies per-container WFP rules that permit the MXC client
-container to connect only to the configured loopback address and port. `allowedProxyPeer` adds proxy identity binding
-on top of that common endpoint enforcement.
-
-All deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
-`privateNetworkClientServer`. This is a Windows capability requirement, not a statement that the proxy connection
-enters the MXC client container; the client initiates that connection. The capability is bidirectional, so it also
-permits private-network server traffic.
+All deployments retain the base Model 2 client policy. `allowedProxyPeer` adds proxy identity binding on top of the
+common WFP endpoint enforcement.
 
 `ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
 opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
@@ -158,11 +152,10 @@ apply when `runtimeConfig.networkProxy` is present.
 The proxy endpoint is runtime metadata, not shared network policy. MXC configures the per-container WinHTTP proxy,
 applies WFP endpoint scoping, and grants the private-network capability selected by `ingress.default`.
 
-The identity-scoped and host-loopback paths are
-mutually exclusive. When `allowedProxyPeer` is present, MXC resolves the package family or AppContainer profile and
-grants the private-network capability selected by `ingress.default`. When it is omitted, MXC uses the configured proxy
-endpoint without peer identity binding and requires bidirectional host-loopback access. MXC configures the per-container
-WinHTTP proxy for either path.
+The identity-scoped and host-loopback paths are mutually exclusive. When `allowedProxyPeer` is present, MXC resolves
+the package family or AppContainer profile and grants the private-network capability selected by `ingress.default`.
+When it is omitted, MXC uses the configured proxy endpoint without peer identity binding and requires bidirectional
+host-loopback access. MXC configures the per-container WinHTTP proxy for either path.
 
 The caller must:
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -97,9 +97,11 @@ Packaged and unpackaged non-AppContainer proxies use the host-loopback path inst
 }
 ```
 
-MXC does not grant `privateNetworkClientServer` for this path. The proxy is not isolated or authorized by an
-AppContainer identity, so it is intended primarily for development and debugging. Packaged deployments can own the
-port-scoped firewall rule in the package; unpackaged deployments require an installer- or administrator-owned rule.
+MXC does not grant `privateNetworkClientServer` for this path. `ingress.hostLoopback: "allow"` selects the Windows
+loopback exemption, which is bidirectional and cannot be scoped to only the configured proxy endpoint. The proxy is not
+isolated or authorized by an AppContainer identity, so this compatibility path is intended primarily for development
+and debugging. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged deployments
+require an installer- or administrator-owned rule.
 
 #### HTTP client guidance
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -132,8 +132,10 @@ An unpackaged non-AppContainer proxy has no package family or AppContainer profi
 
 MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
 identity-scoped proxy. The difference is that MXC identifies this proxy only by the configured endpoint and enables
-bidirectional host-loopback access. This weaker option is intended primarily for development and debugging and requires
-an installer- or administrator-owned firewall rule.
+bidirectional host-loopback access. This is the lowest-enforcement deployment option. On an enforcing BaseContainer
+path, WFP still restricts the MXC client container's egress to the configured loopback address and port, but Windows
+cannot verify which host process owns that endpoint. It is intended primarily for development and debugging and
+requires an installer- or administrator-owned firewall rule.
 
 #### HTTP client guidance
 
@@ -175,7 +177,7 @@ An AppContainer proxy is recommended. Supported deployment options are:
 | Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
 | Packaged non-AppContainer | Package family name | Package identity and package firewall rule |
-| Unpackaged non-AppContainer | Omit | Host-loopback access and administrator firewall rule |
+| Unpackaged non-AppContainer | Omit | Endpoint-only WFP and administrator firewall rule |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -187,7 +187,8 @@ The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall
 declaration shown in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
 `uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
-requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port. See
+requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port.
+See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -77,17 +77,44 @@ communication must set `ingress.default` to `"allow"` and accept that Windows en
 server behavior. On an enforcing BaseContainer path, per-container WFP permits the MXC client container to connect only
 to the configured loopback address and port and blocks direct public and private destinations.
 
-#### Non-AppContainer proxy (explicit opt-in)
+#### Proxy deployment choices
 
-Packaged and unpackaged non-AppContainer proxies use the host-loopback path instead of an identity-scoped peer:
+Model 2 involves two separate processes:
+
+- **MXC client container:** the BaseContainer created by MXC, which runs the caller's workload and initiates HTTP/S
+  connections to the proxy.
+- **Proxy process:** a caller-created process that is already running outside the MXC client container. It may run in an
+  AppContainer or without AppContainer isolation.
+
+| Proxy process | `allowedProxyPeer` | Client-container ingress | Proxy binding |
+|---|---|---|---|
+| AppContainer | Package family/profile | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
+| Non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "deny"` | Endpoint only |
+
+Both deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
+`privateNetworkClientServer`. This is a Windows capability requirement, not a statement that the proxy connection
+enters the MXC client container; the client initiates that connection. The capability is bidirectional, so it also
+permits private-network server traffic.
+
+`ingress.hostLoopback` retains its shared-policy meaning: host-initiated connections entering a listener in the MXC
+client container. The proxy does not require that inbound path, so it remains `"deny"` for both deployments.
+
+#### Contained AppContainer proxy
+
+Use the canonical [ProcessContainer schema 0.8 configuration](examples/0.8.0-schema.md), which shows
+`runtimeConfig.networkProxy`, `processContainer.network.allowedProxyPeer`, and their relationship in one place.
+
+#### Non-AppContainer proxy
+
+Packaged and unpackaged non-AppContainer proxies omit the AppContainer peer identity:
 
 ```jsonc
 {
   "network": {
     "egress": { "default": "deny" },
     "ingress": {
-      "default": "deny",
-      "hostLoopback": "allow"
+      "default": "allow",
+      "hostLoopback": "deny"
     }
   },
   "runtimeConfig": {
@@ -97,11 +124,11 @@ Packaged and unpackaged non-AppContainer proxies use the host-loopback path inst
 }
 ```
 
-MXC does not grant `privateNetworkClientServer` for this path. `ingress.hostLoopback: "allow"` selects the Windows
-loopback exemption, which is bidirectional and cannot be scoped to only the configured proxy endpoint. The proxy is not
-isolated or authorized by an AppContainer identity, so this compatibility path is intended primarily for development
-and debugging. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged deployments
-require an installer- or administrator-owned rule.
+MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
+AppContainer proxy. The difference is that MXC identifies the proxy only by the configured endpoint, not by an
+AppContainer identity. This weaker option is intended primarily for development and debugging. Packaged deployments
+can own the port-scoped firewall rule in the package; unpackaged deployments require an installer- or
+administrator-owned rule.
 
 #### HTTP client guidance
 
@@ -136,8 +163,8 @@ An AppContainer proxy is recommended. Supported deployment options are:
 |---|---|---|
 | Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
-| Packaged non-AppContainer | Omit | Host-loopback access and package firewall rule |
-| Unpackaged non-AppContainer | Omit | Host-loopback access and administrator firewall rule |
+| Packaged non-AppContainer | Omit | Endpoint-only binding and package firewall rule |
+| Unpackaged non-AppContainer | Omit | Endpoint-only binding and administrator firewall rule |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -102,6 +102,22 @@ The caller must:
 - keep it alive until the client exits; and
 - leave egress deny-default with no direct allow or deny rules.
 
+#### Proxy identity and firewall authorization
+
+A packaged AppContainer proxy is recommended. Supported deployment options are:
+
+| Proxy deployment | `allowedProxyPeer` | Enforcement |
+|---|---|---|
+| Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
+| Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
+
+The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
+Firewall's block-inbound-to-non-allowed-apps policy. A packaged proxy uses the package-owned firewall declaration shown
+in the [schema 0.8 examples](examples/0.8.0-schema.md); a packaged AppContainer also needs AppContainer trust. An
+unpackaged AppContainer proxy requires its installer or administrator to own the equivalent firewall rule. See
+[CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
+for unpackaged profile creation.
+
 ### Model 3: externally blocked (most restrictive)
 
 - **Capabilities:** none; no host or peer loopback exemptions.

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -96,14 +96,15 @@ bind only the exact loopback address and port supplied to MXC.
 | Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
 
 All deployments retain the base Model 2 client policy. `allowedProxyPeer` adds proxy identity binding on top of the
-common WFP endpoint enforcement. The packaged row covers both AppContainer and non-AppContainer proxies because their
+common WFP endpoint enforcement. The proxy endpoint is the loopback address and port in
+`runtimeConfig.networkProxy`. The packaged row covers both AppContainer and non-AppContainer proxies because their
 client policy and package identity are the same; the enforcement table below separates their additional protections.
 
 `ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
 opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
-non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. That also permits the MXC
-client container to reach other host-loopback services and permits host-loopback clients to reach listeners in the MXC
-client container.
+non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. That authorizes both
+host-loopback directions, but Model 2 WFP still restricts client-container egress to the configured proxy endpoint.
+Host-loopback clients can reach listeners in the MXC client container.
 
 #### Identity-scoped proxy
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -77,6 +77,30 @@ communication must set `ingress.default` to `"allow"` and accept that Windows en
 server behavior. On an enforcing BaseContainer path, per-container WFP permits the MXC client container to connect only
 to the configured loopback address and port and blocks direct public and private destinations.
 
+#### Non-AppContainer proxy (explicit opt-in)
+
+Packaged and unpackaged non-AppContainer proxies use the host-loopback path instead of an identity-scoped peer:
+
+```jsonc
+{
+  "network": {
+    "egress": { "default": "deny" },
+    "ingress": {
+      "default": "deny",
+      "hostLoopback": "allow"
+    }
+  },
+  "runtimeConfig": {
+    "networkProxy": "http://127.0.0.1:8080"
+  }
+  // No processContainer.network.allowedProxyPeer.
+}
+```
+
+MXC does not grant `privateNetworkClientServer` for this path. The proxy is not isolated or authorized by an
+AppContainer identity, so it is intended primarily for development and debugging. Packaged deployments can own the
+port-scoped firewall rule in the package; unpackaged deployments require an installer- or administrator-owned rule.
+
 #### HTTP client guidance
 
 Code inside the ProcessContainer should use WinHTTP or an HTTP library that queries the system for proxy information.
@@ -120,11 +144,6 @@ declaration shown in the [schema 0.8 examples](examples/0.8.0-schema.md); its ap
 requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port. See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.
-
-For a non-AppContainer proxy, omit `processContainer.network.allowedProxyPeer` and set
-`ingress.hostLoopback: "allow"`. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged
-deployments require the installer or administrator to own it. These paths do not provide AppContainer isolation or
-proxy-peer identity scoping and are intended primarily for development and debugging.
 
 ### Model 3: externally blocked (most restrictive)
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -137,7 +137,8 @@ MXC grants the client container `privateNetworkClientServer` through `ingress.de
 identity-scoped proxy. The difference is that MXC identifies this proxy only by the configured endpoint and enables
 bidirectional host-loopback access. This is the lowest-enforcement deployment option because common WFP endpoint
 scoping remains, but Windows cannot verify which host process owns that endpoint. It is intended primarily for
-development and debugging and requires an installer- or administrator-owned firewall rule.
+development and debugging and requires an installer- or administrator-owned firewall rule scoped to the proxy
+executable and configured port.
 
 #### HTTP client guidance
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -113,8 +113,9 @@ A packaged AppContainer proxy is recommended. Supported deployment options are:
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged proxy uses the package-owned firewall declaration shown
-in the [schema 0.8 examples](examples/0.8.0-schema.md); a packaged AppContainer also needs AppContainer trust. An
-unpackaged AppContainer proxy requires its installer or administrator to own the equivalent firewall rule. See
+in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
+`uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
+requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port. See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -86,11 +86,15 @@ Model 2 involves two separate processes:
 - **Proxy process:** a caller-created process that is already running outside the MXC client container. It may be
   packaged or unpackaged, with or without AppContainer isolation.
 
-| External proxy | `allowedProxyPeer` | MXC client policy | Proxy binding |
+| External proxy | `allowedProxyPeer` | MXC client policy | Additional proxy identity |
 |---|---|---|---|
-| Packaged proxy | PFN | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
-| Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
-| Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | Host loopback and endpoint |
+| Packaged proxy | PFN | `default: "allow"`; `hostLoopback: "deny"` | Package identity |
+| Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | AppContainer profile |
+| Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
+
+Regardless of proxy type, an enforcing BaseContainer path applies per-container WFP rules that permit the MXC client
+container to connect only to the configured loopback address and port. `allowedProxyPeer` adds proxy identity binding
+on top of that common endpoint enforcement.
 
 All deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
 `privateNetworkClientServer`. This is a Windows capability requirement, not a statement that the proxy connection
@@ -132,10 +136,9 @@ An unpackaged non-AppContainer proxy has no package family or AppContainer profi
 
 MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
 identity-scoped proxy. The difference is that MXC identifies this proxy only by the configured endpoint and enables
-bidirectional host-loopback access. This is the lowest-enforcement deployment option. On an enforcing BaseContainer
-path, WFP still restricts the MXC client container's egress to the configured loopback address and port, but Windows
-cannot verify which host process owns that endpoint. It is intended primarily for development and debugging and
-requires an installer- or administrator-owned firewall rule.
+bidirectional host-loopback access. This is the lowest-enforcement deployment option because common WFP endpoint
+scoping remains, but Windows cannot verify which host process owns that endpoint. It is intended primarily for
+development and debugging and requires an installer- or administrator-owned firewall rule.
 
 #### HTTP client guidance
 
@@ -170,14 +173,15 @@ The caller must:
 
 #### Proxy identity and firewall authorization
 
-An AppContainer proxy is recommended. Supported deployment options are:
+The WFP loopback-address-and-port restriction described above applies to every row. The table compares the additional
+OS enforcement provided for the external proxy. A packaged AppContainer proxy provides the best enforcement.
 
-| Proxy deployment | `allowedProxyPeer` | Enforcement |
+| Proxy deployment | `allowedProxyPeer` | Additional OS enforcement |
 |---|---|---|
-| Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
+| Packaged AppContainer | Package family name | **Best:** AppContainer isolation, package identity, package firewall |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
-| Packaged non-AppContainer | Package family name | Package identity and package firewall rule |
-| Unpackaged non-AppContainer | Omit | Endpoint-only WFP and administrator firewall rule |
+| Packaged non-AppContainer | Package family name | Package identity and package firewall; no AppContainer isolation |
+| Unpackaged non-AppContainer | Omit | **Least:** no proxy identity or isolation; administrator firewall |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -104,20 +104,27 @@ The caller must:
 
 #### Proxy identity and firewall authorization
 
-A packaged AppContainer proxy is recommended. Supported deployment options are:
+An AppContainer proxy is recommended. Supported deployment options are:
 
 | Proxy deployment | `allowedProxyPeer` | Enforcement |
 |---|---|---|
 | Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
+| Packaged non-AppContainer | Omit | Host-loopback access and package firewall rule |
+| Unpackaged non-AppContainer | Omit | Host-loopback access and administrator firewall rule |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
-Firewall's block-inbound-to-non-allowed-apps policy. A packaged proxy uses the package-owned firewall declaration shown
-in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
+Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall
+declaration shown in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
 `uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
 requires its installer or administrator to own an equivalent rule scoped to the proxy executable and configured port. See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.
+
+For a non-AppContainer proxy, omit `processContainer.network.allowedProxyPeer` and set
+`ingress.hostLoopback: "allow"`. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged
+deployments require the installer or administrator to own it. These paths do not provide AppContainer isolation or
+proxy-peer identity scoping and are intended primarily for development and debugging.
 
 ### Model 3: externally blocked (most restrictive)
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -86,18 +86,20 @@ Model 2 involves two separate processes:
 - **Proxy process:** a caller-created process that is already running outside the MXC client container. It may run in an
   AppContainer or without AppContainer isolation.
 
-| Proxy process | `allowedProxyPeer` | Client-container ingress | Proxy binding |
+| External proxy | `allowedProxyPeer` | MXC client policy | Proxy binding |
 |---|---|---|---|
 | AppContainer | Package family/profile | `default: "allow"`; `hostLoopback: "deny"` | Identity and endpoint |
-| Non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "deny"` | Endpoint only |
+| Non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | Host loopback and endpoint |
 
 Both deployments use `ingress.default: "allow"` because ProcessContainer uses it as the capability gate for
 `privateNetworkClientServer`. This is a Windows capability requirement, not a statement that the proxy connection
 enters the MXC client container; the client initiates that connection. The capability is bidirectional, so it also
 permits private-network server traffic.
 
-`ingress.hostLoopback` retains its shared-policy meaning: host-initiated connections entering a listener in the MXC
-client container. The proxy does not require that inbound path, so it remains `"deny"` for both deployments.
+`ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes the AppContainer peer without opening general
+host-loopback access, so that path keeps `hostLoopback: "deny"`. A non-AppContainer proxy has no peer identity, so its
+endpoint requires `hostLoopback: "allow"`. That also permits the MXC client container to reach other host-loopback
+services and permits host-loopback clients to reach listeners in the MXC client container.
 
 #### Contained AppContainer proxy
 
@@ -114,7 +116,7 @@ Packaged and unpackaged non-AppContainer proxies omit the AppContainer peer iden
     "egress": { "default": "deny" },
     "ingress": {
       "default": "allow",
-      "hostLoopback": "deny"
+      "hostLoopback": "allow"
     }
   },
   "runtimeConfig": {
@@ -126,9 +128,9 @@ Packaged and unpackaged non-AppContainer proxies omit the AppContainer peer iden
 
 MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
 AppContainer proxy. The difference is that MXC identifies the proxy only by the configured endpoint, not by an
-AppContainer identity. This weaker option is intended primarily for development and debugging. Packaged deployments
-can own the port-scoped firewall rule in the package; unpackaged deployments require an installer- or
-administrator-owned rule.
+AppContainer identity, and enables bidirectional host-loopback access. This weaker option is intended primarily for
+development and debugging. Packaged deployments can own the port-scoped firewall rule in the package; unpackaged
+deployments require an installer- or administrator-owned rule.
 
 #### HTTP client guidance
 
@@ -148,6 +150,12 @@ apply when `runtimeConfig.networkProxy` is present.
 The proxy endpoint is runtime metadata, not shared network policy. MXC configures the per-container WinHTTP proxy,
 applies WFP endpoint scoping, and grants the private-network capability selected by `ingress.default`.
 
+The two proxy identity paths are mutually exclusive. When
+`allowedProxyPeer` is present, MXC resolves the peer and grants the private-network capability selected by
+`ingress.default`. When it is omitted, MXC uses the configured proxy endpoint without binding that endpoint to an
+AppContainer identity and requires bidirectional host-loopback access. MXC configures the per-container WinHTTP proxy
+for either path.
+
 The caller must:
 
 - create and authorize the proxy;
@@ -163,8 +171,8 @@ An AppContainer proxy is recommended. Supported deployment options are:
 |---|---|---|
 | Packaged AppContainer | Package family name | AppContainer isolation and package firewall rule |
 | Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
-| Packaged non-AppContainer | Omit | Endpoint-only binding and package firewall rule |
-| Unpackaged non-AppContainer | Omit | Endpoint-only binding and administrator firewall rule |
+| Packaged non-AppContainer | Omit | Host-loopback access and package firewall rule |
+| Unpackaged non-AppContainer | Omit | Host-loopback access and administrator firewall rule |
 
 The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
 Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall


### PR DESCRIPTION
## 📖 Description

Adds stacked ProcessContainer proxy deployment guidance for schema 0.8.

- Covers packaged and unpackaged proxies, with and without AppContainer isolation.
- Defines proxy identity, endpoint, `hostLoopback`, WFP, and firewall responsibilities.
- Adds a packaged AppContainer proxy manifest and configuration example.

## 🔗 References

- #811 defines the shared networking and ProcessContainer enforcement contract.

## 🔍 Validation

- Confirmed #814 is stacked directly on #811.
- Confirmed the package manifest XML is well formed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/814)
