### PR TITLE
Add exact 0.6 configuration contract

### DIFF
--- a/src/core/mxc_config_contract/src/lib.rs
+++ b/src/core/mxc_config_contract/src/lib.rs
@@ -19,5 +19,7 @@
 mod registry;
 mod version;
 
+pub mod published;
+
 pub use registry::{descriptor, supported_versions, ContractDescriptor, ContractStatus, CONTRACTS};
 pub use version::{probe_version, ContractVersion, ContractVersion::*, VersionProbeError};

--- a/src/core/mxc_config_contract/src/published/mod.rs
+++ b/src/core/mxc_config_contract/src/published/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Immutable published configuration contracts.
+//!
+//! Once published, contract modules must not be modified. Runtime adaptation
+//! belongs outside this module.
+
+/// The published `0.6.0-alpha` configuration contract.
+pub mod v0_6_0_alpha;

--- a/src/core/mxc_config_contract/src/published/v0_6_0_alpha/mod.rs
+++ b/src/core/mxc_config_contract/src/published/v0_6_0_alpha/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Immutable wire types for the published `0.6.0-alpha` configuration contract.
+//!
+//! These types validate the JSON structure and value constraints of the
+//! published contract. They preserve omitted optional fields for a later
+//! adapter to default and normalize.
+
+mod network;
+mod primitives;
+mod request;
+
+pub use network::{DefaultNetworkPolicy, Network, NetworkEnforcementMode, NetworkProxy};
+pub use primitives::{NonEmptyString, OptionalField, True};
+pub use request::{
+    Containment, Fallback, Filesystem, Lifecycle, Lxc, Process, ProcessContainer,
+    ProcessContainerUi, ProcessContainerUiIsolation, Request, Ui, UiClipboard, Version,
+};

--- a/src/core/mxc_config_contract/src/published/v0_6_0_alpha/network.rs
+++ b/src/core/mxc_config_contract/src/published/v0_6_0_alpha/network.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::num::NonZeroU16;
+
+use super::primitives::{OptionalField, True};
+
+/// The default outbound network policy.
+#[derive(Debug, serde::Deserialize)]
+pub enum DefaultNetworkPolicy {
+    /// Allow outbound network access by default.
+    #[serde(rename = "allow")]
+    Allow,
+    /// Block outbound network access by default.
+    #[serde(rename = "block")]
+    Block,
+}
+
+/// The mechanism used to enforce network policy.
+#[derive(Debug, serde::Deserialize)]
+pub enum NetworkEnforcementMode {
+    /// Enforce policy through containment capabilities.
+    #[serde(rename = "capabilities")]
+    Capabilities,
+    /// Enforce policy through host firewall rules.
+    #[serde(rename = "firewall")]
+    Firewall,
+    /// Enforce policy through both capabilities and firewall rules.
+    #[serde(rename = "both")]
+    Both,
+}
+
+/// One of the proxy configurations accepted by the `0.6.0-alpha` contract.
+#[derive(Debug, serde::Deserialize)]
+pub enum NetworkProxy {
+    /// Connect to an existing proxy on a non-zero localhost TCP port.
+    #[serde(rename = "localhost")]
+    Localhost(NonZeroU16),
+    /// Start and use MXC's built-in test proxy.
+    #[serde(rename = "builtinTestServer")]
+    BuiltinTestServer(True),
+    /// Connect through the supplied proxy URL.
+    #[serde(rename = "url")]
+    Url(String),
+}
+
+/// Network access policy shared by the stable containment backends.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Network {
+    /// Optional default network posture.
+    #[serde(default)]
+    pub default_policy: OptionalField<DefaultNetworkPolicy>,
+    /// Optional network enforcement mechanism.
+    #[serde(default)]
+    pub enforcement_mode: OptionalField<NetworkEnforcementMode>,
+    /// Optional hosts allowed when the default policy blocks access.
+    #[serde(default)]
+    pub allowed_hosts: OptionalField<Vec<String>>,
+    /// Optional hosts blocked when the default policy allows access.
+    #[serde(default)]
+    pub blocked_hosts: OptionalField<Vec<String>>,
+    /// Optional permission to bind and accept local network connections.
+    #[serde(default)]
+    pub allow_local_network: OptionalField<bool>,
+    /// Optional proxy configuration.
+    #[serde(default)]
+    pub proxy: OptionalField<NetworkProxy>,
+}

--- a/src/core/mxc_config_contract/src/published/v0_6_0_alpha/primitives.rs
+++ b/src/core/mxc_config_contract/src/published/v0_6_0_alpha/primitives.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use serde::{de, Deserialize, Deserializer};
+
+/// A marker that deserializes only from the JSON value `true`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct True;
+
+impl<'de> Deserialize<'de> for True {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if bool::deserialize(deserializer)? {
+            Ok(Self)
+        } else {
+            Err(de::Error::custom("expected true"))
+        }
+    }
+}
+
+/// An optional JSON field that distinguishes omission from explicit `null`.
+///
+/// A missing field becomes an empty `OptionalField` through Serde's `default`
+/// handling. A present field must deserialize as `T`; explicit `null` is
+/// therefore rejected unless `T` itself accepts it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionalField<T>(Option<T>);
+
+impl<T> Default for OptionalField<T> {
+    fn default() -> Self {
+        Self(None)
+    }
+}
+
+impl<T> OptionalField<T> {
+    /// Returns a shared reference to the value when the field was present.
+    pub fn as_ref(&self) -> Option<&T> {
+        self.0.as_ref()
+    }
+
+    /// Converts the field into its optional value.
+    pub fn into_option(self) -> Option<T> {
+        self.0
+    }
+}
+
+impl<'de, T> Deserialize<'de> for OptionalField<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        T::deserialize(deserializer).map(|value| Self(Some(value)))
+    }
+}
+
+/// A non-empty string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonEmptyString(String);
+
+impl NonEmptyString {
+    /// Creates a validated string.
+    ///
+    /// Returns an error when `value` is empty.
+    pub fn new(value: String) -> Result<Self, String> {
+        if value.is_empty() {
+            Err("string must not be empty".to_string())
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    /// Returns the validated string as a borrowed string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes the wrapper and returns the validated string.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for NonEmptyString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_empty_string_accepts_valid() {
+        let value = NonEmptyString::new("abc".to_string()).unwrap();
+        assert_eq!(value.as_str(), "abc");
+    }
+
+    #[test]
+    fn non_empty_string_rejects_empty() {
+        let error = NonEmptyString::new(String::new()).unwrap_err();
+        assert_eq!(error, "string must not be empty");
+    }
+}

--- a/src/core/mxc_config_contract/src/published/v0_6_0_alpha/request.rs
+++ b/src/core/mxc_config_contract/src/published/v0_6_0_alpha/request.rs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use super::network::Network;
+use super::primitives::{NonEmptyString, OptionalField};
+
+/// The exact version marker accepted by this contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+pub enum Version {
+    /// The published `0.6.0-alpha` contract.
+    #[serde(rename = "0.6.0-alpha")]
+    V0_6_0Alpha,
+}
+
+/// Stable containment selections available in `0.6.0-alpha`.
+#[derive(Debug, serde::Deserialize)]
+pub enum Containment {
+    /// Select the host's native process-containment backend.
+    #[serde(rename = "process")]
+    Process,
+    /// Select the Windows ProcessContainer backend.
+    #[serde(rename = "processcontainer", alias = "appcontainer")]
+    ProcessContainer,
+    /// Select the Linux LXC backend.
+    #[serde(rename = "lxc")]
+    Lxc,
+    /// Select the Linux Bubblewrap backend.
+    #[serde(rename = "bubblewrap")]
+    Bubblewrap,
+}
+
+/// Container lifecycle settings.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Lifecycle {
+    /// Whether to destroy the container when execution ends.
+    #[serde(default)]
+    pub destroy_on_exit: OptionalField<bool>,
+    /// Whether to preserve applied policy after execution ends.
+    #[serde(default)]
+    pub preserve_policy: OptionalField<bool>,
+}
+
+/// Process execution settings.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Process {
+    /// The non-empty command line to execute.
+    pub command_line: NonEmptyString,
+    /// Optional working directory.
+    #[serde(default)]
+    pub cwd: OptionalField<String>,
+    /// Optional environment entries encoded as `KEY=VALUE` strings.
+    #[serde(default)]
+    pub env: OptionalField<Vec<String>>,
+    /// Optional execution timeout in milliseconds.
+    #[serde(default)]
+    pub timeout: OptionalField<u32>,
+}
+
+/// Filesystem access policy.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Filesystem {
+    /// Optional paths granted read-write access.
+    #[serde(default)]
+    pub readwrite_paths: OptionalField<Vec<String>>,
+    /// Optional paths granted read-only access.
+    #[serde(default)]
+    pub readonly_paths: OptionalField<Vec<String>>,
+    /// Optional paths denied access.
+    #[serde(default)]
+    pub denied_paths: OptionalField<Vec<String>>,
+}
+
+/// Operator consent for containment fallback behavior.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Fallback {
+    /// Whether the runtime may mutate host filesystem DACLs as a fallback.
+    #[serde(default)]
+    pub allow_dacl_mutation: OptionalField<bool>,
+}
+
+/// Clipboard access granted to the contained process.
+#[derive(Debug, serde::Deserialize)]
+pub enum UiClipboard {
+    /// Deny clipboard reads and writes.
+    #[serde(rename = "none")]
+    None,
+    /// Allow clipboard reads.
+    #[serde(rename = "read")]
+    Read,
+    /// Allow clipboard writes.
+    #[serde(rename = "write")]
+    Write,
+    /// Allow clipboard reads and writes.
+    #[serde(rename = "all")]
+    All,
+}
+
+/// Cross-platform user-interface policy.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Ui {
+    /// Whether visible user interface is disabled.
+    #[serde(default)]
+    pub disable: OptionalField<bool>,
+    /// Optional clipboard access level.
+    #[serde(default)]
+    pub clipboard: OptionalField<UiClipboard>,
+    /// Whether keyboard and mouse input injection is allowed.
+    #[serde(default)]
+    pub injection: OptionalField<bool>,
+}
+
+/// Isolation level for ProcessContainer desktop resources.
+#[derive(Debug, serde::Deserialize)]
+pub enum ProcessContainerUiIsolation {
+    /// Isolate the complete container user-interface environment.
+    #[serde(rename = "container")]
+    Container,
+    /// Isolate desktop resources.
+    #[serde(rename = "desktop")]
+    Desktop,
+    /// Isolate user-interface handles.
+    #[serde(rename = "handles")]
+    Handles,
+    /// Isolate user-interface atoms.
+    #[serde(rename = "atoms")]
+    Atoms,
+}
+
+/// ProcessContainer-specific user-interface policy.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProcessContainerUi {
+    /// Optional desktop-resource isolation level.
+    #[serde(default)]
+    pub isolation: OptionalField<ProcessContainerUiIsolation>,
+    /// Whether desktop system control is allowed.
+    #[serde(default)]
+    pub desktop_system_control: OptionalField<bool>,
+    /// Optional system-settings access level.
+    #[serde(default)]
+    pub system_settings: OptionalField<String>,
+    /// Whether Input Method Editor access is allowed.
+    #[serde(default)]
+    pub ime: OptionalField<bool>,
+}
+
+/// ProcessContainer-specific settings.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProcessContainer {
+    /// Whether least-privilege mode is enabled.
+    #[serde(default)]
+    pub least_privilege: OptionalField<bool>,
+    /// Optional AppContainer capability names.
+    #[serde(default)]
+    pub capabilities: OptionalField<Vec<String>>,
+    /// Optional ProcessContainer-specific user-interface policy.
+    #[serde(default)]
+    pub ui: OptionalField<ProcessContainerUi>,
+}
+
+/// Linux LXC distribution settings.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Lxc {
+    /// The Linux distribution name.
+    pub distribution: String,
+    /// The distribution release.
+    pub release: String,
+}
+
+/// A complete one-shot `0.6.0-alpha` configuration request.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Request {
+    /// The exact contract version marker.
+    pub version: Version,
+    /// Optional externally assigned container identifier.
+    #[serde(default)]
+    pub container_id: OptionalField<String>,
+    /// Optional containment selection.
+    #[serde(default)]
+    pub containment: OptionalField<Containment>,
+    /// Optional lifecycle settings.
+    #[serde(default)]
+    pub lifecycle: OptionalField<Lifecycle>,
+    /// The process to execute.
+    pub process: Process,
+    /// Optional filesystem policy.
+    #[serde(default)]
+    pub filesystem: OptionalField<Filesystem>,
+    /// Optional fallback consent.
+    #[serde(default)]
+    pub fallback: OptionalField<Fallback>,
+    /// Optional network policy.
+    #[serde(default)]
+    pub network: OptionalField<Network>,
+    /// Optional cross-platform user-interface policy.
+    #[serde(default)]
+    pub ui: OptionalField<Ui>,
+    /// Optional ProcessContainer settings.
+    ///
+    /// The legacy `appContainer` spelling is accepted as an alias.
+    #[serde(alias = "appContainer", default)]
+    pub process_container: OptionalField<ProcessContainer>,
+    /// Optional LXC distribution settings.
+    #[serde(default)]
+    pub lxc: OptionalField<Lxc>,
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[path = "v0_6_0_alpha/common.rs"]
+mod common;
+#[path = "v0_6_0_alpha/enums.rs"]
+mod enums;
+#[path = "v0_6_0_alpha/fixtures.rs"]
+mod fixtures;
+#[path = "v0_6_0_alpha/network.rs"]
+mod network;
+#[path = "v0_6_0_alpha/optional_fields.rs"]
+mod optional_fields;
+#[path = "v0_6_0_alpha/root.rs"]
+mod root;

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/common.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/common.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use mxc_config_contract::published::v0_6_0_alpha::Request;
+
+pub(crate) fn assert_valid(json: &str) {
+    serde_json::from_str::<Request>(json).unwrap();
+}
+
+pub(crate) fn assert_invalid(json: &str) {
+    assert_invalid_with_context(json, "invalid configuration");
+}
+
+pub(crate) fn assert_invalid_cases<'a>(
+    cases: impl IntoIterator<Item = (&'a str, &'a str, &'a str)>,
+    failure_kind: &str,
+) {
+    for (name, required_fields, invalid_fields) in cases {
+        let json = format!(
+            r#"{{
+                {required_fields},
+                {invalid_fields}
+            }}"#
+        );
+
+        assert_invalid_with_context(&json, &format!("{failure_kind} '{name}'"));
+    }
+}
+
+fn assert_invalid_with_context(json: &str, context: &str) {
+    if let Err(error) = serde_json::from_str::<serde_json::Value>(json) {
+        panic!("{context} used malformed test JSON: {error}");
+    }
+
+    assert!(
+        serde_json::from_str::<Request>(json).is_err(),
+        "{context} was accepted"
+    );
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/enums.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/enums.rs
@@ -1,0 +1,217 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::common::{assert_invalid, assert_valid};
+
+// Enum value tests
+#[test]
+fn accepts_every_containment_value() {
+    for containment in ["process", "processcontainer", "lxc", "bubblewrap"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "containment": "{containment}",
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_invalid_containment_value() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "containment": "invalid",
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn accepts_every_default_network_policy_value() {
+    for default_network_policy in ["allow", "block"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "network": {{
+                    "defaultPolicy": "{default_network_policy}"
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_invalid_default_network_policy_value() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "network": {
+                "defaultPolicy": "invalid"
+            },
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn accepts_every_network_enforcement_mode_value() {
+    for network_enforcement_mode in ["capabilities", "firewall", "both"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "network": {{
+                    "enforcementMode": "{network_enforcement_mode}"
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_invalid_network_enforcement_mode_value() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "network": {
+                "enforcementMode": "invalid"
+            },
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn accepts_every_ui_clipboard_value() {
+    for ui_clipboard in ["none", "read", "write", "all"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "ui": {{
+                    "clipboard": "{ui_clipboard}"
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_invalid_ui_clipboard_value() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "ui": {
+                "clipboard": "invalid"
+            },
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn accepts_every_process_container_ui_isolation_value() {
+    for process_container_ui_isolation in ["container", "desktop", "handles", "atoms"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "processContainer": {{
+                    "ui": {{
+                        "isolation": "{process_container_ui_isolation}"
+                    }}
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_invalid_process_container_ui_isolation_value() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "processContainer": {
+                "ui": {
+                    "isolation": "invalid"
+                }
+            },
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+#[ignore = "rolling parser currently accepts Serde's externally tagged object encoding. Design decision needed to determine whether this format should be rejected"]
+fn rejects_object_encoding_for_fieldless_enums() {
+    let cases = [
+        r#"{
+                "version": {"0.6.0-alpha": null},
+                "process": {"commandLine": "echo"}
+            }"#,
+        r#"{
+                "version": "0.6.0-alpha",
+                "containment": {"process": null},
+                "process": {"commandLine": "echo"}
+            }"#,
+        r#"{
+                "version": "0.6.0-alpha",
+                "network": {"defaultPolicy": {"allow": null}},
+                "process": {"commandLine": "echo"}
+            }"#,
+        r#"{
+                "version": "0.6.0-alpha",
+                "network": {"enforcementMode": {"both": null}},
+                "process": {"commandLine": "echo"}
+            }"#,
+        r#"{
+                "version": "0.6.0-alpha",
+                "ui": {"clipboard": {"all": null}},
+                "process": {"commandLine": "echo"}
+            }"#,
+        r#"{
+                "version": "0.6.0-alpha",
+                "processContainer": {
+                    "ui": {"isolation": {"desktop": null}}
+                },
+                "process": {"commandLine": "echo"}
+            }"#,
+    ];
+
+    for case in cases {
+        assert_invalid(case);
+    }
+}
+
+use mxc_config_contract::published::v0_6_0_alpha::{Containment, Request};
+
+#[test]
+fn appcontainer_containment_alias_maps_to_process_container() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "containment": "appcontainer",
+        "process": {
+            "commandLine": "echo"
+        }
+    }"#;
+
+    let request: Request = serde_json::from_str(json).unwrap();
+
+    assert!(matches!(
+        request.containment.as_ref(),
+        Some(Containment::ProcessContainer)
+    ));
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use mxc_config_contract::published::v0_6_0_alpha::Request;
+
+const VALID_FIXTURES: &[(&str, &str)] = &[
+    ("minimal", include_str!("fixtures/valid/minimal.json")),
+    ("complete", include_str!("fixtures/valid/complete.json")),
+    (
+        "empty optional objects",
+        include_str!("fixtures/valid/empty_optional_objects.json"),
+    ),
+    (
+        "appContainer alias",
+        include_str!("fixtures/valid/app_container_alias.json"),
+    ),
+    (
+        "localhost proxy",
+        include_str!("fixtures/valid/proxy_localhost.json"),
+    ),
+    (
+        "built-in proxy",
+        include_str!("fixtures/valid/proxy_builtin.json"),
+    ),
+    ("URL proxy", include_str!("fixtures/valid/proxy_url.json")),
+];
+
+const INVALID_FIXTURES: &[(&str, &str)] = &[
+    (
+        "experimental field",
+        include_str!("fixtures/invalid/experimental.json"),
+    ),
+    (
+        "state-aware request",
+        include_str!("fixtures/invalid/state_aware.json"),
+    ),
+    (
+        "unknown root field",
+        include_str!("fixtures/invalid/unknown_root_field.json"),
+    ),
+    (
+        "unknown nested field",
+        include_str!("fixtures/invalid/unknown_nested_field.json"),
+    ),
+    (
+        "incomplete LXC section",
+        include_str!("fixtures/invalid/incomplete_lxc.json"),
+    ),
+];
+
+#[test]
+fn accepts_valid_fixtures() {
+    for (name, json) in VALID_FIXTURES {
+        serde_json::from_str::<Request>(json)
+            .unwrap_or_else(|error| panic!("valid fixture '{name}' was rejected: {error}"));
+    }
+}
+
+#[test]
+fn rejects_invalid_fixtures() {
+    for (name, json) in INVALID_FIXTURES {
+        assert!(
+            serde_json::from_str::<Request>(json).is_err(),
+            "invalid fixture '{name}' was accepted"
+        );
+    }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/experimental.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/experimental.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo experimental"
+  },
+  "experimental": {
+    "test": {}
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/incomplete_lxc.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/incomplete_lxc.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo lxc"
+  },
+  "lxc": {
+    "distribution": "ubuntu"
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/state_aware.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/state_aware.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.6.0-alpha",
+  "phase": "exec",
+  "sandboxId": "example:12345678",
+  "process": {
+    "commandLine": "echo state-aware"
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/unknown_nested_field.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/unknown_nested_field.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo nested"
+  },
+  "network": {
+    "unknownField": true
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/unknown_root_field.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/invalid/unknown_root_field.json
@@ -1,0 +1,7 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo root"
+  },
+  "unknownField": true
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/app_container_alias.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/app_container_alias.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo alias"
+  },
+  "appContainer": {
+    "leastPrivilege": true,
+    "capabilities": [
+      "internetClient"
+    ]
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/complete.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/complete.json
@@ -1,0 +1,59 @@
+{
+  "version": "0.6.0-alpha",
+  "containerId": "complete-example",
+  "containment": "processcontainer",
+  "lifecycle": {
+    "destroyOnExit": false,
+    "preservePolicy": true
+  },
+  "process": {
+    "commandLine": "echo complete",
+    "cwd": "/work",
+    "env": [
+      "EXAMPLE=value"
+    ],
+    "timeout": 1000
+  },
+  "filesystem": {
+    "readwritePaths": [
+      "/work"
+    ],
+    "readonlyPaths": [
+      "/input"
+    ],
+    "deniedPaths": [
+      "/secret"
+    ]
+  },
+  "fallback": {
+    "allowDaclMutation": false
+  },
+  "network": {
+    "defaultPolicy": "allow",
+    "enforcementMode": "capabilities",
+    "blockedHosts": [
+      "blocked.example"
+    ],
+    "allowLocalNetwork": true,
+    "proxy": {
+      "url": "http://proxy.example:8080"
+    }
+  },
+  "ui": {
+    "disable": false,
+    "clipboard": "read",
+    "injection": true
+  },
+  "processContainer": {
+    "leastPrivilege": true,
+    "capabilities": [
+      "internetClient"
+    ],
+    "ui": {
+      "isolation": "container",
+      "desktopSystemControl": false,
+      "systemSettings": "none",
+      "ime": false
+    }
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/empty_optional_objects.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/empty_optional_objects.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo empty"
+  },
+  "lifecycle": {},
+  "filesystem": {},
+  "fallback": {},
+  "network": {},
+  "ui": {},
+  "processContainer": {
+    "ui": {}
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/minimal.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/minimal.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo hello"
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_builtin.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_builtin.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo proxy"
+  },
+  "network": {
+    "proxy": {
+      "builtinTestServer": true
+    }
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_localhost.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_localhost.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo proxy"
+  },
+  "network": {
+    "proxy": {
+      "localhost": 8080
+    }
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_url.json
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/fixtures/valid/proxy_url.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.6.0-alpha",
+  "process": {
+    "commandLine": "echo proxy"
+  },
+  "network": {
+    "proxy": {
+      "url": "http://proxy.example:8080"
+    }
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/network.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/network.rs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::common::{assert_invalid, assert_valid};
+
+// Network proxy tests
+#[test]
+fn accepts_localhost_proxy_port_boundaries() {
+    for proxy_port in [1, 65535] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "network": {{
+                    "proxy": {{
+                        "localhost": {proxy_port}
+                    }}
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn rejects_localhost_proxy_port_out_of_bounds() {
+    for proxy_port in [0, 65536] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "network": {{
+                    "proxy": {{
+                        "localhost": {proxy_port}
+                    }}
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_invalid(&json);
+    }
+}
+
+#[test]
+fn accepts_builtin_test_server_true() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {
+                "builtinTestServer": true
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn rejects_builtin_test_server_false() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {
+                "builtinTestServer": false
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_builtin_test_server_null() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {
+                "builtinTestServer": null
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_builtin_test_server_non_boolean_values() {
+    for builtin_test_server in ["0", "1", "\"true\"", "\"false\"", "[]", "{}"] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "network": {{
+                    "proxy": {{
+                        "builtinTestServer": {builtin_test_server}
+                    }}
+                }},
+                "process": {{"commandLine": "echo"}}
+            }}"#
+        );
+
+        assert_invalid(&json);
+    }
+}
+
+#[test]
+fn accepts_url_proxy() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {
+                "url": "http://myproxy:8080"
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn rejects_all_combinations_of_proxy_with_multiple_variants() {
+    let builtin_test_server = r#""builtinTestServer": true"#;
+    let localhost = r#""localhost": 8080"#;
+    let url = r#""url": "http://myproxy:8080""#;
+
+    for combo in [
+        format!("{builtin_test_server}, {localhost}"),
+        format!("{builtin_test_server}, {url}"),
+        format!("{localhost}, {url}"),
+        format!("{builtin_test_server}, {localhost}, {url}"),
+    ]
+    .iter()
+    {
+        let json = format!(
+            r#"{{
+        "version": "0.6.0-alpha",
+        "network": {{
+            "proxy": {{ {combo} }}
+        }},
+        "process": {{"commandLine": "echo"}}
+    }}"#,
+        );
+
+        assert_invalid(&json);
+    }
+}
+
+#[test]
+fn rejects_empty_proxy_object() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {}
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_unknown_proxy_field() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "network": {
+            "proxy": {
+                "unknownField": true
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/optional_fields.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/optional_fields.rs
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::common::{assert_invalid_cases, assert_valid};
+use mxc_config_contract::published::v0_6_0_alpha::Request;
+
+#[test]
+fn accepts_empty_optional_objects() {
+    for field in [
+        r#""lifecycle": {}"#,
+        r#""filesystem": {}"#,
+        r#""fallback": {}"#,
+        r#""network": {}"#,
+        r#""ui": {}"#,
+        r#""processContainer": {}"#,
+        r#""processContainer": {"ui": {}}"#,
+    ] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "process": {{"commandLine": "echo"}},
+                {field}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn accepts_empty_optional_array_for_process_env() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {"commandLine": "echo", "env": []}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn accepts_empty_optional_arrays() {
+    for field in [
+        r#""filesystem": {"readwritePaths": []}"#,
+        r#""filesystem": {"readonlyPaths": []}"#,
+        r#""filesystem": {"deniedPaths": []}"#,
+        r#""network": {"allowedHosts": []}"#,
+        r#""network": {"blockedHosts": []}"#,
+        r#""processContainer": {"capabilities": []}"#,
+    ] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "process": {{"commandLine": "echo"}},
+                {field}
+            }}"#
+        );
+
+        assert_valid(&json);
+    }
+}
+
+#[test]
+fn optional_fields_may_be_absent() {
+    let json = r#"{
+            "version": "0.6.0-alpha",
+            "process": {"commandLine": "echo"}
+        }"#;
+
+    serde_json::from_str::<Request>(json).unwrap();
+}
+
+#[test]
+fn optional_fields_reject_null() {
+    let version = r#""version": "0.6.0-alpha""#;
+    let process = r#""process": {"commandLine": "echo"}"#;
+    let version_and_process = format!("{version}, {process}");
+
+    assert_invalid_cases(
+        [
+            (
+                "containerId",
+                version_and_process.as_str(),
+                r#""containerId": null"#,
+            ),
+            (
+                "containment",
+                version_and_process.as_str(),
+                r#""containment": null"#,
+            ),
+            (
+                "lifecycle",
+                version_and_process.as_str(),
+                r#""lifecycle": null"#,
+            ),
+            (
+                "filesystem",
+                version_and_process.as_str(),
+                r#""filesystem": null"#,
+            ),
+            (
+                "fallback",
+                version_and_process.as_str(),
+                r#""fallback": null"#,
+            ),
+            (
+                "network",
+                version_and_process.as_str(),
+                r#""network": null"#,
+            ),
+            ("ui", version_and_process.as_str(), r#""ui": null"#),
+            (
+                "processContainer",
+                version_and_process.as_str(),
+                r#""processContainer": null"#,
+            ),
+            (
+                "appContainer",
+                version_and_process.as_str(),
+                r#""appContainer": null"#,
+            ),
+            ("lxc", version_and_process.as_str(), r#""lxc": null"#),
+            (
+                "lifecycle.destroyOnExit",
+                version_and_process.as_str(),
+                r#""lifecycle": {"destroyOnExit": null}"#,
+            ),
+            (
+                "lifecycle.preservePolicy",
+                version_and_process.as_str(),
+                r#""lifecycle": {"preservePolicy": null}"#,
+            ),
+            (
+                "process.cwd",
+                version,
+                r#""process": {"commandLine": "echo", "cwd": null}"#,
+            ),
+            (
+                "process.env",
+                version,
+                r#""process": {"commandLine": "echo", "env": null}"#,
+            ),
+            (
+                "process.timeout",
+                version,
+                r#""process": {"commandLine": "echo", "timeout": null}"#,
+            ),
+            (
+                "filesystem.readwritePaths",
+                version_and_process.as_str(),
+                r#""filesystem": {"readwritePaths": null}"#,
+            ),
+            (
+                "filesystem.readonlyPaths",
+                version_and_process.as_str(),
+                r#""filesystem": {"readonlyPaths": null}"#,
+            ),
+            (
+                "filesystem.deniedPaths",
+                version_and_process.as_str(),
+                r#""filesystem": {"deniedPaths": null}"#,
+            ),
+            (
+                "fallback.allowDaclMutation",
+                version_and_process.as_str(),
+                r#""fallback": {"allowDaclMutation": null}"#,
+            ),
+            (
+                "network.defaultPolicy",
+                version_and_process.as_str(),
+                r#""network": {"defaultPolicy": null}"#,
+            ),
+            (
+                "network.enforcementMode",
+                version_and_process.as_str(),
+                r#""network": {"enforcementMode": null}"#,
+            ),
+            (
+                "network.allowedHosts",
+                version_and_process.as_str(),
+                r#""network": {"allowedHosts": null}"#,
+            ),
+            (
+                "network.blockedHosts",
+                version_and_process.as_str(),
+                r#""network": {"blockedHosts": null}"#,
+            ),
+            (
+                "network.allowLocalNetwork",
+                version_and_process.as_str(),
+                r#""network": {"allowLocalNetwork": null}"#,
+            ),
+            (
+                "network.proxy",
+                version_and_process.as_str(),
+                r#""network": {"proxy": null}"#,
+            ),
+            (
+                "ui.disable",
+                version_and_process.as_str(),
+                r#""ui": {"disable": null}"#,
+            ),
+            (
+                "ui.clipboard",
+                version_and_process.as_str(),
+                r#""ui": {"clipboard": null}"#,
+            ),
+            (
+                "ui.injection",
+                version_and_process.as_str(),
+                r#""ui": {"injection": null}"#,
+            ),
+            (
+                "processContainer.leastPrivilege",
+                version_and_process.as_str(),
+                r#""processContainer": {"leastPrivilege": null}"#,
+            ),
+            (
+                "processContainer.capabilities",
+                version_and_process.as_str(),
+                r#""processContainer": {"capabilities": null}"#,
+            ),
+            (
+                "processContainer.ui",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": null}"#,
+            ),
+            (
+                "processContainer.ui.isolation",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": {"isolation": null}}"#,
+            ),
+            (
+                "processContainer.ui.desktopSystemControl",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": {"desktopSystemControl": null}}"#,
+            ),
+            (
+                "processContainer.ui.systemSettings",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": {"systemSettings": null}}"#,
+            ),
+            (
+                "processContainer.ui.ime",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": {"ime": null}}"#,
+            ),
+        ],
+        "null optional field",
+    );
+}

--- a/src/core/mxc_config_contract/tests/v0_6_0_alpha/root.rs
+++ b/src/core/mxc_config_contract/tests/v0_6_0_alpha/root.rs
@@ -1,0 +1,518 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::common::{assert_invalid, assert_invalid_cases, assert_valid};
+
+// Root object tests
+#[test]
+fn rejects_unknown_root_field() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": {"commandLine": "echo"},
+            "unknownField": true
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_duplicate_root_fields() {
+    let version = r#""version": "0.6.0-alpha""#;
+    let process = r#""process": {"commandLine": "echo"}"#;
+    let version_and_process = format!("{version}, {process}");
+
+    assert_invalid_cases(
+        [
+            (
+                "version",
+                process,
+                r#""version": "0.6.0-alpha", "version": "0.6.0-alpha""#,
+            ),
+            (
+                "containerId",
+                version_and_process.as_str(),
+                r#""containerId": "first", "containerId": "second""#,
+            ),
+            (
+                "containment",
+                version_and_process.as_str(),
+                r#""containment": "process", "containment": "processcontainer""#,
+            ),
+            (
+                "lifecycle",
+                version_and_process.as_str(),
+                r#""lifecycle": {"destroyOnExit": true}, "lifecycle": {"preservePolicy": false}"#,
+            ),
+            (
+                "process",
+                version,
+                r#""process": {"commandLine": "echo"}, "process": {"commandLine": "echo again"}"#,
+            ),
+            (
+                "filesystem",
+                version_and_process.as_str(),
+                r#""filesystem": {"readonlyPaths": ["/first"]}, "filesystem": {"readonlyPaths": ["/second"]}"#,
+            ),
+            (
+                "fallback",
+                version_and_process.as_str(),
+                r#""fallback": {"allowDaclMutation": true}, "fallback": {"allowDaclMutation": false}"#,
+            ),
+            (
+                "network",
+                version_and_process.as_str(),
+                r#""network": {"defaultPolicy": "allow"}, "network": {"defaultPolicy": "block"}"#,
+            ),
+            (
+                "ui",
+                version_and_process.as_str(),
+                r#""ui": {"disable": true}, "ui": {"disable": false}"#,
+            ),
+            (
+                "processContainer",
+                version_and_process.as_str(),
+                r#""processContainer": {"leastPrivilege": true}, "processContainer": {"leastPrivilege": false}"#,
+            ),
+            (
+                "lxc",
+                version_and_process.as_str(),
+                r#""lxc": {"distribution": "ubuntu", "release": "20.04"}, "lxc": {"distribution": "alpine", "release": "3.20"}"#,
+            ),
+        ],
+        "duplicate root field",
+    );
+}
+
+#[test]
+fn rejects_unknown_nested_fields() {
+    let version = r#""version": "0.6.0-alpha""#;
+    let process = r#""process": {"commandLine": "echo"}"#;
+    let version_and_process = format!("{version}, {process}");
+
+    assert_invalid_cases(
+        [
+            (
+                "lifecycle",
+                version_and_process.as_str(),
+                r#""lifecycle": {"unknownField": true}"#,
+            ),
+            (
+                "process",
+                version,
+                r#""process": {"commandLine": "echo", "unknownField": true}"#,
+            ),
+            (
+                "filesystem",
+                version_and_process.as_str(),
+                r#""filesystem": {"unknownField": true}"#,
+            ),
+            (
+                "fallback",
+                version_and_process.as_str(),
+                r#""fallback": {"unknownField": true}"#,
+            ),
+            (
+                "network",
+                version_and_process.as_str(),
+                r#""network": {"unknownField": true}"#,
+            ),
+            (
+                "ui",
+                version_and_process.as_str(),
+                r#""ui": {"unknownField": true}"#,
+            ),
+            (
+                "processContainer",
+                version_and_process.as_str(),
+                r#""processContainer": {"unknownField": true}"#,
+            ),
+            (
+                "processContainer.ui",
+                version_and_process.as_str(),
+                r#""processContainer": {"ui": {"unknownField": true}}"#,
+            ),
+            (
+                "lxc",
+                version_and_process.as_str(),
+                r#""lxc": {"distribution": "ubuntu", "release": "20.04", "unknownField": true}"#,
+            ),
+        ],
+        "unknown field in nested object",
+    );
+}
+
+#[test]
+fn rejects_duplicate_nested_field() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": {
+                "commandLine": "echo",
+                "commandLine": "echo again"
+            }
+        }"#,
+    );
+}
+
+// Version field tests
+#[test]
+fn rejects_missing_version() {
+    assert_invalid(
+        r#"{
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_duplicate_version() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "version": "0.6.0-alpha",
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_invalid_version() {
+    assert_invalid(
+        r#"{
+            "version": "invalid",
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_non_exact_version() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0",
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_non_string_version() {
+    assert_invalid(
+        r#"{
+            "version": 0.6,
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_null_version() {
+    assert_invalid(
+        r#"{
+            "version": null,
+            "process": {"commandLine": "echo"}
+        }"#,
+    );
+}
+
+// Required field tests
+#[test]
+fn rejects_missing_process() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha"
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_null_process() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": null
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_missing_process_command_line() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": {}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_null_process_command_line() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": {"commandLine": null}
+        }"#,
+    );
+}
+
+#[test]
+fn rejects_empty_process_command_line() {
+    assert_invalid(
+        r#"{
+            "version": "0.6.0-alpha",
+            "process": {"commandLine": ""}
+        }"#,
+    );
+}
+
+// processcontainer and appcontainer tests
+#[test]
+fn accepts_process_container() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "processContainer": {
+            "ui": {
+                "isolation": "container"
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn accepts_app_container_alias() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "appContainer": {
+            "ui": {
+                "isolation": "container"
+            }
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn rejects_process_container_and_app_container_alias_together() {
+    let json = r#"{
+            "version": "0.6.0-alpha",
+            "processContainer": {
+                "ui": {
+                    "isolation": "container"
+                }
+            },
+            "appContainer": {
+                "ui": {
+                    "isolation": "container"
+                }
+            },
+            "process": {"commandLine": "echo"}
+        }"#;
+
+    assert_invalid(json);
+}
+
+// Numerics and collections
+#[test]
+fn rejects_negative_process_timeout() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo",
+            "timeout": -1
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_process_timeout_above_u32() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo",
+            "timeout": 4294967296
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_non_string_process_env_items() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo",
+            "env": ["A=1", 123]
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_non_string_filesystem_read_only_path_items() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo"
+        },
+        "filesystem": {
+            "readonlyPaths": [123]
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_non_string_filesystem_read_write_path_items() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo"
+        },
+        "filesystem": {
+            "readwritePaths": [123]
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_non_string_filesystem_denied_path_items() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {
+            "commandLine": "echo"
+        },
+        "filesystem": {
+            "deniedPaths": [123]
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_non_string_process_container_capabilities() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "processContainer": {
+            "capabilities": [123]
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+// Lxc tests
+#[test]
+fn accepts_lxc() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "lxc": {
+            "distribution": "ubuntu",
+            "release": "20.04"
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_valid(json);
+}
+
+#[test]
+fn rejects_lxc_missing_distribution() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "lxc": {
+            "release": "20.04"
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_lxc_missing_release() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "lxc": {
+            "distribution": "ubuntu"
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_lxc_null_distribution() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "lxc": {
+            "distribution": null,
+            "release": "20.04"
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+#[test]
+fn rejects_lxc_null_release() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "lxc": {
+            "distribution": "ubuntu",
+            "release": null
+        },
+        "process": {"commandLine": "echo"}
+    }"#;
+
+    assert_invalid(json);
+}
+
+// Experimental tests
+#[test]
+fn rejects_experimental_field() {
+    let json = r#"{
+        "version": "0.6.0-alpha",
+        "process": {"commandLine": "echo"},
+        "experimental": {
+            "someField": true
+        }
+    }"#;
+
+    assert_invalid(json);
+}
+
+// State-aware tests
+#[test]
+fn rejects_state_aware_fields() {
+    for field in [
+        r#""phase": "somePhase""#,
+        r#""sandboxId": "someId""#,
+        r#""correlationVector": "someVector""#,
+    ] {
+        let json = format!(
+            r#"{{
+                "version": "0.6.0-alpha",
+                "process": {{"commandLine": "echo"}},
+                {field}
+            }}"#
+        );
+
+        assert_invalid(&json);
+    }
+}


### PR DESCRIPTION
This PR adds an immutable Rust wire contract for exact 0.6.0-alpha MXC configurations.

Details

* Defines recursively closed, version-specific request, policy, and proxy types.
* Preserves absent-versus-null distinctions and enforces schema value constraints during deserialization.
* Adds representative fixtures and table-driven structural validation tests, with object-form enum rejection ignored pending a compatibility decision.

Tests

* `cargo fmt --all -- --check`
* `cargo clippy -p mxc_config_contract --all-targets -- -D warnings`
* `cargo test -p mxc_config_contract` (78 passed, 1 ignored)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/816)