### PR TITLE
Relay live exec pipes to executor stdio

### DIFF
--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -241,6 +241,7 @@ pub trait StatefulSandboxBackend {
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
+        consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError>;
 
     fn stop(
@@ -357,7 +358,7 @@ const r = await execInSandboxAsync(
 ```rust
 // Parser populates request.script_code = "echo hello" from the wire-format `process`
 // block (same path as one-shot). The dispatcher then calls:
-backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None)
+backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecConsumer::Executor)
 // returns Ok(ExecHandle { stdout, stderr, stdin, waiter, terminator })
 ```
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -945,7 +945,7 @@ const r = await execInSandboxAsync(
 // Parser populates request.script_code = "echo hello", request.script_timeout =
 // 5000 from the wire-format `process` block (same path as one-shot). The
 // dispatcher then calls:
-backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None)
+backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecConsumer::Executor)
 // returns Ok(ExecHandle { ... pipe handles + waiter ... })
 ```
 
@@ -1212,11 +1212,28 @@ pub trait StatefulSandboxBackend {
     }
 
     /// Required. Must execute the workload and return a handle.
+    ///
+    /// `consumer` is the caller's intent and is authoritative. This is
+    /// deliberately not `StdioMode`: that enum's `Inherit` means the OS hands
+    /// the child the executor's own handles, which no state-aware backend can
+    /// do, since the workload runs inside an isolation session, a VM, or
+    /// behind an SDK callback. What matters here is who is on the other end,
+    /// because that fixes the topology of the returned streams.
+    ///
+    /// `Library` (the library / FFI streaming path) means the caller drives
+    /// the streams itself, so an implementation must surface separate raw pipe
+    /// handles, allocate no pseudo-console, and not touch the host console.
+    /// `Executor` (the executor path) means the handle is relayed to the
+    /// binary's own stdio, where a pseudo-console is legitimate — and where
+    /// stderr may therefore arrive merged into stdout, leaving
+    /// `ExecHandle::stderr` null. A backend that probes the host to decide how
+    /// to wire stdio must confine that probe to the `Executor` case.
     fn exec(
         &mut self,
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
+        consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError>;
 
     /// Optional. Default returns success with no metadata.
@@ -1311,7 +1328,8 @@ pub struct ExecHandle {
     pub stdout: PipeHandle,
     /// Stderr pipe handle from the running process. Executor relays to its own stderr.
     pub stderr: PipeHandle,
-    /// Stdin pipe handle. Executor relays from its own stdin.
+    /// Stdin pipe handle. Not consumed by the executor relay, which forwards
+    /// no input; the streaming path hands it to an in-process caller.
     pub stdin: PipeHandle,
     /// Function to wait for exit; returns the exit code.
     pub waiter: Box<dyn FnOnce() -> Result<i32, MxcError> + Send>,
@@ -1334,8 +1352,10 @@ dispatcher from `experimental.<backend>.<phase>` and passed as the `config` para
 `MxcError` is the typed Rust equivalent of its SDK counterpart. `PipeHandle` is a
 platform-abstracted pipe-handle wrapper — a kernel `HANDLE` on Windows, a file
 descriptor on Linux. The executor's outer driver reads from `ExecHandle.stdout` /
-`stderr` and writes to `stdin`, awaits exit via `waiter`, and calls `terminator` on
-cancellation signals.
+`stderr`, awaits exit via `waiter`, and calls `terminator` to tear the exec down.
+It does **not** write to `stdin`: forwarding input needs an ownership model
+`ExecHandle` does not have yet, since a pipe reaches EOF only once every write
+handle is closed and the relay can only duplicate the backend's handle.
 
 `mint_random_token()` is a small helper in `wxc_common` that produces a short hex string
 (mirroring the SDK's `randomBytes`-based id minting in `sandbox.ts`); it is used by the
@@ -1466,9 +1486,9 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
             validate_exec_common(request)?;
             backend.validate_exec(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let handle = backend.exec(sandbox_id, request, config)?;
+            let handle = backend.exec(sandbox_id, request, config, ExecConsumer::Executor)?;
             // relay_exec_to_stdio streams the script's pipes to the executor's
-            // stdout/stderr/stdin live, awaits exit, and returns the script's exit code.
+            // stdout/stderr live, awaits exit, and returns the script's exit code.
             let exit_code = relay_exec_to_stdio(handle)?;
             Ok(DispatchOutcome::ExecCompleted { exit_code })
         }

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -13,7 +13,8 @@ use serde::Serialize;
 use wxc_common::models::{ExecutionRequest, IsolationSessionProvisionConfig};
 use wxc_common::mxc_error::MxcError;
 use wxc_common::state_aware_backend::{
-    DeprovisionResult, ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
+    DeprovisionResult, ExecConsumer, ExecHandle, ProvisionResult, StartResult,
+    StatefulSandboxBackend, StopResult,
 };
 
 use windows::Win32::Foundation::HANDLE;
@@ -222,6 +223,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
+        _consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError> {
         let agent_user_name = extract_agent_user_name(sandbox_id)?;
         let manager =

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -18,7 +18,8 @@ use wxc_common::mxc_error::MxcError;
 use wxc_common::process_util::resolve_sibling_binary;
 use wxc_common::script_runner::get_timeout_milliseconds;
 use wxc_common::state_aware_backend::{
-    DeprovisionResult, ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
+    DeprovisionResult, ExecConsumer, ExecHandle, ProvisionResult, StartResult,
+    StatefulSandboxBackend, StopResult,
 };
 
 use windows::Win32::Foundation::HANDLE;
@@ -755,6 +756,7 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
+        _consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError> {
         extract_token(sandbox_id)?;
 
@@ -1273,7 +1275,12 @@ mod tests {
     fn exec_without_live_daemon_is_not_started() {
         let mut backend = WindowsSandboxRunner::new();
         let err = backend
-            .exec("wsb:abcd1234", &ExecutionRequest::default(), None)
+            .exec(
+                "wsb:abcd1234",
+                &ExecutionRequest::default(),
+                None,
+                ExecConsumer::Executor,
+            )
             .unwrap_err();
         // With no daemon holding the sandbox, exec reports NotStarted rather
         // than running anything.
@@ -1284,7 +1291,12 @@ mod tests {
     fn exec_rejects_malformed_id_first() {
         let mut backend = WindowsSandboxRunner::new();
         let err = backend
-            .exec("iso:abc", &ExecutionRequest::default(), None)
+            .exec(
+                "iso:abc",
+                &ExecutionRequest::default(),
+                None,
+                ExecConsumer::Executor,
+            )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedId);
     }
@@ -1496,7 +1508,12 @@ mod tests {
         let _g = StateAwareRootGuard::new();
         let mut backend = WindowsSandboxRunner::new();
         let err = backend
-            .exec("wsb:cccc3333", &ExecutionRequest::default(), None)
+            .exec(
+                "wsb:cccc3333",
+                &ExecutionRequest::default(),
+                None,
+                ExecConsumer::Executor,
+            )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::NotStarted);
     }

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -19,7 +19,7 @@ use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{ContainerPolicy, ExecutionRequest, NetworkPolicy};
 use wxc_common::mxc_error::MxcError;
 use wxc_common::state_aware_backend::{
-    null_pipe_handle, DeprovisionResult, ExecHandle, ProvisionResult, StartResult,
+    null_pipe_handle, DeprovisionResult, ExecConsumer, ExecHandle, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
 use wxc_common::wire::WslcProvisionPhase;
@@ -137,6 +137,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
+        _consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError> {
         // Cooperative proxy: inject HTTP(S)_PROXY (and scrub caller-supplied
         // proxy vars). `exec_proxy_url` yields the routable URL only when the

--- a/src/core/mxc_engine/src/state_aware.rs
+++ b/src/core/mxc_engine/src/state_aware.rs
@@ -114,7 +114,7 @@ pub fn exec_state_aware(
             let handle =
                 wxc_common::state_aware_dispatch::dispatch_state_aware_exec(&mut runner, parsed)?;
             Ok(Box::new(
-                wxc_common::exec_stream::ExecSandboxProcess::from_exec_handle(handle),
+                wxc_common::exec_stream::ExecSandboxProcess::from_exec_handle(handle)?,
             ))
         }
         #[cfg(all(target_os = "windows", feature = "wslc"))]
@@ -123,7 +123,7 @@ pub fn exec_state_aware(
             let handle =
                 wxc_common::state_aware_dispatch::dispatch_state_aware_exec(&mut runner, parsed)?;
             Ok(Box::new(
-                wxc_common::exec_stream::ExecSandboxProcess::from_exec_handle(handle),
+                wxc_common::exec_stream::ExecSandboxProcess::from_exec_handle(handle)?,
             ))
         }
         // Feature-off build: keep the documented `backend_unavailable` contract

--- a/src/core/wxc_common/src/exec_stream.rs
+++ b/src/core/wxc_common/src/exec_stream.rs
@@ -30,11 +30,19 @@
 //! [`try_clone_to_owned`]: std::os::windows::io::BorrowedHandle::try_clone_to_owned
 
 use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use crate::mxc_error::MxcError;
 use crate::sandbox_process::SandboxProcess;
 use crate::state_aware_backend::{ExecHandle, PipeHandle};
+
+/// An [`ExecHandle`]'s streams, once classified.
+struct PreparedStreams {
+    stdout: Option<Box<dyn Read + Send>>,
+    stderr: Option<Box<dyn Read + Send>>,
+    stdin: Option<Box<dyn Write + Send>>,
+}
 
 /// A streaming [`SandboxProcess`] backed by a state-aware [`ExecHandle`].
 pub struct ExecSandboxProcess {
@@ -56,7 +64,13 @@ pub struct ExecSandboxProcess {
 impl ExecSandboxProcess {
     /// Wrap an [`ExecHandle`] as a streaming process handle. Spawns a background
     /// thread to run the handle's `waiter` so exit can be polled.
-    pub fn from_exec_handle(handle: ExecHandle) -> Self {
+    ///
+    /// Fails rather than degrading if a stream the backend *named* cannot be
+    /// duplicated, or if the waiter thread cannot start: the caller would
+    /// otherwise be handed a process whose live output nobody drains, which
+    /// blocks the child once its pipe fills. Either way the exec that was
+    /// already started is terminated rather than orphaned.
+    pub fn from_exec_handle(handle: ExecHandle) -> Result<Self, MxcError> {
         let ExecHandle {
             stdout,
             stderr,
@@ -65,16 +79,82 @@ impl ExecSandboxProcess {
             terminator,
         } = handle;
 
-        let waiter_thread = std::thread::spawn(waiter);
+        let streams = wrap_read_checked(stdout, "stdout").and_then(|out| {
+            let err = wrap_read_checked(stderr, "stderr")?;
+            let input = wrap_write_checked(stdin, "stdin")?;
+            Ok(PreparedStreams {
+                stdout: out,
+                stderr: err,
+                stdin: input,
+            })
+        });
 
-        Self {
-            stdout: wrap_read(stdout),
-            stderr: wrap_read(stderr),
-            stdin: wrap_write(stdin),
+        Self::from_prepared_streams(streams, waiter, terminator)
+    }
+
+    /// Build the handle from already-classified streams.
+    ///
+    /// Split from [`from_exec_handle`](Self::from_exec_handle) so the setup
+    /// failure path is reachable in a test without fabricating an invalid OS
+    /// handle: a caller can hand this an `Err` directly and observe the exec
+    /// being terminated and then reaped.
+    fn from_prepared_streams(
+        streams: Result<PreparedStreams, MxcError>,
+        waiter: Box<dyn FnOnce() -> Result<i32, MxcError> + Send>,
+        terminator: Box<dyn FnOnce() + Send>,
+    ) -> Result<Self, MxcError> {
+        let PreparedStreams {
+            stdout,
+            stderr,
+            stdin,
+        } = match streams {
+            Ok(streams) => streams,
+            Err(error) => {
+                // Terminating is a request, not a reaping: run the waiter so
+                // the backend's completion work happens and no zombie is left
+                // behind. Its outcome is discarded so the setup error survives.
+                terminator();
+                let _ = waiter();
+                return Err(error);
+            }
+        };
+
+        // The waiter is handed to the thread through a shared slot rather than
+        // moved directly, because `Builder::spawn` consumes and drops the
+        // closure when the OS refuses a thread -- leaving no way to reap the
+        // exec we are about to terminate. On failure the slot still holds it.
+        let waiter_slot = Arc::new(Mutex::new(Some(waiter)));
+        let thread_slot = Arc::clone(&waiter_slot);
+        let spawned = std::thread::Builder::new()
+            .name("mxc-exec-waiter".to_string())
+            .spawn(
+                move || match thread_slot.lock().ok().and_then(|mut w| w.take()) {
+                    Some(waiter) => waiter(),
+                    None => Err(MxcError::backend_error("exec waiter was already consumed")),
+                },
+            );
+
+        let waiter_thread = match spawned {
+            Ok(thread) => thread,
+            Err(error) => {
+                terminator();
+                if let Some(waiter) = waiter_slot.lock().ok().and_then(|mut w| w.take()) {
+                    let _ = waiter();
+                }
+                return Err(MxcError::backend_error(format!(
+                    "failed to start the exec waiter thread: {error}"
+                )));
+            }
+        };
+
+        Ok(Self {
+            stdout,
+            stderr,
+            stdin,
             waiter: Some(waiter_thread),
             terminator: Some(terminator),
             exit: None,
-        }
+        })
     }
 
     /// Join the waiter thread, caching and returning its exit code.
@@ -165,13 +245,27 @@ fn wrap_write(handle: PipeHandle) -> Option<Box<dyn Write + Send>> {
     dup_handle_to_file(handle).map(|f| Box::new(f) as Box<dyn Write + Send>)
 }
 
+/// Whether a [`PipeHandle`] is the null sentinel, i.e. a stream the backend
+/// does not expose. Distinct from a *valid-looking* handle that cannot be
+/// duplicated, which is a failure rather than an absence.
+#[cfg(target_os = "windows")]
+pub(crate) fn is_null_pipe(handle: PipeHandle) -> bool {
+    handle.0.is_null()
+}
+
+/// Whether a [`PipeHandle`] is the null sentinel — see the Windows variant.
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn is_null_pipe(handle: PipeHandle) -> bool {
+    handle < 0
+}
+
 /// Duplicate a non-null Windows pipe `HANDLE` into an owned [`File`], leaving
 /// the caller's original handle untouched. Returns `None` for a null handle or
 /// if duplication fails.
 #[cfg(target_os = "windows")]
 fn dup_handle_to_file(handle: PipeHandle) -> Option<std::fs::File> {
     use std::os::windows::io::BorrowedHandle;
-    if handle.0.is_null() {
+    if is_null_pipe(handle) {
         return None;
     }
     // SAFETY: a non-null exec pipe handle is valid for the borrow; we only
@@ -190,13 +284,52 @@ fn wrap_write(handle: PipeHandle) -> Option<Box<dyn Write + Send>> {
     dup_fd_to_file(handle).map(|f| Box::new(f) as Box<dyn Write + Send>)
 }
 
+/// Decide what a wrap attempt means, given whether the handle was the null
+/// sentinel. Split out from the OS call so the policy can be tested directly,
+/// without fabricating an invalid handle to force a duplication failure.
+///
+/// - null handle -> `Ok(None)`: the backend does not expose this stream.
+/// - non-null, wrap succeeded -> `Ok(Some(_))`.
+/// - non-null, wrap failed -> `Err`: the backend named a stream that cannot be
+///   duplicated (handle exhaustion, or a stale handle). Callers must treat this
+///   as fatal, never as absence: nothing would drain that live pipe, so the
+///   child blocks once it fills and its waiter never returns.
+fn classify_stream<T>(
+    is_null: bool,
+    wrap: impl FnOnce() -> Option<T>,
+    stream: &str,
+) -> Result<Option<T>, MxcError> {
+    if is_null {
+        return Ok(None);
+    }
+    wrap().map(Some).ok_or_else(|| {
+        MxcError::backend_error(format!("failed to duplicate the exec {stream} pipe handle"))
+    })
+}
+
+/// Wrap a readable exec pipe, distinguishing *absent* from *failed*.
+pub(crate) fn wrap_read_checked(
+    handle: PipeHandle,
+    stream: &str,
+) -> Result<Option<Box<dyn Read + Send>>, MxcError> {
+    classify_stream(is_null_pipe(handle), || wrap_read(handle), stream)
+}
+
+/// Writable counterpart of [`wrap_read_checked`].
+pub(crate) fn wrap_write_checked(
+    handle: PipeHandle,
+    stream: &str,
+) -> Result<Option<Box<dyn Write + Send>>, MxcError> {
+    classify_stream(is_null_pipe(handle), || wrap_write(handle), stream)
+}
+
 /// Duplicate a non-negative pipe fd into an owned [`File`] (via `dup`), leaving
 /// the caller's original fd untouched. Returns `None` for an invalid fd or if
 /// duplication fails.
 #[cfg(not(target_os = "windows"))]
 fn dup_fd_to_file(handle: PipeHandle) -> Option<std::fs::File> {
     use std::os::fd::BorrowedFd;
-    if handle < 0 {
+    if is_null_pipe(handle) {
         return None;
     }
     // SAFETY: a non-negative exec pipe fd is valid for the borrow; we only
@@ -208,8 +341,92 @@ fn dup_fd_to_file(handle: PipeHandle) -> Option<std::fs::File> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mxc_error::MxcErrorCode;
     use crate::state_aware_backend::null_pipe_handle;
     use std::sync::mpsc;
+
+    /// The null sentinel means "this backend exposes no such stream", and the
+    /// wrap is never even attempted.
+    #[test]
+    fn classify_stream_treats_null_as_absent() {
+        let mut attempted = false;
+        let got: Option<u8> = classify_stream(
+            true,
+            || {
+                attempted = true;
+                None
+            },
+            "stdout",
+        )
+        .expect("a null handle is absence, not failure");
+        assert!(got.is_none());
+        assert!(!attempted, "a null handle must not be duplicated");
+    }
+
+    /// A named stream that wraps successfully is passed through.
+    #[test]
+    fn classify_stream_passes_through_a_successful_wrap() {
+        let got = classify_stream(false, || Some(7u8), "stdout").unwrap();
+        assert_eq!(got, Some(7));
+    }
+
+    /// A stream the backend named but that cannot be duplicated is a setup
+    /// failure, and the exec it refers to has *already started*. It must be
+    /// terminated and then reaped, in that order.
+    ///
+    /// The order is asserted, not just the calls: terminating is a request, so
+    /// running the waiter first would block on a child nobody has asked to
+    /// stop. With no live streams involved, nothing else here would notice the
+    /// two being swapped.
+    #[test]
+    fn from_prepared_streams_terminates_then_reaps_on_setup_failure() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let terminator_tx = tx.clone();
+
+        let result = ExecSandboxProcess::from_prepared_streams(
+            Err(MxcError::backend_error("stdout could not be duplicated")),
+            Box::new(move || {
+                let _ = tx.send("waiter");
+                Ok(0)
+            }),
+            Box::new(move || {
+                let _ = terminator_tx.send("terminator");
+            }),
+        );
+
+        let err = result
+            .err()
+            .expect("a named-but-undupable stream must fail the constructor");
+        assert!(
+            err.message.contains("could not be duplicated"),
+            "the setup error must survive teardown: {}",
+            err.message
+        );
+        assert_eq!(
+            rx.try_recv().ok(),
+            Some("terminator"),
+            "the exec must be terminated first"
+        );
+        assert_eq!(
+            rx.try_recv().ok(),
+            Some("waiter"),
+            "and then reaped -- terminating alone leaves it unreaped"
+        );
+    }
+
+    /// A named stream that will not wrap is a failure, never absence: nothing
+    /// would drain that live pipe and the child would block once it filled.
+    #[test]
+    fn classify_stream_treats_a_failed_wrap_as_an_error() {
+        let err = classify_stream(false, || None::<u8>, "stderr")
+            .expect_err("a named-but-undupable stream must not be reported as absent");
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+        assert!(
+            err.message.contains("stderr"),
+            "the failing stream should be named: {}",
+            err.message
+        );
+    }
 
     /// An ExecHandle with null pipes (the IsolationSession shape) exposes no
     /// streams and yields the waiter's exit code.
@@ -222,7 +439,7 @@ mod tests {
             waiter: Box::new(|| Ok(7)),
             terminator: Box::new(|| {}),
         };
-        let mut proc = ExecSandboxProcess::from_exec_handle(handle);
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
         assert!(proc.take_stdout().is_none());
         assert!(proc.take_stderr().is_none());
         assert!(proc.take_stdin().is_none());
@@ -247,7 +464,7 @@ mod tests {
                 let _ = tx.send(());
             }),
         };
-        let mut proc = ExecSandboxProcess::from_exec_handle(handle);
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
         proc.kill().unwrap();
         proc.kill().unwrap(); // second kill is a no-op
                               // Exactly one terminator signal.
@@ -296,7 +513,7 @@ mod tests {
             waiter: Box::new(|| Ok(0)),
             terminator: Box::new(|| {}),
         };
-        let mut proc = ExecSandboxProcess::from_exec_handle(handle);
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
         // The adapter duplicated the handle; the test's original can now drop.
         drop(reader);
 
@@ -321,7 +538,7 @@ mod tests {
             waiter: Box::new(|| Ok(0)),
             terminator: Box::new(|| {}),
         };
-        let mut proc = ExecSandboxProcess::from_exec_handle(handle);
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
         drop(writer); // original write end closed; adapter owns a duplicate
 
         {

--- a/src/core/wxc_common/src/state_aware_backend.rs
+++ b/src/core/wxc_common/src/state_aware_backend.rs
@@ -72,11 +72,65 @@ pub struct DeprovisionResult<M> {
     pub metadata: Option<M>,
 }
 
+/// Who will consume an exec's streams — the state-aware counterpart to
+/// [`StdioMode`](crate::sandbox_process::StdioMode).
+///
+/// This is deliberately **not** `StdioMode`. That enum offers `Inherit`,
+/// meaning the OS hands the child the executor's own stdin/stdout/stderr. No
+/// state-aware backend can do that: the workload runs inside an isolation
+/// session, inside a VM, or behind an SDK callback, so its streams always have
+/// to be materialised on this side of the boundary and copied across. For this
+/// contract `Inherit` is not merely ambiguous, it is unimplementable.
+///
+/// What a state-aware backend needs to know is who is on the other end, because
+/// that decides the **topology** of the streams it returns:
+///
+/// * [`Executor`](Self::Executor) — the executor binary relays onto its own
+///   stdio for a human. The backend may allocate a pseudo-console inside the
+///   sandbox when the executor is itself on a TTY. A pseudo-console has a
+///   single output stream, so stderr is then merged into stdout and
+///   [`ExecHandle::stderr`] is null. That is a correct result, not a failure.
+///
+///   Under this variant the relay forwards **no** input, so the backend must
+///   not give the child a stdin pipe whose write end it retains: nothing would
+///   ever write to it or close it, and a workload that reads stdin would block
+///   forever. Give the child a stdin already at EOF, and return a null
+///   [`ExecHandle::stdin`].
+/// * [`Library`](Self::Library) — an in-process caller (the Rust SDK, the FFI)
+///   drives the streams itself. The backend must return separate raw stdout and
+///   stderr pipes, allocate no pseudo-console, and leave the host's console
+///   untouched.
+///
+/// The value is **authoritative**. A backend that probes the host to shape
+/// stdio ("is my stdout a terminal?") may consult that probe only within
+/// `Executor`. Under `Library` the probe is meaningless — an embedded host's
+/// stdout says nothing about the sandbox — and acting on it risks mutating
+/// console state the caller owns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecConsumer {
+    /// The executor binary, relaying the streams to its own stdio.
+    Executor,
+    /// An in-process caller, driving the returned streams itself.
+    Library,
+}
+
 /// Streaming exec handle. The dispatcher relays `stdout` / `stderr` to the
-/// executor's own streams, forwards executor stdin into `stdin`, awaits exit
-/// via `waiter`, and calls `terminator` on cancellation signals. Pipe-handle
-/// ownership stays with the underlying process object; the relay does not
-/// close them.
+/// executor's own streams, awaits exit via `waiter`, and calls `terminator` to
+/// tear the exec down.
+///
+/// # Handle ownership
+///
+/// Ownership of `stdout` and `stderr` stays with the underlying process object:
+/// consumers duplicate them and never close the originals.
+///
+/// `stdin` is **not consumed by the executor relay**, which forwards no input.
+/// The streaming path does hand it to an in-process caller, but with a caveat
+/// that is a known gap rather than a contract: because the handle is duplicated
+/// rather than taken, dropping the writer a caller obtained does not close the
+/// child's stdin, so a workload reading to EOF will not see one. Closing it
+/// needs an ownership model this type does not have yet — a pipe reaches EOF
+/// only once *every* write handle is closed, and nothing here can close the
+/// backend's original.
 pub struct ExecHandle {
     pub stdout: PipeHandle,
     pub stderr: PipeHandle,
@@ -149,11 +203,34 @@ pub trait StatefulSandboxBackend {
     }
 
     /// Required. Executes the workload and returns a streaming handle.
+    ///
+    /// `consumer` carries the **caller's** intent and is authoritative — see
+    /// [`ExecConsumer`] for the full contract, including why this is not
+    /// [`StdioMode`](crate::sandbox_process::StdioMode) and what each variant
+    /// implies for the topology of the returned streams.
+    ///
+    /// In short: [`ExecConsumer::Library`] means an in-process caller drives
+    /// the returned handle, so the backend must surface separate real pipe
+    /// handles and must not touch the host's console;
+    /// [`ExecConsumer::Executor`] means the executor binary is relaying to its
+    /// own stdio, where a pseudo-console is legitimate and stderr may therefore
+    /// arrive merged into stdout.
+    ///
+    /// # Not yet honored
+    ///
+    /// The above states what an implementation must satisfy to be driven
+    /// through the streaming entry points; it is **not** a description of
+    /// current behaviour. No in-tree backend honors `Library` yet: each relays
+    /// internally and returns null handles, and IsolationSession still probes
+    /// the host console whatever the caller asked for. Until a backend surfaces
+    /// real handles, the streaming path yields a process with no streams, so
+    /// treat these backends as executor-path only.
     fn exec(
         &mut self,
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
+        consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError>;
 
     /// Optional. Default returns success with no metadata.
@@ -254,6 +331,7 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
+            _consumer: ExecConsumer,
         ) -> Result<ExecHandle, MxcError> {
             Err(MxcError::backend_error("StubBackend::exec not implemented"))
         }
@@ -335,7 +413,12 @@ mod tests {
         // surface this code rather than aborting the test binary.
         let mut b = StubBackend;
         let err = b
-            .exec("stub:abcd1234", &ExecutionRequest::default(), None)
+            .exec(
+                "stub:abcd1234",
+                &ExecutionRequest::default(),
+                None,
+                ExecConsumer::Executor,
+            )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::BackendError);
     }

--- a/src/core/wxc_common/src/state_aware_dispatch.rs
+++ b/src/core/wxc_common/src/state_aware_dispatch.rs
@@ -16,9 +16,14 @@
 //! `StatefulSandboxBackend` impl. It validates, calls the right phase method,
 //! and wraps the typed result into a wire-format response envelope.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::exec_stream::wrap_read_checked;
 use crate::id::parse_sandbox_id_prefix;
 use crate::models::ContainmentBackend;
 use crate::mxc_error::{MxcError, ResponseEnvelope};
@@ -87,6 +92,8 @@ pub fn dispatch_state_aware_exec<B: StatefulSandboxBackend>(
     let config = parsed.deserialize_config::<B::ExecConfig>(B::BACKEND_KEY, "exec")?;
     validate_exec_common(&request)?;
     backend.validate_exec(&sandbox_id, &request, config.as_ref())?;
+    // The caller drives the returned streams itself, so the backend must
+    // surface real pipes and leave this process's console alone.
     backend.exec(&sandbox_id, &request, config, ExecConsumer::Library)
 }
 
@@ -191,15 +198,299 @@ fn backend_from_prefix(prefix: &str) -> Result<ContainmentBackend, MxcError> {
 
 /// Streams the running process's pipes to executor stdio and waits for exit.
 ///
-/// Backends that perform their own internal relay (e.g. IsolationSession,
-/// which reuses the one-shot path's relay threads) hand back zero pipe
-/// handles plus a waiter closure that yields the already-captured exit code
-/// — this function is a thin call-through in that case. When a backend
-/// surfaces live pipe handles, this function will gain `process_util`-driven
-/// relay threads and a waiter join; that path lands when the first such
-/// backend appears.
+/// Relay threads start **before** the waiter runs: a child that fills its
+/// stdout pipe buffer would otherwise block forever, since nothing would be
+/// draining it while we wait.
+///
+/// - **stdout / stderr** are pumped to this process's own streams and drained
+///   after the waiter returns, so output already in flight is not lost to the
+///   executor exiting first. That drain is time-bounded: see [`drain_pumps`]
+///   for what is given up when a writer outlives the workload.
+/// - **stdin is not forwarded.** `ExecHandle::stdin` is left untouched here.
+///   Forwarding it correctly needs an ownership model this type does not yet
+///   have -- a pipe reaches EOF only once *every* write handle is closed, and
+///   the relay can only borrow-and-duplicate the backend's handle, so neither
+///   side is able to close the child's stdin. It also needs a stop signal, as a
+///   read on the executor's stdin never returns when that stdin is a console or
+///   node-pty handle held open by a parent. IsolationSession's own relay
+///   documents both hazards and solves them with
+///   `create_relay_thread_with_stop`; the generic path will need an equivalent.
+///
+///   Until that exists, a backend under [`ExecConsumer::Executor`] **must not
+///   give the child a stdin pipe whose write end it keeps**. Nothing here writes
+///   to that pipe and nothing can close it, so a workload that reads stdin
+///   blocks forever -- and it does so while this function is inside `waiter()`,
+///   which the drain bound does not cover, hanging the executor with the sandbox
+///   still alive. Wire the child's stdin to something already at EOF instead.
+///
+/// Each stream is written through and flushed as it arrives rather than via
+/// `io::copy`, because Rust's stdout is line-buffered: a progress indicator
+/// that emits partial lines (or bare `\r`) must still appear progressively.
+///
+/// **Backend contract:** the backend must not retain its own copy of the
+/// child's *write* ends. The pumps finish on EOF, which the OS reports only
+/// once every writer handle is closed; a retained duplicate keeps a pump alive
+/// until the drain gives up on it, costing that delay and the output still
+/// buffered behind it.
+///
+/// A backend that relays internally hands back null pipe handles plus a waiter
+/// that yields the already-captured exit code. No wrapping succeeds, no thread
+/// is spawned, and this reduces to calling the waiter — the original
+/// call-through behaviour, unchanged.
+///
+/// Deliberately not built on IsolationSession's `pipe_relay`, which solves the
+/// same problem for that backend: it lives in a `backends/*` crate that
+/// `wxc_common` must not depend on, it is Windows-only (raw `HANDLE`s and
+/// `CreateThread`), and it is `unsafe`. This dispatcher is cross-platform and
+/// stays in safe `std::io`. Its per-write flush is the same conclusion that
+/// relay reached independently.
 fn relay_exec_to_stdio(handle: ExecHandle) -> Result<i32, MxcError> {
-    (handle.waiter)()
+    let ExecHandle {
+        stdout,
+        stderr,
+        stdin: _,
+        waiter,
+        terminator,
+    } = handle;
+
+    // Classify every stream before committing to anything. A null handle is an
+    // absent stream and is fine; a handle the backend named but that cannot be
+    // duplicated is a setup failure -- see `wrap_read_checked`.
+    let streams = wrap_read_checked(stdout, "stdout").and_then(|out| {
+        let err = wrap_read_checked(stderr, "stderr")?;
+        Ok(RelayStreams {
+            stdout: out,
+            stderr: err,
+        })
+    });
+
+    relay_prepared_streams(streams, waiter, terminator)
+}
+
+/// The streams a relay will pump, once classified.
+struct RelayStreams {
+    stdout: Option<Box<dyn std::io::Read + Send>>,
+    stderr: Option<Box<dyn std::io::Read + Send>>,
+}
+
+/// Run the relay over already-classified streams.
+///
+/// Split from [`relay_exec_to_stdio`] so the failure paths are reachable in a
+/// test without fabricating an invalid OS handle: a caller can hand this an
+/// `Err` directly and observe the exec being terminated and then reaped.
+fn relay_prepared_streams(
+    streams: Result<RelayStreams, MxcError>,
+    waiter: Box<dyn FnOnce() -> Result<i32, MxcError> + Send>,
+    terminator: Box<dyn FnOnce() + Send>,
+) -> Result<i32, MxcError> {
+    let streams = match streams {
+        Ok(streams) => streams,
+        Err(error) => return abort_relay(waiter, terminator, Vec::new(), error),
+    };
+
+    // Pumps are started fallibly and *before* the waiter runs: a child that
+    // fills its stdout pipe buffer would otherwise block forever, since nothing
+    // would be draining it while we wait. `thread::spawn` would panic if the OS
+    // refused, which here would unwind past the terminator and leave the
+    // workload running.
+    let mut pumps: Vec<Pump> = Vec::new();
+
+    if let Some(src) = streams.stdout {
+        match spawn_pump("mxc-relay-stdout", src, std::io::stdout()) {
+            Ok(pump) => pumps.push(pump),
+            Err(error) => return abort_relay(waiter, terminator, pumps, error),
+        }
+    }
+    if let Some(src) = streams.stderr {
+        match spawn_pump("mxc-relay-stderr", src, std::io::stderr()) {
+            Ok(pump) => pumps.push(pump),
+            Err(error) => return abort_relay(waiter, terminator, pumps, error),
+        }
+    }
+
+    // `terminator` stays alive until the end of this scope: the closure may own
+    // resources tied to the running process, and the waiter-error path below
+    // still needs to invoke it.
+    let exit_code = waiter();
+
+    // A waiter error means "I could not determine the exit", not "the child is
+    // dead" -- so the workload may still be running and still holding the write
+    // ends. Terminate before draining, exactly as `abort_relay` does. The drain
+    // is bounded, so the cost of getting this order wrong is not a hang: it is a
+    // stall for the whole grace period, followed by the loss of whatever output
+    // was still buffered behind those write ends.
+    if exit_code.is_err() {
+        terminator();
+    }
+
+    // Drain what the child wrote before it exited. Bounded -- see `drain_pumps`.
+    drain_pumps(pumps);
+
+    exit_code
+}
+
+/// Join `pumps`, giving them at most [`POST_EXIT_DRAIN_GRACE`] between them.
+///
+/// A pump only ends at EOF, which needs *every* writer closed -- and a
+/// backgrounded descendant that inherited the pipe can hold its write end open
+/// long after the foreground command exits (the same hazard `sandbox_process`
+/// documents, and solves there with a cancel-and-discard). Once the exit code
+/// is in hand, truncating late output is the lesser loss against never
+/// returning it at all.
+///
+/// A pump that misses the deadline is **muted** rather than merely abandoned.
+/// Its thread outlives this call still holding a live read handle, and an
+/// unmuted one would go on writing to the process's stdout -- where it can
+/// interleave with whatever the caller emits next. The error envelope is the
+/// case that matters: it is JSON, and a machine parses it, so a stray chunk of
+/// child output appended to it turns a diagnosable backend error into a parse
+/// failure.
+///
+/// Muting is not instantaneous: a pump blocked mid-write can still land the
+/// chunk it already committed to. It takes effect from the next read onward,
+/// which closes the window that lasts as long as the process does.
+fn drain_pumps(pumps: Vec<Pump>) {
+    drain_pumps_within(pumps, POST_EXIT_DRAIN_GRACE);
+}
+
+/// [`drain_pumps`] with the grace period injected — the seam that lets a test
+/// drive the expiry path without waiting out the real one.
+fn drain_pumps_within(pumps: Vec<Pump>, grace: Duration) {
+    let deadline = Instant::now() + grace;
+    for pump in pumps {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if pump.finished.recv_timeout(remaining).is_ok() {
+            let _ = pump.thread.join();
+        } else {
+            pump.mute();
+        }
+    }
+}
+
+/// How long the relay waits for its pumps to drain after the exec has exited.
+/// Long enough to flush what a finished child left in the pipe, short enough
+/// that a descendant holding the write end open cannot wedge the executor.
+const POST_EXIT_DRAIN_GRACE: Duration = Duration::from_secs(5);
+
+/// A running pump: the thread, plus a signal it sends when its copy loop ends.
+/// The signal is what makes the post-exit drain boundable -- `JoinHandle` has
+/// no timed join.
+struct Pump {
+    thread: std::thread::JoinHandle<()>,
+    finished: std::sync::mpsc::Receiver<()>,
+    muted: Arc<AtomicBool>,
+}
+
+impl Pump {
+    /// Stop this pump writing to its destination, without waiting for it.
+    ///
+    /// The thread keeps reading and discarding rather than stopping outright:
+    /// its source is still connected to the workload, and abandoning a full
+    /// pipe is what wedges a child that is still writing.
+    fn mute(&self) {
+        self.muted.store(true, Ordering::Relaxed);
+    }
+}
+
+/// Tear down a relay that could not be set up: terminate the exec that was
+/// already started, drain any pump that did start, then **run the waiter** so
+/// the exec is reaped rather than merely signalled.
+///
+/// Terminating is a request, not a reaping. Dropping the waiter instead of
+/// running it skips whatever completion work the backend put behind it and, for
+/// a local child on Unix, leaves a zombie until the executor exits. The
+/// streaming adapter's `Drop` already terminates-then-joins for this reason;
+/// this is the same contract on the failure path.
+///
+/// Running it is as much as this can promise. `waiter` is `FnOnce`, so if it
+/// fails -- which by its own contract means the exit could not be determined,
+/// not that the child is gone -- it has been consumed and no reaping operation
+/// is left to retry. Closing that gap needs a separate, infallible reaper on
+/// [`ExecHandle`]; until then a failed wait during teardown can leave the exec
+/// terminated but unreaped.
+///
+/// The drain is bounded for the same reason the post-exit one is: terminating
+/// the foreground child does *not* guarantee its write ends are closed, because
+/// a backgrounded descendant may still hold them. An unbounded join here would
+/// hang before reaching the waiter and so defeat the one thing this function
+/// exists to guarantee.
+///
+/// The waiter's own outcome is discarded: the setup error is what the caller
+/// needs to see, and masking it with a teardown result would hide the cause.
+fn abort_relay(
+    waiter: Box<dyn FnOnce() -> Result<i32, MxcError> + Send>,
+    terminator: Box<dyn FnOnce() + Send>,
+    pumps: Vec<Pump>,
+    error: MxcError,
+) -> Result<i32, MxcError> {
+    terminator();
+    drain_pumps(pumps);
+    let _ = waiter();
+    Err(error)
+}
+
+/// Start one named pump thread, reporting an OS refusal instead of panicking.
+///
+/// The returned [`Pump`] carries a completion signal alongside the join handle
+/// so callers can bound how long they wait for it; see [`drain_pumps`].
+fn spawn_pump<R, W>(name: &str, src: R, dst: W) -> Result<Pump, MxcError>
+where
+    R: std::io::Read + Send + 'static,
+    W: std::io::Write + Send + 'static,
+{
+    let muted = Arc::new(AtomicBool::new(false));
+    let thread_muted = Arc::clone(&muted);
+    let (finished_tx, finished) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            pump_stream(src, dst, &thread_muted);
+            let _ = finished_tx.send(());
+        })
+        .map(|thread| Pump {
+            thread,
+            finished,
+            muted,
+        })
+        .map_err(|error| MxcError::backend_error(format!("failed to start {name}: {error}")))
+}
+
+/// Copy `src` to `dst` until EOF, flushing after every chunk so output reaches
+/// the terminal as it is produced.
+///
+/// **Draining does not stop when the destination breaks.** If the executor's
+/// own stdout goes away, this keeps reading and discards instead of returning:
+/// the backend still holds the read handle's peer, so the child may never see
+/// a broken pipe -- it would simply fill the buffer and block forever while the
+/// waiter waits for an exit that cannot come. Losing output is recoverable;
+/// wedging the workload is not.
+///
+/// `muted` is the same policy imposed from outside: set once the relay has
+/// stopped waiting for this pump, so it stops writing to a destination it no
+/// longer has exclusive use of, while still draining its source. See
+/// [`drain_pumps`].
+///
+/// Read errors do end the pump: there is nothing left to drain.
+fn pump_stream<R: std::io::Read, W: std::io::Write>(mut src: R, mut dst: W, muted: &AtomicBool) {
+    let mut buf = [0u8; 8192];
+    let mut discarding = false;
+    loop {
+        match src.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                if !discarding && !muted.load(Ordering::Relaxed) {
+                    // A failed flush is as fatal to the destination as a failed
+                    // write: either way nothing more will reach it.
+                    let wrote = dst.write_all(&buf[..n]).and_then(|()| dst.flush());
+                    if wrote.is_err() {
+                        discarding = true;
+                    }
+                }
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(_) => break,
+        }
+    }
 }
 
 // ---------- Wire-format envelope construction ----------
@@ -279,6 +570,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
     use std::cell::Cell;
+    use std::time::Duration;
 
     /// Fully-configurable backend stub for dispatcher tests.
     /// Each phase is wired to either succeed (the default — empty result with
@@ -289,11 +581,6 @@ mod tests {
         provision_calls: Cell<u32>,
         start_calls: Cell<u32>,
         exec_calls: Cell<u32>,
-        /// The [`ExecConsumer`] the dispatcher passed to the most recent
-        /// `exec`. Recorded so the caller-intent split can be asserted --
-        /// swapping the two would otherwise compile and silently change
-        /// behaviour on both paths.
-        last_exec_consumer: Cell<Option<ExecConsumer>>,
         stop_calls: Cell<u32>,
         deprovision_calls: Cell<u32>,
         validate_provision_calls: Cell<u32>,
@@ -301,6 +588,11 @@ mod tests {
         validate_exec_calls: Cell<u32>,
         validate_stop_calls: Cell<u32>,
         validate_deprovision_calls: Cell<u32>,
+        /// The [`ExecConsumer`] the dispatcher passed to the most recent
+        /// `exec`. Recorded so the caller-intent split can be asserted --
+        /// swapping the two would otherwise compile and silently change
+        /// behaviour on both paths.
+        last_exec_consumer: Cell<Option<ExecConsumer>>,
         provision_error: Option<MxcError>,
         validate_provision_error: Option<MxcError>,
     }
@@ -311,7 +603,6 @@ mod tests {
                 provision_calls: Cell::new(0),
                 start_calls: Cell::new(0),
                 exec_calls: Cell::new(0),
-                last_exec_consumer: Cell::new(None),
                 stop_calls: Cell::new(0),
                 deprovision_calls: Cell::new(0),
                 validate_provision_calls: Cell::new(0),
@@ -319,6 +610,7 @@ mod tests {
                 validate_exec_calls: Cell::new(0),
                 validate_stop_calls: Cell::new(0),
                 validate_deprovision_calls: Cell::new(0),
+                last_exec_consumer: Cell::new(None),
                 provision_error: None,
                 validate_provision_error: None,
             }
@@ -516,6 +808,10 @@ mod tests {
         }
     }
 
+    /// Like [`parsed`], but with a command line set so the request survives
+    /// `validate_exec_common` and dispatch actually reaches `exec`. The default
+    /// request has an empty `script_code`, which is rejected before the backend
+    /// is called.
     fn parsed_runnable_exec(sandbox_id: &str) -> ParsedStateAwareRequest {
         let mut p = parsed(Phase::Exec, Some(sandbox_id), None);
         p.request.script_code = "echo hi".to_string();
@@ -617,37 +913,6 @@ mod tests {
         assert_eq!(b.validate_exec_calls.get(), 1);
         assert_eq!(b.exec_calls.get(), 0);
         assert_eq!(env, json!({"result": {}}));
-    }
-
-    // The two dispatch entry points differ in who consumes the exec's streams,
-    // and the backend has to be told which. Both directions are pinned.
-
-    /// The executor path relays the handle to its own stdio, so the backend is
-    /// told a human is on the other end and a pseudo-console is legitimate.
-    #[test]
-    fn executor_dispatch_passes_executor_consumer_to_exec() {
-        let mut b = StubBackend::new();
-        let _ = dispatch_state_aware(&mut b, parsed_runnable_exec("stubd:abc"), false);
-        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
-        assert_eq!(
-            b.last_exec_consumer.get(),
-            Some(ExecConsumer::Executor),
-            "the executor path must not ask a backend for caller-owned pipes"
-        );
-    }
-
-    /// The streaming path hands the caller the streams, so the backend must be
-    /// told to surface separate raw pipes and leave the host console alone.
-    #[test]
-    fn streaming_dispatch_passes_library_consumer_to_exec() {
-        let mut b = StubBackend::new();
-        let _ = dispatch_state_aware_exec(&mut b, parsed_runnable_exec("stubd:abc"));
-        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
-        assert_eq!(
-            b.last_exec_consumer.get(),
-            Some(ExecConsumer::Library),
-            "the streaming path must never let a backend touch the caller's console"
-        );
     }
 
     // The remaining three phases complete the dry-run contract: `--dry-run`
@@ -884,5 +1149,549 @@ mod tests {
         };
         let err = resolve_backend(&p).unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedId);
+    }
+
+    // ===== caller-intent split =============================================
+    //
+    // Which mode each entry point sends is the whole point of the parameter,
+    // and getting it backwards would compile: the executor would lose its
+    // interactive console, and an embedded caller would have its own console
+    // written to by a sandbox. Both directions are pinned.
+
+    /// The executor path relays the handle to its own stdio, so the backend is
+    /// told a human is on the other end and a pseudo-console is legitimate.
+    #[test]
+    fn executor_dispatch_passes_executor_consumer_to_exec() {
+        let mut b = StubBackend::new();
+        let _ = dispatch_state_aware(&mut b, parsed_runnable_exec("stubd:abc"), false);
+        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
+        assert_eq!(
+            b.last_exec_consumer.get(),
+            Some(ExecConsumer::Executor),
+            "the executor path must not ask a backend for caller-owned pipes"
+        );
+    }
+
+    /// The streaming path hands the caller the streams, so the backend must be
+    /// told to surface separate raw pipes and leave the host console alone.
+    #[test]
+    fn streaming_dispatch_passes_library_consumer_to_exec() {
+        let mut b = StubBackend::new();
+        let _ = dispatch_state_aware_exec(&mut b, parsed_runnable_exec("stubd:abc"));
+        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
+        assert_eq!(
+            b.last_exec_consumer.get(),
+            Some(ExecConsumer::Library),
+            "the streaming path must never let a backend touch the caller's console"
+        );
+    }
+
+    // ===== relay_exec_to_stdio =============================================
+
+    use crate::state_aware_backend::null_pipe_handle;
+    use std::io::{Read, Write};
+
+    // Build a PipeHandle from a live pipe end. The relay duplicates it, so the
+    // original stays owned by the test.
+    #[cfg(target_os = "windows")]
+    fn reader_handle(r: &std::io::PipeReader) -> crate::state_aware_backend::PipeHandle {
+        use std::os::windows::io::AsRawHandle;
+        windows::Win32::Foundation::HANDLE(r.as_raw_handle() as _)
+    }
+    #[cfg(not(target_os = "windows"))]
+    fn reader_handle(r: &std::io::PipeReader) -> crate::state_aware_backend::PipeHandle {
+        use std::os::fd::AsRawFd;
+        r.as_raw_fd()
+    }
+
+    /// The all-null handle shape (what every in-tree state-aware backend
+    /// returns today) must stay a pure call-through: no threads, no wrapping,
+    /// just the waiter's exit code. This is the regression guard for the
+    /// pre-relay behaviour.
+    #[test]
+    fn relay_with_null_handles_returns_waiter_exit_code() {
+        let handle = ExecHandle {
+            stdout: null_pipe_handle(),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Ok(42)),
+            terminator: Box::new(|| {}),
+        };
+        assert_eq!(relay_exec_to_stdio(handle).unwrap(), 42);
+    }
+
+    /// A waiter error still surfaces unchanged through the relay.
+    #[test]
+    fn relay_with_null_handles_propagates_waiter_error() {
+        let handle = ExecHandle {
+            stdout: null_pipe_handle(),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Err(MxcError::backend_error("waiter blew up"))),
+            terminator: Box::new(|| {}),
+        };
+        let err = relay_exec_to_stdio(handle).unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+    }
+
+    /// The top-level relay really wraps the handle and pumps it.
+    ///
+    /// Asserted by consumption rather than by observing output: a pipe delivers
+    /// its bytes once, to whoever reads first, so if the relay's pump drained
+    /// them the test's own reader sees EOF afterwards. Reverting
+    /// `relay_exec_to_stdio` to its original waiter-only body leaves the bytes
+    /// sitting in the pipe and fails this.
+    ///
+    /// That matters because every other relay test calls `relay_prepared_streams`
+    /// or `pump_stream` directly, so without this one the entry point the change
+    /// is named for could be gutted with the suite still green.
+    ///
+    /// `reader` deliberately stays alive across the call: the relay duplicates
+    /// the handle *inside* it, so dropping it earlier would hand the relay a
+    /// closed handle and silently produce no stream. EOF still arrives, because
+    /// that depends on the *write* end, which is already closed.
+    ///
+    /// This does print one line to the real console, because relaying to
+    /// `std::io::stdout()` is the behaviour under test and a pump thread's
+    /// writes bypass the harness's capture. The payload is kept to a single
+    /// short line for that reason; the assertion is `leftover`, not the console.
+    #[test]
+    fn relay_drains_a_real_stdout_pipe_and_returns_exit_code() {
+        let (mut reader, mut writer) = std::io::pipe().expect("pipe");
+        writer.write_all(b"relayed-stdout\n").unwrap();
+        drop(writer); // EOF, so the pump can finish
+
+        let handle = ExecHandle {
+            stdout: reader_handle(&reader),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Ok(3)),
+            terminator: Box::new(|| {}),
+        };
+
+        assert_eq!(relay_exec_to_stdio(handle).unwrap(), 3);
+
+        let mut leftover = Vec::new();
+        reader.read_to_end(&mut leftover).unwrap();
+        assert!(
+            leftover.is_empty(),
+            "the relay must have consumed the pipe; found {:?}",
+            String::from_utf8_lossy(&leftover)
+        );
+    }
+
+    /// A non-null handle the backend named but that cannot be duplicated is a
+    /// setup failure, not an absent stream. The relay must surface it, and must
+    /// both terminate *and* reap the exec it already started -- terminating
+    /// alone would skip the backend's completion work and, for a local child,
+    /// leave a zombie.
+    ///
+    /// Driven through `relay_prepared_streams` with an `Err` rather than a
+    /// fabricated invalid handle: `BorrowedHandle`/`BorrowedFd::borrow_raw`
+    /// require a live handle, so passing a bogus raw value to force the failure
+    /// would break their safety contract to test it.
+    #[test]
+    fn relay_with_failed_stream_setup_terminates_and_reaps() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let waiter_tx = tx.clone();
+        let result = relay_prepared_streams(
+            Err(MxcError::backend_error(
+                "failed to duplicate the exec stdout pipe handle",
+            )),
+            Box::new(move || {
+                let _ = waiter_tx.send("waiter");
+                Ok(0)
+            }),
+            Box::new(move || {
+                let _ = tx.send("terminator");
+            }),
+        );
+
+        let err = result.unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+        assert!(
+            err.message.contains("stdout"),
+            "the setup error must survive teardown: {}",
+            err.message
+        );
+
+        // Terminate first, then reap: killing is a request, waiting is what
+        // actually collects the process.
+        let order: Vec<&str> = rx.try_iter().collect();
+        assert_eq!(
+            order,
+            vec!["terminator", "waiter"],
+            "the exec must be terminated and then waited for"
+        );
+    }
+
+    /// The terminator must NOT be invoked on a normal completion — it is the
+    /// cancellation path, not the teardown path.
+    #[test]
+    fn relay_does_not_invoke_terminator_on_normal_completion() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = ExecHandle {
+            stdout: null_pipe_handle(),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Ok(0)),
+            terminator: Box::new(move || {
+                let _ = tx.send(());
+            }),
+        };
+        assert_eq!(relay_exec_to_stdio(handle).unwrap(), 0);
+        assert!(
+            rx.try_recv().is_err(),
+            "terminator must not fire when the process exited on its own"
+        );
+    }
+
+    /// Every byte crosses the pump, including across multiple reads.
+    #[test]
+    fn pump_stream_copies_all_bytes() {
+        let (src_r, mut src_w) = std::io::pipe().expect("pipe");
+        let (mut dst_r, dst_w) = std::io::pipe().expect("pipe");
+
+        let payload: Vec<u8> = (0..40_000u32).map(|i| (i % 251) as u8).collect();
+        let expected = payload.clone();
+        let writer = std::thread::spawn(move || {
+            src_w.write_all(&payload).unwrap();
+            drop(src_w);
+        });
+        let unmuted = Arc::new(AtomicBool::new(false));
+        let pump = std::thread::spawn(move || pump_stream(src_r, dst_w, &unmuted));
+
+        let mut got = Vec::new();
+        dst_r.read_to_end(&mut got).unwrap();
+        writer.join().unwrap();
+        pump.join().unwrap();
+
+        assert_eq!(got.len(), expected.len(), "byte count must match");
+        assert_eq!(got, expected, "payload must survive the pump intact");
+    }
+
+    /// A destination that breaks mid-stream must not stop the pump draining.
+    ///
+    /// The backend still holds the peer of the read handle, so a child whose
+    /// output is no longer being consumed does not necessarily see a broken
+    /// pipe -- it fills the buffer and blocks, and the waiter then waits for an
+    /// exit that cannot happen. Discarding is the lesser loss.
+    #[test]
+    fn pump_stream_keeps_draining_after_the_destination_fails() {
+        /// Accepts the first write, then fails every write and flush.
+        struct FailsAfterFirstWrite {
+            writes: usize,
+        }
+        impl std::io::Write for FailsAfterFirstWrite {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.writes += 1;
+                if self.writes > 1 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "destination gone",
+                    ));
+                }
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                if self.writes > 1 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "destination gone",
+                    ));
+                }
+                Ok(())
+            }
+        }
+
+        let (src_r, mut src_w) = std::io::pipe().expect("pipe");
+        let unmuted = Arc::new(AtomicBool::new(false));
+        let pump = std::thread::spawn(move || {
+            pump_stream(src_r, FailsAfterFirstWrite { writes: 0 }, &unmuted);
+        });
+
+        // Far more than one buffer, so the writer would block if the pump
+        // stopped reading after the destination broke.
+        let chunk = vec![b'x'; 8192];
+        for _ in 0..16 {
+            src_w
+                .write_all(&chunk)
+                .expect("the pump must keep draining");
+        }
+        drop(src_w);
+
+        // The join is the assertion: a pump that stopped reading would leave
+        // the writes above blocked and never reach EOF.
+        pump.join().expect("pump thread should finish");
+    }
+
+    /// The pumps must start *before* the waiter runs.
+    ///
+    /// Nothing else covers this: the other relay test prewrites a few bytes and
+    /// uses an instantly-returning waiter, and the payload test calls
+    /// `pump_stream` directly, so both would still pass if the wait happened
+    /// first.
+    ///
+    /// The source signals as soon as it is first read and then reports EOF, and
+    /// the waiter blocks until **both** signals arrive; a relay that waited
+    /// before draining would never produce them. Both streams are supplied
+    /// deliberately: with stdout alone, moving only the stderr pump below the
+    /// waiter would go unnoticed, and an stderr-heavy child would then fill its
+    /// pipe and deadlock exactly as this rule exists to prevent.
+    ///
+    /// Signalling rather than filling a pipe keeps this independent of the
+    /// platform's pipe-buffer size and, more importantly, writes nothing: the
+    /// pumps run on spawned threads whose direct `std::io::stdout()` writes
+    /// bypass the test harness's capture, so a volume-based version of this
+    /// test dumps its payload into the console output of every run, passing or
+    /// not.
+    ///
+    /// The waiter times out rather than blocking forever, so the regression
+    /// surfaces as a failed assertion instead of a hung suite.
+    #[test]
+    fn relay_starts_pumps_before_waiting() {
+        struct SignalsOnFirstRead(Option<std::sync::mpsc::Sender<()>>);
+        impl std::io::Read for SignalsOnFirstRead {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                if let Some(tx) = self.0.take() {
+                    let _ = tx.send(());
+                }
+                Ok(0) // EOF: the pump has done its job by reading at all.
+            }
+        }
+
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let streams = RelayStreams {
+            stdout: Some(Box::new(SignalsOnFirstRead(Some(started_tx.clone())))),
+            stderr: Some(Box::new(SignalsOnFirstRead(Some(started_tx)))),
+        };
+
+        let waiter = Box::new(move || {
+            let mut started = 0;
+            while started < 2 {
+                if started_rx.recv_timeout(Duration::from_secs(10)).is_err() {
+                    return Err(MxcError::backend_error(format!(
+                        "only {started} of the 2 pumps had started when the waiter began waiting"
+                    )));
+                }
+                started += 1;
+            }
+            Ok(0)
+        });
+
+        let result = relay_prepared_streams(Ok(streams), waiter, Box::new(|| {}));
+        assert_eq!(
+            result.expect("the pumps must be draining while the waiter waits"),
+            0
+        );
+    }
+
+    /// A waiter that *errors* means the exit could not be determined, not that
+    /// the child is dead. The relay must terminate **before** draining: the
+    /// workload may still hold the write ends, and a bounded drain that runs
+    /// first burns its entire grace and then discards what was still buffered.
+    ///
+    /// Both halves are pinned, and they need different instruments. The
+    /// terminator is observed directly, because the returned error comes from
+    /// the waiter and would arrive whether or not anything was terminated. The
+    /// *ordering* is pinned by the clock: the only thing that can deliver EOF to
+    /// this pump is the terminator dropping the write end, so terminating first
+    /// ends the drain at once, whereas draining first waits out the full
+    /// `POST_EXIT_DRAIN_GRACE` before giving up.
+    #[test]
+    fn relay_terminates_before_draining_when_the_waiter_errors() {
+        let (src_r, src_w) = std::io::pipe().expect("pipe");
+        // Held by the terminator alone: dropping it is what lets the pump EOF.
+        let writer = Arc::new(std::sync::Mutex::new(Some(src_w)));
+        let closer = Arc::clone(&writer);
+        let terminated = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&terminated);
+
+        let started = Instant::now();
+        let result = relay_prepared_streams(
+            Ok(RelayStreams {
+                stdout: Some(Box::new(src_r)),
+                stderr: None,
+            }),
+            Box::new(|| Err(MxcError::backend_error("could not determine the exit"))),
+            Box::new(move || {
+                flag.store(true, Ordering::Relaxed);
+                closer.lock().expect("writer lock").take();
+            }),
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            terminated.load(Ordering::Relaxed),
+            "a waiter error leaves the child possibly alive, so it must be terminated"
+        );
+        assert!(
+            elapsed < POST_EXIT_DRAIN_GRACE / 2,
+            "the terminator must run before the drain, not after it; took {elapsed:?}"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::BackendError);
+        assert!(
+            err.message.contains("could not determine the exit"),
+            "the waiter's error must survive teardown: {}",
+            err.message
+        );
+    }
+
+    /// Output must appear as it is produced, not be held until EOF.
+    ///
+    /// The destination is wrapped in a `BufWriter` large enough to swallow the
+    /// whole payload, which is what makes this discriminating: the real sink is
+    /// `std::io::stdout()`, and that is line-buffered, so a pump that wrote
+    /// without flushing would strand a partial line exactly like this. Against
+    /// a bare `PipeWriter` the bytes would become readable whether or not the
+    /// pump flushed, and the test would prove nothing.
+    ///
+    /// The payload carries no newline and the source stays open, so the only
+    /// thing that can deliver it is the pump's explicit flush; without it,
+    /// `read_exact` blocks until the harness times the test out.
+    #[test]
+    fn pump_stream_flushes_before_eof() {
+        let (src_r, mut src_w) = std::io::pipe().expect("pipe");
+        let (mut dst_r, dst_w) = std::io::pipe().expect("pipe");
+        let dst = std::io::BufWriter::with_capacity(64 * 1024, dst_w);
+
+        let unmuted = Arc::new(AtomicBool::new(false));
+        let pump = std::thread::spawn(move || pump_stream(src_r, dst, &unmuted));
+
+        src_w.write_all(b"no-newline-yet").unwrap();
+        src_w.flush().unwrap();
+
+        let mut got = [0u8; 14];
+        dst_r
+            .read_exact(&mut got)
+            .expect("partial line must arrive before EOF");
+        assert_eq!(&got, b"no-newline-yet");
+
+        drop(src_w);
+        pump.join().unwrap();
+    }
+
+    /// A muted pump stops writing but keeps reading.
+    ///
+    /// Both halves matter and the test pins both. Muting exists so a pump the
+    /// relay has stopped waiting for cannot append stray bytes to whatever the
+    /// caller emits next; draining on regardless is what stops the workload
+    /// wedging on a pipe nobody empties.
+    #[test]
+    fn a_muted_pump_stops_writing_but_keeps_draining() {
+        let (src_r, mut src_w) = std::io::pipe().expect("pipe");
+        let (mut dst_r, dst_w) = std::io::pipe().expect("pipe");
+
+        let muted = Arc::new(AtomicBool::new(false));
+        let thread_muted = Arc::clone(&muted);
+        let pump = std::thread::spawn(move || pump_stream(src_r, dst_w, &thread_muted));
+
+        src_w.write_all(b"before").unwrap();
+        src_w.flush().unwrap();
+        let mut got = [0u8; 6];
+        dst_r.read_exact(&mut got).expect("pre-mute output");
+        assert_eq!(&got, b"before");
+
+        muted.store(true, Ordering::Relaxed);
+
+        // Far more than one pipe buffer. If muting stopped the pump reading,
+        // these writes would block and the test would never finish.
+        let chunk = vec![b'x'; 8192];
+        for _ in 0..16 {
+            src_w
+                .write_all(&chunk)
+                .expect("a muted pump must still drain its source");
+        }
+        drop(src_w);
+        pump.join().unwrap();
+
+        // Nothing written after the mute: the destination saw only "before",
+        // so reading it to the end now yields EOF immediately.
+        let mut leftover = Vec::new();
+        dst_r.read_to_end(&mut leftover).unwrap();
+        assert!(
+            leftover.is_empty(),
+            "a muted pump wrote {} bytes it should have discarded",
+            leftover.len()
+        );
+    }
+
+    /// `abort_relay` must terminate *before* draining, not merely before
+    /// reaping.
+    ///
+    /// Called directly, because the only route to it through
+    /// `relay_prepared_streams` is a classification failure, which by
+    /// construction has no pumps yet -- so that path can never distinguish the
+    /// two orders. The reachable non-empty case is a `spawn_pump` refusal,
+    /// which cannot be injected from a test.
+    ///
+    /// The clock is the instrument: the terminator is the only thing that can
+    /// deliver EOF here, so terminating first ends the drain at once, while
+    /// draining first waits out the whole grace and then mutes the pump.
+    #[test]
+    fn abort_relay_terminates_before_draining() {
+        let (src_r, src_w) = std::io::pipe().expect("pipe");
+        let (dst_r, dst_w) = std::io::pipe().expect("pipe");
+        // Held by the terminator alone: dropping it is what lets the pump EOF.
+        let writer = Arc::new(std::sync::Mutex::new(Some(src_w)));
+        let closer = Arc::clone(&writer);
+        let pump = spawn_pump("test-abort-pump", src_r, dst_w).expect("spawn");
+
+        let started = Instant::now();
+        let result = abort_relay(
+            Box::new(|| Ok(0)),
+            Box::new(move || {
+                closer.lock().expect("writer lock").take();
+            }),
+            vec![pump],
+            MxcError::backend_error("stream setup failed"),
+        );
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < POST_EXIT_DRAIN_GRACE / 2,
+            "the terminator must run before the drain, not after it; took {elapsed:?}"
+        );
+        let err = result.expect_err("abort_relay must surface the setup error");
+        assert!(
+            err.message.contains("stream setup failed"),
+            "the setup error must survive teardown: {}",
+            err.message
+        );
+
+        drop(dst_r);
+    }
+
+    /// The drain is bounded, and what it abandons it mutes.
+    ///
+    /// This is the guarantee both drain sites depend on. `abort_relay` needs it
+    /// most: an unbounded join there would hang before reaching the waiter and
+    /// so defeat the very reaping that function exists to perform.
+    #[test]
+    fn drain_pumps_bounds_the_wait_and_mutes_what_it_abandons() {
+        // A source that never ends. Holding `src_w` open is what makes this the
+        // hazard case: the pump cannot reach EOF, so an unbounded join hangs.
+        let (src_r, src_w) = std::io::pipe().expect("pipe");
+        let (dst_r, dst_w) = std::io::pipe().expect("pipe");
+        let pump = spawn_pump("test-endless-pump", src_r, dst_w).expect("spawn");
+        let muted = Arc::clone(&pump.muted);
+
+        let started = Instant::now();
+        drain_pumps_within(vec![pump], Duration::from_millis(50));
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "the drain must give up on an endless pump, took {elapsed:?}"
+        );
+        assert!(
+            muted.load(Ordering::Relaxed),
+            "an abandoned pump must be muted so it cannot write after the relay returns"
+        );
+
+        // Release the thread rather than leaving it parked for the run.
+        drop(src_w);
+        drop(dst_r);
     }
 }

--- a/src/core/wxc_common/src/state_aware_dispatch.rs
+++ b/src/core/wxc_common/src/state_aware_dispatch.rs
@@ -23,7 +23,8 @@ use crate::id::parse_sandbox_id_prefix;
 use crate::models::ContainmentBackend;
 use crate::mxc_error::{MxcError, ResponseEnvelope};
 use crate::state_aware_backend::{
-    DeprovisionResult, ExecHandle, ProvisionResult, StartResult, StatefulSandboxBackend, StopResult,
+    DeprovisionResult, ExecConsumer, ExecHandle, ProvisionResult, StartResult,
+    StatefulSandboxBackend, StopResult,
 };
 use crate::state_aware_request::{ParsedStateAwareRequest, Phase};
 use crate::validator::validate_exec_common;
@@ -86,7 +87,7 @@ pub fn dispatch_state_aware_exec<B: StatefulSandboxBackend>(
     let config = parsed.deserialize_config::<B::ExecConfig>(B::BACKEND_KEY, "exec")?;
     validate_exec_common(&request)?;
     backend.validate_exec(&sandbox_id, &request, config.as_ref())?;
-    backend.exec(&sandbox_id, &request, config)
+    backend.exec(&sandbox_id, &request, config, ExecConsumer::Library)
 }
 
 /// Per-backend phase router. The `run_state_aware` arm for a participating
@@ -132,7 +133,7 @@ pub fn dispatch_state_aware<B: StatefulSandboxBackend>(
             if dry_run {
                 return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
             }
-            let handle = backend.exec(&sandbox_id, &request, config)?;
+            let handle = backend.exec(&sandbox_id, &request, config, ExecConsumer::Executor)?;
             let exit_code = relay_exec_to_stdio(handle)?;
             Ok(DispatchOutcome::ExecCompleted { exit_code })
         }
@@ -288,6 +289,11 @@ mod tests {
         provision_calls: Cell<u32>,
         start_calls: Cell<u32>,
         exec_calls: Cell<u32>,
+        /// The [`ExecConsumer`] the dispatcher passed to the most recent
+        /// `exec`. Recorded so the caller-intent split can be asserted --
+        /// swapping the two would otherwise compile and silently change
+        /// behaviour on both paths.
+        last_exec_consumer: Cell<Option<ExecConsumer>>,
         stop_calls: Cell<u32>,
         deprovision_calls: Cell<u32>,
         validate_provision_calls: Cell<u32>,
@@ -305,6 +311,7 @@ mod tests {
                 provision_calls: Cell::new(0),
                 start_calls: Cell::new(0),
                 exec_calls: Cell::new(0),
+                last_exec_consumer: Cell::new(None),
                 stop_calls: Cell::new(0),
                 deprovision_calls: Cell::new(0),
                 validate_provision_calls: Cell::new(0),
@@ -359,8 +366,10 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
+            consumer: ExecConsumer,
         ) -> Result<ExecHandle, MxcError> {
             self.exec_calls.set(self.exec_calls.get() + 1);
+            self.last_exec_consumer.set(Some(consumer));
             Err(MxcError::backend_error("stub exec not wired"))
         }
         fn stop(
@@ -475,6 +484,7 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
+            _consumer: ExecConsumer,
         ) -> Result<ExecHandle, MxcError> {
             Err(MxcError::backend_error("typed stub exec not wired"))
         }
@@ -504,6 +514,12 @@ mod tests {
             experimental_raw: exp,
             source_text: None,
         }
+    }
+
+    fn parsed_runnable_exec(sandbox_id: &str) -> ParsedStateAwareRequest {
+        let mut p = parsed(Phase::Exec, Some(sandbox_id), None);
+        p.request.script_code = "echo hi".to_string();
+        p
     }
 
     fn assert_envelope(outcome: DispatchOutcome) -> Value {
@@ -601,6 +617,37 @@ mod tests {
         assert_eq!(b.validate_exec_calls.get(), 1);
         assert_eq!(b.exec_calls.get(), 0);
         assert_eq!(env, json!({"result": {}}));
+    }
+
+    // The two dispatch entry points differ in who consumes the exec's streams,
+    // and the backend has to be told which. Both directions are pinned.
+
+    /// The executor path relays the handle to its own stdio, so the backend is
+    /// told a human is on the other end and a pseudo-console is legitimate.
+    #[test]
+    fn executor_dispatch_passes_executor_consumer_to_exec() {
+        let mut b = StubBackend::new();
+        let _ = dispatch_state_aware(&mut b, parsed_runnable_exec("stubd:abc"), false);
+        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
+        assert_eq!(
+            b.last_exec_consumer.get(),
+            Some(ExecConsumer::Executor),
+            "the executor path must not ask a backend for caller-owned pipes"
+        );
+    }
+
+    /// The streaming path hands the caller the streams, so the backend must be
+    /// told to surface separate raw pipes and leave the host console alone.
+    #[test]
+    fn streaming_dispatch_passes_library_consumer_to_exec() {
+        let mut b = StubBackend::new();
+        let _ = dispatch_state_aware_exec(&mut b, parsed_runnable_exec("stubd:abc"));
+        assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
+        assert_eq!(
+            b.last_exec_consumer.get(),
+            Some(ExecConsumer::Library),
+            "the streaming path must never let a backend touch the caller's console"
+        );
     }
 
     // The remaining three phases complete the dry-run contract: `--dry-run`


### PR DESCRIPTION
## 📖 Description

`relay_exec_to_stdio` was a call-through to the exec handle's waiter, with a note that the real relay would land when a backend first surfaced live pipe handles. This implements it, so that backend has something to plug into.

`StatefulSandboxBackend::exec` also gains an `ExecConsumer`, so a backend learns **who will consume** its streams instead of probing the host. `ExecConsumer::Executor` means the executor binary will relay them to its own stdio for a human; `ExecConsumer::Library` means an in-process caller (the Rust SDK, the FFI) will drive them itself.

This is deliberately *not* `sandbox_process::StdioMode`. That enum's `Inherit` means the OS hands the child the executor's own handles, and no state-aware backend can do that — the workload runs inside an isolation session, inside a VM, or behind an SDK callback, so its streams always have to be materialised on this side of the boundary and copied. Reusing it would have made the variant unimplementable rather than merely ambiguous. The replacement also captures the distinction that actually matters, because it fixes stream *topology* rather than wiring: under `Executor` a backend may allocate a pseudo-console when the executor is on a TTY, and a pseudo-console has a single output stream, so stderr arrives merged into stdout and `ExecHandle::stderr` is legitimately null. Under `Library` the backend must return separate raw pipes and allocate no console.

**No behaviour changes.** All three in-tree state-aware backends relay internally and return null pipe handles, so no stream wrap succeeds, no thread is spawned, and the relay reduces to calling the waiter exactly as before. This is groundwork for reaching IsolationSession from the in-process Rust SDK, where an embedded caller must own the streams.

Ordering is load-bearing, and the failure paths are part of the same deliverable — a relay that cannot fail safely is not usable groundwork:

- Pumps start **before** the waiter: a child that fills its stdout pipe would otherwise block forever with nothing draining it. They are started fallibly, because `thread::spawn` panics on an OS refusal and would unwind past the terminator, leaving the workload running.
- Setup failure terminates **and then** reaps. Terminating is a request, not a reaping; dropping the waiter skips the backend's completion work.
- A waiter *error* means the exit could not be determined, not that the child is gone, so it terminates before draining rather than joining pipes whose writer is still alive.
- The post-exit drain is **time-bounded**. A pump only ends at EOF, which needs every writer closed, and a backgrounded descendant can hold one open long after the foreground command exits. Once the exit code is in hand, truncating late output beats never returning.
- A pump the drain abandons is **muted**, so it cannot append stray bytes to whatever the caller emits next — the JSON error envelope in particular, which a machine parses.

A stream the backend *named* but that cannot be duplicated is now a hard error rather than silent absence, in the relay and in the streaming adapter alike: degrading would hand a caller a live pipe nobody drains, which blocks the child once it fills. That makes `ExecSandboxProcess::from_exec_handle` fallible.

**stdin is deliberately not forwarded.** Doing it correctly needs an ownership model `ExecHandle` does not have — a pipe reaches EOF only once *every* write handle is closed, and the relay can only duplicate the backend's rather than take it, so neither side could close the child's stdin — plus a stop signal, since a read on the executor's stdin never returns when that stdin is a console or node-pty handle held open by a parent. IsolationSession's own `pipe_relay` documents both hazards and solves them with `create_relay_thread_with_stop`; the generic path will need an equivalent. The contract states the precondition that makes today's behaviour safe: under `Executor`, a backend must not hand the child a stdin pipe whose write end it keeps.

Not built on IsolationSession's `pipe_relay`: it lives in a `backends/*` crate that `wxc_common` must not depend on, is Windows-only, and is `unsafe`. Its per-write flush is the same conclusion reached independently here.

## 🔗 References

No linked issue. Groundwork for exposing the IsolationSession state-aware lifecycle through the in-process Rust SDK; follow-up changes return real pipe handles from that backend and add the SDK-level opt-in.

## 🔍 Validation

19 new unit tests over real OS pipes, host- and feature-independent. They pin the all-null path as a regression guard, drive real pipes end-to-end, and cover the failure paths: terminate-then-reap on setup failure, terminate-before-drain on a waiter error, the bounded drain, and muting.

Every behavioural claim above is mutation-verified: 12 mutations, each reverting one behaviour, each confirmed to fail the test that names it. Six of those are **reorderings** rather than deletions, since a test asserting only that a call happened will happily pass when that call moves — the terminate/drain/reap orderings and pump-start-before-waiter are pinned that way. Mutations are also checked for compiling, because one that fails to build exits non-zero and would otherwise be mistaken for a caught regression.

Full local gate set green on this exact tree: `fmt`, `clippy -D warnings`, build and test with `isolation_session` on and off, arm64 build, versioning scripts, C# SDK, Node SDK unit + integration, and the elevated `wxc_host_prep` tests (16/16). On a host with the OS-side isolation service, the IsolationSession end-to-end suites ran **90 passed / 0 failed / 0 skipped** with no leaked agent accounts, and the interactive terminal tests (resize, streaming, interactive shell) passed at the console.

## ✅ Checklist

- [x] Signed the Contributor License Agreement

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/829)
