### PR TITLE
Package and sign PLM with Windows binaries

### DIFF
--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -48,6 +48,7 @@ jobs:
         cargoFeatures: hyperlight isolation_session microvm wslc
         signPattern: |
             wxc-exec.exe
+            plm.exe
             wxc-host-prep.exe
             winhttp-proxy-shim.exe
             wxc-windows-sandbox-daemon.exe

--- a/.github/workflows/Build.Windows.Job.yml
+++ b/.github/workflows/Build.Windows.Job.yml
@@ -77,6 +77,7 @@ jobs:
           name: wxc-binaries-${{ matrix.target }}
           path: |
             src/target/${{ matrix.target }}/release/wxc-exec.exe
+            src/target/${{ matrix.target }}/release/plm.exe
             src/target/${{ matrix.target }}/release/wxc-host-prep.exe
             src/target/${{ matrix.target }}/release/winhttp-proxy-shim.exe
             src/target/${{ matrix.target }}/release/wxc-windows-sandbox-daemon.exe

--- a/build.bat
+++ b/build.bat
@@ -158,6 +158,10 @@ for %%T in (x86_64-pc-windows-msvc aarch64-pc-windows-msvc) do (
         if not exist "sdk\dotnet\Microsoft.Mxc.Sdk\runtimes\!RID!\native" mkdir "sdk\dotnet\Microsoft.Mxc.Sdk\runtimes\!RID!\native"
         copy /Y "!BIN_DIR!\mxc_ffi.dll" "sdk\dotnet\Microsoft.Mxc.Sdk\runtimes\!RID!\native\" >nul
         echo   Copied !RID!\native\mxc_ffi.dll
+        if exist "!BIN_DIR!\plm.exe" (
+            copy /Y "!BIN_DIR!\plm.exe" "sdk\dotnet\Microsoft.Mxc.Sdk\runtimes\!RID!\native\" >nul
+            echo   Copied !RID!\native\plm.exe
+        )
     )
 )
 

--- a/sdk/node/tests/integration/test-helpers.ts
+++ b/sdk/node/tests/integration/test-helpers.ts
@@ -47,6 +47,7 @@ export function getSdkBinDir(): string {
 
 export const EXPECTED_WINDOWS_BINARIES = [
   'wxc-exec.exe',
+  'plm.exe',
   'wxc-host-prep.exe',
   'winhttp-proxy-shim.exe',
   'wxc-test-proxy.exe',
@@ -70,8 +71,6 @@ export const EXPECTED_MACOS_BINARIES = [
 const OPTIONAL_BINARIES = [
   'wslcsdk.dll',          // Only built with --with-wslc
   'wxc-wslc-daemon.exe',  // Only built with --with-wslc
-  'plm.exe',       // Permissive Learning Mode helper (Windows-only); staged
-                   // only when the plm crate is included in the build.
 ];
 
 // Combined list of all known binaries across platforms. The npm package


### PR DESCRIPTION
## 📖 Description

Packages `plm.exe` with the Windows executor artifacts and applies the same signing path as the other Windows executables.

- GitHub Actions uploads `plm.exe` in both x64 and ARM64 `wxc-binaries-*` artifacts.
- Azure official builds include `plm.exe` in the shared Windows `signPattern`, so ESRP runs `SigntoolSign` and `SigntoolVerify` before the binary is copied into the published artifact.
- SDK package integration tests require `plm.exe` in the Windows native assets instead of treating it as optional.

## 🔗 References

Related to #813.

## 🔍 Validation

- Built `plm.exe` in release mode for `x86_64-pc-windows-msvc`.
- Parsed both modified workflow YAML files.
- Verified `plm.exe` is present in the GitHub artifact list, Azure sign-and-copy pattern, and required Windows package binary list.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/834)