### PR TITLE
Give an in-process caller real exec streams from the isolation-session backend

### DIFF
--- a/docs/isolation-session/state-aware-rust.md
+++ b/docs/isolation-session/state-aware-rust.md
@@ -359,12 +359,13 @@ concurrent provisions are independent and all succeed.
 
 ### Multiple exec calls against the same sandbox
 
-The runner's `exec` impl reuses the existing one-shot `create_process` path
-synchronously: `manager.create_process(&options)` blocks until the agent
-process exits and the relay drains. Two concurrent exec calls against the
-same `sandboxId` from two `wxc-exec` processes are not coordinated by MXC;
-the OS-side service serialises (or rejects, depending on session state) at
-its own layer.
+The runner's `exec` impl blocks for an **executor** consumer: it reuses the
+one-shot `create_process` path, and that call runs until the agent process
+exits and the relay drains. For an **in-process** consumer it starts the
+process and returns without waiting, handing back the live pipe handles and a
+waiter, so the caller decides when to block. Either way, two concurrent exec
+calls against the same `sandboxId` are not coordinated by MXC; the OS-side
+service serialises (or rejects, depending on session state) at its own layer.
 
 ### Deprovision and concurrent sandboxes
 
@@ -452,12 +453,31 @@ State-aware exec (and other phases) use OS-level cancellation in v1:
   `SendCtrlClose` → `Terminate`) handles the timeout case from inside the
   agent process before returning.
 
-`ExecHandle.terminator` is currently a no-op closure on the
-IsolationSession path because the backend reuses the one-shot
-`create_process` synchronously and there is no mid-flight cancellation
-seam. Future work — explicit Rust-layer `AbortSignal` plumbing — would
-require splitting `create_process` into a non-blocking start + a separate
-waiter, with `terminator` invoking `IsoSessionProcess::Terminate()`.
+`ExecHandle.terminator` is a no-op closure on the IsolationSession path
+when the consumer is the executor binary, which reuses the one-shot
+`create_process` synchronously and so has no mid-flight cancellation
+seam. For an in-process consumer the backend instead starts the process
+without waiting and returns a terminator that calls
+`IsoSessionProcess::Terminate()`, alongside the real pipe handles and a
+waiter that blocks on exit.
+
+That terminator reports **nothing**: `ExecHandle.terminator` is an
+infallible `FnOnce()`, so the backend requests termination and discards
+whether the platform even accepted it. The underlying
+`StartedProcess::terminate` does distinguish an accepted request from a
+rejected one — it is the handle type that has nowhere to carry the
+answer. Teardown is also not bounded: the streaming adapter's `Drop`
+joins the waiter unconditionally, and nothing in that path caps the
+wait. A process that survives the kill can park that waiter by either of
+two routes — in its leading `WaitForExit` (INFINITE when the caller
+supplied no timeout), or, when a timeout was supplied, in the graceful
+ladder's tier 3, which is `Terminate` followed by an INFINITE
+`WaitForExit(0)`. Neither is certain to stall: tier 1 ends a child that
+exits on stdin EOF once the caller has dropped its own duplicate of the
+write end, and tier 3's `Terminate` is a fresh attempt that may land
+where the first did not. The narrow claim is that nothing bounds the
+join if the process does survive. Making the terminator fallible end to
+end, and bounding that join, is future work.
 
 ## Known issues
 

--- a/src/backends/isolation_session/common/src/manager.rs
+++ b/src/backends/isolation_session/common/src/manager.rs
@@ -199,13 +199,17 @@ impl IsolationSessionManager {
         check_result(&result, op::START_SESSION, StalePromotion::Eligible)
     }
 
-    /// Step 3: Create a process inside the started isolation session.
-    /// Output is streamed live to wxc-exec's stdio via internal relay
-    /// threads; only the exit code is returned to the caller.
-    pub(super) fn create_process(
+    /// Step 3a: Start a process inside the started isolation session, and
+    /// return it **without waiting**.
+    ///
+    /// Split out of [`Self::create_process`] so the caller chooses how the
+    /// streams are consumed: the executor path bridges them with its own relay
+    /// threads and blocks (see `create_process`), while an in-process SDK
+    /// caller takes the raw handles and drives them itself.
+    pub(super) fn start_process(
         &self,
         options: &ProcessOptions,
-    ) -> Result<i32, IsolationSessionError> {
+    ) -> Result<StartedProcess, IsolationSessionError> {
         let proc_options = build_iso_process_options(options)?;
 
         let async_op = self
@@ -239,6 +243,49 @@ impl IsolationSessionManager {
             .Process()
             .map_err(|e| transport_err(op::RUN_PROCESS, "get Process failed", &e))?;
 
+        // A getter that errors is a backend failure, not an absent stream:
+        // propagate it rather than coercing to 0, which downstream treats as
+        // "no handle" and silently skips the corresponding stdio relay. A
+        // genuinely returned 0 still means absent and is preserved.
+        let stdout = process
+            .OutputHandle()
+            .map_err(|e| transport_err(op::RUN_PROCESS, "get OutputHandle failed", &e))?;
+        let stderr = process
+            .ErrorHandle()
+            .map_err(|e| transport_err(op::RUN_PROCESS, "get ErrorHandle failed", &e))?;
+        let stdin = process
+            .InputHandle()
+            .map_err(|e| transport_err(op::RUN_PROCESS, "get InputHandle failed", &e))?;
+
+        Ok(StartedProcess {
+            process,
+            stdout,
+            stderr,
+            stdin,
+        })
+    }
+
+    /// Step 3: Create a process inside the started isolation session and run it
+    /// to completion. Output is streamed live to wxc-exec's stdio via internal
+    /// relay threads; only the exit code is returned to the caller.
+    ///
+    /// This is the **executor** path. An in-process caller that wants the
+    /// streams itself uses [`Self::start_process`] instead.
+    pub(super) fn create_process(
+        &self,
+        options: &ProcessOptions,
+    ) -> Result<i32, IsolationSessionError> {
+        // `StartedProcess` deliberately has no close-on-drop: this path hands
+        // the raw handle values to relay threads it may abandon, so an early
+        // return must leave them open (see "Handle validity" below). The
+        // handles are released exactly once, by the explicit `process.Close()`
+        // at the point in the normal sequence where that is safe.
+        let started = self.start_process(options)?;
+        let process = &started.process;
+        let stdout_handle_val = started.stdout;
+        let stderr_handle_val = started.stderr;
+        let stdin_handle_val = started.stdin;
+
         // Three pipe relay threads bridge wxc-exec's stdio with the pipe
         // handles owned by `IsoSessionProcess`, crossing the desktop-session
         // boundary that kernel console-handle inheritance cannot.
@@ -260,20 +307,17 @@ impl IsolationSessionManager {
         // leaves it reading memory it owns, not a dead frame. We still join on
         // the normal path (INFINITE for stdout/stderr, bounded for stdin) so
         // all output is drained before the call returns.
-        // A getter that errors is a backend failure, not an absent stream:
-        // propagate it rather than coercing to 0, which downstream treats as
-        // "no handle" and silently skips the corresponding stdio relay. A
-        // genuinely returned 0 still means absent and is preserved.
-        let stdout_handle_val = process
-            .OutputHandle()
-            .map_err(|e| transport_err(op::RUN_PROCESS, "get OutputHandle failed", &e))?;
-        let stderr_handle_val = process
-            .ErrorHandle()
-            .map_err(|e| transport_err(op::RUN_PROCESS, "get ErrorHandle failed", &e))?;
-        let stdin_handle_val = process
-            .InputHandle()
-            .map_err(|e| transport_err(op::RUN_PROCESS, "get InputHandle failed", &e))?;
-
+        //
+        // Handle validity is a separate question from param memory and does not
+        // follow from it. An abandoned relay goes on reading and writing the raw
+        // handle values it was given, so those must stay open for as long as it
+        // might run — and nothing joins it, so that is until wxc-exec exits.
+        // Every `?` from the stderr-relay spawn onward can therefore return with
+        // a relay still live, and closing the handles on the way out would leave
+        // it operating on a value the OS is free to recycle. Leaking them on
+        // those paths is the deliberate choice, and is why `StartedProcess`
+        // itself does not close on drop; the streaming consumer, which has no
+        // relays and no other teardown point, opts in via `ClosingProcess`.
         let wxc_stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) }
             .map_err(|e| lifecycle_err(format!("GetStdHandle(stdout) failed: {}", e)))?;
         let wxc_stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) }
@@ -420,7 +464,7 @@ impl IsolationSessionManager {
             .WaitForExit(options.timeout_ms)
             .map_err(|e| transport_err(op::RUN_PROCESS, "WaitForExit failed", &e))?;
 
-        let exit_code = wait_with_graceful_shutdown(&process)?;
+        let exit_code = wait_with_graceful_shutdown(process)?;
 
         // Signal the stdin relay to exit. Effective for waitable (console)
         // handles; for pipe handles the bounded wait below expires and we
@@ -477,6 +521,147 @@ impl IsolationSessionManager {
         check_result(&result, op::REMOVE_USER, StalePromotion::Eligible)
     }
 }
+
+/// A process started inside an isolation session but **not yet awaited**.
+///
+/// Separating start from wait is what makes streaming possible: the executor
+/// path hands these handles to its own relay threads and blocks, while an
+/// in-process SDK caller takes them and drives them itself.
+///
+/// **Handle ownership stays here.** The three pipe handles belong to the
+/// `IsoSessionProcess` and are released by its `Close()`; a consumer duplicates
+/// them and must never close the originals. A `0` means the stream is genuinely
+/// absent, not that a getter failed — `start_process` propagates getter errors
+/// rather than coercing them.
+pub(super) struct StartedProcess {
+    pub(super) process: IsoSessionProcess,
+    pub(super) stdout: u64,
+    pub(super) stderr: u64,
+    pub(super) stdin: u64,
+}
+
+impl StartedProcess {
+    /// Block until the process exits and yield its exit code, escalating
+    /// through the graceful-shutdown ladder if it outlives `timeout_ms`.
+    ///
+    /// The *instruction sequence* is the one the executor path runs inline, but
+    /// the ladder's first two tiers are **inert for a consumer that holds
+    /// duplicates of the pipe handles**, so do not read this as executor-
+    /// equivalent behaviour:
+    ///
+    /// - Tier 1 closes the backend's stdin write end, but a pipe reaches EOF
+    ///   only when *every* write end is closed. A streaming adapter duplicates
+    ///   that handle, so tier 1 alone does not produce EOF — the child sees one
+    ///   only once the caller has dropped its duplicate too.
+    /// - Tier 2 (`SendCtrlClose`) is ConPTY-only and returns `E_NOTIMPL`
+    ///   otherwise, and a library consumer never allocates one.
+    ///
+    /// For a consumer still holding that duplicate, the ladder therefore
+    /// degrades to the full 5s + 3s stall followed by tier 3's hard terminate.
+    /// Making tier 1 work unconditionally needs an owned or transferable stdin
+    /// on the handle type, which is tracked separately.
+    pub(super) fn wait(&self, timeout_ms: u32) -> Result<i32, IsolationSessionError> {
+        // `WaitForExit` is a Win32 `WaitForSingleObject` on a kernel handle —
+        // no COM round-trip. On timeout it returns -1; the ladder below then
+        // decides what to do about a process that is still running.
+        let _ = self
+            .process
+            .WaitForExit(timeout_ms)
+            .map_err(|e| transport_err(op::RUN_PROCESS, "WaitForExit failed", &e))?;
+        wait_with_graceful_shutdown(&self.process)
+    }
+
+    /// Kill the process now, reporting whether the kill request was *accepted*.
+    ///
+    /// Deliberately **not** the graceful ladder [`Self::wait`] uses. That ladder
+    /// gives a well-behaved child up to eight seconds to notice a closed stdin
+    /// or a Ctrl-Close, which is right for a shutdown and wrong for a caller who
+    /// asked to terminate: `SandboxProcess::kill` promises to kill, and a
+    /// cancellation path that takes eight seconds to act reads as a hang.
+    ///
+    /// The post-kill wait is **bounded**. `WaitForExit(0)` means INFINITE here,
+    /// so waiting on the assumption that `Terminate` succeeded would wedge this
+    /// call forever if it ever failed against a live process.
+    ///
+    /// That bound covers *this call only*, and does not make teardown as a whole
+    /// bounded. The streaming adapter's `Drop` runs the terminator and then
+    /// joins the waiter thread unconditionally, and a process that survives the
+    /// kill can park that thread by either of two routes — so supplying a
+    /// timeout does not bound it:
+    ///
+    /// - With no timeout, the waiter is still sitting in its leading
+    ///   `WaitForExit(timeout_ms)`, which is INFINITE for `0`.
+    /// - With a timeout, that call returns and the waiter proceeds into
+    ///   [`wait_with_graceful_shutdown`], which ends in `Terminate` followed by
+    ///   `WaitForExit(0)` — INFINITE again.
+    ///
+    /// Neither route is *certain* to stall: the ladder's tier 3 is a fresh
+    /// `Terminate` that may land where this one did not, and its tier 1 ends a
+    /// child that exits on stdin EOF, once the caller has dropped its own
+    /// duplicate of the write end. The narrow claim is only that nothing in this
+    /// function bounds that wait — so if the process does survive, it is the
+    /// join that waits, not this call.
+    ///
+    /// **What this does not tell you.** The bounded wait's result is discarded,
+    /// so a `Terminate` the platform accepted but that left the process running
+    /// still yields `Ok(())`. Surfacing that needs somewhere to surface it to:
+    /// `ExecHandle::terminator` is an infallible `FnOnce()`, so even the `Err`
+    /// this *does* return is dropped at that boundary. Making the path fallible
+    /// end to end is tracked separately.
+    pub(super) fn terminate(&self) -> Result<(), IsolationSessionError> {
+        self.process
+            .Terminate()
+            .map_err(|e| transport_err(op::RUN_PROCESS, "Terminate failed", &e))?;
+        // Bounded rather than INFINITE so a `Terminate` that was accepted but
+        // never took effect cannot park the caller inside this function. The
+        // result is discarded because there is nowhere to report it; see the
+        // note above, which also covers why this does not bound teardown.
+        let _ = self.process.WaitForExit(TERMINATE_WAIT_MS);
+        Ok(())
+    }
+}
+
+/// A [`StartedProcess`] that releases the session process's pipe handles when
+/// it goes out of scope.
+///
+/// Close-on-drop is **opt-in per consumer** rather than a property of
+/// [`StartedProcess`] itself, because the two consumers need opposite things:
+///
+/// - The streaming consumer has no other teardown point — it hands the handles
+///   to an in-process caller and never returns to this crate — so without this
+///   a long-lived host would leak three handles per exec, and that host is
+///   exactly who the streaming path exists for.
+/// - [`IsolationSessionManager::create_process`] must **not** close on the way
+///   out. It gives the raw handle values to relay threads it may abandon on an
+///   early return, so closing would leave a live thread operating on a value
+///   the OS is free to recycle. It closes explicitly instead, at the one point
+///   in its sequence where every relay has been joined or abandoned on purpose.
+pub(super) struct ClosingProcess(StartedProcess);
+
+impl ClosingProcess {
+    pub(super) fn new(started: StartedProcess) -> Self {
+        Self(started)
+    }
+}
+
+impl std::ops::Deref for ClosingProcess {
+    type Target = StartedProcess;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for ClosingProcess {
+    fn drop(&mut self) {
+        let _ = self.0.process.Close();
+    }
+}
+
+/// How long [`StartedProcess::terminate`] waits for a kill to land before
+/// reporting success anyway. Bounded so a failed `Terminate` cannot wedge that
+/// call; generous enough that a normal kill is observed synchronously.
+const TERMINATE_WAIT_MS: u32 = 5_000;
 
 /// Three-tier graceful shutdown for an `IsoSessionProcess` that's still
 /// running after `WaitForExit(timeout_ms)` returns. Tier 1: close stdin —

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -7,6 +7,7 @@
 //! between caller invocations.
 
 use std::io::IsTerminal;
+use std::sync::Arc;
 
 use serde::Serialize;
 
@@ -20,7 +21,7 @@ use wxc_common::state_aware_backend::{
 use windows::Win32::Foundation::HANDLE;
 
 use super::error::map_lifecycle_error;
-use super::manager::IsolationSessionManager;
+use super::manager::{ClosingProcess, IsolationSessionManager};
 use super::policy::{validate_post_provision_policy, validate_provision_policy};
 use super::process_options::build_process_options;
 use super::sandbox_id::{self, SandboxIdPayload};
@@ -51,6 +52,30 @@ pub struct IsolationSessionProvisionMetadata {
 /// format and its rationale.
 fn extract_agent_user_name(sandbox_id: &str) -> Result<String, MxcError> {
     Ok(sandbox_id::decode(sandbox_id)?.agent_user_name)
+}
+
+/// Whether this exec should ask the OS API to set up a ConPTY.
+///
+/// `host_is_terminal` is a **closure**, not a value, and that is load-bearing:
+/// Rust evaluates arguments eagerly, so passing the probe's result would run the
+/// probe on the `Library` path too — contradicting the contract this function
+/// exists to enforce. Taking a closure makes "never probes under `Library`" a
+/// property of the code rather than a claim in a comment, and one a test can
+/// actually observe.
+///
+/// The rule itself: only [`ExecConsumer::Executor`] may consult the host. Under
+/// `Library` an embedded host's stdout says nothing about the sandbox, and
+/// allocating a pseudo-console would both merge stderr into stdout — destroying
+/// the separate streams the caller asked for — and touch console state the
+/// caller owns.
+fn wants_interactive_console(
+    consumer: ExecConsumer,
+    host_is_terminal: impl FnOnce() -> bool,
+) -> bool {
+    match consumer {
+        ExecConsumer::Executor => host_is_terminal(),
+        ExecConsumer::Library => false,
+    }
 }
 
 impl StatefulSandboxBackend for IsolationSessionRunner {
@@ -211,42 +236,128 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         validate_post_provision_policy(request).map_err(map_lifecycle_error)
     }
 
-    /// Reuses `IsolationSessionManager::create_process` — the same path the
-    /// one-shot runner uses. Output streams to wxc-exec's stdout/stderr via
-    /// internal relay threads while the call is in flight; the call returns
-    /// once the process has exited and the relays have drained. The
-    /// resulting `ExecHandle` carries sentinel pipe handles plus a waiter
-    /// closure that yields the already-captured exit code, so the
-    /// dispatcher's `relay_exec_to_stdio` is a thin call-through.
+    /// Executes the workload inside the running isolation session.
+    ///
+    /// **The two consumers get different shapes, deliberately** — see
+    /// [`ExecConsumer`]. Under `Executor` this keeps the backend's own relay:
+    /// `create_process` blocks, bridging the guest's pipes to wxc-exec's stdio
+    /// through internal threads that also manage the ConPTY, the raw-VT console
+    /// mode, the viewport size and stdin. None of that exists in the
+    /// dispatcher's generic relay — which since the relay landed does not
+    /// forward stdin at all — so handing it real handles here would regress the
+    /// interactive shell. The returned `ExecHandle` therefore carries sentinel
+    /// handles plus a waiter yielding the already-captured exit code, and the
+    /// dispatcher's relay stays a call-through.
+    ///
+    /// Under `Library` the caller drives the streams, so this starts the process
+    /// without waiting and hands back its real pipe handles, a waiter that
+    /// blocks on exit, and a terminator that actually kills. It performs **no**
+    /// console probe: an embedded host's stdout says nothing about the sandbox,
+    /// and touching console state would mutate something the caller owns.
+    ///
+    /// # Testing gap — deliberate, and not closable here
+    ///
+    /// The `Library` branch has **no end-to-end coverage**: nothing proves that
+    /// the returned handles really stream, or that the terminator really kills.
+    /// Two independent reasons, and neither is fixable at this layer:
+    ///
+    /// 1. It needs a host running the OS-side isolation-session service, which
+    ///    CI and most dev machines do not have.
+    /// 2. More fundamentally, the path is unreachable through the public
+    ///    in-process entry points even *on* such a host:
+    ///    `mxc_engine::exec_state_aware` calls `require_experimental_optin`,
+    ///    and `config_parser` hardcodes `experimental_enabled: false` with the
+    ///    only setter sitting on the one-shot builder. Until the state-aware
+    ///    entry points take an `experimental` parameter, every in-process call
+    ///    against this backend is rejected before it reaches `exec`.
+    ///
+    /// A test could fake its way past (2) by building the request in-crate with
+    /// the flag set, but that scaffolding would have to be deleted as soon as
+    /// the real opt-in lands. The end-to-end proof belongs with the change that
+    /// makes this path publicly reachable.
+    ///
+    /// What *is* pinned here: the consumer split itself
+    /// (`wants_interactive_console`), and — in `wxc_common` — that
+    /// `ExecSandboxProcess::wait` drains streams the caller did not take, which
+    /// is the deadlock this branch would otherwise arm.
     fn exec(
         &mut self,
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
-        _consumer: ExecConsumer,
+        consumer: ExecConsumer,
     ) -> Result<ExecHandle, MxcError> {
         let agent_user_name = extract_agent_user_name(sandbox_id)?;
         let manager =
             IsolationSessionManager::new(&agent_user_name).map_err(map_lifecycle_error)?;
 
-        let interactive = std::io::stdout().is_terminal();
-        let options = build_process_options(request, interactive);
+        match consumer {
+            ExecConsumer::Executor => {
+                let options = build_process_options(
+                    request,
+                    wants_interactive_console(consumer, || std::io::stdout().is_terminal()),
+                );
 
-        let exit_code = manager
-            .create_process(&options)
-            .map_err(map_lifecycle_error)?;
+                let exit_code = manager
+                    .create_process(&options)
+                    .map_err(map_lifecycle_error)?;
 
-        // The output relay completed inside `create_process`. The dispatcher
-        // sees zero pipe handles, skips its own relay setup, and gets the
-        // exit code from the waiter closure.
-        let null = HANDLE(std::ptr::null_mut());
-        Ok(ExecHandle {
-            stdout: null,
-            stderr: null,
-            stdin: null,
-            waiter: Box::new(move || Ok(exit_code)),
-            terminator: Box::new(|| {}),
-        })
+                // The output relay completed inside `create_process`. The
+                // dispatcher sees zero pipe handles, skips its own relay setup,
+                // and gets the exit code from the waiter closure.
+                let null = HANDLE(std::ptr::null_mut());
+                Ok(ExecHandle {
+                    stdout: null,
+                    stderr: null,
+                    stdin: null,
+                    waiter: Box::new(move || Ok(exit_code)),
+                    terminator: Box::new(|| {}),
+                })
+            }
+            ExecConsumer::Library => {
+                let options = build_process_options(
+                    request,
+                    wants_interactive_console(consumer, || std::io::stdout().is_terminal()),
+                );
+                let timeout_ms = options.timeout_ms;
+
+                let started = Arc::new(ClosingProcess::new(
+                    manager
+                        .start_process(&options)
+                        .map_err(map_lifecycle_error)?,
+                ));
+
+                // Read the handles before the closures take ownership. A zero
+                // means the stream is genuinely absent, which is exactly the
+                // sentinel the consumer already treats as "no stream".
+                let stdout = HANDLE(started.stdout as *mut std::ffi::c_void);
+                let stderr = HANDLE(started.stderr as *mut std::ffi::c_void);
+                let stdin = HANDLE(started.stdin as *mut std::ffi::c_void);
+
+                // `IsoSessionProcess` is an agile WinRT object (the bindings
+                // declare it `Send + Sync`), so both closures can hold it
+                // without the apartment-affine worker thread the WSLC backend
+                // needs.
+                let waiter_process = Arc::clone(&started);
+                Ok(ExecHandle {
+                    stdout,
+                    stderr,
+                    stdin,
+                    waiter: Box::new(move || {
+                        waiter_process.wait(timeout_ms).map_err(map_lifecycle_error)
+                    }),
+                    // `ExecHandle::terminator` cannot report failure, so a
+                    // failed kill is logged-by-discard here. The fallible
+                    // signature still earns its keep: it is what stops
+                    // `terminate` from waiting INFINITE on a `Terminate` that
+                    // never landed, and it lets a future handle type surface
+                    // the error without changing the backend.
+                    terminator: Box::new(move || {
+                        let _ = started.terminate();
+                    }),
+                })
+            }
+        }
     }
 }
 
@@ -263,6 +374,49 @@ mod tests {
     // silently swallow every per-phase config (the field would still
     // deserialize from the containment slot via models.rs's serde
     // rename — only the experimental block would go missing).
+    // ====== Consumer-conditional stdio ======
+
+    /// A library caller must never get a ConPTY — **including on a host whose
+    /// stdout is a terminal**, which is the only case that can distinguish a
+    /// correct implementation from one that ignores the consumer.
+    ///
+    /// Allocating one here would be doubly wrong: a pseudo-console merges
+    /// stderr into stdout, so the caller would silently lose the separate
+    /// stream it asked for, and setting it up touches console state the caller
+    /// owns.
+    #[test]
+    fn a_library_caller_never_gets_an_interactive_console() {
+        let mut probed = false;
+        assert!(
+            !wants_interactive_console(ExecConsumer::Library, || {
+                probed = true;
+                true
+            }),
+            "a terminal host must not leak a console into the library path"
+        );
+        assert!(
+            !probed,
+            "the library path must not even evaluate the host probe -- passing the \
+             probe's value rather than a closure would run it eagerly"
+        );
+    }
+
+    /// The executor path is the only one allowed to act on the probe, and it
+    /// must actually follow it rather than hardcoding either answer.
+    ///
+    /// Both host answers are asserted, so hardcoding `true` *or* `false` fails.
+    #[test]
+    fn the_executor_path_follows_the_host() {
+        assert!(
+            wants_interactive_console(ExecConsumer::Executor, || true),
+            "a terminal host must still get an interactive console"
+        );
+        assert!(
+            !wants_interactive_console(ExecConsumer::Executor, || false),
+            "a piped host must not get one"
+        );
+    }
+
     #[test]
     fn backend_key_matches_wire_format() {
         assert_eq!(

--- a/src/core/wxc_common/src/exec_stream.rs
+++ b/src/core/wxc_common/src/exec_stream.rs
@@ -23,24 +23,49 @@
 //! The adapter closes only its duplicates on drop; the backend's originals (and
 //! its `waiter`/`terminator`, which may also reference them) are untouched — so
 //! there is no double-close even for a backend that keeps and closes its own
-//! pipe ends. The only in-tree state-aware backend today (IsolationSession)
-//! relays internally and returns null pipe handles, so its streams are simply
-//! absent here.
+//! pipe ends. IsolationSession is exactly that case under
+//! [`ExecConsumer::Library`]: it is the only state-aware backend that returns
+//! real pipe handles, and it closes its own ends when its process object drops.
+//! Under [`ExecConsumer::Executor`] it relays internally and returns null
+//! handles, and the other state-aware backends (Windows Sandbox, WSLc) return
+//! null handles on every path — in those cases the streams are simply absent
+//! here.
+//!
+//! Each readable duplicate is wrapped as a **cancellable** reader, so a read on
+//! it can be made to return EOF on demand. That is what lets
+//! [`wait`](SandboxProcess::wait) end its own safety-drain of a stream the
+//! caller did not take instead of detaching the thread doing it, and what lets a
+//! caller abandon a read on a stream it *did* take — see
+//! [`stdout_closer`](SandboxProcess::stdout_closer).
 //!
 //! [`try_clone_to_owned`]: std::os::windows::io::BorrowedHandle::try_clone_to_owned
+//! [`ExecConsumer::Library`]: crate::state_aware_backend::ExecConsumer::Library
+//! [`ExecConsumer::Executor`]: crate::state_aware_backend::ExecConsumer::Executor
 
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use crate::mxc_error::MxcError;
-use crate::sandbox_process::SandboxProcess;
+use crate::sandbox_process::{boxed_closer, cancel_and_join_discard, SandboxProcess, StreamCloser};
 use crate::state_aware_backend::{ExecHandle, PipeHandle};
+
+/// The platform's closer for a cancellable read — fired to make an in-flight
+/// read on a not-taken stream return EOF, so its discard thread ends and can be
+/// joined rather than detached. Same type the process-spawning backends store.
+#[cfg(target_os = "windows")]
+type StreamCanceller = crate::process_util::PipeReadCanceller;
+/// The platform's closer for a cancellable read — see the Windows variant.
+#[cfg(not(target_os = "windows"))]
+type StreamCanceller = crate::interruptible_reader::ReadCanceller;
+
+/// A wrapped readable stream plus the closer that EOFs it on demand.
+type ReadStream = (Box<dyn Read + Send>, StreamCanceller);
 
 /// An [`ExecHandle`]'s streams, once classified.
 struct PreparedStreams {
-    stdout: Option<Box<dyn Read + Send>>,
-    stderr: Option<Box<dyn Read + Send>>,
+    stdout: Option<ReadStream>,
+    stderr: Option<ReadStream>,
     stdin: Option<Box<dyn Write + Send>>,
 }
 
@@ -49,6 +74,12 @@ pub struct ExecSandboxProcess {
     stdout: Option<Box<dyn Read + Send>>,
     stderr: Option<Box<dyn Read + Send>>,
     stdin: Option<Box<dyn Write + Send>>,
+    /// Closers for the two readable streams, kept whether or not the caller
+    /// takes them: [`wait`](SandboxProcess::wait) fires one to end its own
+    /// safety-drain, and [`stdout_closer`](SandboxProcess::stdout_closer) hands
+    /// a clone to a caller that took the stream and needs to abandon a read.
+    stdout_canceller: Option<StreamCanceller>,
+    stderr_canceller: Option<StreamCanceller>,
     /// The background thread running the handle's `waiter`. Taken and joined by
     /// the first [`wait`](SandboxProcess::wait) / successful
     /// [`try_wait`](SandboxProcess::try_wait).
@@ -79,8 +110,8 @@ impl ExecSandboxProcess {
             terminator,
         } = handle;
 
-        let streams = wrap_read_checked(stdout, "stdout").and_then(|out| {
-            let err = wrap_read_checked(stderr, "stderr")?;
+        let streams = wrap_cancellable_read_checked(stdout, "stdout").and_then(|out| {
+            let err = wrap_cancellable_read_checked(stderr, "stderr")?;
             let input = wrap_write_checked(stdin, "stdin")?;
             Ok(PreparedStreams {
                 stdout: out,
@@ -119,6 +150,11 @@ impl ExecSandboxProcess {
             }
         };
 
+        // Split each stream from its closer: the stream may be taken by the
+        // caller, the closer is kept either way.
+        let (stdout, stdout_canceller) = split_stream(stdout);
+        let (stderr, stderr_canceller) = split_stream(stderr);
+
         // The waiter is handed to the thread through a shared slot rather than
         // moved directly, because `Builder::spawn` consumes and drops the
         // closure when the OS refuses a thread -- leaving no way to reap the
@@ -151,6 +187,8 @@ impl ExecSandboxProcess {
             stdout,
             stderr,
             stdin,
+            stdout_canceller,
+            stderr_canceller,
             waiter: Some(waiter_thread),
             terminator: Some(terminator),
             exit: None,
@@ -173,6 +211,118 @@ impl ExecSandboxProcess {
         self.exit = Some(code);
         Ok(code)
     }
+
+    /// Drain whatever output the caller did not take, concurrently with the
+    /// wait, then join the waiter.
+    ///
+    /// The [`SandboxProcess`] contract promises that taking only one stream is
+    /// safe, and this is what makes that true: an untaken pipe nobody reads
+    /// fills, the child blocks writing to it, and the waiter then waits for an
+    /// exit that cannot happen. Both drains start **before** the join for the
+    /// same reason the relay starts its pumps before its waiter.
+    ///
+    /// Afterwards each discard is **cancelled and then joined**, via the same
+    /// [`cancel_and_join_discard`] the process-spawning backends use. A plain
+    /// join would be wrong twice over — a waiter that returned `Err` means the
+    /// exit could not be determined, *not* that the child is gone, and even on
+    /// a clean exit a backgrounded descendant that inherited the write end
+    /// keeps the pipe open past the foreground child's death — so in both cases
+    /// the discard's `io::copy` would never reach EOF and `wait` would never
+    /// return. Cancelling first makes the read report EOF, which ends the
+    /// thread and bounds the join. Cutting a discard short loses nothing: every
+    /// byte was going to `sink()`, and a stream the caller *took* has no
+    /// discard and so is never cancelled here.
+    ///
+    /// This is what satisfies the contract on
+    /// [`stdout_closer`](SandboxProcess::stdout_closer) that `wait` "already
+    /// cancels its own internal safety-drain".
+    ///
+    /// # Not covered
+    ///
+    /// An untaken `stdin` is dropped rather than closed, which does **not**
+    /// deliver EOF to the child: the handle here is a duplicate, and the
+    /// original belongs to the backend's process object. A workload that reads
+    /// stdin to EOF will still block. Closing that cycle needs an owned or
+    /// closable `ExecHandle::stdin`, which is tracked separately.
+    fn drain_and_join(&mut self) -> std::io::Result<i32> {
+        // Deliberately **not** gated on `self.exit`. A cached exit code means a
+        // previous `try_wait` observed the child finish; it says nothing about
+        // whether anything drained. Returning early here would let
+        // `try_wait()` then `wait()` skip the drain the contract promises.
+        let drain_stdout = match spawn_discard_checked(self.stdout.take()) {
+            Ok(drain) => drain,
+            Err(error) => return Err(self.abort_after_drain_failure(None, error)),
+        };
+        let drain_stderr = match spawn_discard_checked(self.stderr.take()) {
+            Ok(drain) => drain,
+            Err(error) => return Err(self.abort_after_drain_failure(drain_stdout, error)),
+        };
+
+        let result = self.join_waiter();
+
+        cancel_and_join_discard(drain_stdout, &self.stdout_canceller);
+        cancel_and_join_discard(drain_stderr, &self.stderr_canceller);
+        result
+    }
+
+    /// Tear down after a discard thread could not be started.
+    ///
+    /// Waiting is only safe once every untaken stream has a reader. Without one,
+    /// the child can block writing to the stream we failed to cover and the
+    /// waiter never returns — so the caller would be stuck inside `wait` with no
+    /// way to reach `kill`. Terminate instead, then reap the waiter so the
+    /// backend's completion work still runs, then cancel and join whichever
+    /// discard did start — only stdout's can have, since stderr's failure is
+    /// what brought us here. Returns the original error so the caller reports
+    /// the cause rather than the cleanup.
+    fn abort_after_drain_failure(
+        &mut self,
+        stdout_drain: Option<JoinHandle<()>>,
+        error: std::io::Error,
+    ) -> std::io::Error {
+        if let Some(terminator) = self.terminator.take() {
+            terminator();
+        }
+        let _ = self.join_waiter();
+        cancel_and_join_discard(stdout_drain, &self.stdout_canceller);
+        error
+    }
+}
+
+/// Split a prepared stream into the stream itself and its closer.
+///
+/// The stream may later be taken by the caller; the closer is retained either
+/// way, so `wait` can still end a discard and a caller that took the stream can
+/// still be handed one.
+fn split_stream(
+    prepared: Option<ReadStream>,
+) -> (Option<Box<dyn Read + Send>>, Option<StreamCanceller>) {
+    match prepared {
+        Some((stream, canceller)) => (Some(stream), Some(canceller)),
+        None => (None, None),
+    }
+}
+
+/// Spawn a thread that reads `reader` to EOF and discards it. `None` in,
+/// `Ok(None)` out — there is nothing to drain.
+///
+/// The fallible counterpart of [`crate::sandbox_process::spawn_discard`], which
+/// uses `thread::spawn` and so panics when the OS refuses a thread. This one
+/// sits under `wait`, which returns `io::Result` and is reached through the
+/// FFI, where an unwind becomes a reported panic instead of an error — the same
+/// reason the waiter thread above uses `Builder::spawn`.
+fn spawn_discard_checked(
+    reader: Option<Box<dyn Read + Send>>,
+) -> std::io::Result<Option<JoinHandle<()>>> {
+    let Some(mut reader) = reader else {
+        return Ok(None);
+    };
+    let thread = std::thread::Builder::new()
+        .name("mxc-exec-drain".to_string())
+        .spawn(move || {
+            let _ = std::io::copy(&mut reader, &mut std::io::sink());
+        })?;
+    Ok(Some(thread))
 }
 
 impl SandboxProcess for ExecSandboxProcess {
@@ -186,6 +336,19 @@ impl SandboxProcess for ExecSandboxProcess {
 
     fn take_stderr(&mut self) -> Option<Box<dyn Read + Send>> {
         self.stderr.take()
+    }
+
+    /// A closer for a stdout the caller **took** and is reading, so it can
+    /// abandon that read without killing the child — the case a backgrounded
+    /// descendant holding the write end open past the foreground command's exit
+    /// would otherwise leave stuck.
+    fn stdout_closer(&self) -> Option<Box<dyn StreamCloser>> {
+        boxed_closer(&self.stdout_canceller)
+    }
+
+    /// A closer for a taken stderr — see [`stdout_closer`](Self::stdout_closer).
+    fn stderr_closer(&self) -> Option<Box<dyn StreamCloser>> {
+        boxed_closer(&self.stderr_canceller)
     }
 
     fn try_wait(&mut self) -> std::io::Result<Option<i32>> {
@@ -213,7 +376,7 @@ impl SandboxProcess for ExecSandboxProcess {
     }
 
     fn wait(&mut self) -> std::io::Result<i32> {
-        self.join_waiter()
+        self.drain_and_join()
     }
 }
 
@@ -240,6 +403,25 @@ fn wrap_read(handle: PipeHandle) -> Option<Box<dyn Read + Send>> {
     dup_handle_to_file(handle).map(|f| Box::new(f) as Box<dyn Read + Send>)
 }
 
+/// Wrap a readable pipe as a **cancellable** reader plus its closer, so a
+/// discard of it can be ended on demand rather than abandoned.
+///
+/// Separate from [`wrap_read`] because the executor's relay does not need a
+/// closer — it has its own mute-and-abandon path — and only the streaming
+/// adapter stores one.
+#[cfg(target_os = "windows")]
+fn wrap_cancellable_read(handle: PipeHandle) -> Option<ReadStream> {
+    use std::os::windows::io::IntoRawHandle;
+    // Hand the duplicate straight to the interruptible reader: `into_raw_handle`
+    // releases it from the std wrapper without closing it, and
+    // `process_util::OwnedHandle` takes over closing it.
+    let raw = dup_handle_to_owned(handle)?.into_raw_handle();
+    let owned = crate::process_util::OwnedHandle::new(windows::Win32::Foundation::HANDLE(raw as _));
+    let reader = crate::process_util::InterruptiblePipeReader::new(owned);
+    let canceller = reader.canceller();
+    Some((Box::new(reader) as Box<dyn Read + Send>, canceller))
+}
+
 #[cfg(target_os = "windows")]
 fn wrap_write(handle: PipeHandle) -> Option<Box<dyn Write + Send>> {
     dup_handle_to_file(handle).map(|f| Box::new(f) as Box<dyn Write + Send>)
@@ -263,7 +445,7 @@ pub(crate) fn is_null_pipe(handle: PipeHandle) -> bool {
 /// the caller's original handle untouched. Returns `None` for a null handle or
 /// if duplication fails.
 #[cfg(target_os = "windows")]
-fn dup_handle_to_file(handle: PipeHandle) -> Option<std::fs::File> {
+fn dup_handle_to_owned(handle: PipeHandle) -> Option<std::os::windows::io::OwnedHandle> {
     use std::os::windows::io::BorrowedHandle;
     if is_null_pipe(handle) {
         return None;
@@ -271,12 +453,34 @@ fn dup_handle_to_file(handle: PipeHandle) -> Option<std::fs::File> {
     // SAFETY: a non-null exec pipe handle is valid for the borrow; we only
     // duplicate it (DuplicateHandle) and never take ownership of the original.
     let borrowed = unsafe { BorrowedHandle::borrow_raw(handle.0 as _) };
-    borrowed.try_clone_to_owned().ok().map(std::fs::File::from)
+    borrowed.try_clone_to_owned().ok()
+}
+
+#[cfg(target_os = "windows")]
+fn dup_handle_to_file(handle: PipeHandle) -> Option<std::fs::File> {
+    dup_handle_to_owned(handle).map(std::fs::File::from)
 }
 
 #[cfg(not(target_os = "windows"))]
 fn wrap_read(handle: PipeHandle) -> Option<Box<dyn Read + Send>> {
     dup_fd_to_file(handle).map(|f| Box::new(f) as Box<dyn Read + Send>)
+}
+
+/// Wrap a readable pipe as a cancellable reader — see the Windows variant.
+///
+/// Note this does **not** leave the backend's original fd wholly untouched, as
+/// [`dup_fd_to_file`] alone would: `InterruptibleReader` sets `O_NONBLOCK`, and
+/// that is a property of the open file description, which every `dup` shares.
+/// The backend's fd therefore becomes non-blocking too. Harmless while no
+/// state-aware backend is non-Windows — all three are Windows — but a Unix one
+/// that later reads or re-hands its own fd would see `EAGAIN` where it expected
+/// a blocking read.
+#[cfg(not(target_os = "windows"))]
+fn wrap_cancellable_read(handle: PipeHandle) -> Option<ReadStream> {
+    let file = dup_fd_to_file(handle)?;
+    let reader = crate::interruptible_reader::InterruptibleReader::new(file.into()).ok()?;
+    let canceller = reader.canceller();
+    Some((Box::new(reader) as Box<dyn Read + Send>, canceller))
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -315,6 +519,21 @@ pub(crate) fn wrap_read_checked(
     classify_stream(is_null_pipe(handle), || wrap_read(handle), stream)
 }
 
+/// Cancellable counterpart of [`wrap_read_checked`], for the streaming adapter.
+///
+/// Module-private: unlike [`wrap_read_checked`], which the executor's relay also
+/// calls, this one has a single caller in this file.
+fn wrap_cancellable_read_checked(
+    handle: PipeHandle,
+    stream: &str,
+) -> Result<Option<ReadStream>, MxcError> {
+    classify_stream(
+        is_null_pipe(handle),
+        || wrap_cancellable_read(handle),
+        stream,
+    )
+}
+
 /// Writable counterpart of [`wrap_read_checked`].
 pub(crate) fn wrap_write_checked(
     handle: PipeHandle,
@@ -344,6 +563,7 @@ mod tests {
     use crate::mxc_error::MxcErrorCode;
     use crate::state_aware_backend::null_pipe_handle;
     use std::sync::mpsc;
+    use std::time::{Duration, Instant};
 
     /// The null sentinel means "this backend exposes no such stream", and the
     /// wrap is never even attempted.
@@ -470,6 +690,266 @@ mod tests {
                               // Exactly one terminator signal.
         assert!(rx.recv().is_ok());
         assert!(rx.try_recv().is_err());
+    }
+
+    /// `wait()` drains a stream the caller never took.
+    ///
+    /// This is the guarantee that makes the `SandboxProcess` contract's "taking
+    /// only one stream is always safe" true. Without it the untaken pipe fills,
+    /// the child blocks writing to it, and the waiter waits for an exit that
+    /// cannot happen — so a regression here **deadlocks** rather than failing an
+    /// assertion, which is the honest signature of the defect.
+    ///
+    /// The payload is far larger than a pipe buffer on purpose: a smaller one
+    /// would fit and pass whether or not anything drained.
+    #[test]
+    fn wait_drains_a_stream_the_caller_never_took() {
+        let (stdout_r, mut stdout_w) = std::io::pipe().expect("pipe");
+
+        // The "child": writes more than any pipe buffer holds, then closes.
+        // Its completion is what the waiter blocks on, exactly as a real child's
+        // exit would be.
+        let writer = std::thread::spawn(move || {
+            let chunk = vec![b'x'; 8192];
+            for _ in 0..64 {
+                if stdout_w.write_all(&chunk).is_err() {
+                    return false;
+                }
+            }
+            drop(stdout_w);
+            true
+        });
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let handle = ExecHandle {
+            stdout: reader_handle(&stdout_r),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            // Stands in for a real wait: it cannot return until the writer has
+            // finished, which it cannot do unless someone is draining.
+            waiter: Box::new(move || {
+                let wrote_everything = done_rx
+                    .recv_timeout(std::time::Duration::from_secs(30))
+                    .map_err(|_| MxcError::backend_error("the child never finished writing"))?;
+                if wrote_everything {
+                    Ok(0)
+                } else {
+                    Err(MxcError::backend_error("the child's writes failed"))
+                }
+            }),
+            terminator: Box::new(|| {}),
+        };
+
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
+        // Deliberately take nothing.
+        let writer_result = std::thread::spawn(move || {
+            let ok = writer.join().unwrap_or(false);
+            let _ = done_tx.send(ok);
+        });
+
+        assert_eq!(
+            proc.wait().expect("wait must drain the untaken stdout"),
+            0,
+            "an untaken stream must be drained, not left to block the child"
+        );
+        writer_result.join().unwrap();
+        drop(stdout_r);
+    }
+
+    /// A failing waiter must not leave `wait()` parked on a live pipe.
+    ///
+    /// The regression this pins: a waiter error means the exit could not be
+    /// determined, **not** that the child is gone. Joining the discard
+    /// unconditionally then blocks on a pipe that never EOFs, and the caller
+    /// cannot even fall back to `kill` because it is stuck inside `wait`.
+    ///
+    /// The writer is deliberately kept alive for the whole call — that is what
+    /// makes this discriminating. An unbounded join hangs here; cancelling the
+    /// discard's read first ends it and surfaces the waiter's error.
+    #[test]
+    fn wait_returns_a_waiter_error_even_with_a_live_writer() {
+        let (stdout_r, stdout_w) = std::io::pipe().expect("pipe");
+
+        let handle = ExecHandle {
+            stdout: reader_handle(&stdout_r),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Err(MxcError::backend_error("could not determine the exit"))),
+            terminator: Box::new(|| {}),
+        };
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
+
+        let started = Instant::now();
+        let err = proc
+            .wait()
+            .expect_err("a waiter error must reach the caller");
+        let elapsed = started.elapsed();
+
+        assert!(
+            err.to_string().contains("could not determine the exit"),
+            "the waiter's error must survive the drain: {err}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "wait must not block indefinitely on a writer it does not control; took {elapsed:?}"
+        );
+
+        // Held open across the assertions on purpose: dropping it earlier would
+        // deliver the EOF whose absence is the point of the test.
+        drop(stdout_w);
+        drop(stdout_r);
+    }
+
+    /// `wait` must **tear its discard down**, not walk away from it.
+    ///
+    /// This is the regression the cancellable drain exists for, and the other
+    /// tests do not pin it: the live-writer test only asserts that `wait`
+    /// returns promptly, which the previous design — join with a 5s bound, then
+    /// abandon the thread — also satisfied. Abandoning leaks the thread *and*
+    /// the duplicated handle it is still reading, once per exec, in exactly the
+    /// long-lived host this path serves.
+    ///
+    /// Made observable by closing the test's own read end first, so the
+    /// adapter's duplicate is the only one left. If `wait` joined its discard,
+    /// that duplicate is closed by the time it returns and the writer sees a
+    /// broken pipe. If it abandoned the thread, the thread is still parked in a
+    /// read holding the duplicate open, and the write succeeds.
+    #[test]
+    fn wait_tears_down_its_discard_rather_than_abandoning_it() {
+        let (stdout_r, mut stdout_w) = std::io::pipe().expect("pipe");
+
+        let handle = ExecHandle {
+            stdout: reader_handle(&stdout_r),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            // Fails, so the child cannot be assumed gone — the case where the
+            // old design gave up on the join and detached the thread.
+            waiter: Box::new(|| Err(MxcError::backend_error("could not determine the exit"))),
+            terminator: Box::new(|| {}),
+        };
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
+
+        // The adapter duplicated it; this end is no longer needed, and dropping
+        // it now is what makes the duplicate's fate observable below.
+        drop(stdout_r);
+
+        proc.wait()
+            .expect_err("the waiter fails, but the drain must still be torn down");
+
+        let wrote = stdout_w.write_all(b"x");
+        assert_eq!(
+            wrote.map_err(|e| e.kind()),
+            Err(std::io::ErrorKind::BrokenPipe),
+            "wait() left its discard thread holding the pipe open instead of \
+             cancelling and joining it"
+        );
+    }
+
+    /// A caller that took a stream must be able to abandon a read on it without
+    /// killing the child.
+    ///
+    /// The writer is held open for the whole test, so the read has no reason to
+    /// end on its own: reaching EOF is only possible because the closer fired.
+    /// This is the capability `stdout_closer` exists for — a backgrounded
+    /// descendant holding the write end open past the foreground command's exit
+    /// would otherwise strand the caller in a read it cannot cancel.
+    #[test]
+    fn a_taken_stream_can_be_abandoned_with_its_closer() {
+        let (stdout_r, stdout_w) = std::io::pipe().expect("pipe");
+
+        let handle = ExecHandle {
+            stdout: reader_handle(&stdout_r),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Ok(0)),
+            terminator: Box::new(|| {}),
+        };
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
+
+        let mut taken = proc.take_stdout().expect("stdout must be exposed");
+        let closer = proc
+            .stdout_closer()
+            .expect("a stream this adapter exposes must come with a closer");
+
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut sink = Vec::new();
+            let _ = tx.send(taken.read_to_end(&mut sink).map(|_| ()));
+        });
+
+        // Let the reader block on the empty pipe before abandoning it. The
+        // canceller also short-circuits a read that has not started yet, so the
+        // sleep is a courtesy rather than a correctness requirement.
+        std::thread::sleep(Duration::from_millis(50));
+        closer.close();
+
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("closing the stream must end the read");
+        assert!(
+            outcome.is_ok(),
+            "an abandoned read reports EOF, not an error: {outcome:?}"
+        );
+
+        // Held open on purpose: an early drop would deliver the EOF whose
+        // absence is what makes this test discriminating.
+        drop(stdout_w);
+        drop(stdout_r);
+    }
+
+    /// A prior `try_wait()` must not let `wait()` skip the drain.
+    ///
+    /// `self.exit` records that the child finished; it says nothing about
+    /// whether anything was drained. Returning early on it would silently
+    /// break the contract for exactly the caller who polls before waiting.
+    ///
+    /// The proof is that `wait` **consumed the stream**, not that it copied
+    /// every byte. The discard is cancelled as soon as the waiter returns, and
+    /// with the exit already cached that is immediate, so how much of a finished
+    /// child's buffered output the discard reads first is a race. Bytes were
+    /// only ever a proxy; taking the stream is the step an early return skips,
+    /// and it is deterministic.
+    #[test]
+    fn wait_still_drains_after_a_successful_try_wait() {
+        let (stdout_r, mut stdout_w) = std::io::pipe().expect("pipe");
+        stdout_w.write_all(b"left in the pipe").unwrap();
+        drop(stdout_w); // EOF, so the drain can finish
+
+        let handle = ExecHandle {
+            stdout: reader_handle(&stdout_r),
+            stderr: null_pipe_handle(),
+            stdin: null_pipe_handle(),
+            waiter: Box::new(|| Ok(0)),
+            terminator: Box::new(|| {}),
+        };
+        let mut proc = ExecSandboxProcess::from_exec_handle(handle).unwrap();
+
+        // Guards against the assertion below going vacuous: if the wrap had
+        // produced nothing there would be no stream for `wait` to take, and
+        // "is_none() afterwards" would hold no matter what `wait` did.
+        assert!(
+            proc.stdout.is_some(),
+            "precondition: the adapter must have wrapped the test's stdout"
+        );
+
+        // Poll until the waiter thread has finished, caching the exit code.
+        let started = Instant::now();
+        while proc.try_wait().unwrap().is_none() {
+            assert!(
+                started.elapsed() < Duration::from_secs(10),
+                "the waiter should have completed"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        assert_eq!(proc.wait().unwrap(), 0);
+
+        assert!(
+            proc.stdout.is_none(),
+            "wait() skipped the drain after try_wait(): the untaken stream was never drained"
+        );
+
+        drop(stdout_r);
     }
 
     // Build a PipeHandle from a live pipe end's raw handle/fd (the adapter

--- a/src/core/wxc_common/src/state_aware_backend.rs
+++ b/src/core/wxc_common/src/state_aware_backend.rs
@@ -216,15 +216,24 @@ pub trait StatefulSandboxBackend {
     /// own stdio, where a pseudo-console is legitimate and stderr may therefore
     /// arrive merged into stdout.
     ///
-    /// # Not yet honored
+    /// # Honored by one backend so far
     ///
     /// The above states what an implementation must satisfy to be driven
-    /// through the streaming entry points; it is **not** a description of
-    /// current behaviour. No in-tree backend honors `Library` yet: each relays
-    /// internally and returns null handles, and IsolationSession still probes
-    /// the host console whatever the caller asked for. Until a backend surfaces
-    /// real handles, the streaming path yields a process with no streams, so
-    /// treat these backends as executor-path only.
+    /// through the streaming entry points. It is not yet a description of every
+    /// backend's behaviour:
+    ///
+    /// - **IsolationSession** honors both variants. Under `Library` it starts
+    ///   the process without waiting, hands back its real pipe handles, a waiter
+    ///   that blocks on exit and a terminator that kills, and does not touch the
+    ///   host console. Under `Executor` it relays internally and returns null
+    ///   handles.
+    /// - **Windows Sandbox** and **WSLc** relay internally and return null
+    ///   handles whatever the caller asked for, so for those two the streaming
+    ///   path still yields a process with no streams — treat them as
+    ///   executor-path only.
+    ///
+    /// Reaching any of this from an in-process caller additionally requires the
+    /// experimental opt-in, which the state-aware entry points do not yet expose.
     fn exec(
         &mut self,
         sandbox_id: &str,


### PR DESCRIPTION
## 📖 Description

`IsolationSessionRunner::exec` always ran the process to completion internally and handed back null pipe handles, a waiter yielding the already-captured exit code, and a terminator that did nothing. That is exactly what the executor binary needs — it relays through its own console and has the exit code by the time it returns — but it leaves an in-process caller with nothing to drive. This makes the returned handle conditional on the consumer, so the Rust SDK and the FFI can drive an `exec` phase live.

**The executor path is unchanged.** Under `ExecConsumer::Executor` the internal relay still runs and the handles stay null, so the interactive experience keeps the console-mode handling, resize forwarding and stdin forwarding that the generic relay does not have. Under `ExecConsumer::Library` the process is started without waiting, and the caller gets the real pipe handles, a waiter that blocks on exit, and a terminator that kills.

Uniform real handles for both consumers was considered and rejected for now: the generic relay lacks console mode, resize *and* stdin, so routing the executor through it would regress the interactive path. Nothing here forecloses that — the split below is the prerequisite either way.

**Splitting starting from waiting.** `create_process` started a process, relayed its stdio, waited for exit and tore it down in one call. `start_process` now returns a `StartedProcess` carrying the process object and its three pipe handles, with `wait` and `terminate` for driving it afterwards; `create_process` is rebuilt on it and keeps its previous behaviour, including relay spawn and join order and the point at which it closes the process.

**Handle ownership is opt-in per consumer**, via `ClosingProcess`, because the two consumers need opposite things. A streaming consumer has no other teardown point, so without close-on-drop it would leak three handles per exec — and that consumer is precisely who this path exists for. `create_process` must *not* close on the way out: it hands the raw handle values to relay threads it may abandon on an early return, and closing there would leave a live thread operating on a value the OS is free to recycle. A wrapper rather than a `Drop` on `StartedProcess` also avoids `ManuallyDrop` at the call site, which would suppress the process object's own COM release along with the close.

**Draining untaken output, cancellably.** `ExecSandboxProcess::wait` joined the waiter while the process could still be writing. A caller that takes neither stream — which the run-to-completion path does — leaves both pipes unread, so a child producing more than a pipe buffer's worth of output blocks and the waiter never returns. Each untaken stream now gets a discard reader started *before* the join, and cancelled after it.

Cancelling rather than plain-joining matters in both directions: a waiter that returned `Err` means the exit could not be determined, not that the child is gone, and even on a clean exit a backgrounded descendant that inherited the write end keeps the pipe open past the foreground child's death. So each readable duplicate is wrapped as an interruptible reader and its canceller kept, which is what the existing `cancel_and_join_discard` needs — the same helper the process-spawning backends already use. This adapter was the one `SandboxProcess` implementation not honouring the trait's documented promise that `wait` cancels its own safety-drain.

The cancellers are also exposed as `stdout_closer` / `stderr_closer`, which previously defaulted to `None` here: a caller that *took* a stream can now abandon a read a descendant is holding open, without killing the child.

Drain completion is tracked separately from the cached exit code, so a prior `try_wait` does not make a later `wait` skip draining. The discard threads are started fallibly, since `thread::spawn` panics when the OS refuses a thread and this sits under a `wait` that returns `io::Result` and is reached through the FFI.

The console probe belongs to the consumer split rather than beside it. An embedded host's stdout says nothing about the sandbox, and touching console state would mutate something the caller owns, so the `Library` arm must not probe at all. `wants_interactive_console` takes the host answer as a closure so that is a property of the code rather than an assertion in a comment — Rust evaluates arguments eagerly, so passing the probe by value would run it on both arms.

**Known gaps, each documented in code rather than left to be discovered:**

- The `Library` path has **no end-to-end coverage**, and cannot get any at this layer: it needs a host running the OS-side isolation-session service, and it is unreachable through the public in-process entry points regardless, since the parser hardcodes `experimental_enabled: false` and the only setter is on the one-shot builder. A test faking past that would be deleted as soon as the real opt-in lands.
- `ExecHandle::terminator` is an infallible `FnOnce()`, so the terminator **reports nothing** — the backend requests termination and discards whether the platform accepted it. `StartedProcess::terminate` is the layer that distinguishes an accepted request; the handle type has nowhere to carry the answer.
- A timed-out exec reports its eventual exit code rather than a timeout, so `WaitOutcome::TimedOut` is not reachable through this backend. Carrying it needs the same reshape of `ExecHandle`'s waiter that making the terminator fallible does.
- Teardown is not bounded if a process survives `Terminate` — the adapter's `Drop` joins the waiter unconditionally. That `Drop` is shared by every state-aware backend, so bounding it belongs with the change that makes the terminator fallible, not here.
- Untaken stdin is only dropped. The handle is duplicated rather than transferred, so dropping it does not close the child's stdin and a workload reading to EOF will not see one.

## 🔗 References

No linked issue. Continues the work started in #829, which added the generic relay and the `ExecConsumer` distinction; this is the first backend to return real pipe handles through it. A follow-up makes the state-aware entry points able to opt in to experimental backends, which is what finally makes this path publicly reachable.

## 🔍 Validation

Unit coverage pins what can be pinned host-independently: the consumer split itself, and — in `wxc_common` — that `wait` drains streams the caller did not take, that it tears that drain down rather than abandoning it, and that a caller who took a stream can abandon a read on it. Every behavioural claim is mutation-verified: 9 mutations, each reverting one behaviour, each confirmed to fail the test that names it. Two are **reorderings** rather than deletions, since a test asserting that a call happened will pass when that call merely moves; one surfaces as a hang rather than a failure. Mutations are checked for compiling, because one that fails to build exits non-zero and would otherwise read as a caught regression.

Full local gate set green on this exact tree: `fmt`, `clippy -D warnings`, build and test with `isolation_session` on and off, arm64 build, versioning scripts, C# SDK, Node SDK unit + integration, and the elevated `wxc_host_prep` tests (16/16). On a host with the OS-side isolation service, the end-to-end suites ran **90 passed / 0 failed / 0 skipped** with an empty account-leak delta, and the interactive terminal tests (resize, streaming, interactive shell) passed at the console — the executor path's only real oracle, and the reason this change deliberately leaves it untouched.

## ✅ Checklist

- [x] Signed the Contributor License Agreement

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/839)