### PR TITLE
[WSLC] Fix runner use-after-free and session boot timeout (Closes #722)

### DIFF
--- a/docs/wsl/wsl-container-support-plan.md
+++ b/docs/wsl/wsl-container-support-plan.md
@@ -267,7 +267,7 @@ Implements `ScriptRunner` trait. Orchestrates the full lifecycle using WSLC SDK:
 **I/O and process behavior:**
 - `WSLContainerRunner` captures stdout/stderr from native Win32 HANDLEs returned by `WslcProcessGetIOHandles()` and returns them in `ScriptResponse`, matching the current `AppContainerScriptRunner` behavior
 - The exit code is retrieved via `WslcProcessGetExitCode()` after the process exit event signals
-- The `timeout` config field is enforced via `WslcSetSessionSettingsTimeout()` at the session level, plus a Rust-side watchdog that calls `WslcStopContainer(WSLC_SIGNAL_SIGKILL)` if needed
+- `WslcSetSessionSettingsTimeout()` receives a fixed session **boot** budget (`SESSION_BOOT_TIMEOUT_MS`, 180s) — the deadline for bringing the WSL session up — and is deliberately independent of `scriptTimeout`, so a short command timeout cannot abort a cold VM boot. The `scriptTimeout` config field (the per-command runtime deadline) is enforced separately at the process wait (`wait_timeout_ms`), plus a Rust-side watchdog that calls `WslcStopContainer(WSLC_SIGNAL_SIGKILL)` if needed
 
 **Path translation (Windows host → Linux container):**
 - Volume mounts use `WslcSetContainerSettingsVolumes()` which accepts `WslcContainerVolume` structs with explicit `windowsPath` (PCWSTR) and `containerPath` (PCSTR) fields

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -148,6 +148,13 @@ fn write_through(mut sink: impl std::io::Write, bytes: &[u8]) -> std::io::Result
 /// misbehaving runtime can't park teardown forever.
 const EXIT_CALLBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// VM/session boot budget, in milliseconds. This is the deadline for bringing
+/// the WSL session up, and is deliberately independent of the per-command
+/// `scriptTimeout` (the command runtime deadline is enforced separately at the
+/// wait, see [`wait_timeout_ms`]). A short `scriptTimeout` must not be able to
+/// abort a cold VM boot.
+const SESSION_BOOT_TIMEOUT_MS: u32 = 180_000;
+
 /// Lock a mutex, tolerating poisoning: every mutex here guards plain output
 /// state with no invariant a panicking writer could break.
 fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
@@ -759,11 +766,9 @@ impl WSLContainerRunner {
                 return Err(sdk_error("WslcSetSessionSettingsMemory failed", hr, ""));
             }
         }
-        if request.script_timeout > 0 {
-            let hr = sdk.WslcSetSessionSettingsTimeout(&mut settings, request.script_timeout);
-            if hr != S_OK {
-                return Err(sdk_error("WslcSetSessionSettingsTimeout failed", hr, ""));
-            }
+        let hr = sdk.WslcSetSessionSettingsTimeout(&mut settings, SESSION_BOOT_TIMEOUT_MS);
+        if hr != S_OK {
+            return Err(sdk_error("WslcSetSessionSettingsTimeout failed", hr, ""));
         }
         if self.config.gpu {
             let hr = sdk.WslcSetSessionSettingsFeatureFlags(
@@ -1462,25 +1467,27 @@ impl WSLContainerRunner {
         // therefore only ever sees `"tcp"` today, but the explicit branch is
         // retained so this code keeps compiling cleanly if/when the parser
         // starts accepting UDP after an SDK update.
-        if !self.config.port_mappings.is_empty() {
-            let mappings: Vec<WslcContainerPortMapping> = self
-                .config
-                .port_mappings
-                .iter()
-                .map(|pm| WslcContainerPortMapping {
-                    windowsPort: pm.windows_port,
-                    containerPort: pm.container_port,
-                    protocol: if pm.protocol == "udp" {
-                        WslcPortProtocol::WSLC_PORT_PROTOCOL_UDP
-                    } else {
-                        WslcPortProtocol::WSLC_PORT_PROTOCOL_TCP
-                    },
-                    // Default bind address (typically loopback/0.0.0.0 per
-                    // SDK config). Not exposed in the MXC config today.
-                    windowsAddress: ptr::null_mut(),
-                })
-                .collect();
-
+        // Built at function scope: these arrays must outlive
+        // `WslcCreateContainer` below, which is the call that actually consumes
+        // the pointers handed to `WslcSetContainerSettingsPortMappings`.
+        let mappings: Vec<WslcContainerPortMapping> = self
+            .config
+            .port_mappings
+            .iter()
+            .map(|pm| WslcContainerPortMapping {
+                windowsPort: pm.windows_port,
+                containerPort: pm.container_port,
+                protocol: if pm.protocol == "udp" {
+                    WslcPortProtocol::WSLC_PORT_PROTOCOL_UDP
+                } else {
+                    WslcPortProtocol::WSLC_PORT_PROTOCOL_TCP
+                },
+                // Default bind address (typically loopback/0.0.0.0 per
+                // SDK config). Not exposed in the MXC config today.
+                windowsAddress: ptr::null_mut(),
+            })
+            .collect();
+        if !mappings.is_empty() {
             let hr = sdk.WslcSetContainerSettingsPortMappings(
                 &mut container_settings,
                 mappings.as_ptr(),
@@ -1520,17 +1527,18 @@ impl WSLContainerRunner {
             })
             .collect();
 
-        if !mounts.is_empty() {
-            let volumes: Vec<WslcContainerVolume> = wide_paths
-                .iter()
-                .zip(mounts.iter())
-                .map(|((win, ctr), m)| WslcContainerVolume {
-                    windowsPath: win.as_ptr(),
-                    containerPath: ctr.as_ptr() as PCSTR,
-                    readOnly: if m.read_only { 1 } else { 0 },
-                })
-                .collect();
-
+        // Built at function scope alongside `wide_paths`: these structs point
+        // into `wide_paths` and must outlive `WslcCreateContainer` below.
+        let volumes: Vec<WslcContainerVolume> = wide_paths
+            .iter()
+            .zip(mounts.iter())
+            .map(|((win, ctr), m)| WslcContainerVolume {
+                windowsPath: win.as_ptr(),
+                containerPath: ctr.as_ptr() as PCSTR,
+                readOnly: if m.read_only { 1 } else { 0 },
+            })
+            .collect();
+        if !volumes.is_empty() {
             let hr = sdk.WslcSetContainerSettingsVolumes(
                 &mut container_settings,
                 volumes.as_ptr(),


### PR DESCRIPTION
## 📖 Description

- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Fixes two defects in the WSLc container runner (`wsl_container_runner.rs`) reported in #722:

**A. Use-after-free of borrowed mapping/volume pointers.** The `mappings` and `volumes` `Vec`s were declared inside the `if` blocks that populate them, so they were dropped before the `WslcCreateContainer` FFI call that borrows their pointers. They are now hoisted to function scope so they outlive the create call (mirroring the existing `wide_paths` keep-alive pattern).

**B. Session boot timeout incorrectly tied to script timeout.** `WslcSetSessionSettingsTimeout` was being passed `request.script_timeout`, conflating the container/session boot budget with the per-exec command timeout. It now uses a dedicated `SESSION_BOOT_TIMEOUT_MS` constant (180s).

## Validation

- `cargo clippy -p wslc_common --target x86_64-pc-windows-msvc --all-targets -- -D warnings` — clean
- `cargo test -p wslc_common --target x86_64-pc-windows-msvc` — 182 passed / 0 failed

Closes #722

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/846)