### PR TITLE
Fix inherited output handle test race

### DIFF
--- a/src/host/plm/src/start.rs
+++ b/src/host/plm/src/start.rs
@@ -573,42 +573,63 @@ mod tests {
 
     #[test]
     fn inherited_output_handle_cannot_block_control_completion() {
+        struct DescendantCleanup {
+            pid_path: PathBuf,
+        }
+
+        impl DescendantCleanup {
+            fn pid(&self) -> Option<u32> {
+                std::fs::read_to_string(&self.pid_path)
+                    .ok()?
+                    .trim()
+                    .parse()
+                    .ok()
+            }
+        }
+
+        impl Drop for DescendantCleanup {
+            fn drop(&mut self) {
+                let Some(pid) = self.pid() else {
+                    return;
+                };
+                let _ = Command::new("taskkill.exe")
+                    .args(["/PID", &pid.to_string(), "/T", "/F"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
+            }
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        let cleanup = DescendantCleanup {
+            pid_path: directory.path().join("descendant.pid"),
+        };
+        let pid_path = cleanup.pid_path.to_string_lossy().replace('\'', "''");
         let mut command = Command::new("powershell.exe");
         command.args([
             "-NoProfile",
             "-Command",
-            "$p = Start-Process powershell.exe -NoNewWindow -PassThru -ArgumentList \
-             '-NoProfile','-Command','Start-Sleep -Seconds 60'; Write-Output \"PID=$($p.Id)\"",
+            &format!(
+                "$p = Start-Process powershell.exe -NoNewWindow -PassThru -ArgumentList \
+                 '-NoProfile','-Command','Start-Sleep -Seconds 120'; \
+                 [IO.File]::WriteAllText('{pid_path}', [string]$p.Id); \
+                 Write-Output \"PID=$($p.Id)\""
+            ),
         ]);
         let started = Instant::now();
 
-        let error =
-            run_wpr_command(command, "test", "powershell.exe", Duration::from_secs(5)).unwrap_err();
+        let error = run_wpr_command(command, "test", "powershell.exe", Duration::from_secs(30))
+            .unwrap_err();
         let control_elapsed = started.elapsed();
         let message = format!("{error:#}");
-        let pid = message
-            .split("PID=")
-            .nth(1)
-            .and_then(|suffix| {
-                suffix
-                    .chars()
-                    .take_while(char::is_ascii_digit)
-                    .collect::<String>()
-                    .parse::<u32>()
-                    .ok()
-            })
-            .expect("descendant PID should be retained in partial stdout");
-        let _ = Command::new("powershell.exe")
-            .args([
-                "-NoProfile",
-                "-Command",
-                &format!("Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue"),
-            ])
-            .status();
+        let pid = cleanup
+            .pid()
+            .expect("descendant PID should be recorded for cleanup");
 
         assert!(message.contains("output drain failed"));
+        assert!(message.contains(&format!("PID={pid}")));
         assert!(may_have_changed_wpr_state(&error));
-        assert!(control_elapsed < Duration::from_secs(15));
+        assert!(control_elapsed < Duration::from_secs(40));
     }
 
     /// Whether `element` carries an attribute `name` whose (unescaped)


### PR DESCRIPTION
## 📖 Description

Fixes the race in `start::tests::inherited_output_handle_cannot_block_control_completion` that intermittently failed when PowerShell could not start and emit its descendant PID within the previous five-second control timeout.

The test now uses a 30-second startup ceiling while preserving its normal approximately three-second runtime. It records the descendant PID in a dedicated temporary file before emitting the captured `PID=` marker, so cleanup does not depend on successfully parsing partial stdout.

A `Drop` guard terminates the descendant process tree with `taskkill /T /F` on every exit path, including assertion failures, preventing the test from leaking its sleeping PowerShell process onto CI runners.

## 🔗 References

Fixes #845

## 🔍 Validation

- `inherited_output_handle_cannot_block_control_completion` passed 30 consecutive runs
- Full `cargo test -p plm`: 179 passed, 1 ignored
- `cargo clippy -p plm --all-targets -- -D warnings`
- Confirmed zero remaining `Start-Sleep -Seconds 120` descendant processes after repetition runs

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (not applicable; test-only fix)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (not applicable; no architecture or convention change)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (not applicable; `Cargo.lock` unchanged)

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/848)