### PR TITLE
[WSLC] Honor state-aware portMappings and reject redundant one-shot host lists (Closes #824)

### DIFF
--- a/docs/wsl/wsl-container-getting-started.md
+++ b/docs/wsl/wsl-container-getting-started.md
@@ -353,18 +353,21 @@ that combine the proxy with a `block` default or host lists are **rejected**.
 
 ### Per-host filtering is not supported
 
-WSLC **cannot** enforce per-host egress filtering. `allowedHosts` with
-`defaultPolicy: "block"` (an allowlist) or `blockedHosts` with
-`defaultPolicy: "allow"` (a blocklist) would require in-container `iptables`
-rules, but a WSLC container runs **without** `CAP_NET_ADMIN` (the SDK's
-`Privileged` flag does not grant it), so those rules cannot be applied — and MXC
-has no VM-level enforcement hook either (WSLC cannot expose one without breaking
-other security promises such as MDE). Rather than fail the run at exec time,
-such configs are **rejected at config-parse time**:
+WSLC **cannot** enforce per-host egress filtering. Any allowlist
+(`allowedHosts` with `defaultPolicy: "block"`) or blocklist (`blockedHosts`
+with `defaultPolicy: "allow"`) would require in-container `iptables` rules, but
+a WSLC container runs **without** `CAP_NET_ADMIN` (the SDK's `Privileged` flag
+does not grant it), so those rules cannot be applied — and MXC has no VM-level
+enforcement hook either (WSLC cannot expose one without breaking other security
+promises such as MDE). Because the lists cannot be honoured, **any** non-empty
+`allowedHosts` or `blockedHosts` is rejected — including a list that is
+redundant with the default (`blockedHosts` under `block`, `allowedHosts` under
+`allow`), which would otherwise be silently ignored. Rather than fail the run at
+exec time, such configs are **rejected up front** (a config-parse error for
+one-shot runs; a `policy_validation` error for the state-aware lifecycle):
 
 ```
-WSLc: per-host egress filtering (allowedHosts with defaultPolicy='block', or
-blockedHosts with defaultPolicy='allow') is not supported. ...
+WSLc: per-host egress filtering (allowedHosts/blockedHosts) is not supported. ...
 ```
 
 Use `network.proxy` (with `defaultPolicy: "allow"`) for cooperative host

--- a/docs/wsl/wslc-state-aware.md
+++ b/docs/wsl/wslc-state-aware.md
@@ -90,6 +90,14 @@ whose value equals the default — because an explicit default is indistinguisha
 one by value alone. Only the exec-phase cooperative `proxy` is accepted after provision; a
 proxy-only `network` block (no mode fields) is therefore honored at exec.
 
+## Port forwarding
+
+`experimental.wslc.provision.portMappings` forwards host (Windows) ports to the container, mirroring
+the one-shot `experimental.wslc.portMappings` surface. Each entry is `{ windowsPort, containerPort }`
+(both 1–65535; `protocol` defaults to and only accepts `tcp` — `udp` is rejected because the WSLC
+SDK runtime returns `E_NOTIMPL`). Port mappings are per-container, applied at `WslcCreateContainer`
+during `provision`, and frozen for the sandbox's lifetime. A duplicate `windowsPort` is rejected with
+`policy_validation`. Post-provision phases carry no port config.
 ## Error mapping
 
 `state_aware.rs::map_daemon_error` maps daemon errors to the cross-backend wire error codes:

--- a/schemas/dev/mxc-config.schema.0.8.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.8.0-dev.json
@@ -907,7 +907,7 @@
       "type": "object"
     },
     "WslcProvisionPhase": {
-      "description": "Per-phase WSLc **provision** configuration (state-aware lifecycle), nested under `experimental.wslc.provision`. Carries only what the amortized daemon session honors: the container image (or a local tarball to import).\n\nFilesystem mounts and network mode derive from the top-level `policy` section (readwrite / readonly paths, network), not from here. The one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath` / `portMappings`) are deliberately absent: the daemon shares a single session across sandboxes and does not apply per-sandbox sizing. start / exec / stop / deprovision carry no backend-specific config (the exec command flows through the top-level `process` section), so they have no phase struct.",
+      "description": "Per-phase WSLc **provision** configuration (state-aware lifecycle), nested under `experimental.wslc.provision`. Carries what the amortized daemon session honors: the container image (or a local tarball to import) and the host↔container port forwards.\n\nFilesystem mounts and network mode derive from the top-level `policy` section (readwrite / readonly paths, network), not from here. The one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath`) are deliberately absent: the daemon shares a single session across sandboxes and does not apply per-sandbox sizing. `portMappings`, by contrast, is per-container (not per-session) so it is honored here, matching the one-shot surface. start / exec / stop / deprovision carry no backend-specific config (the exec command flows through the top-level `process` section), so they have no phase struct.",
       "properties": {
         "image": {
           "description": "Container image reference (e.g. `alpine:latest`). Defaults to `alpine:latest` when omitted.",
@@ -920,6 +920,16 @@
           "description": "Path to a local image tarball to import instead of pulling.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "portMappings": {
+          "description": "Host → container port forwards. Only TCP is currently supported; the parser rejects `udp` because the WSLC SDK runtime returns `E_NOTIMPL` for UDP port mappings. Mirrors the one-shot `Wslc::port_mappings`.",
+          "items": {
+            "$ref": "#/definitions/PortMapping"
+          },
+          "type": [
+            "array",
             "null"
           ]
         }

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -459,9 +459,9 @@ export interface Wslc {
 }
 
 /**
- * Per-phase WSLc **provision** configuration (state-aware lifecycle), nested under `experimental.wslc.provision`. Carries only what the amortized daemon session honors: the container image (or a local tarball to import).
+ * Per-phase WSLc **provision** configuration (state-aware lifecycle), nested under `experimental.wslc.provision`. Carries what the amortized daemon session honors: the container image (or a local tarball to import) and the host↔container port forwards.
  * 
- * Filesystem mounts and network mode derive from the top-level `policy` section (readwrite / readonly paths, network), not from here. The one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath` / `portMappings`) are deliberately absent: the daemon shares a single session across sandboxes and does not apply per-sandbox sizing. start / exec / stop / deprovision carry no backend-specific config (the exec command flows through the top-level `process` section), so they have no phase struct.
+ * Filesystem mounts and network mode derive from the top-level `policy` section (readwrite / readonly paths, network), not from here. The one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath`) are deliberately absent: the daemon shares a single session across sandboxes and does not apply per-sandbox sizing. `portMappings`, by contrast, is per-container (not per-session) so it is honored here, matching the one-shot surface. start / exec / stop / deprovision carry no backend-specific config (the exec command flows through the top-level `process` section), so they have no phase struct.
  */
 export interface WslcProvisionPhase {
   /**
@@ -472,6 +472,10 @@ export interface WslcProvisionPhase {
    * Path to a local image tarball to import instead of pulling.
    */
   imageTarPath?: string | null;
+  /**
+   * Host → container port forwards. Only TCP is currently supported; the parser rejects `udp` because the WSLC SDK runtime returns `E_NOTIMPL` for UDP port mappings. Mirrors the one-shot `Wslc::port_mappings`.
+   */
+  portMappings?: PortMapping[] | null;
   [k: string]: unknown;
 }
 

--- a/sdk/node/src/state-aware-types.ts
+++ b/sdk/node/src/state-aware-types.ts
@@ -5,6 +5,7 @@ import {
   ContainmentBackend,
   FilesystemConfig,
   NetworkConfig,
+  PortMapping,
   ProcessConfig,
 } from './types.js';
 
@@ -186,6 +187,14 @@ export interface WslcProvisionConfig {
    * `experimental.wslc.provision.imageTarPath` on the wire.
    */
   imageTarPath?: string;
+  /**
+   * Host↔container port mappings applied at provision and frozen for the life
+   * of the sandbox. Per-container (not per-session), so — unlike the one-shot
+   * sizing knobs — they are honored here, matching the one-shot surface. Only
+   * TCP is supported (`protocol` defaults to `"tcp"`); `"udp"` is rejected.
+   * Nested under `experimental.wslc.provision.portMappings` on the wire.
+   */
+  portMappings?: PortMapping[];
 }
 
 export interface WslcStartConfig {

--- a/sdk/node/tests/unit/wire-conformance-state-aware.test.ts
+++ b/sdk/node/tests/unit/wire-conformance-state-aware.test.ts
@@ -32,7 +32,7 @@
 
 import { test } from 'node:test';
 
-import type { ProcessConfig } from '../../src/types.js';
+import type { ProcessConfig, PortMapping as PublicPortMapping } from '../../src/types.js';
 
 import type {
   Phase,
@@ -139,10 +139,11 @@ type _ProvisionWireKeysNonVacuous = AssertTrue<
 // WSLc is the second state-aware backend, so the oracle must cover it too or a
 // wire-model change to the WSLc surface would regenerate `wire.ts`, pass the
 // codegen gate, and leave the SDK silently lagging with no CI signal. WSLc's
-// only per-phase wire object is provision (`image` / `imageTarPath`); start,
-// exec, stop, and deprovision have wire associated type `()` and must expose no
-// backend-specific field. `filesystem` and `network` are lifted top-level wire
-// fields (see `LiftedPhaseKey`), so they are excluded from the backend-key sets.
+// only per-phase wire object is provision (`image` / `imageTarPath` /
+// `portMappings`); start, exec, stop, and deprovision have wire associated type
+// `()` and must expose no backend-specific field. `filesystem` and `network`
+// are lifted top-level wire fields (see `LiftedPhaseKey`), so they are excluded
+// from the backend-key sets.
 type _WslcProvisionPublicKeys = AssertTrue<
   Equivalent<Exclude<BackendKeys<WslcProvisionConfig>, WireKeys<WireWslcProvisionPhase>>, never>
 >;
@@ -151,9 +152,20 @@ type _WslcProvisionWireKeys = AssertTrue<
 >;
 type _WslcProvisionFieldValueTypes = AssertTrue<
   Equivalent<
-    PublicFieldValues<WslcProvisionConfig>,
-    WireFieldValues<WireWslcProvisionPhase>
+    PublicFieldValues<WslcProvisionConfig, WslcProvisionValueKeys>,
+    WireFieldValues<WireWslcProvisionPhase, WslcProvisionValueKeys>
   >
+>;
+
+// `portMappings` is a reused public one-shot leaf (`PortMapping[]`); its shape is
+// pinned by the one-shot oracle (public `PortMapping` ↔ wire `PortMapping`, incl.
+// the nullable `protocol`). It is excluded from the structural value comparison
+// above (the generated wire element carries a `[k: string]: unknown` index
+// signature and a nullable `protocol` that strict `Equivalent` would trip on) and
+// instead asserted to REUSE the public leaf, mirroring the `process` delegation.
+type WslcProvisionValueKeys = Exclude<BackendKeys<WslcProvisionConfig>, 'portMappings'>;
+type _WslcProvisionPortMappingsReuse = AssertTrue<
+  Equivalent<NonNullable<WslcProvisionConfig['portMappings']>, PublicPortMapping[]>
 >;
 
 type _WslcStartNoBackendKeys = AssertTrue<Equivalent<BackendKeys<WslcStartConfig>, never>>;
@@ -166,10 +178,10 @@ type _WslcDeprovisionNoBackendKeys = AssertTrue<
 // Non-vacuity guards (see the isolation_session pins above): pin the derived key
 // sets so a derivation bug fails the oracle rather than silently disabling it.
 type _WslcProvisionKeysNonVacuous = AssertTrue<
-  Equivalent<BackendKeys<WslcProvisionConfig>, 'image' | 'imageTarPath'>
+  Equivalent<BackendKeys<WslcProvisionConfig>, 'image' | 'imageTarPath' | 'portMappings'>
 >;
 type _WslcProvisionWireKeysNonVacuous = AssertTrue<
-  Equivalent<WireKeys<WireWslcProvisionPhase>, 'image' | 'imageTarPath'>
+  Equivalent<WireKeys<WireWslcProvisionPhase>, 'image' | 'imageTarPath' | 'portMappings'>
 >;
 
 // --- delegation to the one-shot oracle (documented, asserted) --------------
@@ -197,6 +209,7 @@ export type StateAwareWireConformanceAssertions = [
   _WslcProvisionPublicKeys,
   _WslcProvisionWireKeys,
   _WslcProvisionFieldValueTypes,
+  _WslcProvisionPortMappingsReuse,
   _WslcStartNoBackendKeys,
   _WslcExecNoBackendKeys,
   _WslcStopNoBackendKeys,

--- a/src/backends/wslc/common/src/container_steps.rs
+++ b/src/backends/wslc/common/src/container_steps.rs
@@ -806,22 +806,24 @@ pub unsafe fn resolve_image(
 ///
 /// # Safety
 /// `sdk` must hold valid function pointers and `session` must be a live handle.
+#[allow(clippy::too_many_arguments)]
 pub unsafe fn create_daemon_container(
     sdk: &WslcSdk,
     session: WslcSession,
     image: &str,
     mounts: &[VolumeMount],
+    port_mappings: &[PortMapping],
     net_mode: WslcContainerNetworkingMode,
     keepalive: &mut ProcessSettings,
     logger: &mut Logger,
 ) -> Result<WslcContainerGuard, ScriptResponse> {
-    // Daemon containers never forward ports (no state-aware port-mapping config)
-    // and set no container flags (auto-remove/gpu/privileged are one-shot-only).
+    // Daemon containers set no container flags (auto-remove / gpu / privileged
+    // are one-shot-only); port forwards come from the provision phase config.
     let mut container_settings = ContainerSettings::build(
         sdk,
         image,
         mounts,
-        &[],
+        port_mappings,
         net_mode,
         WslcContainerFlags::WSLC_CONTAINER_FLAG_NONE,
         logger,

--- a/src/backends/wslc/common/src/daemon_protocol.rs
+++ b/src/backends/wslc/common/src/daemon_protocol.rs
@@ -37,7 +37,7 @@ pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024;
 /// from the same build, so in normal operation both sides always match; the
 /// version guards against a stale daemon left running by a different mxc
 /// install. Bump only for incompatible changes to framing or message shape.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 // ---------------------------------------------------------------------------
 // Per-phase config structs (daemon-internal; NOT the public wire schema)
@@ -51,6 +51,15 @@ pub struct VolumeMount {
     pub host: String,
     pub container: String,
     pub read_only: bool,
+}
+
+/// One host→container port forward, mirroring the one-shot runner's port
+/// handling. Only TCP is supported today (the wire model rejects `udp`), so no
+/// protocol field is carried — the daemon programs every entry as TCP.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PortMapping {
+    pub windows_port: u16,
+    pub container_port: u16,
 }
 
 /// Container network mode. Mirrors exactly what the one-shot WSLc runner
@@ -84,6 +93,9 @@ pub struct ProvisionConfig {
     /// Container network mode.
     #[serde(default)]
     pub network: NetworkMode,
+    /// Host↔container port forwards (TCP). Empty = no forwarding.
+    #[serde(default)]
+    pub port_mappings: Vec<PortMapping>,
 }
 
 /// Inputs to `start`: the container was created at provision; start boots it.
@@ -330,6 +342,10 @@ mod tests {
                 read_only: true,
             }],
             network: NetworkMode::Bridged,
+            port_mappings: vec![PortMapping {
+                windows_port: 8080,
+                container_port: 80,
+            }],
         }));
     }
 

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -27,8 +27,8 @@ use wxc_common::wire::WslcProvisionPhase;
 use crate::container_steps::OutStream;
 use crate::daemon_client::{DaemonClient, DaemonError};
 use crate::daemon_protocol::{
-    DeprovisionConfig, ErrKind, ExecConfig, NetworkMode, ProvisionConfig, StartConfig, StopConfig,
-    VolumeMount,
+    DeprovisionConfig, ErrKind, ExecConfig, NetworkMode, PortMapping, ProvisionConfig, StartConfig,
+    StopConfig, VolumeMount,
 };
 use crate::policy::{
     exec_proxy_url, validate_exec_policy, validate_post_provision_policy, validate_provision_policy,
@@ -316,6 +316,7 @@ fn build_provision_config(
         .as_ref()
         .and_then(|c| c.image.clone())
         .unwrap_or_else(|| DEFAULT_IMAGE.to_string());
+    let port_mappings = map_provision_port_mappings(config.as_ref())?;
     let image_tar_path = config.and_then(|c| c.image_tar_path);
 
     // WSLc provision-time filesystem-policy gate (D6 normalization → D3
@@ -344,7 +345,45 @@ fn build_provision_config(
         image_tar_path,
         volumes,
         network,
+        port_mappings,
     })
+}
+
+/// Map + validate the provision phase's port mappings (wire → daemon). Mirrors
+/// the one-shot parser: `windowsPort` / `containerPort` must be > 0, and a
+/// duplicate `windowsPort` is rejected. Only TCP is representable — the wire
+/// model rejects `udp` at deserialize — so no protocol is carried through.
+fn map_provision_port_mappings(
+    config: Option<&WslcProvisionPhase>,
+) -> Result<Vec<PortMapping>, MxcError> {
+    let Some(mappings) = config.and_then(|c| c.port_mappings.as_ref()) else {
+        return Ok(Vec::new());
+    };
+    let mut converted = Vec::with_capacity(mappings.len());
+    let mut seen = std::collections::HashSet::new();
+    for (idx, m) in mappings.iter().enumerate() {
+        if m.windows_port == 0 {
+            return Err(MxcError::policy_validation(format!(
+                "experimental.wslc.provision.portMappings[{idx}]: 'windowsPort' must be > 0"
+            )));
+        }
+        if m.container_port == 0 {
+            return Err(MxcError::policy_validation(format!(
+                "experimental.wslc.provision.portMappings[{idx}]: 'containerPort' must be > 0"
+            )));
+        }
+        if !seen.insert(m.windows_port) {
+            return Err(MxcError::policy_validation(format!(
+                "experimental.wslc.provision.portMappings: duplicate windowsPort {}",
+                m.windows_port
+            )));
+        }
+        converted.push(PortMapping {
+            windows_port: m.windows_port,
+            container_port: m.container_port,
+        });
+    }
+    Ok(converted)
 }
 
 /// State-aware adapter over the shared WSLc provision policy gate
@@ -412,6 +451,7 @@ fn split_env(env: &[String]) -> Vec<(String, String)> {
 mod tests {
     use super::*;
     use wxc_common::models::ContainerPolicy;
+    use wxc_common::wire::{PortMapping as WirePortMapping, TransportProtocol};
 
     #[test]
     fn backend_key_matches_wire_format() {
@@ -497,6 +537,7 @@ mod tests {
         let phase = WslcProvisionPhase {
             image: Some("custom/image:tag".to_string()),
             image_tar_path: Some("C:\\images\\custom.tar".to_string()),
+            port_mappings: None,
         };
         let cfg = build_provision_config(&ExecutionRequest::default(), Some(phase)).unwrap();
         assert_eq!(cfg.image, "custom/image:tag");
@@ -504,6 +545,82 @@ mod tests {
             cfg.image_tar_path.as_deref(),
             Some("C:\\images\\custom.tar")
         );
+        assert!(cfg.port_mappings.is_empty());
+    }
+
+    #[test]
+    fn build_provision_config_forwards_port_mappings() {
+        let phase = WslcProvisionPhase {
+            image: None,
+            image_tar_path: None,
+            port_mappings: Some(vec![
+                WirePortMapping {
+                    windows_port: 8080,
+                    container_port: 80,
+                    protocol: None,
+                },
+                WirePortMapping {
+                    windows_port: 8443,
+                    container_port: 443,
+                    protocol: Some(TransportProtocol::Tcp),
+                },
+            ]),
+        };
+        let cfg = build_provision_config(&ExecutionRequest::default(), Some(phase)).unwrap();
+        assert_eq!(cfg.port_mappings.len(), 2);
+        assert_eq!(cfg.port_mappings[0].windows_port, 8080);
+        assert_eq!(cfg.port_mappings[0].container_port, 80);
+        assert_eq!(cfg.port_mappings[1].windows_port, 8443);
+        assert_eq!(cfg.port_mappings[1].container_port, 443);
+    }
+
+    #[test]
+    fn build_provision_config_rejects_duplicate_windows_port() {
+        let phase = WslcProvisionPhase {
+            image: None,
+            image_tar_path: None,
+            port_mappings: Some(vec![
+                WirePortMapping {
+                    windows_port: 8080,
+                    container_port: 80,
+                    protocol: None,
+                },
+                WirePortMapping {
+                    windows_port: 8080,
+                    container_port: 8080,
+                    protocol: None,
+                },
+            ]),
+        };
+        let err = build_provision_config(&ExecutionRequest::default(), Some(phase)).unwrap_err();
+        assert_eq!(
+            err.code,
+            wxc_common::mxc_error::MxcErrorCode::PolicyValidation
+        );
+        assert!(
+            err.message.contains("duplicate windowsPort"),
+            "got: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn build_provision_config_rejects_zero_port() {
+        let phase = WslcProvisionPhase {
+            image: None,
+            image_tar_path: None,
+            port_mappings: Some(vec![WirePortMapping {
+                windows_port: 0,
+                container_port: 80,
+                protocol: None,
+            }]),
+        };
+        let err = build_provision_config(&ExecutionRequest::default(), Some(phase)).unwrap_err();
+        assert_eq!(
+            err.code,
+            wxc_common::mxc_error::MxcErrorCode::PolicyValidation
+        );
+        assert!(err.message.contains("windowsPort"), "got: {}", err.message);
     }
 
     #[test]
@@ -511,6 +628,7 @@ mod tests {
         let cfg = build_provision_config(&ExecutionRequest::default(), None).unwrap();
         assert_eq!(cfg.image, DEFAULT_IMAGE);
         assert!(cfg.image_tar_path.is_none());
+        assert!(cfg.port_mappings.is_empty());
     }
 
     #[test]

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -640,14 +640,13 @@ impl ScriptRunner for WSLContainerRunner {
     /// (an already-built `ExecutionRequest`, bypassing the parser) fail here
     /// instead of late in `execute` on the broken in-container iptables path.
     fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        if request.policy.needs_host_filtering() {
+        if request.policy.has_host_lists() {
             return Err(ScriptResponse::error(
-                "WSLc: per-host egress filtering (allowedHosts with \
-                 defaultPolicy='block', or blockedHosts with defaultPolicy='allow') \
-                 is not supported. A WSLc container has no CAP_NET_ADMIN for in-container \
-                 iptables, and VM-level enforcement is not available without breaking other \
-                 security guarantees (e.g. MDE). Use network.proxy (defaultPolicy='allow') \
-                 for cooperative host filtering, or remove the host lists.",
+                "WSLc: per-host egress filtering (allowedHosts/blockedHosts) is not supported. \
+                 A WSLc container has no CAP_NET_ADMIN for in-container iptables, and VM-level \
+                 enforcement is not available without breaking other security guarantees (e.g. \
+                 MDE). Use network.proxy (defaultPolicy='allow') for cooperative host filtering, \
+                 or remove the host lists.",
             ));
         }
         if request.policy.allow_local_network {
@@ -2341,6 +2340,42 @@ mod tests {
         };
         let runner = WSLContainerRunner::new(&WslcConfig::default());
         assert!(runner.validate_runner(&request).is_err());
+    }
+
+    #[test]
+    fn validate_runner_rejects_redundant_block_with_blocked_hosts() {
+        // block default + blocklist is redundant but must fail closed (#824 Gap 1),
+        // matching the parser and the state-aware reject_host_filtering.
+        let request = ExecutionRequest {
+            containment: wxc_common::models::ContainmentBackend::Wslc,
+            policy: wxc_common::models::ContainerPolicy {
+                default_network_policy: NetworkPolicy::Block,
+                blocked_hosts: vec!["evil.com".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runner = WSLContainerRunner::new(&WslcConfig::default());
+        let err = runner.validate_runner(&request).unwrap_err();
+        assert!(err.error_message.contains("per-host egress filtering"));
+    }
+
+    #[test]
+    fn validate_runner_rejects_redundant_allow_with_allowed_hosts() {
+        // allow default + allowlist is the fail-open typo: previously accepted and
+        // ignored, now rejected (#824 Gap 1).
+        let request = ExecutionRequest {
+            containment: wxc_common::models::ContainmentBackend::Wslc,
+            policy: wxc_common::models::ContainerPolicy {
+                default_network_policy: NetworkPolicy::Allow,
+                allowed_hosts: vec!["github.com".to_string()],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runner = WSLContainerRunner::new(&WslcConfig::default());
+        let err = runner.validate_runner(&request).unwrap_err();
+        assert!(err.error_message.contains("per-host egress filtering"));
     }
 
     #[test]

--- a/src/backends/wslc/daemon/src/session_manager.rs
+++ b/src/backends/wslc/daemon/src/session_manager.rs
@@ -41,7 +41,7 @@ use wslc_common::wslc_bindings::{
     WslcContainer, WslcContainerGuard, WslcContainerNetworkingMode, WslcSdk, WslcSessionGuard,
 };
 use wxc_common::logger::{Logger, Mode};
-use wxc_common::models::ScriptResponse;
+use wxc_common::models::{PortMapping, ScriptResponse};
 
 /// Fixed name of the single WSL2 utility-VM session the daemon owns.
 const SESSION_NAME: &str = "mxc-wslc-daemon";
@@ -390,6 +390,17 @@ impl Worker {
                 read_only: v.read_only,
             })
             .collect();
+        // Daemon port mappings carry only ports (TCP-only today); map to the
+        // domain `PortMapping` that `ContainerSettings::build` consumes.
+        let port_mappings: Vec<PortMapping> = config
+            .port_mappings
+            .iter()
+            .map(|p| PortMapping {
+                windows_port: p.windows_port,
+                container_port: p.container_port,
+                protocol: "tcp".to_string(),
+            })
+            .collect();
         let net_mode = match config.network {
             NetworkMode::None => WslcContainerNetworkingMode::WSLC_CONTAINER_NETWORKING_MODE_NONE,
             NetworkMode::Bridged => {
@@ -419,6 +430,7 @@ impl Worker {
                 session,
                 &config.image,
                 &mounts,
+                &port_mappings,
                 net_mode,
                 &mut keepalive,
                 &mut self.logger,
@@ -877,6 +889,7 @@ mod tests {
                 image_tar_path: None,
                 volumes: Vec::new(),
                 network: Default::default(),
+                port_mappings: Vec::new(),
             })
             .await
             .unwrap();

--- a/src/backends/wslc/daemon/tests/daemon_ipc.rs
+++ b/src/backends/wslc/daemon/tests/daemon_ipc.rs
@@ -112,6 +112,7 @@ fn full_lifecycle_over_pipe() {
             image_tar_path: None,
             volumes: Vec::new(),
             network: Default::default(),
+            port_mappings: Vec::new(),
         })
         .expect("provision");
 

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -125,7 +125,7 @@ pub fn load_request_with_options(
         let cfg: wire::MxcConfig = config_deserialize::from_str(&json_str)
             .map_err(|error| WxcError::ConfigParse(error.to_string()))?;
 
-        convert_wire_config(cfg, logger, true, opts.allow_missing_command)
+        convert_wire_config(cfg, logger, true, opts.allow_missing_command, false)
     })();
     log_one_shot_error(logger, &result);
     result
@@ -147,7 +147,7 @@ pub fn load_request_from_value(
         let cfg: wire::MxcConfig = config_deserialize::from_value(config)
             .map_err(|error| WxcError::ConfigParse(error.to_string()))?;
 
-        convert_wire_config(cfg, logger, true, allow_missing_command)
+        convert_wire_config(cfg, logger, true, allow_missing_command, false)
     })();
     log_one_shot_error(logger, &result);
     result
@@ -231,7 +231,7 @@ fn parse_mxc_request_json(
     } else {
         let cfg: wire::MxcConfig = config_deserialize::from_str(json_str)
             .map_err(|error| ParseError::OneShot(WxcError::ConfigParse(error.to_string())))?;
-        convert_wire_config(cfg, logger, true, allow_missing_command)
+        convert_wire_config(cfg, logger, true, allow_missing_command, false)
             .map(MxcRequest::OneShot)
             .map_err(ParseError::OneShot)
     }
@@ -738,6 +738,7 @@ fn convert_wire_config(
     logger: &mut Logger,
     require_process: bool,
     allow_missing_command: bool,
+    state_aware: bool,
 ) -> Result<ExecutionRequest, WxcError> {
     // `phase` / `sandboxId` are state-aware-only fields. The state-aware path
     // consumes them before delegating here, so if either is still present the
@@ -1058,18 +1059,25 @@ fn convert_wire_config(
         // WSLc cannot enforce per-host egress filtering: containers lack
         // CAP_NET_ADMIN (so in-container iptables aborts at exec), and WSLc
         // cannot expose VM-level enforcement without breaking other security
-        // guarantees (e.g. MDE). Reject up front; the backend's validate_runner
-        // enforces the same for requests that bypass this parser. Bare defaults
-        // with no host lists (full cutoff / full NAT) are enforceable, left as-is.
+        // guarantees (e.g. MDE). Reject any non-empty host list up front —
+        // including one redundant with the default (`block` + blockedHosts,
+        // `allow` + allowedHosts), which would otherwise be silently ignored
+        // (a fail-open footgun). The backend's validate_runner enforces the
+        // same for requests that bypass this parser. Bare defaults with no host
+        // lists (full cutoff / full NAT) are enforceable, left as-is.
+        //
+        // One-shot only: the state-aware path reaches the same rejection through
+        // the backend policy gate (`reject_host_filtering`), which reports it as
+        // `policy_validation` rather than a parse error, so firing here would
+        // mislabel a well-formed but unsupported policy as `malformed_request`.
         if containment == ContainmentBackend::Wslc {
-            if policy.needs_host_filtering() {
-                let msg = "WSLc: per-host egress filtering (allowedHosts with \
-                           defaultPolicy='block', or blockedHosts with \
-                           defaultPolicy='allow') is not supported. A WSLc container has \
-                           no CAP_NET_ADMIN for in-container iptables, and VM-level \
-                           enforcement is not available without breaking other security \
-                           guarantees (e.g. MDE). Use network.proxy (defaultPolicy='allow') \
-                           for cooperative host filtering, or remove the host lists.";
+            if !state_aware && policy.has_host_lists() {
+                let msg = "WSLc: per-host egress filtering (allowedHosts/blockedHosts) is not \
+                           supported. A WSLc container has no CAP_NET_ADMIN for in-container \
+                           iptables, and VM-level enforcement is not available without breaking \
+                           other security guarantees (e.g. MDE). Use network.proxy \
+                           (defaultPolicy='allow') for cooperative host filtering, or remove the \
+                           host lists.";
                 logger.log_line(msg);
                 return Err(WxcError::ConfigParse(msg.to_string()));
             }
@@ -1465,7 +1473,8 @@ fn convert_wire_state_aware(
     cfg.lifecycle = None;
 
     let require_process = phase == Phase::Exec;
-    let mut request = convert_wire_config(cfg, logger, require_process, allow_missing_command)?;
+    let mut request =
+        convert_wire_config(cfg, logger, require_process, allow_missing_command, true)?;
 
     // Populate the typed `experimental.telemetry` field from the raw block that
     // was peeled off above. The rest of `experimental` is typed per-backend at
@@ -4185,6 +4194,54 @@ mod tests {
             "network": {
                 "defaultPolicy": "allow",
                 "blockedHosts": ["evil.example"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        assert!(
+            format!("{err}").contains("per-host egress filtering"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn wslc_rejects_redundant_block_with_blocked_hosts() {
+        // 'block' default + a blocklist is redundant (block already denies), but
+        // must still be rejected rather than silently ignored — a fail-open
+        // footgun otherwise (#824 Gap 1).
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "containment": "wslc",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "defaultPolicy": "block",
+                "blockedHosts": ["evil.example"]
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+
+        let err = load_request(&encoded, &mut logger, true).unwrap_err();
+        assert!(
+            format!("{err}").contains("per-host egress filtering"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn wslc_rejects_redundant_allow_with_allowed_hosts() {
+        // 'allow' default + an allowlist is the classic "I meant an allowlist"
+        // typo: it would previously permit ALL egress (the list ignored). Reject
+        // it instead of failing open (#824 Gap 1).
+        let json = r#"{
+            "version": "0.6.0-alpha",
+            "containment": "wslc",
+            "process": {"commandLine": "echo hi"},
+            "network": {
+                "defaultPolicy": "allow",
+                "allowedHosts": ["github.com"]
             }
         }"#;
         let encoded = base64_encode(json.as_bytes());

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -557,6 +557,16 @@ impl ContainerPolicy {
             &self.blocked_hosts,
         )
     }
+
+    /// True when any host list is present, regardless of the default policy.
+    /// Unlike [`needs_host_filtering`], this also flags a list that is
+    /// *redundant* with the default (`block` + `blockedHosts`, `allow` +
+    /// `allowedHosts`). WSLc cannot enforce per-host filtering in any form, so
+    /// it must fail closed on any non-empty list rather than silently ignore a
+    /// redundant one.
+    pub fn has_host_lists(&self) -> bool {
+        !self.allowed_hosts.is_empty() || !self.blocked_hosts.is_empty()
+    }
 }
 
 /// Windows denial-capture settings (from `processContainer.captureDenials`).

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -544,16 +544,19 @@ pub struct Wslc {
 }
 
 /// Per-phase WSLc **provision** configuration (state-aware lifecycle), nested
-/// under `experimental.wslc.provision`. Carries only what the amortized daemon
-/// session honors: the container image (or a local tarball to import).
+/// under `experimental.wslc.provision`. Carries what the amortized daemon
+/// session honors: the container image (or a local tarball to import) and the
+/// host↔container port forwards.
 ///
 /// Filesystem mounts and network mode derive from the top-level `policy`
 /// section (readwrite / readonly paths, network), not from here. The
-/// one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath`
-/// / `portMappings`) are deliberately absent: the daemon shares a single session
-/// across sandboxes and does not apply per-sandbox sizing. start / exec / stop /
-/// deprovision carry no backend-specific config (the exec command flows through
-/// the top-level `process` section), so they have no phase struct.
+/// one-shot-only sizing knobs (`cpuCount` / `memoryMb` / `gpu` / `storagePath`)
+/// are deliberately absent: the daemon shares a single session across sandboxes
+/// and does not apply per-sandbox sizing. `portMappings`, by contrast, is
+/// per-container (not per-session) so it is honored here, matching the one-shot
+/// surface. start / exec / stop / deprovision carry no backend-specific config
+/// (the exec command flows through the top-level `process` section), so they
+/// have no phase struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
 #[serde(rename_all = "camelCase")]
@@ -563,6 +566,10 @@ pub struct WslcProvisionPhase {
     pub image: Option<String>,
     /// Path to a local image tarball to import instead of pulling.
     pub image_tar_path: Option<String>,
+    /// Host → container port forwards. Only TCP is currently supported; the
+    /// parser rejects `udp` because the WSLC SDK runtime returns `E_NOTIMPL`
+    /// for UDP port mappings. Mirrors the one-shot `Wslc::port_mappings`.
+    pub port_mappings: Option<Vec<PortMapping>>,
 }
 
 /// A single host → container port forward. Reachable only under the permissive

--- a/tests/configs/wslc_state_aware_provision_ports.json
+++ b/tests/configs/wslc_state_aware_provision_ports.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.8.0-alpha",
+    "phase": "provision",
+    "containment": "wslc",
+    "network": {
+        "defaultPolicy": "allow"
+    },
+    "experimental": {
+        "wslc": {
+            "provision": {
+                "image": "alpine:latest",
+                "portMappings": [
+                    { "windowsPort": 18080, "containerPort": 80, "protocol": "tcp" }
+                ]
+            }
+        }
+    }
+}

--- a/tests/scripts/run_wslc_state_aware_tests.ps1
+++ b/tests/scripts/run_wslc_state_aware_tests.ps1
@@ -686,6 +686,109 @@ try {
     }
 }
 
+# ---------------- Lifecycle C2: port mappings at provision ----------------
+
+# Connect to a TCP port on the Windows host and return the bytes the peer sends
+# on connect (ASCII), or $null if no listener answers within the retry budget.
+# Used to prove a provision-time portMapping actually wires host->container NAT.
+function Get-TcpResponse {
+    param(
+        [string]$HostName,
+        [int]$Port,
+        [int]$Retries = 15,
+        [int]$DelayMs = 1000
+    )
+    for ($i = 0; $i -lt $Retries; $i++) {
+        $client = $null
+        try {
+            $client = [System.Net.Sockets.TcpClient]::new()
+            $iar = $client.BeginConnect($HostName, $Port, $null, $null)
+            if (-not $iar.AsyncWaitHandle.WaitOne(2000)) { throw "connect timeout" }
+            $client.EndConnect($iar)
+            $stream = $client.GetStream()
+            $stream.ReadTimeout = 3000
+            $buf = New-Object byte[] 256
+            $n = $stream.Read($buf, 0, $buf.Length)
+            if ($n -gt 0) {
+                return [System.Text.Encoding]::ASCII.GetString($buf, 0, $n)
+            }
+        } catch {
+            Start-Sleep -Milliseconds $DelayMs
+        } finally {
+            if ($client) { $client.Close() }
+        }
+    }
+    return $null
+}
+
+# Provisions with experimental.wslc.provision.portMappings and drives a real
+# functional port round-trip: a detached listener in the container answers on
+# containerPort 80, and the harness connects through the mapped Windows host
+# port 18080 and asserts the payload. This regresses #824 — an implementation
+# that silently drops portMappings leaves nothing listening on 18080, so the
+# host connect fails. The listener script is base64-piped to `sh` to keep the
+# argv-split commandLine free of nested quotes.
+$script:portSandboxId = $null
+$portDeprovisionedOk = $false
+try {
+    $portProvisionedOk = Run-StateAwareTest "C2: provision (port mappings)" {
+        $r = Invoke-StateAware -ConfigFile 'wslc_state_aware_provision_ports.json'
+        $envObj = Assert-ResultEnvelope $r "port-mapped provision"
+        if ($envObj) { $script:portSandboxId = [string]$envObj.result.sandboxId }
+    }
+
+    $portStartedOk = $false
+    if ($portProvisionedOk) {
+        $portStartedOk = Run-StateAwareTest "C2: start" {
+            $r = Invoke-StateAware -ConfigFile 'wslc_state_aware_start.json' -SandboxId $script:portSandboxId
+            $null = Assert-ResultEnvelope $r "port-mapped start"
+        }
+    }
+
+    $portListenerOk = $false
+    if ($portStartedOk) {
+        $portListenerOk = Run-StateAwareTest "C2: exec starts detached listener on container port 80" {
+            $listenerScript = @'
+setsid sh -c 'while true; do printf MXC_PORTMAP_OK | nc -l -p 80 || sleep 1; done' </dev/null >/dev/null 2>&1 &
+sleep 1
+echo LISTENER_UP
+'@
+            $listenerB64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($listenerScript))
+            $listenerCmd = "sh -c 'echo $listenerB64 | base64 -d | sh'"
+            $req = @{ phase = 'exec'; sandboxId = $script:portSandboxId; process = @{ commandLine = $listenerCmd; timeout = 30000 } }
+            $r = Invoke-StateAware -Request $req
+            Assert-True ($r.ExitCode -eq 0) "listener-start exec exit code = 0"
+            Assert-True ($r.Stdout -match 'LISTENER_UP') "listener reported ready ($($r.Stdout.Trim()))"
+        }
+    }
+
+    if ($portListenerOk) {
+        Run-StateAwareTest "C2: port forward round-trip (windows 18080 -> container 80)" {
+            $payload = Get-TcpResponse -HostName '127.0.0.1' -Port 18080
+            Assert-True ($payload -eq 'MXC_PORTMAP_OK') `
+                "host port 18080 forwards to the container listener (got '$payload')"
+        } | Out-Null
+    }
+
+    if ($portProvisionedOk) {
+        Run-StateAwareTest "C2: stop" {
+            $r = Invoke-StateAware -ConfigFile 'wslc_state_aware_stop.json' -SandboxId $script:portSandboxId
+            $null = Assert-ResultEnvelope $r "port-mapped stop"
+        } | Out-Null
+        $portDeprovPassed = Run-StateAwareTest "C2: deprovision" {
+            $r = Invoke-StateAware -ConfigFile 'wslc_state_aware_deprovision.json' -SandboxId $script:portSandboxId
+            $null = Assert-ResultEnvelope $r "port-mapped deprovision"
+        }
+        if ($portDeprovPassed) { $portDeprovisionedOk = $true }
+    }
+} finally {
+    if ($null -ne $script:portSandboxId -and -not $portDeprovisionedOk) {
+        Write-Host ""
+        Write-Host "[cleanup] best-effort deprovision of $script:portSandboxId" -ForegroundColor DarkGray
+        try { $null = Invoke-StateAware -ConfigFile 'wslc_state_aware_deprovision.json' -SandboxId $script:portSandboxId } catch { }
+    }
+}
+
 # ---------------- Lifecycle D: validation rejections ----------------
 
 # Validation runs before any daemon call, so these never provision a real


### PR DESCRIPTION
## 📖 Description
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Brings the WSLc **state-aware** network-policy surface into parity with the **one-shot** surface (#824), closing two gaps where the two paths silently diverged, plus supporting doc/test fixes.

**Gap 1 — one-shot dropped redundant host lists.** A host list that was redundant with the default (`blockedHosts` under `defaultPolicy: "block"`, `allowedHosts` under `"allow"`) previously slipped past `needs_host_filtering()` and was silently ignored — a fail-open footgun, since WSLc cannot enforce per-host filtering (no `CAP_NET_ADMIN`, no VM-level hook). The parser now rejects **any** non-empty `allowedHosts`/`blockedHosts` up front (`has_host_lists()`). Bare `defaultPolicy` with no host lists (full cutoff / full NAT) stays supported.

**Gap 2 — state-aware dropped provision-time portMappings.** `experimental.wslc.provision.portMappings` was accepted but never wired into the container's WSL2 NAT. Added the field to the provision wire/domain model, mapped it through `build_provision_config`, and bumped the daemon `PROTOCOL_VERSION` (2 → 3) so the host->container forward is actually installed. Now verified by a functional round-trip.

### Error-code parity fix
Widening Gap 1 initially made state-aware requests with host lists fail at **parse time** as `malformed_request`. State-aware requests now skip the parser-level host-list rejection (via a `state_aware` flag threaded into `convert_wire_config`) and fall through to the backend's `reject_host_filtering` policy gate, which reports the well-formed-but-unsupported policy as `policy_validation` — matching every other post-parse policy rejection. One-shot keeps the parse-time rejection (it has no backend gate). The neighbouring `allowLocalNetwork` rejection deliberately stays firing on both paths, since the provision policy gate does not cover it (gating it would fail-open).

### Tests & docs
- New fixture `tests/configs/wslc_state_aware_provision_ports.json`.
- `run_wslc_state_aware_tests.ps1` C2 rewritten from a provision/start/exec smoke into a real port round-trip: a detached in-container listener on port 80, connected through the mapped Windows host port 18080 with a payload assertion — genuinely regresses #824.
- `docs/wsl/wsl-container-getting-started.md` updated: all non-empty host lists (incl. redundant combos) are rejected, with the current error message and the one-shot (parse) vs state-aware (`policy_validation`) distinction.

### Validation
- `cargo fmt` / `clippy -p wxc_common -D warnings` clean; `cargo test -p wxc_common` (594) and `cargo test --workspace` green.
- WSLc state-aware E2E harness on a live WSL2 host: **63/63 passed** (incl. the new port round-trip and the corrected `policy_validation` rejection).

Closes #824
## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/862)