### PR TITLE
Recognize the absent-chain message both iptables backends emit

### DIFF
--- a/src/backends/lxc/common/src/network_ingress.rs
+++ b/src/backends/lxc/common/src/network_ingress.rs
@@ -241,14 +241,22 @@ impl StepKind {
     /// A spawn failure never reaches here — it is a real error by construction.
     fn stderr_means_absent(self, stderr: &str) -> bool {
         let s = stderr.to_ascii_lowercase();
+        // An absent chain is reported without the "no chain/target/match"
+        // phrasing.  iptables 1.8.10, nf_tables: "Chain 'X' does not exist";
+        // legacy: "Couldn't load target `X':No such file or directory".
+        let absent_chain = s.contains("does not exist") || s.contains("couldn't load target");
         match self {
-            // Deleting a jump rule that is not present in INPUT.
+            // The jump rule is absent because its target chain is gone, or
+            // because the chain remains with no INPUT reference left.
             StepKind::Unhook => {
                 s.contains("no chain/target/match by that name")
                     || s.contains("does a matching rule exist")
+                    || absent_chain
             }
             // Flushing or deleting a chain that does not exist.
-            StepKind::Flush | StepKind::Delete => s.contains("no chain/target/match by that name"),
+            StepKind::Flush | StepKind::Delete => {
+                s.contains("no chain/target/match by that name") || absent_chain
+            }
         }
     }
 }
@@ -2672,5 +2680,27 @@ mod tests {
             !StepKind::Flush.stderr_means_absent("does a matching rule exist in that chain?"),
             "a missing-rule message must not clear a chain flush/delete step"
         );
+    }
+
+    /// A fresh container has no MXCI chain, so the reset that precedes every
+    /// install must read an absent chain as benign.  Until it did, inbound
+    /// default-deny could not install on any `iptables-nft` host.  Strings
+    /// captured verbatim from iptables 1.8.10 under `LC_ALL=C`.
+    #[test]
+    fn absent_chain_messages_from_both_backends_are_recognized() {
+        let observed = [
+            "iptables v1.8.10 (nf_tables): Chain 'MXCI-CLI-LX-72gim3ftle7wtxye' does not exist",
+            "ip6tables v1.8.10 (nf_tables): Chain 'MXCI-CLI-LX-72gim3ftle7wtxye' does not exist",
+            "iptables v1.8.10 (legacy): Couldn't load target \
+             `MXCI-CLI-LX-72gim3ftle7wtxye':No such file or directory",
+        ];
+
+        for stderr in observed {
+            assert!(
+                StepKind::Unhook.stderr_means_absent(stderr),
+                "unhook must read {stderr:?} as an absent chain; misreading it aborts \
+                 every install on that host"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Problem

Inbound default-deny could not install on **any** host whose `iptables` uses the
nf_tables backend — the default on Ubuntu, Debian, RHEL, and Alpine.  It failed
on every install, not intermittently:

```
inbound teardown for chain 'MXCI-<name>' failed: iptables v1.8.10 (nf_tables):
Chain 'MXCI-<name>' does not exist
```

Install resets leftover state first, and that reset unhooks before it flushes and
deletes.  A fresh container has never had the chain, so the unhook is *expected*
to fail — `stderr_means_absent` is what makes that benign.  It matched only the
legacy wording, so the reset failed fatally and aborted the install.

## Fix

Recognize the absent-chain message from both backends.  Strings captured from
iptables 1.8.10 under `LC_ALL=C`:

| Step | nf_tables | legacy | matched before |
| --- | --- | --- | --- |
| unhook | `Chain 'X' does not exist` | ``Couldn't load target `X':...`` | ❌ |
| flush / delete | `No chain/target/match by that name.` | same | ✅ |

Legacy is matched on `couldn't load target`, so a bare `No such file or
directory` spawn failure still does not count as proof the chain is gone.

## Verification

`tests/scripts/run_lxc_inbound_deny_test.sh` against real LXC containers
(Ubuntu 24.04 on WSL 2, LXC 5.0.3): FAIL before, both cases PASS after.  The
added unit test fails if the fix is reverted.

## 🔗 References

Relates to AB#62864412
Follow-up to #836
