### PR TITLE
Document 0.7 contract annotations (Phase 4.1)

### DIFF
--- a/src/core/mxc_config_contract/src/published/v0_7_0_alpha/request.rs
+++ b/src/core/mxc_config_contract/src/published/v0_7_0_alpha/request.rs
@@ -215,8 +215,10 @@ pub struct Seatbelt {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Request {
+    /// Optional JSON Schema reference for editor validation.
     #[serde(rename = "$schema", default)]
     pub schema: OptionalField<String>,
+    /// Optional human-readable annotation ignored by the runtime.
     #[serde(rename = "_comment", default)]
     pub comment: OptionalField<serde_json::Value>,
     /// The exact contract version marker.


### PR DESCRIPTION
## 📖 Description

Document 0.7 contract annotations

This PR documents the annotation fields exposed by the published `0.7.0-alpha` configuration contract.

Details

* Document the optional `$schema` editor-validation reference.
* Document the ignored `_comment` annotation value.
* Make the contract crate pass a strict `missing_docs` rustdoc build.

## 🔗 References

- #838

## 🔍 Validation

Tests

* `cargo fmt --all -- --check`
* `$env:RUSTDOCFLAGS='-D missing-docs'; cargo doc -p mxc_config_contract --no-deps`
* `cargo test -p mxc_config_contract` (175 tests passed)
* `cargo clippy -p mxc_config_contract --all-targets -- -D warnings`
* `git diff --check`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task