### PR TITLE
[Bubblewrap] Scrub inherited FTP proxy env variables 

### DIFF
--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -260,10 +260,10 @@ Bubblewrap because it requires **no root and no `CAP_NET_ADMIN`**.
    supply their own proxy via `localhost: <port>` or `url: <url>`.
 2. The sandbox is then started **without** `--unshare-net` so the sandbox
    shares the host network namespace and can reach the loopback proxy.
-3. The command builder sets `HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, and
-   `https_proxy` inside the sandbox via `bwrap --setenv` (any
-   caller-supplied values for these keys, including `NO_PROXY` /
-   `no_proxy`, are stripped before injection). The runner deliberately
+3. The command builder sets `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`,
+   `FTP_PROXY`, and their lowercase variants inside the sandbox via
+   `bwrap --setenv` (caller-supplied values for these keys, including
+   `NO_PROXY` / `no_proxy`, are stripped before injection). The runner deliberately
    does **not** set `NO_PROXY`: since the sandbox shares the host netns,
    a `NO_PROXY=localhost,127.0.0.1` entry would let cooperating clients
    bypass the proxy for host-loopback destinations, defeating

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -167,7 +167,7 @@ pub fn build_args(request: &ExecutionRequest, proxy_address: Option<&ProxyAddres
 /// - drops `--unshare-net` (the sandbox needs to reach the loopback proxy on
 ///   the host's network namespace),
 /// - strips any caller-supplied `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` /
-///   `NO_PROXY` entries from `request.env`,
+///   `FTP_PROXY` / `NO_PROXY` entries from `request.env`,
 /// - emits `--setenv` for the proxy keys (all but `NO_PROXY`) pointing at the
 ///   proxy URL.
 ///
@@ -731,6 +731,9 @@ mod tests {
             "HTTP_PROXY=http://attacker.example:9999".into(),
             "https_proxy=http://attacker.example:9999".into(),
             "ALL_PROXY=http://attacker.example:9999".into(),
+            "FTP_PROXY=http://attacker.example:9999".into(),
+            "ftp_proxy=http://attacker.example:9999".into(),
+            "NO_PROXY=*".into(),
             "PATH=/usr/bin".into(),
         ];
         let addr = ProxyAddress::new("127.0.0.1".into(), 9000);
@@ -749,6 +752,25 @@ mod tests {
         // The proxy URL is the one we set, not the attacker's.
         let http_pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();
         assert_eq!(args[http_pos + 1], "http://127.0.0.1:9000");
+
+        // FTP variables point at the configured proxy rather than a
+        // caller-controlled alternative.
+        for key in ["FTP_PROXY", "ftp_proxy"] {
+            let pos = args
+                .iter()
+                .position(|arg| arg == key)
+                .unwrap_or_else(|| panic!("missing --setenv {key} in {args:?}"));
+            assert_eq!(args[pos + 1], "http://127.0.0.1:9000");
+        }
+
+        // Bypass variables remain absent after clearing the caller's
+        // environment.
+        for key in ["NO_PROXY", "no_proxy"] {
+            assert!(
+                !args.iter().any(|arg| arg == key),
+                "proxy mode must not emit caller-controlled {key}: {args:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/core/wxc_common/src/proxy_env.rs
+++ b/src/core/wxc_common/src/proxy_env.rs
@@ -15,7 +15,7 @@
 //!    workload cannot pre-disable the proxy via its own `HTTP_PROXY` (or a
 //!    `NO_PROXY` exemption). This only sanitizes the *initial* env; the model
 //!    is cooperative, so a workload can still mutate its own env at runtime.
-//! 2. **Set** the HTTP/HTTPS/ALL proxy keys ([`PROXY_SET_KEYS`]) to the
+//! 2. **Set** the HTTP/HTTPS/ALL/FTP proxy keys ([`PROXY_SET_KEYS`]) to the
 //!    configured URL — never `NO_PROXY` (a host exemption list, not a target).
 //!
 //! `NO_PROXY` is kept out of [`PROXY_SET_KEYS`] and handled per-backend:
@@ -35,25 +35,29 @@ pub const PROXY_ENV_KEYS: &[&str] = &[
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "ALL_PROXY",
+    "FTP_PROXY",
     "http_proxy",
     "https_proxy",
     "all_proxy",
+    "ftp_proxy",
     "NO_PROXY",
     "no_proxy",
 ];
 
 /// Proxy env var keys that are actively *set* to the configured proxy URL.
 ///
-/// The HTTP/HTTPS/ALL keys (upper- and lower-case) are set. `NO_PROXY` is
+/// The HTTP/HTTPS/ALL/FTP keys (upper- and lower-case) are set. `NO_PROXY` is
 /// deliberately omitted (it is a host-exemption list, not a proxy target; see
 /// module docs and [`PROXY_NEUTRALIZE_KEYS`]).
 pub const PROXY_SET_KEYS: &[&str] = &[
     "HTTP_PROXY",
     "HTTPS_PROXY",
     "ALL_PROXY",
+    "FTP_PROXY",
     "http_proxy",
     "https_proxy",
     "all_proxy",
+    "ftp_proxy",
 ];
 
 /// Proxy env var keys that [`apply_cooperative_proxy_env`] sets to the *empty
@@ -129,7 +133,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sets_all_http_https_proxy_keys_to_url() {
+    fn sets_all_proxy_keys_to_url() {
         let env = apply_cooperative_proxy_env(&[], "http://127.0.0.1:8080");
         for key in PROXY_SET_KEYS {
             assert!(
@@ -137,6 +141,15 @@ mod tests {
                 "missing {key}: {env:?}"
             );
         }
+    }
+
+    #[test]
+    fn sets_ftp_proxy_to_override_image_environment() {
+        // WSLc merges these entries over image ENV, so emitting both spellings
+        // is what overrides an image-baked FTP proxy.
+        let env = apply_cooperative_proxy_env(&[], "http://127.0.0.1:8080");
+        assert!(env.contains(&"FTP_PROXY=http://127.0.0.1:8080".to_string()));
+        assert!(env.contains(&"ftp_proxy=http://127.0.0.1:8080".to_string()));
     }
 
     #[test]
@@ -166,6 +179,8 @@ mod tests {
             "FOO=bar".to_string(),
             "HTTP_PROXY=http://attacker.example:9999".to_string(),
             "https_proxy=http://attacker.example:9999".to_string(),
+            "FTP_PROXY=http://attacker.example:9999".to_string(),
+            "ftp_proxy=http://attacker.example:9999".to_string(),
             "NO_PROXY=example.com".to_string(),
             "PATH=/usr/bin".to_string(),
         ];


### PR DESCRIPTION
## 📖 Description
Adds FTP_PROXY and ftp_proxy to the managed proxy-variable set so caller-supplied FTP proxy settings cannot conflict with an MXC-configured proxy. Extends shared and Bubblewrap unit tests.

## 🔗 References
Refs AB#62864253.

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/914)