### PR TITLE
[Bubblewrap] Fix denied-masking test fixture ownership

### DIFF
--- a/tests/scripts/run_bwrap_denied_masking_test.sh
+++ b/tests/scripts/run_bwrap_denied_masking_test.sh
@@ -49,24 +49,31 @@ sudo mkdir -p "$DIR"
 echo "VISIBLE_SECRET" | sudo tee "$VISIBLE" > /dev/null
 echo "FILE_SECRET" | sudo tee "$FILE" > /dev/null
 echo "DIR_SECRET" | sudo tee "$DIR/inner.txt" > /dev/null
+sudo chown -R "$(id -u):$(id -g)" "$BASE"
 
-# Sanity: all fixtures are readable on the host.
-if ! sudo cat "$VISIBLE" | grep -q "VISIBLE_SECRET"; then
+# Sanity: all fixtures are accessible to the invoking user. The filesystem
+# delegation check intentionally rejects a read-write path the caller cannot
+# write, so root-owned fixtures would prevent the sandbox from starting.
+if ! cat "$VISIBLE" | grep -q "VISIBLE_SECRET"; then
     echo "FAIL: fixture setup — visible.txt not readable on host."
     exit 1
 fi
-if ! sudo cat "$FILE" | grep -q "FILE_SECRET"; then
+if ! cat "$FILE" | grep -q "FILE_SECRET"; then
     echo "FAIL: fixture setup — secret_file.txt not readable on host."
     exit 1
 fi
-if ! sudo cat "$DIR/inner.txt" | grep -q "DIR_SECRET"; then
+if ! cat "$DIR/inner.txt" | grep -q "DIR_SECRET"; then
     echo "FAIL: fixture setup — secret_dir/inner.txt not readable on host."
     exit 1
 fi
 
 echo "Running Bubblewrap denied-path masking test (denied file + denied dir)..."
-OUTPUT=$("$LXC_EXEC" --experimental \
-    "$REPO_DIR/tests/configs/bubblewrap_denied_masking.json" 2>&1 || true)
+if ! OUTPUT=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_denied_masking.json" 2>&1); then
+    echo "$OUTPUT"
+    echo "FAIL: denied-path masking sandbox did not start."
+    exit 1
+fi
 echo "$OUTPUT"
 
 FAIL=0
@@ -116,10 +123,15 @@ echo "DIR_TARGET_SECRET" | sudo tee "$SYMBASE/real_dir/inner.txt" > /dev/null
 echo "FILE_TARGET_SECRET" | sudo tee "$SYMBASE/real_file.txt" > /dev/null
 sudo ln -s "$SYMBASE/real_dir" "$SYMBASE/link_to_dir"
 sudo ln -s "$SYMBASE/real_file.txt" "$SYMBASE/link_to_file"
+sudo chown -R "$(id -u):$(id -g)" "$SYMBASE"
 
 echo "Running Bubblewrap denied-symlink -> dir masking test..."
-DIR_OUT=$("$LXC_EXEC" --experimental \
-    "$REPO_DIR/tests/configs/bubblewrap_denied_symlink_dir.json" 2>&1 || true)
+if ! DIR_OUT=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_denied_symlink_dir.json" 2>&1); then
+    echo "$DIR_OUT"
+    echo "FAIL: denied-symlink -> dir sandbox did not start."
+    exit 1
+fi
 echo "$DIR_OUT"
 if echo "$DIR_OUT" | grep -q "CONTROL_OK" \
     && echo "$DIR_OUT" | grep -q "SYMDIR_MASKED_OK" \
@@ -131,8 +143,12 @@ else
 fi
 
 echo "Running Bubblewrap denied-symlink -> file masking test..."
-FILE_OUT=$("$LXC_EXEC" --experimental \
-    "$REPO_DIR/tests/configs/bubblewrap_denied_symlink_file.json" 2>&1 || true)
+if ! FILE_OUT=$("$LXC_EXEC" --experimental \
+    "$REPO_DIR/tests/configs/bubblewrap_denied_symlink_file.json" 2>&1); then
+    echo "$FILE_OUT"
+    echo "FAIL: denied-symlink -> file sandbox did not start."
+    exit 1
+fi
 echo "$FILE_OUT"
 if echo "$FILE_OUT" | grep -q "CONTROL_OK" \
     && echo "$FILE_OUT" | grep -q "SYMFILE_MASKED_OK" \


### PR DESCRIPTION
## 📖 Description
Makes denied-masking fixtures writable by the invoking user so MXC’s delegation check permits the test sandbox to start. Also fails immediately on executor errors instead of reporting misleading masking failures.

## 🔗 References
Fixes #913.

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/915)