### PR TITLE
Fix FTP proxy environment spec on main

### DIFF
--- a/src/core/wxc_common/tests/proxy_env_spec.rs
+++ b/src/core/wxc_common/tests/proxy_env_spec.rs
@@ -175,8 +175,7 @@ fn every_set_and_neutralize_key_is_in_the_scrub_list() {
 
 // Protects client (d): a sandboxed workload cannot pre-set a proxy variable to
 // escape the cooperative proxy. Every managed key the caller supplies -- in any
-// case, and the FTP family that is scrubbed but never re-set -- is gone or
-// replaced; the workload's `evil` target never survives.
+// case -- is gone or replaced; the workload's `evil` target never survives.
 #[test]
 fn cooperative_env_scrubs_all_caller_supplied_proxy_keys() {
     let caller = vec![
@@ -191,9 +190,8 @@ fn cooperative_env_scrubs_all_caller_supplied_proxy_keys() {
 
     assert!(!result.iter().any(|e| e.contains("evil")));
     assert!(!result.iter().any(|e| e.contains("internal.example.com")));
-    assert!(!result
-        .iter()
-        .any(|e| key_of(e).eq_ignore_ascii_case("FTP_PROXY")));
+    assert_eq!(value_for(&result, "FTP_PROXY"), Some(PROXY_URL));
+    assert_eq!(value_for(&result, "ftp_proxy"), Some(PROXY_URL));
 }
 
 // Protects client (d): duplicate and mixed-case proxy keys are an obvious


### PR DESCRIPTION
## 📖 Description
Updates the proxy environment contract test to expect FTP_PROXY and ftp_proxy to be replaced with the configured proxy URL, matching current behavior.

## 🔗 References
Fixes #922.

## 🔍 Validation
<!-- How did you test? List manual steps or note automated test coverage. -->

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [ ] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [ ] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/923)