### PR TITLE
Guard the proxy key contract against hand-written expectations

### DIFF
--- a/src/core/wxc_common/tests/proxy_env_spec.rs
+++ b/src/core/wxc_common/tests/proxy_env_spec.rs
@@ -194,6 +194,36 @@ fn cooperative_env_scrubs_all_caller_supplied_proxy_keys() {
     assert_eq!(value_for(&result, "ftp_proxy"), Some(PROXY_URL));
 }
 
+// Protects clients (b), (c), and (d): the three key-set constants are the
+// contract, so this derives the expected state of every managed key from them
+// instead of naming keys by hand. A hand-written per-key expectation can
+// silently disagree with the constant that actually drives the behavior --
+// which is how an assertion that FTP_PROXY stays absent survived FTP_PROXY
+// being added to PROXY_SET_KEYS, leaving the suite asserting both at once.
+#[test]
+fn every_managed_key_lands_in_the_state_its_constants_dictate() {
+    let hostile = "http://attacker.example:9999";
+    let caller: Vec<String> = PROXY_ENV_KEYS
+        .iter()
+        .map(|key| format!("{key}={hostile}"))
+        .collect();
+
+    let result = apply_cooperative_proxy_env(&caller, PROXY_URL);
+
+    for key in PROXY_ENV_KEYS {
+        let expected = if PROXY_SET_KEYS.contains(key) {
+            Some(PROXY_URL)
+        } else if PROXY_NEUTRALIZE_KEYS.contains(key) {
+            Some("")
+        } else {
+            None
+        };
+        assert_eq!(value_for(&result, key), expected, "managed key {key}");
+    }
+
+    assert!(!result.iter().any(|entry| entry.contains(hostile)));
+}
+
 // Protects client (d): duplicate and mixed-case proxy keys are an obvious
 // evasion attempt. Neither the second copy nor an unusual casing survives with
 // the workload's value.

--- a/tests/configs/wslc_filesystem.json
+++ b/tests/configs/wslc_filesystem.json
@@ -3,11 +3,11 @@
   "containerId": "wslc-filesystem-test",
   "containment": "wslc",
   "process": {
-    "commandLine": "set -e; ls -la /mnt/c/workspace >/dev/null && echo 'PASS: filesystem mount visible' || { echo 'FAIL: /mnt/c/workspace not visible'; exit 1; }; cpus=$(nproc); echo \"CPU_COUNT=$cpus\"; [ \"$cpus\" = \"2\" ] && echo 'PASS: cpuCount enforced (nproc=2)' || { echo \"FAIL: expected nproc=2, got $cpus\"; exit 1; }; mem_kb=$(awk '/MemTotal:/ {print $2}' /proc/meminfo); mem_mb=$((mem_kb/1024)); echo \"MEM_TOTAL_MB=$mem_mb\"; [ $mem_mb -ge 820 ] && [ $mem_mb -le 1075 ] && echo 'PASS: memoryMb enforced (~1024MB, kernel-visible 80-105%)' || { echo \"FAIL: expected 820-1075MB, got ${mem_mb}MB\"; exit 1; }",
-    "cwd": "C:\\workspace"
+    "commandLine": "set -e; ls -la /mnt/c/wslcfs >/dev/null && echo 'PASS: filesystem mount visible' || { echo 'FAIL: /mnt/c/wslcfs not visible'; exit 1; }; cpus=$(nproc); echo \"CPU_COUNT=$cpus\"; [ \"$cpus\" = \"2\" ] && echo 'PASS: cpuCount enforced (nproc=2)' || { echo \"FAIL: expected nproc=2, got $cpus\"; exit 1; }; mem_kb=$(awk '/MemTotal:/ {print $2}' /proc/meminfo); mem_mb=$((mem_kb/1024)); echo \"MEM_TOTAL_MB=$mem_mb\"; [ $mem_mb -ge 820 ] && [ $mem_mb -le 1075 ] && echo 'PASS: memoryMb enforced (~1024MB, kernel-visible 80-105%)' || { echo \"FAIL: expected 820-1075MB, got ${mem_mb}MB\"; exit 1; }",
+    "cwd": "C:\\wslcfs"
   },
   "filesystem": {
-    "readwritePaths": ["C:\\workspace"]
+    "readwritePaths": ["C:\\wslcfs"]
   },
   "network": {
     "defaultPolicy": "allow"

--- a/tests/configs/wslc_network_proxy.json
+++ b/tests/configs/wslc_network_proxy.json
@@ -3,8 +3,8 @@
   "containerId": "wslc-network-proxy",
   "containment": "wslc",
   "process": {
-    "commandLine": "set -e; ( while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 9\\r\\nConnection: close\\r\\n\\r\\nPROXY_HIT' | nc -l -p 8888 -w 2 >/dev/null 2>&1; done ) & sleep 1; echo \"PROXY_ENV HTTP_PROXY=[$HTTP_PROXY] http_proxy=[$http_proxy] NO_PROXY=[$NO_PROXY] no_proxy=[$no_proxy]\"; BODY=$(wget -q -O - http://example.com/ 2>/dev/null || true); echo \"CLIENT_GOT=[$BODY]\"; case \"$BODY\" in *PROXY_HIT*) echo WSLC_PROXY_FUNCTIONAL_OK ;; *) echo WSLC_PROXY_FAIL ;; esac",
-    "env": ["HTTP_PROXY=http://attacker.invalid:1", "http_proxy=http://attacker.invalid:1", "NO_PROXY=*", "no_proxy=attacker.invalid"]
+    "commandLine": "set -e; ( while true; do printf 'HTTP/1.0 200 OK\\r\\nContent-Length: 9\\r\\nConnection: close\\r\\n\\r\\nPROXY_HIT' | nc -l -p 8888 -w 2 >/dev/null 2>&1; done ) & sleep 1; echo \"PROXY_ENV HTTP_PROXY=[$HTTP_PROXY] http_proxy=[$http_proxy] FTP_PROXY=[$FTP_PROXY] ftp_proxy=[$ftp_proxy] NO_PROXY=[$NO_PROXY] no_proxy=[$no_proxy]\"; BODY=$(wget -q -O - http://example.com/ 2>/dev/null || true); echo \"CLIENT_GOT=[$BODY]\"; case \"$BODY\" in *PROXY_HIT*) echo WSLC_PROXY_FUNCTIONAL_OK ;; *) echo WSLC_PROXY_FAIL ;; esac",
+    "env": ["HTTP_PROXY=http://attacker.invalid:1", "http_proxy=http://attacker.invalid:1", "FTP_PROXY=http://attacker.invalid:1", "ftp_proxy=http://attacker.invalid:1", "NO_PROXY=*", "no_proxy=attacker.invalid"]
   },
   "network": {
     "defaultPolicy": "allow",

--- a/tests/configs/wslc_readonly_mount.json
+++ b/tests/configs/wslc_readonly_mount.json
@@ -3,10 +3,10 @@
   "containerId": "wslc-readonly-mount",
   "containment": "wslc",
   "process": {
-    "commandLine": "cat /mnt/c/workspace/test.txt && echo 'Read succeeded' && echo 'write test' > /mnt/c/workspace/readonly_write_test.txt && echo 'Write succeeded (unexpected)' || echo 'Write blocked (expected for readonly)'"
+    "commandLine": "cat /mnt/c/wslcro/test.txt && echo 'Read succeeded' && echo 'write test' > /mnt/c/wslcro/readonly_write_test.txt && echo 'Write succeeded (unexpected)' || echo 'Write blocked (expected for readonly)'"
   },
   "filesystem": {
-    "readonlyPaths": ["C:\\workspace"]
+    "readonlyPaths": ["C:\\wslcro"]
   },
   "network": {
     "defaultPolicy": "block"

--- a/tests/scripts/run_wslc_all_tests.ps1
+++ b/tests/scripts/run_wslc_all_tests.ps1
@@ -216,33 +216,37 @@ $null = $results.Add((Run-WslcTest "wslc_large_output.json"))
 
 Write-Host "`n--- Filesystem Tests ---" -ForegroundColor Cyan
 
-# wslc_filesystem.json also asserts cpuCount + memoryMb enforcement via nproc and /proc/meminfo.
-$null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
-    -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))
-
-# Fixed paths must match tests\configs\wslc_readonly_mount.json.
+# Fixed paths must match tests\configs\wslc_filesystem.json and
+# tests\configs\wslc_readonly_mount.json.
+$fsFixtureDir = "C:\wslcfs"
 $readonlyFixtureDir = "C:\wslcro"
 $readonlyFixture = Join-Path $readonlyFixtureDir "test.txt"
 
-function Remove-ReadonlyFixture {
+function Remove-FilesystemFixtures {
+    Remove-Item -Recurse -Force $fsFixtureDir -ErrorAction SilentlyContinue
     Remove-Item -Recurse -Force $readonlyFixtureDir -ErrorAction SilentlyContinue
 }
 
-# Seed the readonly fixture the same way the LXC and bubblewrap suites do
-# (run_lxc_filesystem_test.sh:21, run_bwrap_filesystem_test.sh:25).  Without
-# this, wslc_readonly_mount.json cats a file that was never created and fails
-# for a missing fixture rather than for a mount defect.  The root is test-only
-# and removed in the finally, so a developer's C:\workspace -- which the
-# prerequisites above tell them to fill with alpine.tar -- is never written to,
-# and a mount that is wrongly writable does not leave its probe file behind.
-Remove-ReadonlyFixture
+# Both filesystem configs mount a host directory the suite owns outright, so a
+# run needs nothing hand-made and never touches C:\workspace, where the
+# prerequisites above tell the developer to keep alpine.tar.  wslc_filesystem
+# only needs its mount target to exist; wslc_readonly_mount also reads
+# test.txt, seeded the way the LXC and bubblewrap suites seed theirs
+# (run_lxc_filesystem_test.sh:21, run_bwrap_filesystem_test.sh:25).  The
+# finally removes both roots, including the probe file a wrongly-writable
+# mount would leave behind.
+Remove-FilesystemFixtures
 try {
+    $null = New-Item -ItemType Directory -Path $fsFixtureDir -Force
     $null = New-Item -ItemType Directory -Path $readonlyFixtureDir -Force
     Set-Content -Path $readonlyFixture -Value "test content" -Encoding ascii
 
+    # wslc_filesystem.json also asserts cpuCount + memoryMb enforcement via nproc and /proc/meminfo.
+    $null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
+        -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))
     $null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "Read succeeded"))
 } finally {
-    Remove-ReadonlyFixture
+    Remove-FilesystemFixtures
 }
 
 Write-Host "`n--- Object Validation Tests ---" -ForegroundColor Cyan

--- a/tests/scripts/run_wslc_all_tests.ps1
+++ b/tests/scripts/run_wslc_all_tests.ps1
@@ -216,22 +216,34 @@ $null = $results.Add((Run-WslcTest "wslc_large_output.json"))
 
 Write-Host "`n--- Filesystem Tests ---" -ForegroundColor Cyan
 
-# Seed the readonly fixture the same way the LXC and bubblewrap suites do
-# (run_lxc_filesystem_test.sh:21, run_bwrap_filesystem_test.sh:25).  Without
-# this, wslc_readonly_mount.json cats a file that was never created and fails
-# for a missing fixture rather than for a mount defect.
-$readonlyFixtureDir = "C:\workspace"
-$readonlyFixture = Join-Path $readonlyFixtureDir "test.txt"
-if (-not (Test-Path $readonlyFixtureDir))
-{
-    $null = New-Item -ItemType Directory -Path $readonlyFixtureDir -Force
-}
-Set-Content -Path $readonlyFixture -Value "test content" -Encoding ascii
-
 # wslc_filesystem.json also asserts cpuCount + memoryMb enforcement via nproc and /proc/meminfo.
 $null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
     -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))
-$null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "Read succeeded"))
+
+# Fixed paths must match tests\configs\wslc_readonly_mount.json.
+$readonlyFixtureDir = "C:\wslcro"
+$readonlyFixture = Join-Path $readonlyFixtureDir "test.txt"
+
+function Remove-ReadonlyFixture {
+    Remove-Item -Recurse -Force $readonlyFixtureDir -ErrorAction SilentlyContinue
+}
+
+# Seed the readonly fixture the same way the LXC and bubblewrap suites do
+# (run_lxc_filesystem_test.sh:21, run_bwrap_filesystem_test.sh:25).  Without
+# this, wslc_readonly_mount.json cats a file that was never created and fails
+# for a missing fixture rather than for a mount defect.  The root is test-only
+# and removed in the finally, so a developer's C:\workspace -- which the
+# prerequisites above tell them to fill with alpine.tar -- is never written to,
+# and a mount that is wrongly writable does not leave its probe file behind.
+Remove-ReadonlyFixture
+try {
+    $null = New-Item -ItemType Directory -Path $readonlyFixtureDir -Force
+    Set-Content -Path $readonlyFixture -Value "test content" -Encoding ascii
+
+    $null = $results.Add((Run-WslcTest "wslc_readonly_mount.json" -OutputContains "Read succeeded"))
+} finally {
+    Remove-ReadonlyFixture
+}
 
 Write-Host "`n--- Object Validation Tests ---" -ForegroundColor Cyan
 # Object-based validation (roadmap D6): a directory under readwritePaths and a

--- a/tests/scripts/run_wslc_all_tests.ps1
+++ b/tests/scripts/run_wslc_all_tests.ps1
@@ -215,6 +215,19 @@ $null = $results.Add((Run-WslcTest "wslc_stderr.json" -OutputContains "stdout me
 $null = $results.Add((Run-WslcTest "wslc_large_output.json"))
 
 Write-Host "`n--- Filesystem Tests ---" -ForegroundColor Cyan
+
+# Seed the readonly fixture the same way the LXC and bubblewrap suites do
+# (run_lxc_filesystem_test.sh:21, run_bwrap_filesystem_test.sh:25).  Without
+# this, wslc_readonly_mount.json cats a file that was never created and fails
+# for a missing fixture rather than for a mount defect.
+$readonlyFixtureDir = "C:\workspace"
+$readonlyFixture = Join-Path $readonlyFixtureDir "test.txt"
+if (-not (Test-Path $readonlyFixtureDir))
+{
+    $null = New-Item -ItemType Directory -Path $readonlyFixtureDir -Force
+}
+Set-Content -Path $readonlyFixture -Value "test content" -Encoding ascii
+
 # wslc_filesystem.json also asserts cpuCount + memoryMb enforcement via nproc and /proc/meminfo.
 $null = $results.Add((Run-WslcTest "wslc_filesystem.json" `
     -OutputMatches "(?s)PASS: filesystem mount visible.*PASS: cpuCount enforced.*PASS: memoryMb enforced"))

--- a/tests/scripts/run_wslc_proxy_test.ps1
+++ b/tests/scripts/run_wslc_proxy_test.ps1
@@ -96,6 +96,15 @@ if ($pass -and ($childLine -match 'attacker\.invalid')) {
     $reason = "caller-supplied proxy env var leaked to the child (attacker.invalid not scrubbed)"
 }
 
+# The FTP family is set to the proxy as well, so an image-baked ftp_proxy
+# cannot send FTP traffic somewhere the operator did not choose. Matched
+# case-sensitively: -notmatch would let the upper-case entry satisfy both
+# checks and leave the lower-case one untested.
+if ($pass -and (($childLine -cnotmatch 'FTP_PROXY=\[http://127\.0\.0\.1:8888\]') -or ($childLine -cnotmatch 'ftp_proxy=\[http://127\.0\.0\.1:8888\]'))) {
+    $pass = $false
+    $reason = "runner did not inject/scrub the FTP proxy family (expected http://127.0.0.1:8888)"
+}
+
 # NO_PROXY / no_proxy must be neutralized to empty so an image-baked or
 # caller-supplied exemption (e.g. NO_PROXY=*) cannot disable the proxy.
 if ($pass -and (($childLine -notmatch 'NO_PROXY=\[\]') -or ($childLine -notmatch 'no_proxy=\[\]'))) {


### PR DESCRIPTION
## Problem

`cooperative_env_scrubs_all_caller_supplied_proxy_keys` asserted `FTP_PROXY`
was absent from the result while `cooperative_env_sets_every_set_key_to_the_proxy_url`
asserted every `PROXY_SET_KEYS` entry was present at the proxy URL. Both
cannot hold. #923 corrected the assertion, so `main` is green — but nothing
prevents the next hand-written per-key expectation from drifting away from
the constant that drives the behavior in exactly the same way.

## What this adds

`every_managed_key_lands_in_the_state_its_constants_dictate` derives the
expected post-state of all ten managed keys from `PROXY_SET_KEYS` and
`PROXY_NEUTRALIZE_KEYS` rather than naming keys by hand, and it does so
under hostile caller input for every key.

No existing test covered that combination. The scrub test supplies hostile
values but checks three keys; the set test checks every key but starts from
an empty caller environment.

The WSLc proxy e2e gains the FTP family for the same reason. The assertion
is case-sensitive (`-cnotmatch`) because PowerShell `-notmatch` is not,
which would let the upper-case entry satisfy both checks and leave a
lower-case attacker value untested.

## Scope

In: `proxy_env_spec.rs` (additive only), `wslc_network_proxy.json`,
`run_wslc_proxy_test.ps1`, `run_wslc_all_tests.ps1`,
`wslc_readonly_mount.json`, `wslc_filesystem.json`. Out: `proxy_env.rs` — the
behavior is correct and is not touched.

Also makes the WSLc filesystem tests supply their own fixtures. Both configs
mounted `C:\workspace`, which nothing in the repo creates, and
`wslc_readonly_mount.json` cat a `test.txt` that nothing wrote. So the
readonly test failed on a missing fixture rather than on a mount defect, and
the filesystem test passed only on a machine where the developer had already
made `C:\workspace` by hand for the tar prerequisites; on a clean machine it
failed with `FAIL: /mnt/c/workspace not visible`.

They now mount `C:\wslcfs` and `C:\wslcro`, which the harness creates and
removes in `try`/`finally` the way every other WSLc fixture script does
(`run_wslc_denied_masking_test.ps1:50-61,107-108`).
`windows_path_to_container_path` derives the guest paths from the host roots
(`policy_mapping.rs:39-65`). Cleanup also removes the probe file a
wrongly-writable readonly mount would leave behind.

`C:\workspace` is where the prerequisites tell the developer to keep
`alpine.tar`, so the suite no longer writes to it or creates it. The tar
imports still read it, which is a genuine prerequisite the harness cannot
produce, and those tests already skip when it is absent
(`run_wslc_all_tests.ps1:117-124`).

The redundant half of this PR was dropped. #923 landed the same assertion
fix an hour earlier and asserts both `FTP_PROXY` and `ftp_proxy` where this
branch asserted only the upper-case one, so this now sits on top of #923
rather than competing with it.

## Verification

- `wxc_common` 786 passed / 0 failed on Windows, 706 on Linux under WSL.
- The new test is mutation-verified: deleting the neutralize loop from
  `proxy_env.rs` fails it at `proxy_env_spec.rs:221`. Reverted; `proxy_env.rs`
  is absent from the diff.
- `cargo clippy -p wxc_common --all-targets -- -D warnings` clean.
- LXC e2e 20 passed / 1 failed; the failure is a GitHub API rate limit
  against `api.github.com/zen` and the diff touches no LXC file.
- **WSLc e2e: 23/23 passed (2 documented tar skips), state-aware 57/57.**
  The new FTP assertion ran against a live container and the attacker-supplied
  `FTP_PROXY` / `ftp_proxy` values were scrubbed and replaced with the proxy
  URL. This required upgrading the host to WSL 2.9.4; the suite could not run
  at all before.
- That suite figure predates the fixture change, so both filesystem configs
  were re-run afterwards from a clean state with neither root present.
  `wslc_filesystem.json` printed all three PASS lines and exited 0.
  `wslc_readonly_mount.json` read `test content` from `/mnt/c/wslcro/test.txt`,
  printed `Read succeeded`, had its write probe refused with
  `Read-only file system`, and exited 0. Both roots were gone afterwards and
  `C:\workspace` was untouched.
