### PR TITLE
fix(seatbelt): allow signaling sandbox children

### DIFF
--- a/docs/macos-support/seatbelt-backend.md
+++ b/docs/macos-support/seatbelt-backend.md
@@ -29,6 +29,8 @@ provides:
 - **UI isolation** by denying mach-lookup of `com.apple.windowserver`,
   pasteboard, and HID iokit user clients when `ui.disable` /
   `ui.clipboard=none` / `ui.injection=false`.
+- **Process-tree management** by allowing signals only between processes that
+  inherited the same sandbox.
 
 The macOS sandbox is **process-scoped**, not container-scoped: there is no named
 container, no lifecycle, and nothing to clean up. The sandbox lives only

--- a/sdk/node/tests/integration/macos-seatbelt.test.ts
+++ b/sdk/node/tests/integration/macos-seatbelt.test.ts
@@ -81,14 +81,27 @@ describe('macOS Seatbelt Container', {
   });
 
   it('should allow a process to signal its child', async () => {
+    // The EXIT trap matters on the failing path this test exists to catch: if
+    // `kill -TERM` is denied, `exit 1` would otherwise skip `wait` and orphan
+    // the child. The runner deliberately won't group-kill it afterwards (a
+    // reaped pid/pgid can be recycled), so it would outlive the test.
+    const script = [
+      'sleep 5 </dev/null >/dev/null 2>&1 & child=$!',
+      `trap 'kill -KILL "$child" 2>/dev/null || true; wait "$child" 2>/dev/null || true' 0`,
+      'kill -TERM "$child" || exit 1',
+      'wait "$child"; status=$?',
+      'trap - 0',
+      'test "$status" -eq 143',
+    ].join('\n');
     const result = await sdk.spawnSandboxAsync(
-      'sleep 30 & child=$!; kill -TERM "$child" || exit 1; wait "$child"; test "$?" -eq 143',
+      script,
       { version: schemaVersion },
       seatbeltSpawnOptions,
       undefined,
       'seatbelt-child-signal',
     );
-    assert.strictEqual(result.exitCode, 0, `Expected exit 0: ${result.stderr}`);
+    // `spawnSandboxAsync` merges PTY output into `stdout`; `stderr` is always ''.
+    assert.strictEqual(result.exitCode, 0, `Expected exit 0: ${result.stdout}`);
   });
 
   it('should deny filesystem access by default', async () => {

--- a/sdk/node/tests/integration/macos-seatbelt.test.ts
+++ b/sdk/node/tests/integration/macos-seatbelt.test.ts
@@ -80,6 +80,17 @@ describe('macOS Seatbelt Container', {
     assert.strictEqual(result.exitCode, 42);
   });
 
+  it('should allow a process to signal its child', async () => {
+    const result = await sdk.spawnSandboxAsync(
+      'sleep 30 & child=$!; kill -TERM "$child" || exit 1; wait "$child"; test "$?" -eq 143',
+      { version: schemaVersion },
+      seatbeltSpawnOptions,
+      undefined,
+      'seatbelt-child-signal',
+    );
+    assert.strictEqual(result.exitCode, 0, `Expected exit 0: ${result.stderr}`);
+  });
+
   it('should deny filesystem access by default', async () => {
     // The default seatbelt profile denies access to /Users.
     const result = await sdk.spawnSandboxAsync(

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -60,7 +60,7 @@ pub fn build_profile_with_proxy(
     // Minimum allow rules so a child process can actually run. These are
     // the same things Apple's own built-in profiles (e.g. no-internet)
     // include: dyld + system libraries, mach-lookup of the basic agents,
-    // sysctl reads, and signaling self.
+    // sysctl reads, and signaling processes in the same sandbox.
     out.push_str(BASELINE_ALLOW);
 
     // Filesystem — read-only system paths every process needs.
@@ -93,7 +93,7 @@ const BASELINE_ALLOW: &str = "\
 ;; --- baseline (required for any process to start) ---
 (allow process-fork)
 (allow process-exec)
-(allow signal (target self))
+(allow signal (target same-sandbox))
 (allow sysctl-read)
 (allow file-read-metadata)
 (allow mach-lookup
@@ -696,6 +696,7 @@ mod tests {
         assert!(p.contains("(deny default)"));
         assert!(p.contains("(allow process-fork)"));
         assert!(p.contains("(allow process-exec)"));
+        assert!(p.contains("(allow signal (target same-sandbox))"));
         assert!(p.contains("/usr/lib"));
         assert!(p.contains("/System"));
         assert!(p.contains("(subpath \"/bin\")"));


### PR DESCRIPTION
## Why

Seatbelt currently permits a sandboxed process to signal only itself. Tools that manage child worker pools can spawn workers but receive `EPERM` when terminating them; `oxfmt` completes its work and then crashes recursively while Tinypool tries to shut down its child processes.

`same-sandbox` is the narrow Seatbelt target for this behavior: descendants inheriting the profile can signal one another, while processes outside the sandbox remain unavailable.

## What changed

- replace the self-only signal rule with `target same-sandbox`
- cover the generated profile and a real child `SIGTERM` in the macOS integration suite
- document process-tree management in the Seatbelt backend

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p seatbelt_common`
- integration test TypeScript type-check
- freshly built `mxc-exec-mac` running `sleep 30 & child=$!; kill -TERM $child; wait $child; test $? -eq 143` inside Seatbelt
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/934)