### PR TITLE
Add captureDenials to the .NET SDK

### DIFF
--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Sample/Program.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Sample/Program.cs
@@ -27,6 +27,21 @@ var policy = new SandboxPolicy
     TimeoutMs = 30_000,
 };
 
+// Set MXC_SAMPLE_CAPTURE_DENIALS=1 to opt into Windows denial capture without
+// changing the sample's default host requirements or generating traces by default.
+if (OperatingSystem.IsWindows()
+    && string.Equals(
+        Environment.GetEnvironmentVariable("MXC_SAMPLE_CAPTURE_DENIALS"),
+        "1",
+        StringComparison.Ordinal))
+{
+    policy.CaptureDenials = new CaptureDenialsPolicy
+    {
+        Mode = CaptureDenialsMode.Block,
+        RetainEtl = false,
+    };
+}
+
 Console.WriteLine($"Running: {command}");
 
 try
@@ -38,6 +53,23 @@ try
     if (!string.IsNullOrWhiteSpace(result.Stderr))
     {
         Console.WriteLine($"stderr    : {result.Stderr.TrimEnd()}");
+    }
+    foreach (var warning in result.Warnings)
+    {
+        Console.WriteLine($"warning   : {warning}");
+    }
+    if (result.OutputMetadata?.CaptureDenials is { } capture)
+    {
+        Console.WriteLine($"denials   : {capture.OutputPath}");
+        if (capture.EtlPath is not null)
+        {
+            Console.WriteLine($"ETL       : {capture.EtlPath}");
+        }
+    }
+    if (result.OutputMetadata?.CaptureDenialsError is { } captureError)
+    {
+        Console.WriteLine($"capture error: {captureError.Message}");
+        Console.WriteLine($"retained ETL : {captureError.EtlPath}");
     }
 
     // Streaming variant: spawn the same command as a live process and stream

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Sample/Program.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Sample/Program.cs
@@ -91,6 +91,19 @@ try
 
         var streamResult = proc.Wait();
         Console.WriteLine($"streamed exit code : {streamResult.ExitCode}");
+        if (proc.OutputMetadata?.CaptureDenials is { } streamCapture)
+        {
+            Console.WriteLine($"stream denials    : {streamCapture.OutputPath}");
+            if (streamCapture.EtlPath is not null)
+            {
+                Console.WriteLine($"stream ETL        : {streamCapture.EtlPath}");
+            }
+        }
+        if (proc.OutputMetadata?.CaptureDenialsError is { } streamCaptureError)
+        {
+            Console.WriteLine($"stream capture error: {streamCaptureError.Message}");
+            Console.WriteLine($"stream retained ETL : {streamCaptureError.EtlPath}");
+        }
     }
 
     // State-aware lifecycle: provision -> start -> exec -> stop -> deprovision.

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Mxc.Sdk;
 using Xunit;
 
@@ -59,12 +58,7 @@ public class MxcSandboxTests
             },
         };
 
-        var options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-        };
-        var json = JsonSerializer.Serialize(policy, options);
+        var json = MxcSandbox.SerializePolicy(policy);
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
@@ -87,13 +81,7 @@ public class MxcSandboxTests
             Version = "0.8.0-alpha",
             CaptureDenials = new CaptureDenialsPolicy(),
         };
-        var options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-        };
-
-        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(policy, options));
+        using var doc = JsonDocument.Parse(MxcSandbox.SerializePolicy(policy));
         var capture = doc.RootElement.GetProperty("captureDenials");
 
         Assert.Equal("block", capture.GetProperty("mode").GetString());
@@ -105,13 +93,7 @@ public class MxcSandboxTests
     public void SandboxPolicy_OmitsCaptureDenialsWhenNotConfigured()
     {
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
-        var options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
-        };
-
-        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(policy, options));
+        using var doc = JsonDocument.Parse(MxcSandbox.SerializePolicy(policy));
 
         Assert.False(doc.RootElement.TryGetProperty("captureDenials", out _));
     }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Mxc.Sdk;
 using Xunit;
 
@@ -50,11 +51,18 @@ public class MxcSandboxTests
             TimeoutMs = 5000,
             Filesystem = new FilesystemPolicy { ReadwritePaths = { "/tmp" } },
             Ui = new UiPolicy { AllowWindows = true, Clipboard = ClipboardPolicy.Read },
+            CaptureDenials = new CaptureDenialsPolicy
+            {
+                Mode = CaptureDenialsMode.Allow,
+                OutputPath = @"C:\logs\denials.json",
+                RetainEtl = true,
+            },
         };
 
         var options = new JsonSerializerOptions
         {
-            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
         };
         var json = JsonSerializer.Serialize(policy, options);
 
@@ -65,6 +73,47 @@ public class MxcSandboxTests
         Assert.Equal("/tmp", root.GetProperty("filesystem").GetProperty("readwritePaths")[0].GetString());
         Assert.Equal("read", root.GetProperty("ui").GetProperty("clipboard").GetString());
         Assert.True(root.GetProperty("ui").GetProperty("allowWindows").GetBoolean());
+        var capture = root.GetProperty("captureDenials");
+        Assert.Equal("allow", capture.GetProperty("mode").GetString());
+        Assert.Equal(@"C:\logs\denials.json", capture.GetProperty("outputPath").GetString());
+        Assert.True(capture.GetProperty("retainEtl").GetBoolean());
+    }
+
+    [Fact]
+    public void CaptureDenialsPolicy_DefaultsToBlockAndOmitsOutputPath()
+    {
+        var policy = new SandboxPolicy
+        {
+            Version = "0.8.0-alpha",
+            CaptureDenials = new CaptureDenialsPolicy(),
+        };
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(policy, options));
+        var capture = doc.RootElement.GetProperty("captureDenials");
+
+        Assert.Equal("block", capture.GetProperty("mode").GetString());
+        Assert.False(capture.GetProperty("retainEtl").GetBoolean());
+        Assert.False(capture.TryGetProperty("outputPath", out _));
+    }
+
+    [Fact]
+    public void SandboxPolicy_OmitsCaptureDenialsWhenNotConfigured()
+    {
+        var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+        };
+
+        using var doc = JsonDocument.Parse(JsonSerializer.Serialize(policy, options));
+
+        Assert.False(doc.RootElement.TryGetProperty("captureDenials", out _));
     }
 
     [Fact]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
@@ -57,7 +57,7 @@ public static class MxcSandbox
         ArgumentNullException.ThrowIfNull(policy);
         ArgumentNullException.ThrowIfNull(command);
 
-        var policyJson = JsonSerializer.Serialize(policy, PolicyJsonOptions);
+        var policyJson = SerializePolicy(policy);
         var policyBuf = ToNullTerminatedUtf8(policyJson);
         var commandBuf = ToNullTerminatedUtf8(command);
 
@@ -122,7 +122,7 @@ public static class MxcSandbox
         ArgumentNullException.ThrowIfNull(policy);
         ArgumentNullException.ThrowIfNull(command);
 
-        var policyJson = JsonSerializer.Serialize(policy, PolicyJsonOptions);
+        var policyJson = SerializePolicy(policy);
         var policyBuf = ToNullTerminatedUtf8(policyJson);
         var commandBuf = ToNullTerminatedUtf8(command);
 
@@ -155,6 +155,12 @@ public static class MxcSandbox
         Encoding.UTF8.GetBytes(value, 0, value.Length, buffer, 0);
         buffer[byteCount] = 0;
         return buffer;
+    }
+
+    internal static string SerializePolicy(SandboxPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        return JsonSerializer.Serialize(policy, PolicyJsonOptions);
     }
 
     private static unsafe string? PtrToString(byte* p) =>

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxOutputMetadata.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxOutputMetadata.cs
@@ -24,7 +24,10 @@ public sealed class CaptureDenialsErrorOutput
     [JsonPropertyName("message")]
     public string Message { get; init; } = string.Empty;
 
-    /// <summary>Absolute path to the retained ETL trace.</summary>
+    /// <summary>
+    /// Absolute path to the retained ETL trace. Delete this file after use; do not delete its
+    /// parent directory unless the caller independently owns or positively recognizes it.
+    /// </summary>
     [JsonPropertyName("etlPath")]
     public string EtlPath { get; init; } = string.Empty;
 }
@@ -52,7 +55,11 @@ public sealed class CaptureDenialsOutput
     [JsonPropertyName("deniedResourcesTruncated")]
     public bool DeniedResourcesTruncated { get; init; }
 
-    /// <summary>Absolute path to the retained ETL trace, when requested.</summary>
+    /// <summary>
+    /// Absolute path to the retained ETL trace, when requested. Delete this file after use; do
+    /// not delete its parent directory unless the caller independently owns or positively
+    /// recognizes it.
+    /// </summary>
     [JsonPropertyName("etlPath")]
     public string? EtlPath { get; init; }
 }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxPolicy.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxPolicy.cs
@@ -52,6 +52,10 @@ public enum CaptureDenialsMode
 
     /// <summary>
     /// Allow and record the access. This relaxes containment for the run and emits a warning.
+    /// <see cref="MxcSandbox.Run(SandboxPolicy, string)"/> and
+    /// <see cref="MxcSandbox.RunAsync(SandboxPolicy, string, CancellationToken)"/> expose that
+    /// warning; streaming processes returned by
+    /// <see cref="MxcSandbox.Spawn(SandboxPolicy, string)"/> currently do not.
     /// </summary>
     Allow,
 }
@@ -69,15 +73,17 @@ public sealed class CaptureDenialsPolicy
     /// <summary>
     /// Optional absolute path for the JSON denials document. The parent directory must exist.
     /// MXC inserts a per-run identifier into the file stem and reports the actual path through
-    /// output metadata. When omitted, MXC uses a managed temporary path.
+    /// output metadata. When omitted, MXC uses a run-unique file in the system temporary
+    /// directory.
     /// </summary>
     [JsonPropertyName("outputPath")]
     public string? OutputPath { get; set; }
 
     /// <summary>
     /// Preserve the sealed ETL trace and report its path through output metadata. Retained traces
-    /// can contain sensitive paths and identifiers; callers must delete both the trace and its
-    /// now-empty per-run parent directory.
+    /// can contain sensitive paths and identifiers; callers must delete the reported trace after
+    /// use. Do not delete its parent directory unless the caller independently owns or positively
+    /// recognizes that directory.
     /// </summary>
     [JsonPropertyName("retainEtl")]
     public bool RetainEtl { get; set; }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxPolicy.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxPolicy.cs
@@ -28,9 +28,59 @@ public sealed class SandboxPolicy
     [JsonPropertyName("ui")]
     public UiPolicy? Ui { get; set; }
 
+    /// <summary>
+    /// Windows ProcessContainer denial capture. Its presence enables capture;
+    /// Linux and macOS backends ignore it.
+    /// </summary>
+    [JsonPropertyName("captureDenials")]
+    public CaptureDenialsPolicy? CaptureDenials { get; set; }
+
     /// <summary>Execution timeout in milliseconds (<c>null</c> = no timeout).</summary>
     [JsonPropertyName("timeoutMs")]
     public uint? TimeoutMs { get; set; }
+}
+
+/// <summary>
+/// How <c>captureDenials</c> handles each ungranted access check while recording it.
+/// </summary>
+public enum CaptureDenialsMode
+{
+    /// <summary>
+    /// Keep the access denied and record the denial, preserving deny-by-default containment.
+    /// </summary>
+    Block,
+
+    /// <summary>
+    /// Allow and record the access. This relaxes containment for the run and emits a warning.
+    /// </summary>
+    Allow,
+}
+
+/// <summary>
+/// Windows ProcessContainer denial-capture settings. The presence of this section enables
+/// capture and reports the resulting document through <see cref="SandboxOutputMetadata"/>.
+/// </summary>
+public sealed class CaptureDenialsPolicy
+{
+    /// <summary>How ungranted access checks are handled while recording them.</summary>
+    [JsonPropertyName("mode")]
+    public CaptureDenialsMode Mode { get; set; } = CaptureDenialsMode.Block;
+
+    /// <summary>
+    /// Optional absolute path for the JSON denials document. The parent directory must exist.
+    /// MXC inserts a per-run identifier into the file stem and reports the actual path through
+    /// output metadata. When omitted, MXC uses a managed temporary path.
+    /// </summary>
+    [JsonPropertyName("outputPath")]
+    public string? OutputPath { get; set; }
+
+    /// <summary>
+    /// Preserve the sealed ETL trace and report its path through output metadata. Retained traces
+    /// can contain sensitive paths and identifiers; callers must delete both the trace and its
+    /// now-empty per-run parent directory.
+    /// </summary>
+    [JsonPropertyName("retainEtl")]
+    public bool RetainEtl { get; set; }
 }
 
 /// <summary>Filesystem section of a <see cref="SandboxPolicy"/>.</summary>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -52,6 +52,47 @@ when `permissiveLearningMode` disabled deny-by-default. MXC never writes these
 to the host's stderr, so inspecting `Warnings` is the only way to learn that
 containment was relaxed.
 
+### Denial capture (Windows)
+
+Set `SandboxPolicy.CaptureDenials` to record Windows ProcessContainer accesses
+that the policy does not grant:
+
+```csharp
+var policy = new SandboxPolicy
+{
+    Version = "0.8.0-alpha",
+    CaptureDenials = new CaptureDenialsPolicy
+    {
+        // Block is the safe default: deny the access and record it.
+        // Allow records what would have been denied but relaxes containment.
+        Mode = CaptureDenialsMode.Block,
+        // Optional absolute destination. MXC inserts a per-run ID into the stem.
+        OutputPath = @"C:\logs\denials.json",
+        // Retained ETLs can contain sensitive paths and identifiers.
+        RetainEtl = false,
+    },
+};
+
+RunResult result = MxcSandbox.Run(policy, "cmd /c type C:\\blocked.txt");
+if (result.OutputMetadata?.CaptureDenials is { } capture)
+{
+    Console.WriteLine($"denials: {capture.OutputPath}");
+    Console.WriteLine($"unique denials: {capture.TotalDenials}");
+}
+
+foreach (string warning in result.Warnings)
+{
+    Console.Error.WriteLine(warning);
+}
+```
+
+`OutputPath`'s parent directory must already exist. When it is omitted, MXC
+uses a managed temporary location. If `RetainEtl` is `true`, delete the
+reported ETL after use and remove its now-empty per-run parent directory.
+`CaptureDenialsMode.Allow` intentionally weakens deny-by-default containment;
+always inspect `RunResult.Warnings`. Linux and macOS accept the policy for
+cross-platform parity but do not act on it.
+
 ### Streaming
 
 `MxcSandbox.Spawn(policy, command)` returns a live `MxcSandboxProcess` you can

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -44,8 +44,10 @@ generated JSON document and carries its summary. When ETL retention is enabled,
 `OutputMetadata.CaptureDenials.EtlPath` identifies the retained trace. If
 capture finalization fails after retaining the trace,
 `OutputMetadata.CaptureDenialsError` carries both the failure and its path.
-After deleting a retained ETL, also remove its now-empty per-run parent
-directory.
+Delete every reported ETL file after use. Do not delete its parent directory
+unless your application independently owns or positively recognizes that
+directory; it may be a shared location such as the system temporary directory
+or the configured output directory.
 
 `RunResult.Warnings` carries security warnings raised during the run — notably
 when `permissiveLearningMode` disabled deny-by-default. MXC never writes these
@@ -87,11 +89,15 @@ foreach (string warning in result.Warnings)
 ```
 
 `OutputPath`'s parent directory must already exist. When it is omitted, MXC
-uses a managed temporary location. If `RetainEtl` is `true`, delete the
-reported ETL after use and remove its now-empty per-run parent directory.
+uses a run-unique file in the system temporary directory. Delete every reported
+ETL file after use, including an ETL reported through
+`CaptureDenialsError.EtlPath`; do not delete its parent directory unless your
+application independently owns or positively recognizes that directory.
 `CaptureDenialsMode.Allow` intentionally weakens deny-by-default containment;
-always inspect `RunResult.Warnings`. Linux and macOS accept the policy for
-cross-platform parity but do not act on it.
+always inspect `RunResult.Warnings`. Streaming processes currently do not
+expose warnings, so use `Run` or `RunAsync` when warning inspection is required.
+Linux and macOS accept the policy for cross-platform parity but do not act on
+it.
 
 ### Streaming
 


### PR DESCRIPTION
## 📖 Description

Adds `captureDenials` policy configuration to the .NET SDK, including block/allow modes, optional output paths, and retained ETL configuration. The sample now demonstrates opt-in denial capture and reports capture metadata for run-to-completion and streaming execution.

The documentation covers sensitive ETL cleanup and notes that streaming processes do not currently expose security warnings; callers that use allow mode and need warning inspection should use `Run` or `RunAsync`.

## 🔗 References

- Native and FFI denial-capture support already present on `main`.

## 🔍 Validation

- `dotnet test sdk\dotnet\Microsoft.Mxc.Sdk.slnx` — 39 passed
- `node scripts\check-dotnet-bindings-codegen.js`
- `node scripts\check-dotnet-errorcode-parity.js`
- `git diff --check`
- Eight-axis adversarial review completed; all High and Medium findings resolved

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/938)