### PR TITLE
Validate 0.8 networking schema by backend

### DIFF
--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -54,6 +54,7 @@ use wxc_common::sandbox_process::{
     SandboxBackend, SandboxProcess, StdioMode, StreamCloser,
 };
 use wxc_common::script_runner::get_timeout_milliseconds;
+use wxc_common::validator::validate_network_policy_support;
 use wxc_common::{string_util, ui_policy};
 
 pub(crate) const CAPTURE_DENIALS_FALLBACK_UNSUPPORTED_MSG: &str =
@@ -1529,6 +1530,13 @@ impl AppContainerScriptRunner {
 
 impl SandboxBackend for AppContainerScriptRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, self.network_policy_support())?;
+        if request.policy.allowed_proxy_peer.is_some() {
+            return Err(ScriptResponse::error(
+                "processContainer.network.allowedProxyPeer requires BaseContainer support",
+            ));
+        }
+
         // AppContainer fallback tiers have no native capture path, so retainEtl
         // is honored only by a guarded-WPR provider that can transfer the ETL.
         validate_retain_etl_supported(

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -1531,11 +1531,6 @@ impl AppContainerScriptRunner {
 impl SandboxBackend for AppContainerScriptRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
         validate_network_policy_support(request, self.network_policy_support())?;
-        if request.policy.allowed_proxy_peer.is_some() {
-            return Err(ScriptResponse::error(
-                "processContainer.network.allowedProxyPeer requires BaseContainer support",
-            ));
-        }
 
         // AppContainer fallback tiers have no native capture path, so retainEtl
         // is honored only by a guarded-WPR provider that can transfer the ETL.

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -2201,11 +2201,6 @@ struct BaseChild {
 impl SandboxBackend for BaseContainerRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
         validate_network_policy_support(request, self.network_policy_support())?;
-        if request.policy.allowed_proxy_peer.is_some() {
-            return Err(ScriptResponse::error(
-                "processContainer.network.allowedProxyPeer is not implemented",
-            ));
-        }
 
         let capture_denials = request.policy.capture_denials.is_some();
         if !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty() {

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -83,6 +83,7 @@ use wxc_common::sandbox_process::{
 };
 use wxc_common::script_runner::get_timeout_milliseconds;
 use wxc_common::string_util;
+use wxc_common::validator::validate_network_policy_support;
 
 use windows::Win32::System::Threading::{
     ResumeThread, CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
@@ -2199,6 +2200,13 @@ struct BaseChild {
 
 impl SandboxBackend for BaseContainerRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, self.network_policy_support())?;
+        if request.policy.allowed_proxy_peer.is_some() {
+            return Err(ScriptResponse::error(
+                "processContainer.network.allowedProxyPeer is not implemented",
+            ));
+        }
+
         let capture_denials = request.policy.capture_denials.is_some();
         if !request.policy.allowed_hosts.is_empty() || !request.policy.blocked_hosts.is_empty() {
             return Err(ScriptResponse::error(

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -42,7 +42,7 @@ use wxc_common::sandbox_process::{
     WaitError,
 };
 use wxc_common::unix_proxy_coordinator::UnixProxyCoordinator;
-use wxc_common::validator::validate_common;
+use wxc_common::validator::{validate_common, validate_network_policy_support};
 
 use crate::{
     bwrap_command::{self, ResolvedNetworkMode},
@@ -62,6 +62,7 @@ impl BubblewrapScriptRunner {
 
 impl SandboxBackend for BubblewrapScriptRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, self.network_policy_support())?;
         // User-input validation runs before the environmental `bwrap`
         // probe so config errors are reported deterministically even on
         // hosts without bwrap installed.

--- a/src/backends/hyperlight/common/src/lib.rs
+++ b/src/backends/hyperlight/common/src/lib.rs
@@ -84,6 +84,7 @@ use std::path::{Path, PathBuf};
 use wxc_common::logger::Logger;
 use wxc_common::models::{ExecutionRequest, NetworkPolicy, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 use hyperlight_unikraft::pyhl;
 use hyperlight_unikraft::{AllowList, BlockList, Preopen};
@@ -503,7 +504,9 @@ impl HyperlightScriptRunner {
 
 impl ScriptRunner for HyperlightScriptRunner {
     fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        Self::validate_policies(request).map_err(|e| e.to_response())
+        Self::validate_policies(request).map_err(|e| e.to_response())?;
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
+        Ok(())
     }
 
     fn execute(&mut self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {

--- a/src/backends/isolation_session/common/src/one_shot.rs
+++ b/src/backends/isolation_session/common/src/one_shot.rs
@@ -11,6 +11,7 @@ use std::io::IsTerminal;
 use wxc_common::logger::Logger;
 use wxc_common::models::{ExecutionRequest, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 use super::manager::IsolationSessionManager;
 use super::policy::validate_provision_policy;
@@ -56,7 +57,9 @@ impl ScriptRunner for IsolationSessionRunner {
         // backend configuration, so there is nothing backend-specific to
         // validate here — only the cross-cutting stable-surface policy.
         reject_unsupported_lifecycle(request)?;
-        validate_provision_policy(request).map_err(ScriptResponse::from)
+        validate_provision_policy(request).map_err(ScriptResponse::from)?;
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
+        Ok(())
     }
 
     fn execute(&mut self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {

--- a/src/backends/isolation_session/common/src/policy.rs
+++ b/src/backends/isolation_session/common/src/policy.rs
@@ -70,7 +70,11 @@ pub(super) fn validate_post_provision_policy(
     if request.policy.network_proxy.is_enabled() {
         return Err(IsolationSessionError::Policy(ERR_PROXY_POLICY.to_string()));
     }
-    if request.policy.network_specified || request.policy.network_mode_specified {
+    if request.policy.network_specified
+        || request.policy.network_mode_specified
+        || request.policy.network_egress.is_some()
+        || request.policy.network_ingress.is_some()
+    {
         return Err(IsolationSessionError::Policy(
             ERR_NETWORK_IMMUTABLE.to_string(),
         ));
@@ -137,7 +141,9 @@ fn validate_provision_network_policy(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::models::{ContainerPolicy, ProxyAddress, ProxyConfig, UiPolicy};
+    use wxc_common::models::{
+        ContainerPolicy, NetworkEgressPolicy, ProxyAddress, ProxyConfig, UiPolicy,
+    };
     use wxc_common::mxc_error::MxcErrorCode;
 
     fn assert_policy_err_contains(err: IsolationSessionError, expected: &str) {
@@ -593,6 +599,21 @@ mod tests {
         // No network supplied → inherit what provision established.
         let request = ExecutionRequest::default();
         assert!(validate_post_provision_policy(&request).is_ok());
+    }
+
+    #[test]
+    fn post_provision_policy_rejects_raw_directional_policy() {
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                network_egress: Some(NetworkEgressPolicy::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_policy_err_contains(
+            validate_post_provision_policy(&request).unwrap_err(),
+            ERR_NETWORK_IMMUTABLE,
+        );
     }
 
     #[test]

--- a/src/backends/isolation_session/common/src/policy.rs
+++ b/src/backends/isolation_session/common/src/policy.rs
@@ -67,7 +67,14 @@ pub(super) fn validate_post_provision_policy(
 ) -> Result<(), IsolationSessionError> {
     reject_filesystem_policy(request)?;
     reject_ui_policy(request)?;
-    if request.policy.network_specified {
+    if request.policy.network_proxy.is_enabled() {
+        return Err(IsolationSessionError::Policy(ERR_PROXY_POLICY.to_string()));
+    }
+    if request.policy.network_specified
+        || request.policy.network_mode_specified
+        || request.policy.network_egress.is_some()
+        || request.policy.network_ingress.is_some()
+    {
         return Err(IsolationSessionError::Policy(
             ERR_NETWORK_IMMUTABLE.to_string(),
         ));

--- a/src/backends/isolation_session/common/src/policy.rs
+++ b/src/backends/isolation_session/common/src/policy.rs
@@ -70,11 +70,7 @@ pub(super) fn validate_post_provision_policy(
     if request.policy.network_proxy.is_enabled() {
         return Err(IsolationSessionError::Policy(ERR_PROXY_POLICY.to_string()));
     }
-    if request.policy.network_specified
-        || request.policy.network_mode_specified
-        || request.policy.network_egress.is_some()
-        || request.policy.network_ingress.is_some()
-    {
+    if request.policy.network_specified || request.policy.network_mode_specified {
         return Err(IsolationSessionError::Policy(
             ERR_NETWORK_IMMUTABLE.to_string(),
         ));

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -17,6 +17,7 @@ use wxc_common::state_aware_backend::{
     DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
+use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
 
 use windows::Win32::Foundation::HANDLE;
 
@@ -181,6 +182,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         request: &ExecutionRequest,
         config: Option<&IsolationSessionProvisionConfig>,
     ) -> Result<(), MxcError> {
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         // Structural only — MXC carries `appId` for a future OS consumer and
         // does not judge what a valid application identity looks like.
         if let Some(app_id) = config.and_then(|c| c.app_id.as_deref()) {

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -378,7 +378,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::models::{ContainerPolicy, NetworkPolicy};
+    use wxc_common::models::{ContainerPolicy, NetworkPolicy, ProxyAddress, ProxyConfig};
     use wxc_common::mxc_error::MxcErrorCode;
 
     // ====== Wire-format constants ======
@@ -761,6 +761,44 @@ mod tests {
             .validate_deprovision(&valid_sandbox_id(), &req, None)
             .unwrap_err();
         assert_eq!(d.code, MxcErrorCode::PolicyValidation);
+    }
+
+    #[test]
+    fn validate_post_provision_hooks_reject_runtime_proxy() {
+        let runner = IsolationSessionRunner::new();
+        let req = ExecutionRequest {
+            policy: ContainerPolicy {
+                network_proxy: ProxyConfig {
+                    address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
+                    builtin_test_server: false,
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        for (label, result) in [
+            (
+                "start",
+                runner.validate_start(&valid_sandbox_id(), &req, None),
+            ),
+            (
+                "exec",
+                runner.validate_exec(&valid_sandbox_id(), &req, None),
+            ),
+            (
+                "stop",
+                runner.validate_stop(&valid_sandbox_id(), &req, None),
+            ),
+            (
+                "deprovision",
+                runner.validate_deprovision(&valid_sandbox_id(), &req, None),
+            ),
+        ] {
+            let error = result.unwrap_err();
+            assert_eq!(error.code, MxcErrorCode::PolicyValidation, "phase {label}");
+            assert!(error.message.contains("proxy"), "phase {label}: {error:?}");
+        }
     }
 
     // ====== UI policy is refused on every phase ======

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -14,6 +14,7 @@ use wxc_common::models::{
     ExecutionRequest, LifecycleConfig, LxcConfig, NetworkEnforcementMode, ScriptResponse,
 };
 use wxc_common::script_runner::ScriptRunner;
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 use crate::filesystem_mounts;
 use crate::lxc_bindings::LxcContainer;
@@ -650,6 +651,11 @@ impl LxcScriptRunner {
 }
 
 impl ScriptRunner for LxcScriptRunner {
+    fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
+        Ok(())
+    }
+
     fn execute(&mut self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {
         // Run with panic catching for safety
         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/src/backends/nanvix/runner/src/lib.rs
+++ b/src/backends/nanvix/runner/src/lib.rs
@@ -59,6 +59,7 @@ use std::time::{Duration, Instant};
 use wxc_common::logger::Logger;
 use wxc_common::models::{ExecutionRequest, NetworkPolicy, ScriptResponse};
 use wxc_common::script_runner::ScriptRunner;
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 /// Multi-binary initrd (daemons + CPython) loaded by NanVix at warm start.
 const INITRD_BINARY: &str = nanvix_common::INITRD_BINARY;
@@ -935,7 +936,9 @@ impl NanVixScriptRunner {
 
 impl ScriptRunner for NanVixScriptRunner {
     fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
-        Self::validate_policies(request).map_err(|e| e.to_response())
+        Self::validate_policies(request).map_err(|e| e.to_response())?;
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
+        Ok(())
     }
 
     fn execute(&mut self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {

--- a/src/backends/seatbelt/common/src/seatbelt_runner.rs
+++ b/src/backends/seatbelt/common/src/seatbelt_runner.rs
@@ -37,7 +37,7 @@ use wxc_common::sandbox_process::{
     WaitError,
 };
 use wxc_common::unix_proxy_coordinator::UnixProxyCoordinator;
-use wxc_common::validator::validate_common;
+use wxc_common::validator::{validate_common, validate_network_policy_support};
 
 use crate::profile_builder::build_profile_with_proxy;
 
@@ -106,6 +106,7 @@ impl SeatbeltScriptRunner {
 
 impl SandboxBackend for SeatbeltScriptRunner {
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, self.network_policy_support())?;
         // Seatbelt cannot filter network by hostname — reject blockedHosts
         // rather than silently allowing traffic the user expects to be denied.
         if !request.policy.blocked_hosts.is_empty() {

--- a/src/backends/windows_sandbox/lifecycle/src/one_shot.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/one_shot.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use wxc_common::logger::Logger;
 use wxc_common::models::{ExecutionRequest, FailurePhase, ScriptResponse};
 use wxc_common::script_runner::{get_timeout_milliseconds, ScriptRunner};
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 use crate::control_plane::{self, HostVmLock};
 use crate::error::OneShotError;
@@ -125,6 +126,11 @@ impl WindowsSandboxRunner {
 }
 
 impl ScriptRunner for WindowsSandboxRunner {
+    fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
+        Ok(())
+    }
+
     fn execute(&mut self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {
         match self.run_one_shot(request, logger) {
             Ok(response) => response,

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -217,6 +217,9 @@ fn reject_post_provision_policy(request: &ExecutionRequest) -> Result<(), MxcErr
         || !p.allowed_hosts.is_empty()
         || !p.blocked_hosts.is_empty()
         || p.network_proxy.is_enabled()
+        || p.network_mode_specified
+        || p.network_egress.is_some()
+        || p.network_ingress.is_some()
     {
         return Err(MxcError::policy_validation(
             "Windows Sandbox filesystem/network policy is fixed at provision; it cannot be \
@@ -1048,7 +1051,7 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::models::{ContainerPolicy, NetworkPolicy};
+    use wxc_common::models::{ContainerPolicy, NetworkEgressPolicy, NetworkPolicy};
     use wxc_common::mxc_error::MxcErrorCode;
 
     /// A `Library` exec is refused before the backend looks for the daemon.
@@ -1306,6 +1309,22 @@ mod tests {
             policy: ContainerPolicy {
                 allowed_hosts: vec!["example.com".into()],
                 default_network_policy: NetworkPolicy::Block,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let err = backend
+            .validate_start("wsb:abcd1234", &req, None)
+            .unwrap_err();
+        assert_eq!(err.code, MxcErrorCode::PolicyValidation);
+    }
+
+    #[test]
+    fn validate_start_rejects_directional_network() {
+        let backend = WindowsSandboxRunner::new();
+        let req = ExecutionRequest {
+            policy: ContainerPolicy {
+                network_egress: Some(NetworkEgressPolicy::default()),
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -218,6 +218,8 @@ fn reject_post_provision_policy(request: &ExecutionRequest) -> Result<(), MxcErr
         || !p.blocked_hosts.is_empty()
         || p.network_proxy.is_enabled()
         || p.network_mode_specified
+        || p.network_egress.is_some()
+        || p.network_ingress.is_some()
     {
         return Err(MxcError::policy_validation(
             "Windows Sandbox filesystem/network policy is fixed at provision; it cannot be \
@@ -1318,12 +1320,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_start_rejects_directional_network() {
+    fn validate_start_rejects_raw_directional_network() {
         let backend = WindowsSandboxRunner::new();
         let req = ExecutionRequest {
             policy: ContainerPolicy {
                 network_egress: Some(NetworkEgressPolicy::default()),
-                network_mode_specified: true,
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -218,8 +218,6 @@ fn reject_post_provision_policy(request: &ExecutionRequest) -> Result<(), MxcErr
         || !p.blocked_hosts.is_empty()
         || p.network_proxy.is_enabled()
         || p.network_mode_specified
-        || p.network_egress.is_some()
-        || p.network_ingress.is_some()
     {
         return Err(MxcError::policy_validation(
             "Windows Sandbox filesystem/network policy is fixed at provision; it cannot be \
@@ -1325,6 +1323,7 @@ mod tests {
         let req = ExecutionRequest {
             policy: ContainerPolicy {
                 network_egress: Some(NetworkEgressPolicy::default()),
+                network_mode_specified: true,
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -21,6 +21,7 @@ use wxc_common::state_aware_backend::{
     DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
+use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
 
 use windows::Win32::Foundation::HANDLE;
 
@@ -997,6 +998,7 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
         request: &ExecutionRequest,
         _config: Option<&()>,
     ) -> Result<(), MxcError> {
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         policy::plan_policy(request)
             .map(|_| ())
             .map_err(map_policy_error)

--- a/src/backends/wslc/common/src/policy.rs
+++ b/src/backends/wslc/common/src/policy.rs
@@ -126,7 +126,10 @@ fn reject_host_filtering(request: &ExecutionRequest) -> Result<(), MxcError> {
 /// block by value) is rejected too. The cooperative proxy is a separate
 /// exec-time concern handled by the callers.
 fn reject_post_provision_network_mode(request: &ExecutionRequest) -> Result<(), MxcError> {
-    if request.policy.network_mode_specified {
+    if request.policy.network_mode_specified
+        || request.policy.network_egress.is_some()
+        || request.policy.network_ingress.is_some()
+    {
         return Err(MxcError::policy_validation(ERR_NETWORK_IMMUTABLE));
     }
     Ok(())

--- a/src/backends/wslc/common/src/policy.rs
+++ b/src/backends/wslc/common/src/policy.rs
@@ -123,15 +123,10 @@ fn reject_host_filtering(request: &ExecutionRequest) -> Result<(), MxcError> {
 /// posture (`defaultPolicy` / `enforcementMode` / `allowLocalNetwork` / host
 /// lists) is bound to the provision phase; presence — not value — is checked so
 /// an explicit `defaultPolicy: "block"` (indistinguishable from an omitted
-/// block by value) is rejected too. State-aware requests do not synthesize
-/// directional defaults, so raw directional fields also indicate an attempted
-/// post-provision policy change. The cooperative proxy is a separate exec-time
-/// concern handled by the callers.
+/// block by value) is rejected too. The cooperative proxy is a separate
+/// exec-time concern handled by the callers.
 fn reject_post_provision_network_mode(request: &ExecutionRequest) -> Result<(), MxcError> {
-    if request.policy.network_mode_specified
-        || request.policy.network_egress.is_some()
-        || request.policy.network_ingress.is_some()
-    {
+    if request.policy.network_mode_specified {
         return Err(MxcError::policy_validation(ERR_NETWORK_IMMUTABLE));
     }
     Ok(())

--- a/src/backends/wslc/common/src/policy.rs
+++ b/src/backends/wslc/common/src/policy.rs
@@ -123,10 +123,15 @@ fn reject_host_filtering(request: &ExecutionRequest) -> Result<(), MxcError> {
 /// posture (`defaultPolicy` / `enforcementMode` / `allowLocalNetwork` / host
 /// lists) is bound to the provision phase; presence — not value — is checked so
 /// an explicit `defaultPolicy: "block"` (indistinguishable from an omitted
-/// block by value) is rejected too. The cooperative proxy is a separate
-/// exec-time concern handled by the callers.
+/// block by value) is rejected too. State-aware requests do not synthesize
+/// directional defaults, so raw directional fields also indicate an attempted
+/// post-provision policy change. The cooperative proxy is a separate exec-time
+/// concern handled by the callers.
 fn reject_post_provision_network_mode(request: &ExecutionRequest) -> Result<(), MxcError> {
-    if request.policy.network_mode_specified {
+    if request.policy.network_mode_specified
+        || request.policy.network_egress.is_some()
+        || request.policy.network_ingress.is_some()
+    {
         return Err(MxcError::policy_validation(ERR_NETWORK_IMMUTABLE));
     }
     Ok(())

--- a/src/backends/wslc/common/src/sandbox.rs
+++ b/src/backends/wslc/common/src/sandbox.rs
@@ -31,6 +31,7 @@ use wxc_common::sandbox_process::{
     boxed_closer, cancel_and_join_discard, spawn_discard, take_boxed_read, SandboxBackend,
     SandboxProcess, StdioMode, StreamCloser,
 };
+use wxc_common::script_runner::ScriptRunner;
 use wxc_common::validator::validate_common;
 
 use crate::stream_buffer::{StreamCanceller, StreamReader};
@@ -38,6 +39,10 @@ use crate::wsl_container_runner::{OutputMode, StartedContainer, WSLContainerRunn
 use crate::wslc_bindings::WslcSignal;
 
 impl SandboxBackend for WSLContainerRunner {
+    fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        ScriptRunner::validate_runner(self, request)
+    }
+
     fn spawn(
         &mut self,
         request: &ExecutionRequest,

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -526,12 +526,11 @@ mod tests {
     }
 
     #[test]
-    fn post_provision_hooks_reject_directional_network_fields() {
+    fn post_provision_hooks_reject_raw_directional_network_fields() {
         let runner = WslcStateAwareRunner::new();
         let request = ExecutionRequest {
             policy: ContainerPolicy {
                 network_egress: Some(NetworkEgressPolicy::default()),
-                network_mode_specified: true,
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -22,6 +22,7 @@ use wxc_common::state_aware_backend::{
     null_pipe_handle, DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult,
     StartResult, StatefulSandboxBackend, StopResult,
 };
+use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
 use wxc_common::wire::WslcProvisionPhase;
 
 use crate::container_steps::OutStream;
@@ -228,6 +229,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         request: &ExecutionRequest,
         _config: Option<&WslcProvisionPhase>,
     ) -> Result<(), MxcError> {
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         validate_provision_policy(request)
     }
 

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -240,6 +240,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         _config: Option<&()>,
     ) -> Result<(), MxcError> {
         validate_sandbox_id(sandbox_id)?;
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         validate_post_provision_policy(request)
     }
 
@@ -250,6 +251,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         _config: Option<&()>,
     ) -> Result<(), MxcError> {
         validate_sandbox_id(sandbox_id)?;
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         validate_exec_policy(request)
     }
 
@@ -260,6 +262,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         _config: Option<&()>,
     ) -> Result<(), MxcError> {
         validate_sandbox_id(sandbox_id)?;
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         validate_post_provision_policy(request)
     }
 
@@ -270,6 +273,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         _config: Option<&()>,
     ) -> Result<(), MxcError> {
         validate_sandbox_id(sandbox_id)?;
+        validate_state_aware_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         validate_post_provision_policy(request)
     }
 }
@@ -429,7 +433,7 @@ fn split_env(env: &[String]) -> Vec<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wxc_common::models::ContainerPolicy;
+    use wxc_common::models::{ContainerPolicy, NetworkEgressPolicy};
 
     /// A `Library` exec is refused before the backend touches the daemon.
     ///
@@ -519,6 +523,24 @@ mod tests {
     #[test]
     fn validate_sandbox_id_rejects_uppercase_hex() {
         assert!(validate_sandbox_id("wslc:0123456789ABCDEF0123456789abcdef").is_err());
+    }
+
+    #[test]
+    fn post_provision_hooks_reject_directional_network_fields() {
+        let runner = WslcStateAwareRunner::new();
+        let request = ExecutionRequest {
+            policy: ContainerPolicy {
+                network_egress: Some(NetworkEgressPolicy::default()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let id = "wslc:0123456789abcdef0123456789abcdef";
+
+        assert!(runner.validate_start(id, &request, None).is_err());
+        assert!(runner.validate_exec(id, &request, None).is_err());
+        assert!(runner.validate_stop(id, &request, None).is_err());
+        assert!(runner.validate_deprovision(id, &request, None).is_err());
     }
 
     #[test]

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -531,6 +531,7 @@ mod tests {
         let request = ExecutionRequest {
             policy: ContainerPolicy {
                 network_egress: Some(NetworkEgressPolicy::default()),
+                network_mode_specified: true,
                 ..Default::default()
             },
             ..Default::default()

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -28,6 +28,7 @@ use wxc_common::models::{ExecutionRequest, NetworkPolicy, ScriptResponse, WslcCo
 use wxc_common::sandbox_process::StdioMode;
 use wxc_common::script_runner::ScriptRunner;
 use wxc_common::string_util::{to_wide, CoTaskMemPWSTR};
+use wxc_common::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 use crate::container_steps::sdk_error;
 use crate::policy_mapping;
@@ -656,6 +657,7 @@ impl ScriptRunner for WSLContainerRunner {
                  ports with experimental.wslc portMappings instead.",
             ));
         }
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         Ok(())
     }
 

--- a/src/core/wxc_common/src/sandbox_process.rs
+++ b/src/core/wxc_common/src/sandbox_process.rs
@@ -20,6 +20,7 @@ use std::io::{Read, Write};
 use crate::logger::Logger;
 use crate::models::{ExecutionRequest, FailurePhase, SandboxOutputMetadata, ScriptResponse};
 use crate::script_runner::ScriptRunner;
+use crate::validator::{validate_network_policy_support, NetworkPolicySupport};
 
 /// A handle to a running sandboxed process.
 ///
@@ -360,9 +361,20 @@ pub enum StdioMode {
 /// calls this directly with [`StdioMode::Pipes`]; the CLI executor binaries
 /// reach it through the [`Runner`] bridge.
 pub trait SandboxBackend {
-    /// Backend-specific validation, run before [`spawn`](SandboxBackend::spawn)
-    /// and on dry-run. Override to reject unsupported policies; default accepts.
-    fn validate(&self, _request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+    /// Declares optional network policy features this backend fully enforces.
+    ///
+    /// Return a named feature constant or compose constants with `|`. Use
+    /// [`NetworkPolicySupport::ALL`] only when every feature is enforced.
+    fn network_policy_support(&self) -> NetworkPolicySupport {
+        NetworkPolicySupport::LEGACY
+    }
+
+    /// Validates shared network support and backend-specific constraints.
+    ///
+    /// Override to add backend-specific checks. Implementations must first call
+    /// `validate_network_policy_support(request, self.network_policy_support())`.
+    fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, self.network_policy_support())?;
         Ok(())
     }
 

--- a/src/core/wxc_common/src/script_runner.rs
+++ b/src/core/wxc_common/src/script_runner.rs
@@ -3,7 +3,7 @@
 
 use crate::logger::Logger;
 use crate::models::{ExecutionRequest, ScriptResponse};
-use crate::validator::validate_common;
+use crate::validator::{validate_common, validate_network_policy_support, NetworkPolicySupport};
 
 /// Trait for executing scripts within a containment backend.
 ///
@@ -11,13 +11,13 @@ use crate::validator::validate_common;
 /// to provide a uniform interface for `wxc-exec`.
 ///
 /// Implementors provide [`execute`](ScriptRunner::execute) and optionally
-/// [`validate`](ScriptRunner::validate). The provided
+/// [`validate_runner`](ScriptRunner::validate_runner). The provided
 /// [`run`](ScriptRunner::run) method handles validation, dry-run mode,
 /// and delegates to [`execute`](ScriptRunner::execute).
 pub trait ScriptRunner {
-    /// Validate the request before execution. Override to add
-    /// runner-specific checks. Default accepts all requests.
-    fn validate_runner(&self, _request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+    /// Validate shared network support and runner-specific constraints.
+    fn validate_runner(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        validate_network_policy_support(request, NetworkPolicySupport::LEGACY)?;
         Ok(())
     }
 

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -31,13 +31,17 @@ impl NetworkPolicySupport {
     /// Support for the runtime loopback proxy endpoint.
     pub const RUNTIME_PROXY: Self = Self(1 << 3);
 
+    /// Support for restricting a ProcessContainer proxy to a named peer.
+    pub const PROXY_PEER_IDENTITY: Self = Self(1 << 5);
+
     /// A backend that fully supports every optional network policy feature.
     pub const ALL: Self = Self(
         Self::EGRESS_DEFAULT.0
             | Self::EGRESS_RULES.0
             | Self::INGRESS_DEFAULT.0
             | Self::HOST_LOOPBACK.0
-            | Self::RUNTIME_PROXY.0,
+            | Self::RUNTIME_PROXY.0
+            | Self::PROXY_PEER_IDENTITY.0,
     );
 
     /// Returns whether all features in `required` are supported.
@@ -152,9 +156,16 @@ pub fn validate_network_policy_support(
         ));
     }
 
+    if !support.contains(NetworkPolicySupport::PROXY_PEER_IDENTITY)
+        && request.policy.allowed_proxy_peer.is_some()
+    {
+        return Err(ScriptResponse::error(
+            "processContainer.network.allowedProxyPeer is not supported by the selected backend",
+        ));
+    }
+
     if !support.contains(NetworkPolicySupport::RUNTIME_PROXY)
-        && request.policy.network_egress.is_some()
-        && request.policy.network_proxy.is_enabled()
+        && request.policy.runtime_network_proxy_specified
     {
         return Err(ScriptResponse::error(
             "runtimeConfig.networkProxy is not supported by the selected backend",
@@ -350,7 +361,7 @@ mod tests {
         assert!(error.error_message.contains("network.ingress.hostLoopback"));
 
         let mut request = ExecutionRequest::default();
-        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.runtime_network_proxy_specified = true;
         request.policy.network_proxy = ProxyConfig {
             address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
             builtin_test_server: false,
@@ -364,6 +375,19 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.error_message.contains("runtimeConfig.networkProxy"));
+
+        let mut request = ExecutionRequest::default();
+        request.policy.allowed_proxy_peer = Some("Contoso.Proxy_123".to_string());
+        let error = validate_network_policy_support(
+            &request,
+            NetworkPolicySupport::EGRESS_DEFAULT
+                | NetworkPolicySupport::EGRESS_RULES
+                | NetworkPolicySupport::INGRESS_DEFAULT
+                | NetworkPolicySupport::HOST_LOOPBACK
+                | NetworkPolicySupport::RUNTIME_PROXY,
+        )
+        .unwrap_err();
+        assert!(error.error_message.contains("allowedProxyPeer"));
     }
 
     #[test]
@@ -382,6 +406,8 @@ mod tests {
             address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
             builtin_test_server: false,
         };
+        request.policy.runtime_network_proxy_specified = true;
+        request.policy.allowed_proxy_peer = Some("Contoso.Proxy_123".to_string());
         assert!(validate_network_policy_support(&request, NetworkPolicySupport::ALL,).is_ok());
     }
 
@@ -444,7 +470,8 @@ mod tests {
             | NetworkPolicySupport::EGRESS_RULES
             | NetworkPolicySupport::INGRESS_DEFAULT
             | NetworkPolicySupport::HOST_LOOPBACK
-            | NetworkPolicySupport::RUNTIME_PROXY;
+            | NetworkPolicySupport::RUNTIME_PROXY
+            | NetworkPolicySupport::PROXY_PEER_IDENTITY;
 
         assert_eq!(support, NetworkPolicySupport::ALL);
     }

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::models::{ExecutionRequest, ScriptResponse};
+use crate::models::{ExecutionRequest, NetworkAction, NetworkPolicy, ScriptResponse};
 use crate::mxc_error::MxcError;
 
 /// Declares which optional network policy features a backend enforces.
@@ -59,11 +59,32 @@ pub fn validate_network_policy_support(
     request: &ExecutionRequest,
     support: NetworkPolicySupport,
 ) -> Result<(), ScriptResponse> {
+    let directional_posture_supplied = request.policy.network_mode_specified
+        || (request.policy.network_egress.is_some() && request.policy.network_proxy.is_enabled());
+
     if !support.contains(NetworkPolicySupport::EGRESS_DEFAULT)
-        && request.policy.network_egress.is_some()
+        && request
+            .policy
+            .network_egress
+            .as_ref()
+            .is_some_and(|egress| {
+                directional_posture_supplied || egress.default == NetworkAction::Allow
+            })
     {
         return Err(ScriptResponse::error(
             "network.egress.default is not supported by the selected backend",
+        ));
+    }
+    if !support.contains(NetworkPolicySupport::EGRESS_DEFAULT)
+        && request
+            .policy
+            .network_egress
+            .as_ref()
+            .is_some_and(|egress| egress.default == NetworkAction::Deny)
+        && request.policy.default_network_policy == NetworkPolicy::Allow
+    {
+        return Err(ScriptResponse::error(
+            "network.egress.default='deny' conflicts with the legacy outbound policy",
         ));
     }
 
@@ -80,18 +101,54 @@ pub fn validate_network_policy_support(
     }
 
     if !support.contains(NetworkPolicySupport::INGRESS_DEFAULT)
-        && request.policy.network_ingress.is_some()
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| {
+                directional_posture_supplied || ingress.default == NetworkAction::Allow
+            })
     {
         return Err(ScriptResponse::error(
             "network.ingress.default is not supported by the selected backend",
         ));
     }
+    if !support.contains(NetworkPolicySupport::INGRESS_DEFAULT)
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| ingress.default == NetworkAction::Deny)
+        && request.policy.allow_local_network
+    {
+        return Err(ScriptResponse::error(
+            "network.ingress.default='deny' conflicts with the legacy inbound policy",
+        ));
+    }
 
     if !support.contains(NetworkPolicySupport::HOST_LOOPBACK)
-        && request.policy.network_ingress.is_some()
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| {
+                directional_posture_supplied || ingress.host_loopback == NetworkAction::Allow
+            })
     {
         return Err(ScriptResponse::error(
             "network.ingress.hostLoopback is not supported by the selected backend",
+        ));
+    }
+    if !support.contains(NetworkPolicySupport::HOST_LOOPBACK)
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| ingress.host_loopback == NetworkAction::Deny)
+        && request.policy.allow_local_network
+    {
+        return Err(ScriptResponse::error(
+            "network.ingress.hostLoopback='deny' conflicts with the legacy inbound policy",
         ));
     }
 
@@ -253,33 +310,60 @@ mod tests {
             default: NetworkAction::Allow,
             ..Default::default()
         });
-        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+        let error =
+            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
+        assert!(error.error_message.contains("network.egress.default"));
 
+        let mut request = ExecutionRequest::default();
         request.policy.network_egress = Some(NetworkEgressPolicy {
             allow: vec![NetworkRule::default()],
             ..Default::default()
         });
-        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+        let error = validate_network_policy_support(&request, NetworkPolicySupport::EGRESS_DEFAULT)
+            .unwrap_err();
+        assert!(error.error_message.contains("allow/deny rules"));
 
-        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        let mut request = ExecutionRequest::default();
         request.policy.network_ingress = Some(NetworkIngressPolicy {
             default: NetworkAction::Allow,
             ..Default::default()
         });
-        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+        let error = validate_network_policy_support(
+            &request,
+            NetworkPolicySupport::EGRESS_DEFAULT | NetworkPolicySupport::EGRESS_RULES,
+        )
+        .unwrap_err();
+        assert!(error.error_message.contains("network.ingress.default"));
 
+        let mut request = ExecutionRequest::default();
         request.policy.network_ingress = Some(NetworkIngressPolicy {
             host_loopback: NetworkAction::Allow,
             ..Default::default()
         });
-        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+        let error = validate_network_policy_support(
+            &request,
+            NetworkPolicySupport::EGRESS_DEFAULT
+                | NetworkPolicySupport::EGRESS_RULES
+                | NetworkPolicySupport::INGRESS_DEFAULT,
+        )
+        .unwrap_err();
+        assert!(error.error_message.contains("network.ingress.hostLoopback"));
 
-        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy::default());
         request.policy.network_proxy = ProxyConfig {
             address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
             builtin_test_server: false,
         };
-        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+        let error = validate_network_policy_support(
+            &request,
+            NetworkPolicySupport::EGRESS_DEFAULT
+                | NetworkPolicySupport::EGRESS_RULES
+                | NetworkPolicySupport::INGRESS_DEFAULT
+                | NetworkPolicySupport::HOST_LOOPBACK,
+        )
+        .unwrap_err();
+        assert!(error.error_message.contains("runtimeConfig.networkProxy"));
     }
 
     #[test]
@@ -305,15 +389,53 @@ mod tests {
     fn partial_network_support_rejects_undeclared_directional_defaults() {
         let mut request = ExecutionRequest::default();
         request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.network_mode_specified = true;
         let error = validate_network_policy_support(&request, NetworkPolicySupport::RUNTIME_PROXY)
             .unwrap_err();
         assert!(error.error_message.contains("network.egress.default"));
 
         request.policy.network_egress = None;
         request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        request.policy.network_mode_specified = true;
         let error = validate_network_policy_support(&request, NetworkPolicySupport::EGRESS_DEFAULT)
             .unwrap_err();
         assert!(error.error_message.contains("network.ingress.default"));
+    }
+
+    #[test]
+    fn network_support_rejects_inconsistent_dual_model_defaults() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.default_network_policy = NetworkPolicy::Allow;
+        let error =
+            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
+        assert!(error.error_message.contains("legacy outbound policy"));
+
+        let mut request = ExecutionRequest::default();
+        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        request.policy.allow_local_network = true;
+        let error = validate_network_policy_support(&request, NetworkPolicySupport::HOST_LOOPBACK)
+            .unwrap_err();
+        assert!(error.error_message.contains("network.ingress.default"));
+        assert!(error.error_message.contains("legacy inbound policy"));
+
+        let mut request = ExecutionRequest::default();
+        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        request.policy.allow_local_network = true;
+        let error =
+            validate_network_policy_support(&request, NetworkPolicySupport::INGRESS_DEFAULT)
+                .unwrap_err();
+        assert!(error.error_message.contains("network.ingress.hostLoopback"));
+        assert!(error.error_message.contains("legacy inbound policy"));
+    }
+
+    #[test]
+    fn network_support_accepts_implicit_directional_defaults_for_legacy_backends() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_ok());
     }
 
     #[test]

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -1,8 +1,132 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::models::{ExecutionRequest, ScriptResponse};
+use crate::models::{ExecutionRequest, NetworkAction, ScriptResponse};
 use crate::mxc_error::MxcError;
+
+/// Declares which optional network policy features a backend enforces.
+///
+/// Backends compose the named feature constants with `|`. Shared validation
+/// rejects unsupported requests before backend-specific validation or process
+/// creation runs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NetworkPolicySupport(u8);
+
+impl NetworkPolicySupport {
+    /// Support for the legacy network policy without additive 0.8 features.
+    pub const LEGACY: Self = Self(0);
+
+    /// Support for the outbound network default policy.
+    pub const EGRESS_DEFAULT: Self = Self(1 << 4);
+
+    /// Support for CIDR, protocol, and port allow/deny rules.
+    pub const EGRESS_RULES: Self = Self(1 << 0);
+
+    /// Support for the inbound network default policy.
+    pub const INGRESS_DEFAULT: Self = Self(1 << 1);
+
+    /// Support for bidirectional host-loopback access.
+    pub const HOST_LOOPBACK: Self = Self(1 << 2);
+
+    /// Support for the runtime loopback proxy endpoint.
+    pub const RUNTIME_PROXY: Self = Self(1 << 3);
+
+    /// A backend that fully supports every optional network policy feature.
+    pub const ALL: Self = Self(
+        Self::EGRESS_DEFAULT.0
+            | Self::EGRESS_RULES.0
+            | Self::INGRESS_DEFAULT.0
+            | Self::HOST_LOOPBACK.0
+            | Self::RUNTIME_PROXY.0,
+    );
+
+    /// Returns whether all features in `required` are supported.
+    pub const fn contains(self, required: Self) -> bool {
+        self.0 & required.0 == required.0
+    }
+}
+
+impl std::ops::BitOr for NetworkPolicySupport {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self(self.0 | rhs.0)
+    }
+}
+
+/// Reject network policy features that the selected backend cannot enforce.
+pub fn validate_network_policy_support(
+    request: &ExecutionRequest,
+    support: NetworkPolicySupport,
+) -> Result<(), ScriptResponse> {
+    if !support.contains(NetworkPolicySupport::EGRESS_DEFAULT)
+        && request
+            .policy
+            .network_egress
+            .as_ref()
+            .is_some_and(|egress| egress.default == NetworkAction::Allow)
+    {
+        return Err(ScriptResponse::error(
+            "network.egress.default='allow' is not supported by the selected backend",
+        ));
+    }
+
+    if !support.contains(NetworkPolicySupport::EGRESS_RULES)
+        && request
+            .policy
+            .network_egress
+            .as_ref()
+            .is_some_and(|egress| !egress.allow.is_empty() || !egress.deny.is_empty())
+    {
+        return Err(ScriptResponse::error(
+            "network.egress allow/deny rules are not supported by the selected backend",
+        ));
+    }
+
+    if !support.contains(NetworkPolicySupport::INGRESS_DEFAULT)
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| ingress.default == NetworkAction::Allow)
+    {
+        return Err(ScriptResponse::error(
+            "network.ingress.default='allow' is not supported by the selected backend",
+        ));
+    }
+
+    if !support.contains(NetworkPolicySupport::HOST_LOOPBACK)
+        && request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| ingress.host_loopback == NetworkAction::Allow)
+    {
+        return Err(ScriptResponse::error(
+            "network.ingress.hostLoopback='allow' is not supported by the selected backend",
+        ));
+    }
+
+    if !support.contains(NetworkPolicySupport::RUNTIME_PROXY)
+        && request.policy.network_egress.is_some()
+        && request.policy.network_proxy.is_enabled()
+    {
+        return Err(ScriptResponse::error(
+            "runtimeConfig.networkProxy is not supported by the selected backend",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Reject network policy features unsupported by a state-aware backend.
+pub fn validate_state_aware_network_policy_support(
+    request: &ExecutionRequest,
+    support: NetworkPolicySupport,
+) -> Result<(), MxcError> {
+    validate_network_policy_support(request, support)
+        .map_err(|response| MxcError::policy_validation(response.error_message))
+}
 
 /// Validates non-backend-specific parts of the request (e.g. non-empty script).
 pub fn validate_common(request: &ExecutionRequest) -> Result<(), ScriptResponse> {
@@ -41,7 +165,10 @@ pub fn validate_exec_common(request: &ExecutionRequest) -> Result<(), MxcError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::ExecutionRequest;
+    use crate::models::{
+        ExecutionRequest, NetworkEgressPolicy, NetworkIngressPolicy, NetworkRule, ProxyAddress,
+        ProxyConfig,
+    };
     use crate::mxc_error::MxcErrorCode;
 
     #[test]
@@ -129,5 +256,87 @@ mod tests {
         req.testing_features_enabled = true;
 
         assert!(validate_common(&req).is_ok());
+    }
+
+    #[test]
+    fn network_support_rejects_unimplemented_features() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy {
+            default: NetworkAction::Allow,
+            ..Default::default()
+        });
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+
+        request.policy.network_egress = Some(NetworkEgressPolicy {
+            allow: vec![NetworkRule::default()],
+            ..Default::default()
+        });
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+
+        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.network_ingress = Some(NetworkIngressPolicy {
+            default: NetworkAction::Allow,
+            ..Default::default()
+        });
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+
+        request.policy.network_ingress = Some(NetworkIngressPolicy {
+            host_loopback: NetworkAction::Allow,
+            ..Default::default()
+        });
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+
+        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        request.policy.network_proxy = ProxyConfig {
+            address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
+            builtin_test_server: false,
+        };
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).is_err());
+    }
+
+    #[test]
+    fn network_support_accepts_declared_features() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy {
+            default: NetworkAction::Allow,
+            allow: vec![NetworkRule::default()],
+            ..Default::default()
+        });
+        request.policy.network_ingress = Some(NetworkIngressPolicy {
+            default: NetworkAction::Allow,
+            host_loopback: NetworkAction::Allow,
+        });
+        request.policy.network_proxy = ProxyConfig {
+            address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
+            builtin_test_server: false,
+        };
+        assert!(validate_network_policy_support(&request, NetworkPolicySupport::ALL,).is_ok());
+    }
+
+    #[test]
+    fn network_support_features_compose() {
+        let support = NetworkPolicySupport::EGRESS_DEFAULT
+            | NetworkPolicySupport::EGRESS_RULES
+            | NetworkPolicySupport::INGRESS_DEFAULT
+            | NetworkPolicySupport::HOST_LOOPBACK
+            | NetworkPolicySupport::RUNTIME_PROXY;
+
+        assert_eq!(support, NetworkPolicySupport::ALL);
+    }
+
+    #[test]
+    fn state_aware_network_support_uses_policy_validation_errors() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy {
+            default: NetworkAction::Allow,
+            ..Default::default()
+        });
+
+        let error =
+            validate_state_aware_network_policy_support(&request, NetworkPolicySupport::LEGACY)
+                .unwrap_err();
+
+        assert_eq!(error.code, MxcErrorCode::PolicyValidation);
+        assert!(error.message.contains("network.egress.default='allow'"));
     }
 }

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::models::{ExecutionRequest, NetworkAction, ScriptResponse};
+use crate::models::{ExecutionRequest, NetworkAction, NetworkPolicy, ScriptResponse};
 use crate::mxc_error::MxcError;
 
 /// Declares which optional network policy features a backend enforces.
@@ -59,6 +59,35 @@ pub fn validate_network_policy_support(
     request: &ExecutionRequest,
     support: NetworkPolicySupport,
 ) -> Result<(), ScriptResponse> {
+    if support == NetworkPolicySupport::LEGACY {
+        if request
+            .policy
+            .network_egress
+            .as_ref()
+            .is_some_and(|egress| egress.default == NetworkAction::Deny)
+            && request.policy.default_network_policy == NetworkPolicy::Allow
+        {
+            return Err(ScriptResponse::error(
+                "network.egress.default='deny' conflicts with the legacy outbound policy",
+            ));
+        }
+
+        if request
+            .policy
+            .network_ingress
+            .as_ref()
+            .is_some_and(|ingress| {
+                ingress.default == NetworkAction::Deny
+                    || ingress.host_loopback == NetworkAction::Deny
+            })
+            && request.policy.allow_local_network
+        {
+            return Err(ScriptResponse::error(
+                "deny-by-default network.ingress conflicts with the legacy inbound policy",
+            ));
+        }
+    }
+
     if !support.contains(NetworkPolicySupport::EGRESS_DEFAULT)
         && request
             .policy
@@ -311,6 +340,23 @@ mod tests {
             builtin_test_server: false,
         };
         assert!(validate_network_policy_support(&request, NetworkPolicySupport::ALL,).is_ok());
+    }
+
+    #[test]
+    fn legacy_network_support_rejects_conflicting_dual_model_values() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_egress = Some(NetworkEgressPolicy::default());
+        request.policy.default_network_policy = NetworkPolicy::Allow;
+        let error =
+            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
+        assert!(error.error_message.contains("legacy outbound policy"));
+
+        request.policy.default_network_policy = NetworkPolicy::Block;
+        request.policy.network_ingress = Some(NetworkIngressPolicy::default());
+        request.policy.allow_local_network = true;
+        let error =
+            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
+        assert!(error.error_message.contains("legacy inbound policy"));
     }
 
     #[test]

--- a/src/core/wxc_common/src/validator.rs
+++ b/src/core/wxc_common/src/validator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::models::{ExecutionRequest, NetworkAction, NetworkPolicy, ScriptResponse};
+use crate::models::{ExecutionRequest, ScriptResponse};
 use crate::mxc_error::MxcError;
 
 /// Declares which optional network policy features a backend enforces.
@@ -59,44 +59,11 @@ pub fn validate_network_policy_support(
     request: &ExecutionRequest,
     support: NetworkPolicySupport,
 ) -> Result<(), ScriptResponse> {
-    if support == NetworkPolicySupport::LEGACY {
-        if request
-            .policy
-            .network_egress
-            .as_ref()
-            .is_some_and(|egress| egress.default == NetworkAction::Deny)
-            && request.policy.default_network_policy == NetworkPolicy::Allow
-        {
-            return Err(ScriptResponse::error(
-                "network.egress.default='deny' conflicts with the legacy outbound policy",
-            ));
-        }
-
-        if request
-            .policy
-            .network_ingress
-            .as_ref()
-            .is_some_and(|ingress| {
-                ingress.default == NetworkAction::Deny
-                    || ingress.host_loopback == NetworkAction::Deny
-            })
-            && request.policy.allow_local_network
-        {
-            return Err(ScriptResponse::error(
-                "deny-by-default network.ingress conflicts with the legacy inbound policy",
-            ));
-        }
-    }
-
     if !support.contains(NetworkPolicySupport::EGRESS_DEFAULT)
-        && request
-            .policy
-            .network_egress
-            .as_ref()
-            .is_some_and(|egress| egress.default == NetworkAction::Allow)
+        && request.policy.network_egress.is_some()
     {
         return Err(ScriptResponse::error(
-            "network.egress.default='allow' is not supported by the selected backend",
+            "network.egress.default is not supported by the selected backend",
         ));
     }
 
@@ -113,26 +80,18 @@ pub fn validate_network_policy_support(
     }
 
     if !support.contains(NetworkPolicySupport::INGRESS_DEFAULT)
-        && request
-            .policy
-            .network_ingress
-            .as_ref()
-            .is_some_and(|ingress| ingress.default == NetworkAction::Allow)
+        && request.policy.network_ingress.is_some()
     {
         return Err(ScriptResponse::error(
-            "network.ingress.default='allow' is not supported by the selected backend",
+            "network.ingress.default is not supported by the selected backend",
         ));
     }
 
     if !support.contains(NetworkPolicySupport::HOST_LOOPBACK)
-        && request
-            .policy
-            .network_ingress
-            .as_ref()
-            .is_some_and(|ingress| ingress.host_loopback == NetworkAction::Allow)
+        && request.policy.network_ingress.is_some()
     {
         return Err(ScriptResponse::error(
-            "network.ingress.hostLoopback='allow' is not supported by the selected backend",
+            "network.ingress.hostLoopback is not supported by the selected backend",
         ));
     }
 
@@ -195,8 +154,8 @@ pub fn validate_exec_common(request: &ExecutionRequest) -> Result<(), MxcError> 
 mod tests {
     use super::*;
     use crate::models::{
-        ExecutionRequest, NetworkEgressPolicy, NetworkIngressPolicy, NetworkRule, ProxyAddress,
-        ProxyConfig,
+        ExecutionRequest, NetworkAction, NetworkEgressPolicy, NetworkIngressPolicy, NetworkRule,
+        ProxyAddress, ProxyConfig,
     };
     use crate::mxc_error::MxcErrorCode;
 
@@ -343,20 +302,18 @@ mod tests {
     }
 
     #[test]
-    fn legacy_network_support_rejects_conflicting_dual_model_values() {
+    fn partial_network_support_rejects_undeclared_directional_defaults() {
         let mut request = ExecutionRequest::default();
         request.policy.network_egress = Some(NetworkEgressPolicy::default());
-        request.policy.default_network_policy = NetworkPolicy::Allow;
-        let error =
-            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
-        assert!(error.error_message.contains("legacy outbound policy"));
+        let error = validate_network_policy_support(&request, NetworkPolicySupport::RUNTIME_PROXY)
+            .unwrap_err();
+        assert!(error.error_message.contains("network.egress.default"));
 
-        request.policy.default_network_policy = NetworkPolicy::Block;
+        request.policy.network_egress = None;
         request.policy.network_ingress = Some(NetworkIngressPolicy::default());
-        request.policy.allow_local_network = true;
-        let error =
-            validate_network_policy_support(&request, NetworkPolicySupport::LEGACY).unwrap_err();
-        assert!(error.error_message.contains("legacy inbound policy"));
+        let error = validate_network_policy_support(&request, NetworkPolicySupport::EGRESS_DEFAULT)
+            .unwrap_err();
+        assert!(error.error_message.contains("network.ingress.default"));
     }
 
     #[test]
@@ -383,6 +340,6 @@ mod tests {
                 .unwrap_err();
 
         assert_eq!(error.code, MxcErrorCode::PolicyValidation);
-        assert!(error.message.contains("network.egress.default='allow'"));
+        assert!(error.message.contains("network.egress.default"));
     }
 }


### PR DESCRIPTION
## 📖 Description

Adds backend capability validation for schema 0.8 directional networking. Backends reject network features they do not enforce. Applies validation to one-shot and state-aware WSLC, Windows Sandbox, and IsolationSession paths.

Does not add backend enforcement.

## 🔗 References

- Stacked on #961

## 🔍 Validation

- `cargo test -p wxc_common validator::tests::`
- `cargo check -p wslc_common -p windows_sandbox_lifecycle -p isolation_session_common`
- `cargo fmt --all -- --check`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task
