### PR TITLE
Validate exact contract capabilities

### DIFF
--- a/src/core/mxc_config_contract/src/dev/mod.rs
+++ b/src/core/mxc_config_contract/src/dev/mod.rs
@@ -165,8 +165,8 @@ pub use primitives::{NonEmptyString, OptionalField, True};
 pub use request::{parse_request, Request, RequestParseError};
 pub use stable::{
     CaptureDenials, CaptureDenialsMode, Fallback, Filesystem, LaunchMethod, Lifecycle, Lxc,
-    Process, ProcessContainer, ProcessContainerUi, ProcessContainerUiIsolation, Seatbelt, Ui,
-    UiClipboard,
+    Process, ProcessContainer, ProcessContainerCapability, ProcessContainerUi,
+    ProcessContainerUiIsolation, Seatbelt, Ui, UiClipboard,
 };
 pub use state_aware::{probe_containment, Containment, ContainmentProbeError};
 pub use state_aware::{probe_phase, Phase, PhaseProbeError};

--- a/src/core/mxc_config_contract/src/dev/stable.rs
+++ b/src/core/mxc_config_contract/src/dev/stable.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use super::primitives::{NonEmptyString, OptionalField};
+use serde::{de, Deserialize, Deserializer};
 
 /// Container lifecycle settings.
 #[derive(Debug, serde::Deserialize)]
@@ -147,6 +148,55 @@ pub struct CaptureDenials {
     pub retain_etl: OptionalField<bool>,
 }
 
+/// An AppContainer capability name supplied by the caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessContainerCapability(String);
+
+impl ProcessContainerCapability {
+    /// Creates a validated capability name.
+    ///
+    /// Commas are rejected because BaseContainer uses them as its wire
+    /// delimiter. Learning-mode capabilities are reserved for MXC's dedicated
+    /// learning-mode and denial-capture controls.
+    pub fn new(value: String) -> Result<Self, String> {
+        if value.contains(',') {
+            return Err(
+                "capability must not contain a comma; provide multiple capabilities as separate array entries"
+                    .to_string(),
+            );
+        }
+        if value.eq_ignore_ascii_case("learningModeLogging")
+            || value.eq_ignore_ascii_case("permissiveLearningMode")
+        {
+            return Err(
+                "learningModeLogging and permissiveLearningMode are reserved; use learningMode, --audit, or captureDenials instead"
+                    .to_string(),
+            );
+        }
+        Ok(Self(value))
+    }
+
+    /// Returns the validated capability name.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes the wrapper and returns the validated capability name.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for ProcessContainerCapability {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(de::Error::custom)
+    }
+}
+
 /// ProcessContainer-specific settings.
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -157,9 +207,12 @@ pub struct ProcessContainer {
     /// Optional learning-mode (deny-and-record)
     #[serde(default)]
     pub learning_mode: OptionalField<bool>,
-    /// Optional AppContainer capability names.
+    /// Optional AppContainer capability names. Each entry must contain one
+    /// name; commas are rejected because BaseContainer uses them as its wire
+    /// delimiter. `learningModeLogging` and `permissiveLearningMode` are
+    /// reserved; use `learningMode`, `--audit`, or `captureDenials` instead.
     #[serde(default)]
-    pub capabilities: OptionalField<Vec<String>>,
+    pub capabilities: OptionalField<Vec<ProcessContainerCapability>>,
     /// Optional capture-denials policy.
     #[serde(default)]
     pub capture_denials: OptionalField<CaptureDenials>,

--- a/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures.rs
+++ b/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures.rs
@@ -70,6 +70,18 @@ const INVALID_FIXTURES: &[(&str, &str)] = &[
         "seatbelt unknown field",
         include_str!("fixtures/invalid/seatbelt_unknown_field.json"),
     ),
+    (
+        "comma-delimited ProcessContainer capability",
+        include_str!("fixtures/invalid/capability_with_comma.json"),
+    ),
+    (
+        "reserved learning-mode logging capability",
+        include_str!("fixtures/invalid/capability_learning_mode_logging_reserved.json"),
+    ),
+    (
+        "reserved permissive learning-mode capability",
+        include_str!("fixtures/invalid/capability_permissive_learning_mode_reserved.json"),
+    ),
 ];
 
 #[test]

--- a/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_learning_mode_logging_reserved.json
+++ b/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_learning_mode_logging_reserved.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.8.0-alpha",
+  "process": {
+    "commandLine": "echo invalid"
+  },
+  "processContainer": {
+    "capabilities": [
+      "LEARNINGmodeLOGGING"
+    ]
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_permissive_learning_mode_reserved.json
+++ b/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_permissive_learning_mode_reserved.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.8.0-alpha",
+  "process": {
+    "commandLine": "echo invalid"
+  },
+  "processContainer": {
+    "capabilities": [
+      "PERMISSIVElearningMODE"
+    ]
+  }
+}

--- a/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_with_comma.json
+++ b/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/invalid/capability_with_comma.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.8.0-alpha",
+  "process": {
+    "commandLine": "echo invalid"
+  },
+  "processContainer": {
+    "capabilities": [
+      "internetClient,privateNetworkClientServer"
+    ]
+  }
+}

--- a/src/core/mxc_config_contract/tests/version_boundaries/compatibility.rs
+++ b/src/core/mxc_config_contract/tests/version_boundaries/compatibility.rs
@@ -139,8 +139,11 @@ fn app_container_section_alias_remains_accepted_across_registered_contracts() {
         v08_process_container
             .capabilities
             .as_ref()
-            .expect("0.8 capabilities"),
-        &vec!["internetClient".to_string()]
+            .expect("0.8 capabilities")
+            .iter()
+            .map(mxc_config_contract::dev::ProcessContainerCapability::as_str)
+            .collect::<Vec<_>>(),
+        vec!["internetClient"]
     );
 }
 

--- a/src/core/wxc_common/src/config_contract_adapters/dev/one_shot.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/dev/one_shot.rs
@@ -96,7 +96,12 @@ fn convert_process_container(value: contract::ProcessContainer) -> wire::Process
     wire::ProcessContainer {
         least_privilege: least_privilege.into_option(),
         learning_mode: learning_mode.into_option(),
-        capabilities: capabilities.into_option(),
+        capabilities: capabilities.into_option().map(|capabilities| {
+            capabilities
+                .into_iter()
+                .map(contract::ProcessContainerCapability::into_inner)
+                .collect()
+        }),
         capture_denials: capture_denials.into_option().map(convert_capture_denials),
         ui: ui.into_option().map(convert_process_container_ui),
     }


### PR DESCRIPTION
This PR fixes exact-contract validation for caller-supplied ProcessContainer capabilities.

Details

* Reject comma-delimited capability entries and reserved learning-mode capabilities case-insensitively.
* Add exact-contract parser fixtures for each rejected capability class.

Tests

* cargo test -p mxc_config_contract
* cargo clippy -p mxc_config_contract --all-targets -- -D warnings
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/966)