### PR TITLE
Clarify separate capability entries

### DIFF
--- a/src/core/mxc_config_contract/src/dev/stable.rs
+++ b/src/core/mxc_config_contract/src/dev/stable.rs
@@ -161,7 +161,7 @@ impl ProcessContainerCapability {
     pub fn new(value: String) -> Result<Self, String> {
         if value.contains(',') {
             return Err(
-                "capability must not contain a comma; provide multiple capabilities as separate array entries"
+                "capability must not contain a comma; provide multiple capabilities as separate array entries, for example [\"internetClient\", \"privateNetworkClientServer\"]"
                     .to_string(),
             );
         }

--- a/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/valid/complete.json
+++ b/src/core/mxc_config_contract/tests/v0_8_0_alpha/fixtures/valid/complete.json
@@ -48,7 +48,8 @@
     "leastPrivilege": true,
     "learningMode": false,
     "capabilities": [
-      "internetClient"
+      "internetClient",
+      "privateNetworkClientServer"
     ],
     "ui": {
       "isolation": "container",


### PR DESCRIPTION
This PR clarifies how callers should represent multiple AppContainer capabilities.

Details

* Include a concrete capability-array example in the comma validation error.
* Exercise multiple valid capability entries in the exact-contract fixture.

Tests

* `cargo fmt --all -- --check`
* `cargo check -p mxc_config_contract --all-targets`
* `cargo clippy -p mxc_config_contract --all-targets -- -D warnings`
* `cargo test -p mxc_config_contract` (573 passed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/986)