### PR TITLE
Clarify 0.8 proxy host-loopback comments

### DIFF
--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -93,7 +93,7 @@ bind only the exact loopback address and port supplied to MXC.
 |---|---|---|---|
 | Packaged proxy | Package Family Name | `default: "allow"`; `hostLoopback: "deny"` | Package identity |
 | Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | AppContainer profile |
-| Unpackaged non-AppContainer | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
+| Unpackaged non-AppContainer (compatibility) | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
 
 All deployments retain the base Model 2 client policy. `allowedProxyPeer` adds proxy identity binding on top of the
 common WFP endpoint enforcement. The proxy endpoint is the loopback address and port in
@@ -102,8 +102,9 @@ client policy and package identity are the same; the enforcement table below sep
 
 `ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
 opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
-non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. That authorizes both
-host-loopback directions, but Model 2 WFP still restricts client-container egress to the configured proxy endpoint.
+non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. This is a weaker
+compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It authorizes both
+host-loopback directions, although WFP still restricts client-container egress to the configured proxy endpoint.
 Host-loopback clients can reach listeners in the MXC client container.
 
 #### Identity-scoped proxy
@@ -113,7 +114,7 @@ Use the canonical [ProcessContainer schema 0.8 configuration](examples/0.8.0-sch
 Use the installed Package Family Name for a packaged proxy, regardless of whether it has AppContainer isolation. Use
 the AppContainer profile name for an unpackaged AppContainer proxy.
 
-#### Unpackaged non-AppContainer proxy
+#### Unpackaged non-AppContainer proxy (compatibility)
 
 An unpackaged non-AppContainer proxy has no package family or AppContainer profile identity:
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -93,7 +93,7 @@ bind only the exact loopback address and port supplied to MXC.
 |---|---|---|---|
 | Packaged proxy | Package Family Name | `default: "allow"`; `hostLoopback: "deny"` | Package identity |
 | Unpackaged AppContainer | Profile | `default: "allow"`; `hostLoopback: "deny"` | AppContainer profile |
-| Unpackaged non-AppContainer (compatibility) | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
+| Unpackaged non-AppContainer (development/testing compatibility) | Omit | `default: "allow"`; `hostLoopback: "allow"` | None |
 
 All deployments retain the base Model 2 client policy. `allowedProxyPeer` adds proxy identity binding on top of the
 common WFP endpoint enforcement. The proxy endpoint is the loopback address and port in
@@ -103,9 +103,9 @@ client policy and package identity are the same; the enforcement table below sep
 `ingress.hostLoopback` is bidirectional. `allowedProxyPeer` authorizes a package family or AppContainer profile without
 opening general host-loopback access, so identity-scoped paths keep `hostLoopback: "deny"`. Only an unpackaged
 non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopback: "allow"`. This is a weaker
-compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It authorizes both
-host-loopback directions, although WFP still restricts client-container egress to the configured proxy endpoint.
-Host-loopback clients can reach listeners in the MXC client container.
+development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
+authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
+endpoint. Host-loopback clients can reach listeners in the MXC client container.
 
 #### Identity-scoped proxy
 
@@ -114,7 +114,7 @@ Use the canonical [ProcessContainer schema 0.8 configuration](examples/0.8.0-sch
 Use the installed Package Family Name for a packaged proxy, regardless of whether it has AppContainer isolation. Use
 the AppContainer profile name for an unpackaged AppContainer proxy.
 
-#### Unpackaged non-AppContainer proxy (compatibility)
+#### Unpackaged non-AppContainer proxy (development/testing compatibility)
 
 An unpackaged non-AppContainer proxy has no package family or AppContainer profile identity:
 

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -33,7 +33,8 @@ do not apply when runtime proxy configuration selects model 2.
 - **No direct internet + loopback HTTP(S) proxy (more restrictive).** The container has no direct internet path; the
   proxy is its only internet egress. Cooperating clients route HTTP(S) to the proxy, where the consumer can inspect
   and filter it. A client that ignores the proxy and tries to reach the internet directly is dropped. Backend-specific
-  private-network behavior is described below.
+  private-network behavior is described below. The single endpoint named by `runtimeConfig.networkProxy` is a defined,
+  narrowly scoped exception to the container-to-host closure. It does not grant general host-loopback access.
 - **No direct internet + no inbound (most restrictive):** This is the most
   restrictive model. External network traffic is dropped; backend-local
   intra-sandbox IPC is described separately below.
@@ -64,7 +65,9 @@ Throughout this document, the deny-all-except-proxy posture (the GA goal) refers
   `HTTP_PROXY`/`HTTPS_PROXY` on Linux and macOS. Windows uses both per-AppContainer WinHTTP configuration and proxy
   environment variables for non-WinHTTP clients. A client that ignores the proxy cannot reach the internet directly
   on an enforcing model-2 path because the egress restriction drops everything except the localhost proxy port. In
-  model 1, such a client may instead egress directly, subject to the IP/CIDR/port/protocol rules.
+  model 1, such a client may instead egress directly, subject to the IP/CIDR/port/protocol rules. In model 2, access to
+  the configured proxy endpoint is the sanctioned egress path and is allowed independently of
+  `ingress.hostLoopback`; no other host-loopback endpoint is opened by the proxy configuration.
 - **What is NOT routed:** Non-HTTP traffic (raw TCP/UDP sockets, SSH, custom protocols, QUIC, WebRTC, etc.) is never
   redirected to the proxy. In model 2, direct internet traffic is blocked. On ProcessContainer, private-network
   traffic follows `ingress.default` because AppContainer exposes one bidirectional private-network capability. In
@@ -101,7 +104,7 @@ Ingress has two allow/deny controls and no rule arrays:
 - `ingress.default` controls LAN/private-network inbound traffic where the
   backend supports it.
 - `ingress.hostLoopback` controls host-loopback connectivity in both directions: container-to-host and
-  host-to-container.
+  host-to-container, except for the single outbound proxy endpoint named by `runtimeConfig.networkProxy`.
 
 The specific `hostLoopback` value overrides `default` for the host-loopback
 path. For example, `default: deny` with `hostLoopback: allow` permits
@@ -109,19 +112,28 @@ bidirectional host-loopback connectivity while denying other inbound traffic.
 A backend that cannot enforce both directions must reject `hostLoopback: allow`
 rather than accept it with partial enforcement.
 
+When `runtimeConfig.networkProxy` is present, `hostLoopback: deny` remains valid
+and blocks every host-loopback path other than outbound connections to that
+exact proxy endpoint. This exception is part of model 2, not a general grant of
+host-loopback access. A backend that cannot make the proxy reachable without
+opening broader host-loopback access must reject model 2 rather than require
+`hostLoopback: allow` or silently weaken the policy.
+
 **Scope:**
 
 - Intra-container loopback: allowed on backends with private loopback;
   Seatbelt cannot separate it from host loopback
 - Container-originated private-network traffic: controlled by `egress` on backends that cleanly separate
   private-network ingress from egress; backend-specific limitations are documented below
-- Container-to-host-loopback and host-loopback-to-container traffic: controlled by `ingress.hostLoopback`
+- Container-to-host-loopback and host-loopback-to-container traffic: controlled by `ingress.hostLoopback`, except for
+  outbound access to the exact model-2 proxy endpoint
 - LAN/private-network inbound: controlled by `ingress.default`, where supported
 - WAN inbound: not enabled by the GA policy
 
 **Use cases for `ingress.hostLoopback: allow`:**
 
-- Caller-provided services or proxies listening on host loopback and accessed from the container
+- Caller-provided services other than the configured network proxy, listening on host loopback and accessed from the
+  container
 - MCP servers in SSE/WebSocket mode (server listens on a port for client connections from host)
 - Language server daemons (e.g., TypeScript language server) accessed from host IDE
 - Local dev servers (e.g., npm run dev on port 3000) accessed from host browser
@@ -175,13 +187,13 @@ Direct internet, no proxy (least restrictive). OR no egress at all: default deny
 
 ### Connectivity model 2
 
-No direct internet, loopback proxy only (more restrictive). Proxy
+No direct internet, loopback proxy only (more restrictive).
 
 ```json
 {
   "network": {
     "egress": { "default": "deny" },
-    "ingress": { "default": "allow", "hostLoopback": "allow" }
+    "ingress": { "default": "deny", "hostLoopback": "deny" }
   },
   "runtimeConfig": { // runtime data passed to MXC (not policy)
     // http(s)://localhost:<port>, http(s)://127.0.0.1:<port>, or http(s)://[::1]:<port>
@@ -190,13 +202,13 @@ No direct internet, loopback proxy only (more restrictive). Proxy
 }
 ```
 
-The example shows the identity-less ProcessContainer posture: private-network
-ingress is enabled so host loopback can reach the proxy, while direct egress
-remains deny-by-default. When `runtimeConfig.networkProxy` is present,
-cooperating HTTP(S) clients are configured to use the proxy; clients that ignore
-the proxy settings are blocked from direct egress. Without runtime proxy
-configuration, the deny defaults form model 3. Backend-specific proxy
-reachability requirements are documented below.
+This backend-neutral example keeps general host-loopback and private-network
+access denied. `runtimeConfig.networkProxy` authorizes only outbound access to
+the exact proxy endpoint as the model-2 exception. Cooperating HTTP(S) clients
+are configured to use the proxy; clients that ignore the proxy settings are
+blocked from direct egress. Without runtime proxy configuration, the deny
+defaults form model 3. Backends may use different mechanisms to make the proxy
+reachable, but must preserve this policy meaning.
 
 This schema follows container-ecosystem conventions (CIDR peers, egress/ingress, to/ports), modeled loosely on
 Kubernetes NetworkPolicy (the CNCF standard layered on CNI/OCI) rather than on platform firewall primitives. MXC keeps
@@ -245,8 +257,9 @@ backend rejects configurations it cannot enforce.
 
 **Decision:** GA defines outbound configuration and inbound control.
 `ingress.default: deny` blocks LAN/private-network inbound traffic, and
-`ingress.hostLoopback: deny` separately blocks host-loopback connectivity in both directions. The host-loopback value
-overrides `default` for that path.
+`ingress.hostLoopback: deny` separately blocks host-loopback connectivity in both directions, except for the exact
+outbound proxy endpoint when `runtimeConfig.networkProxy` selects model 2. The host-loopback value overrides `default`
+for all other host-loopback traffic.
 Intra-container loopback is allowed on backends with private loopback.
 Seatbelt has the caveat described below.
 
@@ -254,7 +267,8 @@ Seatbelt has the caveat described below.
 
 - **Attack surface:** Host-loopback access can expose host services to contained code and container listeners to the
   host. For agentic workloads, either direction can create command-and-control, exfiltration, or lateral-movement paths.
-- **Opt-in model:** Customers must explicitly set `ingress.hostLoopback: allow` when either direction is required.
+- **Opt-in model:** Customers must explicitly set `ingress.hostLoopback: allow` when either direction is required beyond
+  the configured model-2 proxy endpoint.
 - **GA enforcement:** Windows process containers use loopback exemption rules
   scoped to the AppContainer SID. WSLc/LXC/Bubblewrap require paired routing
   and filtering for both directions across their private network namespaces.
@@ -287,7 +301,10 @@ sockets come with their own security questions and should be outlined in a separ
 
 ### D5: Proxy is HTTP/S via platform-native APIs; localhost only for GA
 
-**Decision:** For GA, proxy routing covers HTTP and HTTPS traffic routed through the platform's native proxy surface. The proxy must be on localhost (same-machine loopback) for GA. Remote proxies are out of scope for GA.
+**Decision:** For GA, proxy routing covers HTTP and HTTPS traffic routed through the platform's native proxy surface.
+The proxy must be on localhost (same-machine loopback) for GA. Remote proxies are out of scope for GA. When configured,
+the exact endpoint in `runtimeConfig.networkProxy` is the sole sanctioned exception to container-to-host closure;
+`ingress.hostLoopback: deny` blocks all other host-loopback access.
 
 **Platform-specific enforcement:**
 
@@ -350,8 +367,8 @@ does not satisfy model 2; see the implementation doc for its limitations.
 
 - **Model 2 (recommended):** Grants no `internetClient`, so direct internet traffic is blocked. Any packaged proxy,
   with or without AppContainer isolation, uses its Package Family Name in `allowedProxyPeer`; an unpackaged
-  AppContainer proxy uses its profile name. The MXC client requires `ingress.default: "allow"` to grant
-  `privateNetworkClientServer`. That capability permits private-network client and server traffic by Windows design.
+  AppContainer proxy uses its profile name. Proxy reachability is scoped to that peer and endpoint; it does not require
+  `ingress.default: "allow"` or `ingress.hostLoopback: "allow"`.
 - **Model 1:** Grants `internetClient`, allowing direct internet egress under WFP IP/CIDR/port/protocol rules.
   Private-network outbound also requires `ingress.default: "allow"` and remains subject to the same `egress` rules.
 - **Model 3:** Grants no `internetClient`, private-network capability, or loopback exemptions.
@@ -364,7 +381,7 @@ does not satisfy model 2; see the implementation doc for its limitations.
 | Port filtering | Port filtering via WFP | Port ranges supported. |
 | Protocol filtering | Protocol filtering via WFP | Schema values are `tcp`, `udp`, `icmp`, and `any`; WFP maps ICMP by address family. |
 | Default-deny | WFP block-all baseline filter at lower precedence than explicit allows. AppContainer has no internetClient capability. | |
-| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration | Private network follows `ingress.default` |
+| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration and scoped peer access | The configured endpoint is the model-2 exception; other private network and host loopback follow `ingress` |
 | Per-sandbox scoping | AppContainer SID, unique per sandbox instance | |
 | Private network | `privateNetworkClientServer` via `ingress.default` | Capability gate; `egress` filters outbound |
 | Inbound | Capabilities and loopback rules | Private network uses `ingress.default`; loopback is separate |

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -397,8 +397,8 @@ than strict model-2 enforcement.
   AppContainer proxy uses its profile name. Windows requires `ingress.default: "allow"` to grant the bidirectional
   `privateNetworkClientServer` capability. With `allowedProxyPeer`, proxy reachability remains scoped to that peer and
   endpoint and `ingress.hostLoopback` stays `"deny"`. An identity-less host proxy cannot use peer scoping and is the
-  documented compatibility path that requires `ingress.hostLoopback: "allow"`; it does not provide the strict
-  host-loopback-closure guarantee.
+  documented development/testing compatibility path that requires `ingress.hostLoopback: "allow"`; it does not
+  provide the strict host-loopback-closure guarantee.
 - **Model 1:** Grants `internetClient`, allowing direct internet egress under WFP IP/CIDR/port/protocol rules.
   Private-network outbound also requires `ingress.default: "allow"` and remains subject to the same `egress` rules.
 - **Model 3:** Grants no `internetClient`, private-network capability, or loopback exemptions.
@@ -411,7 +411,7 @@ than strict model-2 enforcement.
 | Port filtering | Port filtering via WFP | Port ranges supported. |
 | Protocol filtering | Protocol filtering via WFP | Schema values are `tcp`, `udp`, `icmp`, and `any`; WFP maps ICMP by address family. |
 | Default-deny | WFP block-all baseline filter at lower precedence than explicit allows. AppContainer has no internetClient capability. | |
-| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration, endpoint filtering, and optional scoped peer access | Identity-scoped proxies keep `hostLoopback: "deny"`; the identity-less compatibility path requires `"allow"` |
+| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration, endpoint filtering, and optional scoped peer access | Identity-scoped proxies keep `hostLoopback: "deny"`; the identity-less development/testing compatibility path requires `"allow"` |
 | Per-sandbox scoping | AppContainer SID, unique per sandbox instance | |
 | Private network | `privateNetworkClientServer` via `ingress.default` | Capability gate; `egress` filters outbound |
 | Inbound | Capabilities and loopback rules | Private network uses `ingress.default`; loopback is separate |

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -115,9 +115,10 @@ rather than accept it with partial enforcement.
 When `runtimeConfig.networkProxy` is present, `hostLoopback: deny` remains valid
 and blocks every host-loopback path other than outbound connections to that
 exact proxy endpoint. This exception is part of model 2, not a general grant of
-host-loopback access. A backend that cannot make the proxy reachable without
-opening broader host-loopback access must reject model 2 rather than require
-`hostLoopback: allow` or silently weaken the policy.
+host-loopback access. An enforcing model-2 implementation must preserve that
+meaning or reject the configuration. A temporary compatibility path may require
+broader host-loopback access only when its backend section explicitly documents
+the weaker posture; such a path does not provide the strict model-2 guarantee.
 
 **Scope:**
 
@@ -202,13 +203,18 @@ No direct internet, loopback proxy only (more restrictive).
 }
 ```
 
-This backend-neutral example keeps general host-loopback and private-network
-access denied. `runtimeConfig.networkProxy` authorizes only outbound access to
-the exact proxy endpoint as the model-2 exception. Cooperating HTTP(S) clients
-are configured to use the proxy; clients that ignore the proxy settings are
-blocked from direct egress. Without runtime proxy configuration, the deny
-defaults form model 3. Backends may use different mechanisms to make the proxy
-reachable, but must preserve this policy meaning.
+This backend-neutral example expresses the portable model-2 policy intent:
+general host-loopback and private-network access remain denied, while
+`runtimeConfig.networkProxy` designates the exact outbound proxy endpoint for
+the model-2 exception. Cooperating HTTP(S) clients are configured to use the
+proxy; clients that ignore the proxy settings are blocked from direct egress.
+Without runtime proxy configuration, the deny defaults form model 3. Backends
+may use different mechanisms to make the proxy reachable. An enforcing path
+must preserve this meaning; a backend that cannot do so rejects the
+configuration unless its section below explicitly identifies a temporary,
+weaker compatibility posture. The example expresses the shared contract; the
+GA Scope by Backend section states whether each backend accepts this exact JSON
+or requires a documented backend-specific configuration.
 
 This schema follows container-ecosystem conventions (CIDR peers, egress/ingress, to/ports), modeled loosely on
 Kubernetes NetworkPolicy (the CNCF standard layered on CNI/OCI) rather than on platform firewall primitives. MXC keeps
@@ -315,6 +321,20 @@ the exact endpoint in `runtimeConfig.networkProxy` is the sole sanctioned except
 | Linux (LXC, Bubblewrap) | iptables permits only the proxy endpoint; proxy variables are routing hints. |
 | macOS (Seatbelt) | Seatbelt profile confines network-outbound to the loopback proxy port. MXC-set `HTTP_PROXY`/`HTTPS_PROXY` env variables are an advisory routing hint; a client that ignores the variables is denied by the profile (only the proxy port is reachable), so it is dropped, not bypassed. |
 
+**Backend implementation rule:** A backend implementing model 2:
+
+1. validates that `runtimeConfig.networkProxy` names an HTTP/S loopback endpoint with an explicit port;
+2. makes only that outbound endpoint reachable, or only its backend-specific translation when the sandbox has a
+   private network namespace;
+3. applies `ingress.hostLoopback` to every other container-to-host and host-to-container loopback path; and
+4. rejects the configuration if it cannot preserve those semantics.
+
+A backend-specific compatibility path may instead require a broader ingress
+setting only when its section documents both the required configuration and the
+resulting loss of isolation. Capability gates such as ProcessContainer's
+`ingress.default: "allow"` do not turn the proxy exception into general
+host-loopback permission.
+
 **Why localhost only:** Remote proxies introduce trust boundary issues (proxy on different machine = different security context). Localhost proxy simplifies GA implementation and ensures proxy is under the same administrative control as the sandbox.
 
 **Proxy environment-variable hygiene (all backends):** The sandbox starts with all HTTP(S)-related proxy environment variables cleared to empty (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `FTP_PROXY`, `NO_PROXY`, and their lowercase variants). The sandbox never inherits host or stale proxy settings. MXC sets these variables explicitly, and only to the configured loopback proxy, when a proxy is in use (model 2); in model 1 they remain empty.
@@ -344,6 +364,11 @@ AppContainer requires the bidirectional `privateNetworkClientServer` capability 
 flow in either direction. ProcessContainer therefore requires `ingress.default: "allow"` for outbound private-network
 access, after which `egress` rules apply to both public and private outbound destinations.
 
+This capability coupling is a backend mapping, not a change to the shared
+meaning of `ingress.default`. The ProcessContainer section identifies which
+proxy deployments retain strict endpoint scoping and which compatibility
+deployment additionally requires general host-loopback access.
+
 ### D8: Delegation from the invoking user
 
 **Decision:** Like the filesystem configuration, the network configuration is a delegation: the contained code receives no more network access than the invoking user could exercise themselves.
@@ -359,16 +384,21 @@ already implemented.
 
 ### Process containers (Windows): GA target and compatibility behavior
 
-The model-2 guarantees below apply to ProcessContainer paths with OS-scoped
-proxy enforcement. The AppContainer compatibility fallback is cooperative and
-does not satisfy model 2; see the implementation doc for its limitations.
+The strict host-loopback guarantee applies to the identity-scoped
+ProcessContainer path with OS-scoped proxy enforcement. The identity-less host
+proxy path requires broader host-loopback access, and the AppContainer fallback
+is cooperative; both are explicitly documented compatibility behaviors rather
+than strict model-2 enforcement.
 
 **Connectivity models:**
 
 - **Model 2 (recommended):** Grants no `internetClient`, so direct internet traffic is blocked. Any packaged proxy,
   with or without AppContainer isolation, uses its Package Family Name in `allowedProxyPeer`; an unpackaged
-  AppContainer proxy uses its profile name. Proxy reachability is scoped to that peer and endpoint; it does not require
-  `ingress.default: "allow"` or `ingress.hostLoopback: "allow"`.
+  AppContainer proxy uses its profile name. Windows requires `ingress.default: "allow"` to grant the bidirectional
+  `privateNetworkClientServer` capability. With `allowedProxyPeer`, proxy reachability remains scoped to that peer and
+  endpoint and `ingress.hostLoopback` stays `"deny"`. An identity-less host proxy cannot use peer scoping and is the
+  documented compatibility path that requires `ingress.hostLoopback: "allow"`; it does not provide the strict
+  host-loopback-closure guarantee.
 - **Model 1:** Grants `internetClient`, allowing direct internet egress under WFP IP/CIDR/port/protocol rules.
   Private-network outbound also requires `ingress.default: "allow"` and remains subject to the same `egress` rules.
 - **Model 3:** Grants no `internetClient`, private-network capability, or loopback exemptions.
@@ -381,7 +411,7 @@ does not satisfy model 2; see the implementation doc for its limitations.
 | Port filtering | Port filtering via WFP | Port ranges supported. |
 | Protocol filtering | Protocol filtering via WFP | Schema values are `tcp`, `udp`, `icmp`, and `any`; WFP maps ICMP by address family. |
 | Default-deny | WFP block-all baseline filter at lower precedence than explicit allows. AppContainer has no internetClient capability. | |
-| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration and scoped peer access | The configured endpoint is the model-2 exception; other private network and host loopback follow `ingress` |
+| Proxy (HTTP/S only) | Per-AppContainer WinHTTP configuration, endpoint filtering, and optional scoped peer access | Identity-scoped proxies keep `hostLoopback: "deny"`; the identity-less compatibility path requires `"allow"` |
 | Per-sandbox scoping | AppContainer SID, unique per sandbox instance | |
 | Private network | `privateNetworkClientServer` via `ingress.default` | Capability gate; `egress` filters outbound |
 | Inbound | Capabilities and loopback rules | Private network uses `ingress.default`; loopback is separate |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -47,7 +47,10 @@ Direct egress rules and `runtimeConfig.networkProxy` select different
 connectivity models and cannot be combined. A ProcessContainer proxy requires
 `ingress.default: "allow"`. Identity-scoped proxies set `allowedProxyPeer` and
 keep `hostLoopback: "deny"`; identity-less host proxies omit
-`allowedProxyPeer` and require `hostLoopback: "allow"`.
+`allowedProxyPeer` and require `hostLoopback: "allow"`. The identity-less route
+is a weaker compatibility deployment because it opens both host-loopback
+directions; it is not the strict proxy-endpoint exception defined by the shared
+model-2 policy.
 
 ```json
 {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -48,9 +48,9 @@ connectivity models and cannot be combined. A ProcessContainer proxy requires
 `ingress.default: "allow"`. Identity-scoped proxies set `allowedProxyPeer` and
 keep `hostLoopback: "deny"`; identity-less host proxies omit
 `allowedProxyPeer` and require `hostLoopback: "allow"`. The identity-less route
-is a weaker compatibility deployment because it opens both host-loopback
-directions; it is not the strict proxy-endpoint exception defined by the shared
-model-2 policy.
+is a weaker development/testing compatibility deployment because it opens both
+host-loopback directions; it is not the strict proxy-endpoint exception
+defined by the shared model-2 policy.
 
 ```json
 {


### PR DESCRIPTION
## 📖 Description

Clarifies the schema 0.8 model-2 networking contract across all containment backends:

- `runtimeConfig.networkProxy` designates one sanctioned outbound proxy-endpoint exception to `ingress.hostLoopback: "deny"`.
- Every other container-to-host and host-to-container loopback path remains governed by `ingress.hostLoopback`.
- Backends must enforce the exact endpoint (or its private-namespace translation), reject the configuration, or explicitly document a weaker compatibility posture.
- ProcessContainer's Windows capability mapping and identity-less development/testing compatibility path are distinguished from the portable contract.

This resolves the ambiguity that caused Bubblewrap and LXC to interpret the proxy exception privately.

## 🔗 References

Resolves #981

Related to #979 and #983.

## 🔍 Validation

- Compared the shared policy wording with the ProcessContainer parser validation and backend documentation.
- Reconciled the shared policy, ProcessContainer guide, and schema reference.
- Ran `git diff --check`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (not applicable: no build, architecture, or convention change)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (not applicable: `Cargo.lock` is unchanged)

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/989)