### PR TITLE
Increase official build job timeouts to two hours

### DIFF
--- a/.azure-pipelines/templates/Mac.Build.Job.yml
+++ b/.azure-pipelines/templates/Mac.Build.Job.yml
@@ -18,6 +18,7 @@ parameters:
 jobs:
 - job: 'build_arm64_MAC'
   displayName: 'Build (arm64 MAC)'
+  timeoutInMinutes: 120
 
   pool:
     name: Azure Pipelines

--- a/.azure-pipelines/templates/Rust.Build.Job.yml
+++ b/.azure-pipelines/templates/Rust.Build.Job.yml
@@ -17,6 +17,7 @@ jobs:
   - job: 'build_${{ item.arch }}_${{ item.component }}'
     displayName: 'Build (${{ item.arch }} ${{ item.component }})'
     dependsOn: []
+    timeoutInMinutes: 120
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
       ${{ if eq(item.os, 'windows') }}:


### PR DESCRIPTION
## 📖 Description

Raise the shared Rust matrix and macOS binary build job timeouts from Azure DevOps' default 60 minutes to 120 minutes.

The official x64 Windows build now regularly needs more than an hour to compile, test, sign, and finish post-job work. Build 155140412 completed its tests and signing but was canceled at the one-hour limit before the job could finish.

## 🔗 References

- [Failed official build 155140412](https://microsoft.visualstudio.com/Dart/_build/results?buildId=155140412&view=results)

## 🔍 Validation

- `git diff --check`
- Confirmed both binary-build job templates set `timeoutInMinutes: 120`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/997)