### PR TITLE
Update package versions to 0.8.0

### DIFF
--- a/sdk/dotnet/Microsoft.Mxc.Sdk/Microsoft.Mxc.Sdk.csproj
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/Microsoft.Mxc.Sdk.csproj
@@ -8,7 +8,7 @@
     <LangVersion>latest</LangVersion>
     <RootNamespace>Microsoft.Mxc.Sdk</RootNamespace>
     <AssemblyName>Microsoft.Mxc.Sdk</AssemblyName>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <Description>C# SDK for MXC (Microsoft eXecution Container), binding the native mxc_ffi library.</Description>

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/mxc-sdk",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "TypeScript SDK for MXC (Microsoft eXecution Containers)",
   "type": "module",
   "types": "dist/index.d.ts",

--- a/sdk/node/tests/integration/package-lock.json
+++ b/sdk/node/tests/integration/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "node_modules/@microsoft/mxc-sdk": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "resolved": "file:../..",
       "license": "MIT",
       "dependencies": {

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "appcontainer_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flatbuffers",
  "getrandom 0.2.17",
@@ -214,7 +214,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bwrap_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "lxc_common",
  "nix",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hyperlight-unikraft",
  "wxc_common",
@@ -1184,7 +1184,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "isolation_session_bindings"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "semver",
  "windows",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "isolation_session_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "isolation_session_bindings",
@@ -1279,7 +1279,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "learning_mode_core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "same-file",
  "serde",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "learning_mode_windows"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flatbuffers",
  "learning_mode_core",
@@ -1387,7 +1387,7 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lxc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "lxc_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
  "mxc_pty",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "mxc-sdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
  "mxc_engine",
@@ -1496,14 +1496,14 @@ dependencies = [
 
 [[package]]
 name = "mxc_build_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "winresource",
 ]
 
 [[package]]
 name = "mxc_config_contract"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "schemars",
  "serde",
@@ -1513,7 +1513,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_darwin"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "mxc_build_common",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_diagnostic_console"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "mxc_build_common",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_engine"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "appcontainer_common",
  "bwrap_common",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_ffi"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "csbindgen",
  "mxc-sdk",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_pty"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
  "nix",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "mxc_schema_gen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "mxc_config_contract",
@@ -1587,14 +1587,14 @@ dependencies = [
 
 [[package]]
 name = "mxc_schema_support"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "mxc_telemetry"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "tracelogging",
  "uuid",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix_binaries"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "nanvix_build_common",
  "nanvix_common",
@@ -1610,14 +1610,14 @@ dependencies = [
 
 [[package]]
 name = "nanvix_build_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "nanvix_common",
 ]
 
 [[package]]
 name = "nanvix_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "nanvix_runner"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
  "nanvix_common",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "process_security_environment_spec"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flatbuffers",
 ]
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "sandbox_spec"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flatbuffers",
 ]
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "seatbelt_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libc",
  "wxc_common",
@@ -2992,7 +2992,7 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_sandbox_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "getrandom 0.2.17",
  "serde",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "windows_sandbox_lifecycle"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -3155,7 +3155,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wslc_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3173,7 +3173,7 @@ dependencies = [
 
 [[package]]
 name = "wxc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "appcontainer_common",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "cidr",
@@ -3222,7 +3222,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_e2e_tests"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bwrap_common",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_host_prep"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "embed-manifest",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_test_driver"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_test_proxy"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "clap",
@@ -3275,7 +3275,7 @@ version = "0.1.0"
 
 [[package]]
 name = "wxc_windows_sandbox_daemon"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_windows_sandbox_guest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "mxc_build_common",
@@ -3304,7 +3304,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_winhttp_proxy_shim"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "mxc_build_common",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "wxc_wslc_daemon"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "mxc_build_common",

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -58,7 +58,7 @@ split-debuginfo = "packed"
 strip = "debuginfo"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 

--- a/tests/playground/package-lock.json
+++ b/tests/playground/package-lock.json
@@ -24,7 +24,7 @@
     },
     "../../sdk/node": {
       "name": "@microsoft/mxc-sdk",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "node-pty": "^1.2.0-beta.12",


### PR DESCRIPTION
## 📖 Description

Updates the MXC package versions from `0.7.0` to `0.8.0` so published artifacts reflect the current release line. This keeps the Rust workspace, Node SDK, C# SDK, and linked Node integration/playground lockfiles synchronized.

## 🔗 References

No linked issue.

## 🔍 Validation

- `cargo check --manifest-path src/Cargo.toml -p wxc_common --quiet`
- `node scripts/check-version-sync.js`
- Regenerated the Node integration and playground lockfiles from the local SDK package

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (not applicable; package metadata only)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1006)