### PR TITLE
Fix npm package SBOM generation under network isolation

### DIFF
--- a/.azure-pipelines/templates/1ES.Build.Stages.yml
+++ b/.azure-pipelines/templates/1ES.Build.Stages.yml
@@ -66,6 +66,7 @@ stages:
   jobs:
   - template: Package.NpmSdk.Job.yml
     parameters:
+      isOfficialBuild: ${{ parameters.isOfficialBuild }}
       targets:
         - artifact: wxc-binaries-x86_64-pc-windows-msvc
           sdkArch: x64

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -35,6 +35,10 @@ jobs:
   steps:
     - checkout: self
 
+    # The post-job SBOM generator inspects the Rust workspace. Configure Cargo
+    # for the internal feed so network isolation does not send it to crates.io.
+    - template: Cargo.Setup.Private.yml@self
+
     - task: UseNode@1
       displayName: Use Node.js 20
       inputs:

--- a/.azure-pipelines/templates/Package.NpmSdk.Job.yml
+++ b/.azure-pipelines/templates/Package.NpmSdk.Job.yml
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 parameters:
+- name: isOfficialBuild
+  type: boolean
+  default: false
 - name: targets
   type: object
   default:
@@ -36,8 +39,11 @@ jobs:
     - checkout: self
 
     # The post-job SBOM generator inspects the Rust workspace. Configure Cargo
-    # for the internal feed so network isolation does not send it to crates.io.
-    - template: Cargo.Setup.Private.yml@self
+    # for the appropriate mirror so network isolation does not send it to crates.io.
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - template: Cargo.Setup.Private.yml@self
+    - ${{ else }}:
+      - template: Cargo.Setup.Public.yml@self
 
     - task: UseNode@1
       displayName: Use Node.js 20


### PR DESCRIPTION
## 📖 Description

I hit a snag while attempting to publish the v0.8 npm package. The `Package Npm Sdk` job's post-job SBOM generation is timing out under 1ES network isolation because Cargo attempts to reach crates.io directly while inspecting the Rust workspace.

Now I thread the shared `isOfficialBuild` setting into the npm packaging job and configure Cargo immediately after checkout. Official builds authenticate against `Mxc-Azure-Feed`; unofficial PR/CI builds use the public `MxcDependencies` mirror. This should allow the post-job SBOM task to use the private azure feed instead of the public crates.io.

Note: SBom is mandatory for running a release pipeline, so without it, it fails.

## 🔗 References

## 🔍 Validation

- Parsed both modified Azure Pipelines templates successfully as YAML.
- Confirmed official packaging selects `Cargo.Setup.Private.yml`.
- Confirmed unofficial PR/CI packaging selects `Cargo.Setup.Public.yml`, matching `Lint.Job.yml`.
- Confirmed the source build reported network-isolation blocking followed by the 20-minute manifest-generation timeout.
- The official packaging pipeline must run to verify the post-job SBOM generator succeeds with the authenticated feed.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.