### PR TITLE
Add Apple Container samples and qualification

### DIFF
--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -73,7 +73,7 @@ Pick `0.7.0-alpha` for new code on any supported platform.
 | --- | --- | --- | --- |
 | Windows 11 24H2+ (verified on 25H2) | `processcontainer` | `windows_sandbox`, `wslc`, `microvm`, `isolation_session` | `processcontainer`: 26100 (24H2)<br>`isolation_session`: 26300.8553 ([Insider Preview](https://learn.microsoft.com/en-us/windows-insider/release-notes/experimental/preview-build-26300-8553)) |
 | Linux x64 / ARM64 | `bubblewrap` | `lxc` | — |
-| macOS ARM64 (schema `0.7.0-alpha`+) | `seatbelt` | `apple_container` (config only) | — |
+| macOS ARM64 (schema `0.7.0-alpha`+) | `seatbelt` | `apple_container` | `apple_container`: macOS 26 on Apple silicon |
 
 The default `processcontainer`, `bubblewrap`, `lxc`, and `seatbelt` backends work out of the box. **Experimental backends** (`windows_sandbox`, `wslc`, `microvm`, `isolation_session`, `hyperlight`, `apple_container`) require `{ experimental: true }` in `SandboxSpawnOptions` when you spawn — see [Choosing a Backend](#choosing-a-backend).
 
@@ -201,7 +201,7 @@ console.log(result.stdout);
 | `microvm` | `microvm` | Windows | Experimental | [`docs/nanvix-microvm/nanvix.md`](https://github.com/microsoft/mxc/blob/main/docs/nanvix-microvm/nanvix.md) — MicroVM via NanVix on Windows Hypervisor Platform |
 | `wslc` | (concrete only) | Windows | Experimental | [`docs/wsl/wsl-container-getting-started.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wsl-container-getting-started.md) |
 | `isolation_session` | (concrete only) | Windows | Experimental | [`docs/isolation-session/oneshot.md`](https://github.com/microsoft/mxc/blob/main/docs/isolation-session/oneshot.md) |
-| `apple_container` | (concrete only) | macOS ARM64 | Experimental, config only | — |
+| `apple_container` | (concrete only) | macOS 26 ARM64 | Experimental | — |
 
 Experimental backends require `{ experimental: true }` in `SandboxSpawnOptions`:
 
@@ -216,15 +216,26 @@ schema version `0.8.0-alpha`:
 
 ```typescript
 const config = createAppleContainerConfig(
-  { version: '0.8.0-alpha' },
+  {
+    version: '0.8.0-alpha',
+    timeoutMs: 30_000,
+    network: { allowOutbound: true },
+  },
   { image: 'docker.io/library/alpine:3.23', cpuCount: 2, memoryMb: 1024 },
 );
-config.process!.commandLine = 'echo hello';
+config.process!.commandLine = 'printf "hello from "; uname -srm';
+
+const child = spawnSandboxFromConfig(config, { experimental: true });
+child.onExit(({ exitCode }) => {
+  console.log(`Apple Container exited with ${exitCode}`);
+});
 ```
 
-This increment exposes and validates the configuration contract only.
-`spawnSandboxFromConfig(config, { experimental: true })` currently fails with
-`unsupported_containment` before creating Apple Container resources.
+Apple Container must be installed at `/usr/local/bin/container`, its service
+must already be running, and the installed CLI must match the version qualified
+by MXC. The backend runs Linux images rather than macOS executables. A
+default-block network policy additionally requires the digest-qualified MXC
+guest-init image to be installed locally.
 
 Backend-specific tuning lives on the returned `ContainerConfig`. The full set of fields per backend is in the JSON schemas — they're the source of truth:
 

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -371,8 +371,9 @@ export function createConfigFromPolicy(
 /**
  * Creates an experimental Apple Container config for macOS.
  *
- * Runtime execution is not implemented yet; spawning the returned config
- * currently fails with `unsupported_containment` before creating resources.
+ * The returned config runs a Linux OCI image through the separately installed
+ * Apple Container runtime. Pass `{ experimental: true }` to
+ * `spawnSandboxFromConfig`.
  */
 export function createAppleContainerConfig(
     policy: SandboxPolicy,

--- a/src/backends/apple_container/common/src/policy.rs
+++ b/src/backends/apple_container/common/src/policy.rs
@@ -374,6 +374,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn rejects_denied_and_mapped_path_overlap_in_either_direction() {
         let root =
             std::env::temp_dir().join(format!("mxc-apple-policy-overlap-{}", std::process::id()));
@@ -396,6 +397,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn mount_preserves_requested_guest_path_after_host_canonicalization() {
         let root = std::env::temp_dir().join(format!(
             "mxc-apple-policy-destination-{}",

--- a/src/backends/apple_container/common/src/policy.rs
+++ b/src/backends/apple_container/common/src/policy.rs
@@ -20,7 +20,7 @@ pub enum PolicyError {
     Plan(#[from] PlanError),
     #[error("{0}")]
     Resource(#[from] ResourceError),
-    #[error("failed to canonicalize Apple Container mount path {path:?}: {source}")]
+    #[error("failed to canonicalize Apple Container policy path {path:?}: {source}")]
     Canonicalize {
         path: String,
         #[source]
@@ -190,17 +190,26 @@ fn build_mounts(request: &ExecutionRequest) -> Result<Vec<MountPlan>, PolicyErro
     ] {
         for requested in paths {
             let requested_path = Path::new(requested);
-            if !requested_path.is_absolute() {
+            let guest_path = normalize_absolute(requested_path).ok_or_else(|| {
+                rejected(format!(
+                    "Apple Container mount path {requested:?} must be absolute and normalized"
+                ))
+            })?;
+            let guest_text = guest_path.to_str().ok_or_else(|| {
+                rejected(format!(
+                    "Apple Container mount path {requested:?} is not valid UTF-8"
+                ))
+            })?;
+            if guest_text.contains(',') {
                 return Err(rejected(format!(
-                    "Apple Container mount path {requested:?} must be absolute"
+                    "Apple Container mount path {guest_text:?} contains ',' and cannot be represented safely"
                 )));
             }
-            let canonical = std::fs::canonicalize(requested_path).map_err(|source| {
-                PolicyError::Canonicalize {
+            let canonical =
+                std::fs::canonicalize(&guest_path).map_err(|source| PolicyError::Canonicalize {
                     path: requested.clone(),
                     source,
-                }
-            })?;
+                })?;
             let canonical_text = canonical.to_str().ok_or_else(|| {
                 rejected(format!(
                     "Apple Container mount path {requested:?} resolves to a non-UTF-8 path"
@@ -221,7 +230,7 @@ fn build_mounts(request: &ExecutionRequest) -> Result<Vec<MountPlan>, PolicyErro
                     "Apple Container has {conflict} mount destination {canonical:?}"
                 )));
             }
-            mounts.push(MountPlan::new(&canonical, &canonical, access)?);
+            mounts.push(MountPlan::new(&canonical, guest_path, access)?);
         }
     }
 
@@ -231,16 +240,53 @@ fn build_mounts(request: &ExecutionRequest) -> Result<Vec<MountPlan>, PolicyErro
                 "Apple Container denied path {denied:?} must be an absolute normalized path"
             ))
         })?;
+        let denied =
+            resolve_existing_prefix(&denied).map_err(|source| PolicyError::Canonicalize {
+                path: denied.to_string_lossy().into_owned(),
+                source,
+            })?;
         if destinations
             .keys()
-            .any(|mapped| denied == *mapped || denied.starts_with(mapped))
+            .any(|mapped| denied.starts_with(mapped) || mapped.starts_with(&denied))
         {
             return Err(rejected(format!(
-                "Apple Container cannot deny {denied:?} because it is within a mapped path"
+                "Apple Container cannot combine denied path {denied:?} with an overlapping mapped path"
             )));
         }
     }
     Ok(mounts)
+}
+
+fn resolve_existing_prefix(path: &Path) -> std::io::Result<PathBuf> {
+    let mut prefix = path;
+    let mut absent_tail = Vec::new();
+    loop {
+        match std::fs::canonicalize(prefix) {
+            Ok(mut canonical) => {
+                for component in absent_tail.iter().rev() {
+                    canonical.push(component);
+                }
+                return Ok(canonical);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                match std::fs::symlink_metadata(prefix) {
+                    Ok(_) => return Err(error),
+                    Err(metadata_error)
+                        if metadata_error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(metadata_error) => return Err(metadata_error),
+                }
+                let Some(name) = prefix.file_name() else {
+                    return Err(error);
+                };
+                absent_tail.push(name.to_os_string());
+                let Some(parent) = prefix.parent() else {
+                    return Err(error);
+                };
+                prefix = parent;
+            }
+            Err(error) => return Err(error),
+        }
+    }
 }
 
 fn normalize_absolute(path: &Path) -> Option<PathBuf> {
@@ -325,5 +371,47 @@ mod tests {
     #[test]
     fn accepts_default_deny_policy() {
         assert!(validate_policy(&request()).is_ok());
+    }
+
+    #[test]
+    fn rejects_denied_and_mapped_path_overlap_in_either_direction() {
+        let root =
+            std::env::temp_dir().join(format!("mxc-apple-policy-overlap-{}", std::process::id()));
+        let child = root.join("child");
+        std::fs::create_dir_all(&child).unwrap();
+
+        for (mapped, denied) in [(&root, &child), (&child, &root)] {
+            let mut request = request();
+            request.policy.readwrite_paths = vec![mapped.to_string_lossy().into_owned()];
+            request.policy.denied_paths = vec![denied.to_string_lossy().into_owned()];
+
+            let error = build_run_plan(&request, None).unwrap_err();
+
+            assert!(
+                error.to_string().contains("overlapping mapped path"),
+                "{error}"
+            );
+        }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn mount_preserves_requested_guest_path_after_host_canonicalization() {
+        let root = std::env::temp_dir().join(format!(
+            "mxc-apple-policy-destination-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut request = request();
+        request.policy.readwrite_paths = vec![root.to_string_lossy().into_owned()];
+
+        let plan = build_run_plan(&request, None).unwrap();
+
+        assert_eq!(plan.mounts[0].guest_path, root);
+        assert_eq!(
+            plan.mounts[0].host_path,
+            std::fs::canonicalize(&root).unwrap()
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/backends/apple_container/common/src/recovery.rs
+++ b/src/backends/apple_container/common/src/recovery.rs
@@ -79,12 +79,12 @@ impl RecoveryGuard {
         create_private_directory(&directory)?;
         let path = directory.join(format!("{}.json", plan.ownership_token.as_str()));
         let temporary_path = directory.join(format!(".{}.tmp", plan.ownership_token.as_str()));
-        let mut file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create_new(true)
-            .mode(0o600)
-            .open(&temporary_path)?;
+        let mut options = fs::OpenOptions::new();
+        options.read(true).write(true).create_new(true).mode(0o600);
+        #[cfg(target_os = "macos")]
+        options.custom_flags(libc::O_EXLOCK);
+        let mut file = options.open(&temporary_path)?;
+        #[cfg(not(target_os = "macos"))]
         lock_exclusive(&file, false)?;
         let write_result = (|| {
             serde_json::to_writer(&mut file, &RecoveryRecord::from_plan(plan, container_hint))?;
@@ -137,11 +137,16 @@ pub fn stale_recoveries() -> Result<Vec<StaleRecovery>, RecoveryError> {
         if !matches!(extension, Some("json" | "tmp")) {
             continue;
         }
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => return Err(error.into()),
+        };
         record_count += 1;
         if record_count > MAX_RECOVERY_RECORDS {
             return Err(RecoveryError::TooManyRecords);
         }
-        if !fs::symlink_metadata(&path)?.file_type().is_file() {
+        if !metadata.file_type().is_file() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("recovery record {path:?} is not a regular file"),

--- a/src/backends/apple_container/common/src/runtime.rs
+++ b/src/backends/apple_container/common/src/runtime.rs
@@ -447,8 +447,52 @@ fn cleanup_resource(
             return Ok(());
         }
     }
-    run_checked(runner, &delete_command(resource))?;
-    Ok(())
+    match run_checked(runner, &delete_command(resource)) {
+        Ok(_) => Ok(()),
+        Err(delete_error) if resource.name.kind() == ResourceKind::Container && !stop_container => {
+            // The foreground CLI can exit a few milliseconds before Apple's
+            // persisted container state becomes terminal. Re-prove ownership
+            // before escalating to the same bounded stop/delete path used for
+            // timeout cleanup.
+            match verify_ownership(runner, resource) {
+                Ok(false) => return Ok(()),
+                Ok(true) => {}
+                Err(probe_error) => {
+                    return Err(CliError::Command(format!(
+                        "{delete_error}; ownership re-check failed: {probe_error}"
+                    )));
+                }
+            }
+            let stop_result = run_checked(runner, &stop_container_command(resource));
+            match verify_ownership(runner, resource) {
+                Ok(false) => return Ok(()),
+                Ok(true) => {}
+                Err(probe_error) => {
+                    let stop_detail = stop_result
+                        .err()
+                        .map(|error| format!("; fallback stop failed: {error}"))
+                        .unwrap_or_default();
+                    return Err(CliError::Command(format!(
+                        "{delete_error}{stop_detail}; ownership check after fallback stop failed: \
+                         {probe_error}"
+                    )));
+                }
+            }
+            run_checked(runner, &delete_command(resource))
+                .map(|_| ())
+                .map_err(|retry_error| {
+                    let stop_detail = stop_result
+                        .err()
+                        .map(|error| format!("; fallback stop failed: {error}"))
+                        .unwrap_or_default();
+                    CliError::Command(format!(
+                        "{delete_error}{stop_detail}; delete after fallback stop also failed: \
+                         {retry_error}"
+                    ))
+                })
+        }
+        Err(error) => Err(error),
+    }
 }
 
 struct SecureEnvironmentFile {

--- a/src/backends/apple_container/common/tests/runtime_integration.rs
+++ b/src/backends/apple_container/common/tests/runtime_integration.rs
@@ -3,8 +3,15 @@
 
 #![cfg(target_os = "macos")]
 
-use std::io::{Read, Write};
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
 
+use apple_container_common::cli::NETWORK_BLOCK_INIT_IMAGE;
 use apple_container_common::AppleContainerBackend;
 use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{
@@ -12,61 +19,378 @@ use wxc_common::models::{
 };
 use wxc_common::sandbox_process::{SandboxBackend, StdioMode};
 
-#[test]
-#[ignore = "requires Apple Container 1.2.2 and the alpine:3.22 image"]
-fn streams_stdin_stdout_stderr_and_propagates_exit_code() {
-    let request = ExecutionRequest {
+const ALPINE_IMAGE: &str = "docker.io/library/alpine:3.22";
+const PYTHON_IMAGE: &str = "docker.io/library/python:3.13-alpine";
+const INTEGRATION_REQUIREMENTS: &str =
+    "requires Apple Container 1.2.2 and the qualification images";
+
+static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+struct RunOutput {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(label: &str) -> Self {
+        let sequence = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "mxc-apple-qualification-{}-{sequence}-{label}",
+            std::process::id()
+        ));
+        fs::create_dir(&path).expect("create qualification temp directory");
+        Self { path }
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn request(script: impl Into<String>, image: &str, network: NetworkPolicy) -> ExecutionRequest {
+    ExecutionRequest {
         container_id: "runtime-integration".to_string(),
-        script_code:
-            "read value; printf 'stdout:%s\\n' \"$value\"; printf 'stderr:%s\\n' \"$value\" >&2; exit 9"
-                .to_string(),
+        script_code: script.into(),
         containment: ContainmentBackend::AppleContainer,
         script_timeout: 30_000,
         experimental_enabled: true,
         experimental: ExperimentalConfig {
             apple_container: Some(AppleContainerConfig {
-                image: "docker.io/library/alpine:3.22".to_string(),
+                image: image.to_string(),
                 cpu_count: Some(1),
                 memory_mb: Some(512),
             }),
             ..Default::default()
         },
         policy: wxc_common::models::ContainerPolicy {
-            default_network_policy: NetworkPolicy::Allow,
+            default_network_policy: network,
             ..Default::default()
         },
         ..Default::default()
-    };
+    }
+}
+
+fn spawn_request(
+    request: &ExecutionRequest,
+) -> Result<Box<dyn wxc_common::sandbox_process::SandboxProcess>, String> {
     let mut backend = AppleContainerBackend::new();
     let mut logger = Logger::new(Mode::Buffer);
-    let mut process = backend
-        .spawn(&request, &mut logger, StdioMode::Pipes)
-        .expect("spawn Apple Container");
+    backend
+        .spawn(request, &mut logger, StdioMode::Pipes)
+        .map_err(|response| response.error_message)
+}
 
+fn resource_ids(args: &[&str], prefix: &str) -> Vec<String> {
+    let output = Command::new("/usr/local/bin/container")
+        .args(args)
+        .output()
+        .expect("list Apple Container resources");
+    assert!(
+        output.status.success(),
+        "resource listing failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("parse resource listing")
+        .as_array()
+        .expect("resource listing must be an array")
+        .iter()
+        .filter_map(|resource| resource.get("id")?.as_str())
+        .filter(|id| id.starts_with(prefix))
+        .map(str::to_string)
+        .collect()
+}
+
+fn crash_recovery_records() -> Vec<PathBuf> {
+    let directory = PathBuf::from(std::env::var_os("HOME").expect("HOME"))
+        .join("Library/Application Support/Microsoft/MXC/apple-container/recovery");
+    match fs::read_dir(directory) {
+        Ok(entries) => entries
+            .map(|entry| entry.expect("read recovery entry").path())
+            .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("json"))
+            .filter(|path| {
+                fs::read_to_string(path)
+                    .expect("read recovery record")
+                    .contains("\"containerHint\":\"crash-orphan\"")
+            })
+            .collect(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
+        Err(error) => panic!("read recovery directory: {error}"),
+    }
+}
+
+fn run_request(request: &ExecutionRequest, input: &[u8]) -> io::Result<RunOutput> {
+    let mut process = spawn_request(request).map_err(io::Error::other)?;
     let mut stdin = process.take_stdin().expect("stdin pipe");
-    stdin.write_all(b"stream-value\n").expect("write stdin");
-    drop(stdin);
-
     let mut stdout = process.take_stdout().expect("stdout pipe");
     let mut stderr = process.take_stderr().expect("stderr pipe");
-    let stdout_thread = std::thread::spawn(move || {
+    let stdout_thread = thread::spawn(move || {
         let mut output = String::new();
-        stdout.read_to_string(&mut output).expect("read stdout");
-        output
+        stdout.read_to_string(&mut output)?;
+        Ok::<_, io::Error>(output)
     });
-    let stderr_thread = std::thread::spawn(move || {
+    let stderr_thread = thread::spawn(move || {
         let mut output = String::new();
-        stderr.read_to_string(&mut output).expect("read stderr");
-        output
+        stderr.read_to_string(&mut output)?;
+        Ok::<_, io::Error>(output)
     });
 
-    assert_eq!(process.wait().expect("wait"), 9);
+    stdin.write_all(input)?;
+    drop(stdin);
+    let exit_code = process.wait();
+    let stdout = stdout_thread
+        .join()
+        .map_err(|_| io::Error::other("stdout reader panicked"))??;
+    let stderr = stderr_thread
+        .join()
+        .map_err(|_| io::Error::other("stderr reader panicked"))??;
+
+    Ok(RunOutput {
+        exit_code: exit_code?,
+        stdout,
+        stderr,
+    })
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn streams_stdin_stdout_stderr_and_propagates_exit_code() {
+    let output = run_request(
+        &request(
+            "read value; printf 'stdout:%s\\n' \"$value\"; \
+             printf 'stderr:%s\\n' \"$value\" >&2; exit 9",
+            ALPINE_IMAGE,
+            NetworkPolicy::Allow,
+        ),
+        b"stream-value\n",
+    )
+    .expect(INTEGRATION_REQUIREMENTS);
+
+    assert_eq!(output.exit_code, 9);
+    assert_eq!(output.stdout, "stdout:stream-value\n");
+    assert_eq!(output.stderr, "stderr:stream-value\n");
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn honors_environment_working_directory_and_mount_access() {
+    let root = TempDir::new("policy");
+    let readwrite = root.path.join("readwrite");
+    let readonly = root.path.join("readonly");
+    fs::create_dir(&readwrite).unwrap();
+    fs::create_dir(&readonly).unwrap();
+    fs::write(readonly.join("input.txt"), "read-only-input\n").unwrap();
+
+    let script = format!(
+        "test \"$MXC_QUALIFICATION\" = expected && \
+         test \"$PWD\" = \"{readwrite}\" && \
+         cat \"{readonly}/input.txt\" && \
+         printf 'written\\n' > output.txt && \
+         if printf 'forbidden\\n' > \"{readonly}/forbidden.txt\" 2>/dev/null; then \
+           exit 41; \
+         fi && \
+         cat output.txt",
+        readwrite = readwrite.display(),
+        readonly = readonly.display(),
+    );
+    let mut request = request(script, ALPINE_IMAGE, NetworkPolicy::Allow);
+    request.working_directory = readwrite.to_string_lossy().into_owned();
+    request.env = vec!["MXC_QUALIFICATION=expected".to_string()];
+    request.policy.readwrite_paths = vec![readwrite.to_string_lossy().into_owned()];
+    request.policy.readonly_paths = vec![readonly.to_string_lossy().into_owned()];
+
+    let output = run_request(&request, b"").expect(INTEGRATION_REQUIREMENTS);
+
+    assert_eq!(output.exit_code, 0, "{}", output.stderr);
+    assert_eq!(output.stdout, "read-only-input\nwritten\n");
     assert_eq!(
-        stdout_thread.join().expect("stdout thread"),
-        "stdout:stream-value\n"
+        fs::read_to_string(readwrite.join("output.txt")).unwrap(),
+        "written\n"
+    );
+    assert!(!readonly.join("forbidden.txt").exists());
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn timeout_terminates_the_workload_and_cleans_up() {
+    let mut request = request("sleep 60", ALPINE_IMAGE, NetworkPolicy::Allow);
+    request.script_timeout = 500;
+    let mut process = spawn_request(&request).expect(INTEGRATION_REQUIREMENTS);
+
+    let error = process.wait().expect_err("workload should time out");
+
+    assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    assert!(error.to_string().contains("timed out"), "{error}");
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn concurrent_runs_keep_streams_and_resources_isolated() {
+    let runs = ["first", "second", "third"].map(|marker| {
+        thread::spawn(move || {
+            run_request(
+                &request(
+                    format!("sleep 1; printf '{marker}\\n'"),
+                    ALPINE_IMAGE,
+                    NetworkPolicy::Allow,
+                ),
+                b"",
+            )
+        })
+    });
+
+    for (run, expected) in runs.into_iter().zip(["first\n", "second\n", "third\n"]) {
+        let output = run
+            .join()
+            .expect("qualification thread")
+            .expect(INTEGRATION_REQUIREMENTS);
+        assert_eq!(output.exit_code, 0, "{}", output.stderr);
+        assert_eq!(output.stdout, expected);
+    }
+}
+
+#[test]
+#[ignore = "helper invoked by crash_recovery_reclaims_orphaned_resources"]
+fn crash_recovery_helper() {
+    if std::env::var_os("MXC_APPLE_CRASH_HELPER").is_none() {
+        return;
+    }
+    let mut crash_request = request("sleep 60", ALPINE_IMAGE, NetworkPolicy::Block);
+    crash_request.container_id = "crash-orphan".to_string();
+    let _process = spawn_request(&crash_request).expect(INTEGRATION_REQUIREMENTS);
+    thread::sleep(Duration::from_secs(3));
+    std::process::exit(86);
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn crash_recovery_reclaims_orphaned_resources() {
+    let status = Command::new(std::env::current_exe().expect("current test executable"))
+        .args([
+            "--ignored",
+            "--exact",
+            "crash_recovery_helper",
+            "--nocapture",
+        ])
+        .env("MXC_APPLE_CRASH_HELPER", "1")
+        .status()
+        .expect("launch crash helper");
+    assert_eq!(status.code(), Some(86));
+
+    assert_eq!(
+        resource_ids(&["list", "--all", "--format", "json"], "mxc-crash-orphan-").len(),
+        1,
+        "crash helper must leave exactly one owned container"
     );
     assert_eq!(
-        stderr_thread.join().expect("stderr thread"),
-        "stderr:stream-value\n"
+        resource_ids(
+            &["network", "list", "--format", "json"],
+            "mxc-crash-orphan-"
+        )
+        .len(),
+        1,
+        "crash helper must leave exactly one owned network"
     );
+    assert_eq!(
+        crash_recovery_records().len(),
+        1,
+        "crash helper must leave exactly one recovery record"
+    );
+
+    let output = run_request(
+        &request("printf 'recovered\\n'", ALPINE_IMAGE, NetworkPolicy::Allow),
+        b"",
+    )
+    .expect("next run must reclaim the orphan before launching");
+
+    assert_eq!(output.exit_code, 0, "{}", output.stderr);
+    assert_eq!(output.stdout, "recovered\n");
+    assert!(
+        resource_ids(&["list", "--all", "--format", "json"], "mxc-crash-orphan-").is_empty(),
+        "recovery must remove the orphaned container"
+    );
+    assert!(
+        resource_ids(
+            &["network", "list", "--format", "json"],
+            "mxc-crash-orphan-"
+        )
+        .is_empty(),
+        "recovery must remove the orphaned network"
+    );
+    assert!(
+        crash_recovery_records().is_empty(),
+        "recovery must remove the orphaned recovery record"
+    );
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn blocked_network_preserves_loopback_and_denies_public_egress() {
+    let script = r#"python3 - <<'PY'
+import socket
+import threading
+
+for family, address in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+    listener = socket.socket(family, socket.SOCK_STREAM)
+    listener.bind((address, 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def serve():
+        connection, _ = listener.accept()
+        connection.sendall(b"pong")
+        connection.close()
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    client = socket.create_connection((address, port), timeout=3)
+    assert client.recv(4) == b"pong"
+    client.close()
+    thread.join(3)
+    assert not thread.is_alive()
+    listener.close()
+
+try:
+    socket.create_connection(("1.1.1.1", 443), timeout=3)
+except OSError:
+    print("blocked-network-qualified")
+else:
+    raise SystemExit("public direct-IP egress unexpectedly succeeded")
+PY"#;
+    let output = run_request(&request(script, PYTHON_IMAGE, NetworkPolicy::Block), b"")
+        .expect(INTEGRATION_REQUIREMENTS);
+
+    assert_eq!(output.exit_code, 0, "{}", output.stderr);
+    assert_eq!(output.stdout, "blocked-network-qualified\n");
+}
+
+#[test]
+#[ignore = "requires Apple Container 1.2.2 and the qualification images"]
+fn workload_root_cannot_remove_block_network_firewall() {
+    let output = run_request(
+        &request(
+            "test -x /usr/sbin/iptables || { echo 'iptables is missing' >&2; exit 41; }; \
+             if /usr/sbin/iptables -w -F >/tmp/flush.out 2>&1; then \
+               cat /tmp/flush.out >&2; exit 42; \
+             fi; \
+             grep -Eiq 'permission denied|operation not permitted' /tmp/flush.out || { \
+               cat /tmp/flush.out >&2; exit 43; \
+             }; \
+             printf 'firewall-protected\\n'",
+            NETWORK_BLOCK_INIT_IMAGE,
+            NetworkPolicy::Block,
+        ),
+        b"",
+    )
+    .expect(INTEGRATION_REQUIREMENTS);
+
+    assert_eq!(output.exit_code, 0, "{}", output.stderr);
+    assert_eq!(output.stdout, "firewall-protected\n");
 }

--- a/tests/examples/30_apple_container_allow.json
+++ b/tests/examples/30_apple_container_allow.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "../../schemas/dev/mxc-config.schema.0.8.0-dev.json",
+    "version": "0.8.0-alpha",
+    "containment": "apple_container",
+    "containerId": "apple-container-allow",
+    "process": {
+        "commandLine": "printf 'MXC_BACKEND=%s\\n' \"$MXC_BACKEND\" && uname -a",
+        "cwd": "/",
+        "env": [
+            "MXC_BACKEND=apple_container"
+        ],
+        "timeout": 30000
+    },
+    "network": {
+        "defaultPolicy": "allow"
+    },
+    "experimental": {
+        "apple_container": {
+            "image": "docker.io/library/alpine:3.22",
+            "cpuCount": 2,
+            "memoryMb": 1024
+        }
+    }
+}

--- a/tests/examples/31_apple_container_block.json
+++ b/tests/examples/31_apple_container_block.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "../../schemas/dev/mxc-config.schema.0.8.0-dev.json",
+    "version": "0.8.0-alpha",
+    "containment": "apple_container",
+    "containerId": "apple-container-block",
+    "process": {
+        "commandLine": "printf 'workspace output\\n' > result.txt && cat /tmp/mxc-apple-inputs/message.txt && cat result.txt",
+        "cwd": "/tmp/mxc-apple-workspace",
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readwritePaths": [
+            "/tmp/mxc-apple-workspace"
+        ],
+        "readonlyPaths": [
+            "/tmp/mxc-apple-inputs"
+        ]
+    },
+    "network": {
+        "defaultPolicy": "block"
+    },
+    "experimental": {
+        "apple_container": {
+            "image": "docker.io/library/alpine:3.22",
+            "cpuCount": 2,
+            "memoryMb": 1024
+        }
+    }
+}

--- a/tests/scripts/README.md
+++ b/tests/scripts/README.md
@@ -53,6 +53,17 @@ Linux / macOS (`.sh`):
 Individual `run_bwrap_*.sh` / `run_lxc_*.sh` scripts run one case each; the
 aggregate scripts above are what CI dispatches to.
 
+### macOS qualification
+
+| Script | Description | Extra prerequisites |
+|--------|-------------|---------------------|
+| `run_apple_container_network_qualification.sh` | Local Apple Container network-boundary qualification | macOS 26+, Apple silicon, Apple Container 1.2.2 with its service running, Node.js |
+
+The Apple Container wrapper reproducibly builds and verifies the fixed MXC
+guest-init image before testing IPv4/IPv6 loopback, public and host access,
+unsolicited host-to-guest access, and workload firewall tampering. It is a
+local qualification gate and is not dispatched by CI.
+
 Not every script runs in CI: several depend on local OS features such as
 Windows Sandbox, WHP, proxy setup, or stress-test duration. The ones CI does
 run are reached through the dispatchers below rather than being invoked

--- a/tests/scripts/apple_container_network_qualification.mjs
+++ b/tests/scripts/apple_container_network_qualification.mjs
@@ -1,0 +1,607 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import net from "node:net";
+import os from "node:os";
+import process from "node:process";
+
+const COMMAND_TIMEOUT_MS = 90_000;
+const CONNECT_TIMEOUT_MS = 3_000;
+const IMAGE =
+  process.env.APPLE_CONTAINER_QUALIFICATION_IMAGE ??
+  "docker.io/library/python:3.13-alpine";
+const INIT_IMAGE = process.env.APPLE_CONTAINER_QUALIFICATION_INIT_IMAGE;
+const EXTERNAL_CONTROL = { host: "1.1.1.1", port: 443 };
+const OWNERSHIP_LABEL = "com.microsoft.mxc.qualification=true";
+const FIREWALL_TAMPER_PROGRAM = String.raw`
+test -x /usr/sbin/iptables || {
+  printf 'MXC_QUALIFICATION={"ok":false,"code":"IPTABLES_MISSING"}\n'
+  exit 41
+}
+cap_eff="$(awk '/^CapEff:/ { print $2 }' /proc/self/status)"
+if [ $((0x$cap_eff & 0x1000)) -ne 0 ]; then
+  printf 'MXC_QUALIFICATION={"ok":false,"code":"CAP_NET_ADMIN_PRESENT","message":"CapEff=%s"}\n' "$cap_eff"
+  exit 42
+fi
+set +e
+output="$(/usr/sbin/iptables -w -F 2>&1)"
+status="$?"
+set -e
+if [ "$status" -eq 0 ]; then
+  printf 'MXC_QUALIFICATION={"ok":false,"code":"FLUSH_SUCCEEDED","message":"CapEff=%s"}\n' "$cap_eff"
+  exit 43
+fi
+if ! printf '%s' "$output" | grep -Eiq 'permission denied|operation not permitted'; then
+  printf 'MXC_QUALIFICATION={"ok":false,"code":"WRONG_FAILURE","message":"CapEff=%s"}\n' "$cap_eff"
+  exit 44
+fi
+printf 'MXC_QUALIFICATION={"ok":true,"code":"EPERM","message":"CapEff=%s"}\n' "$cap_eff"
+`;
+
+const LOOPBACK_PROGRAM = String.raw`
+import json
+import socket
+import threading
+
+results = []
+for family, host, label in (
+    (socket.AF_INET, "127.0.0.1", "ipv4"),
+    (socket.AF_INET6, "::1", "ipv6"),
+):
+    listener = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        listener.bind((host, 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        accepted = []
+
+        def serve():
+            connection, _ = listener.accept()
+            accepted.append(connection.recv(16).decode())
+            connection.sendall(b"pong")
+            connection.close()
+
+        thread = threading.Thread(target=serve)
+        thread.start()
+        client = socket.socket(family, socket.SOCK_STREAM)
+        client.settimeout(3)
+        client.connect((host, port))
+        client.sendall(b"ping")
+        reply = client.recv(16).decode()
+        client.close()
+        thread.join(3)
+        results.append({
+            "family": label,
+            "ok": reply == "pong" and accepted == ["ping"],
+            "port": port,
+        })
+    except OSError as error:
+        results.append({
+            "family": label,
+            "ok": False,
+            "code": error.errno,
+            "message": str(error),
+        })
+    finally:
+        listener.close()
+
+print("MXC_QUALIFICATION=" + json.dumps(results))
+`;
+
+const CONNECT_PROGRAM = String.raw`
+import json
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+try:
+    connection = socket.create_connection((host, port), timeout=3)
+    connection.close()
+    result = {"ok": True}
+except OSError as error:
+    result = {
+        "ok": False,
+        "code": error.errno if error.errno is not None else type(error).__name__,
+        "message": str(error),
+    }
+print("MXC_QUALIFICATION=" + json.dumps(result))
+sys.exit(0 if result["ok"] else 23)
+`;
+
+function randomToken() {
+  return `${process.pid.toString(16)}${Date.now().toString(16)}${Math.random()
+    .toString(16)
+    .slice(2, 10)}`;
+}
+
+function run(command, args, { allowFailure = false } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        child.kill("SIGKILL");
+      }
+    }, COMMAND_TIMEOUT_MS);
+
+    child.once("error", (error) => {
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (exitCode, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      const result = {
+        exitCode,
+        signal,
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+      };
+      if (!allowFailure && exitCode !== 0) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} failed with exit ${exitCode}: ${result.stderr || result.stdout}`,
+          ),
+        );
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+function initImageArgs() {
+  return ["--init-image", INIT_IMAGE];
+}
+
+function parseMarker(output) {
+  let marker = null;
+  for (const line of output.split(/\r?\n/u)) {
+    if (line.startsWith("MXC_QUALIFICATION=")) {
+      marker = line;
+    }
+  }
+  if (!marker) {
+    throw new Error(`probe produced no qualification marker: ${output}`);
+  }
+  return JSON.parse(marker.slice("MXC_QUALIFICATION=".length));
+}
+
+function nonLoopbackIpv4Address() {
+  for (const addresses of Object.values(os.networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      const ipv4 = address.family === "IPv4" || address.family === 4;
+      if (ipv4 && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+  return null;
+}
+
+function listen(host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer((socket) => {
+      socket.on("error", () => {});
+      socket.end("host-control");
+    });
+    server.once("error", reject);
+    server.listen({ host, port: 0, exclusive: true }, () => {
+      resolve({ server, address: server.address() });
+    });
+  });
+}
+
+function connectFromHost(host, port) {
+  return new Promise((resolve) => {
+    const socket = net.createConnection({ host, port });
+    let finished = false;
+
+    const finish = (result) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(CONNECT_TIMEOUT_MS, () => {
+      finish({ ok: false, code: "ETIMEDOUT" });
+    });
+    socket.once("connect", () => finish({ ok: true }));
+    socket.once("error", (error) => {
+      finish({ ok: false, code: error.code, message: error.message });
+    });
+  });
+}
+
+async function runGuestConnect(
+  binary,
+  networkName,
+  host,
+  port,
+  containerName,
+  trackedContainers,
+  { guestFirewall = false } = {},
+) {
+  trackedContainers.add(containerName);
+  const result = await run(
+    binary,
+    [
+      "run",
+      "--name",
+      containerName,
+      "--label",
+      OWNERSHIP_LABEL,
+      "--network",
+      networkName,
+      ...(guestFirewall ? initImageArgs() : []),
+      "--progress",
+      "none",
+      IMAGE,
+      "python3",
+      "-c",
+      CONNECT_PROGRAM,
+      host,
+      String(port),
+    ],
+    { allowFailure: true },
+  );
+  const probe = parseMarker(result.stdout);
+  return {
+    commandExitCode: result.exitCode,
+    probe,
+    stderr: result.stderr,
+  };
+}
+
+function inspectContainerAddress(json) {
+  const parsed = JSON.parse(json);
+  const container = Array.isArray(parsed) ? parsed[0] : parsed;
+  const cidr = container?.status?.networks?.[0]?.ipv4Address;
+  if (typeof cidr !== "string") {
+    throw new Error("container inspect did not return an IPv4 network address");
+  }
+  return cidr.split("/", 1)[0];
+}
+
+function report(profile, direction, destination, result) {
+  const outcome = result?.ok ? "PASS" : `DENY(${result?.code ?? "UNKNOWN"})`;
+  console.log(
+    [
+      os.release(),
+      os.arch(),
+      profile,
+      direction,
+      destination,
+      outcome,
+      result?.message ?? "",
+    ].join("\t"),
+  );
+}
+
+async function cleanup(binary, containerNames, networkName) {
+  for (const containerName of containerNames) {
+    await run(binary, ["delete", "--force", containerName], {
+      allowFailure: true,
+    });
+  }
+  if (networkName) {
+    await run(binary, ["network", "delete", networkName], {
+      allowFailure: true,
+    });
+  }
+}
+
+async function waitForGuestListener(binary, containerName, guestPort) {
+  let lastResult = null;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const control = await run(
+      binary,
+      [
+        "exec",
+        containerName,
+        "python3",
+        "-c",
+        CONNECT_PROGRAM,
+        "127.0.0.1",
+        String(guestPort),
+      ],
+      { allowFailure: true },
+    );
+    try {
+      lastResult = parseMarker(control.stdout);
+    } catch {
+      lastResult = null;
+    }
+    if (lastResult?.ok) {
+      return lastResult;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return lastResult;
+}
+
+async function main(binary) {
+  const token = randomToken();
+  const networkName = `mxc-qualification-net-${token}`;
+  const listenerContainer = `mxc-qualification-listener-${token}`;
+  const trackedContainers = new Set();
+  const hostAddress = nonLoopbackIpv4Address();
+  if (!hostAddress) {
+    console.error("SKIP: no non-loopback IPv4 host address is available.");
+    process.exitCode = 77;
+    return;
+  }
+
+  const hostListener = await listen(hostAddress);
+  let networkCreated = false;
+
+  try {
+    const hostControl = await connectFromHost(
+      hostAddress,
+      hostListener.address.port,
+    );
+    report("unsandboxed", "host", "host-non-loopback-listener", hostControl);
+    if (!hostControl.ok) {
+      throw new Error("unsandboxed host-listener control failed");
+    }
+
+    await run(binary, [
+      "network",
+      "create",
+      "--internal",
+      "--label",
+      OWNERSHIP_LABEL,
+      networkName,
+    ]);
+    networkCreated = true;
+
+    const loopbackContainer = `mxc-qualification-loopback-${token}`;
+    trackedContainers.add(loopbackContainer);
+    const loopback = await run(binary, [
+      "run",
+      "--name",
+      loopbackContainer,
+      "--label",
+      OWNERSHIP_LABEL,
+      "--network",
+      networkName,
+      ...initImageArgs(),
+      "--progress",
+      "none",
+      IMAGE,
+      "python3",
+      "-c",
+      LOOPBACK_PROGRAM,
+    ]);
+    const loopbackResults = parseMarker(loopback.stdout);
+    if (!Array.isArray(loopbackResults)) {
+      throw new Error(`guest loopback probe produced no result: ${loopback.stdout}`);
+    }
+    for (const result of loopbackResults) {
+      report(
+        "internal",
+        "guest-to-guest",
+        `${result.family}-loopback`,
+        result,
+      );
+    }
+
+    const natExternal = await runGuestConnect(
+      binary,
+      "default",
+      EXTERNAL_CONTROL.host,
+      EXTERNAL_CONTROL.port,
+      `mxc-qualification-nat-external-${token}`,
+      trackedContainers,
+    );
+    report(
+      "default-nat",
+      "guest-outbound",
+      "public-direct-ip",
+      natExternal.probe,
+    );
+
+    const internalExternal = await runGuestConnect(
+      binary,
+      networkName,
+      EXTERNAL_CONTROL.host,
+      EXTERNAL_CONTROL.port,
+      `mxc-qualification-block-external-${token}`,
+      trackedContainers,
+      { guestFirewall: true },
+    );
+    report(
+      "internal",
+      "guest-outbound",
+      "public-direct-ip",
+      internalExternal.probe,
+    );
+
+    const natHost = await runGuestConnect(
+      binary,
+      "default",
+      hostAddress,
+      hostListener.address.port,
+      `mxc-qualification-nat-host-${token}`,
+      trackedContainers,
+    );
+    report(
+      "default-nat",
+      "guest-outbound",
+      "host-non-loopback-listener",
+      natHost.probe,
+    );
+
+    const internalHost = await runGuestConnect(
+      binary,
+      networkName,
+      hostAddress,
+      hostListener.address.port,
+      `mxc-qualification-block-host-${token}`,
+      trackedContainers,
+      { guestFirewall: true },
+    );
+    report(
+      "internal",
+      "guest-outbound",
+      "host-non-loopback-listener",
+      internalHost.probe,
+    );
+
+    const guestPort = 38_000 + Math.floor(Math.random() * 10_000);
+    trackedContainers.add(listenerContainer);
+    await run(binary, [
+      "run",
+      "--detach",
+      "--name",
+      listenerContainer,
+      "--label",
+      OWNERSHIP_LABEL,
+      "--network",
+      networkName,
+      ...initImageArgs(),
+      "--progress",
+      "none",
+      IMAGE,
+      "python3",
+      "-m",
+      "http.server",
+      String(guestPort),
+      "--bind",
+      "0.0.0.0",
+    ]);
+    const guestSelfResult = await waitForGuestListener(
+      binary,
+      listenerContainer,
+      guestPort,
+    );
+    report(
+      "internal",
+      "guest-self",
+      "guest-listener",
+      guestSelfResult,
+    );
+    if (!guestSelfResult?.ok) {
+      throw new Error("guest listener control failed before inbound isolation test");
+    }
+
+    const inspected = await run(binary, ["inspect", listenerContainer]);
+    const guestAddress = inspectContainerAddress(inspected.stdout);
+    const hostToGuest = await connectFromHost(guestAddress, guestPort);
+    report("internal", "host-inbound", "guest-listener", hostToGuest);
+
+    const tamperContainer = `mxc-qualification-tamper-${token}`;
+    trackedContainers.add(tamperContainer);
+    const tamper = await run(
+      binary,
+      [
+        "run",
+        "--name",
+        tamperContainer,
+        "--label",
+        OWNERSHIP_LABEL,
+        "--network",
+        networkName,
+        "--init-image",
+        INIT_IMAGE,
+        "--progress",
+        "none",
+        INIT_IMAGE,
+        "/bin/sh",
+        "-c",
+        FIREWALL_TAMPER_PROGRAM,
+      ],
+      { allowFailure: true },
+    );
+    const firewallTamper = parseMarker(tamper.stdout);
+    report("internal", "workload-root", "firewall-flush", firewallTamper);
+
+    const failures = [];
+    if (!loopbackResults.every((result) => result.ok)) {
+      failures.push("guest IPv4/IPv6 loopback did not both succeed");
+    }
+    if (internalExternal.probe?.ok) {
+      failures.push("internal network permitted public direct-IP egress");
+    }
+    if (!natExternal.probe?.ok) {
+      console.log(
+        "INCONCLUSIVE: default NAT could not reach the public direct-IP control.",
+      );
+    }
+    if (internalHost.probe?.ok) {
+      failures.push("internal network permitted access to a macOS host listener");
+    }
+    if (!natHost.probe?.ok) {
+      console.log(
+        "INCONCLUSIVE: default NAT could not reach the macOS host-listener control.",
+      );
+    }
+    if (hostToGuest.ok) {
+      failures.push("macOS could reach an unpublished listener in the guest");
+    }
+    if (!firewallTamper?.ok || firewallTamper.code !== "EPERM") {
+      failures.push("workload root firewall tamper was not denied with EPERM");
+    }
+
+    if (failures.length > 0) {
+      throw new Error(`network security gate failed: ${failures.join("; ")}`);
+    }
+    if (!natExternal.probe?.ok || !natHost.probe?.ok) {
+      throw new Error("network security gate is inconclusive because a control failed");
+    }
+
+    console.log(
+      "\nQUALIFICATION PASS: Apple Container networking met the tested MXC boundary.",
+    );
+  } finally {
+    hostListener.server.close();
+    await cleanup(
+      binary,
+      trackedContainers,
+      networkCreated ? networkName : null,
+    );
+  }
+}
+
+const [binary] = process.argv.slice(2);
+if (!binary) {
+  console.error(
+    "usage: apple_container_network_qualification.mjs /path/to/container",
+  );
+  process.exit(2);
+}
+if (!INIT_IMAGE) {
+  console.error(
+    "APPLE_CONTAINER_QUALIFICATION_INIT_IMAGE is required; run the qualification wrapper.",
+  );
+  process.exit(2);
+}
+
+try {
+  await main(binary);
+} catch (error) {
+  console.error(`FAIL: ${error.stack ?? error.message}`);
+  process.exitCode = 1;
+}

--- a/tests/scripts/run_apple_container_network_qualification.sh
+++ b/tests/scripts/run_apple_container_network_qualification.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SKIP_EXIT=77
+INIT_IMAGE="local/mxc-loopback-init:0.2"
+
+skip() {
+    echo "SKIP: $1"
+    exit "$SKIP_EXIT"
+}
+
+[ "$(uname -s)" = "Darwin" ] || skip "Apple Container requires macOS."
+[ "$(uname -m)" = "arm64" ] || skip "Apple Container requires Apple silicon."
+
+macos_major="$(sw_vers -productVersion | cut -d. -f1)"
+[ "$macos_major" -ge 26 ] || skip "Apple Container requires macOS 26 or later."
+
+command -v node >/dev/null 2>&1 || skip "Node.js is required by the qualification harness."
+
+if [ -n "${APPLE_CONTAINER_BIN:-}" ]; then
+    APPLE_CONTAINER_BIN="$(cd "$(dirname "$APPLE_CONTAINER_BIN")" && pwd)/$(basename "$APPLE_CONTAINER_BIN")"
+else
+    APPLE_CONTAINER_BIN="/usr/local/bin/container"
+fi
+
+[ -x "$APPLE_CONTAINER_BIN" ] ||
+    skip "Apple Container is not installed at $APPLE_CONTAINER_BIN."
+
+if ! "$APPLE_CONTAINER_BIN" system status --format json >/dev/null 2>&1; then
+    skip "Apple Container service is not running; run 'container system start'."
+fi
+
+"$REPO_ROOT/src/backends/apple_container/init/build.sh"
+export APPLE_CONTAINER_QUALIFICATION_INIT_IMAGE="$INIT_IMAGE"
+
+echo "Apple Container network qualification"
+echo "Binary: $APPLE_CONTAINER_BIN"
+echo "MXC init: $APPLE_CONTAINER_QUALIFICATION_INIT_IMAGE"
+"$APPLE_CONTAINER_BIN" --version
+sw_vers
+uname -a
+sysctl -n hw.optional.arm64 2>/dev/null || true
+echo
+
+exec node "$SCRIPT_DIR/apple_container_network_qualification.mjs" "$APPLE_CONTAINER_BIN"


### PR DESCRIPTION
## 📖 Description

Adds the samples and local qualification layer for the experimental Apple
Container one-shot backend introduced by #972.

- adds raw allow-network and default-block `0.8.0-alpha` configurations;
- updates the Node SDK example and runtime guidance;
- expands real-runtime coverage for streams, mounts, timeout cleanup,
  concurrency, network isolation, firewall tamper resistance, and hard-exit
  recovery;
- adds a local network-boundary harness that reproducibly builds and verifies
  the pinned MXC init image before qualification;
- hardens mount overlap validation, recovery record creation, and bounded
  cleanup uncovered by the qualification suite.

The Apple Container qualification remains local-only and does not add a CI
workflow.

## 🔗 References

- #972

## 🔍 Validation

- Validated 234 example/config files against the dev schema.
- Built the Node SDK and passed the three targeted Apple Container unit tests.
- Passed all 25 `apple_container_common` unit tests.
- Passed all eight ignored real-runtime Apple Container qualification tests.
- Passed the local Apple Container network-boundary qualification.
- Ran both raw sample configurations through `mxc-exec-mac`.
- Passed the exact macOS release build/test package matrix and Clippy with
  warnings denied.
- Passed Rust formatting and diff whitespace checks.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with
the GitHub Actions build; it runs on merge to `main`, and Microsoft reviewers
with write access can trigger it on a PR with `/azp run`.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1030)