### PR TITLE
Upgrade the C# test suite to xUnit v3 and report skips as skips

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ rustup component add rust-analyzer
 npm install -g typescript-language-server typescript
 ```
 
-Building or testing the C# SDK (`sdk/dotnet/`) additionally requires the .NET SDK (net8.0 or newer; a net8.0 target is used).
+Building the C# SDK (`sdk/dotnet/`) additionally requires the .NET SDK; the projects target `net8.0`. Running the tests with `dotnet test` requires .NET SDK 10 or newer.
 
 ## Build Commands
 
@@ -138,7 +138,7 @@ npm test
 npm run test:integration
 
 # C# SDK (from sdk/dotnet/)
-dotnet test Microsoft.Mxc.Sdk.slnx           # builds mxc_ffi via cargo (Rust toolchain required)
+dotnet test --solution Microsoft.Mxc.Sdk.slnx   # builds mxc_ffi via cargo (Rust toolchain required)
 
 # Local PowerShell helpers — run from repo root, require built binaries
 tests\scripts\run_test_configs.ps1            # All test configs via wxc_test_driver

--- a/global.json
+++ b/global.json
@@ -1,0 +1,1 @@
+{ "test": { "runner": "Microsoft.Testing.Platform" } }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/Microsoft.Mxc.Sdk.Tests.csproj
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/Microsoft.Mxc.Sdk.Tests.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <!-- xUnit v3 test projects are executables that run themselves. -->
+    <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -11,9 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Mxc.Sdk.Tests;
 public class MxcLifecycleE2ETests
 {
     // Opt-in gate shared with the streaming E2E tests: a host that can really run
-    // a sandbox sets MXC_E2E_HOST_PREPPED=1. Elsewhere these return early.
+    // a sandbox sets MXC_E2E_HOST_PREPPED=1. Elsewhere these skip.
     private static bool HostRunsIsolationSession =>
         Environment.GetEnvironmentVariable("MXC_E2E_HOST_PREPPED") == "1"
         && OperatingSystem.IsWindows();
@@ -138,15 +138,15 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Exec_RunsAsTheAgentUserFromTheProvisionMetadata()
     {
-        if (!HostRunsIsolationSession)
-        {
-            return; // skipped: no isolation-session host available
-        }
+        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
 
         var started = ProvisionAndStart();
         using (started.Teardown)
         {
-            var run = await MxcLifecycle.ExecInSandboxAsync(started.Id, $"{Cmd} /c whoami");
+            var run = await MxcLifecycle.ExecInSandboxAsync(
+            started.Id,
+            $"{Cmd} /c whoami",
+            TestContext.Current.CancellationToken);
 
             Assert.Equal(0, run.ExitCode);
             Assert.Equal(started.AgentUserName.ToLowerInvariant(), AccountOf(run.Stdout));
@@ -158,10 +158,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Exec_PropagatesANonZeroExitCode()
     {
-        if (!HostRunsIsolationSession)
-        {
-            return; // skipped: no isolation-session host available
-        }
+        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -181,10 +178,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Deprovision_RetiresTheSandboxId()
     {
-        if (!HostRunsIsolationSession)
-        {
-            return; // skipped: no isolation-session host available
-        }
+        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -203,10 +197,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Lifecycle_RunsEndToEnd()
     {
-        if (!HostRunsIsolationSession)
-        {
-            return; // skipped: no isolation-session host available
-        }
+        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -223,10 +214,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Workspace_IsSharedWithTheAgent_AndRemovedOnDeprovision()
     {
-        if (!HostRunsIsolationSession)
-        {
-            return; // skipped: no isolation-session host available
-        }
+        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
 
         var started = ProvisionAndStart();
         using (started.Teardown)

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
@@ -64,12 +64,10 @@ public class MxcLifecycleTests
         // cannot: it is a separate entry point. That gate short-circuits ahead of
         // backend dispatch, which is also why this test cannot pin the
         // experimental opt-in.
-        if (!Console.IsOutputRedirected || !Console.IsInputRedirected)
-        {
-            // A console host satisfies the terminal gate, so the call would
-            // dispatch a real attached exec rather than be refused by it.
-            return;
-        }
+        Assert.SkipUnless(
+            Console.IsOutputRedirected && Console.IsInputRedirected,
+            "a console host satisfies the terminal gate, so the call would "
+                + "dispatch a real attached exec rather than be refused by it");
 
         var ex = Assert.Throws<MxcException>(
             () => MxcLifecycle.ExecInSandboxAttached(

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxProcessTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxProcessTests.cs
@@ -12,8 +12,7 @@ public class MxcSandboxProcessTests
     // Real spawn requires a host able to launch a sandboxed process (an
     // elevated, host-prepped Windows host, or a capable Linux/macOS host). CI
     // lanes that provide one set MXC_E2E_HOST_PREPPED=1 to opt in; elsewhere the
-    // streaming round-trip test returns early (skips), mirroring the Rust
-    // `#[ignore]` gating.
+    // gated tests skip.
     private static bool HostCanSpawn =>
         Environment.GetEnvironmentVariable("MXC_E2E_HOST_PREPPED") == "1";
 
@@ -45,10 +44,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void StreamingEchoRoundTrip_ReadsStdout_AndExitsZero()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
         var command = OperatingSystem.IsWindows()
@@ -71,10 +67,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task StreamingEcho_WaitForExitWithOutputAsync_CapturesStdout()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
         var command = OperatingSystem.IsWindows()
@@ -82,7 +75,8 @@ public class MxcSandboxProcessTests
             : "echo mxc_async_ok";
 
         using var proc = MxcSandbox.Spawn(policy, command);
-        var (result, stdout, _) = await proc.WaitForExitWithOutputAsync();
+        var (result, stdout, _) = await proc.WaitForExitWithOutputAsync(
+            TestContext.Current.CancellationToken);
 
         Assert.False(result.TimedOut);
         Assert.Equal(0, result.ExitCode);
@@ -92,10 +86,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task Streaming_WritesStdin_AndReadsEchoedStdout()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // A cmd builtin (set /p) reads one stdin line and echoes it with delayed
         // expansion — no external process spawn, so it is robust to the sandbox
@@ -130,10 +121,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void Wait_IgnoringOutput_DoesNotDeadlock_AndExitsZero()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // The caller never touches StandardOutput/Error; Wait() must drain the
         // untaken streams so a chatty child cannot wedge on a full pipe.
@@ -152,10 +140,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void Dispose_AfterSpawn_IsIdempotent()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
         var command = OperatingSystem.IsWindows()
@@ -171,10 +156,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task Dispose_WhileReadingStdout_DoesNotCrash()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // Regression guard for the stream use-after-free: take stdout, start a
         // blocking read on a background thread, then dispose the process from
@@ -205,13 +187,15 @@ public class MxcSandboxProcessTests
             {
                 readError = e;
             }
-        });
+        }, TestContext.Current.CancellationToken);
 
         // Give the reader a moment to park inside the native read, then dispose.
-        await Task.Delay(50);
+        await Task.Delay(50, TestContext.Current.CancellationToken);
         proc.Dispose();
 
-        var finished = await Task.WhenAny(reader, Task.Delay(TimeSpan.FromSeconds(10))) == reader;
+        var finished = await Task.WhenAny(
+            reader,
+            Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)) == reader;
         Assert.True(finished, "reader should finish after dispose");
         Assert.Null(readError);
     }
@@ -226,10 +210,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void Kill_TerminatesRunningChild()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
         using var proc = MxcSandbox.Spawn(policy, BlockerCommand);
@@ -245,10 +226,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task Kill_DuringWaitAsync_Unblocks()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // The poll-based Wait design exists so Kill stays responsive during a
         // WaitAsync from another thread; prove the await completes after Kill.
@@ -257,13 +235,15 @@ public class MxcSandboxProcessTests
         var stdin = proc.StandardInput; // hold stdin open so the child blocks
         Assert.NotNull(stdin);
 
-        var waitTask = proc.WaitAsync();
-        await Task.Delay(100); // let the wait loop park
+        var waitTask = proc.WaitAsync(TestContext.Current.CancellationToken);
+        await Task.Delay(100, TestContext.Current.CancellationToken); // let the wait loop park
         Assert.False(waitTask.IsCompleted, "child should still be running");
 
         proc.Kill();
 
-        var finished = await Task.WhenAny(waitTask, Task.Delay(TimeSpan.FromSeconds(10)));
+        var finished = await Task.WhenAny(
+            waitTask,
+            Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         Assert.Same(waitTask, finished);
         var result = await waitTask;
         Assert.NotEqual(0, result.ExitCode);
@@ -272,10 +252,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task WaitAsync_Cancellation_AbandonsWithoutKilling()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // Cancelling WaitAsync abandons the wait (throwing) without killing the
         // child — the exact path that previously triggered the stream UAF.
@@ -295,10 +272,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task StandardError_IsReadable()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         var policy = new SandboxPolicy { Version = "0.8.0-alpha" };
         // Write one line to stdout and one to stderr (both cmd builtins).
@@ -306,7 +280,7 @@ public class MxcSandboxProcessTests
         using var proc = MxcSandbox.Spawn(policy, command);
 
         var (result, stdout, stderr) =
-            await proc.WaitForExitWithOutputAsync();
+            await proc.WaitForExitWithOutputAsync(TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("to-out", Encoding.UTF8.GetString(stdout));
@@ -316,10 +290,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task OutputHeavyChild_DoesNotDeadlock()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // Emit well over a pipe buffer (~64KB) on BOTH stdout and stderr. If the
         // streams were not drained concurrently the child would wedge on a full
@@ -329,7 +300,8 @@ public class MxcSandboxProcessTests
             @"C:\Windows\System32\cmd.exe /c for /L %i in (1,1,12000) do @(echo out-%i& echo err-%i 1>&2)";
         using var proc = MxcSandbox.Spawn(policy, command);
 
-        var (result, stdout, stderr) = await proc.WaitForExitWithOutputAsync();
+        var (result, stdout, stderr) = await proc.WaitForExitWithOutputAsync(
+            TestContext.Current.CancellationToken);
 
         Assert.Equal(0, result.ExitCode);
         Assert.True(stdout.Length > 64 * 1024, $"stdout was {stdout.Length} bytes");
@@ -341,10 +313,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void Wait_EnforcesPolicyTimeout()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // A short policy timeout must be honoured by the polling Wait() path:
         // try_wait never kills and spawn starts no native watchdog, so without
@@ -365,10 +334,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public void StandardOutput_AfterWaitDrains_Throws()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // Wait() drains any untaken standard stream on an internal task. Handing
         // that same stream back to the caller afterwards would race the drainer on
@@ -385,10 +351,7 @@ public class MxcSandboxProcessTests
     [Fact]
     public async Task WaitForExitWithOutputAsync_Cancellation_DoesNotDeadlock()
     {
-        if (!HostCanSpawn)
-        {
-            return; // skipped: no host backend available
-        }
+        Assert.SkipUnless(HostCanSpawn, "no host backend available");
 
         // Cancelling while the child is blocked (its pipes never reach EOF) must
         // not deadlock: the cancellation path kills the child so the parked native
@@ -401,7 +364,9 @@ public class MxcSandboxProcessTests
 
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
         var call = proc.WaitForExitWithOutputAsync(cts.Token);
-        var finished = await Task.WhenAny(call, Task.Delay(TimeSpan.FromSeconds(10)));
+        var finished = await Task.WhenAny(
+            call,
+            Task.Delay(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken));
         Assert.Same(call, finished);
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => call);
     }

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -187,11 +187,11 @@ device state into collection.
   interactive terminal inside an isolation session. Terminal behaviour has no
   automated oracle, so its `interactive`, `streaming` and `resize` scenarios are
   judged by whoever runs them; each states what to look for.
-- **`Microsoft.Mxc.Sdk.Tests`** — xUnit tests (`dotnet test`). The lifecycle and
-  streaming end-to-end tests need a capable host and run only when
+- **`Microsoft.Mxc.Sdk.Tests`** — xUnit v3 tests. The lifecycle and streaming
+  end-to-end tests need a capable host and skip, with a reason, unless
   `MXC_E2E_HOST_PREPPED=1`.
 
-Build/test everything: `dotnet test sdk/dotnet/Microsoft.Mxc.Sdk.slnx`.
+Build/test everything: `dotnet test --solution sdk/dotnet/Microsoft.Mxc.Sdk.slnx`.
 
 Run native telemetry-consent integration tests in the **Debug** configuration.
 


### PR DESCRIPTION
## 📖 Description

Host-gated tests in the C# suite early-`return` when `MXC_E2E_HOST_PREPPED` is unset. xUnit v2 counts an early return as a **pass**, so a test that never ran was indistinguishable from one that did — the suite reported green having exercised nothing.

xUnit v3 addresses both halves: `Assert.SkipUnless` reports a skip together with its reason, and test projects build as executables that run themselves.

Three gates convert — the `MXC_E2E_HOST_PREPPED` gates in `MxcSandboxProcessTests` and `MxcLifecycleE2ETests`, and the redirected-stdio gate guarding the attached-exec refusal in `MxcLifecycleTests`.

v3 runs on Microsoft.Testing.Platform, which the .NET 10 SDK no longer dispatches through the VSTest target. `global.json` selects the MTP runner, the documented invocation becomes `dotnet test --solution`, and `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` are removed since `xunit.v3` supplies the runner. Running the tests therefore needs .NET SDK 10 or newer, stated separately from the `net8.0` target the projects build against.

v3's `xUnit1051` analyzer requires `TestContext.Current.CancellationToken` at calls that accept one, and `TreatWarningsAsErrors` makes that a build failure, so those call sites now pass the test's token. No test assertion changed, and no test was added or removed.

**Limitation:** CI builds the solution but does not run these tests, so this gets three-OS coverage of restore, compilation and apphost generation — discovery, the runner and skip reporting are not covered by CI yet.

## 🔗 References

Follows #1035, which exposed the state-aware sandbox lifecycle through the C# SDK.

## 🔍 Validation

- Full local CI-parity gauntlet green, elevated: fmt, clippy, build and test with `isolation_session` on and off, ARM64 build, versioning gates, the C# SDK legs, and the Node SDK unit and integration suites.
- The isolation-session E2E suites on a capable Windows host: all green, including the C# suite running against real isolation sessions, with no leaked agent accounts.
- Operator-run interactive terminal scenarios across all four surfaces (`wxc-exec`, Rust SDK, C ABI, .NET SDK).
- Before and after on the same suite: previously no skips were reported on an incapable host; the host-gated tests now report as skips carrying their reason. The attached-exec terminal gate reports a skip under a console host in both the local gate and the E2E run — under v2 that was a silent pass.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Updated documentation (if applicable)
- [x] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1037)