### PR TITLE
[Bubblewrap] Define `any` as a protocol floor, not "all protocols"

### DIFF
--- a/docs/bwrap-support/bubblewrap-backend.md
+++ b/docs/bwrap-support/bubblewrap-backend.md
@@ -425,6 +425,26 @@ remaining covering blocks, so `allow 0.0.0.0/0 except 1.1.1.0/24` becomes a set
 of accepts that provably omit the carve-out rather than an accept followed by a
 hoped-for later deny.
 
+**Protocol support.** `ports[].protocol` accepts `tcp`, `udp`, `icmp`, and
+`any`. What Bubblewrap actually enforces is bounded by its *transport*, not by
+its rule engine: every mode that installs egress rules puts the sandbox behind
+`slirp4netns`, a userspace network stack that carries **TCP, UDP, and ICMP echo
+only**. No other IP protocol — SCTP, DCCP, GRE — has a path out of the
+namespace, whether or not a rule names it.
+
+| Selector | Rules emitted | Notes |
+|---|---|---|
+| `tcp` | `-p tcp` | |
+| `udp` | `-p udp` | |
+| `icmp` | `-p icmp` (IPv4) / `-p icmpv6` (IPv6) | Expands by destination address family, per the 0.8 contract. |
+| `any`, no `port` | no `-p` match at all | Matches every protocol, ICMP included. |
+| `any` with a `port` | `-p tcp` and `-p udp` | ICMP is omitted: it carries no port numbers for a port-scoped rule to name. |
+
+This meets the 0.8 floor — `any` covers at minimum TCP, UDP, and ICMPv4/6.
+ICMPv6 is satisfied vacuously: `slirp4netns` is launched without
+`--enable-ipv6`, so the namespace has no IPv6 route. The `ip6tables` rules
+render correctly, but nothing traverses them.
+
 **Mode selection.** Directional never resolves to the shared host namespace:
 
 | Directional policy | Resolved mode |

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -227,7 +227,7 @@ Egress peer and port fields (used in `egress.allow[]` / `egress.deny[]`; not sho
 |---|---|---|
 | `to[].cidr` | IPv4 / IPv6 CIDR, or 0.0.0.0/0 / ::/0 for any | Single CIDR string (CNI/Kubernetes style), replacing separate address + prefix length. |
 | `to[].except` | list of CIDRs, optional | Exclusions within the peer's CIDR (Kubernetes `ipBlock.except` style). Expressible on Windows process containers (WFP) and the Linux backends (iptables) as additional deny rules; not supported on Seatbelt (no destination filtering). |
-| `ports[].protocol` | tcp / udp / icmp / any | `any` matches all protocols. Enforced on Windows process containers (WFP) and the Linux backends (iptables); not supported on Seatbelt. |
+| `ports[].protocol` | tcp / udp / icmp / any | `any` matches at minimum TCP, UDP, and ICMPv4/6; a backend may match more. Enforced on Windows process containers (WFP) and the Linux backends (iptables); not supported on Seatbelt. |
 | `ports[].port` | uint16, optional | Destination port. Omit `ports` to match all ports/protocols. |
 | `ports[].endPort` | uint16, optional | End of a port range (Kubernetes `endPort` style); requires numeric port. Supported on Windows process containers (WFP) and the Linux backends (iptables); not supported on Seatbelt. |
 
@@ -237,6 +237,14 @@ is rejected rather than broadened into a wildcard.
 
 `icmp` expands by destination address family. A rule containing IPv4 and IPv6 peers produces both ICMPv4 and ICMPv6
 filters; a rule without `to` also produces both.
+
+`any` is a floor, not an exhaustive protocol list. Every backend that enforces
+port rules matches at minimum TCP, UDP, and ICMPv4/6; some match considerably
+more — Windows process containers cover a much wider set of IP protocols. The
+exact set is a backend property, so consult the backend's implementation doc
+when a policy depends on a protocol outside that floor. Pairing `any` with a
+`port` narrows the match to the protocols that carry port numbers, since a
+port-scoped filter cannot name a portless protocol such as ICMP.
 
 Ingress has no CIDR peers or port rules. `ingress.default` and
 `ingress.hostLoopback` are the complete GA ingress surface.

--- a/src/backends/bubblewrap/common/src/network_rules.rs
+++ b/src/backends/bubblewrap/common/src/network_rules.rs
@@ -632,8 +632,11 @@ fn lower_ports(ports: &[NetworkPort]) -> Result<Vec<PortSpec>, String> {
                     range: None,
                 });
             }
-            // Ports exist only for TCP and UDP, so `any` with a port narrows to
-            // those two rather than widening to every protocol on that number.
+            // `--dport` comes from a protocol match extension, so iptables
+            // cannot express a port without naming a protocol; `any` therefore
+            // narrows to TCP and UDP. Safe only because every mode installing
+            // these rules runs behind slirp4netns, which carries nothing else
+            // (#980).
             NetworkProtocol::Any => match range {
                 None => specs.push(PortSpec::ALL),
                 Some(range) => {
@@ -1824,8 +1827,8 @@ mod tests {
         );
     }
 
-    /// Ports exist only for TCP and UDP, so `any` carrying one narrows to those
-    /// two. Emitting no `-p` would open every protocol on that number.
+    /// `any` with a port narrows to TCP and UDP — `--dport` needs a protocol
+    /// match. See the #980 note in `lower_ports`.
     #[test]
     fn an_any_protocol_port_narrows_to_tcp_and_udp() {
         let req = directional_rules_request(


### PR DESCRIPTION
## 📖 Description

The 0.8 networking spec claimed `ports[].protocol: any` **"matches all protocols."** No backend meets that literally, and the set each one covers differs by platform — so the contract promised something nothing delivers.

This redefines `any` as a **floor**: at minimum TCP, UDP and ICMPv4/6, with backends free to match more. It documents Bubblewrap's actual coverage and corrects a factually wrong code comment.

**Spec** — `docs/sandbox-policy/0.8.0/networking/networking.md`
- `any` restated as a floor, with a pointer to per-backend implementation docs.
- New note on `any` + port: pairing them narrows the match to port-bearing protocols, since a port-scoped filter cannot name a portless protocol such as ICMP.

**Bubblewrap** — `docs/bwrap-support/bubblewrap-backend.md`
- New **Protocol support** subsection with the emitted-rule table. Bubblewrap's coverage is bounded by its *transport*, not its rule engine: every mode that installs egress rules sits behind slirp4netns, which carries TCP, UDP and ICMP echo alone.

**Code** — `src/backends/bubblewrap/common/src/network_rules.rs`
- Corrected the comment on the `any` arm of `lower_ports`. The old text claimed *"ports exist only for TCP and UDP"* — false, SCTP and DCCP both have ports. The real constraint is that `--dport` comes from a protocol match extension, so a port cannot be expressed without naming a protocol.

**No behavior change.** Comments only — no rule lowering was modified, and the existing narrowing test's assertions are untouched.

Bubblewrap meets the new floor — `any` with no port emits no `-p` match at all (ICMP covered); `any` with a port emits TCP+UDP, with ICMP correctly absent. ICMPv6 is satisfied vacuously: slirp runs without `--enable-ipv6`.

## 🔗 References

Resolves #980

Cross-backend behavior was probed directly rather than inferred — Winsock protocol catalog and socket creation for protocols 132/33 on Windows, SCTP module and socket availability under WSL2. Details in #980.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1038)