### PR TITLE
[MXC] State-aware contract surface for schema 0.9.0-dev

### DIFF
--- a/schemas/dev/mxc-config.schema.0.9.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.9.0-dev.json
@@ -201,6 +201,17 @@
           ],
           "description": "IsolationSession backend config (Windows)."
         },
+        "lxc": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LxcExperimental"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "LXC backend config (Linux)."
+        },
         "seatbelt": {
           "anyOf": [
             {
@@ -383,6 +394,43 @@
     "Lxc": {
       "additionalProperties": false,
       "description": "LXC container settings.",
+      "properties": {
+        "distribution": {
+          "description": "Distribution image (e.g. `alpine`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "release": {
+          "description": "Distribution release (e.g. `3.23`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "LxcExperimental": {
+      "description": "LXC backend config under the experimental surface. Carries only the per-phase state-aware nesting for the phases that take config (`provision`); the one-shot LXC surface is the stable top-level `lxc` section, so this type is named apart from it rather than shared with it. `start`, `exec`, `stop`, and `deprovision` take no per-phase config payload.",
+      "properties": {
+        "provision": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LxcProvisionPhase"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "State-aware provision-phase configuration."
+        }
+      },
+      "type": "object"
+    },
+    "LxcProvisionPhase": {
+      "description": "Provision-phase LXC configuration (state-aware lifecycle), nested under `experimental.lxc.provision`. Names the container image to create.\n\nFilesystem mounts and network policy derive from the top-level `filesystem` and `network` sections, not from here. It is its own type rather than a shared one because a shared type would advertise its fields on every phase in the generated schema.",
       "properties": {
         "distribution": {
           "description": "Distribution image (e.g. `alpine`).",

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -80,6 +80,10 @@ export interface Experimental {
    */
   isolation_session?: IsolationSession | null;
   /**
+   * LXC backend config (Linux).
+   */
+  lxc?: LxcExperimental | null;
+  /**
    * Seatbelt backend config (pre-promotion alias).
    */
   seatbelt?: Seatbelt | null;
@@ -187,6 +191,34 @@ export interface Lxc {
    * Distribution release (e.g. `3.23`).
    */
   release?: string | null;
+}
+
+/**
+ * LXC backend config under the experimental surface. Carries only the per-phase state-aware nesting for the phases that take config (`provision`); the one-shot LXC surface is the stable top-level `lxc` section, so this type is named apart from it rather than shared with it. `start`, `exec`, `stop`, and `deprovision` take no per-phase config payload.
+ */
+export interface LxcExperimental {
+  /**
+   * State-aware provision-phase configuration.
+   */
+  provision?: LxcProvisionPhase | null;
+  [k: string]: unknown;
+}
+
+/**
+ * Provision-phase LXC configuration (state-aware lifecycle), nested under `experimental.lxc.provision`. Names the container image to create.
+ * 
+ * Filesystem mounts and network policy derive from the top-level `filesystem` and `network` sections, not from here. It is its own type rather than a shared one because a shared type would advertise its fields on every phase in the generated schema.
+ */
+export interface LxcProvisionPhase {
+  /**
+   * Distribution image (e.g. `alpine`).
+   */
+  distribution?: string | null;
+  /**
+   * Distribution release (e.g. `3.23`).
+   */
+  release?: string | null;
+  [k: string]: unknown;
 }
 
 /**

--- a/sdk/node/src/state-aware-helper.ts
+++ b/sdk/node/src/state-aware-helper.ts
@@ -20,13 +20,14 @@ export const WSLC_STATE_AWARE_VERSION = '0.8.0-alpha';
 // Wire-format cross-cutting fields that live at the envelope's top level.
 // Anything else on a per-(backend, phase) Config is backend-specific and is
 // nested under `experimental.<backend>.<phase>`.
-export const CROSS_CUTTING_FIELDS = ['filesystem', 'network', 'ui', 'process'] as const;
+export const CROSS_CUTTING_FIELDS = ['containerId', 'filesystem', 'network', 'ui', 'process'] as const;
 
 // Per-backend wire-format prefix. Each value mirrors the corresponding
 // Rust `<Backend>Runner::ID_PREFIX` const and is the leading segment of a
 // `sandboxId` produced by that backend. Each future state-aware backend
 // declares its own `<BACKEND>_ID_PREFIX` const here.
 export const ISOLATION_SESSION_ID_PREFIX = 'iso';
+export const LXC_ID_PREFIX = 'lxc';
 export const WINDOWS_SANDBOX_ID_PREFIX = 'wsb';
 export const WSLC_ID_PREFIX = 'wslc';
 
@@ -36,6 +37,7 @@ export const WSLC_ID_PREFIX = 'wslc';
 // global constant.
 const DEFAULT_STATE_AWARE_VERSION: Record<StateAwareContainmentBackend, string> = {
   isolation_session: STATE_AWARE_VERSION,
+  lxc: STATE_AWARE_VERSION,
   windows_sandbox: STATE_AWARE_VERSION,
   wslc: WSLC_STATE_AWARE_VERSION,
 };
@@ -48,6 +50,7 @@ const DEFAULT_STATE_AWARE_VERSION: Record<StateAwareContainmentBackend, string> 
 // `malformed_id`.
 export const BACKEND_TO_PREFIX: Record<StateAwareContainmentBackend, string> = {
   isolation_session: ISOLATION_SESSION_ID_PREFIX,
+  lxc: LXC_ID_PREFIX,
   windows_sandbox: WINDOWS_SANDBOX_ID_PREFIX,
   wslc: WSLC_ID_PREFIX,
 };

--- a/sdk/node/src/state-aware-types.ts
+++ b/sdk/node/src/state-aware-types.ts
@@ -19,7 +19,7 @@ export type Phase = 'provision' | 'start' | 'exec' | 'stop' | 'deprovision';
  */
 export type StateAwareContainmentBackend = Extract<
   ContainmentBackend,
-  'isolation_session' | 'windows_sandbox' | 'wslc'
+  'isolation_session' | 'lxc' | 'windows_sandbox' | 'wslc'
 >;
 
 /**
@@ -94,6 +94,70 @@ export interface IsolationSessionDeprovisionConfig {
   version?: string;
 }
 
+export interface LxcProvisionConfig {
+  /** Schema version (semver). */
+  version?: string;
+  /** Optional externally assigned LXC container name. */
+  containerId?: string;
+  /** Linux distribution for the container rootfs, e.g. "alpine" or "ubuntu". */
+  distribution: string;
+  /** Distribution release version, e.g. "3.20" or "24.04". */
+  release: string;
+}
+
+/**
+ * Network policy accepted by LXC state-aware `start`.
+ *
+ * Narrowed to the fields an LXC caller can usefully set, rather than derived
+ * from `NetworkConfig`:
+ *
+ * - `proxy` is rejected at start (`apply_network_policy` returns a
+ *   policy-validation error).
+ * - `removeRulesOnExit` is an SDK-only field emitted inside the top-level
+ *   `network` object. Rust's `wire::Network` is `deny_unknown_fields`, so
+ *   sending it fails the whole request.
+ * - `allowLocalNetwork` deserializes, but start rejects
+ *   `allowLocalNetwork: true` with a policy-validation error
+ *   (`reject_unenforceable_network_policy`). The container's inbound chain can
+ *   only open a source range, and opening every source is broader than the
+ *   local-network access requested.
+ * - `enforcementMode` is not offered.  LXC enforces from `defaultPolicy`,
+ *   `allowedHosts`, and `blockedHosts` alone (`apply_firewall_rules` never
+ *   consults the mode), so exposing it would advertise a setting with no
+ *   effect.  The wire still accepts the field, so a `network` object shared
+ *   with another backend keeps parsing.
+ */
+export interface LxcNetworkConfig {
+  defaultPolicy?: NetworkConfig['defaultPolicy'];
+  allowedHosts?: NetworkConfig['allowedHosts'];
+  blockedHosts?: NetworkConfig['blockedHosts'];
+}
+
+export interface LxcStartConfig {
+  /** Schema version (semver). */
+  version?: string;
+  /** Filesystem mounts to apply before starting the container. */
+  filesystem?: FilesystemConfig;
+  /** iptables policy to install before the container starts. `proxy` is not supported by this backend. */
+  network?: LxcNetworkConfig;
+}
+
+export interface LxcExecConfig {
+  /** Schema version (semver). */
+  version?: string;
+  process: ProcessConfig;
+}
+
+export interface LxcStopConfig {
+  /** Schema version (semver). */
+  version?: string;
+}
+
+export interface LxcDeprovisionConfig {
+  /** Schema version (semver). */
+  version?: string;
+}
+
 /**
  * IsolationSession's provision-phase metadata surfaced to the caller: the
  * per-instance agent user account name minted for this sandbox, the agent
@@ -105,6 +169,11 @@ export interface IsolationSessionProvisionMetadata {
   agentUserName: string;
   agentUserSid: string;
   ephemeralWorkspacePath: string;
+}
+
+export interface LxcProvisionMetadata {
+  containerName: string;
+  created: boolean;
 }
 
 // WindowsSandbox per-(backend, phase) Configs. WindowsSandbox holds a single
@@ -251,6 +320,13 @@ type StateAwareConfigRegistry = DefineStateAwareConfigRegistry<{
     stop: IsolationSessionStopConfig;
     deprovision: IsolationSessionDeprovisionConfig;
   };
+  lxc: {
+    provision: LxcProvisionConfig;
+    start: LxcStartConfig;
+    exec: LxcExecConfig;
+    stop: LxcStopConfig;
+    deprovision: LxcDeprovisionConfig;
+  };
   windows_sandbox: {
     provision: WindowsSandboxProvisionConfig;
     start: WindowsSandboxStartConfig;
@@ -349,6 +425,10 @@ export type StateAwareMetadata = DefineStateAwareMetadataRegistry<{
   isolation_session: {
     provision?: IsolationSessionProvisionMetadata;
     // IsolationSession returns no metadata for start, stop, or deprovision.
+  };
+  lxc: {
+    provision?: LxcProvisionMetadata;
+    // LXC returns no metadata for start, stop, or deprovision.
   };
   // WindowsSandbox returns no metadata for any phase (provision yields only the
   // sandbox id). The key still participates so `StateAwareMetadata[C]` type-

--- a/sdk/node/src/types.ts
+++ b/sdk/node/src/types.ts
@@ -210,9 +210,9 @@ export interface NetworkConfig {
    * TCP/UDP). Independent of `defaultPolicy`. (default: false)
    */
   allowLocalNetwork?: boolean;
-  /** Hostnames or IP addresses/CIDR blocks to allow (firewall mode only) */
+  /** Hostnames or IP addresses/CIDR blocks to allow (Windows and Bubblewrap require firewall mode) */
   allowedHosts?: string[];
-  /** Hostnames or IP addresses to block (firewall mode only) */
+  /** Hostnames or IP addresses to block (Windows and Bubblewrap require firewall mode) */
   blockedHosts?: string[];
   /** Proxy configuration (supported on Windows ProcessContainer, Linux Bubblewrap,
    *  macOS Seatbelt, and WSLC). On Bubblewrap/Seatbelt/WSLC it is a cooperative

--- a/src/core/wxc_common/src/config_contract_adapters/dev/one_shot.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/dev/one_shot.rs
@@ -270,6 +270,7 @@ fn convert_experimental(value: contract::OneShotExperimental) -> wire::Experimen
         windows_sandbox: windows_sandbox.into_option().map(convert_windows_sandbox),
         wslc: wslc.into_option().map(convert_wslc),
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }

--- a/src/core/wxc_common/src/config_contract_adapters/dev/state_aware.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/dev/state_aware.rs
@@ -54,6 +54,7 @@ fn convert_isolation_session_provision_experimental(
         isolation_session: isolation_session
             .into_option()
             .map(convert_state_aware_isolation_session),
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -85,6 +86,7 @@ fn convert_windows_sandbox_provision_experimental(
         windows_sandbox: None,
         wslc: None,
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -125,6 +127,7 @@ fn convert_wslc_provision_experimental(
         windows_sandbox: None,
         wslc: wslc.into_option().map(convert_state_aware_wslc),
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -137,6 +140,7 @@ fn convert_start_experimental(value: contract::StartExperimental) -> wire::Exper
         windows_sandbox: None,
         wslc: None,
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -149,6 +153,7 @@ fn convert_exec_experimental(value: contract::ExecExperimental) -> wire::Experim
         windows_sandbox: None,
         wslc: None,
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -161,6 +166,7 @@ fn convert_stop_experimental(value: contract::StopExperimental) -> wire::Experim
         windows_sandbox: None,
         wslc: None,
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }
@@ -175,6 +181,7 @@ fn convert_deprovision_experimental(
         windows_sandbox: None,
         wslc: None,
         isolation_session: None,
+        lxc: None,
         seatbelt: None,
         telemetry: telemetry.into_option().map(convert_telemetry),
     }

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -336,7 +336,8 @@ const CURRENT_SCHEMA_VERSION: &str = "0.9.0-alpha";
 /// experimental backend sections that don't match the selected
 /// `containment`. Add a new entry when promoting a backend to a top-level
 /// section or graduating one from experimental.
-const KNOWN_EXPERIMENTAL_BACKENDS: &[&str] = &["windows_sandbox", "wslc", "isolation_session"];
+const KNOWN_EXPERIMENTAL_BACKENDS: &[&str] =
+    &["windows_sandbox", "wslc", "isolation_session", "lxc"];
 
 /// Validate that the schema version (semver) is supported by this binary.
 /// Compares major.minor only — patch and pre-release labels are ignored.
@@ -568,9 +569,12 @@ fn validate_experimental_backend_keys(
         return Ok(());
     };
 
-    let matching_key = containment
-        .and_then(|c| c.section_path())
-        .and_then(|path| path.strip_prefix("experimental."));
+    let matching_key = match containment {
+        Some(ContainmentBackend::Lxc) => Some("lxc"),
+        _ => containment
+            .and_then(|c| c.section_path())
+            .and_then(|path| path.strip_prefix("experimental.")),
+    };
 
     let present: Vec<&'static str> = KNOWN_EXPERIMENTAL_BACKENDS
         .iter()
@@ -916,7 +920,7 @@ fn convert_wire_config(
         process_container_network = ac.network;
     }
 
-    // Filesystem section
+    // Filesystem section.
     if let Some(fscfg) = cfg.filesystem {
         if let Some(v) = fscfg.denied_paths {
             policy.denied_paths = v;
@@ -1148,30 +1152,6 @@ fn convert_wire_config(
                        HTTP_PROXY. Use a loopback proxy (127.0.0.1/::1/localhost) or \
                        'network.proxy.builtinTestServer: true' for port-scoped reachability \
                        under deny.";
-            logger.log_line(msg);
-            return Err(WxcError::ConfigParse(msg.to_string()));
-        }
-
-        // LXC is the inverse of the two guards above: it *does* have a
-        // privileged packet-filter layer, and that layer is the only thing that
-        // makes the proxy an exception rather than a suggestion. Under the
-        // default `Capabilities` mode `apply_firewall_rules` installs nothing,
-        // so the runner would inject HTTP(S)_PROXY while leaving direct egress
-        // wide open -- a config that reads as deny-all-except-proxy and
-        // enforces neither half. Reject it rather than auto-promoting, so the
-        // user's stated enforcement is never silently rewritten.
-        if containment == ContainmentBackend::Lxc
-            && policy.network_proxy.is_enabled()
-            && !matches!(
-                policy.network_enforcement_mode,
-                NetworkEnforcementMode::Firewall | NetworkEnforcementMode::Both
-            )
-        {
-            let msg = "LXC: network.proxy requires network.enforcementMode='firewall' \
-                       or 'both'. Under the default 'capabilities' mode no iptables \
-                       rules are installed, so the proxy environment variables would be \
-                       injected while direct egress stayed unrestricted -- any client \
-                       that ignores HTTP_PROXY would bypass the proxy entirely.";
             logger.log_line(msg);
             return Err(WxcError::ConfigParse(msg.to_string()));
         }
@@ -3715,10 +3695,10 @@ mod tests {
     #[test]
     fn proxy_accepted_with_lxc() {
         // LXC requires a routable proxy host: localhost/127.0.0.1 is the
-        // container loopback and unreachable, so use network.proxy.url.
-        // A firewall mode is required, because that is what makes the proxy an
-        // exception to deny-all rather than an unenforced suggestion.
-        let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"url":"http://proxy.example.com:8080"},"enforcementMode":"firewall"}}"#;
+        // container loopback and unreachable, so use network.proxy.url. A proxy
+        // makes the policy require the firewall, so LXC installs the rules that
+        // make it an exception to deny-all; no enforcementMode is needed.
+        let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"url":"http://proxy.example.com:8080"}}}"#;
         let encoded = base64_encode(json.as_bytes());
         let mut logger = test_logger();
 
@@ -3730,48 +3710,32 @@ mod tests {
     }
 
     #[test]
-    fn proxy_with_lxc_accepts_both_mode() {
-        // 'both' also installs the iptables rules, so it satisfies the guard.
-        let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"url":"http://proxy.example.com:8080"},"enforcementMode":"both"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
+    fn proxy_with_lxc_is_accepted_whatever_the_enforcement_mode() {
+        // The behavior change, seen through the parser: an LXC proxy used to be
+        // rejected unless enforcementMode was firewall/both. It is now accepted
+        // regardless -- omitted, capabilities, firewall, and both all parse to
+        // an enabled proxy, because the proxy alone drives the install.
+        for mode in [
+            r#""enforcementMode":"capabilities","#,
+            r#""enforcementMode":"firewall","#,
+            r#""enforcementMode":"both","#,
+            "",
+        ] {
+            let json = format!(
+                r#"{{"process":{{"commandLine":"x"}},"containment":"lxc","network":{{{}"proxy":{{"url":"http://proxy.example.com:8080"}}}}}}"#,
+                mode
+            );
+            let encoded = base64_encode(json.as_bytes());
+            let mut logger = test_logger();
 
-        let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert!(req.policy.network_proxy.is_enabled());
-    }
-
-    #[test]
-    fn proxy_with_lxc_and_omitted_enforcement_mode_is_rejected() {
-        // enforcementMode defaults to 'capabilities', under which
-        // apply_firewall_rules installs nothing. Accepting this config would
-        // inject HTTP(S)_PROXY while leaving direct egress unrestricted, so
-        // anything ignoring the environment variables bypasses the proxy.
-        let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"url":"http://proxy.example.com:8080"}}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let err = load_request(&encoded, &mut logger, true).unwrap_err();
-        assert!(
-            format!("{}", err).contains("network.proxy requires network.enforcementMode"),
-            "expected the LXC enforcement-mode rejection, got: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn proxy_with_lxc_and_explicit_capabilities_mode_is_rejected() {
-        // Stating 'capabilities' explicitly is the same fail-open as omitting
-        // it, so it must be rejected identically rather than read as consent.
-        let json = r#"{"process":{"commandLine":"x"},"containment":"lxc","network":{"proxy":{"url":"http://proxy.example.com:8080"},"enforcementMode":"capabilities"}}"#;
-        let encoded = base64_encode(json.as_bytes());
-        let mut logger = test_logger();
-
-        let err = load_request(&encoded, &mut logger, true).unwrap_err();
-        assert!(
-            format!("{}", err).contains("network.proxy requires network.enforcementMode"),
-            "expected the LXC enforcement-mode rejection, got: {}",
-            err
-        );
+            let req = load_request(&encoded, &mut logger, true).unwrap_or_else(|err| {
+                panic!("an LXC proxy must be accepted (mode fragment {mode:?}), got: {err}")
+            });
+            assert!(
+                req.policy.network_proxy.is_enabled(),
+                "mode fragment {mode:?}: the proxy must be enabled"
+            );
+        }
     }
 
     // The credential guard runs after `convert_wire_proxy`, so a
@@ -6451,6 +6415,33 @@ mod tests {
             msg.contains("experimental.wslc"),
             "error did not name the foreign section: {msg}"
         );
+    }
+
+    #[test]
+    fn state_aware_lxc_experimental_backend_key_is_accepted() {
+        let json = r#"{
+            "phase": "provision",
+            "containment": "lxc",
+            "experimental": {
+                "lxc": {"provision": {"distribution": "alpine", "release": "3.20"}}
+            }
+        }"#;
+        let encoded = base64_encode(json.as_bytes());
+        let mut logger = test_logger();
+        let req = load_mxc_request(&encoded, &mut logger, true)
+            .expect("state-aware lxc config should parse");
+        match req {
+            MxcRequest::StateAware(p) => {
+                assert_eq!(p.phase, Phase::Provision);
+                assert_eq!(p.containment, Some(ContainmentBackend::Lxc));
+                assert!(p
+                    .experimental_raw
+                    .as_ref()
+                    .and_then(|v| v.get("lxc"))
+                    .is_some());
+            }
+            other => panic!("expected state-aware request, got {other:?}"),
+        }
     }
 
     // ---- Abstract-intent coverage ----

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -586,6 +586,8 @@ pub struct Experimental {
     pub wslc: Option<Wslc>,
     /// IsolationSession backend config (Windows).
     pub isolation_session: Option<IsolationSession>,
+    /// LXC backend config (Linux).
+    pub lxc: Option<LxcExperimental>,
     /// Seatbelt backend config (pre-promotion alias).
     #[serde(alias = "macos_sandbox")]
     pub seatbelt: Option<Seatbelt>,
@@ -733,6 +735,36 @@ pub struct IsolationSessionProvisionPhase {
     /// An unpackaged application may pass any string. Carried inside the `sandboxId`
     /// so later lifecycle phases can recover it without the caller re-supplying it.
     pub app_id: Option<String>,
+}
+
+/// LXC backend config under the experimental surface. Carries only the
+/// per-phase state-aware nesting for the phases that take config
+/// (`provision`); the one-shot LXC surface is the stable top-level `lxc`
+/// section, so this type is named apart from it rather than shared with it.
+/// `start`, `exec`, `stop`, and `deprovision` take no per-phase config payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct LxcExperimental {
+    /// State-aware provision-phase configuration.
+    pub provision: Option<LxcProvisionPhase>,
+}
+
+/// Provision-phase LXC configuration (state-aware lifecycle), nested under
+/// `experimental.lxc.provision`. Names the container image to create.
+///
+/// Filesystem mounts and network policy derive from the top-level `filesystem`
+/// and `network` sections, not from here. It is its own type rather than a
+/// shared one because a shared type would advertise its fields on every phase
+/// in the generated schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-gen", derive(schemars::JsonSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct LxcProvisionPhase {
+    /// Distribution image (e.g. `alpine`).
+    pub distribution: Option<String>,
+    /// Distribution release (e.g. `3.23`).
+    pub release: Option<String>,
 }
 
 /// JSON Schema generation from the wire model, gated behind `schema-gen` so


### PR DESCRIPTION
Carries the state-aware contract surface on its own, separate from the LXC backend that implements against it.

- Adds the state-aware fields to the `0.9.0-dev` config schema.
- Adds the `lxc` member on `wire::Experimental` and the generated SDK wire types.
- Adds parser support for the new fields.

The two config-contract adapters are included because `wire::Experimental` is constructed there and the crate does not compile without them.

The LXC backend, its unit tests, and the E2E scripts stay in #849.

Verified: `cargo check --workspace` clean; `cargo test -p wxc_common` 982 passed / 0 failed; `tsc --noEmit` clean; SDK unit tests pass; `check-schema-codegen`, `check-sdk-types-codegen`, `check-schema-versions`, and `check-version-sync` all pass.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1043)