### PR TITLE
[WSLC] Tell users to update MXC when their WSL outruns the pinned SDK

### DIFF
--- a/docs/wsl/wsl-container-getting-started.md
+++ b/docs/wsl/wsl-container-getting-started.md
@@ -408,6 +408,7 @@ the container.
 | `WSLC backend not compiled` | Binary built without `--features wslc` | Rebuild with `build.bat --with-wslc` |
 | `Failed to load wslcsdk.dll` | DLL not in same directory as `wxc-exec.exe` | Copy `wslcsdk.dll` next to the binary |
 | `WSLC runtime unavailable` | WSL runtime package is missing, older than 2.9.3, or the Virtual Machine Platform optional component is disabled | Update WSL with `wsl --update --pre-release`, verify the installed version with `wsl --version`, and enable the Virtual Machine Platform optional component if required. The WSLC SDK DLL is a separate dependency and does not replace the WSL runtime package. |
+| `WSLC runtime unavailable. Missing components: SdkNeedsUpdate` | The opposite direction: your installed WSL is **newer** than the WSLc SDK this MXC build ships (pinned by `WSLC_SDK_VERSION` in `src/backends/wslc/common/build.rs`) | Update MXC to a build with a newer pinned SDK. Do **not** update WSL — it is already ahead, and updating it further will not clear this. |
 | `WSLC image '<name>' not found locally` | Image was not pre-pulled, and no `imageTarPath` is set | Run `.\scripts\setup-wslc.ps1 -Image <name>` (or `wxc-exec.exe --setup-wslc --image <name>`); match the `-StoragePath` to your config's `experimental.wslc.storagePath` if set |
 | `WSLC is an experimental feature` | Missing `--experimental` flag | Add `--experimental` to CLI or `{ experimental: true }` in SDK |
 | `experimental mode` error in SDK | `SandboxSpawnOptions.experimental` not set | Pass `{ experimental: true }` to spawn functions |

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -605,11 +605,14 @@ enum TarFormat {
 /// Builds a user-facing prerequisite error for the components `WslcGetMissingComponents`
 /// reports as missing. `missing` may combine multiple bits, and the guidance is branched
 /// per-component so a user missing only `VirtualMachinePlatform` isn't told to update WSL
-/// (which doesn't enable that Windows optional feature), and vice versa.
+/// (which doesn't enable that Windows optional feature), and vice versa. `SdkNeedsUpdate`
+/// points at MXC rather than WSL, since it means MXC's SDK is the stale side.
 pub(crate) fn wslc_prerequisite_error(missing: WslcComponentFlags) -> String {
     let needs_vmp =
         missing.0 & WslcComponentFlags::WSLC_COMPONENT_FLAG_VIRTUAL_MACHINE_PLATFORM.0 != 0;
     let needs_wsl_package = missing.0 & WslcComponentFlags::WSLC_COMPONENT_FLAG_WSL_PACKAGE.0 != 0;
+    let needs_sdk_update =
+        missing.0 & WslcComponentFlags::WSLC_COMPONENT_FLAG_SDK_NEEDS_UPDATE.0 != 0;
 
     let mut guidance = Vec::new();
     if needs_vmp {
@@ -623,6 +626,14 @@ pub(crate) fn wslc_prerequisite_error(missing: WslcComponentFlags) -> String {
     if needs_wsl_package {
         guidance
             .push("install WSL 2.9.3 or newer and run `wsl --update --pre-release`".to_string());
+    }
+    if needs_sdk_update {
+        // MXC's vendored SDK is behind the installed WSL, so the fix is on MXC's
+        // side — telling the user to install WSL would send them the wrong way.
+        guidance.push(
+            "update MXC — the WSLc SDK it ships is too old for your installed version of WSL"
+                .to_string(),
+        );
     }
     if guidance.is_empty() {
         guidance.push("ensure WSL2 and the WSLC SDK are installed".to_string());
@@ -2590,7 +2601,36 @@ mod tests {
         let message =
             wslc_prerequisite_error(WslcComponentFlags::WSLC_COMPONENT_FLAG_SDK_NEEDS_UPDATE);
 
+        assert_eq!(
+            message,
+            "WSLC runtime unavailable. Missing components: SdkNeedsUpdate (0x4). \
+             Please update MXC — the WSLc SDK it ships is too old for your installed \
+             version of WSL."
+        );
         assert!(message.contains("SdkNeedsUpdate"));
+        assert!(message.contains("update MXC"));
+        // The user's WSL is fine (and newer) — no install/update advice for it.
+        assert!(!message.contains("ensure WSL2 and the WSLC SDK are installed"));
+        assert!(!message.contains("wsl --update"));
+        assert!(!message.contains("Virtual Machine Platform"));
+    }
+
+    #[test]
+    fn prerequisite_error_for_sdk_update_combined_with_another_component() {
+        let combined = WslcComponentFlags::WSLC_COMPONENT_FLAG_SDK_NEEDS_UPDATE
+            | WslcComponentFlags::WSLC_COMPONENT_FLAG_VIRTUAL_MACHINE_PLATFORM;
+        let message = wslc_prerequisite_error(combined);
+
+        assert!(message.contains("update MXC"));
+        assert!(message.contains("Virtual Machine Platform"));
+        assert!(!message.contains("ensure WSL2 and the WSLC SDK are installed"));
+    }
+
+    #[test]
+    fn prerequisite_error_falls_back_for_unrecognized_components() {
+        // An unknown future bit still has to produce actionable text.
+        let message = wslc_prerequisite_error(WslcComponentFlags(0x8000));
+
         assert!(message.contains("ensure WSL2 and the WSLC SDK are installed"));
     }
 }


### PR DESCRIPTION
## 📖 Description
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

`wslc_prerequisite_error` had no `SdkNeedsUpdate` branch, so a WSL 2.9.8.0 user fell through to `"Please ensure WSL2 and the WSLC SDK are installed"` — advice that points the wrong way, since their WSL is fine and it is MXC's pinned SDK (2.9.3) that is behind. The bit now gets its own guidance ("update MXC"), and the troubleshooting table gets a matching row telling users **not** to update WSL further.

No version is baked into the message: `build.rs` never emits `cargo:rustc-env`, so `WSLC_SDK_VERSION` is unreachable at runtime and hardcoding it would rot on the next bump. The `VirtualMachinePlatform` and `WslPackage` branches are unchanged.

Closes #1039
## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1046)