### PR TITLE
[Bubblewrap] Reuse the validated egress plan and pin IPv6/ICMP rendering

### DIFF
--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -11,7 +11,8 @@ use std::collections::HashSet;
 
 use wxc_common::filesystem_resolve::FsIntent;
 use wxc_common::models::{
-    ExecutionRequest, NetworkAction, NetworkEnforcementMode, NetworkPolicy, ProxyAddress,
+    ContainerPolicy, ExecutionRequest, NetworkAction, NetworkEnforcementMode, NetworkPolicy,
+    ProxyAddress,
 };
 use wxc_common::proxy_env::{is_managed_proxy_key, PROXY_SET_KEYS};
 
@@ -149,6 +150,20 @@ fn uses_private_network_contract(request: &ExecutionRequest) -> bool {
     schema_enforces_network_strictly(&request.schema_version)
 }
 
+/// Whether the policy carries the 0.8 directional shape.
+///
+/// Either section is enough: the parser fills both together, but checking only
+/// one would route an ingress-only policy into the legacy path, where its
+/// directional intent is silently discarded. Shared by every site that splits
+/// directional from legacy so the fail-closed reading cannot drift apart.
+///
+/// Distinct from `wxc_common::validator::directional_posture_supplied`, which
+/// also folds in `network_mode_specified` and the proxy; the two are not
+/// interchangeable.
+pub(crate) fn is_directional(policy: &ContainerPolicy) -> bool {
+    policy.network_egress.is_some() || policy.network_ingress.is_some()
+}
+
 impl ResolvedNetworkMode {
     /// Classify the internal request using the proxy's resolved runtime state.
     pub(crate) fn from_request(request: &ExecutionRequest, proxy_active: bool) -> Self {
@@ -166,11 +181,8 @@ impl ResolvedNetworkMode {
         // read a policy that never said either as `Isolated` and take the
         // sandbox offline with the requested rules programmed nowhere.
         //
-        // Either section makes it directional, matching `EgressPlan::for_request`.
-        // Keying on `egress` alone sent an ingress-only request to the legacy
-        // arm, where a leftover `defaultPolicy='allow'` resolves to `Shared` and
-        // programs no chain -- discarding both the ingress denial and the
-        // host-loopback drop. A missing egress defaults to deny, failing closed.
+        // Either section makes it directional (see `is_directional`); a missing
+        // egress defaults to deny, failing closed.
         //
         // Directional never selects `Shared`: the host namespace has no inbound
         // primitive, and `network_ingress` has no `_specified` twin, so a
@@ -179,7 +191,7 @@ impl ResolvedNetworkMode {
         // "allow all outbound" policy with it. The private namespace honors
         // both directions, so an open egress posture becomes an accept-all
         // chain rather than an unfiltered namespace.
-        if request.policy.network_egress.is_some() || request.policy.network_ingress.is_some() {
+        if is_directional(&request.policy) {
             // Off the 0.8 contract there is no private namespace to program.
             // Report the unfiltered truth and let `validate` refuse it rather
             // than pretending the posture was applied.
@@ -442,12 +454,8 @@ pub fn external_proxy_host_rules_rejection(request: &ExecutionRequest) -> Option
     // would refuse every directional runtime proxy -- the one posture the
     // parser already constrains to `egress.default='deny'` with no direct
     // rules, which *is* proxy-only egress and carries no host lists that could
-    // be silently dropped. Either directional section makes it non-legacy,
-    // matching `EgressPlan::for_request` and `ResolvedNetworkMode::from_request`;
-    // keying on `egress` alone refused an ingress-only request as though the
-    // defaulted `Block` had been asked for.
-    let legacy_shape =
-        request.policy.network_egress.is_none() && request.policy.network_ingress.is_none();
+    // be silently dropped.
+    let legacy_shape = !is_directional(&request.policy);
     let conflicts = has_host_rules
         || (legacy_shape && request.policy.default_network_policy == NetworkPolicy::Block);
 
@@ -1370,6 +1378,39 @@ mod tests {
             "the host namespace programs no chain, so the deny posture would be lost"
         );
         assert!(mode.uses_private_netns(), "{mode:?}");
+    }
+
+    /// The predicate is now shared by three call sites, so pin it directly:
+    /// a per-site test would let one drift without failing the others.
+    #[test]
+    fn either_directional_section_alone_marks_the_policy_directional() {
+        use wxc_common::models::{NetworkEgressPolicy, NetworkIngressPolicy};
+
+        let cases = [
+            (None, None, false),
+            (Some(NetworkEgressPolicy::default()), None, true),
+            (None, Some(NetworkIngressPolicy::default()), true),
+            (
+                Some(NetworkEgressPolicy::default()),
+                Some(NetworkIngressPolicy::default()),
+                true,
+            ),
+        ];
+
+        for (egress, ingress, expected) in cases {
+            let policy = ContainerPolicy {
+                network_egress: egress.clone(),
+                network_ingress: ingress.clone(),
+                ..Default::default()
+            };
+            assert_eq!(
+                is_directional(&policy),
+                expected,
+                "egress={:?} ingress={:?}",
+                egress.is_some(),
+                ingress.is_some()
+            );
+        }
     }
 
     /// Build a directional request: no legacy network field is touched, which

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -92,6 +92,87 @@ impl SandboxBackend for BubblewrapScriptRunner {
     }
 
     fn validate(&self, request: &ExecutionRequest) -> Result<(), ScriptResponse> {
+        self.validate_prepared(request).map(|_| ())
+    }
+
+    fn spawn(
+        &mut self,
+        request: &ExecutionRequest,
+        logger: &mut Logger,
+        stdio: StdioMode,
+    ) -> Result<Box<dyn SandboxProcess>, ScriptResponse> {
+        validate_common(request)?;
+        // Keep the plan validation derived so the firewall path installs
+        // exactly what was accepted instead of deriving it again.
+        let egress_plan = self.validate_prepared(request)?;
+        // Object-based FS-policy normalization (D6): tighten aliases of the same
+        // host object to the strictest intent (deny > ro > rw). Done here, close
+        // to mount — config_parser stays string-only and the TOCTOU window
+        // between check and mount is minimized. Only clone the request when an
+        // aliasing conflict actually needs tightening (the common case is none);
+        // an unresolvable path with deniedPaths present fails closed.
+        let normalized;
+        let request = match wxc_common::filesystem_object::normalize_object_conflicts(
+            &request.policy,
+            logger,
+        ) {
+            Ok(Some(policy)) => {
+                normalized = ExecutionRequest {
+                    policy,
+                    ..request.clone()
+                };
+                &normalized
+            }
+            Ok(None) => request,
+            Err(msg) => return Err(ScriptResponse::error(&msg)),
+        };
+        // Delegation check (D3): reject any policy path the invoking user cannot
+        // access, so the sandbox never gains access the caller lacks. Runs AFTER
+        // object normalization so it is evaluated against the already-tightened
+        // intents (a path moved rw -> denied must not then require write access).
+        if let Err(msg) = wxc_common::filesystem_access::check_delegation(&request.policy) {
+            return Err(ScriptResponse::error(&msg));
+        }
+        // Resolve denied paths that traverse a symlink to their real host path
+        // and classify each as a file/dir mask (see [`resolve_denied_paths`]).
+        // Only clones the request when a path needs rewriting (common case:
+        // none). See docs/bwrap-support/bubblewrap-backend.md.
+        let plan = match resolve_denied_paths(&request.policy, logger) {
+            Ok(plan) => plan,
+            Err(msg) => return Err(ScriptResponse::error(&msg)),
+        };
+        let resolved;
+        let request = match plan.paths {
+            Some(denied_paths) => {
+                let mut policy = request.policy.clone();
+                policy.denied_paths = denied_paths;
+                resolved = ExecutionRequest {
+                    policy,
+                    ..request.clone()
+                };
+                &resolved
+            }
+            None => request,
+        };
+        // The masks are built from the list above, not from the one the caller
+        // wrote, so the pin conflict has to be judged against it too.
+        if let Err(msg) = check_pin_against_denied_hosts(request) {
+            return Err(ScriptResponse::error(&msg));
+        }
+        let child = self.spawn_bwrap(request, &plan.files, egress_plan, logger, stdio)?;
+        Ok(Box::new(BubblewrapSandboxProcess::new(child)))
+    }
+}
+
+impl BubblewrapScriptRunner {
+    /// `validate`, plus the egress plan it derived.
+    ///
+    /// Returning the plan lets `spawn` install exactly what validation
+    /// accepted instead of deriving it a second time on every spawn.
+    fn validate_prepared(
+        &self,
+        request: &ExecutionRequest,
+    ) -> Result<Option<network_rules::EgressPlan>, ScriptResponse> {
         validate_network_policy_support(request, self.network_policy_support())?;
         // User-input validation runs before the environmental `bwrap`
         // probe so config errors are reported deterministically even on
@@ -209,11 +290,14 @@ impl SandboxBackend for BubblewrapScriptRunner {
         let firewall_enforced =
             ResolvedNetworkMode::from_request(request, request.policy.network_proxy.is_enabled())
                 == ResolvedNetworkMode::FirewallEnforced;
-        if firewall_enforced {
-            if let Err(error) = network_rules::EgressPlan::for_request(request) {
-                return Err(ScriptResponse::error(&error));
+        let egress_plan = if firewall_enforced {
+            match network_rules::EgressPlan::for_request(request) {
+                Ok(plan) => Some(plan),
+                Err(error) => return Err(ScriptResponse::error(&error)),
             }
-        }
+        } else {
+            None
+        };
 
         // `bwrap` must be present *and* new enough for every flag the argument
         // builder emits — an old binary would otherwise fail at spawn time with
@@ -235,73 +319,7 @@ impl SandboxBackend for BubblewrapScriptRunner {
             }
         }
 
-        Ok(())
-    }
-
-    fn spawn(
-        &mut self,
-        request: &ExecutionRequest,
-        logger: &mut Logger,
-        stdio: StdioMode,
-    ) -> Result<Box<dyn SandboxProcess>, ScriptResponse> {
-        validate_common(request)?;
-        self.validate(request)?;
-        // Object-based FS-policy normalization (D6): tighten aliases of the same
-        // host object to the strictest intent (deny > ro > rw). Done here, close
-        // to mount — config_parser stays string-only and the TOCTOU window
-        // between check and mount is minimized. Only clone the request when an
-        // aliasing conflict actually needs tightening (the common case is none);
-        // an unresolvable path with deniedPaths present fails closed.
-        let normalized;
-        let request = match wxc_common::filesystem_object::normalize_object_conflicts(
-            &request.policy,
-            logger,
-        ) {
-            Ok(Some(policy)) => {
-                normalized = ExecutionRequest {
-                    policy,
-                    ..request.clone()
-                };
-                &normalized
-            }
-            Ok(None) => request,
-            Err(msg) => return Err(ScriptResponse::error(&msg)),
-        };
-        // Delegation check (D3): reject any policy path the invoking user cannot
-        // access, so the sandbox never gains access the caller lacks. Runs AFTER
-        // object normalization so it is evaluated against the already-tightened
-        // intents (a path moved rw -> denied must not then require write access).
-        if let Err(msg) = wxc_common::filesystem_access::check_delegation(&request.policy) {
-            return Err(ScriptResponse::error(&msg));
-        }
-        // Resolve denied paths that traverse a symlink to their real host path
-        // and classify each as a file/dir mask (see [`resolve_denied_paths`]).
-        // Only clones the request when a path needs rewriting (common case:
-        // none). See docs/bwrap-support/bubblewrap-backend.md.
-        let plan = match resolve_denied_paths(&request.policy, logger) {
-            Ok(plan) => plan,
-            Err(msg) => return Err(ScriptResponse::error(&msg)),
-        };
-        let resolved;
-        let request = match plan.paths {
-            Some(denied_paths) => {
-                let mut policy = request.policy.clone();
-                policy.denied_paths = denied_paths;
-                resolved = ExecutionRequest {
-                    policy,
-                    ..request.clone()
-                };
-                &resolved
-            }
-            None => request,
-        };
-        // The masks are built from the list above, not from the one the caller
-        // wrote, so the pin conflict has to be judged against it too.
-        if let Err(msg) = check_pin_against_denied_hosts(request) {
-            return Err(ScriptResponse::error(&msg));
-        }
-        let child = self.spawn_bwrap(request, &plan.files, logger, stdio)?;
-        Ok(Box::new(BubblewrapSandboxProcess::new(child)))
+        Ok(egress_plan)
     }
 }
 
@@ -337,6 +355,7 @@ impl BubblewrapScriptRunner {
         &self,
         request: &ExecutionRequest,
         denied_files: &HashSet<String>,
+        egress_plan: Option<network_rules::EgressPlan>,
         logger: &mut Logger,
         stdio: StdioMode,
     ) -> Result<BwrapChild, ScriptResponse> {
@@ -409,12 +428,19 @@ impl BubblewrapScriptRunner {
             // endpoint. There is no hostname to pin because rule addresses are
             // literals and CIDRs only.
             None if network_mode == ResolvedNetworkMode::FirewallEnforced => {
-                let plan = match network_rules::EgressPlan::for_request(request) {
-                    Ok(plan) => plan,
-                    Err(error) => {
-                        proxy.stop(logger);
-                        return Err(ScriptResponse::error(&error));
-                    }
+                // Reuse the validated plan. It is derived from network policy
+                // only, which the filesystem normalization between the two
+                // points cannot touch. Recompute only if the resolved mode
+                // disagrees with validation's pre-spawn proxy reading.
+                let plan = match egress_plan {
+                    Some(plan) => plan,
+                    None => match network_rules::EgressPlan::for_request(request) {
+                        Ok(plan) => plan,
+                        Err(error) => {
+                            proxy.stop(logger);
+                            return Err(ScriptResponse::error(&error));
+                        }
+                    },
                 };
                 match proxy_network::ProxyNetworkNamespace::start(
                     &plan,

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -105,12 +105,9 @@ impl SandboxBackend for BubblewrapScriptRunner {
         // Keep the plan validation derived so the firewall path installs
         // exactly what was accepted instead of deriving it again.
         let egress_plan = self.validate_prepared(request)?;
-        // Object-based FS-policy normalization (D6): tighten aliases of the same
-        // host object to the strictest intent (deny > ro > rw). Done here, close
-        // to mount — config_parser stays string-only and the TOCTOU window
-        // between check and mount is minimized. Only clone the request when an
-        // aliasing conflict actually needs tightening (the common case is none);
-        // an unresolvable path with deniedPaths present fails closed.
+        // Tighten aliases of the same host object to the strictest intent
+        // (deny > ro > rw). Done here, close to mount, to minimize the TOCTOU
+        // window; an unresolvable path with deniedPaths present fails closed.
         let normalized;
         let request = match wxc_common::filesystem_object::normalize_object_conflicts(
             &request.policy,
@@ -126,10 +123,9 @@ impl SandboxBackend for BubblewrapScriptRunner {
             Ok(None) => request,
             Err(msg) => return Err(ScriptResponse::error(&msg)),
         };
-        // Delegation check (D3): reject any policy path the invoking user cannot
-        // access, so the sandbox never gains access the caller lacks. Runs AFTER
-        // object normalization so it is evaluated against the already-tightened
-        // intents (a path moved rw -> denied must not then require write access).
+        // Reject any policy path the invoking user cannot access, so the sandbox
+        // never gains access the caller lacks. Runs after object normalization
+        // so it sees the already-tightened intents.
         if let Err(msg) = wxc_common::filesystem_access::check_delegation(&request.policy) {
             return Err(ScriptResponse::error(&msg));
         }

--- a/src/backends/bubblewrap/common/src/network_rules.rs
+++ b/src/backends/bubblewrap/common/src/network_rules.rs
@@ -795,7 +795,7 @@ impl EgressPlan {
         // Either section present means the directional shape. The parser fills
         // both in together, but losing the host-loopback drop is silent, so
         // this does not depend on that invariant.
-        if request.policy.network_egress.is_none() && request.policy.network_ingress.is_none() {
+        if !crate::bwrap_command::is_directional(&request.policy) {
             return Self::for_policy(request);
         }
 

--- a/tests/configs/bubblewrap_network_directional_ipv6_icmp.json
+++ b/tests/configs/bubblewrap_network_directional_ipv6_icmp.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-Network-Directional-IPv6-ICMP",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "bash -c 'set -u; echo SANDBOX_NETNS=$(readlink /proc/self/ns/net); capeff=$(grep \"^CapEff\" /proc/self/status | cut -f2); if [ -z \"$capeff\" ]; then echo NO_CAPEFF; exit 1; fi; if [ $((0x$capeff & 0x1000)) -ne 0 ]; then echo CAP_NET_ADMIN_RETAINED; exit 1; fi; echo CAP_NET_ADMIN_DROPPED_OK; echo V6_ICMP_RULES_INSTALLED_OK'"
+  },
+  "network": {
+    "egress": {
+      "default": "deny",
+      "allow": [
+        { "to": [{ "cidr": "2001:4860:4860::8888/128" }] },
+        { "to": [{ "cidr": "2001:db8:1::/48", "except": ["2001:db8:1:dead::/64"] }] },
+        { "to": [{ "cidr": "2606:4700:4700::1111/128" }], "ports": [{ "protocol": "icmp" }] },
+        { "ports": [{ "protocol": "icmp" }] }
+      ]
+    },
+    "ingress": {
+      "default": "deny",
+      "hostLoopback": "deny"
+    }
+  }
+}

--- a/tests/scripts/run_bwrap_directional_test.sh
+++ b/tests/scripts/run_bwrap_directional_test.sh
@@ -310,6 +310,14 @@ run_enforced "directional except carve-out" "bubblewrap_network_directional_exce
 run_enforced "directional ruleless deny" "bubblewrap_network_directional_block.json" \
     EGRESS_BLOCKED_OK
 
+# No other directional config carries an IPv6 peer or an ICMP rule, so the real
+# ip6tables-restore never sees a v6 address or the icmp -> icmpv6 token the v6
+# table requires. Connectivity is not the point: a token or transaction the tool
+# rejects fails namespace setup, so lxc-exec exits before the workload runs.
+run_enforced "directional ipv6 and icmp rendering" \
+    "bubblewrap_network_directional_ipv6_icmp.json" \
+    V6_ICMP_RULES_INSTALLED_OK CAP_NET_ADMIN_DROPPED_OK
+
 # Port narrowing: one address, two ports, only one allowed. Both ports are
 # probed reachable above, so the denied one being closed is the rule working.
 PORT_CONFIG="$WORK_DIR/directional_ports.json"


### PR DESCRIPTION
## 📖 Description
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Three non-blocking follow-ups from the #979 review. No behavior change on the enforced posture; the only new coverage is a test config.

**Build the egress plan once per spawn.** `validate` computed an `EgressPlan` purely to reject bad rule addresses and then discarded it, so `spawn` rebuilt the identical plan moments later. `validate`'s body moves into `validate_prepared`, which returns the plan it already built; the trait method stays a thin delegate for callers that only want the check, and `spawn` passes the plan down to `spawn_bwrap`. `spawn_bwrap` keeps a recompute fallback so the change is provably behavior-preserving: the normalization between the two call sites touches only filesystem fields and carries network policy through unchanged.

**Share the directional-shape check.** The `network_egress.is_some() || network_ingress.is_some()` test was spelled out at
three sites, where a partial edit would route an ingress-only policy down the legacy path and silently discard its posture. It is now `bwrap_command::is_directional`, which lives there rather than in `network_rules` because that module is Linux-gated while `bwrap_command` compiles everywhere.

**Cover IPv6 and ICMP rendering with a live test.** No directional config carried a v6 peer or an ICMP rule, so `ip6tables-restore` never saw a v6 address or the `icmp` → `icmpv6` token swap the v6 table requires. `bubblewrap_network_directional_ipv6_icmp.json` exercises a `/128`, a `/48` with an `except` carve-out, an ICMP rule to a v6 peer, and a `to`-less ICMP rule that fans into both families. Connectivity is deliberately **not** asserted — the namespace has no IPv6 route (#955) — only that the rules install, which a rejected token would prevent by failing namespace setup.

The fourth item in the issue (a flaky test reaching `api.github.com`) was already fixed on main: every Bubblewrap proxy config now uses the local `mxc-test.invalid` fixture. No work was needed.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --target x86_64-unknown-linux-gnu -p bwrap_common --all-targets -- -D warnings` — clean
- `cargo test -p bwrap_common` — 84 passed (includes a new table test pinning all four `is_directional` shape combinations)
- `node scripts/versioning/validate-configs.js` — 268 configs OK
- `bash -n tests/scripts/run_bwrap_directional_test.sh` — clean

The Linux-only `network_rules`/`bwrap_runner` unit tests and the new E2E config
require a Linux host with `bwrap`, so they are covered by CI rather than locally.

Closes #991

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1051)