### PR TITLE
Exit the isolation-session operator drivers with the workload's exit code

### DIFF
--- a/src/core/mxc-sdk/examples/isolation_session_console.rs
+++ b/src/core/mxc-sdk/examples/isolation_session_console.rs
@@ -19,9 +19,13 @@
 //! | `streaming` | Output arrives progressively, not as a burst at exit |
 //! | `resize` | The sandboxed process sees window-size changes live |
 //!
+//! The driver exits with the workload's exit code.
+//!
 //! Any other argument is treated as a literal command line.
 //!
 //! Must run at a real interactive console.
+
+use mxc_sdk::WaitOutcome;
 
 /// Provision mints a real OS account, so an early return or a panic would
 /// otherwise leave one behind on the host.
@@ -77,7 +81,7 @@ const SCENARIOS: &[Scenario] = &[
     },
 ];
 
-fn usage() -> ! {
+fn usage() -> i32 {
     eprintln!("usage: isolation_session_console [interactive|streaming|resize|<command line>]");
     eprintln!();
     for s in SCENARIOS {
@@ -85,15 +89,17 @@ fn usage() -> ! {
     }
     eprintln!();
     eprintln!("Anything else is treated as a literal command line to run in the session.");
-    std::process::exit(2)
+    2
 }
 
-fn main() {
+/// Returns the exit code rather than calling `std::process::exit`, which would
+/// skip the `Teardown` guard.
+fn run() -> i32 {
     let arg = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "interactive".into());
     if arg == "--help" || arg == "-h" {
-        usage();
+        return usage();
     }
 
     let (label, command, guidance) = match SCENARIOS.iter().find(|s| s.name == arg) {
@@ -106,7 +112,7 @@ fn main() {
         .any(|b| b.backend == "isolation_session")
     {
         eprintln!("IsolationSession is not available on this host.");
-        std::process::exit(2);
+        return 2;
     }
 
     let provision = r#"{"phase":"provision","containment":"isolation_session",
@@ -137,7 +143,20 @@ fn main() {
     );
 
     match mxc_sdk::exec_attached(&exec, true) {
-        Ok(outcome) => println!("\n[driver] outcome: {outcome:?}"),
-        Err(e) => println!("\n[driver] exec failed: {e:?}"),
+        Ok(outcome) => {
+            println!("\n[driver] outcome: {outcome:?}");
+            match outcome {
+                WaitOutcome::Exited(code) => code,
+                WaitOutcome::TimedOut => 1,
+            }
+        }
+        Err(e) => {
+            println!("\n[driver] exec failed: {e:?}");
+            1
+        }
     }
+}
+
+fn main() {
+    std::process::exit(run())
 }

--- a/src/ffi/mxc_ffi/examples/attached_console_ffi.rs
+++ b/src/ffi/mxc_ffi/examples/attached_console_ffi.rs
@@ -17,6 +17,9 @@
 //! `isolation_session_console` example asks for: the prompt draws and redraws,
 //! input works, and `exit 7` comes back as `exit_code: 7`. Running both isolates
 //! whether a failure is in the ABI or beneath it.
+//!
+//! The driver exits with the workload's exit code.
+//!
 //! Must run at a real interactive console.
 
 use std::ffi::{CStr, CString};
@@ -83,7 +86,9 @@ impl Drop for Teardown {
     }
 }
 
-fn main() {
+/// Returns the exit code rather than calling `std::process::exit`, which would
+/// skip the `Teardown` guard.
+fn run() -> i32 {
     let command = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "powershell.exe -NoLogo".into());
@@ -102,7 +107,7 @@ fn main() {
         // Panicking here would strand the account this provision just minted,
         // with no id to reclaim it by, so print the payload a human needs.
         eprintln!("[driver] provision returned no sandboxId; reclaim by hand from: {provisioned}");
-        std::process::exit(1);
+        return 1;
     };
     let _teardown = Teardown(sandbox_id.clone());
     eprintln!("[driver] provisioned.");
@@ -136,6 +141,7 @@ fn main() {
             "\n[driver] status: 0, timed_out: {}, exit_code: {}",
             outcome.timed_out, outcome.exit_code
         );
+        outcome.exit_code
     } else {
         let message = if error.message_utf8.is_null() {
             String::from("(no message)")
@@ -148,5 +154,10 @@ fn main() {
         println!("\n[driver] status: {status}, error: {message}");
         // SAFETY: filled by the call and not yet freed.
         unsafe { mxc_error_detail_free(&mut error) };
+        1
     }
+}
+
+fn main() {
+    std::process::exit(run())
 }


### PR DESCRIPTION
## 📖 Description

The two Rust operator drivers that host an interactive terminal inside an isolation session printed the workload's outcome and then let `main` return, so the process exited `0` regardless of what the workload did. An external harness that launches these drivers and reads their exit code learned nothing from them. The .NET driver in `sdk/dotnet/Microsoft.Mxc.Sdk.ConsoleDriver` already returned the workload's code, so it reported correctly while the two Rust surfaces were silently wrong beside it.

Each driver's body moves into a `run() -> i32` whose result `main` passes to `std::process::exit`. Both drivers provision a real OS user account and hold a guard whose `Drop` releases it, and `std::process::exit` skips destructors, so every path returns rather than exiting and the guard always runs. Returning an `i32` also preserves the full Windows exit-code width, which `ExitCode` would truncate to a byte.

Behaviour is otherwise unchanged. Existing failure codes are untouched: usage and the availability guard exit `2`, a missing sandbox id exits `1`, and a failed lifecycle phase in the C ABI driver still panics.

Limitation: these drivers report the workload's exit code, not a summary of the whole run. A failed teardown warns on stderr and does not change the exit code, matching the .NET driver. Distinguishing driver failures from workload exit codes is tracked separately.

## 🔗 References

None.

## 🔍 Validation

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and the Windows build and test matrix with the isolation-session backend both on and off, plus the versioning, .NET SDK and Node SDK suites. `wxc_host_prep` needs elevation and was run separately: 16 passed, 0 failed.

End-to-end on an isolation-capable host: 162 passed, 0 failed, 2 skipped, agent-account leak check clean.

Terminal behaviour has no automated oracle, so an operator ran the interactive scenarios at a real console. Typing `exit 7` now yields `7` on all four surfaces that can host a terminal — `wxc-exec`, the Rust SDK, the C ABI, and the .NET SDK. The two Rust rows previously reported `0`.

Also verified on a host without isolation sessions: `--help` and the availability guard still exit `2`, and a failed provision in the C ABI driver still exits `101`.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)

## 📋 Issue Type

- [x] Bug fix

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1055)