### PR TITLE
[Bubblewrap] Add streaming (spawn_sandbox) test coverage on Linux

### DIFF
--- a/.github/workflows/Build.Linux.Job.yml
+++ b/.github/workflows/Build.Linux.Job.yml
@@ -91,8 +91,11 @@ jobs:
           # sandbox can start (no-op on kernels without this knob).
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
-      # Must run after the install: these skip when bwrap is absent, so running
-      # them earlier would silently exercise nothing.
+      # The job defaults working-directory to src/core/lxc, so the `Test lxc`
+      # step above covers only the lxc package -- nothing else in this job runs
+      # mxc-sdk's tests, making this step their sole CI coverage. It must follow
+      # the install: these skip when bwrap is absent, so running them earlier
+      # would silently exercise nothing.
       - name: Test Bubblewrap streaming (mxc-sdk)
         working-directory: src
         run: cargo test --locked --release --target ${{ matrix.target }}

--- a/.github/workflows/Build.Linux.Job.yml
+++ b/.github/workflows/Build.Linux.Job.yml
@@ -91,6 +91,13 @@ jobs:
           # sandbox can start (no-op on kernels without this knob).
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
+      # Must run after the install: these skip when bwrap is absent, so running
+      # them earlier would silently exercise nothing.
+      - name: Test Bubblewrap streaming (mxc-sdk)
+        working-directory: src
+        run: cargo test --locked --release --target ${{ matrix.target }}
+             -p mxc-sdk --test streaming_bubblewrap
+
       # Runs the Bubblewrap executor characterization tests. lxc-exec was built
       # into src/target/<triple>/release above, where find_binary() locates it.
       - name: Test executor characterization (wxc_e2e_tests)

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1488,6 +1488,7 @@ dependencies = [
 name = "mxc-sdk"
 version = "0.8.0"
 dependencies = [
+ "bwrap_common",
  "libc",
  "mxc_engine",
  "serde_json",

--- a/src/core/mxc-sdk/Cargo.toml
+++ b/src/core/mxc-sdk/Cargo.toml
@@ -36,3 +36,7 @@ required-features = ["isolation_session"]
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 libc = { workspace = true }
+
+# Skip gate for the Bubblewrap streaming tests.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+bwrap_common = { workspace = true }

--- a/src/core/mxc-sdk/tests/streaming_bubblewrap.rs
+++ b/src/core/mxc-sdk/tests/streaming_bubblewrap.rs
@@ -50,8 +50,10 @@ fn bwrap_request(command: &str, timeout_ms: u32) -> SandboxRequest {
     request
 }
 
-/// Whether `pid` still has a `/proc` entry. A zombie still has one, so this
-/// distinguishes "reaped" from merely "exited".
+/// Whether `pid` still has a `/proc` entry. An exited child stays a zombie --
+/// with a live `/proc` entry -- until its parent `wait()`s and the kernel
+/// releases its pid and exit status; that is "reaped". So this distinguishes a
+/// child the SDK actually collected from one it merely stopped running.
 fn proc_entry_exists(pid: u32) -> bool {
     std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
@@ -80,23 +82,36 @@ fn streaming_bubblewrap_bidirectional_stdio() {
 
 #[test]
 fn streaming_bubblewrap_wait_with_output_captures_both_streams() {
-    // Drains both streams concurrently, avoiding the take-both deadlock.
+    // Each stream exceeds the 64 KiB pipe buffer, so a sequential drain would
+    // deadlock. Bounded here rather than by the sandbox timeout, which does not
+    // interrupt a blocked reader.
     if !bwrap_available() {
         return;
     }
-    let proc = spawn_sandbox(bwrap_request("echo to-out; echo to-err 1>&2", 0)).expect("spawn");
+    const BYTES: usize = 256 * 1024;
+    let script = format!("yes a | head -c {BYTES}; yes b | head -c {BYTES} 1>&2");
 
-    let output = proc.wait_with_output().expect("wait_with_output");
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let proc = spawn_sandbox(bwrap_request(&script, 30_000)).expect("spawn");
+        let _ = tx.send(proc.wait_with_output());
+    });
+
+    let output = rx
+        .recv_timeout(std::time::Duration::from_secs(60))
+        .expect("deadlocked: streams are not drained concurrently")
+        .expect("wait_with_output");
+
     assert_eq!(output.outcome, WaitOutcome::Exited(0));
+    assert_eq!(output.stdout.len(), BYTES, "stdout fully drained");
+    assert_eq!(output.stderr.len(), BYTES, "stderr fully drained");
     assert!(
-        String::from_utf8_lossy(&output.stdout).contains("to-out"),
-        "stdout: {:?}",
-        String::from_utf8_lossy(&output.stdout)
+        output.stdout.iter().all(|b| *b == b'a' || *b == b'\n'),
+        "stdout carries its own stream"
     );
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("to-err"),
-        "stderr: {:?}",
-        String::from_utf8_lossy(&output.stderr)
+        output.stderr.iter().all(|b| *b == b'b' || *b == b'\n'),
+        "stderr carries its own stream"
     );
 }
 

--- a/src/core/mxc-sdk/tests/streaming_bubblewrap.rs
+++ b/src/core/mxc-sdk/tests/streaming_bubblewrap.rs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//! Bubblewrap streaming API tests: live stdio, exit-status fidelity,
+//! kill/reap, and output metadata.
+//!
+//! Linux-gated file: the sibling `streaming.rs` is `#![cfg(macos)]` and
+//! `streaming_processcontainer.rs` is `#![cfg(windows)]`, so the Linux cases
+//! need a third file rather than a `#[cfg]` inside either.
+//!
+//! Tests skip when `bwrap` is missing or too old.
+
+#![cfg(target_os = "linux")]
+
+use mxc_sdk::{build_request, spawn_sandbox, SandboxPolicy, SandboxRequest, WaitOutcome};
+
+/// Whether `bwrap` is usable. Reuses the backend's own probe so this gate
+/// cannot drift from the real version check.
+fn bwrap_available() -> bool {
+    match bwrap_common::bwrap_version::probe_bwrap() {
+        Ok(_) => true,
+        Err(err) => {
+            println!("SKIPPED: {err}");
+            false
+        }
+    }
+}
+
+/// A Bubblewrap streaming request (`/tmp` read-write) with the given command
+/// and timeout (ms; `0` == run until exit).
+fn bwrap_request(command: &str, timeout_ms: u32) -> SandboxRequest {
+    let policy = SandboxPolicy {
+        version: "0.7.0-alpha".to_string(),
+        filesystem: Some(mxc_sdk::policy::FilesystemSection {
+            readwrite_paths: vec!["/tmp".to_string()],
+            readonly_paths: vec![],
+            denied_paths: vec![],
+            clear_policy_on_exit: None,
+        }),
+        network: None,
+        ui: None,
+        timeout_ms: if timeout_ms == 0 {
+            None
+        } else {
+            Some(timeout_ms)
+        },
+    };
+    let mut request = build_request(&policy, None).expect("build_request should succeed");
+    request.set_script(command);
+    request
+}
+
+/// Whether `pid` still has a `/proc` entry. A zombie still has one, so this
+/// distinguishes "reaped" from merely "exited".
+fn proc_entry_exists(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+#[test]
+fn streaming_bubblewrap_bidirectional_stdio() {
+    if !bwrap_available() {
+        return;
+    }
+    use std::io::{Read, Write};
+
+    let mut proc = spawn_sandbox(bwrap_request("cat", 0)).expect("spawn");
+
+    let mut stdin = proc.take_stdin().expect("stdin available");
+    let mut stdout = proc.take_stdout().expect("stdout available");
+
+    stdin.write_all(b"ping-pong\n").expect("write stdin");
+    drop(stdin); // close -> cat sees EOF and exits
+
+    let mut out = String::new();
+    stdout.read_to_string(&mut out).expect("read stdout");
+    assert!(out.contains("ping-pong"), "got: {out:?}");
+
+    assert_eq!(proc.wait().expect("wait"), WaitOutcome::Exited(0));
+}
+
+#[test]
+fn streaming_bubblewrap_wait_with_output_captures_both_streams() {
+    // Drains both streams concurrently, avoiding the take-both deadlock.
+    if !bwrap_available() {
+        return;
+    }
+    let proc = spawn_sandbox(bwrap_request("echo to-out; echo to-err 1>&2", 0)).expect("spawn");
+
+    let output = proc.wait_with_output().expect("wait_with_output");
+    assert_eq!(output.outcome, WaitOutcome::Exited(0));
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("to-out"),
+        "stdout: {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("to-err"),
+        "stderr: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn streaming_bubblewrap_stderr_is_readable_live() {
+    // Pins `take_stderr` itself, which `wait_with_output` bypasses.
+    if !bwrap_available() {
+        return;
+    }
+    use std::io::Read;
+
+    let mut proc = spawn_sandbox(bwrap_request("echo diagnostic 1>&2", 0)).expect("spawn");
+
+    let mut stderr = proc.take_stderr().expect("stderr available");
+    let mut err = String::new();
+    stderr.read_to_string(&mut err).expect("read stderr");
+    assert!(err.contains("diagnostic"), "got: {err:?}");
+
+    assert_eq!(proc.wait().expect("wait"), WaitOutcome::Exited(0));
+}
+
+#[test]
+fn streaming_bubblewrap_wait_reports_the_workloads_exit_code() {
+    // `bwrap` sits between the SDK and the workload: pins that the workload's
+    // status propagates, not bwrap's own.
+    if !bwrap_available() {
+        return;
+    }
+    for code in [0, 1, 42] {
+        let mut proc = spawn_sandbox(bwrap_request(&format!("exit {code}"), 0)).expect("spawn");
+        assert_eq!(
+            proc.wait().expect("wait"),
+            WaitOutcome::Exited(code),
+            "workload exited {code}"
+        );
+    }
+}
+
+#[test]
+fn streaming_bubblewrap_id_exposes_a_real_pid() {
+    // Contrast WSLC, which documents `id() == 0` because its SDK exposes no pid.
+    if !bwrap_available() {
+        return;
+    }
+    let mut proc = spawn_sandbox(bwrap_request("sleep 30", 0)).expect("spawn");
+
+    let pid = proc.id();
+    assert!(pid > 0, "id() should expose a real pid, got {pid}");
+    assert!(
+        proc_entry_exists(pid),
+        "pid {pid} should be live while the sandbox runs"
+    );
+
+    proc.kill().expect("kill");
+    let _ = proc.wait();
+}
+
+#[test]
+fn streaming_bubblewrap_kill_reaps_the_child() {
+    if !bwrap_available() {
+        return;
+    }
+    let mut proc = spawn_sandbox(bwrap_request("sleep 30", 0)).expect("spawn");
+    let pid = proc.id();
+
+    assert!(
+        proc.try_wait().expect("try_wait").is_none(),
+        "child should still be running shortly after spawn"
+    );
+
+    proc.kill().expect("kill");
+    assert_ne!(
+        proc.wait().expect("wait after kill"),
+        WaitOutcome::Exited(0),
+        "killed process should not report success"
+    );
+
+    let mut reaped = false;
+    for _ in 0..60 {
+        if !proc_entry_exists(pid) {
+            reaped = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(reaped, "pid {pid} should be reaped, not left as a zombie");
+}
+
+#[test]
+fn streaming_bubblewrap_timeout_reports_timed_out() {
+    if !bwrap_available() {
+        return;
+    }
+    let mut proc = spawn_sandbox(bwrap_request("sleep 30", 1000)).expect("spawn");
+
+    let start = std::time::Instant::now();
+    assert_eq!(
+        proc.wait().expect("wait yields an outcome"),
+        WaitOutcome::TimedOut,
+        "a workload outliving its timeout should report a timeout"
+    );
+    assert!(
+        start.elapsed() < std::time::Duration::from_secs(15),
+        "timeout should fire near 1s, not wait out the 30s sleep (elapsed: {:?})",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn streaming_bubblewrap_reports_no_output_metadata() {
+    // Pins the current contract: Bubblewrap produces no structured outputs
+    // (`captureDenials` is a Windows BaseContainer feature), so the accessor is
+    // callable after terminal teardown and empty. A backend that starts
+    // emitting metadata should update this rather than surprise callers.
+    if !bwrap_available() {
+        return;
+    }
+    let mut proc = spawn_sandbox(bwrap_request("true", 0)).expect("spawn");
+    assert_eq!(proc.wait().expect("wait"), WaitOutcome::Exited(0));
+    assert!(
+        proc.output_metadata().is_none(),
+        "Bubblewrap should report no structured output metadata"
+    );
+}


### PR DESCRIPTION
## 📖 Description
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

The Bubblewrap `spawn_sandbox` / `StdioMode::Pipes` path is shipped in the public Rust SDK but had never been executed by a test on any platform. `streaming.rs` is `#![cfg(macos)]` at file level, so Linux cases need their own file — Windows already got one.

Adds `src/core/mxc-sdk/tests/streaming_bubblewrap.rs` (8 tests, `#![cfg(target_os = "linux")]`) driving the real consumer path (`build_request` from a `SandboxPolicy` → `spawn_sandbox`):

- live `stdout` and `stderr` reads, plus `wait_with_output` draining both without deadlock
- `stdin` write + EOF on close, child observes it and exits
- `wait()` exit-status fidelity across `[0, 1, 42]`
- `id()` exposes a real pid (contrast WSLC's documented `id() == 0`)
- `kill()` reaps the child rather than leaving a zombie
- timeout reports `WaitOutcome::TimedOut`; `output_metadata()` is `None`

**No product bugs found.** Exit-status fidelity through the `bwrap` intermediate — the flagged highest risk — holds; the assertion was mutation-checked to confirm it isn't vacuous. So nothing needed splitting into a separate issue.

Also adds a Linux CI step. `Test lxc` runs from `src/core/lxc`, so it is package-scoped — `mxc-sdk` tests were not running on Linux CI at all. The new step is placed after `Install Bubblewrap`, since these self-skip when `bwrap` is absent and would otherwise pass while exercising nothing. It runs on both the x64 and arm64 matrix arches.

Verified locally in WSL (Ubuntu 24.04, bwrap 0.9.0): 8/8 passing in debug and release across repeated runs; `cargo fmt` and `cargo clippy -D warnings` clean.

Closes #1009

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1056)