### PR TITLE
[Bubblewrap] Stop descendants outliving teardown and close the backend's test coverage gaps

### DIFF
--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
@@ -9,6 +9,62 @@ using Microsoft.Mxc.Sdk.Native;
 namespace Microsoft.Mxc.Sdk;
 
 /// <summary>
+/// Injectable handle that interrupts reads from one sandbox output stream.
+/// </summary>
+public interface ISandboxStreamCloser : IDisposable
+{
+    /// <summary>Close the associated reader.</summary>
+    void Close();
+}
+
+/// <summary>
+/// Injectable abstraction for a live sandboxed process. Implement this
+/// interface in tests to provide in-memory streams and deterministic outcomes.
+/// </summary>
+public interface ISandboxProcess : IDisposable
+{
+    /// <summary>The child process identifier, or zero when unavailable.</summary>
+    uint Id { get; }
+
+    /// <summary>The child's writable standard input.</summary>
+    Stream? StandardInput { get; }
+
+    /// <summary>The child's readable standard output.</summary>
+    Stream? StandardOutput { get; }
+
+    /// <summary>The child's readable standard error.</summary>
+    Stream? StandardError { get; }
+
+    /// <summary>A handle that can interrupt standard-output reads.</summary>
+    ISandboxStreamCloser? StandardOutputCloser { get; }
+
+    /// <summary>A handle that can interrupt standard-error reads.</summary>
+    ISandboxStreamCloser? StandardErrorCloser { get; }
+
+    /// <summary>Security warnings emitted while applying the policy.</summary>
+    IReadOnlyList<string> Warnings { get; }
+
+    /// <summary>Structured feature output available after terminal completion.</summary>
+    SandboxOutputMetadata? OutputMetadata { get; }
+
+    /// <summary>Wait for the child to exit.</summary>
+    SandboxWaitResult Wait();
+
+    /// <summary>Wait asynchronously for the child to exit.</summary>
+    Task<SandboxWaitResult> WaitAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Check whether the child has exited without blocking.</summary>
+    bool TryGetExitCode(out int exitCode);
+
+    /// <summary>Wait while capturing standard output and error.</summary>
+    Task<(SandboxWaitResult Result, byte[] Stdout, byte[] Stderr)> WaitForExitWithOutputAsync(
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Kill the child and its process tree.</summary>
+    void Kill();
+}
+
+/// <summary>
 /// A live sandboxed process spawned by <see cref="MxcSandbox.Spawn(SandboxPolicy, string)"/>.
 /// </summary>
 /// <remarks>
@@ -16,10 +72,11 @@ namespace Microsoft.Mxc.Sdk;
 /// Stream the child's stdio with <see cref="StandardInput"/> /
 /// <see cref="StandardOutput"/> / <see cref="StandardError"/>, wait for it with
 /// <see cref="Wait"/> / <see cref="WaitAsync"/>, or kill it (and its whole tree)
-/// with <see cref="Kill"/>. Each standard stream is a separate object; different
-/// streams may be used concurrently on different threads, but a single stream
-/// must be driven from one thread at a time (its native reads/writes are
-/// serialized internally, since the underlying handle is not concurrency-safe).
+/// with <see cref="Kill"/>. <see cref="Warnings"/> reports policy relaxations
+/// immediately. Each standard stream is a separate object; different streams
+/// may be used concurrently on different threads, but a single stream must be
+/// driven from one thread at a time (its native reads/writes are serialized
+/// internally, since the underlying handle is not concurrency-safe).
 /// </para>
 /// <para>
 /// <b>Draining.</b> Like the underlying Rust <c>Sandbox</c>, <see cref="Wait"/>
@@ -47,7 +104,7 @@ namespace Microsoft.Mxc.Sdk;
 /// native handles and kill the child.
 /// </para>
 /// </remarks>
-public sealed class MxcSandboxProcess : IDisposable
+public sealed class MxcSandboxProcess : ISandboxProcess
 {
     // Poll cadence bounds for the try_wait-based wait loop: start short so a
     // quick child returns promptly, back off to a cap so a long-running child
@@ -57,6 +114,7 @@ public sealed class MxcSandboxProcess : IDisposable
 
     private readonly object _controlLock = new();
     private readonly MxcSandboxHandle _handle;
+    private IReadOnlyList<string>? _warnings;
     private bool _disposed;
 
     // Tracks whether each readable standard stream is still available, has been
@@ -89,8 +147,11 @@ public sealed class MxcSandboxProcess : IDisposable
     internal MxcSandboxProcess(MxcSandboxHandle handle, uint? timeoutMs = null)
     {
         _handle = handle;
-        _timeoutMs = timeoutMs;
+        _timeoutMs = NormalizeTimeout(timeoutMs);
     }
+
+    internal static uint? NormalizeTimeout(uint? timeoutMs) =>
+        timeoutMs is 0 ? null : timeoutMs;
 
     /// <summary>
     /// The child's OS process id (its PID on Unix, process id on Windows).
@@ -153,6 +214,83 @@ public sealed class MxcSandboxProcess : IDisposable
     /// <see langword="null"/> if stderr was not piped.
     /// </summary>
     public Stream? StandardError => TakeReadStream(ref _stderrState, ref _stderr, stdout: false);
+
+    /// <summary>
+    /// A closer that makes an in-flight or subsequent
+    /// <see cref="StandardOutput"/> read return EOF without killing the child.
+    /// </summary>
+    /// <remarks>
+    /// Take <see cref="StandardOutput"/> before requesting its closer. Closing a
+    /// stream that no caller is draining can leave a child blocked on a full
+    /// pipe. Returns <see langword="null"/> when the backend cannot interrupt
+    /// stdout reads. Dispose the returned closer after use; each property access
+    /// returns an independent handle.
+    /// </remarks>
+    public SandboxStreamCloser? StandardOutputCloser =>
+        GetReadCloser(stdout: true);
+
+    /// <summary>
+    /// A closer that makes an in-flight or subsequent
+    /// <see cref="StandardError"/> read return EOF without killing the child.
+    /// </summary>
+    /// <remarks>
+    /// Take <see cref="StandardError"/> first. Returns <see langword="null"/>
+    /// when the backend cannot interrupt stderr reads. Dispose the returned
+    /// closer after use; each property access returns an independent handle.
+    /// </remarks>
+    public SandboxStreamCloser? StandardErrorCloser =>
+        GetReadCloser(stdout: false);
+
+    ISandboxStreamCloser? ISandboxProcess.StandardOutputCloser =>
+        StandardOutputCloser;
+
+    ISandboxStreamCloser? ISandboxProcess.StandardErrorCloser =>
+        StandardErrorCloser;
+
+    /// <summary>
+    /// Security warnings emitted while applying the sandbox policy.
+    /// </summary>
+    public IReadOnlyList<string> Warnings
+    {
+        get
+        {
+            lock (_controlLock)
+            {
+                ThrowIfDisposed();
+                if (_warnings is not null)
+                {
+                    return _warnings;
+                }
+                unsafe
+                {
+                    byte* json = null;
+                    var status = NativeMethods.mxc_sandbox_warnings_json(_handle.Ptr, &json);
+                    if (status != (int)ErrorCode.Success)
+                    {
+                        throw new MxcException(
+                            (ErrorCode)status,
+                            "retrieving sandbox security warnings failed");
+                    }
+                    if (json is null)
+                    {
+                        return _warnings = Array.Empty<string>();
+                    }
+                    try
+                    {
+                        var text = Marshal.PtrToStringUTF8((IntPtr)json);
+                        _warnings = string.IsNullOrEmpty(text)
+                            ? Array.Empty<string>()
+                            : JsonSerializer.Deserialize<string[]>(text) ?? Array.Empty<string>();
+                        return _warnings;
+                    }
+                    finally
+                    {
+                        NativeMethods.mxc_string_free(json);
+                    }
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// Structured outputs produced by optional sandbox features. Metadata is
@@ -227,10 +365,39 @@ public sealed class MxcSandboxProcess : IDisposable
         }
     }
 
+    private SandboxStreamCloser? GetReadCloser(bool stdout)
+    {
+        lock (_controlLock)
+        {
+            ThrowIfDisposed();
+            var state = stdout ? _stdoutState : _stderrState;
+            var stream = stdout ? _stdout : _stderr;
+            if (state != ReadStreamState.CallerOwned)
+            {
+                throw new InvalidOperationException(
+                    "take the standard stream before requesting its closer");
+            }
+            if (stream is null)
+            {
+                return null;
+            }
+            unsafe
+            {
+                var closer = stdout
+                    ? NativeMethods.mxc_sandbox_stdout_closer(_handle.Ptr)
+                    : NativeMethods.mxc_sandbox_stderr_closer(_handle.Ptr);
+                return closer is null
+                    ? null
+                    : new SandboxStreamCloser(MxcStreamCloserHandle.FromRaw(closer));
+            }
+        }
+    }
+
     /// <summary>
-    /// Block until the child exits (honouring the policy's
-    /// <see cref="SandboxPolicy.TimeoutMs"/>), draining any standard stream you
-    /// did not take so the child cannot block on a full pipe.
+    /// Block until the child exits (honouring
+    /// <see cref="SandboxPolicy.TimeoutMs"/> or
+    /// <see cref="StateAwareExecOptions.TimeoutMs"/>), draining any standard
+    /// stream you did not take so the child cannot block on a full pipe.
     /// </summary>
     /// <returns>The exit code, or a timed-out result.</returns>
     /// <exception cref="MxcException">A wait error occurred.</exception>
@@ -244,6 +411,59 @@ public sealed class MxcSandboxProcess : IDisposable
     public Task<SandboxWaitResult> WaitAsync(CancellationToken cancellationToken = default) =>
         Task.Run(() => WaitCore(cancellationToken), cancellationToken);
 
+    /// <summary>
+    /// Check whether the child has exited without blocking.
+    /// </summary>
+    /// <param name="exitCode">
+    /// Receives the child's exit code when this method returns
+    /// <see langword="true"/>, or <c>-1</c> when a native state-aware waiter
+    /// completed because its deadline elapsed; otherwise receives zero.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the child has exited; otherwise
+    /// <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// This is a status probe only. Call <see cref="Wait"/> or
+    /// <see cref="WaitAsync(CancellationToken)"/> after exit to complete
+    /// backend finalization, reclaim descendants, and make output metadata
+    /// available.
+    /// </remarks>
+    /// <exception cref="MxcException">The process status could not be queried.</exception>
+    public bool TryGetExitCode(out int exitCode)
+    {
+        return TryGetTerminalStatus(out exitCode, out _);
+    }
+
+    private bool TryGetTerminalStatus(out int exitCode, out bool timedOut)
+    {
+        lock (_controlLock)
+        {
+            ThrowIfDisposed();
+            var running = 1;
+            var nativeExitCode = 0;
+            var nativeTimedOut = 0;
+            int status;
+            unsafe
+            {
+                status = NativeMethods.mxc_sandbox_try_wait(
+                    _handle.Ptr,
+                    &nativeExitCode,
+                    &running,
+                    &nativeTimedOut);
+            }
+            if (status != (int)ErrorCode.Success)
+            {
+                throw new MxcException(
+                    (ErrorCode)status,
+                    "querying the sandbox process status failed");
+            }
+            exitCode = nativeExitCode;
+            timedOut = nativeTimedOut != 0;
+            return running == 0;
+        }
+    }
+
     private SandboxWaitResult WaitCore(CancellationToken cancellationToken)
     {
         EnsureDrainUntaken();
@@ -253,27 +473,11 @@ public sealed class MxcSandboxProcess : IDisposable
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            int status;
-            int exit = 0;
-            int running = 1;
-            lock (_controlLock)
-            {
-                ThrowIfDisposed();
-                unsafe
-                {
-                    status = NativeMethods.mxc_sandbox_try_wait(_handle.Ptr, &exit, &running);
-                }
-            }
-
-            if (status != (int)ErrorCode.Success)
-            {
-                throw new MxcException((ErrorCode)status, "waiting on the sandbox failed");
-            }
-            if (running == 0)
+            if (TryGetTerminalStatus(out _, out _))
             {
                 // try_wait is intentionally a non-blocking root-process poll.
-                // Complete the native wait so descendant termination and any
-                // backend finalization (including captureDenials) finish before
+                // Complete the native wait so a cached timeout is translated
+                // into TimedOut and all backend finalization finishes before
                 // the managed Wait/WaitAsync contract returns.
                 return WaitBlocking();
             }
@@ -295,14 +499,10 @@ public sealed class MxcSandboxProcess : IDisposable
         }
     }
 
-    /// <summary>
-    /// Block until the child exits using the native blocking wait, which reports
-    /// a policy timeout distinctly (<see cref="SandboxWaitResult.TimedOut"/>).
-    /// Unlike <see cref="Wait"/> this cannot be interrupted by a concurrent
-    /// <see cref="Kill"/> — it holds the control lock for the whole wait — so use
-    /// it only when you will not race a kill.
-    /// </summary>
-    public SandboxWaitResult WaitBlocking()
+    // Called only after try_wait reports exit or the managed deadline expires.
+    // It holds the control lock across the native wait and must not be public:
+    // callers need Wait/WaitAsync so concurrent Kill and Dispose stay responsive.
+    private SandboxWaitResult WaitBlocking()
     {
         EnsureDrainUntaken();
         lock (_controlLock)
@@ -334,6 +534,8 @@ public sealed class MxcSandboxProcess : IDisposable
     {
         var outStream = StandardOutput;
         var errStream = StandardError;
+        using var outCloser = outStream is null ? null : StandardOutputCloser;
+        using var errCloser = errStream is null ? null : StandardErrorCloser;
 
         Task<byte[]> ReadAll(Stream? s) =>
             s is null ? Task.FromResult(Array.Empty<byte>()) : ReadToEndAsync(s, cancellationToken);
@@ -347,6 +549,21 @@ public sealed class MxcSandboxProcess : IDisposable
             var stderr = await stderrTask.ConfigureAwait(false);
             return (result, stdout, stderr);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var readsClosed =
+                CloseQuietly(outCloser, outStream is not null) &
+                CloseQuietly(errCloser, errStream is not null);
+            if (!readsClosed)
+            {
+                KillQuietly();
+            }
+            await Task.WhenAll(SwallowAsync(stdoutTask), SwallowAsync(stderrTask))
+                .ConfigureAwait(false);
+            outStream?.Dispose();
+            errStream?.Dispose();
+            throw;
+        }
         catch
         {
             // On cancellation/failure the reader tasks may be parked in a blocking
@@ -358,6 +575,27 @@ public sealed class MxcSandboxProcess : IDisposable
             await Task.WhenAll(SwallowAsync(stdoutTask), SwallowAsync(stderrTask))
                 .ConfigureAwait(false);
             throw;
+        }
+    }
+
+    private static bool CloseQuietly(SandboxStreamCloser? closer, bool required)
+    {
+        if (closer is null)
+        {
+            return !required;
+        }
+        try
+        {
+            closer.Close();
+            return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+        catch (MxcException)
+        {
+            return false;
         }
     }
 
@@ -512,6 +750,50 @@ public sealed class MxcSandboxProcess : IDisposable
         _stdout?.Dispose();
         _stderr?.Dispose();
     }
+}
+
+/// <summary>
+/// Independently closes a sandbox output reader, making a blocking read return
+/// EOF without terminating the sandboxed process.
+/// </summary>
+public sealed class SandboxStreamCloser : ISandboxStreamCloser
+{
+    private readonly MxcStreamCloserHandle _handle;
+
+    internal SandboxStreamCloser(MxcStreamCloserHandle handle) => _handle = handle;
+
+    /// <summary>
+    /// Close the associated reader. Idempotent and safe to call concurrently
+    /// with that reader.
+    /// </summary>
+    public void Close()
+    {
+        var added = false;
+        try
+        {
+            _handle.DangerousAddRef(ref added);
+            unsafe
+            {
+                var status = NativeMethods.mxc_stream_closer_close(_handle.Ptr);
+                if (status != (int)ErrorCode.Success)
+                {
+                    throw new MxcException(
+                        (ErrorCode)status,
+                        "closing the sandbox output stream failed");
+                }
+            }
+        }
+        finally
+        {
+            if (added)
+            {
+                _handle.DangerousRelease();
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => _handle.Dispose();
 }
 
 /// <summary>Readable <see cref="Stream"/> over a native <c>MxcReadStream</c> (child stdout/stderr).</summary>

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
@@ -9,62 +9,6 @@ using Microsoft.Mxc.Sdk.Native;
 namespace Microsoft.Mxc.Sdk;
 
 /// <summary>
-/// Injectable handle that interrupts reads from one sandbox output stream.
-/// </summary>
-public interface ISandboxStreamCloser : IDisposable
-{
-    /// <summary>Close the associated reader.</summary>
-    void Close();
-}
-
-/// <summary>
-/// Injectable abstraction for a live sandboxed process. Implement this
-/// interface in tests to provide in-memory streams and deterministic outcomes.
-/// </summary>
-public interface ISandboxProcess : IDisposable
-{
-    /// <summary>The child process identifier, or zero when unavailable.</summary>
-    uint Id { get; }
-
-    /// <summary>The child's writable standard input.</summary>
-    Stream? StandardInput { get; }
-
-    /// <summary>The child's readable standard output.</summary>
-    Stream? StandardOutput { get; }
-
-    /// <summary>The child's readable standard error.</summary>
-    Stream? StandardError { get; }
-
-    /// <summary>A handle that can interrupt standard-output reads.</summary>
-    ISandboxStreamCloser? StandardOutputCloser { get; }
-
-    /// <summary>A handle that can interrupt standard-error reads.</summary>
-    ISandboxStreamCloser? StandardErrorCloser { get; }
-
-    /// <summary>Security warnings emitted while applying the policy.</summary>
-    IReadOnlyList<string> Warnings { get; }
-
-    /// <summary>Structured feature output available after terminal completion.</summary>
-    SandboxOutputMetadata? OutputMetadata { get; }
-
-    /// <summary>Wait for the child to exit.</summary>
-    SandboxWaitResult Wait();
-
-    /// <summary>Wait asynchronously for the child to exit.</summary>
-    Task<SandboxWaitResult> WaitAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>Check whether the child has exited without blocking.</summary>
-    bool TryGetExitCode(out int exitCode);
-
-    /// <summary>Wait while capturing standard output and error.</summary>
-    Task<(SandboxWaitResult Result, byte[] Stdout, byte[] Stderr)> WaitForExitWithOutputAsync(
-        CancellationToken cancellationToken = default);
-
-    /// <summary>Kill the child and its process tree.</summary>
-    void Kill();
-}
-
-/// <summary>
 /// A live sandboxed process spawned by <see cref="MxcSandbox.Spawn(SandboxPolicy, string)"/>.
 /// </summary>
 /// <remarks>
@@ -72,11 +16,10 @@ public interface ISandboxProcess : IDisposable
 /// Stream the child's stdio with <see cref="StandardInput"/> /
 /// <see cref="StandardOutput"/> / <see cref="StandardError"/>, wait for it with
 /// <see cref="Wait"/> / <see cref="WaitAsync"/>, or kill it (and its whole tree)
-/// with <see cref="Kill"/>. <see cref="Warnings"/> reports policy relaxations
-/// immediately. Each standard stream is a separate object; different streams
-/// may be used concurrently on different threads, but a single stream must be
-/// driven from one thread at a time (its native reads/writes are serialized
-/// internally, since the underlying handle is not concurrency-safe).
+/// with <see cref="Kill"/>. Each standard stream is a separate object; different
+/// streams may be used concurrently on different threads, but a single stream
+/// must be driven from one thread at a time (its native reads/writes are
+/// serialized internally, since the underlying handle is not concurrency-safe).
 /// </para>
 /// <para>
 /// <b>Draining.</b> Like the underlying Rust <c>Sandbox</c>, <see cref="Wait"/>
@@ -104,7 +47,7 @@ public interface ISandboxProcess : IDisposable
 /// native handles and kill the child.
 /// </para>
 /// </remarks>
-public sealed class MxcSandboxProcess : ISandboxProcess
+public sealed class MxcSandboxProcess : IDisposable
 {
     // Poll cadence bounds for the try_wait-based wait loop: start short so a
     // quick child returns promptly, back off to a cap so a long-running child
@@ -114,7 +57,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
 
     private readonly object _controlLock = new();
     private readonly MxcSandboxHandle _handle;
-    private IReadOnlyList<string>? _warnings;
     private bool _disposed;
 
     // Tracks whether each readable standard stream is still available, has been
@@ -147,11 +89,8 @@ public sealed class MxcSandboxProcess : ISandboxProcess
     internal MxcSandboxProcess(MxcSandboxHandle handle, uint? timeoutMs = null)
     {
         _handle = handle;
-        _timeoutMs = NormalizeTimeout(timeoutMs);
+        _timeoutMs = timeoutMs;
     }
-
-    internal static uint? NormalizeTimeout(uint? timeoutMs) =>
-        timeoutMs is 0 ? null : timeoutMs;
 
     /// <summary>
     /// The child's OS process id (its PID on Unix, process id on Windows).
@@ -214,83 +153,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
     /// <see langword="null"/> if stderr was not piped.
     /// </summary>
     public Stream? StandardError => TakeReadStream(ref _stderrState, ref _stderr, stdout: false);
-
-    /// <summary>
-    /// A closer that makes an in-flight or subsequent
-    /// <see cref="StandardOutput"/> read return EOF without killing the child.
-    /// </summary>
-    /// <remarks>
-    /// Take <see cref="StandardOutput"/> before requesting its closer. Closing a
-    /// stream that no caller is draining can leave a child blocked on a full
-    /// pipe. Returns <see langword="null"/> when the backend cannot interrupt
-    /// stdout reads. Dispose the returned closer after use; each property access
-    /// returns an independent handle.
-    /// </remarks>
-    public SandboxStreamCloser? StandardOutputCloser =>
-        GetReadCloser(stdout: true);
-
-    /// <summary>
-    /// A closer that makes an in-flight or subsequent
-    /// <see cref="StandardError"/> read return EOF without killing the child.
-    /// </summary>
-    /// <remarks>
-    /// Take <see cref="StandardError"/> first. Returns <see langword="null"/>
-    /// when the backend cannot interrupt stderr reads. Dispose the returned
-    /// closer after use; each property access returns an independent handle.
-    /// </remarks>
-    public SandboxStreamCloser? StandardErrorCloser =>
-        GetReadCloser(stdout: false);
-
-    ISandboxStreamCloser? ISandboxProcess.StandardOutputCloser =>
-        StandardOutputCloser;
-
-    ISandboxStreamCloser? ISandboxProcess.StandardErrorCloser =>
-        StandardErrorCloser;
-
-    /// <summary>
-    /// Security warnings emitted while applying the sandbox policy.
-    /// </summary>
-    public IReadOnlyList<string> Warnings
-    {
-        get
-        {
-            lock (_controlLock)
-            {
-                ThrowIfDisposed();
-                if (_warnings is not null)
-                {
-                    return _warnings;
-                }
-                unsafe
-                {
-                    byte* json = null;
-                    var status = NativeMethods.mxc_sandbox_warnings_json(_handle.Ptr, &json);
-                    if (status != (int)ErrorCode.Success)
-                    {
-                        throw new MxcException(
-                            (ErrorCode)status,
-                            "retrieving sandbox security warnings failed");
-                    }
-                    if (json is null)
-                    {
-                        return _warnings = Array.Empty<string>();
-                    }
-                    try
-                    {
-                        var text = Marshal.PtrToStringUTF8((IntPtr)json);
-                        _warnings = string.IsNullOrEmpty(text)
-                            ? Array.Empty<string>()
-                            : JsonSerializer.Deserialize<string[]>(text) ?? Array.Empty<string>();
-                        return _warnings;
-                    }
-                    finally
-                    {
-                        NativeMethods.mxc_string_free(json);
-                    }
-                }
-            }
-        }
-    }
 
     /// <summary>
     /// Structured outputs produced by optional sandbox features. Metadata is
@@ -365,39 +227,10 @@ public sealed class MxcSandboxProcess : ISandboxProcess
         }
     }
 
-    private SandboxStreamCloser? GetReadCloser(bool stdout)
-    {
-        lock (_controlLock)
-        {
-            ThrowIfDisposed();
-            var state = stdout ? _stdoutState : _stderrState;
-            var stream = stdout ? _stdout : _stderr;
-            if (state != ReadStreamState.CallerOwned)
-            {
-                throw new InvalidOperationException(
-                    "take the standard stream before requesting its closer");
-            }
-            if (stream is null)
-            {
-                return null;
-            }
-            unsafe
-            {
-                var closer = stdout
-                    ? NativeMethods.mxc_sandbox_stdout_closer(_handle.Ptr)
-                    : NativeMethods.mxc_sandbox_stderr_closer(_handle.Ptr);
-                return closer is null
-                    ? null
-                    : new SandboxStreamCloser(MxcStreamCloserHandle.FromRaw(closer));
-            }
-        }
-    }
-
     /// <summary>
-    /// Block until the child exits (honouring
-    /// <see cref="SandboxPolicy.TimeoutMs"/> or
-    /// <see cref="StateAwareExecOptions.TimeoutMs"/>), draining any standard
-    /// stream you did not take so the child cannot block on a full pipe.
+    /// Block until the child exits (honouring the policy's
+    /// <see cref="SandboxPolicy.TimeoutMs"/>), draining any standard stream you
+    /// did not take so the child cannot block on a full pipe.
     /// </summary>
     /// <returns>The exit code, or a timed-out result.</returns>
     /// <exception cref="MxcException">A wait error occurred.</exception>
@@ -411,59 +244,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
     public Task<SandboxWaitResult> WaitAsync(CancellationToken cancellationToken = default) =>
         Task.Run(() => WaitCore(cancellationToken), cancellationToken);
 
-    /// <summary>
-    /// Check whether the child has exited without blocking.
-    /// </summary>
-    /// <param name="exitCode">
-    /// Receives the child's exit code when this method returns
-    /// <see langword="true"/>, or <c>-1</c> when a native state-aware waiter
-    /// completed because its deadline elapsed; otherwise receives zero.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> when the child has exited; otherwise
-    /// <see langword="false"/>.
-    /// </returns>
-    /// <remarks>
-    /// This is a status probe only. Call <see cref="Wait"/> or
-    /// <see cref="WaitAsync(CancellationToken)"/> after exit to complete
-    /// backend finalization, reclaim descendants, and make output metadata
-    /// available.
-    /// </remarks>
-    /// <exception cref="MxcException">The process status could not be queried.</exception>
-    public bool TryGetExitCode(out int exitCode)
-    {
-        return TryGetTerminalStatus(out exitCode, out _);
-    }
-
-    private bool TryGetTerminalStatus(out int exitCode, out bool timedOut)
-    {
-        lock (_controlLock)
-        {
-            ThrowIfDisposed();
-            var running = 1;
-            var nativeExitCode = 0;
-            var nativeTimedOut = 0;
-            int status;
-            unsafe
-            {
-                status = NativeMethods.mxc_sandbox_try_wait(
-                    _handle.Ptr,
-                    &nativeExitCode,
-                    &running,
-                    &nativeTimedOut);
-            }
-            if (status != (int)ErrorCode.Success)
-            {
-                throw new MxcException(
-                    (ErrorCode)status,
-                    "querying the sandbox process status failed");
-            }
-            exitCode = nativeExitCode;
-            timedOut = nativeTimedOut != 0;
-            return running == 0;
-        }
-    }
-
     private SandboxWaitResult WaitCore(CancellationToken cancellationToken)
     {
         EnsureDrainUntaken();
@@ -473,11 +253,27 @@ public sealed class MxcSandboxProcess : ISandboxProcess
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (TryGetTerminalStatus(out _, out _))
+            int status;
+            int exit = 0;
+            int running = 1;
+            lock (_controlLock)
+            {
+                ThrowIfDisposed();
+                unsafe
+                {
+                    status = NativeMethods.mxc_sandbox_try_wait(_handle.Ptr, &exit, &running);
+                }
+            }
+
+            if (status != (int)ErrorCode.Success)
+            {
+                throw new MxcException((ErrorCode)status, "waiting on the sandbox failed");
+            }
+            if (running == 0)
             {
                 // try_wait is intentionally a non-blocking root-process poll.
-                // Complete the native wait so a cached timeout is translated
-                // into TimedOut and all backend finalization finishes before
+                // Complete the native wait so descendant termination and any
+                // backend finalization (including captureDenials) finish before
                 // the managed Wait/WaitAsync contract returns.
                 return WaitBlocking();
             }
@@ -499,10 +295,14 @@ public sealed class MxcSandboxProcess : ISandboxProcess
         }
     }
 
-    // Called only after try_wait reports exit or the managed deadline expires.
-    // It holds the control lock across the native wait and must not be public:
-    // callers need Wait/WaitAsync so concurrent Kill and Dispose stay responsive.
-    private SandboxWaitResult WaitBlocking()
+    /// <summary>
+    /// Block until the child exits using the native blocking wait, which reports
+    /// a policy timeout distinctly (<see cref="SandboxWaitResult.TimedOut"/>).
+    /// Unlike <see cref="Wait"/> this cannot be interrupted by a concurrent
+    /// <see cref="Kill"/> — it holds the control lock for the whole wait — so use
+    /// it only when you will not race a kill.
+    /// </summary>
+    public SandboxWaitResult WaitBlocking()
     {
         EnsureDrainUntaken();
         lock (_controlLock)
@@ -534,8 +334,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
     {
         var outStream = StandardOutput;
         var errStream = StandardError;
-        using var outCloser = outStream is null ? null : StandardOutputCloser;
-        using var errCloser = errStream is null ? null : StandardErrorCloser;
 
         Task<byte[]> ReadAll(Stream? s) =>
             s is null ? Task.FromResult(Array.Empty<byte>()) : ReadToEndAsync(s, cancellationToken);
@@ -549,21 +347,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
             var stderr = await stderrTask.ConfigureAwait(false);
             return (result, stdout, stderr);
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            var readsClosed =
-                CloseQuietly(outCloser, outStream is not null) &
-                CloseQuietly(errCloser, errStream is not null);
-            if (!readsClosed)
-            {
-                KillQuietly();
-            }
-            await Task.WhenAll(SwallowAsync(stdoutTask), SwallowAsync(stderrTask))
-                .ConfigureAwait(false);
-            outStream?.Dispose();
-            errStream?.Dispose();
-            throw;
-        }
         catch
         {
             // On cancellation/failure the reader tasks may be parked in a blocking
@@ -575,27 +358,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
             await Task.WhenAll(SwallowAsync(stdoutTask), SwallowAsync(stderrTask))
                 .ConfigureAwait(false);
             throw;
-        }
-    }
-
-    private static bool CloseQuietly(SandboxStreamCloser? closer, bool required)
-    {
-        if (closer is null)
-        {
-            return !required;
-        }
-        try
-        {
-            closer.Close();
-            return true;
-        }
-        catch (ObjectDisposedException)
-        {
-            return false;
-        }
-        catch (MxcException)
-        {
-            return false;
         }
     }
 
@@ -750,50 +512,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
         _stdout?.Dispose();
         _stderr?.Dispose();
     }
-}
-
-/// <summary>
-/// Independently closes a sandbox output reader, making a blocking read return
-/// EOF without terminating the sandboxed process.
-/// </summary>
-public sealed class SandboxStreamCloser : ISandboxStreamCloser
-{
-    private readonly MxcStreamCloserHandle _handle;
-
-    internal SandboxStreamCloser(MxcStreamCloserHandle handle) => _handle = handle;
-
-    /// <summary>
-    /// Close the associated reader. Idempotent and safe to call concurrently
-    /// with that reader.
-    /// </summary>
-    public void Close()
-    {
-        var added = false;
-        try
-        {
-            _handle.DangerousAddRef(ref added);
-            unsafe
-            {
-                var status = NativeMethods.mxc_stream_closer_close(_handle.Ptr);
-                if (status != (int)ErrorCode.Success)
-                {
-                    throw new MxcException(
-                        (ErrorCode)status,
-                        "closing the sandbox output stream failed");
-                }
-            }
-        }
-        finally
-        {
-            if (added)
-            {
-                _handle.DangerousRelease();
-            }
-        }
-    }
-
-    /// <inheritdoc/>
-    public void Dispose() => _handle.Dispose();
 }
 
 /// <summary>Readable <see cref="Stream"/> over a native <c>MxcReadStream</c> (child stdout/stderr).</summary>

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -583,6 +583,13 @@ pub(crate) fn build_args_classified_with_mode(
             .map(String::from),
     );
 
+    // `--unshare-pid` alone does not make killing our `bwrap` handle tear the
+    // sandbox down: bwrap forks, so pid 1 of the new namespace is that child,
+    // not the process we spawned. Without this flag a backgrounded descendant
+    // outlives a timeout kill and keeps running after `run_teardown()` has
+    // removed the network enforcement it was sandboxed by.
+    args.push("--die-with-parent".into());
+
     // Network: full-block and proxy modes use a private namespace. Proxy mode
     // receives rootless connectivity from the runner's slirp supervisor.
     // Per-host firewall mode continues to share the host namespace.
@@ -806,6 +813,15 @@ mod tests {
         assert!(args.contains(&"--unshare-pid".to_string()));
         assert!(args.contains(&"--unshare-ipc".to_string()));
         assert!(args.contains(&"--unshare-uts".to_string()));
+    }
+
+    /// Dropping this flag silently reintroduces a real leak: a backgrounded
+    /// descendant survives the timeout kill and keeps running after teardown
+    /// has removed its network enforcement.
+    #[test]
+    fn basic_args_request_die_with_parent() {
+        let args = build_args(&base_request(), None);
+        assert!(args.contains(&"--die-with-parent".to_string()));
     }
 
     struct NetworkPlanCase {

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -512,8 +512,8 @@ impl BubblewrapScriptRunner {
                     .stderr(Stdio::piped());
             }
             StdioMode::Inherit => {
-                // The child (bwrap, PID 1 of the sandbox) inherits the binary's
-                // stdio directly — a TTY when the binary has one.
+                // The child (bwrap) inherits the binary's stdio directly — a
+                // TTY when the binary has one.
                 command
                     .stdin(Stdio::inherit())
                     .stdout(Stdio::inherit())
@@ -523,9 +523,10 @@ impl BubblewrapScriptRunner {
         // Pipes mode: put bwrap in its own process group so a timeout / `kill()`
         // can tree-kill it with a single `killpg` without touching the host's
         // group. Inherit mode keeps bwrap in the executor's group (so it retains
-        // the controlling terminal and can't be SIGTTIN-stopped reading it); it's
-        // PID 1 of the new pid namespace (`--unshare-pid`), so killing the root
-        // process alone tears the whole sandbox down.
+        // the controlling terminal and can't be SIGTTIN-stopped reading it);
+        // there, killing bwrap relies on `--die-with-parent` to take the
+        // sandbox down, since bwrap forks and is not itself PID 1 of the new
+        // pid namespace.
         let group = stdio == StdioMode::Pipes;
         if group {
             command.process_group(0);
@@ -638,7 +639,7 @@ struct BwrapChild {
     stderr_canceller: Option<ReadCanceller>,
     /// `true` when bwrap leads its own process group (`Pipes` mode), so
     /// termination signals the whole group; `false` for `Inherit` mode, where
-    /// killing bwrap (pid 1 of the namespace) alone tears the sandbox down.
+    /// killing bwrap relies on `--die-with-parent` to take the sandbox with it.
     group: bool,
     proxy: UnixProxyCoordinator,
     proxy_network: Option<proxy_network::ProxyNetworkNamespace>,
@@ -785,8 +786,8 @@ impl Drop for BubblewrapSandboxProcess {
         // Kill and reap the child *before* removing network enforcement —
         // otherwise an abandoned-but-running sandbox would keep egressing after
         // its iptables/proxy rules were torn down, and the child would leak as
-        // a zombie. `kill()` group-kills (bwrap is PID 1 of the pid namespace),
-        // then we reap.
+        // a zombie. `kill()` group-kills in `Pipes` mode and relies on
+        // `--die-with-parent` otherwise, then we reap.
         let _ = self.kill();
         let _ = self.inner.child.wait();
         self.run_teardown();

--- a/src/backends/bubblewrap/common/src/bwrap_runner.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_runner.rs
@@ -730,8 +730,9 @@ impl SandboxProcess for BubblewrapSandboxProcess {
         } else {
             // Inherit mode: bwrap shares the executor's group (no
             // `process_group(0)`), so a group-kill would hit the executor.
-            // bwrap is pid 1 of the sandbox pid namespace, so killing the root
-            // alone tears the whole namespace (every descendant) down.
+            // Killing bwrap alone suffices because `--die-with-parent` makes
+            // the sandbox die with it — bwrap is *not* pid 1 of the namespace
+            // (it forks), so without that flag descendants would survive.
             self.inner.child.kill()
         }
     }
@@ -751,8 +752,8 @@ impl SandboxProcess for BubblewrapSandboxProcess {
             Err(WaitError::Timeout) => {
                 // Tree-kill so descendants die too and release any stdout/stderr
                 // pipe write-ends (else the drain threads below could block).
-                // `kill()` group-kills in Pipes mode, and in Inherit mode kills
-                // bwrap (pid 1 of the namespace), which tears the sandbox down.
+                // `kill()` group-kills in Pipes mode; in Inherit mode it kills
+                // bwrap, which `--die-with-parent` turns into a full teardown.
                 let _ = self.kill();
                 let _ = self.inner.child.wait();
                 Err(std::io::Error::new(

--- a/src/backends/bubblewrap/common/src/bwrap_version.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_version.rs
@@ -25,6 +25,7 @@ use std::process::{Command, Stdio};
 /// |--------------|-----------------------|
 /// | `--bind`, `--ro-bind`, `--dev`, `--proc`, `--tmpfs`, `--symlink`, `--chdir`, `--setenv`, `--unshare-*` | 0.1.0 |
 /// | `--ro-bind-try` (deny-by-default baseline mounts) | 0.3.1 |
+/// | `--die-with-parent` (descendants die with the sandbox) | 0.4.0 |
 /// | `--clearenv` (minimal sandbox environment) | **0.5.0** |
 ///
 /// `--clearenv` is therefore the flag that sets the floor. If the argument

--- a/src/testing/wxc_e2e_tests/tests/e2e_bubblewrap_characterization.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_bubblewrap_characterization.rs
@@ -151,11 +151,19 @@ fn bubblewrap_timeout_is_enforced() {
     if !ready() {
         return;
     }
+    // Named so the assertion messages below cannot drift from the values they
+    // describe when these are tuned.
+    const TIMEOUT_MS: u64 = 1500;
+    const DESCENDANT_SLEEP_SECS: u64 = 8;
+    // Comfortably above the timeout and comfortably below the descendant's
+    // lifetime, so a pass means teardown did not wait the descendant out.
+    const MAX_ELAPSED: Duration = Duration::from_secs(6);
+
     let mut cfg = config(
         "timeout",
-        "echo CHAR_BEFORE; (/bin/sleep 8; echo CHAR_AFTER) & wait",
+        &format!("echo CHAR_BEFORE; (/bin/sleep {DESCENDANT_SLEEP_SECS}; echo CHAR_AFTER) & wait"),
     );
-    cfg["process"]["timeout"] = json!(1500);
+    cfg["process"]["timeout"] = json!(TIMEOUT_MS);
     let started = Instant::now();
     let result = run_platform_config_value("bwrap timeout", &cfg, &[], None);
     let elapsed = started.elapsed();
@@ -175,7 +183,8 @@ fn bubblewrap_timeout_is_enforced() {
          Output:\n{out}"
     );
     assert!(
-        elapsed < Duration::from_secs(6),
-        "a 1500ms timeout should not wait out the 8s descendant; took {elapsed:?}"
+        elapsed < MAX_ELAPSED,
+        "a {TIMEOUT_MS}ms timeout should not wait out the {DESCENDANT_SLEEP_SECS}s \
+         descendant; took {elapsed:?}"
     );
 }

--- a/src/testing/wxc_e2e_tests/tests/e2e_bubblewrap_characterization.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_bubblewrap_characterization.rs
@@ -3,16 +3,13 @@
 
 //! Bubblewrap (Linux) executor **characterization** tests.
 //!
-//! These lock in the *current* run-to-completion behavior of the `lxc-exec`
-//! Bubblewrap path before the unified `SandboxBackend`/`Runner` refactor lands.
-//! They assert what the code does **today**.
+//! These lock in the run-to-completion behavior of the `lxc-exec` Bubblewrap
+//! path. They assert what the code does **today**.
 //!
-//! Unlike Seatbelt, Bubblewrap already `--clearenv`s unconditionally and runs
-//! the child with `stdin` closed, so the env/stdin contracts pinned here are
-//! ones the refactor should *preserve*. (The stdin/`SIGTTIN` regression that the
-//! refactor introduces is only observable under a real PTY, which the
-//! `.output()`-based harness cannot provide — that needs a separate PTY harness
-//! and is tracked as a follow-up.)
+//! Bubblewrap `--clearenv`s unconditionally, so the env contract pinned here is
+//! deliberate rather than incidental. The harness captures via `.output()` and
+//! so cannot provide a real PTY; the stdin/`SIGTTIN` behavior that needs one is
+//! tracked separately.
 //!
 //! They run in the existing Linux CI job (`cargo test`) **only when `bwrap` is
 //! installed** — `has_bwrap()` skips them cleanly otherwise. Each test also
@@ -20,6 +17,7 @@
 #![cfg(target_os = "linux")]
 
 use serde_json::json;
+use std::time::{Duration, Instant};
 use wxc_e2e_tests::{has_bwrap, has_platform_exec, run_platform_config_value};
 
 const SCHEMA_VERSION: &str = "0.7.0-alpha";
@@ -140,23 +138,27 @@ fn bubblewrap_honors_explicit_process_cwd() {
 }
 
 /// Characterizes that a `process.timeout` shorter than the workload is
-/// enforced and surfaces as a non-zero exit.
+/// enforced, and that it takes a backgrounded descendant down with it.
 ///
-/// NOTE: on current `main`, the Bubblewrap run-to-completion timeout kills only
-/// the `bwrap` parent (`child.kill()`), so a forked descendant can survive,
-/// keep the stdout pipe open, and have its post-timeout output captured (the
-/// call can even block until the descendant exits). That tree-kill behavior is
-/// something the unified `Runner` refactor changes, so this test deliberately
-/// does NOT assert the absence of post-timeout output or a wall-clock bound —
-/// only that the timeout fires and fails the run.
+/// The descendant is the load-bearing case: `bwrap` forks, so pid 1 of the
+/// sandbox namespace is not the process the executor spawned. Killing that
+/// handle tears the sandbox down only because `--die-with-parent` is set —
+/// without it the descendant outlives the timeout, keeps writing to the
+/// inherited stdout, and runs on after teardown has dropped its network
+/// enforcement.
 #[test]
 fn bubblewrap_timeout_is_enforced() {
     if !ready() {
         return;
     }
-    let mut cfg = config("timeout", "echo CHAR_BEFORE; /bin/sleep 5; echo CHAR_AFTER");
+    let mut cfg = config(
+        "timeout",
+        "echo CHAR_BEFORE; (/bin/sleep 8; echo CHAR_AFTER) & wait",
+    );
     cfg["process"]["timeout"] = json!(1500);
+    let started = Instant::now();
     let result = run_platform_config_value("bwrap timeout", &cfg, &[], None);
+    let elapsed = started.elapsed();
     let out = result.combined_output();
     assert!(
         out.contains("CHAR_BEFORE"),
@@ -166,5 +168,14 @@ fn bubblewrap_timeout_is_enforced() {
         result.code,
         Some(0),
         "a timed-out run should exit non-zero. Output:\n{out}"
+    );
+    assert!(
+        !out.contains("CHAR_AFTER"),
+        "the descendant outlived the timeout and wrote post-timeout output. \
+         Output:\n{out}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(6),
+        "a 1500ms timeout should not wait out the 8s descendant; took {elapsed:?}"
     );
 }

--- a/tests/configs/bubblewrap_network_egress_budget_rejected.json
+++ b/tests/configs/bubblewrap_network_egress_budget_rejected.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-Egress-Budget-Rejected",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "echo EGRESS_BUDGET_SHOULD_NOT_RUN"
+  },
+  "network": {
+    "egress": {
+      "default": "deny",
+      "allow": [
+        {
+          "to": [
+            {
+              "cidr": "0.0.0.0/0",
+              "except": [
+                "1.0.0.1/32",
+                "2.0.0.1/32",
+                "3.0.0.1/32",
+                "4.0.0.1/32",
+                "5.0.0.1/32",
+                "6.0.0.1/32",
+                "7.0.0.1/32",
+                "8.0.0.1/32",
+                "9.0.0.1/32",
+                "10.0.0.1/32",
+                "11.0.0.1/32",
+                "12.0.0.1/32",
+                "13.0.0.1/32",
+                "14.0.0.1/32",
+                "15.0.0.1/32",
+                "16.0.0.1/32",
+                "17.0.0.1/32",
+                "18.0.0.1/32",
+                "19.0.0.1/32",
+                "20.0.0.1/32"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "ingress": {
+      "default": "deny",
+      "hostLoopback": "deny"
+    }
+  }
+}

--- a/tests/configs/bubblewrap_readonly_denial.json
+++ b/tests/configs/bubblewrap_readonly_denial.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-Readonly-Denial",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "B=/tmp/mxc_rodenial; if cat \"$B/test.txt\" 2>/dev/null | grep -q RO_CONTENT; then echo READ_OK; else echo READ_MISSING; fi; if ( echo mutated > \"$B/test.txt\" ) 2>/dev/null; then echo WRITE_LEAK; else echo WRITE_DENIED_OK; fi; if ( : > \"$B/new.txt\" ) 2>/dev/null; then echo CREATE_LEAK; else echo CREATE_DENIED_OK; fi"
+  },
+  "filesystem": {
+    "readonlyPaths": ["/tmp/mxc_rodenial"]
+  }
+}

--- a/tests/configs/bubblewrap_teardown_timeout.json
+++ b/tests/configs/bubblewrap_teardown_timeout.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-Teardown-Timeout",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "echo TEARDOWN_STARTED; (/bin/sleep 987; echo TEARDOWN_DESCENDANT_LEAKED) & wait",
+    "timeout": 1500
+  }
+}

--- a/tests/configs/bubblewrap_teardown_timeout_netns.json
+++ b/tests/configs/bubblewrap_teardown_timeout_netns.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.8.0-alpha",
+  "containerId": "CLI-Bubblewrap-Teardown-Timeout-Netns",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "echo TEARDOWN_STARTED; (/bin/sleep 986; echo TEARDOWN_DESCENDANT_LEAKED) & wait",
+    "timeout": 1500
+  },
+  "network": {
+    "egress": {
+      "default": "deny",
+      "allow": [{ "to": [{ "cidr": "203.0.113.0/24" }] }]
+    },
+    "ingress": {
+      "default": "deny",
+      "hostLoopback": "deny"
+    }
+  }
+}

--- a/tests/configs/bubblewrap_version_gate.json
+++ b/tests/configs/bubblewrap_version_gate.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.7.0-alpha",
+  "containerId": "CLI-Bubblewrap-Version-Gate",
+  "containment": "bubblewrap",
+  "process": {
+    "commandLine": "echo VERSION_GATE_WORKLOAD_RAN"
+  }
+}

--- a/tests/scripts/run_bwrap_all_tests.sh
+++ b/tests/scripts/run_bwrap_all_tests.sh
@@ -80,6 +80,9 @@ run_test() {
 
 run_test "Basic Bubblewrap" "$SCRIPT_DIR/run_bwrap_basic_test.sh"
 run_test "Bubblewrap Filesystem" "$SCRIPT_DIR/run_bwrap_filesystem_test.sh"
+run_test "Bubblewrap Read-Only Denial" "$SCRIPT_DIR/run_bwrap_readonly_denial_test.sh"
+run_test "Bubblewrap Version Gate" "$SCRIPT_DIR/run_bwrap_version_gate_test.sh"
+run_test "Bubblewrap Teardown" "$SCRIPT_DIR/run_bwrap_teardown_test.sh"
 run_test "Bubblewrap Object Validation" "$SCRIPT_DIR/run_bwrap_filesystem_object_test.sh"
 run_test "Bubblewrap Most-Specific Path" "$SCRIPT_DIR/run_bwrap_most_specific_test.sh"
 run_test "Bubblewrap Denied Masking" "$SCRIPT_DIR/run_bwrap_denied_masking_test.sh"

--- a/tests/scripts/run_bwrap_directional_test.sh
+++ b/tests/scripts/run_bwrap_directional_test.sh
@@ -104,6 +104,16 @@ run_rejected "a directional section before 0.8 is refused" \
     "require schema version 0.8 or later" \
     "DIRECTIONAL_PRE_0_8_SHOULD_NOT_RUN"
 
+# The per-peer block budget. `except` is the amplifier: 20 dispersed /32
+# exclusions look small but split 0.0.0.0/0 past the 256-block ceiling, because
+# each one carves its own full-depth path down the prefix tree. Rules must be
+# refused up front rather than part-way through a run with a partial policy
+# already installed.
+run_rejected "an egress peer that over-expands its block budget is refused" \
+    "bubblewrap_network_egress_budget_rejected.json" \
+    "expands into more than 256 address blocks" \
+    "EGRESS_BUDGET_SHOULD_NOT_RUN"
+
 # ---------------------------------------------------------------------------
 # 2. Enforcement
 # ---------------------------------------------------------------------------

--- a/tests/scripts/run_bwrap_readonly_denial_test.sh
+++ b/tests/scripts/run_bwrap_readonly_denial_test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Bubblewrap read-only denial test.
+#
+# Existing filesystem coverage asserts a `readonlyPaths` entry is present and
+# readable. That is the mount succeeding, not the property the policy promises:
+# nothing asserted that a WRITE to it actually fails.
+#
+# The fixture is owned by the invoking user, so a write would succeed on the
+# host. Any denial inside the sandbox is therefore attributable to the
+# read-only mount rather than to file permissions. Reading the fixture acts as
+# a positive control, proving the mount is really present.
+#
+# The host is re-checked afterwards: a sandbox write must not reach the
+# original file, and must not create a new one.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+# The fixture lives under /tmp and is created by the invoking user, so the test
+# needs no elevation. Note the sandbox mounts a fresh tmpfs at /tmp, so the
+# read-only bind is what makes the fixture visible inside at all.
+RO_DIR="/tmp/mxc_rodenial"
+
+cleanup() { rm -rf "$RO_DIR"; }
+trap cleanup EXIT
+
+rm -rf "$RO_DIR"
+mkdir -p "$RO_DIR"
+echo "RO_CONTENT" > "$RO_DIR/test.txt"
+
+# Sanity: the host CAN write here, so an in-sandbox denial is the policy's doing.
+if ! echo "RO_CONTENT" > "$RO_DIR/test.txt"; then
+    echo "FAIL: fixture setup — host cannot write test.txt."
+    exit 1
+fi
+
+echo "Running Bubblewrap read-only denial test..."
+OUTPUT=$("$LXC_EXEC" --experimental "$REPO_DIR/tests/configs/bubblewrap_readonly_denial.json" 2>&1)
+echo "$OUTPUT"
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+echo "$OUTPUT" | grep -q "READ_OK" || fail "read-only path was not readable (mount missing?)."
+echo "$OUTPUT" | grep -q "WRITE_DENIED_OK" || fail "a write to a readonlyPaths entry was not denied."
+echo "$OUTPUT" | grep -q "CREATE_DENIED_OK" || fail "file creation under a readonlyPaths entry was not denied."
+if echo "$OUTPUT" | grep -q "WRITE_LEAK"; then
+    fail "sandbox reported a successful write to a read-only path."
+fi
+if echo "$OUTPUT" | grep -q "CREATE_LEAK"; then
+    fail "sandbox reported a successful create under a read-only path."
+fi
+
+# The host side is the one that matters: the mount must not have been a
+# writable copy that silently accepted the write.
+grep -q "RO_CONTENT" "$RO_DIR/test.txt" || fail "host file was modified through the read-only mount."
+[ ! -e "$RO_DIR/new.txt" ] || fail "host file was created through the read-only mount."
+
+echo "PASS: readonlyPaths denies writes and creates, on both sides of the mount."

--- a/tests/scripts/run_bwrap_teardown_test.sh
+++ b/tests/scripts/run_bwrap_teardown_test.sh
@@ -61,10 +61,16 @@ assert_no_survivors() {
     fi
 
     # The run must actually have timed out; otherwise there was never anything
-    # to leak and the assertions below are vacuous.
+    # to leak and the assertions below are vacuous. A nonzero exit alone is not
+    # enough -- any backend error raised after TEARDOWN_STARTED would satisfy
+    # the survivor checks trivially -- so pin the timeout diagnostic itself.
     if [ "$rc" = 0 ]; then
         echo "$out"
         fail "$label (the run did not time out, so this proves nothing)"
+    fi
+    if ! grep -qF "script timed out" <<<"$out"; then
+        echo "$out"
+        fail "$label (exited $rc for some reason other than the timeout, so this proves nothing)"
     fi
     if ! grep -qF "TEARDOWN_STARTED" <<<"$out"; then
         echo "$out"
@@ -77,6 +83,10 @@ assert_no_survivors() {
 
     if pgrep -f "$sleep_marker" >/dev/null 2>&1; then
         pgrep -af "$sleep_marker" || true
+        # Clean up before failing: the marker uniquely identifies this test's
+        # descendant, and leaving it sleeping for ~16 minutes would pollute the
+        # host and skew the baseline counts of any later run.
+        pkill -f "$sleep_marker" || true
         fail "$label (a backgrounded descendant outlived the sandbox)"
     fi
 
@@ -104,6 +114,9 @@ if command -v slirp4netns >/dev/null 2>&1; then
         "bubblewrap_teardown_timeout_netns.json" "sleep 986"
 else
     echo "SKIP: slirp4netns not installed; the private-namespace teardown case needs it."
+    # 77, not 0: run_bwrap_all_tests.sh must record SKIPPED, not a false PASS,
+    # or strict CI cannot tell that the slirp case never ran.
+    exit 77
 fi
 
 echo "All Bubblewrap teardown tests passed."

--- a/tests/scripts/run_bwrap_teardown_test.sh
+++ b/tests/scripts/run_bwrap_teardown_test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Bubblewrap teardown test.
+#
+# Nothing asserted that a run leaves no survivors. The claim that a leak is
+# unreachable by construction -- the namespace dies with the process holding
+# it -- was untested, and it was FALSE for descendants: `bwrap` forks, so pid 1
+# of the sandbox namespace is not the process the executor spawned, and killing
+# that handle on timeout left a backgrounded child running after teardown had
+# already removed its network enforcement. `--die-with-parent` closes that; this
+# test is the regression lock.
+#
+# Each timed-out run backgrounds a long sleep with a unique duration, which is
+# the survivor probe: the sleep far outlasts the 1500ms timeout, so if it is
+# still present afterwards it survived teardown. Process counts are compared
+# against a pre-run baseline so unrelated `bwrap`/`slirp4netns` processes on a
+# developer's machine cannot be mistaken for leaks.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+count_proc() { pgrep -c -f "$1" 2>/dev/null || true; }
+
+# Runs a config that is expected to time out, then asserts nothing outlived it.
+assert_no_survivors() {
+    local label="$1"
+    local config="$2"
+    local sleep_marker="$3"
+
+    echo "Running Bubblewrap teardown test: $label..."
+
+    local bwrap_before slirp_before
+    bwrap_before=$(count_proc '^bwrap')
+    slirp_before=$(count_proc 'slirp4netns')
+
+    # Output goes to a file rather than `$(...)`: a surviving descendant keeps
+    # the pipe's write end open, so command substitution would block for the
+    # full sleep duration instead of failing. `timeout` bounds the executor
+    # itself, which must exit long before the sleep does.
+    local log rc=0
+    log=$(mktemp)
+    timeout 60 "$LXC_EXEC" --experimental "$REPO_DIR/tests/configs/$config" >"$log" 2>&1 || rc=$?
+    local out
+    out=$(cat "$log")
+    rm -f "$log"
+
+    if [ "$rc" = 124 ]; then
+        fail "$label (the executor itself hung and was killed after 60s)"
+    fi
+
+    # The run must actually have timed out; otherwise there was never anything
+    # to leak and the assertions below are vacuous.
+    if [ "$rc" = 0 ]; then
+        echo "$out"
+        fail "$label (the run did not time out, so this proves nothing)"
+    fi
+    if ! grep -qF "TEARDOWN_STARTED" <<<"$out"; then
+        echo "$out"
+        fail "$label (the workload never started, so this proves nothing)"
+    fi
+
+    # Teardown is synchronous with the executor exiting, but the kernel reaps
+    # asynchronously; give it a moment before declaring a leak.
+    sleep 2
+
+    if pgrep -f "$sleep_marker" >/dev/null 2>&1; then
+        pgrep -af "$sleep_marker" || true
+        fail "$label (a backgrounded descendant outlived the sandbox)"
+    fi
+
+    local bwrap_after slirp_after
+    bwrap_after=$(count_proc '^bwrap')
+    slirp_after=$(count_proc 'slirp4netns')
+
+    if [ "$bwrap_after" -gt "$bwrap_before" ]; then
+        fail "$label (orphaned bwrap: $bwrap_before before, $bwrap_after after)"
+    fi
+    if [ "$slirp_after" -gt "$slirp_before" ]; then
+        fail "$label (orphaned slirp4netns: $slirp_before before, $slirp_after after)"
+    fi
+
+    echo "PASS: $label"
+}
+
+assert_no_survivors "a timed-out run leaves no descendant or orphaned bwrap" \
+    "bubblewrap_teardown_timeout.json" "sleep 987"
+
+# The private-namespace path additionally stands up slirp4netns, which is the
+# other thing that could outlive the run.
+if command -v slirp4netns >/dev/null 2>&1; then
+    assert_no_survivors "a timed-out private-namespace run leaves no slirp4netns" \
+        "bubblewrap_teardown_timeout_netns.json" "sleep 986"
+else
+    echo "SKIP: slirp4netns not installed; the private-namespace teardown case needs it."
+fi
+
+echo "All Bubblewrap teardown tests passed."

--- a/tests/scripts/run_bwrap_version_gate_test.sh
+++ b/tests/scripts/run_bwrap_version_gate_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Bubblewrap version-gating test.
+#
+# `bwrap_version.rs` carries unit tests for parsing and comparison, but nothing
+# asserted the end-to-end behavior when `bwrap` is missing or too old. The
+# property that matters to a user is that the run stops with a readable,
+# actionable error instead of an opaque spawn failure ("No such file or
+# directory") or an "unknown option" from an old binary.
+#
+# Both cases are staged with a PATH shim rather than by touching the host's
+# real installation. The same config is also run unshimmed as a positive
+# control, so a failure below is attributable to the gate and not to a config
+# that could never have run.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+LXC_EXEC="$REPO_DIR/src/target/release/lxc-exec"
+
+if [ ! -f "$LXC_EXEC" ]; then
+    LXC_EXEC="$REPO_DIR/src/target/debug/lxc-exec"
+fi
+
+if [ ! -f "$LXC_EXEC" ]; then
+    echo "Error: lxc-exec not found. Run build.sh first."
+    exit 1
+fi
+
+CONFIG="$REPO_DIR/tests/configs/bubblewrap_version_gate.json"
+SHIM_DIR="$(mktemp -d)"
+SENTINEL="VERSION_GATE_WORKLOAD_RAN"
+
+cleanup() { rm -rf "$SHIM_DIR"; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# Asserts the run was refused, refused for the stated reason, and refused
+# before the workload started.
+assert_gated() {
+    local label="$1"
+    local marker="$2"
+    local out rc=0
+    shift 2
+    echo "Running Bubblewrap version-gate test: $label..."
+    out=$(env "$@" "$LXC_EXEC" --experimental "$CONFIG" 2>&1) || rc=$?
+    if [ "$rc" = 0 ]; then
+        echo "$out"
+        fail "$label (the run was accepted)"
+    fi
+    if grep -qF "$SENTINEL" <<<"$out"; then
+        echo "$out"
+        fail "$label (the workload ran despite the version gate)"
+    fi
+    if ! grep -qF "$marker" <<<"$out"; then
+        echo "$out"
+        fail "$label (refused, but not for the expected reason: '$marker')"
+    fi
+    echo "PASS: $label"
+}
+
+# Positive control: an empty shim dir is the only difference between this run
+# and the "absent" case below.
+echo "Running Bubblewrap version-gate test: control (real bwrap)..."
+if ! "$LXC_EXEC" --experimental "$CONFIG" 2>&1 | grep -qF "$SENTINEL"; then
+    fail "control — the config did not run with a real bwrap on PATH."
+fi
+echo "PASS: control (real bwrap)"
+
+# PATH points at a directory with no `bwrap` in it. lxc-exec is invoked by
+# absolute path, so only the sandbox binary lookup is affected.
+assert_gated "an absent bwrap is reported, not spawned into" \
+    "is not installed or not on PATH" \
+    "PATH=$SHIM_DIR"
+
+# A shim that reports a version below the floor set by `--clearenv`.
+printf '#!/bin/sh\necho "bubblewrap 0.3.0"\n' > "$SHIM_DIR/bwrap"
+chmod +x "$SHIM_DIR/bwrap"
+assert_gated "a too-old bwrap is refused before any flag is passed to it" \
+    "is too old" \
+    "PATH=$SHIM_DIR:$PATH"
+
+echo "All Bubblewrap version-gate tests passed."


### PR DESCRIPTION
## 📖 Description
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

Closes #1008, which asked for tests covering seven Bubblewrap gaps. Item 7 (stale characterization comments) turned out to be hiding a real bug, so this carries a one-line product fix alongside the tests.

**The bug.** The runner assumed killing the spawned handle collapsed the sandbox, because `--unshare-pid` made that handle pid 1. It doesn't — `bwrap` forks, so the executor holds the outer monitor and backgrounded descendants survive. Worse than litter: `run_teardown()` drops iptables/proxy enforcement while they're still running, so survivors briefly outlive their own network policy. Fixed with `--die-with-parent` (bubblewrap 0.4.0, below our 0.5.0 floor — no `MIN_BWRAP_VERSION` bump); the two comments claiming otherwise are corrected.

**Tests added** — egress budget over-expansion refused at validate time (item 1), `readonlyPaths` denying writes and creates on both sides of the mount (item 4), end-to-end bwrap version gating for absent and too-old binaries (item 6), and teardown leaving no descendant, orphaned `bwrap`, or `slirp4netns` across both the plain and private-namespace paths (item 3).

**Two items needed no new tests, because the issue's premises were wrong** — see [this comment](https://github.com/microsoft/mxc/issues/1008#issuecomment-5433532841) for the detail. Item 2's quoted `needs_iptables_rules(request) && !proxy.is_active()` no longer exists; mutual exclusion is now structural via 'ResolvedNetworkMode` andis already pinned (mutating the gate fails 12 tests). Item 5's "nested `deniedPaths` is rejected" is WSLc-only — Bubblewrap *masks* instead, which is already covered by `bubblewrap_denied_masking.json`.

## Validation

`run_bwrap_all_tests.sh`: 14 passed, 0 failed, 1 skipped (`Inbound Deny`, pre-existing — needs root, and the suite refuses to run as root). Plus `cargo fmt` clean, `clippy -D warnings` clean, 283 `bwrap_common` unit tests, 6/6 characterization e2e.

Every new test is mutation-proven non-vacuous: the read-only test yields `WRITE_LEAK`/`CREATE_LEAK` and a genuinely mutated host file when flipped to `readwritePaths`, and the teardown test fails against a pre-fix binary showing the
actual leaked process.

## Note for reviewers

The shell scripts prefer `src/target/release/lxc-exec` and fall back to `debug`. A stale copy silently produces false results — rebuild both before running the suite.

## 📋 Issue Type
<!-- Select the type that best describes this PR -->
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1057)