### PR TITLE
fix: delay-load winhvplatform.dll to prevent loader crash on WHP-less hosts

### DIFF
--- a/sdk/node/src/platform.ts
+++ b/sdk/node/src/platform.ts
@@ -138,9 +138,9 @@ function isUiCapabilitySupport(value: unknown): value is UiCapabilitySupport {
 
 /**
  * Run the probe binary and merge its results into `support`: the isolation
- * tier, any warnings, portable UI capabilities, and — when the probe reports
- * the isolation-session service available — the `isolation_session` method.
- * On any failure (binary missing, timeout, malformed JSON), the function
+ * tier, any warnings, portable UI capabilities, and the `isolation_session`
+ * and `hyperlight` methods when the probe reports them available. On any
+ * failure (binary missing, timeout, malformed JSON), the function
  * silently leaves those fields unset, so callers see the same contract as
  * pre-probe SDKs.
  */
@@ -165,6 +165,9 @@ function populateIsolationFromProbe(support: PlatformSupport): void {
         }
         if (facts.isolationSessionAvailable === true) {
           support.availableMethods.push('isolation_session');
+        }
+        if (facts.hyperlightAvailable === true) {
+          support.availableMethods.push('hyperlight');
         }
       }
     }

--- a/sdk/node/tests/unit/platform.test.ts
+++ b/sdk/node/tests/unit/platform.test.ts
@@ -388,6 +388,39 @@ describe('isolation_session availability gate', () => {
   });
 });
 
+describe('hyperlight availability gate', () => {
+  beforeEach(() => {
+    _resetPlatformSupportCache();
+  });
+
+  afterEach(() => {
+    _setProbeRunner(null);
+    _resetPlatformSupportCache();
+  });
+
+  it('includes hyperlight when the probe reports it available', { skip: !isWindows }, () => {
+    _setProbeRunner(() =>
+      JSON.stringify({ tier: 'base-container', probes: { hyperlightAvailable: true } }),
+    );
+    const support = getPlatformSupport();
+    assert.ok(
+      support.availableMethods.includes('hyperlight'),
+      `expected hyperlight present, got: ${support.availableMethods.join(',')}`,
+    );
+  });
+
+  it('omits hyperlight when the probe reports it unavailable', { skip: !isWindows }, () => {
+    _setProbeRunner(() =>
+      JSON.stringify({ tier: 'base-container', probes: { hyperlightAvailable: false } }),
+    );
+    const support = getPlatformSupport();
+    assert.ok(
+      !support.availableMethods.includes('hyperlight'),
+      `expected hyperlight absent, got: ${support.availableMethods.join(',')}`,
+    );
+  });
+});
+
 // The Bubblewrap probe gates on version, not just presence: `--clearenv`
 // (emitted unconditionally by the Rust argument builder) only exists in
 // bwrap 0.5.0+. Mirrors the Rust tests in

--- a/src/Cargo.lock
+++ b/src/Cargo.lock
@@ -1022,6 +1022,7 @@ name = "hyperlight_common"
 version = "0.8.0"
 dependencies = [
  "hyperlight-unikraft",
+ "windows",
  "wxc_common",
 ]
 

--- a/src/backends/appcontainer/common/src/probe.rs
+++ b/src/backends/appcontainer/common/src/probe.rs
@@ -70,6 +70,10 @@ pub struct ProbeFacts {
     /// the isolation-session backend; `wxc-exec --probe` overrides it when
     /// that backend is compiled in.
     pub isolation_session_available: bool,
+    /// Whether Hyperlight (WHP micro-VM) is available on this host. Always
+    /// `false` here — overridden by `wxc-exec --probe` when the hyperlight
+    /// feature is compiled in and WHP is loadable.
+    pub hyperlight_available: bool,
     /// Platform-agnostic UI restrictions this host can enforce.
     pub ui_capabilities: UiCapabilitySupport,
 }
@@ -132,6 +136,7 @@ pub fn run_probe(policy: &ContainerPolicy) -> ProbeOutput {
         base_container_supports_deny_paths:
             crate::base_container_runner::BaseContainerRunner::base_container_supports_deny_paths(),
         isolation_session_available: false,
+        hyperlight_available: false,
         ui_capabilities: crate::job_object::supported_ui_restrictions().into(),
     };
     match fallback_detector::detect(policy, /* prefer_base_container */ true) {
@@ -208,6 +213,7 @@ mod tests {
                 bfs_compiled_in: false,
                 base_container_supports_deny_paths: false,
                 isolation_session_available: true,
+                hyperlight_available: false,
                 ui_capabilities: all_ui_capabilities(),
             },
             error: None,
@@ -245,6 +251,7 @@ mod tests {
                 bfs_compiled_in: false,
                 base_container_supports_deny_paths: false,
                 isolation_session_available: false,
+                hyperlight_available: false,
                 ui_capabilities: UiCapabilitySupport {
                     can_block_input_injection: false,
                     can_block_input_method_changes: false,

--- a/src/backends/hyperlight/common/Cargo.toml
+++ b/src/backends/hyperlight/common/Cargo.toml
@@ -10,6 +10,9 @@ wxc_common = { workspace = true }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 hyperlight-unikraft = { version = "0.12.1", optional = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { workspace = true }
+
 [features]
 default = []
 hyperlight = ["dep:hyperlight-unikraft"]

--- a/src/backends/hyperlight/common/src/lib.rs
+++ b/src/backends/hyperlight/common/src/lib.rs
@@ -89,6 +89,20 @@ use wxc_common::validator::{validate_network_policy_support, NetworkPolicySuppor
 use hyperlight_unikraft::pyhl;
 use hyperlight_unikraft::{AllowList, BlockList, Preopen};
 
+// -- Availability probe -------------------------------------------------------
+
+/// WHP is delay-loaded; check before pyhl::install warms a VM.
+#[cfg(target_os = "windows")]
+pub fn is_whp_available() -> bool {
+    use windows::core::w;
+    use windows::Win32::System::LibraryLoader::{LoadLibraryExW, LOAD_LIBRARY_SEARCH_SYSTEM32};
+
+    // SAFETY: LOAD_LIBRARY_SEARCH_SYSTEM32 restricts to %SystemRoot%\system32.
+    let module =
+        unsafe { LoadLibraryExW(w!("winhvplatform.dll"), None, LOAD_LIBRARY_SEARCH_SYSTEM32) };
+    module.is_ok()
+}
+
 // -- Error classification ----------------------------------------------------
 
 #[derive(Debug)]

--- a/src/core/lxc/build.rs
+++ b/src/core/lxc/build.rs
@@ -11,6 +11,18 @@ fn main() {
     #[cfg(all(target_os = "linux", feature = "microvm"))]
     copy_nanvix_binaries();
 
+    // Delay-load winhvplatform.dll so WHP-less hosts don't crash before main().
+    // CARGO_CFG_TARGET_* (not #[cfg]) because build.rs cfg gates are host, not target.
+    #[cfg(feature = "hyperlight")]
+    {
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if target_os == "windows" && target_arch == "x86_64" {
+            println!("cargo:rustc-link-arg=/DELAYLOAD:winhvplatform.dll");
+            println!("cargo:rustc-link-lib=delayimp");
+        }
+    }
+
     println!("cargo:rerun-if-changed=build.rs");
 }
 

--- a/src/core/lxc/src/main.rs
+++ b/src/core/lxc/src/main.rs
@@ -131,6 +131,16 @@ fn main() {
     if cli.setup_hyperlight {
         #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
         {
+            // WHP is delay-loaded; check before pyhl::install warms a VM.
+            #[cfg(target_os = "windows")]
+            if !hyperlight_common::is_whp_available() {
+                eprintln!(
+                    "Error: --setup-hyperlight requires Windows Hypervisor Platform (WHP). \
+                     Enable the HypervisorPlatform optional feature and reboot."
+                );
+                process::exit(1);
+            }
+
             let mut logger = Logger::new(if cli.debug {
                 Mode::Console
             } else {

--- a/src/core/mxc_engine/src/probe.rs
+++ b/src/core/mxc_engine/src/probe.rs
@@ -150,6 +150,14 @@ fn windows_backends(capture_denials_usable: bool) -> Vec<AvailableBackend> {
         ));
     }
 
+    // WHP is delay-loaded; check before pyhl::install warms a VM.
+    #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
+    if hyperlight_common::is_whp_available() {
+        backends.push(AvailableBackend::tierless(
+            ContainmentBackend::Hyperlight.wire_name(),
+        ));
+    }
+
     backends
 }
 
@@ -263,7 +271,7 @@ mod tests {
     /// from `ContainmentBackend` (the same source as the `push` calls) so the
     /// emitted names can't be typo'd, and checked against the `wire::Containment`
     /// serde names so the two enums can't drift.
-    const EMITTABLE_BACKENDS: [ContainmentBackend; 7] = [
+    const EMITTABLE_BACKENDS: [ContainmentBackend; 8] = [
         ContainmentBackend::Seatbelt,
         ContainmentBackend::Bubblewrap,
         ContainmentBackend::Lxc,
@@ -271,6 +279,7 @@ mod tests {
         ContainmentBackend::WindowsSandbox,
         ContainmentBackend::Wslc,
         ContainmentBackend::IsolationSession,
+        ContainmentBackend::Hyperlight,
     ];
 
     /// Complements [`every_reported_backend_is_a_real_wire_name`] (host subset)

--- a/src/core/mxc_engine/src/run.rs
+++ b/src/core/mxc_engine/src/run.rs
@@ -371,6 +371,8 @@ fn resolve_runner_inner(
 
 /// Construct the Hyperlight runner, shared by the Windows and Linux bodies.
 /// Requires x86_64 (Hyperlight needs KVM or WHP) and the `hyperlight` feature.
+/// On Windows, pre-checks that `winhvplatform.dll` is loadable so a missing
+/// WHP becomes a typed error rather than a delay-load SEH exception.
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 fn resolve_hyperlight(request: &ExecutionRequest) -> Result<ResolvedRunner, MxcError> {
     #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
@@ -379,6 +381,14 @@ fn resolve_hyperlight(request: &ExecutionRequest) -> Result<ResolvedRunner, MxcE
             return Err(MxcError::malformed_request(
                 "Hyperlight (Hyperlight+Unikraft) is an experimental feature. \
                  Use --experimental flag.",
+            ));
+        }
+        // WHP is delay-loaded; check before pyhl::install warms a VM.
+        #[cfg(target_os = "windows")]
+        if !hyperlight_common::is_whp_available() {
+            return Err(MxcError::unsupported_containment(
+                "Hyperlight requires Windows Hypervisor Platform (WHP). \
+                 Enable the HypervisorPlatform Windows optional feature and reboot.",
             ));
         }
         Ok(ResolvedRunner::without_guard(Box::new(

--- a/src/core/mxc_engine/src/run.rs
+++ b/src/core/mxc_engine/src/run.rs
@@ -386,7 +386,7 @@ fn resolve_hyperlight(request: &ExecutionRequest) -> Result<ResolvedRunner, MxcE
         // WHP is delay-loaded; check before pyhl::install warms a VM.
         #[cfg(target_os = "windows")]
         if !hyperlight_common::is_whp_available() {
-            return Err(MxcError::unsupported_containment(
+            return Err(MxcError::backend_unavailable(
                 "Hyperlight requires Windows Hypervisor Platform (WHP). \
                  Enable the HypervisorPlatform Windows optional feature and reboot.",
             ));

--- a/src/core/wxc/build.rs
+++ b/src/core/wxc/build.rs
@@ -12,6 +12,18 @@ fn main() {
     #[cfg(all(windows, feature = "microvm"))]
     copy_nanvix_binaries();
 
+    // Delay-load winhvplatform.dll so WHP-less hosts don't crash before main().
+    // CARGO_CFG_TARGET_* (not #[cfg]) because build.rs cfg gates are host, not target.
+    #[cfg(feature = "hyperlight")]
+    {
+        let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        if target_os == "windows" && target_arch == "x86_64" {
+            println!("cargo:rustc-link-arg=/DELAYLOAD:winhvplatform.dll");
+            println!("cargo:rustc-link-lib=delayimp");
+        }
+    }
+
     // Re-run prerequisite checks when PATH changes (e.g., after installing Python).
     #[cfg(windows)]
     println!("cargo:rerun-if-env-changed=PATH");

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -782,6 +782,13 @@ fn main() {
             output.probes.isolation_session_available = mxc_engine::isolation_session_available();
             output
         };
+        // WHP is delay-loaded; check before pyhl::install warms a VM.
+        #[cfg(all(target_os = "windows", feature = "hyperlight", target_arch = "x86_64"))]
+        let output = {
+            let mut output = output;
+            output.probes.hyperlight_available = hyperlight_common::is_whp_available();
+            output
+        };
         match appcontainer_common::probe::to_json_pretty(&output) {
             Ok(s) => println!("{s}"),
             Err(e) => {
@@ -826,6 +833,16 @@ fn main() {
     if cli.setup_hyperlight {
         #[cfg(all(feature = "hyperlight", target_arch = "x86_64"))]
         {
+            // WHP is delay-loaded; check before pyhl::install warms a VM.
+            #[cfg(target_os = "windows")]
+            if !hyperlight_common::is_whp_available() {
+                eprintln!(
+                    "Error: --setup-hyperlight requires Windows Hypervisor Platform (WHP). \
+                     Enable the HypervisorPlatform optional feature and reboot."
+                );
+                process::exit(1);
+            }
+
             let mut logger = Logger::new(if cli.debug {
                 Mode::Console
             } else {


### PR DESCRIPTION
- [x] I have signed the [Contributor License Agreement](https://opensource.microsoft.com/cla/).
- [x] This pull request is related to an issue.
- [ ] If this PR changes build commands, project architecture, or key conventions, I have updated [`.github/copilot-instructions.md`](.github/copilot-instructions.md).

-----

## Summary

The `hyperlight-host` crate statically imports `winhvplatform.dll`, which causes `wxc-exec.exe` to crash with `STATUS_DLL_NOT_FOUND` (0xC0000135) on hosts without Windows Hypervisor Platform before `main()` even runs, killing `--probe` and every other backend.

This PR applies `/DELAYLOAD:winhvplatform.dll` at the final link so the DLL is resolved on first use rather than at load time, adds a runtime `is_whp_available()` probe, and gates all Hyperlight entry points (`resolve_hyperlight`, `--setup-hyperlight`, `--probe`) behind it so missing WHP produces a typed error instead of a crash.


Closes #1053
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1059)