### PR TITLE
fix: fail closed when LXC container network doesn't initialize

### DIFF
--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -240,7 +240,19 @@ impl LxcScriptRunner {
         let needs_network = needs_network(&request.policy, uses_directional_schema);
 
         if needs_network {
-            Self::wait_for_network(&container_name, Duration::from_secs(10), logger);
+            // Fail closed: proceeding without an IP silently breaks DNS and produces
+            // flaky failures. Alpine DHCP leases can arrive at ~9s, so allow 30s.
+            let timeout = Duration::from_secs(30);
+            if !Self::wait_for_network(&container_name, timeout, logger) {
+                if self.destroy_on_exit || container_created {
+                    let _ = container.destroy();
+                }
+                return ScriptResponse::error(&format!(
+                    "Container network did not initialize within {:.0}s; \
+                     check that lxc-net/dnsmasq is running and able to assign an IP.",
+                    timeout.as_secs_f64()
+                ));
+            }
         }
 
         // Configure network rules

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -96,6 +96,34 @@ impl LxcScriptRunner {
         false
     }
 
+    fn enforce_network_readiness<P, D>(
+        &self,
+        container_name: &str,
+        container_created: bool,
+        timeout: Duration,
+        logger: &mut Logger,
+        readiness_probe: P,
+        mut destroy_container: D,
+    ) -> Option<ScriptResponse>
+    where
+        P: FnOnce(&str, Duration, &mut Logger) -> bool,
+        D: FnMut(),
+    {
+        if readiness_probe(container_name, timeout, logger) {
+            return None;
+        }
+
+        if self.destroy_on_exit || container_created {
+            destroy_container();
+        }
+
+        Some(ScriptResponse::error(&format!(
+            "Container network did not initialize within {:.0}s; \
+             check that lxc-net/dnsmasq is running and able to assign an IP.",
+            timeout.as_secs_f64()
+        )))
+    }
+
     /// Core execution logic.
     fn run_internal(&self, request: &ExecutionRequest, logger: &mut Logger) -> ScriptResponse {
         // Object-based FS-policy normalization (D6): tighten aliases of the same
@@ -243,15 +271,17 @@ impl LxcScriptRunner {
             // Fail closed: proceeding without an IP silently breaks DNS and produces
             // flaky failures. Alpine DHCP leases can arrive at ~9s, so allow 30s.
             let timeout = Duration::from_secs(30);
-            if !Self::wait_for_network(&container_name, timeout, logger) {
-                if self.destroy_on_exit || container_created {
+            if let Some(response) = self.enforce_network_readiness(
+                &container_name,
+                container_created,
+                timeout,
+                logger,
+                Self::wait_for_network,
+                || {
                     let _ = container.destroy();
-                }
-                return ScriptResponse::error(&format!(
-                    "Container network did not initialize within {:.0}s; \
-                     check that lxc-net/dnsmasq is running and able to assign an IP.",
-                    timeout.as_secs_f64()
-                ));
+                },
+            ) {
+                return response;
             }
         }
 
@@ -682,6 +712,7 @@ fn uuid_simple() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wxc_common::logger::Mode;
 
     #[test]
     fn uuid_simple_is_8_chars() {
@@ -934,6 +965,37 @@ mod tests {
         LxcScriptRunner::new(&config, "mxc-guard-test", &LifecycleConfig::default())
     }
 
+    fn runner_for_network_readiness_tests(destroy_on_exit: bool) -> LxcScriptRunner {
+        let config = LxcConfig {
+            distribution: "alpine".to_string(),
+            release: "3.23".to_string(),
+        };
+        let lifecycle = LifecycleConfig {
+            destroy_on_exit,
+            ..LifecycleConfig::default()
+        };
+        LxcScriptRunner::new(&config, "mxc-network-test", &lifecycle)
+    }
+
+    fn fail_network_readiness(
+        runner: &LxcScriptRunner,
+        container_created: bool,
+    ) -> (ScriptResponse, bool) {
+        let mut logger = Logger::new(Mode::Buffer);
+        let mut destroyed = false;
+        let response = runner
+            .enforce_network_readiness(
+                "mxc-network-test",
+                container_created,
+                Duration::from_secs(1),
+                &mut logger,
+                |_name, _timeout, _logger| false,
+                || destroyed = true,
+            )
+            .expect("a failing readiness probe should return an error response");
+        (response, destroyed)
+    }
+
     /// What the 0.8 parser produces for a config stating only `network.egress`:
     /// the egress section as written, plus an ingress section filled in from
     /// its defaults.
@@ -1059,6 +1121,58 @@ mod tests {
         assert!(
             !log.contains("Creating LXC container"),
             "the guard must return before container creation, log was: {log}"
+        );
+    }
+
+    #[test]
+    fn network_readiness_timeout_returns_the_fail_closed_error_response() {
+        let runner = runner_for_network_readiness_tests(false);
+        let (response, _) = fail_network_readiness(&runner, false);
+
+        assert!(
+            response
+                .error_message
+                .contains("Container network did not initialize within 1s"),
+            "the fail-closed readiness timeout message changed unexpectedly: {}",
+            response.error_message
+        );
+        assert_eq!(
+            response.standard_err, response.error_message,
+            "error responses should carry the message in stderr as well"
+        );
+    }
+
+    #[test]
+    fn network_readiness_timeout_preserves_a_reused_container_when_destroy_on_exit_is_false() {
+        let runner = runner_for_network_readiness_tests(false);
+        let (_, destroyed) = fail_network_readiness(&runner, false);
+
+        assert!(
+            !destroyed,
+            "a reused container should be preserved on readiness timeout when destroyOnExit=false"
+        );
+    }
+
+    #[test]
+    fn network_readiness_timeout_destroys_newly_created_container_even_when_destroy_on_exit_is_false(
+    ) {
+        let runner = runner_for_network_readiness_tests(false);
+        let (_, destroyed) = fail_network_readiness(&runner, true);
+
+        assert!(
+            destroyed,
+            "a newly created container must be destroyed on readiness timeout even when destroyOnExit=false"
+        );
+    }
+
+    #[test]
+    fn network_readiness_timeout_destroys_a_reused_container_when_destroy_on_exit_is_true() {
+        let runner = runner_for_network_readiness_tests(true);
+        let (_, destroyed) = fail_network_readiness(&runner, false);
+
+        assert!(
+            destroyed,
+            "a reused container must be destroyed on readiness timeout when destroyOnExit=true"
         );
     }
 }


### PR DESCRIPTION
## 📖 Description

Fixes a network-readiness race in the LXC backend that has been causing flaky **"LXC Network"** and **"LXC Network Enforcement"** E2E failures on `main` and multiple unrelated PRs.

The 10s timeout was also too tight because Alpine DHCP leases via lxc-net/dnsmasq frequently land at ~8–10s.


## 🔗 References

Addresses the recurring flaky failures in the LXC Network / Network Enforcement validation E2E jobs seen on `main` and unrelated PRs. No issue filed yet.

## 🔍 Validation

- `cargo check -p lxc_common --target x86_64-unknown-linux-gnu` — passes
- `cargo fmt --all -- --check` (from `src/`) — passes
- Logic: on timeout the container is now destroyed and an error surfaces instead of running DNS-broken workloads; happy path returns as soon as an IP is assigned.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1062)