### PR TITLE
[SDK] Add Linux and macOS Node SDK coverage for schema 0.8 networking

### DIFF
--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -96,7 +96,7 @@ Assign matching owner(s) with `assign_to_user` using this map:
 | @mgudgin | SDK configuration and policy (Area-SDK-Configuration, Area-SDK-Policy) |
 | @huzaifa-d | SDK API, executor schema, and TypeScript build (Area-SDK-Api, Area-Executor-Schema, Area-Build-TypeScript) |
 | @bbonaby | Rust build (Area-Build-Rust) |
-| @theelliotm | macOS / Seatbelt, SDK and executor and validation test infrastructure (Area-Test-SDK, Area-Test-Executor) |
+| @theelliotm | SDK and executor test infrastructure (Area-Test-SDK, Area-Test-Executor) |
 
 Rules:
 

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -96,7 +96,7 @@ Assign matching owner(s) with `assign_to_user` using this map:
 | @mgudgin | SDK configuration and policy (Area-SDK-Configuration, Area-SDK-Policy) |
 | @huzaifa-d | SDK API, executor schema, and TypeScript build (Area-SDK-Api, Area-Executor-Schema, Area-Build-TypeScript) |
 | @bbonaby | Rust build (Area-Build-Rust) |
-| @theelliotm | SDK and executor test infrastructure (Area-Test-SDK, Area-Test-Executor) |
+| @theelliotm | macOS / Seatbelt, SDK and executor and validation test infrastructure (Area-Test-SDK, Area-Test-Executor) |
 
 Rules:
 

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -268,10 +268,7 @@ That single port is the sandbox's entire outbound universe. The kernel enforces
 it. A client that opens raw sockets and ignores `HTTP_PROXY` **cannot** reach
 the internet or any other host-local service — it simply fails to connect.
 
-> ⚠️ **`ingress.hostLoopback: "allow"` widens that.** It is accepted alongside a
-> proxy, and it emits `(allow network-outbound (remote ip "localhost:*"))` in
-> addition to the port-scoped proxy allow (the proxy rule is written last so it
-> survives if either ever becomes a deny). Outbound is then *every port on this
+> ⚠️ **`ingress.hostLoopback: "allow"` widens outbound** to *every port on this
 > host*, not just the proxy port, and the confinement claim above no longer
 > holds. Keep `ingress: {"default": "deny", "hostLoopback": "deny"}` whenever
 > the proxy is meant to be the only way out. This won't prevent TCP responses

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -181,7 +181,7 @@ This is the cross-backend
 
 | Field | Behavior |
 |---|---|
-| `egress.default` | `"deny"` → no outbound rule; baseline `(deny default)` blocks all IP sockets. `"allow"` → `(allow network-outbound)`, `(allow network-bind (local ip))`, `(allow system-socket)`. |
+| `egress.default` | `"deny"` → no *general* outbound rule; baseline `(deny default)` blocks IP sockets, except for the host-loopback path (`ingress.hostLoopback`) and a `runtimeConfig.networkProxy` endpoint, which are carved out of it. `"allow"` → `(allow network-outbound)`, `(allow network-bind (local ip))`, `(allow system-socket)`. |
 | `egress.allow` / `egress.deny` | **Rejected** if non-empty — no CIDR/port/protocol primitive exists |
 | `ingress.default` | `"allow"` → `(allow network-inbound (local ip))`. This is what permits `listen()` — `network-bind` alone is not enough. |
 | `ingress.hostLoopback` | Controls sandbox → host loopback. Must equal `ingress.default`. **Defaults to `"deny"`.** |
@@ -251,13 +251,13 @@ This distinction matters, and it's easy to get backwards.
 
 | Question | Enforced? |
 |---|---|
-| Can the sandbox reach anything *other than* the proxy? | **No — kernel-enforced.** |
+| Can the sandbox reach anything *other than* the proxy? | **No — kernel-enforced**, provided `ingress.hostLoopback` stays `"deny"` (see the caveat below). |
 | Will a client actually *speak to* the proxy? | Not enforced — cooperative. |
 | Is traffic transparently redirected into the proxy? | No. |
 
 **Egress confinement is real.** A proxy is only ever accepted alongside a deny
-egress default (proxy + `"allow"` is [rejected](#network)), so the profile
-always ends up as:
+egress default (proxy + `"allow"` is [rejected](#network)), so with the
+recommended `hostLoopback: "deny"` the profile ends up as:
 
 ```lisp
 (deny default)
@@ -267,6 +267,15 @@ always ends up as:
 That single port is the sandbox's entire outbound universe. The kernel enforces
 it. A client that opens raw sockets and ignores `HTTP_PROXY` **cannot** reach
 the internet or any other host-local service — it simply fails to connect.
+
+> ⚠️ **`ingress.hostLoopback: "allow"` widens that.** It is accepted alongside a
+> proxy, and it emits `(allow network-outbound (remote ip "localhost:*"))` in
+> addition to the port-scoped proxy allow (the proxy rule is written last so it
+> survives if either ever becomes a deny). Outbound is then *every port on this
+> host*, not just the proxy port, and the confinement claim above no longer
+> holds. Keep `ingress: {"default": "deny", "hostLoopback": "deny"}` whenever
+> the proxy is meant to be the only way out. This won't prevent TCP responses
+> from reaching the sandbox.
 
 **Proxy usage is cooperative.** MXC injects `HTTP_PROXY` / `HTTPS_PROXY` /
 `ALL_PROXY` (and lowercase forms) and strips any caller-supplied proxy vars.
@@ -489,6 +498,7 @@ once you can see the rules that were emitted.
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Internet works, but `localhost:3000` is refused | [The `hostLoopback` trap](#the-hostloopback-trap) — you set `egress.default: "allow"` and left `ingress` out, so `hostLoopback` defaulted to `deny` | Add `ingress: {default: "allow", hostLoopback: "allow"}` |
+| `egress.default: "deny"`, but the sandbox still reaches services on your machine | `ingress.hostLoopback: "allow"` opens every port on every address of this host — it isn't gated by `egress`. | Set/omit `ingress: {default: "deny", hostLoopback: "deny"}`, or use a loopback `runtimeConfig.networkProxy` for one port only |
 | All network fails and you didn't configure any | Omitting `network` denies everything — it isn't "unset", it's deny | Add an explicit `egress`/`ingress` block |
 | `guiAccess: true` rejected: "cannot be combined with `ui.disable=true`" | `ui.disable` defaults to `true`, so an omitted `ui` section conflicts | Add `ui: {disable: false}` |
 | `readwritePaths` on `/System` or `/usr` still can't write | SIP outranks the profile | Nothing to fix — pick a different path |

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -495,7 +495,7 @@ once you can see the rules that were emitted.
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Internet works, but `localhost:3000` is refused | [The `hostLoopback` trap](#the-hostloopback-trap) — you set `egress.default: "allow"` and left `ingress` out, so `hostLoopback` defaulted to `deny` | Add `ingress: {default: "allow", hostLoopback: "allow"}` |
-| `egress.default: "deny"`, but the sandbox still reaches services on your machine | `ingress.hostLoopback: "allow"` opens every port on every address of this host — it isn't gated by `egress`. | Set/omit `ingress: {default: "deny", hostLoopback: "deny"}`, or use a loopback `runtimeConfig.networkProxy` for one port only |
+| `egress.default: "deny"`, but the sandbox still reaches services on your machine | `ingress.hostLoopback: "allow"` opens every port on every address of this host — it isn't gated by `egress`. | Set `ingress: {default: "deny", hostLoopback: "deny"}` or omit `ingress` entirely. If one host port is still needed, also set a loopback `runtimeConfig.networkProxy`. |
 | All network fails and you didn't configure any | Omitting `network` denies everything — it isn't "unset", it's deny | Add an explicit `egress`/`ingress` block |
 | `guiAccess: true` rejected: "cannot be combined with `ui.disable=true`" | `ui.disable` defaults to `true`, so an omitted `ui` section conflicts | Add `ui: {disable: false}` |
 | `readwritePaths` on `/System` or `/usr` still can't write | SIP outranks the profile | Nothing to fix — pick a different path |

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -271,8 +271,8 @@ the internet or any other host-local service — it simply fails to connect.
 > ⚠️ **`ingress.hostLoopback: "allow"` widens outbound** to *every port on this
 > host*, not just the proxy port, and the confinement claim above no longer
 > holds. Keep `ingress: {"default": "deny", "hostLoopback": "deny"}` whenever
-> the proxy is meant to be the only way out. This won't prevent TCP responses
-> from reaching the sandbox.
+> the proxy is meant to be the only way out. This won't prevent the proxy's 
+> TCP responses from reaching the sandbox.
 
 **Proxy usage is cooperative.** MXC injects `HTTP_PROXY` / `HTTPS_PROXY` /
 `ALL_PROXY` (and lowercase forms) and strips any caller-supplied proxy vars.
@@ -495,7 +495,6 @@ once you can see the rules that were emitted.
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Internet works, but `localhost:3000` is refused | [The `hostLoopback` trap](#the-hostloopback-trap) — you set `egress.default: "allow"` and left `ingress` out, so `hostLoopback` defaulted to `deny` | Add `ingress: {default: "allow", hostLoopback: "allow"}` |
-| `egress.default: "deny"`, but the sandbox still reaches services on your machine | `ingress.hostLoopback: "allow"` opens every port on every address of this host — it isn't gated by `egress`. | Set `ingress: {default: "deny", hostLoopback: "deny"}` or omit `ingress` entirely. If one host port is still needed, also set a loopback `runtimeConfig.networkProxy`. |
 | All network fails and you didn't configure any | Omitting `network` denies everything — it isn't "unset", it's deny | Add an explicit `egress`/`ingress` block |
 | `guiAccess: true` rejected: "cannot be combined with `ui.disable=true`" | `ui.disable` defaults to `true`, so an omitted `ui` section conflicts | Add `ui: {disable: false}` |
 | `readwritePaths` on `/System` or `/usr` still can't write | SIP outranks the profile | Nothing to fix — pick a different path |

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1296,12 +1296,7 @@ describe('createConfigFromPolicy', () => {
       }
     });
 
-    it('should forward egress allow/deny rules on macOS for native Seatbelt validation', () => {
-      // Seatbelt declares EGRESS_DEFAULT | INGRESS_DEFAULT | HOST_LOOPBACK |
-      // RUNTIME_PROXY but no EGRESS_RULES, so per-rule egress is rejected by
-      // the backend's own validate(). As with the legacy host lists above, the
-      // SDK forwards the request untouched and leaves that limitation to
-      // native validation rather than duplicating the capability matrix.
+    it('should forward egress allow/deny rules on macOS untouched, leaving their rejection to Seatbelt', () => {
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
@@ -1387,14 +1382,6 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should forward a hostLoopback that diverges from ingress.default on macOS', () => {
-      // Seatbelt can only enforce the container-to-host half of the
-      // bidirectional hostLoopback posture (an inbound filter scoped to
-      // loopback is either a no-op or breaks bind()), so
-      // validate_seatbelt_network_policy refuses a hostLoopback that differs
-      // from ingress.default. That invariant lives in the backend's own
-      // validate() — deliberately not in wxc_common's parser — so the SDK
-      // forwards the divergent pair verbatim and lets the backend report it
-      // rather than second-guessing a per-backend rule at authoring time.
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
@@ -1416,13 +1403,6 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should not synthesize a hostLoopback value when the caller omits it', () => {
-      // Regression guard for the open ambiguity in #1032: the spec reads
-      // hostLoopback as overriding `default` (absent => inherit) while the
-      // parser resolves an omitted value to 'deny' outright. Resolving that
-      // default is the native parser's call — if the SDK filled one in, it
-      // would silently pre-empt whichever reading wins, and on Seatbelt it
-      // would decide for the caller whether the pair diverges (an authoring
-      // error) or matches.
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
@@ -1441,14 +1421,6 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should forward an allow ingress under a deny egress on macOS', () => {
-      // The valid-but-surprising Seatbelt shape: hostLoopback is not gated by
-      // egress, so this emits `(allow network-outbound (remote ip
-      // "localhost:*"))` on top of the deny baseline plus the inbound grant —
-      // no internet, but every port on every address of this host is
-      // reachable, and the sandbox can serve. Documented in
-      // docs/seatbelt/seatbelt-backend.md ("hostLoopback is not subordinate to
-      // egress"); the SDK's job is to forward the pair verbatim so that
-      // posture is never silently narrowed at authoring time.
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
@@ -1470,14 +1442,6 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should emit an egress-independent ingress block on macOS', () => {
-      // The Seatbelt profile builder makes hostLoopback's *emitted rule*
-      // conditional on the egress default: hostLoopback='deny' under an allow
-      // egress emits `(deny network-outbound (remote ip "localhost:*"))`,
-      // hostLoopback='allow' under a deny egress emits the matching allow, and
-      // the two matching combinations emit nothing because the baseline
-      // already covers them. That coupling is a profile-generation detail —
-      // the wire config the SDK authors must carry the caller's directional
-      // intent unchanged and identically for either egress default.
       mockDarwin();
       try {
         const ingress = { default: 'deny', hostLoopback: 'deny' } as const;

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1310,6 +1310,7 @@ describe('createConfigFromPolicy', () => {
             egress: {
               default: 'deny',
               allow: [{ to: [{ cidr: '203.0.113.0/24' }], ports: [{ protocol: 'tcp', port: 443 }] }],
+              deny: [{ to: [{ cidr: '203.0.113.128/25' }] }],
             },
             ingress: { default: 'deny', hostLoopback: 'deny' },
           },
@@ -1318,6 +1319,7 @@ describe('createConfigFromPolicy', () => {
         assert.deepStrictEqual(config.network!.egress, {
           default: 'deny',
           allow: [{ to: [{ cidr: '203.0.113.0/24' }], ports: [{ protocol: 'tcp', port: 443 }] }],
+          deny: [{ to: [{ cidr: '203.0.113.128/25' }] }],
         });
       } finally {
         restore();

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -895,6 +895,262 @@ describe('createConfigFromPolicy', () => {
         restore();
       }
     });
+
+    it('should forward schema 0.8 directional rules unchanged for the default process containment', () => {
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: {
+              default: 'deny',
+              allow: [{
+                to: [{ cidr: '203.0.113.0/24', except: ['203.0.113.5/32'] }],
+                ports: [{ protocol: 'tcp', port: 443 }],
+              }],
+              deny: [{ to: [{ cidr: '198.51.100.0/24' }] }],
+            },
+            ingress: { default: 'deny', hostLoopback: 'deny' },
+          },
+        });
+
+        assert.strictEqual(config.containment, 'process');
+        assert.strictEqual(config.lxc, undefined);
+        assert.deepStrictEqual(config.network, {
+          egress: {
+            default: 'deny',
+            allow: [{
+              to: [{ cidr: '203.0.113.0/24', except: ['203.0.113.5/32'] }],
+              ports: [{ protocol: 'tcp', port: 443 }],
+            }],
+            deny: [{ to: [{ cidr: '198.51.100.0/24' }] }],
+          },
+          ingress: { default: 'deny', hostLoopback: 'deny' },
+        });
+        // The legacy-only fields must stay absent: directional configs carry
+        // no defaultPolicy, and applyLinuxNetworkPolicy must not promote
+        // enforcementMode off directional rules (it keys off allowedHosts /
+        // blockedHosts, which directional authoring never populates).
+        assert.strictEqual(config.network!.defaultPolicy, undefined);
+        assert.strictEqual(config.network!.allowLocalNetwork, undefined);
+        assert.strictEqual(config.network!.enforcementMode, undefined);
+        assert.strictEqual(config.processContainer, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward schema 0.8 directional rules unchanged for explicit bubblewrap containment', () => {
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy(
+          {
+            version: '0.8.0-alpha',
+            network: {
+              egress: { default: 'allow', deny: [{ to: [{ cidr: '10.0.0.0/8' }] }] },
+              ingress: { default: 'deny', hostLoopback: 'deny' },
+            },
+          },
+          'bubblewrap',
+        );
+
+        assert.strictEqual(config.containment, 'bubblewrap');
+        assert.deepStrictEqual(config.network, {
+          egress: { default: 'allow', deny: [{ to: [{ cidr: '10.0.0.0/8' }] }] },
+          ingress: { default: 'deny', hostLoopback: 'deny' },
+        });
+        assert.strictEqual(config.network!.enforcementMode, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward runtimeConfig.networkProxy for bubblewrap containment', () => {
+      mockLinux();
+      try {
+        for (const containment of ['process', 'bubblewrap'] as const) {
+          const config = createConfigFromPolicy(
+            {
+              version: '0.8.0-alpha',
+              network: {
+                egress: { default: 'deny' },
+                ingress: { default: 'deny', hostLoopback: 'deny' },
+              },
+              runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+            },
+            containment,
+          );
+
+          assert.deepStrictEqual(config.runtimeConfig, {
+            networkProxy: 'http://127.0.0.1:8080',
+          });
+          assert.deepStrictEqual(config.network, {
+            egress: { default: 'deny' },
+            ingress: { default: 'deny', hostLoopback: 'deny' },
+          });
+        }
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward runtimeConfig.networkProxy on Linux for explicit lxc containment', () => {
+      // The schema 0.8 field is not wired for LXC: lxc_network_policy_support()
+      // omits RUNTIME_PROXY, so validate_runner rejects it. That is a genuine
+      // capability gap — runtimeConfig.networkProxy must name a canonical
+      // loopback host, and inside LXC's netns loopback is the container's own,
+      // which is exactly the topology the legacy `network.proxy` path rejects.
+      // Either way it is the backend's answer to give, so the SDK's directional
+      // path forwards the field verbatim rather than gating it at authoring
+      // time.
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy(
+          {
+            version: '0.8.0-alpha',
+            network: {
+              egress: { default: 'deny' },
+              ingress: { default: 'deny', hostLoopback: 'deny' },
+            },
+            runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+          },
+          'lxc',
+        );
+
+        assert.strictEqual(config.containment, 'lxc');
+        assert.deepStrictEqual(config.runtimeConfig, {
+          networkProxy: 'http://127.0.0.1:8080',
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward directional rules for explicit lxc containment without a runtime proxy', () => {
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy(
+          {
+            version: '0.8.0-alpha',
+            network: {
+              egress: { default: 'deny', allow: [{ to: [{ cidr: '203.0.113.0/24' }] }] },
+              ingress: { default: 'deny', hostLoopback: 'allow' },
+            },
+          },
+          'lxc',
+        );
+
+        assert.strictEqual(config.containment, 'lxc');
+        assert.ok(config.lxc);
+        assert.deepStrictEqual(config.network, {
+          egress: { default: 'deny', allow: [{ to: [{ cidr: '203.0.113.0/24' }] }] },
+          ingress: { default: 'deny', hostLoopback: 'allow' },
+        });
+        assert.strictEqual(config.network!.enforcementMode, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward allowedProxyPeer unchanged on Linux for native rejection', () => {
+      // Bubblewrap/LXC declare no PROXY_PEER_IDENTITY support, so the native
+      // validator owns the rejection (as it does for the legacy host lists on
+      // Unix backends). The SDK must not silently drop a security-relevant
+      // field it cannot honor.
+      mockLinux();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' },
+            ingress: { default: 'allow', hostLoopback: 'deny' },
+          },
+          runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+          processContainer: { network: { allowedProxyPeer: 'Contoso.Proxy_1234567890abc' } },
+        });
+
+        assert.deepStrictEqual(config.processContainer!.network, {
+          allowedProxyPeer: 'Contoso.Proxy_1234567890abc',
+        });
+        // The Windows capability derivation must not leak into Linux configs.
+        assert.strictEqual(config.processContainer!.capabilities, undefined);
+        assert.strictEqual(config.processContainer!.ui, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject mixed legacy and directional network fields on Linux', () => {
+      mockLinux();
+      try {
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.8.0-alpha',
+            network: {
+              allowedHosts: ['example.com'],
+              egress: { default: 'deny' },
+            },
+          }),
+          { message: /cannot mix/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward an inbound-allow ingress posture unchanged on Linux', () => {
+      // Bubblewrap refuses ingress.default='allow' and hostLoopback='allow'
+      // natively: its private netns is routed by rootless slirp4netns, which
+      // offers no route in, and the hostLoopback deny is bidirectional (it also
+      // drops egress to slirp's gateway 10.0.2.2, the host's own loopback).
+      // Those are backend-enforced postures, not authoring-time ones, so the
+      // SDK forwards the request untouched — a caller who later switches the
+      // same policy to lxc (which supports the same directional bits with a
+      // real bridge) must get the identical wire config.
+      mockLinux();
+      try {
+        const policy = {
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' as const },
+            ingress: { default: 'allow' as const, hostLoopback: 'allow' as const },
+          },
+        };
+        const viaBubblewrap = createConfigFromPolicy(policy, 'bubblewrap');
+        const viaLxc = createConfigFromPolicy(policy, 'lxc');
+
+        assert.deepStrictEqual(viaBubblewrap.network!.ingress, {
+          default: 'allow',
+          hostLoopback: 'allow',
+        });
+        assert.deepStrictEqual(viaLxc.network!.ingress, viaBubblewrap.network!.ingress);
+        assert.deepStrictEqual(viaLxc.network!.egress, viaBubblewrap.network!.egress);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject schema 0.8 directional fields on older schemas on Linux', () => {
+      mockLinux();
+      try {
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.7.0-alpha',
+            network: { ingress: { default: 'deny' } },
+          }),
+          { message: /does not support network\.egress/ },
+        );
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.7.0-alpha',
+            runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+          }),
+          { message: /does not support network\.egress/ },
+        );
+      } finally {
+        restore();
+      }
+    });
   });
 
   describe('macOS', () => {
@@ -982,6 +1238,260 @@ describe('createConfigFromPolicy', () => {
           network: { proxy: { url: 'http://127.0.0.1:8080' } },
         });
         assert.deepStrictEqual(config.network!.proxy, { url: 'http://127.0.0.1:8080' });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward schema 0.8 directional defaults unchanged on macOS', () => {
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'allow' },
+            ingress: { default: 'deny', hostLoopback: 'deny' },
+          },
+        });
+
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.ok(config.seatbelt);
+        assert.deepStrictEqual(config.network, {
+          egress: { default: 'allow' },
+          ingress: { default: 'deny', hostLoopback: 'deny' },
+        });
+        // Directional configs must not carry the legacy mapping fields the
+        // Seatbelt profile builder falls back to when they are populated.
+        assert.strictEqual(config.network!.defaultPolicy, undefined);
+        assert.strictEqual(config.network!.allowLocalNetwork, undefined);
+        assert.strictEqual(config.network!.proxy, undefined);
+        assert.strictEqual(config.processContainer, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward runtimeConfig.networkProxy unchanged on macOS', () => {
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' },
+            ingress: { default: 'deny', hostLoopback: 'deny' },
+          },
+          runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+        });
+
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.runtimeConfig, {
+          networkProxy: 'http://127.0.0.1:8080',
+        });
+        assert.deepStrictEqual(config.network, {
+          egress: { default: 'deny' },
+          ingress: { default: 'deny', hostLoopback: 'deny' },
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward egress allow/deny rules on macOS for native Seatbelt validation', () => {
+      // Seatbelt declares EGRESS_DEFAULT | INGRESS_DEFAULT | HOST_LOOPBACK |
+      // RUNTIME_PROXY but no EGRESS_RULES, so per-rule egress is rejected by
+      // the backend's own validate(). As with the legacy host lists above, the
+      // SDK forwards the request untouched and leaves that limitation to
+      // native validation rather than duplicating the capability matrix.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: {
+              default: 'deny',
+              allow: [{ to: [{ cidr: '203.0.113.0/24' }], ports: [{ protocol: 'tcp', port: 443 }] }],
+            },
+            ingress: { default: 'deny', hostLoopback: 'deny' },
+          },
+        });
+
+        assert.deepStrictEqual(config.network!.egress, {
+          default: 'deny',
+          allow: [{ to: [{ cidr: '203.0.113.0/24' }], ports: [{ protocol: 'tcp', port: 443 }] }],
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward allowedProxyPeer unchanged on macOS for native rejection', () => {
+      // Seatbelt declares no PROXY_PEER_IDENTITY support; the native validator
+      // owns the rejection. The Windows-only capability/UI derivation must not
+      // appear in a macOS config.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' },
+            ingress: { default: 'allow', hostLoopback: 'deny' },
+          },
+          runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
+          processContainer: { network: { allowedProxyPeer: 'Contoso.Proxy_1234567890abc' } },
+        });
+
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.processContainer!.network, {
+          allowedProxyPeer: 'Contoso.Proxy_1234567890abc',
+        });
+        assert.strictEqual(config.processContainer!.capabilities, undefined);
+        assert.strictEqual(config.processContainer!.ui, undefined);
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject mixed legacy and directional network fields on macOS', () => {
+      mockDarwin();
+      try {
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.8.0-alpha',
+            network: {
+              proxy: { url: 'http://127.0.0.1:8080' },
+              egress: { default: 'deny' },
+            },
+          }),
+          { message: /cannot mix/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should reject schema 0.8 directional fields on older schemas on macOS', () => {
+      mockDarwin();
+      try {
+        assert.throws(
+          () => createConfigFromPolicy({
+            version: '0.7.0-alpha',
+            network: { egress: { default: 'allow' } },
+          }),
+          { message: /does not support network\.egress/ },
+        );
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward a hostLoopback that diverges from ingress.default on macOS', () => {
+      // Seatbelt can only enforce the container-to-host half of the
+      // bidirectional hostLoopback posture (an inbound filter scoped to
+      // loopback is either a no-op or breaks bind()), so
+      // validate_seatbelt_network_policy refuses a hostLoopback that differs
+      // from ingress.default. That invariant lives in the backend's own
+      // validate() — deliberately not in wxc_common's parser — so the SDK
+      // forwards the divergent pair verbatim and lets the backend report it
+      // rather than second-guessing a per-backend rule at authoring time.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' },
+            ingress: { default: 'allow', hostLoopback: 'deny' },
+          },
+        });
+
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.network!.ingress, {
+          default: 'allow',
+          hostLoopback: 'deny',
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should not synthesize a hostLoopback value when the caller omits it', () => {
+      // Regression guard for the open ambiguity in #1032: the spec reads
+      // hostLoopback as overriding `default` (absent => inherit) while the
+      // parser resolves an omitted value to 'deny' outright. Resolving that
+      // default is the native parser's call — if the SDK filled one in, it
+      // would silently pre-empt whichever reading wins, and on Seatbelt it
+      // would decide for the caller whether the pair diverges (an authoring
+      // error) or matches.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'allow' },
+            ingress: { default: 'allow' },
+          },
+        });
+
+        assert.deepStrictEqual(config.network!.ingress, { default: 'allow' });
+        assert.ok(!('hostLoopback' in config.network!.ingress!));
+      } finally {
+        restore();
+      }
+    });
+
+    it('should forward an allow ingress under a deny egress on macOS', () => {
+      // The valid-but-surprising Seatbelt shape: hostLoopback is not gated by
+      // egress, so this emits `(allow network-outbound (remote ip
+      // "localhost:*"))` on top of the deny baseline plus the inbound grant —
+      // no internet, but every port on every address of this host is
+      // reachable, and the sandbox can serve. Documented in
+      // docs/seatbelt/seatbelt-backend.md ("hostLoopback is not subordinate to
+      // egress"); the SDK's job is to forward the pair verbatim so that
+      // posture is never silently narrowed at authoring time.
+      mockDarwin();
+      try {
+        const config = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: {
+            egress: { default: 'deny' },
+            ingress: { default: 'allow', hostLoopback: 'allow' },
+          },
+        });
+
+        assert.strictEqual(config.containment, 'seatbelt');
+        assert.deepStrictEqual(config.network, {
+          egress: { default: 'deny' },
+          ingress: { default: 'allow', hostLoopback: 'allow' },
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('should emit an egress-independent ingress block on macOS', () => {
+      // The Seatbelt profile builder makes hostLoopback's *emitted rule*
+      // conditional on the egress default: hostLoopback='deny' under an allow
+      // egress emits `(deny network-outbound (remote ip "localhost:*"))`,
+      // hostLoopback='allow' under a deny egress emits the matching allow, and
+      // the two matching combinations emit nothing because the baseline
+      // already covers them. That coupling is a profile-generation detail —
+      // the wire config the SDK authors must carry the caller's directional
+      // intent unchanged and identically for either egress default.
+      mockDarwin();
+      try {
+        const ingress = { default: 'deny', hostLoopback: 'deny' } as const;
+        const underDeny = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: { egress: { default: 'deny' }, ingress },
+        });
+        const underAllow = createConfigFromPolicy({
+          version: '0.8.0-alpha',
+          network: { egress: { default: 'allow' }, ingress },
+        });
+
+        assert.deepStrictEqual(underDeny.network!.ingress, { default: 'deny', hostLoopback: 'deny' });
+        assert.deepStrictEqual(underAllow.network!.ingress, underDeny.network!.ingress);
+        assert.strictEqual(underDeny.network!.egress!.default, 'deny');
+        assert.strictEqual(underAllow.network!.egress!.default, 'allow');
       } finally {
         restore();
       }


### PR DESCRIPTION
## 📖 Description
Adds Node SDK unit coverage for schema 0.8 directional networking on Linux and macOS, following up on the Windows-focused tests from #977.

**Linux** — `network.egress` / `network.ingress` forwarded verbatim for `process`, `bubblewrap`, and `lxc`; `runtimeConfig.networkProxy` forwarding; `processContainer.network.allowedProxyPeer` passed through for native rejection. Asserts the legacy-only fields (`defaultPolicy`, `allowLocalNetwork`, `enforcementMode`) stay absent, so `applyLinuxNetworkPolicy` never promotes an enforcement mode off directional rules.

**macOS** — the same forwarding for `seatbelt`, plus the cases Seatbelt's own `validate()` owns rather than the SDK: `egress.allow`/`deny` (no `EGRESS_RULES` capability) and a `hostLoopback` that diverges from `ingress.default`. Also guards that an omitted `hostLoopback` is not synthesized (the open ambiguity in #1032) and that the ingress block is emitted identically under either egress default.

**Rejections** — mixed legacy + directional fields, and 0.8 fields on a pre-0.8 schema, covered on both platforms.

Also documents in `docs/seatbelt/seatbelt-backend.md` that `ingress.hostLoopback: "allow"` is not subordinate to `egress.default` and widens the proxy-only confinement claim — the behavior two of the new tests pin.

No production code changes; test and docs only.

## 🔗 References
Resolves #988

Found issue #1074 during work.

## 🔍 Validation
`npm test` in `sdk/node/` — 304 pass, 0 fail (323 total, 19 skipped), including the 20 new cases.

## ✅ Checklist
- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
- [ ] Bug fix
- [ ] Feature
- [x] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1075)