### PR TITLE
Enforce ProcessContainer ingress policy

### DIFF
--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,13 +106,11 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-- MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
+MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
 `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
 `QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
 the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot
 represent it.
-- `MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
-cannot use that reserved identity.
 
 #### Identity-scoped proxy
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,12 +106,12 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
+- MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
 `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
 `QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
 the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot
-represent it. The PSEC 1.1 ingress table replaces the reserved
-`MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
+represent it.
+- `MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
 cannot use that reserved identity.
 
 #### Identity-scoped proxy

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -111,6 +111,7 @@ MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ing
 `QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
 the legacy PSEC 1.0/SBOX capability mapping;
 `hostLoopback: "allow"` is rejected because the legacy contracts cannot represent it.
+Caller-supplied `allowedProxyPeer` values cannot use the reserved `MXC-Loopback` identity.
 
 #### Identity-scoped proxy
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,10 +106,12 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-- MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
+MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
 `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
-`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot represent it.
-- `MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
+`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
+the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot
+represent it. The PSEC 1.1 ingress table replaces the reserved
+`MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
 cannot use that reserved identity.
 
 #### Identity-scoped proxy

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,12 +106,11 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
+- MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
 `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
-`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
-the legacy PSEC 1.0/SBOX capability mapping;
-`hostLoopback: "allow"` is rejected because the legacy contracts cannot represent it.
-Caller-supplied `allowedProxyPeer` values cannot use the reserved `MXC-Loopback` identity.
+`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot represent it.
+- `MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
+cannot use that reserved identity.
 
 #### Identity-scoped proxy
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,9 +106,11 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-On the PSEC path, MXC maps `hostLoopback: "allow"` to the `networkLoopback` capability and the reserved
-`MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
-cannot use that reserved identity.
+MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
+`IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
+`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
+the legacy PSEC 1.0/SBOX capability mapping;
+`hostLoopback: "allow"` is rejected because the legacy contracts cannot represent it.
 
 #### Identity-scoped proxy
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -108,9 +108,9 @@ authorizes both host-loopback directions, although WFP still restricts client-co
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
 MXC passes `ingress.default` and `ingress.hostLoopback` through the PSEC 1.1 ingress table when
 `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and
-`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Otherwise, compatible directional defaults use
-the legacy PSEC 1.0/SBOX capability mapping; `hostLoopback: "allow"` is rejected because the legacy contracts cannot
-represent it.
+`QueryProcessSecurityEnvironmentSupport` advertises ingress support. Requests that do not allow host loopback use the
+PSEC 1.0 capability mapping; `hostLoopback: "allow"` is rejected when the PSEC 1.1 ingress contract is unavailable.
+The legacy SBOX path remains eligible only when its capability mapping can preserve the request.
 
 #### Identity-scoped proxy
 

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -54,10 +54,7 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: boo
     ) as u64;
 
     let mut spec = PsecProcessSecurityEnvironment::default();
-    spec.version = SchemaVersionT {
-        major: 1,
-        minor: u16::from(ingress_supported),
-    };
+    spec.version = psec_contract_version(ingress_supported);
     spec.capabilities = (!capabilities.is_empty()).then(|| capabilities.join(","));
     spec.disallow_win32k_system_calls = request.policy.ui.disable;
     spec.ui_restrictions = ui_restrictions;
@@ -71,6 +68,14 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: boo
     let spec = spec.pack(&mut builder);
     finish_process_security_environment_buffer(&mut builder, spec);
     builder.finished_data().to_vec()
+}
+
+fn psec_contract_version(ingress_supported: bool) -> SchemaVersionT {
+    let mut minor = 0;
+    if ingress_supported {
+        minor = 1u16;
+    }
+    SchemaVersionT { major: 1, minor }
 }
 
 pub(super) fn build_sbox_spec(request: &ExecutionRequest) -> Vec<u8> {

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -6,10 +6,10 @@
 use process_security_environment_spec::process_security_environment_layout::{
     finish_process_security_environment_buffer, DestinationRuleT as PsecDestinationRuleT,
     EndpointPolicyT as PsecEndpointPolicy, EndpointRuleT as PsecEndpointRuleT,
-    FilterAction as PsecFilterAction, IpProtocol as PsecIpProtocol, IpSubnetT as PsecIpSubnetT,
-    NetworkPolicyT as PsecNetworkPolicy, PortRuleT as PsecPortRuleT,
-    ProcessSecurityEnvironmentT as PsecProcessSecurityEnvironment, ProxyInfoT as PsecProxyInfo,
-    SchemaVersionT,
+    FilterAction as PsecFilterAction, IngressPolicyT as PsecIngressPolicy,
+    IpProtocol as PsecIpProtocol, IpSubnetT as PsecIpSubnetT, NetworkPolicyT as PsecNetworkPolicy,
+    PortRuleT as PsecPortRuleT, ProcessSecurityEnvironmentT as PsecProcessSecurityEnvironment,
+    ProxyInfoT as PsecProxyInfo, SchemaVersionT,
 };
 use sandbox_spec::base_container_layout::{
     endpoint_policyT, finish_sandbox_spec_buffer, proxy_infoT, FilterAction as SboxFilterAction,
@@ -20,11 +20,8 @@ use wxc_common::models::{
     NetworkPort, NetworkProtocol, NetworkRule,
 };
 
-use crate::network_policy_helpers::{
-    add_default_network_capabilities, ensure_capability, uses_network_capabilities,
-};
+use crate::network_policy_helpers::{add_default_network_capabilities, PRIVATE_NETWORK_CAPABILITY};
 
-pub(super) const LOOPBACK_NETWORK_CAPABILITY: &str = "networkLoopback";
 pub(super) const LOOPBACK_NETWORK_PEER: &str = "MXC-Loopback";
 
 const SANDBOX_SPEC_VERSION: &str = "0.1.0";
@@ -42,9 +39,13 @@ pub(super) fn has_conflicting_proxy_identity(policy: &ContainerPolicy) -> bool {
     policy.allowed_proxy_peer.is_some() && unrestricted_host_loopback_allowed(policy)
 }
 
-pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
+pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: bool) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
-    let capabilities = effective_capabilities(&request.policy, true);
+    let mut capabilities = effective_capabilities(&request.policy);
+    if ingress_supported && request.policy.network_ingress.is_some() {
+        capabilities
+            .retain(|capability| !capability.eq_ignore_ascii_case(PRIVATE_NETWORK_CAPABILITY));
+    }
     let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
         &wxc_common::ui_policy::resolve_ui_restrictions(
             &request.policy.ui,
@@ -53,14 +54,20 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
     ) as u64;
 
     let mut spec = PsecProcessSecurityEnvironment::default();
-    spec.version = SchemaVersionT { major: 1, minor: 0 };
+    spec.version = SchemaVersionT {
+        major: 1,
+        minor: u16::from(ingress_supported),
+    };
     spec.capabilities = (!capabilities.is_empty()).then(|| capabilities.join(","));
     spec.disallow_win32k_system_calls = request.policy.ui.disable;
     spec.ui_restrictions = ui_restrictions;
     spec.fs_read_write = non_empty_paths(&request.policy.readwrite_paths);
     spec.fs_read_only = non_empty_paths(&request.policy.readonly_paths);
     spec.fs_deny = non_empty_paths(&request.policy.denied_paths);
-    spec.network_policy = Some(Box::new(build_psec_network_policy(&request.policy)));
+    spec.network_policy = Some(Box::new(build_psec_network_policy(
+        &request.policy,
+        ingress_supported,
+    )));
     let spec = spec.pack(&mut builder);
     finish_process_security_environment_buffer(&mut builder, spec);
     builder.finished_data().to_vec()
@@ -68,7 +75,7 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
 
 pub(super) fn build_sbox_spec(request: &ExecutionRequest) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
-    let capabilities = effective_capabilities(&request.policy, false);
+    let capabilities = effective_capabilities(&request.policy);
     let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
         &wxc_common::ui_policy::resolve_ui_restrictions(
             &request.policy.ui,
@@ -93,7 +100,7 @@ pub(super) fn build_sbox_spec(request: &ExecutionRequest) -> Vec<u8> {
     builder.finished_data().to_vec()
 }
 
-fn effective_capabilities(policy: &ContainerPolicy, include_host_loopback: bool) -> Vec<String> {
+fn effective_capabilities(policy: &ContainerPolicy) -> Vec<String> {
     let mut capabilities: Vec<_> = policy
         .capabilities
         .iter()
@@ -101,12 +108,6 @@ fn effective_capabilities(policy: &ContainerPolicy, include_host_loopback: bool)
         .cloned()
         .collect();
     add_default_network_capabilities(policy, &mut capabilities);
-    if include_host_loopback
-        && uses_network_capabilities(policy)
-        && unrestricted_host_loopback_allowed(policy)
-    {
-        ensure_capability(&mut capabilities, LOOPBACK_NETWORK_CAPABILITY);
-    }
     capabilities
 }
 
@@ -133,7 +134,10 @@ fn build_legacy_sbox_network_policy(policy: &ContainerPolicy) -> SboxNetworkPoli
     network
 }
 
-fn build_psec_network_policy(policy: &ContainerPolicy) -> PsecNetworkPolicy {
+fn build_psec_network_policy(
+    policy: &ContainerPolicy,
+    ingress_supported: bool,
+) -> PsecNetworkPolicy {
     let mut network = PsecNetworkPolicy::default();
     if policy.network_proxy.is_enabled() {
         // Proxy and direct egress are mutually exclusive PSEC policy forms.
@@ -158,8 +162,27 @@ fn build_psec_network_policy(policy: &ContainerPolicy) -> PsecNetworkPolicy {
         }
         network.egress = Some(Box::new(egress));
     }
-    network.allowed_appcontainer_peer = allowed_appcontainer_peer(policy);
+    if let Some(ingress_policy) = policy
+        .network_ingress
+        .as_ref()
+        .filter(|_| ingress_supported)
+    {
+        network.allowed_appcontainer_peer = policy.allowed_proxy_peer.clone();
+        let mut ingress = PsecIngressPolicy::default();
+        ingress.default_action = psec_filter_action(ingress_policy.default);
+        ingress.host_loopback = psec_filter_action(ingress_policy.host_loopback);
+        network.ingress = Some(Box::new(ingress));
+    } else {
+        network.allowed_appcontainer_peer = allowed_appcontainer_peer(policy);
+    }
     network
+}
+
+fn psec_filter_action(action: NetworkAction) -> PsecFilterAction {
+    match action {
+        NetworkAction::Allow => PsecFilterAction::allow,
+        NetworkAction::Deny => PsecFilterAction::deny,
+    }
 }
 
 fn effective_egress_default(policy: &ContainerPolicy) -> NetworkAction {

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -26,6 +26,33 @@ pub(super) const LOOPBACK_NETWORK_PEER: &str = "MXC-Loopback";
 
 const SANDBOX_SPEC_VERSION: &str = "0.1.0";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PsecContract {
+    V1_0,
+    V1_1,
+}
+
+impl PsecContract {
+    pub(super) fn for_request(request: &ExecutionRequest) -> Self {
+        if unrestricted_host_loopback_allowed(&request.policy) {
+            Self::V1_1
+        } else {
+            Self::V1_0
+        }
+    }
+
+    pub(super) fn version(self) -> SchemaVersionT {
+        match self {
+            Self::V1_0 => SchemaVersionT { major: 1, minor: 0 },
+            Self::V1_1 => SchemaVersionT { major: 1, minor: 1 },
+        }
+    }
+
+    fn supports_ingress(self) -> bool {
+        self == Self::V1_1
+    }
+}
+
 pub(super) fn requires_psec_networking(policy: &ContainerPolicy) -> bool {
     policy
         .network_egress
@@ -39,8 +66,9 @@ pub(super) fn has_conflicting_proxy_identity(policy: &ContainerPolicy) -> bool {
     policy.allowed_proxy_peer.is_some() && unrestricted_host_loopback_allowed(policy)
 }
 
-pub(super) fn build_psec_spec(request: &ExecutionRequest, use_ingress_contract: bool) -> Vec<u8> {
+pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
+    let contract = PsecContract::for_request(request);
     let capabilities = effective_capabilities(&request.policy);
     let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
         &wxc_common::ui_policy::resolve_ui_restrictions(
@@ -50,7 +78,7 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, use_ingress_contract: 
     ) as u64;
 
     let mut spec = PsecProcessSecurityEnvironment::default();
-    spec.version = psec_contract_version(use_ingress_contract);
+    spec.version = contract.version();
     spec.capabilities = (!capabilities.is_empty()).then(|| capabilities.join(","));
     spec.disallow_win32k_system_calls = request.policy.ui.disable;
     spec.ui_restrictions = ui_restrictions;
@@ -59,19 +87,11 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, use_ingress_contract: 
     spec.fs_deny = non_empty_paths(&request.policy.denied_paths);
     spec.network_policy = Some(Box::new(build_psec_network_policy(
         &request.policy,
-        use_ingress_contract,
+        contract,
     )));
     let spec = spec.pack(&mut builder);
     finish_process_security_environment_buffer(&mut builder, spec);
     builder.finished_data().to_vec()
-}
-
-pub(super) fn psec_contract_version(use_ingress_contract: bool) -> SchemaVersionT {
-    let mut minor = 0;
-    if use_ingress_contract {
-        minor = 1u16;
-    }
-    SchemaVersionT { major: 1, minor }
 }
 
 pub(super) fn build_sbox_spec(request: &ExecutionRequest) -> Vec<u8> {
@@ -137,7 +157,7 @@ fn build_legacy_sbox_network_policy(policy: &ContainerPolicy) -> SboxNetworkPoli
 
 fn build_psec_network_policy(
     policy: &ContainerPolicy,
-    use_ingress_contract: bool,
+    contract: PsecContract,
 ) -> PsecNetworkPolicy {
     let mut network = PsecNetworkPolicy::default();
     if policy.network_proxy.is_enabled() {
@@ -163,7 +183,7 @@ fn build_psec_network_policy(
         }
         network.egress = Some(Box::new(egress));
     }
-    let ingress_policy = if use_ingress_contract {
+    let ingress_policy = if contract.supports_ingress() {
         policy.network_ingress.as_ref()
     } else {
         None

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -20,7 +20,7 @@ use wxc_common::models::{
     NetworkPort, NetworkProtocol, NetworkRule,
 };
 
-use crate::network_policy_helpers::{add_default_network_capabilities, PRIVATE_NETWORK_CAPABILITY};
+use crate::network_policy_helpers::add_default_network_capabilities;
 
 pub(super) const LOOPBACK_NETWORK_PEER: &str = "MXC-Loopback";
 
@@ -39,13 +39,9 @@ pub(super) fn has_conflicting_proxy_identity(policy: &ContainerPolicy) -> bool {
     policy.allowed_proxy_peer.is_some() && unrestricted_host_loopback_allowed(policy)
 }
 
-pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: bool) -> Vec<u8> {
+pub(super) fn build_psec_spec(request: &ExecutionRequest, use_ingress_contract: bool) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
-    let mut capabilities = effective_capabilities(&request.policy);
-    if ingress_supported && request.policy.network_ingress.is_some() {
-        capabilities
-            .retain(|capability| !capability.eq_ignore_ascii_case(PRIVATE_NETWORK_CAPABILITY));
-    }
+    let capabilities = effective_capabilities(&request.policy);
     let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
         &wxc_common::ui_policy::resolve_ui_restrictions(
             &request.policy.ui,
@@ -54,7 +50,7 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: boo
     ) as u64;
 
     let mut spec = PsecProcessSecurityEnvironment::default();
-    spec.version = psec_contract_version(ingress_supported);
+    spec.version = psec_contract_version(use_ingress_contract);
     spec.capabilities = (!capabilities.is_empty()).then(|| capabilities.join(","));
     spec.disallow_win32k_system_calls = request.policy.ui.disable;
     spec.ui_restrictions = ui_restrictions;
@@ -63,16 +59,16 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest, ingress_supported: boo
     spec.fs_deny = non_empty_paths(&request.policy.denied_paths);
     spec.network_policy = Some(Box::new(build_psec_network_policy(
         &request.policy,
-        ingress_supported,
+        use_ingress_contract,
     )));
     let spec = spec.pack(&mut builder);
     finish_process_security_environment_buffer(&mut builder, spec);
     builder.finished_data().to_vec()
 }
 
-fn psec_contract_version(ingress_supported: bool) -> SchemaVersionT {
+pub(super) fn psec_contract_version(use_ingress_contract: bool) -> SchemaVersionT {
     let mut minor = 0;
-    if ingress_supported {
+    if use_ingress_contract {
         minor = 1u16;
     }
     SchemaVersionT { major: 1, minor }
@@ -141,7 +137,7 @@ fn build_legacy_sbox_network_policy(policy: &ContainerPolicy) -> SboxNetworkPoli
 
 fn build_psec_network_policy(
     policy: &ContainerPolicy,
-    ingress_supported: bool,
+    use_ingress_contract: bool,
 ) -> PsecNetworkPolicy {
     let mut network = PsecNetworkPolicy::default();
     if policy.network_proxy.is_enabled() {
@@ -170,7 +166,7 @@ fn build_psec_network_policy(
     if let Some(ingress_policy) = policy
         .network_ingress
         .as_ref()
-        .filter(|_| ingress_supported)
+        .filter(|_| use_ingress_contract)
     {
         network.allowed_appcontainer_peer = policy.allowed_proxy_peer.clone();
         let mut ingress = PsecIngressPolicy::default();

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -163,11 +163,12 @@ fn build_psec_network_policy(
         }
         network.egress = Some(Box::new(egress));
     }
-    if let Some(ingress_policy) = policy
-        .network_ingress
-        .as_ref()
-        .filter(|_| use_ingress_contract)
-    {
+    let ingress_policy = if use_ingress_contract {
+        policy.network_ingress.as_ref()
+    } else {
+        None
+    };
+    if let Some(ingress_policy) = ingress_policy {
         network.allowed_appcontainer_peer = policy.allowed_proxy_peer.clone();
         let mut ingress = PsecIngressPolicy::default();
         ingress.default_action = psec_filter_action(ingress_policy.default);

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -39,8 +39,8 @@ use windows::Win32::System::Threading::{
 use windows_core::{PCWSTR, PWSTR};
 
 use crate::base_container_helpers::{
-    build_psec_spec, build_sbox_spec, has_conflicting_proxy_identity, psec_contract_version,
-    requires_psec_networking,
+    build_psec_spec, build_sbox_spec, has_conflicting_proxy_identity, requires_psec_networking,
+    PsecContract,
 };
 use crate::capture_output::{
     combine_capture_and_cleanup_results, combine_process_and_teardown_results,
@@ -423,7 +423,7 @@ impl BaseContainerRunner {
 
     #[cfg(test)]
     fn build_process_security_environment_spec(request: &ExecutionRequest) -> Vec<u8> {
-        build_psec_spec(request, request.policy.network_ingress.is_some())
+        build_psec_spec(request)
     }
 
     #[cfg(test)]
@@ -568,7 +568,7 @@ impl BaseContainerRunner {
                 schema_version: "0.8.0-alpha".to_string(),
                 ..Default::default()
             };
-            let specification = build_psec_spec(&request, false);
+            let specification = build_psec_spec(&request);
             SecurityEnvironmentApi::load()
                 .and_then(|api| api.create(&specification, PROCESS_SECURITY_ENVIRONMENT_FLAG_NONE))
                 .and_then(|environment| {
@@ -597,7 +597,7 @@ impl BaseContainerRunner {
             schema_version: "0.8.0-alpha".to_string(),
             ..Default::default()
         };
-        let specification = build_psec_spec(&request, false);
+        let specification = build_psec_spec(&request);
         SecurityEnvironmentApi::load()
             .and_then(|security_environment_api| {
                 CaptureSession::begin(
@@ -702,14 +702,16 @@ impl BaseContainerRunner {
         )
     }
 
-    fn resolve_psec_ingress_contract_support(
-        request: &ExecutionRequest,
-    ) -> Result<bool, ScriptResponse> {
-        let Some(ingress) = request.policy.network_ingress.as_ref() else {
-            return Ok(false);
-        };
-        // PSEC 1.1 ingress is usable only when the OS reports both the contract
-        // version and the ingress capability bit.
+    fn resolve_psec_contract(request: &ExecutionRequest) -> Result<PsecContract, ScriptResponse> {
+        let contract = PsecContract::for_request(request);
+        // PSEC 1.0 preserves the default ingress posture through capability
+        // mapping; only unrestricted host-loopback access requires PSEC 1.1.
+        if contract == PsecContract::V1_0 {
+            return Ok(contract);
+        }
+
+        // PSEC 1.1 is usable only when the OS reports both the contract version
+        // and the ingress capability bit.
         let psec_ingress_contract_supported = SecurityEnvironmentApi::load()
             .and_then(|api| {
                 if api.supports_version(1, 1)? {
@@ -725,20 +727,15 @@ impl BaseContainerRunner {
                 ))
             })?;
         if psec_ingress_contract_supported {
-            return Ok(true);
+            return Ok(contract);
         }
-        // PSEC 1.0 can preserve the default ingress posture through the
-        // capability mapping, but it cannot express host-loopback allow.
-        if ingress.host_loopback == wxc_common::models::NetworkAction::Allow {
-            return Err(ScriptResponse {
-                failure_phase: FailurePhase::Rejected,
-                ..ScriptResponse::error(
-                    "network.ingress.hostLoopback='allow' requires \
-                     Process Security Environment contract version 1.1 with ingress support",
-                )
-            });
-        }
-        Ok(false)
+        Err(ScriptResponse {
+            failure_phase: FailurePhase::Rejected,
+            ..ScriptResponse::error(
+                "network.ingress.hostLoopback='allow' requires Process Security Environment \
+                 contract version 1.1 with ingress support",
+            )
+        })
     }
 
     /// Transitional guard for the legacy SBOX fallback. Remove it with the
@@ -1170,8 +1167,8 @@ impl BaseContainerRunner {
         );
 
         let use_process_security_environment = self.uses_process_security_environment(request);
-        let psec_ingress_contract_supported = use_process_security_environment
-            .then(|| Self::resolve_psec_ingress_contract_support(request))
+        let psec_contract = use_process_security_environment
+            .then(|| Self::resolve_psec_contract(request))
             .transpose()?;
 
         // Launch builtin test proxy if requested (before building spec so we have the port).
@@ -1224,21 +1221,18 @@ impl BaseContainerRunner {
             let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: captureDenials");
         }
 
-        let process_security_environment_spec =
-            if let Some(ingress_contract_supported) = psec_ingress_contract_supported {
-                let contract_version = psec_contract_version(ingress_contract_supported);
-                let psec_spec = build_psec_spec(&request, ingress_contract_supported);
-                let _ = writeln!(
-                    logger,
-                    "process security environment spec built (PSEC {}.{}, {} bytes)",
-                    contract_version.major,
-                    contract_version.minor,
-                    psec_spec.len()
-                );
-                Some(psec_spec)
-            } else {
-                None
-            };
+        let process_security_environment_spec = psec_contract.map(|contract| {
+            let psec_spec = build_psec_spec(&request);
+            let contract_version = contract.version();
+            let _ = writeln!(
+                logger,
+                "process security environment spec built (PSEC {}.{}, {} bytes)",
+                contract_version.major,
+                contract_version.minor,
+                psec_spec.len()
+            );
+            psec_spec
+        });
 
         // Resolve two paths for the capture:
         //   * `capture_etl_path` — a runner-managed `.etl` in a protected
@@ -4112,43 +4106,28 @@ mod tests {
     }
 
     #[test]
-    fn build_process_security_environment_spec_encodes_ingress() {
-        for (default, host_loopback, expected_default, expected_host_loopback) in [
-            (
-                NetworkAction::Deny,
-                NetworkAction::Allow,
-                psec_layout::FilterAction::deny,
-                psec_layout::FilterAction::allow,
-            ),
-            (
-                NetworkAction::Allow,
-                NetworkAction::Deny,
-                psec_layout::FilterAction::allow,
-                psec_layout::FilterAction::deny,
-            ),
-        ] {
-            let mut request = ExecutionRequest::default();
-            request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
-                default,
-                host_loopback,
-            });
-            let expected_capabilities = (default == NetworkAction::Allow)
-                .then_some(crate::network_policy_helpers::PRIVATE_NETWORK_CAPABILITY);
+    fn psec_1_1_encodes_host_loopback_ingress() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
+            default: NetworkAction::Deny,
+            host_loopback: NetworkAction::Allow,
+        });
 
-            let bytes = BaseContainerRunner::build_process_security_environment_spec(&request);
-            let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
-            let network = spec.network_policy().expect("network policy");
-            let ingress = network.ingress().expect("ingress policy");
+        let bytes = BaseContainerRunner::build_process_security_environment_spec(&request);
+        let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
+        let ingress = spec
+            .network_policy()
+            .and_then(|network| network.ingress())
+            .expect("PSEC 1.1 must carry host-loopback policy");
 
-            assert_eq!(spec.version().minor(), 1);
-            assert_eq!(spec.capabilities(), expected_capabilities);
-            assert_eq!(ingress.default_action(), expected_default);
-            assert_eq!(ingress.host_loopback(), expected_host_loopback);
-        }
+        assert_eq!(spec.version().minor(), 1);
+        assert!(spec.capabilities().is_none());
+        assert_eq!(ingress.default_action(), psec_layout::FilterAction::deny);
+        assert_eq!(ingress.host_loopback(), psec_layout::FilterAction::allow);
     }
 
     #[test]
-    fn psec_1_0_preserves_capability_without_ingress_table() {
+    fn psec_1_0_uses_capability_for_ingress_default_allow() {
         let mut request = ExecutionRequest::default();
         request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
             default: NetworkAction::Allow,
@@ -4156,7 +4135,7 @@ mod tests {
         });
         request.policy.allowed_proxy_peer = Some("S-1-15-2-1".into());
 
-        let bytes = build_psec_spec(&request, false);
+        let bytes = build_psec_spec(&request);
         let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
         let network = spec.network_policy().expect("network policy");
 

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -742,8 +742,8 @@ impl BaseContainerRunner {
     }
 
     /// Transitional guard for the legacy SBOX fallback. Remove it with the
-    /// remaining `Experimental_CreateProcessInSandbox` path after PSEC adoption
-    /// reaches critical mass post-9D; tracked by #1129.
+    /// remaining `Experimental_CreateProcessInSandbox` path once PSEC adoption
+    /// reaches critical mass; tracked by #1129.
     ///
     /// Fail closed when the selected legacy SBOX contract cannot preserve the
     /// requested network policy; PSEC ingress support is resolved separately.

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -734,16 +734,12 @@ impl BaseContainerRunner {
         Ok(false)
     }
 
-    fn validate_resolved_network_contract(
+    /// Fail closed when the selected legacy SBOX contract cannot preserve the
+    /// requested network policy; PSEC ingress support is resolved separately.
+    fn validate_legacy_sbox_network_contract(
         request: &ExecutionRequest,
-        use_process_security_environment: bool,
     ) -> Result<(), ScriptResponse> {
-        if use_process_security_environment
-            || Self::legacy_sbox_compatible_with_request(
-                request,
-                Self::query_sandbox_capabilities(),
-            )
-        {
+        if Self::legacy_sbox_compatible_with_request(request, Self::query_sandbox_capabilities()) {
             return Ok(());
         }
 
@@ -1205,7 +1201,6 @@ impl BaseContainerRunner {
         }
         let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Build sandbox spec");
         let capture_denials = request.policy.capture_denials.clone();
-        Self::validate_resolved_network_contract(&request, use_process_security_environment)?;
         let use_guarded_capture = capture_denials.is_some() && !use_process_security_environment;
         let spec_bytes = if !use_process_security_environment {
             let bytes = build_sbox_spec(&request);
@@ -2181,7 +2176,9 @@ impl SandboxBackend for BaseContainerRunner {
             return Ok(());
         }
         let use_process_security_environment = self.uses_process_security_environment(request);
-        Self::validate_resolved_network_contract(request, use_process_security_environment)?;
+        if !use_process_security_environment {
+            Self::validate_legacy_sbox_network_contract(request)?;
+        }
         // BaseContainer's native PSEC/V2 capture seals its own ETL, so when it
         // is selected retainEtl is honored natively regardless of the guarded
         // provider's transfer capability (the native-capture exception).
@@ -3878,11 +3875,7 @@ mod tests {
         let mut request = request_with_rich_network_rules();
         request.policy.capture_denials = Some(Default::default());
 
-        assert!(
-            BaseContainerRunner::validate_resolved_network_contract(&request, true).is_ok(),
-            "PSEC preserves the complete directional policy"
-        );
-        let error = BaseContainerRunner::validate_resolved_network_contract(&request, false)
+        let error = BaseContainerRunner::validate_legacy_sbox_network_contract(&request)
             .expect_err("a late PSEC-to-SBOX transition must fail closed");
         assert_eq!(error.failure_phase, FailurePhase::BackendUnavailable);
         assert!(error
@@ -3894,7 +3887,7 @@ mod tests {
     fn resolved_sbox_contract_accepts_compatible_networking() {
         let request = ExecutionRequest::default();
 
-        assert!(BaseContainerRunner::validate_resolved_network_contract(&request, false).is_ok());
+        assert!(BaseContainerRunner::validate_legacy_sbox_network_contract(&request).is_ok());
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -701,7 +701,7 @@ impl BaseContainerRunner {
         )
     }
 
-    fn supports_psec_ingress(request: &ExecutionRequest) -> Result<bool, ScriptResponse> {
+    fn resolve_psec_ingress_support(request: &ExecutionRequest) -> Result<bool, ScriptResponse> {
         let Some(ingress) = request.policy.network_ingress.as_ref() else {
             return Ok(false);
         };
@@ -1163,9 +1163,8 @@ impl BaseContainerRunner {
         );
 
         let use_process_security_environment = self.uses_process_security_environment(request);
-        Self::validate_resolved_network_contract(request, use_process_security_environment)?;
         let psec_ingress_supported = use_process_security_environment
-            .then(|| Self::supports_psec_ingress(request))
+            .then(|| Self::resolve_psec_ingress_support(request))
             .transpose()?;
 
         // Launch builtin test proxy if requested (before building spec so we have the port).
@@ -1206,6 +1205,7 @@ impl BaseContainerRunner {
         }
         let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Build sandbox spec");
         let capture_denials = request.policy.capture_denials.clone();
+        Self::validate_resolved_network_contract(&request, use_process_security_environment)?;
         let use_guarded_capture = capture_denials.is_some() && !use_process_security_environment;
         let spec_bytes = if !use_process_security_environment {
             let bytes = build_sbox_spec(&request);

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -39,7 +39,8 @@ use windows::Win32::System::Threading::{
 use windows_core::{PCWSTR, PWSTR};
 
 use crate::base_container_helpers::{
-    build_psec_spec, build_sbox_spec, has_conflicting_proxy_identity, requires_psec_networking,
+    build_psec_spec, build_sbox_spec, has_conflicting_proxy_identity, psec_contract_version,
+    requires_psec_networking,
 };
 use crate::capture_output::{
     combine_capture_and_cleanup_results, combine_process_and_teardown_results,
@@ -701,11 +702,15 @@ impl BaseContainerRunner {
         )
     }
 
-    fn resolve_psec_ingress_support(request: &ExecutionRequest) -> Result<bool, ScriptResponse> {
+    fn resolve_psec_ingress_contract_support(
+        request: &ExecutionRequest,
+    ) -> Result<bool, ScriptResponse> {
         let Some(ingress) = request.policy.network_ingress.as_ref() else {
             return Ok(false);
         };
-        let ingress_supported = SecurityEnvironmentApi::load()
+        // PSEC 1.1 ingress is usable only when the OS reports both the contract
+        // version and the ingress capability bit.
+        let psec_ingress_contract_supported = SecurityEnvironmentApi::load()
             .and_then(|api| {
                 if api.supports_version(1, 1)? {
                     api.supports_network_ingress()
@@ -719,9 +724,11 @@ impl BaseContainerRunner {
                     "failed to query Process Security Environment ingress support: {error}"
                 ))
             })?;
-        if ingress_supported {
+        if psec_ingress_contract_supported {
             return Ok(true);
         }
+        // PSEC 1.0 can preserve the default ingress posture through the
+        // capability mapping, but it cannot express host-loopback allow.
         if ingress.host_loopback == wxc_common::models::NetworkAction::Allow {
             return Err(ScriptResponse {
                 failure_phase: FailurePhase::Rejected,
@@ -1159,8 +1166,8 @@ impl BaseContainerRunner {
         );
 
         let use_process_security_environment = self.uses_process_security_environment(request);
-        let psec_ingress_supported = use_process_security_environment
-            .then(|| Self::resolve_psec_ingress_support(request))
+        let psec_ingress_contract_supported = use_process_security_environment
+            .then(|| Self::resolve_psec_ingress_contract_support(request))
             .transpose()?;
 
         // Launch builtin test proxy if requested (before building spec so we have the port).
@@ -1213,16 +1220,21 @@ impl BaseContainerRunner {
             let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: captureDenials");
         }
 
-        let process_security_environment_spec = psec_ingress_supported
-            .map(|ingress_supported| build_psec_spec(&request, ingress_supported));
-        if let Some(psec_spec) = process_security_environment_spec.as_ref() {
-            let _ = writeln!(
-                logger,
-                "process security environment spec built (PSEC 1.{}, {} bytes)",
-                u8::from(psec_ingress_supported.unwrap_or(false)),
-                psec_spec.len()
-            );
-        }
+        let process_security_environment_spec =
+            if let Some(ingress_contract_supported) = psec_ingress_contract_supported {
+                let contract_version = psec_contract_version(ingress_contract_supported);
+                let psec_spec = build_psec_spec(&request, ingress_contract_supported);
+                let _ = writeln!(
+                    logger,
+                    "process security environment spec built (PSEC {}.{}, {} bytes)",
+                    contract_version.major,
+                    contract_version.minor,
+                    psec_spec.len()
+                );
+                Some(psec_spec)
+            } else {
+                None
+            };
 
         // Resolve two paths for the capture:
         //   * `capture_etl_path` — a runner-managed `.etl` in a protected
@@ -4114,6 +4126,8 @@ mod tests {
                 default,
                 host_loopback,
             });
+            let expected_capabilities = (default == NetworkAction::Allow)
+                .then_some(crate::network_policy_helpers::PRIVATE_NETWORK_CAPABILITY);
 
             let bytes = BaseContainerRunner::build_process_security_environment_spec(&request);
             let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
@@ -4121,14 +4135,14 @@ mod tests {
             let ingress = network.ingress().expect("ingress policy");
 
             assert_eq!(spec.version().minor(), 1);
-            assert!(spec.capabilities().is_none());
+            assert_eq!(spec.capabilities(), expected_capabilities);
             assert_eq!(ingress.default_action(), expected_default);
             assert_eq!(ingress.host_loopback(), expected_host_loopback);
         }
     }
 
     #[test]
-    fn psec_1_0_lowers_compatible_ingress_to_legacy_capability() {
+    fn psec_1_0_preserves_capability_without_ingress_table() {
         let mut request = ExecutionRequest::default();
         request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
             default: NetworkAction::Allow,

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -741,6 +741,10 @@ impl BaseContainerRunner {
         Ok(false)
     }
 
+    /// Transitional guard for the legacy SBOX fallback. Remove it with the
+    /// remaining `Experimental_CreateProcessInSandbox` path after PSEC adoption
+    /// reaches critical mass post-9D; tracked by #1129.
+    ///
     /// Fail closed when the selected legacy SBOX contract cannot preserve the
     /// requested network policy; PSEC ingress support is resolved separately.
     fn validate_legacy_sbox_network_contract(
@@ -2188,6 +2192,8 @@ impl SandboxBackend for BaseContainerRunner {
             return Ok(());
         }
         let use_process_security_environment = self.uses_process_security_environment(request);
+        // A selected legacy SBOX contract must not silently drop networking
+        // fields that only PSEC can represent.
         if !use_process_security_environment {
             Self::validate_legacy_sbox_network_contract(request)?;
         }

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -3,7 +3,7 @@
 
 //! `BaseContainerRunner` — executes scripts through the Windows BaseContainer APIs.
 //!
-//! The runner prefers the PSEC 1.0 / `CreateProcessSecurityEnvironment`
+//! The runner prefers the PSEC / `CreateProcessSecurityEnvironment`
 //! two-phase contract whenever its runtime probe succeeds and attaches the
 //! resulting environment to `CreateProcessW`. It temporarily falls back to the
 //! legacy `SandboxSpec` / one-shot `Experimental_CreateProcessInSandbox`
@@ -100,6 +100,7 @@ fn build_child_env_block(
         if !use_process_security_environment && proxy_address.is_none() {
             return Ok(None);
         }
+
         let mut entries = crate::appcontainer_runner::create_default_env_entries()?;
         if let Some(address) = proxy_address {
             crate::appcontainer_runner::inject_proxy_vars(&mut entries, address);
@@ -421,7 +422,7 @@ impl BaseContainerRunner {
 
     #[cfg(test)]
     fn build_process_security_environment_spec(request: &ExecutionRequest) -> Vec<u8> {
-        build_psec_spec(request)
+        build_psec_spec(request, request.policy.network_ingress.is_some())
     }
 
     #[cfg(test)]
@@ -566,7 +567,7 @@ impl BaseContainerRunner {
                 schema_version: "0.8.0-alpha".to_string(),
                 ..Default::default()
             };
-            let specification = build_psec_spec(&request);
+            let specification = build_psec_spec(&request, false);
             SecurityEnvironmentApi::load()
                 .and_then(|api| api.create(&specification, PROCESS_SECURITY_ENVIRONMENT_FLAG_NONE))
                 .and_then(|environment| {
@@ -595,7 +596,7 @@ impl BaseContainerRunner {
             schema_version: "0.8.0-alpha".to_string(),
             ..Default::default()
         };
-        let specification = build_psec_spec(&request);
+        let specification = build_psec_spec(&request, false);
         SecurityEnvironmentApi::load()
             .and_then(|security_environment_api| {
                 CaptureSession::begin(
@@ -698,6 +699,39 @@ impl BaseContainerRunner {
             Self::decode_sbox_proxy_contract(queried_capabilities),
             SboxProxyContract::LegacyOrUnknown
         )
+    }
+
+    fn supports_psec_ingress(request: &ExecutionRequest) -> Result<bool, ScriptResponse> {
+        let Some(ingress) = request.policy.network_ingress.as_ref() else {
+            return Ok(false);
+        };
+        let ingress_supported = SecurityEnvironmentApi::load()
+            .and_then(|api| {
+                if api.supports_version(1, 1)? {
+                    api.supports_network_ingress()
+                } else {
+                    Ok(false)
+                }
+            })
+            .map_err(|error| ScriptResponse {
+                failure_phase: FailurePhase::BackendUnavailable,
+                ..ScriptResponse::error(&format!(
+                    "failed to query Process Security Environment ingress support: {error}"
+                ))
+            })?;
+        if ingress_supported {
+            return Ok(true);
+        }
+        if ingress.host_loopback == wxc_common::models::NetworkAction::Allow {
+            return Err(ScriptResponse {
+                failure_phase: FailurePhase::Rejected,
+                ..ScriptResponse::error(
+                    "network.ingress.hostLoopback='allow' requires \
+                     Process Security Environment contract version 1.1 with ingress support",
+                )
+            });
+        }
+        Ok(false)
     }
 
     fn validate_resolved_network_contract(
@@ -1128,6 +1162,12 @@ impl BaseContainerRunner {
             logger,
         );
 
+        let use_process_security_environment = self.uses_process_security_environment(request);
+        Self::validate_resolved_network_contract(request, use_process_security_environment)?;
+        let psec_ingress_supported = use_process_security_environment
+            .then(|| Self::supports_psec_ingress(request))
+            .transpose()?;
+
         // Launch builtin test proxy if requested (before building spec so we have the port).
         let mut request = request.clone();
         if request.policy.network_proxy.builtin_test_server {
@@ -1164,12 +1204,8 @@ impl BaseContainerRunner {
                  the WinHTTP stack will be proxied; other HTTP stacks may bypass it.",
             );
         }
-
         let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: Build sandbox spec");
-
         let capture_denials = request.policy.capture_denials.clone();
-        let use_process_security_environment = self.uses_process_security_environment(&request);
-        Self::validate_resolved_network_contract(&request, use_process_security_environment)?;
         let use_guarded_capture = capture_denials.is_some() && !use_process_security_environment;
         let spec_bytes = if !use_process_security_environment {
             let bytes = build_sbox_spec(&request);
@@ -1182,12 +1218,13 @@ impl BaseContainerRunner {
             let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: captureDenials");
         }
 
-        let process_security_environment_spec =
-            use_process_security_environment.then(|| build_psec_spec(&request));
+        let process_security_environment_spec = psec_ingress_supported
+            .map(|ingress_supported| build_psec_spec(&request, ingress_supported));
         if let Some(psec_spec) = process_security_environment_spec.as_ref() {
             let _ = writeln!(
                 logger,
-                "process security environment spec built (PSEC 1.0, {} bytes)",
+                "process security environment spec built (PSEC 1.{}, {} bytes)",
+                u8::from(psec_ingress_supported.unwrap_or(false)),
                 psec_spec.len()
             );
         }
@@ -1530,7 +1567,11 @@ impl BaseContainerRunner {
         if use_process_security_environment {
             let psec_spec = process_security_environment_spec
                 .as_deref()
-                .expect("PSEC spec is initialized when the PSEC path is selected");
+                .ok_or_else(|| {
+                    ScriptResponse::error(
+                        "internal error: PSEC contract resolved without a specification",
+                    )
+                })?;
             if capture_denials.is_some() {
                 match self
                     .capture_factory
@@ -3147,7 +3188,6 @@ fn derive_sid_string_from_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::base_container_helpers::{LOOPBACK_NETWORK_CAPABILITY, LOOPBACK_NETWORK_PEER};
     use crate::job_object::to_job_object_uilimit_mask;
     use learning_mode_core::{
         AccessType, AnalysisResult, AnalyzeError, DenialsDocument, DeniedResource, ResourceType,
@@ -4061,22 +4101,59 @@ mod tests {
     }
 
     #[test]
-    fn build_process_security_environment_spec_enables_host_loopback() {
+    fn build_process_security_environment_spec_encodes_ingress() {
+        for (default, host_loopback, expected_default, expected_host_loopback) in [
+            (
+                NetworkAction::Deny,
+                NetworkAction::Allow,
+                psec_layout::FilterAction::deny,
+                psec_layout::FilterAction::allow,
+            ),
+            (
+                NetworkAction::Allow,
+                NetworkAction::Deny,
+                psec_layout::FilterAction::allow,
+                psec_layout::FilterAction::deny,
+            ),
+        ] {
+            let mut request = ExecutionRequest::default();
+            request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
+                default,
+                host_loopback,
+            });
+
+            let bytes = BaseContainerRunner::build_process_security_environment_spec(&request);
+            let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
+            let network = spec.network_policy().expect("network policy");
+            let ingress = network.ingress().expect("ingress policy");
+
+            assert_eq!(spec.version().minor(), 1);
+            assert!(spec.capabilities().is_none());
+            assert_eq!(ingress.default_action(), expected_default);
+            assert_eq!(ingress.host_loopback(), expected_host_loopback);
+        }
+    }
+
+    #[test]
+    fn psec_1_0_lowers_compatible_ingress_to_legacy_capability() {
         let mut request = ExecutionRequest::default();
         request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
-            default: NetworkAction::Deny,
-            host_loopback: NetworkAction::Allow,
+            default: NetworkAction::Allow,
+            host_loopback: NetworkAction::Deny,
         });
+        request.policy.allowed_proxy_peer = Some("S-1-15-2-1".into());
 
-        let bytes = BaseContainerRunner::build_process_security_environment_spec(&request);
+        let bytes = build_psec_spec(&request, false);
         let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
         let network = spec.network_policy().expect("network policy");
 
-        assert_eq!(spec.capabilities(), Some(LOOPBACK_NETWORK_CAPABILITY));
+        assert_eq!(spec.version().minor(), 0);
         assert_eq!(
-            network.allowed_appcontainer_peer(),
-            Some(LOOPBACK_NETWORK_PEER)
+            spec.capabilities(),
+            Some(crate::network_policy_helpers::PRIVATE_NETWORK_CAPABILITY)
         );
+        assert_eq!(network.allowed_appcontainer_peer(), Some("S-1-15-2-1"));
+        assert!(network.ingress().is_none());
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/secenv.rs
+++ b/src/backends/learning_mode/windows/src/secenv.rs
@@ -478,11 +478,17 @@ impl SecurityEnvironmentApi {
         if self.cacheable {
             static CACHE: OnceLock<Result<bool, LearningModeError>> = OnceLock::new();
             CACHE
-                .get_or_init(|| self.query_support(PSE_SUPPORT_FS_DENY))
+                .get_or_init(|| self.query_deny_paths_support())
                 .clone()
         } else {
-            self.query_support(PSE_SUPPORT_FS_DENY)
+            self.query_deny_paths_support()
         }
+    }
+
+    /// Query `QueryProcessSecurityEnvironmentSupport` for the native-deny-path bit,
+    /// without consulting or populating the process-wide cache.
+    fn query_deny_paths_support(&self) -> Result<bool, LearningModeError> {
+        self.query_support(PSE_SUPPORT_FS_DENY)
     }
 
     /// Whether the official PSEC API supports the ingress policy table.

--- a/src/backends/learning_mode/windows/src/secenv.rs
+++ b/src/backends/learning_mode/windows/src/secenv.rs
@@ -18,6 +18,8 @@
 //!     LPCVOID sandboxSpecification, DWORD sandboxSpecificationSize,
 //!     PROCESS_SECURITY_ENVIRONMENT_FLAGS flags,
 //!     HPROCESS_SECURITY_ENVIRONMENT* processSecurityEnvironment);
+//! HRESULT IsProcessSecurityEnvironmentVersionSupported(
+//!     DWORD major, BOOLEAN* available, DWORD* minor);
 //! void CloseProcessSecurityEnvironment(HPROCESS_SECURITY_ENVIRONMENT processSecurityEnvironment);
 //! ```
 //!
@@ -54,6 +56,8 @@ const PROCESSMODEL_DLL: &str = "processmodel.dll";
 const SECURITY_ENVIRONMENT_API_SET_NAME: &str = "api-win-appmodel-processmodel~securityenvironment";
 const SECURITY_ENVIRONMENT_API_SET: &core::ffi::CStr =
     c"api-win-appmodel-processmodel~securityenvironment";
+const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
+const PSE_SUPPORT_NETWORK_INGRESS: u64 = 0x0000_0000_0000_0008;
 
 /// No special behaviour when creating the security environment
 /// (`PROCESS_SECURITY_ENVIRONMENT_FLAGS` value `0`).
@@ -78,6 +82,11 @@ type PfnCreateProcessSecurityEnvironment = unsafe extern "system" fn(
 /// `HRESULT QueryProcessSecurityEnvironmentSupport(UINT64* supportFlags)`.
 type PfnQueryProcessSecurityEnvironmentSupport =
     unsafe extern "system" fn(support_flags: *mut u64) -> HRESULT;
+
+/// `HRESULT IsProcessSecurityEnvironmentVersionSupported(
+/// DWORD major, BOOLEAN* available, DWORD* minor)`.
+type PfnIsProcessSecurityEnvironmentVersionSupported =
+    unsafe extern "system" fn(major: u32, available: *mut u8, minor: *mut u32) -> HRESULT;
 
 /// `void CloseProcessSecurityEnvironment(HPROCESS_SECURITY_ENVIRONMENT processSecurityEnvironment)`.
 type PfnCloseProcessSecurityEnvironment =
@@ -310,6 +319,8 @@ impl SecurityEnvironmentExportReport {
 
 const CREATE_NAMES: &[&core::ffi::CStr] = &[c"CreateProcessSecurityEnvironment"];
 const QUERY_SUPPORT_NAMES: &[&core::ffi::CStr] = &[c"QueryProcessSecurityEnvironmentSupport"];
+const VERSION_SUPPORT_NAMES: &[&core::ffi::CStr] =
+    &[c"IsProcessSecurityEnvironmentVersionSupported"];
 const CLOSE_NAMES: &[&core::ffi::CStr] = &[c"CloseProcessSecurityEnvironment"];
 
 /// Resolved process security-environment exports from `processmodel.dll`.
@@ -450,17 +461,25 @@ impl SecurityEnvironmentApi {
         if self.cacheable {
             static CACHE: OnceLock<Result<bool, LearningModeError>> = OnceLock::new();
             CACHE
-                .get_or_init(|| self.query_deny_paths_support())
+                .get_or_init(|| self.query_support(PSE_SUPPORT_FS_DENY))
                 .clone()
         } else {
-            self.query_deny_paths_support()
+            self.query_support(PSE_SUPPORT_FS_DENY)
         }
     }
 
-    /// Query `QueryProcessSecurityEnvironmentSupport` for the native-deny-path bit,
-    /// without consulting or populating the process-wide cache.
-    fn query_deny_paths_support(&self) -> Result<bool, LearningModeError> {
-        const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
+    /// Whether the official PSEC API supports the ingress policy table.
+    pub fn supports_network_ingress(&self) -> Result<bool, LearningModeError> {
+        self.query_support(PSE_SUPPORT_NETWORK_INGRESS)
+    }
+
+    /// Whether the requested PSEC contract version is supported.
+    pub fn supports_version(&self, major: u32, minor: u32) -> Result<bool, LearningModeError> {
+        query_supported_minor_version(major)
+            .map(|supported| supported.is_some_and(|supported| supported >= minor))
+    }
+
+    fn query_support(&self, capability: u64) -> Result<bool, LearningModeError> {
         let mut support_flags = 0u64;
         // SAFETY: `query_support` matches the official V2 declaration and
         // `support_flags` is a valid out-pointer.
@@ -471,7 +490,7 @@ impl SecurityEnvironmentApi {
                 code: result.0,
             });
         }
-        Ok(support_flags & PSE_SUPPORT_FS_DENY != 0)
+        Ok(support_flags & capability != 0)
     }
 
     /// Create a process security environment from a PSEC FlatBuffer
@@ -521,6 +540,44 @@ impl SecurityEnvironmentApi {
             close: self.close,
         })
     }
+}
+
+fn query_supported_minor_version(major: u32) -> Result<Option<u32>, LearningModeError> {
+    let dll = string_util::to_wide(PROCESSMODEL_DLL);
+    // SAFETY: the DLL name is null-terminated, System32-scoped, and the
+    // resolved function pointer is invoked with the documented ABI.
+    unsafe {
+        let hmodule = LoadLibraryExW(PCWSTR(dll.as_ptr()), None, LOAD_LIBRARY_SEARCH_SYSTEM32)
+            .map_err(|error| LearningModeError::DllLoad(error.to_string()))?;
+        let Some(version_support) =
+            GetProcAddress(hmodule, PCSTR(VERSION_SUPPORT_NAMES[0].as_ptr().cast()))
+        else {
+            return Ok((major == 1).then_some(0));
+        };
+        let version_support = std::mem::transmute::<
+            unsafe extern "system" fn() -> isize,
+            PfnIsProcessSecurityEnvironmentVersionSupported,
+        >(version_support);
+        query_supported_minor_version_with(major, version_support)
+    }
+}
+
+fn query_supported_minor_version_with(
+    major: u32,
+    version_support: PfnIsProcessSecurityEnvironmentVersionSupported,
+) -> Result<Option<u32>, LearningModeError> {
+    let mut available = 0u8;
+    let mut minor = 0u32;
+    // SAFETY: `version_support` has the documented OS ABI and both output
+    // pointers remain valid for the duration of the call.
+    let result = unsafe { version_support(major, &mut available, &mut minor) };
+    if result.is_err() {
+        return Err(LearningModeError::HResultCall {
+            function: "IsProcessSecurityEnvironmentVersionSupported",
+            code: result.0,
+        });
+    }
+    Ok((available != 0).then_some(minor))
 }
 
 /// Resolve the first name in `names` that is present in `hmodule`.
@@ -625,9 +682,8 @@ mod tests {
     static QUERY_CALLS: AtomicUsize = AtomicUsize::new(0);
     static QUERY_RESULT: AtomicI32 = AtomicI32::new(S_OK.0);
     static QUERY_FLAGS: AtomicU64 = AtomicU64::new(0);
-
-    /// Native-deny-path support bit reported by `QueryProcessSecurityEnvironmentSupport`.
-    const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
+    static VERSION_RESULT: AtomicI32 = AtomicI32::new(S_OK.0);
+    static VERSION_MINOR: AtomicUsize = AtomicUsize::new(1);
 
     unsafe extern "system" fn fake_close(_: HANDLE) {
         CLOSE_CALLS.fetch_add(1, Ordering::SeqCst);
@@ -647,6 +703,17 @@ mod tests {
         let result = HRESULT(QUERY_RESULT.load(Ordering::SeqCst));
         if result.is_ok() {
             unsafe { *support_flags = QUERY_FLAGS.load(Ordering::SeqCst) };
+        }
+        result
+    }
+
+    unsafe extern "system" fn fake_version(_: u32, available: *mut u8, minor: *mut u32) -> HRESULT {
+        let result = HRESULT(VERSION_RESULT.load(Ordering::SeqCst));
+        if result.is_ok() {
+            unsafe {
+                *available = 1;
+                *minor = VERSION_MINOR.load(Ordering::SeqCst) as u32;
+            }
         }
         result
     }
@@ -770,23 +837,39 @@ mod tests {
     }
 
     #[test]
-    fn supports_deny_paths_reports_flag_state() {
+    fn support_flags_are_reported_independently() {
         let _guard = QUERY_LOCK.lock().unwrap();
         let api = fake_uncached_api();
 
         reset_query_fakes();
         QUERY_FLAGS.store(PSE_SUPPORT_FS_DENY, Ordering::SeqCst);
         assert!(api.supports_deny_paths().unwrap());
-        assert_eq!(QUERY_CALLS.load(Ordering::SeqCst), 1);
+        assert!(!api.supports_network_ingress().unwrap());
 
         reset_query_fakes();
-        QUERY_FLAGS.store(0, Ordering::SeqCst);
+        QUERY_FLAGS.store(PSE_SUPPORT_NETWORK_INGRESS, Ordering::SeqCst);
         assert!(!api.supports_deny_paths().unwrap());
+        assert!(api.supports_network_ingress().unwrap());
+    }
 
-        reset_query_fakes();
-        // Unrelated support bits must not be mistaken for deny-path support.
-        QUERY_FLAGS.store(0xFFFF_FFFF_FFFF_FFFE, Ordering::SeqCst);
-        assert!(!api.supports_deny_paths().unwrap());
+    #[test]
+    fn supported_minor_version_preserves_api_outcomes() {
+        VERSION_RESULT.store(S_OK.0, Ordering::SeqCst);
+        VERSION_MINOR.store(3, Ordering::SeqCst);
+        assert_eq!(
+            query_supported_minor_version_with(1, fake_version).unwrap(),
+            Some(3)
+        );
+
+        VERSION_RESULT.store(E_FAIL.0, Ordering::SeqCst);
+        let error = query_supported_minor_version_with(1, fake_version).unwrap_err();
+        assert!(matches!(
+            error,
+            LearningModeError::HResultCall {
+                function: "IsProcessSecurityEnvironmentVersionSupported",
+                code
+            } if code == E_FAIL.0
+        ));
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/secenv.rs
+++ b/src/backends/learning_mode/windows/src/secenv.rs
@@ -334,6 +334,7 @@ const CLOSE_NAMES: &[&core::ffi::CStr] = &[c"CloseProcessSecurityEnvironment"];
 pub struct SecurityEnvironmentApi {
     create: PfnCreateProcessSecurityEnvironment,
     query_support: PfnQueryProcessSecurityEnvironmentSupport,
+    version_support: Option<PfnIsProcessSecurityEnvironmentVersionSupported>,
     close: PfnCloseProcessSecurityEnvironment,
     cacheable: bool,
 }
@@ -343,6 +344,10 @@ impl std::fmt::Debug for SecurityEnvironmentApi {
         f.debug_struct("SecurityEnvironmentApi")
             .field("create", &(self.create as *const ()))
             .field("query_support", &(self.query_support as *const ()))
+            .field(
+                "version_support",
+                &self.version_support.map(|function| function as *const ()),
+            )
             .field("close", &(self.close as *const ()))
             .field("cacheable", &self.cacheable)
             .finish()
@@ -397,6 +402,15 @@ impl SecurityEnvironmentApi {
 
             let create_proc = resolve_any(hmodule, CREATE_NAMES)?;
             let query_support_proc = resolve_any(hmodule, QUERY_SUPPORT_NAMES)?;
+            let version_support =
+                GetProcAddress(hmodule, PCSTR(VERSION_SUPPORT_NAMES[0].as_ptr().cast())).map(
+                    |function| {
+                        std::mem::transmute::<
+                            unsafe extern "system" fn() -> isize,
+                            PfnIsProcessSecurityEnvironmentVersionSupported,
+                        >(function)
+                    },
+                );
             let close_proc = resolve_any(hmodule, CLOSE_NAMES)?;
 
             Ok(Self {
@@ -408,6 +422,7 @@ impl SecurityEnvironmentApi {
                     unsafe extern "system" fn() -> isize,
                     PfnQueryProcessSecurityEnvironmentSupport,
                 >(query_support_proc),
+                version_support,
                 close: std::mem::transmute::<
                     unsafe extern "system" fn() -> isize,
                     PfnCloseProcessSecurityEnvironment,
@@ -430,6 +445,7 @@ impl SecurityEnvironmentApi {
         Self {
             create,
             query_support,
+            version_support: None,
             close,
             cacheable: false,
         }
@@ -447,6 +463,7 @@ impl SecurityEnvironmentApi {
         Self {
             create,
             query_support,
+            version_support: None,
             close,
             cacheable: true,
         }
@@ -475,7 +492,10 @@ impl SecurityEnvironmentApi {
 
     /// Whether the requested PSEC contract version is supported.
     pub fn supports_version(&self, major: u32, minor: u32) -> Result<bool, LearningModeError> {
-        query_supported_minor_version(major)
+        let Some(version_support) = self.version_support else {
+            return Ok(major == 1 && minor == 0);
+        };
+        query_supported_minor_version_with(major, version_support)
             .map(|supported| supported.is_some_and(|supported| supported >= minor))
     }
 
@@ -539,26 +559,6 @@ impl SecurityEnvironmentApi {
             handle: env,
             close: self.close,
         })
-    }
-}
-
-fn query_supported_minor_version(major: u32) -> Result<Option<u32>, LearningModeError> {
-    let dll = string_util::to_wide(PROCESSMODEL_DLL);
-    // SAFETY: the DLL name is null-terminated, System32-scoped, and the
-    // resolved function pointer is invoked with the documented ABI.
-    unsafe {
-        let hmodule = LoadLibraryExW(PCWSTR(dll.as_ptr()), None, LOAD_LIBRARY_SEARCH_SYSTEM32)
-            .map_err(|error| LearningModeError::DllLoad(error.to_string()))?;
-        let Some(version_support) =
-            GetProcAddress(hmodule, PCSTR(VERSION_SUPPORT_NAMES[0].as_ptr().cast()))
-        else {
-            return Ok((major == 1).then_some(0));
-        };
-        let version_support = std::mem::transmute::<
-            unsafe extern "system" fn() -> isize,
-            PfnIsProcessSecurityEnvironmentVersionSupported,
-        >(version_support);
-        query_supported_minor_version_with(major, version_support)
     }
 }
 
@@ -870,6 +870,15 @@ mod tests {
                 code
             } if code == E_FAIL.0
         ));
+    }
+
+    #[test]
+    fn missing_version_export_supports_only_the_baseline_contract() {
+        let api = fake_uncached_api();
+
+        assert!(api.supports_version(1, 0).unwrap());
+        assert!(!api.supports_version(1, 1).unwrap());
+        assert!(!api.supports_version(2, 0).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## 📖 Description

Connects ProcessContainer `network.ingress.default` and `network.ingress.hostLoopback` to the OS Process Security Environment (PSEC) ingress contract. MXC emits PSEC 1.1 only when `IsProcessSecurityEnvironmentVersionSupported` reports contract 1.1 or newer and `QueryProcessSecurityEnvironmentSupport` advertises `PSE_SUPPORT_NETWORK_INGRESS`. Otherwise, compatible policies retain PSEC 1.0 or legacy SBOX capability behavior.

The optional version export is resolved during the memoized PSEC API load so repeated SDK/FFI launches do not acquire additional `processmodel.dll` references. OS support-query failures remain retryable `backend_unavailable` errors. When PSEC 1.1 ingress is unavailable, `hostLoopback: allow` is rejected because older contracts cannot represent it. A final compatibility check prevents a late PSEC-to-SBOX fallback from dropping PSEC-only network policy.

## 🔗 References

- Related contract: #1076

## 🔍 Validation

- `cargo fmt --manifest-path src\Cargo.toml --all -- --check`
- `cargo test --manifest-path src\Cargo.toml -p learning_mode_windows --lib` (229 passed)
- `cargo test --manifest-path src\Cargo.toml -p appcontainer_common --lib` (293 passed)
- `cargo clippy --manifest-path src\Cargo.toml -p learning_mode_windows -p appcontainer_common --all-targets -- -D warnings`
- `cargo build --manifest-path src\Cargo.toml -p wxc`
- Real schema 0.8 ProcessContainer connectivity: container-to-host and host-to-container connections succeeded with `hostLoopback: "allow"` and were blocked with `hostLoopback: "deny"`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task

