### PR TITLE
Document ProcessContainer ingress behavior

### DIFF
--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -41,10 +41,10 @@ Package identity can scope a packaged proxy whether or not that proxy uses AppCo
 | `runtimeConfig.networkProxy` | HTTP/S loopback URL with an explicit port |
 | `processContainer.network.allowedProxyPeer` | Installed Package Family Name or AppContainer profile name |
 
-ProcessContainer requires `ingress.default: "allow"` for private-network communication with an identity-scoped proxy.
-Windows implements this on the MXC client with the bidirectional `privateNetworkClientServer` capability, so the
-setting also permits private-network server traffic. `egress.default: "deny"` continues to block direct internet
-traffic.
+The configured proxy endpoint and scoped peer policy permit communication with an identity-scoped proxy.
+`ingress.default` controls inbound private-network traffic independently when OS ingress policy support is available;
+compatibility paths use the bidirectional `privateNetworkClientServer` capability. `egress.default: "deny"` continues
+to block direct internet traffic.
 
 Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required for an identity-scoped ProcessContainer proxy and is
@@ -54,7 +54,7 @@ The proxy must already be running and listening on the loopback address and
 port configured by `runtimeConfig.networkProxy`. See the canonical
 [proxy deployment requirements](../networking.md#proxy-deployment-choices) for endpoint validation and listener
 binding. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient` for external destinations,
-and inbound firewall authorization.
+and may need inbound firewall authorization, depending on the installed Windows build.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -110,8 +110,8 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The manifest example uses port 8080. The proxy developer must ensure that its inbound firewall rule covers the port
-supplied to MXC in `runtimeConfig.networkProxy`.
+The manifest example uses port 8080. If the installed Windows build requires inbound firewall authorization, ensure
+that the rule covers the port supplied to MXC in `runtimeConfig.networkProxy`.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/examples/0.8.0-schema.md
+++ b/docs/process-container/examples/0.8.0-schema.md
@@ -41,10 +41,11 @@ Package identity can scope a packaged proxy whether or not that proxy uses AppCo
 | `runtimeConfig.networkProxy` | HTTP/S loopback URL with an explicit port |
 | `processContainer.network.allowedProxyPeer` | Installed Package Family Name or AppContainer profile name |
 
-The configured proxy endpoint and scoped peer policy permit communication with an identity-scoped proxy.
-`ingress.default` controls inbound private-network traffic independently when OS ingress policy support is available;
-compatibility paths use the bidirectional `privateNetworkClientServer` capability. `egress.default: "deny"` continues
-to block direct internet traffic.
+ProcessContainer requires `ingress.default: "allow"` whenever `runtimeConfig.networkProxy` is present, including for an
+identity-scoped proxy. When OS ingress policy support is available, that setting controls inbound private-network
+traffic only; compatibility paths implement it with the bidirectional `privateNetworkClientServer` capability, so it
+also permits private-network server traffic there. `egress.default: "deny"` continues to block direct internet
+traffic.
 
 Valid endpoints use `localhost`, `127.0.0.1`, or `[::1]` with an explicit
 port. The proxy-specific `network` block above is required for an identity-scoped ProcessContainer proxy and is
@@ -54,7 +55,7 @@ The proxy must already be running and listening on the loopback address and
 port configured by `runtimeConfig.networkProxy`. See the canonical
 [proxy deployment requirements](../networking.md#proxy-deployment-choices) for endpoint validation and listener
 binding. A packaged AppContainer proxy needs `privateNetworkClientServer`, `internetClient` for external destinations,
-and may need inbound firewall authorization, depending on the installed Windows build.
+and inbound firewall authorization.
 
 ### Minimal packaged AppContainer proxy manifest
 
@@ -110,8 +111,8 @@ for package identity, signing, assets, and application metadata.
 `runFullTrust` is required by the firewall extension;
 `TrustLevel="appContainer"` still runs the proxy in an AppContainer.
 
-The manifest example uses port 8080. If the installed Windows build requires inbound firewall authorization, ensure
-that the rule covers the port supplied to MXC in `runtimeConfig.networkProxy`.
+The manifest example uses port 8080. The proxy developer must ensure that its inbound firewall rule covers the port
+supplied to MXC in `runtimeConfig.networkProxy`.
 
 After installing the package, retrieve its exact Package Family Name:
 

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -25,7 +25,7 @@ section 2 and is not equivalent to these guarantees.
 
 The examples below use the schema 0.8 network shape.
 
-Newer Windows builds enforce `ingress` through the OS ingress policy and remove the policy-owned
+Hosts that report OS ingress policy support enforce `ingress` through that policy and omit the policy-owned
 `privateNetworkClientServer` capability. Compatibility paths retain the bidirectional capability mapping, with WFP
 narrowing outbound access where available. The AppContainer fallback rejects combinations that its capability mapping
 cannot preserve. `ingress.hostLoopback: "allow"` requires OS ingress policy support.
@@ -138,7 +138,8 @@ An unpackaged non-AppContainer proxy has no package family or AppContainer profi
 This deployment requires OS ingress policy support; compatibility paths reject `hostLoopback: "allow"`. MXC
 identifies the proxy only by the configured endpoint and enables bidirectional host-loopback access. This is the
 lowest-enforcement deployment option because common WFP endpoint scoping remains, but Windows cannot verify which
-host process owns that endpoint. It is intended primarily for development and debugging.
+host process owns that endpoint. It is intended primarily for development and debugging and requires an installer- or
+administrator-owned firewall rule scoped to the proxy executable and configured port.
 
 #### HTTP client guidance
 
@@ -156,7 +157,8 @@ proxy omits `allowedProxyPeer` and requires `ingress.hostLoopback: "allow"`. Dir
 apply when `runtimeConfig.networkProxy` is present.
 
 The proxy endpoint is runtime metadata, not shared network policy. MXC configures the per-container WinHTTP proxy,
-applies WFP endpoint scoping, and grants the private-network capability selected by `ingress.default`.
+applies WFP endpoint scoping, and applies the OS ingress policy or, on compatibility paths, the private-network
+capability selected by `ingress.default`.
 
 The identity-scoped and host-loopback paths are mutually exclusive. When `allowedProxyPeer` is present, MXC resolves
 the package family or AppContainer profile and applies the OS ingress policy or the compatibility capability selected
@@ -179,17 +181,18 @@ middle rows provide different protections and are not ordered relative to each o
 
 | Proxy deployment | `allowedProxyPeer` | Additional OS enforcement |
 |---|---|---|
-| Packaged AppContainer | Package family name | **Best:** AppContainer isolation and package identity; package firewall rule when required |
-| Unpackaged AppContainer | AppContainer profile name | AppContainer isolation; administrator firewall rule when required |
-| Packaged non-AppContainer | Package family name | Package identity without AppContainer isolation; package firewall rule when required |
-| Unpackaged non-AppContainer | Omit | **Least:** no proxy identity or isolation; administrator firewall rule when required |
+| Packaged AppContainer | Package family name | **Best:** AppContainer isolation, package identity, package firewall |
+| Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
+| Packaged non-AppContainer | Package family name | Package identity and package firewall; no AppContainer isolation |
+| Unpackaged non-AppContainer | Omit | **Least:** no proxy identity or isolation; administrator firewall |
 
-Windows Firewall behavior depends on the installed Windows build. If the proxy's inbound connection is blocked, a
-packaged AppContainer proxy can use the package-owned firewall declaration shown in the
+Neither the scoped peer rule nor the private-network access granted to the MXC client container bypasses Windows
+Firewall's block-inbound-to-non-allowed-apps policy for the proxy process. A packaged AppContainer proxy uses the
+package-owned firewall declaration shown in the
 [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
 `uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
-can use an installer- or administrator-owned rule scoped to the AppContainer profile SID, proxy executable, and
-configured port.
+requires its installer or administrator to own an equivalent rule scoped to the AppContainer profile SID, proxy
+executable, and configured port.
 See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.

--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -21,28 +21,28 @@ section 2 and is not equivalent to these guarantees.
   caller-provided loopback proxy container. MXC also sets `HTTP_PROXY`, `HTTPS_PROXY`, and their lowercase variants to
   the loopback endpoint for runtimes that use proxy environment variables rather than WinHTTP. `NO_PROXY` is a bypass
   list and does not carry the proxy endpoint. The containment boundary is the absence of direct internet capability.
-  Private-network traffic remains available in both directions when `ingress.default` is `"allow"`.
+  On hosts with OS ingress policy support, inbound policy is independent of outbound private-network access.
 
 The examples below use the schema 0.8 network shape.
 
-Windows exposes `privateNetworkClientServer` as one bidirectional AppContainer capability. ProcessContainer therefore
-requires `ingress.default: "allow"` before the container can communicate with private-network addresses. Enabling it
-also permits private-network server traffic. `ingress.default` gates whether the capability exists; `egress` then
-narrows the outbound public and private destinations reachable through the granted capabilities.
-`ingress.hostLoopback` remains the separate host-loopback control.
+Newer Windows builds enforce `ingress` through the OS ingress policy and remove the policy-owned
+`privateNetworkClientServer` capability. Compatibility paths retain the bidirectional capability mapping, with WFP
+narrowing outbound access where available. The AppContainer fallback rejects combinations that its capability mapping
+cannot preserve. `ingress.hostLoopback: "allow"` requires OS ingress policy support.
 
-| Egress default | Ingress default | AppContainer capabilities | Result |
+| Egress default | Ingress default | Compatibility capabilities | Result |
 |---|---|---|---|
 | `deny` | `deny` | None | Internet and private-network traffic are denied. |
 | `allow` | `deny` | `internetClient` | Internet outbound is allowed; private-network traffic is denied. |
-| `deny` | `allow` | `privateNetworkClientServer` | PSEC blocks outbound with WFP and permits private-network inbound. The AppContainer fallback rejects this combination because the capability is bidirectional. |
-| `allow` | `allow` | Both capabilities | Internet outbound and bidirectional private-network traffic are allowed. |
+| `deny` | `allow` | `privateNetworkClientServer` | OS ingress policy support permits inbound independently. The compatibility capability can be paired with WFP outbound blocking where available; the AppContainer fallback rejects this combination. |
+| `allow` | `allow` | Both capabilities | With OS ingress policy support, outbound uses `internetClient` and ingress is enforced independently; compatibility paths use both capabilities. |
 
 This matrix covers the direction defaults without explicit internet egress rules or proxy mode.
 
 ### Model 1: direct egress, WFP-filtered (least restrictive)
 
-- **Capabilities:** `internetClient`, plus `privateNetworkClientServer` only when `ingress.default` is `"allow"`.
+- **Capabilities:** `internetClient` for outbound access. The OS ingress policy enforces `ingress` when supported;
+  compatibility paths add `privateNetworkClientServer` when `ingress.default` is `"allow"`.
 - **Enforcement:** WFP allow/block rules; no proxy.
 
 ```jsonc
@@ -67,15 +67,14 @@ This matrix covers the direction defaults without explicit internet egress rules
 
 | Item | Requirement |
 |---|---|
-| Client capability | `privateNetworkClientServer`, enabled by `ingress.default: "allow"` |
+| Client access to proxy | Proxy endpoint policy plus endpoint-scoped WFP |
 | Proxy capabilities | `privateNetworkClientServer`; also `internetClient` for external destinations |
 | Network policy | `egress.default: "deny"` and `ingress.default: "allow"` |
-| Enforcement | Capability is bidirectional; WFP permits client egress only to the configured proxy endpoint |
+| Enforcement | The OS ingress policy is directional; WFP permits client egress only to the configured proxy endpoint |
 
-This is a ProcessContainer-specific mapping. Callers that need a private-network proxy or any other private-network
-communication must set `ingress.default` to `"allow"` and accept that Windows enables both private-network client and
-server behavior. On an enforcing BaseContainer path, per-container WFP permits the MXC client container to connect only
-to the configured loopback address and port and blocks direct public and private destinations.
+Callers that need a private-network proxy must set `ingress.default` to `"allow"`. When OS ingress policy support is
+available, this does not grant the bidirectional compatibility capability. Per-container WFP permits the MXC client
+container to connect only to the configured loopback address and port and blocks direct public and private destinations.
 
 #### Proxy deployment choices
 
@@ -106,9 +105,8 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-On the PSEC path, MXC maps `hostLoopback: "allow"` to the `networkLoopback` capability and the reserved
-`MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
-cannot use that reserved identity.
+When OS ingress policy support is available, MXC enforces `hostLoopback: "allow"` directly. Compatibility paths reject
+that setting.
 
 #### Identity-scoped proxy
 
@@ -137,12 +135,10 @@ An unpackaged non-AppContainer proxy has no package family or AppContainer profi
 }
 ```
 
-MXC grants the client container `privateNetworkClientServer` through `ingress.default: "allow"`, just as it does for an
-identity-scoped proxy. The difference is that MXC identifies this proxy only by the configured endpoint and enables
-bidirectional host-loopback access. This is the lowest-enforcement deployment option because common WFP endpoint
-scoping remains, but Windows cannot verify which host process owns that endpoint. It is intended primarily for
-development and debugging and requires an installer- or administrator-owned firewall rule scoped to the proxy
-executable and configured port.
+This deployment requires OS ingress policy support; compatibility paths reject `hostLoopback: "allow"`. MXC
+identifies the proxy only by the configured endpoint and enables bidirectional host-loopback access. This is the
+lowest-enforcement deployment option because common WFP endpoint scoping remains, but Windows cannot verify which
+host process owns that endpoint. It is intended primarily for development and debugging.
 
 #### HTTP client guidance
 
@@ -163,7 +159,8 @@ The proxy endpoint is runtime metadata, not shared network policy. MXC configure
 applies WFP endpoint scoping, and grants the private-network capability selected by `ingress.default`.
 
 The identity-scoped and host-loopback paths are mutually exclusive. When `allowedProxyPeer` is present, MXC resolves
-the package family or AppContainer profile and grants the private-network capability selected by `ingress.default`.
+the package family or AppContainer profile and applies the OS ingress policy or the compatibility capability selected
+by `ingress.default`.
 When it is omitted, MXC uses the configured proxy endpoint without peer identity binding and requires bidirectional
 host-loopback access. MXC configures the per-container WinHTTP proxy for either path.
 
@@ -182,17 +179,17 @@ middle rows provide different protections and are not ordered relative to each o
 
 | Proxy deployment | `allowedProxyPeer` | Additional OS enforcement |
 |---|---|---|
-| Packaged AppContainer | Package family name | **Best:** AppContainer isolation, package identity, package firewall |
-| Unpackaged AppContainer | AppContainer profile name | AppContainer isolation and administrator firewall rule |
-| Packaged non-AppContainer | Package family name | Package identity and package firewall; no AppContainer isolation |
-| Unpackaged non-AppContainer | Omit | **Least:** no proxy identity or isolation; administrator firewall |
+| Packaged AppContainer | Package family name | **Best:** AppContainer isolation and package identity; package firewall rule when required |
+| Unpackaged AppContainer | AppContainer profile name | AppContainer isolation; administrator firewall rule when required |
+| Packaged non-AppContainer | Package family name | Package identity without AppContainer isolation; package firewall rule when required |
+| Unpackaged non-AppContainer | Omit | **Least:** no proxy identity or isolation; administrator firewall rule when required |
 
-The scoped peer rule and `privateNetworkClientServer` do not bypass Windows
-Firewall's block-inbound-to-non-allowed-apps policy. A packaged AppContainer proxy uses the package-owned firewall
-declaration shown in the [schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
+Windows Firewall behavior depends on the installed Windows build. If the proxy's inbound connection is blocked, a
+packaged AppContainer proxy can use the package-owned firewall declaration shown in the
+[schema 0.8 examples](examples/0.8.0-schema.md); its application entry uses
 `uap10:RuntimeBehavior="packagedClassicApp"` with `uap10:TrustLevel="appContainer"`. An unpackaged AppContainer proxy
-requires its installer or administrator to own an equivalent rule scoped to the AppContainer profile SID, proxy
-executable, and configured port.
+can use an installer- or administrator-owned rule scoped to the AppContainer profile SID, proxy executable, and
+configured port.
 See
 [CreateAppContainerProfile](https://learn.microsoft.com/windows/win32/api/userenv/nf-userenv-createappcontainerprofile)
 for unpackaged profile creation.
@@ -250,7 +247,8 @@ probe succeed. PSEC is the only ProcessContainer path that receives schema 0.8 e
 host-loopback configuration because it owns the corresponding policy lifetime through workload completion. When PSEC
 is unavailable or incompatible with another requested policy, fall back temporarily to the legacy SBOX contract
 through CPIS. SBOX is eligible only when it can represent the request without dropping PSEC-only networking features;
-otherwise selection continues to AppContainer, where unsupported policy is rejected.
+otherwise selection continues to AppContainer. When OS ingress policy support is reported, MXC enforces `ingress`
+directly and omits the policy-owned `privateNetworkClientServer` capability.
 
 SBOX retains its legacy network contract. It receives only the effective egress default and legacy `network.proxy`
 configuration; schema 0.8 allow/deny filters, `allowedProxyPeer`, and host-loopback configuration are never serialized
@@ -258,14 +256,15 @@ into its FlatBuffer. The SBOX creation API supplies no policy-lifetime handle or
 so MXC cannot safely install and later remove schema 0.8 WFP filters through that path. A valid schema 0.8 runtime proxy
 requires either peer identity or unrestricted host loopback and is therefore rejected when PSEC is unavailable.
 
-**Downlevel behavior:** When PSEC is unavailable, compatible requests use CPIS or the AppContainer fallback.
+**Downlevel behavior:** Compatibility paths without OS ingress policy support use the capability mapping:
 `egress.default: "allow"` grants `internetClient`; `ingress.default: "allow"` grants the bidirectional
-`privateNetworkClientServer` capability. This is the documented ProcessContainer mapping on every tier, not a
-downlevel weakening. Legacy proxy requests retain their existing compatibility behavior; schema 0.8 runtime proxy
-requests do not fall back because neither SBOX nor AppContainer can preserve their peer or host-loopback requirements.
+`privateNetworkClientServer` capability. Legacy proxy requests retain their existing compatibility behavior; schema
+0.8 runtime proxy requests do not fall back because neither SBOX nor AppContainer can preserve their peer or
+host-loopback requirements. These paths cannot provide private-network outbound access when egress is allowed but
+ingress is denied, because Windows exposes that access only through the bidirectional capability.
 
-The AppContainer fallback is selected only when its capability mapping preserves the request. Explicit egress rules,
-proxy peer identity, and host-loopback allow fail with a typed unsupported-policy error when PSEC cannot enforce them.
+Explicit egress rules, proxy peer identity, and host-loopback allow fail with a typed unsupported-policy error when
+PSEC cannot enforce them.
 
 ## 3. WFP enforcement
 
@@ -275,6 +274,6 @@ Downlevel WFP installation, elevation, and reliable cleanup are future work and 
 downlevel support.
 
 WFP implements `egress` rules for public and private destinations. `internetClient` enables public-network access.
-`privateNetworkClientServer`, selected through `ingress.default`, is the prerequisite for private-network access and
-also enables private-network inbound traffic. ProcessContainer therefore cannot allow private-network outbound while
-denying private-network inbound.
+When OS ingress policy support is available, ingress is enforced independently and the policy-owned
+`privateNetworkClientServer` capability is omitted. Compatibility paths retain the capability mapping; the
+AppContainer fallback rejects asymmetric policy it cannot preserve.

--- a/docs/process-container/os-version-support.md
+++ b/docs/process-container/os-version-support.md
@@ -65,6 +65,8 @@ The PSEC probe requires:
 - `QueryProcessSecurityEnvironmentSupport`
 - `CloseProcessSecurityEnvironment`
 
+The support query also reports whether the OS accepts directional ingress policy.
+
 When `processContainer.captureDenials` is present, MXC treats PSEC plus the
 official V2 Learning Mode exports as one native capture capability set:
 
@@ -118,7 +120,7 @@ fallback chain.
 | Aspect | 23H2 | 24H2 | 25H2 | 25H2+ |
 |--------|:--:|:--:|:--:|:--:|
 | `readwritePaths` / `readonlyPaths` grants | ✅ (T3 DACL) | ✅ (T3 DACL) | ✅ (T3 DACL) | ✅ (T1 native, or T3 DACL) |
-| `deniedPaths` | ✅ (T3 DENY ACE) | ✅ (T3 DENY ACE) | ✅ (T3 DENY ACE) | ✅ (T3; T1 only when `SANDBOX_CAP_DENY_PATHS` is set, otherwise rejected at launch and dispatched to T3) |
+| `deniedPaths` | ✅ (T3 DENY ACE) | ✅ (T3 DENY ACE) | ✅ (T3 DENY ACE) | ✅ (T3; T1 when the active contract reports deny-path support) |
 | BFS brokering (T2) | ❌ | ⚠️ disabled in shipping builds | ⚠️ disabled in shipping builds | ⚠️ disabled in shipping builds |
 
 Notes:
@@ -158,14 +160,17 @@ Schema 0.8 support is selected by runtime contract rather than Windows release:
 
 | Schema 0.8 capability | PSEC | Legacy SBOX | AppContainer fallback |
 |---|:---:|:---:|:---:|
-| Directional defaults represented by capabilities | ✅ | ✅ when the capability mapping preserves the request | ✅ when the capability mapping preserves the request |
+| Directional defaults | ✅ (OS ingress policy when reported; capability mapping otherwise) | ✅ when the capability mapping preserves the request | ✅ when the capability mapping preserves the request |
 | Explicit egress IP/CIDR/port/protocol rules | ✅ WFP | ❌ | ❌ |
-| `allowedProxyPeer` or `ingress.hostLoopback: "allow"` | ✅ | ❌ | ❌ |
+| `allowedProxyPeer` | ✅ | ❌ | ❌ |
+| `ingress.hostLoopback: "allow"` | ✅ when OS ingress policy support is reported | ❌ | ❌ |
 | `runtimeConfig.networkProxy` | ✅ | ❌ | ❌ |
 
 PSEC owns the WFP policy lifetime through workload completion. SBOX exposes no
 equivalent cleanup handle, so MXC never installs schema 0.8 WFP filters through
-that contract. The AppContainer fallback also rejects
+that contract. OS ingress policy support replaces the policy-owned
+`privateNetworkClientServer` capability. Compatibility paths retain the capability
+mapping. The AppContainer fallback also rejects
 `egress.default: "deny"` with `ingress.default: "allow"` because
 `privateNetworkClientServer` is bidirectional and no schema 0.8 WFP filter is
 available there to block private-network egress.
@@ -199,12 +204,12 @@ and later (`MIN_BUILD_FOR_INJECTION_LIMIT`) and is therefore unavailable on
 
 - Tier selection: `src/backends/appcontainer/common/src/fallback_detector.rs`,
   `src/backends/appcontainer/common/src/dispatcher.rs`
-- BaseContainer capability probing (`SANDBOX_CAP_*`,
-  `Experimental_QuerySandboxSupport`) and FlatBuffer `SandboxSpec` construction:
+- BaseContainer capability probing and contract construction:
   `src/backends/appcontainer/common/src/base_container_runner.rs`
 - UI-limit build gating (`MIN_BUILD_FOR_IME_LIMIT`,
   `MIN_BUILD_FOR_INJECTION_LIMIT`, `supported_ui_limit_mask_for_build`):
   `src/backends/appcontainer/common/src/job_object.rs`
-- FlatBuffer contract: `external/windows-sdk/BaseContainerSpecification.fbs`
+- FlatBuffer contracts: `external/windows-sdk/BaseContainerSpecification.fbs`,
+  `external/windows-sdk/ProcessSecurityEnvironment.fbs`
 - Product support floor: [README](../../README.md#platforms),
   [SDK README](../../sdk/node/README.md)

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -413,7 +413,9 @@ either posture.
 
 - **Model 2 (recommended):** Grants no `internetClient`, so direct internet traffic is blocked. Any packaged proxy,
   with or without AppContainer isolation, uses its Package Family Name in `allowedProxyPeer`; an unpackaged
-  AppContainer proxy uses its profile name. With `allowedProxyPeer`, proxy reachability remains scoped to that peer and
+  AppContainer proxy uses its profile name. A runtime proxy always requires `ingress.default: "allow"`; on
+  compatibility paths that setting also grants the bidirectional `privateNetworkClientServer` capability. With
+  `allowedProxyPeer`, proxy reachability remains scoped to that peer and
   endpoint and `ingress.hostLoopback` stays `"deny"`. An identity-less host proxy cannot use peer scoping and requires
   OS ingress policy support plus `ingress.hostLoopback: "allow"`; it does not provide the strict
   host-loopback-closure guarantee.

--- a/docs/sandbox-policy/0.8.0/networking/networking.md
+++ b/docs/sandbox-policy/0.8.0/networking/networking.md
@@ -70,9 +70,10 @@ Throughout this document, the deny-all-except-proxy posture (the GA goal) refers
   `ingress.hostLoopback`; no other host-loopback endpoint is opened by the proxy configuration.
 - **What is NOT routed:** Non-HTTP traffic (raw TCP/UDP sockets, SSH, custom protocols, QUIC, WebRTC, etc.) is never
   redirected to the proxy. In model 2, direct internet traffic is blocked. On ProcessContainer, private-network
-  traffic follows `ingress.default` because AppContainer exposes one bidirectional private-network capability. In
-  model 1, non-HTTP traffic is subject to the IP/CIDR/port/protocol rules. Transparently routing this traffic through
-  the proxy is a gap that requires further design and is out of scope for GA.
+  traffic is governed independently when OS ingress policy support is available. Compatibility paths use one
+  bidirectional private-network capability. In model 1, non-HTTP traffic is subject to the
+  IP/CIDR/port/protocol rules. Transparently routing this traffic through the proxy is a gap that requires further
+  design and is out of scope for GA.
 
 **Direct outbound path (model 1 only):**
 
@@ -376,10 +377,10 @@ What is and is not routed through the proxy is described under Outbound Traffic 
 
 **Reality:** Enforcement fidelity varies. A capability available on one backend (e.g., per-AppContainer WFP filters) may not have an equivalent on another. Cooperation-dependent routing (e.g., honoring proxy env vars) is allowed only as an optimization above an enforcing layer that already blocks non-cooperative traffic; it is never the enforcement mechanism itself.
 
-Backends that cleanly separate private-network ingress from egress apply both directions independently. Windows
-AppContainer requires the bidirectional `privateNetworkClientServer` capability before private-network traffic can
-flow in either direction. ProcessContainer therefore requires `ingress.default: "allow"` for outbound private-network
-access, after which `egress` rules apply to both public and private outbound destinations.
+Backends that cleanly separate private-network ingress from egress apply both directions independently.
+ProcessContainer does so when OS ingress policy support is available. Compatibility paths use the bidirectional
+`privateNetworkClientServer` capability; on those paths, private-network outbound access requires
+`ingress.default: "allow"` and remains subject to `egress` rules.
 
 This capability coupling is a backend mapping, not a change to the shared
 meaning of `ingress.default`. The ProcessContainer section identifies which
@@ -403,22 +404,22 @@ already implemented.
 
 The strict host-loopback guarantee applies to the identity-scoped
 ProcessContainer path with OS-scoped proxy enforcement. The identity-less host
-proxy path requires broader host-loopback access and is an explicitly documented
-PSEC compatibility behavior rather than strict model-2 enforcement. Legacy SBOX
-and the AppContainer fallback reject schema 0.8 runtime proxy requests because
-they cannot preserve either posture.
+proxy path requires OS ingress policy support and broader host-loopback access,
+so it is not strict model-2 enforcement. Legacy SBOX and the AppContainer
+fallback reject schema 0.8 runtime proxy requests because they cannot preserve
+either posture.
 
 **Connectivity models:**
 
 - **Model 2 (recommended):** Grants no `internetClient`, so direct internet traffic is blocked. Any packaged proxy,
   with or without AppContainer isolation, uses its Package Family Name in `allowedProxyPeer`; an unpackaged
-  AppContainer proxy uses its profile name. Windows requires `ingress.default: "allow"` to grant the bidirectional
-  `privateNetworkClientServer` capability. With `allowedProxyPeer`, proxy reachability remains scoped to that peer and
-  endpoint and `ingress.hostLoopback` stays `"deny"`. An identity-less host proxy cannot use peer scoping and is the
-  documented development/testing compatibility path that requires `ingress.hostLoopback: "allow"`; it does not
-  provide the strict host-loopback-closure guarantee.
+  AppContainer proxy uses its profile name. With `allowedProxyPeer`, proxy reachability remains scoped to that peer and
+  endpoint and `ingress.hostLoopback` stays `"deny"`. An identity-less host proxy cannot use peer scoping and requires
+  OS ingress policy support plus `ingress.hostLoopback: "allow"`; it does not provide the strict
+  host-loopback-closure guarantee.
 - **Model 1:** Grants `internetClient`, allowing direct internet egress under WFP IP/CIDR/port/protocol rules.
-  Private-network outbound also requires `ingress.default: "allow"` and remains subject to the same `egress` rules.
+  Private-network outbound remains subject to the same `egress` rules. On compatibility paths, it also requires
+  `ingress.default: "allow"` to grant the bidirectional capability.
 - **Model 3:** Grants no `internetClient`, private-network capability, or loopback exemptions.
 
 **Enforcement:**
@@ -429,10 +430,10 @@ they cannot preserve either posture.
 | Port filtering | Port filtering via WFP | Port ranges supported. |
 | Protocol filtering | Protocol filtering via WFP | Schema values are `tcp`, `udp`, `icmp`, and `any`; WFP maps ICMP by address family. |
 | Default-deny | PSEC WFP block-all baseline filter at lower precedence than explicit allows. | A non-empty allow list grants `internetClient` only as the capability prerequisite; WFP still limits egress to explicit allows. With no allows, `internetClient` is absent. |
-| Proxy (HTTP/S only) | PSEC per-AppContainer WinHTTP configuration, endpoint filtering, and optional scoped peer access | Identity-scoped proxies keep `hostLoopback: "deny"`; the identity-less development/testing compatibility path requires `"allow"`; schema 0.8 proxy requests do not fall back to SBOX or AppContainer |
+| Proxy (HTTP/S only) | Per-container WinHTTP configuration, endpoint filtering, and optional scoped peer access | Identity-scoped proxies keep `hostLoopback: "deny"`; the identity-less development/testing path requires OS ingress policy support and `"allow"`; schema 0.8 proxy requests do not fall back to SBOX or AppContainer |
 | Per-sandbox scoping | AppContainer SID, unique per sandbox instance | |
-| Private network | `privateNetworkClientServer` via `ingress.default` | Capability gate; `egress` filters outbound |
-| Inbound | Capabilities and loopback rules | Private network uses `ingress.default`; loopback is separate |
+| Private network | OS ingress policy or compatibility capability mapping | `egress` filters outbound; compatibility paths require `privateNetworkClientServer` |
+| Inbound | OS ingress policy or compatibility capability mapping | Host loopback is controlled separately |
 | DNS | DNS queries follow same IP/CIDR allow/block rules as other traffic. No domain-based filtering. | If DNS resolver IP is blocked, DNS fails. If allowed, sandbox can resolve any domain. **For HTTP(S) via the proxy, DNS resolution happens in the proxy.** |
 | Bypass resistance | High. Kernel-enforced WFP filters. Bypass requires kernel compromise or AppContainer escape (elevation). | |
 

--- a/docs/sandbox-policy/0.8.0/networking/schema-updates.md
+++ b/docs/sandbox-policy/0.8.0/networking/schema-updates.md
@@ -24,9 +24,9 @@ Schemas before 0.8 cannot use the new fields.
 `proxy.builtinTestServer` has no schema 0.8 GA equivalent.
 
 On backends that cleanly separate private-network ingress from egress, `egress` governs all outbound traffic and
-`ingress` governs traffic entering the container. ProcessContainer also applies `egress` rules to all outbound
-destinations, but private-network traffic additionally requires `ingress.default: "allow"` to grant Windows'
-bidirectional `privateNetworkClientServer` capability.
+`ingress` governs traffic entering the container. ProcessContainer follows this model when OS ingress policy support
+is available. Compatibility paths require `ingress.default: "allow"` to grant Windows' bidirectional
+`privateNetworkClientServer` capability before private-network traffic can flow.
 
 This table maps the immutable 0.7 wire fields. In schema 0.7, `allowLocalNetwork` expresses inbound bind/listen
 permission and is honored by Seatbelt; ProcessContainer capabilities are separate. It maps only to
@@ -124,8 +124,8 @@ migrates to deny-default egress with allowed private/LAN inbound:
 }
 ```
 
-On backends that cleanly separate private-network ingress from egress, this does not grant outbound private-network or
-internet access. On ProcessContainer, `ingress.default: "allow"` grants the bidirectional private-network capability,
+This does not grant outbound private-network or internet access when OS ingress policy support is available. On
+ProcessContainer compatibility paths, `ingress.default: "allow"` grants the bidirectional private-network capability,
 but deny-default `egress` still blocks outbound public and private destinations unless an allow rule or the configured
 proxy path applies.
 

--- a/docs/sandbox-policy/0.8.0/networking/schema-updates.md
+++ b/docs/sandbox-policy/0.8.0/networking/schema-updates.md
@@ -15,7 +15,7 @@ Schemas before 0.8 cannot use the new fields.
 | IP/CIDR entries in `blockedHosts` | `egress.deny[].to[].cidr` | Deny overrides allow |
 | DNS names in `allowedHosts` or `blockedHosts` | No GA equivalent | Schema 0.8 accepts only IP/CIDR rules |
 | `enforcementMode` | Removed | The backend enforces the policy or rejects it |
-| `allowLocalNetwork` | `ingress.default` | Capability gate; outbound follows `egress` |
+| `allowLocalNetwork` | `ingress.default` | Inbound policy; outbound follows `egress` |
 | No equivalent | `ingress.hostLoopback` | New bidirectional host-loopback connectivity control |
 | `proxy.localhost` | `runtimeConfig.networkProxy` | Loopback proxy endpoint becomes runtime data |
 | `proxy.url` with an HTTP/S loopback URL | `runtimeConfig.networkProxy` | Loopback URL remains supported |
@@ -30,8 +30,9 @@ is available. Compatibility paths require `ingress.default: "allow"` to grant Wi
 
 This table maps the immutable 0.7 wire fields. In schema 0.7, `allowLocalNetwork` expresses inbound bind/listen
 permission and is honored by Seatbelt; ProcessContainer capabilities are separate. It maps only to
-`ingress.default` and must not change `egress.default`. Under schema 0.8, ProcessContainer uses that ingress value as
-the capability gate for private-network traffic, while outbound private destinations remain subject to `egress`.
+`ingress.default` and must not change `egress.default`. Under schema 0.8, ProcessContainer compatibility paths use
+that ingress value as the capability gate for private-network traffic, while outbound private destinations remain
+subject to `egress`.
 
 ## Direct egress
 


### PR DESCRIPTION
## 📖 Description

Documents ProcessContainer ingress behavior across the networking reference, support matrix, schema guide, and example.
Replaces the old universal capability guidance and clarifies compatibility, host-loopback, and conditional firewall requirements.

## 🔗 References

- Contract: #1076
- Runtime implementation: #1080

## 🔍 Validation

Documentation-only change.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task
