### PR TITLE
[SDK] Gate the C# isolation-session tests on the capability probe

### DIFF
--- a/.github/workflows/SDK.Dotnet.Test.Job.yml
+++ b/.github/workflows/SDK.Dotnet.Test.Job.yml
@@ -38,9 +38,9 @@ jobs:
       # `--no-build` reuses the compile above rather than repeating it.
       #
       # Tests needing a prepared sandbox host gate on MXC_E2E_HOST_PREPPED,
-      # deliberately left unset: no runner satisfies it, and the same variable
-      # also gates the isolation-session tests, which additionally need an
-      # OS-side service. Those report as skips, so what this lane establishes is
+      # deliberately left unset: no runner satisfies it. The isolation-session
+      # tests gate on the SDK's backend probe, and this lane does not build that
+      # backend. Both report as skips, so what this lane establishes is
       # the managed surface plus the native library loading on this platform.
       #
       # A zero exit code is not sufficient evidence on its own, because a run in

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
@@ -19,11 +19,31 @@ namespace Microsoft.Mxc.Sdk.Tests;
 /// </remarks>
 public class MxcLifecycleE2ETests
 {
-    // Opt-in gate shared with the streaming E2E tests: a host that can really run
-    // a sandbox sets MXC_E2E_HOST_PREPPED=1. Elsewhere these skip.
-    private static bool HostRunsIsolationSession =>
-        Environment.GetEnvironmentVariable("MXC_E2E_HOST_PREPPED") == "1"
-        && OperatingSystem.IsWindows();
+    // Evaluated once: this answer decides failure versus skip, so it has to be
+    // the same for every test in the class.
+    private static readonly Lazy<bool> HostRunsIsolationSession = new(() =>
+        MxcSandbox.GetAvailableBackends()
+            .Any(b => b.Backend == ContainmentBackend.IsolationSession));
+
+    // Without this, a run in which everything skipped is indistinguishable from
+    // one that passed. The same variable the Rust isolation-session suite honours.
+    private static bool SkipsAreFailures =>
+        Environment.GetEnvironmentVariable("MXC_ISO_TESTS_REQUIRED") is "1" or "true";
+
+    /// <summary>Skips the calling test when the backend is unavailable, or fails
+    /// it when skips have been declared failures.</summary>
+    private static void RequireIsolationSessionHost()
+    {
+        Assert.False(
+            SkipsAreFailures && !HostRunsIsolationSession.Value,
+            "MXC_ISO_TESTS_REQUIRED is set, but GetAvailableBackends() does not "
+                + "report the isolation-session backend. That needs both a build "
+                + "with MxcWithIsolationSession and a host running the OS-side "
+                + "service.");
+        Assert.SkipUnless(
+            HostRunsIsolationSession.Value,
+            "GetAvailableBackends() does not report the isolation-session backend");
+    }
 
     private const string Cmd = @"C:\Windows\System32\cmd.exe";
 
@@ -137,7 +157,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Exec_RunsAsTheAgentUserFromTheProvisionMetadata()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -157,7 +177,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Exec_PropagatesANonZeroExitCode()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -175,7 +195,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Exec_ReportsConfiguredTimeout()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -197,7 +217,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Deprovision_RetiresTheSandboxId()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -216,7 +236,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Lifecycle_RunsEndToEnd()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -233,7 +253,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Workspace_IsSharedWithTheAgent_AndRemovedOnDeprovision()
     {
-        Assert.SkipUnless(HostRunsIsolationSession, "no isolation-session host available");
+        RequireIsolationSessionHost();
 
         var started = ProvisionAndStart();
         using (started.Teardown)

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -510,9 +510,12 @@ closed rather than upgrading an unreadable device state into collection.
   interactive terminal inside an isolation session. Terminal behaviour has no
   automated oracle, so its `interactive`, `streaming` and `resize` scenarios are
   judged by whoever runs them; each states what to look for.
-- **`Microsoft.Mxc.Sdk.Tests`** — xUnit v3 tests. The lifecycle and streaming
-  end-to-end tests need a capable host and skip, with a reason, unless
-  `MXC_E2E_HOST_PREPPED=1`.
+- **`Microsoft.Mxc.Sdk.Tests`** — xUnit v3 tests. The streaming end-to-end tests
+  need a capable host and skip, with a reason, unless `MXC_E2E_HOST_PREPPED=1`.
+  The isolation-session lifecycle tests skip unless `GetAvailableBackends()`
+  reports that backend, which needs both a build with
+  `-p:MxcWithIsolationSession=true` and a host running the OS-side service. Set
+  `MXC_ISO_TESTS_REQUIRED=1` (or `true`) to turn those skips into failures.
 
 Build/test everything: `dotnet test --solution sdk/dotnet/Microsoft.Mxc.Sdk.slnx`.
 


### PR DESCRIPTION
## 📖 Description

The C# isolation-session lifecycle tests decided whether to run by comparing `MXC_E2E_HOST_PREPPED` to `"1"` — asserting that somebody exported a variable, not that this host can run the backend. They now ask `MxcSandbox.GetAvailableBackends()`, as the Rust isolation-session suite already does.

`GetPlatformSupport()` is deliberately not consulted, though the SDK's documentation directs callers to cross-check it. It excludes isolation sessions by design, so a gate consulting it would be permanently false and these tests would skip forever while reporting green.

Dropping the variable also drops a forcing function, so `MXC_ISO_TESTS_REQUIRED` replaces it: when set, a host-capability skip becomes a failure. A per-test skip fails neither CI nor the local VM harness, so a regressed gate would otherwise be silent.

**Out of scope.** The streaming tests in `MxcSandboxProcessTests` keep `MXC_E2E_HOST_PREPPED`, which now carries a single meaning. No exported probe reports whether a host is prepared for sandbox launch, so they cannot take the same treatment.

## 🔍 Validation

Full local gate green: `fmt`, `clippy -D warnings`, build and test with `isolation_session` ON and OFF, arm64 cross-build, versioning suite, C# and Node SDK legs.

Isolation-session E2E on a live host: 247 passed, 0 failed, 2 skipped across seven suites, no agent accounts leaked. The six gated lifecycle tests ran and passed there by name — the branch no ordinary dev host reaches, since the probe correctly returns false without the OS-side service. Without it they skip naming the probe; with `MXC_ISO_TESTS_REQUIRED=1` they fail instead.

Operator-run interactive TTY scenarios passed on all four surfaces.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Updated documentation (if applicable)

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1086)