### PR TITLE
Rename `ExecConsumer` to `ExecStdio` for the topology it selects

### DIFF
--- a/docs/isolation-session/state-aware-rust.md
+++ b/docs/isolation-session/state-aware-rust.md
@@ -395,9 +395,9 @@ concurrent provisions are independent and all succeed.
 
 ### Multiple exec calls against the same sandbox
 
-The runner's `exec` impl blocks for an **`Executor`** consumer: it reuses the
+The runner's `exec` impl blocks under **`Relayed`**: it reuses the
 one-shot `create_process` path, and that call runs until the agent process
-exits and the relay drains. For a **`Library`** consumer it starts the
+exits and the relay drains. Under **`Piped`** it starts the
 process and returns without waiting, handing back the live pipe handles and a
 waiter, so the caller decides when to block. Either way, two concurrent exec
 calls against the same `sandboxId` are not coordinated by MXC; the OS-side
@@ -496,9 +496,9 @@ State-aware exec (and other phases) use OS-level cancellation in v1:
   agent process before returning.
 
 `ExecHandle.terminator` is a no-op closure on the IsolationSession path
-when the consumer is `Executor`, which reuses the one-shot
+under `Relayed`, which reuses the one-shot
 `create_process` synchronously and so has no mid-flight cancellation
-seam. For a `Library` consumer the backend instead starts the process
+seam. Under `Piped` the backend instead starts the process
 without waiting and returns a terminator that calls
 `IsoSessionProcess::Terminate()`, alongside the real pipe handles and a
 waiter that blocks on exit.
@@ -538,9 +538,7 @@ An exited process is never routed through the shutdown ladder, which reads only 
 and so cannot tell a `259` exit from a live process. The adapter maps
 `TimedOut` onto `ErrorKind::TimedOut`, which is what
 `mxc_sdk::Sandbox::wait` reads as `WaitOutcome::TimedOut`. That outcome
-is reachable only for a `Library` consumer: the `Executor` arm has no
-timeout field in `ScriptResponse` to report one through, so the executor
-arm keeps reporting `Exited`.
+is reachable only under `Piped`; the `Relayed` arm reports `Exited`.
 
 Teardown is bounded only insofar as the kill is: the streaming adapter's
 `Drop` joins the waiter when the kill was accepted, and abandons the

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -241,7 +241,7 @@ pub trait StatefulSandboxBackend {
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError>;
 
     fn stop(
@@ -358,7 +358,7 @@ const r = await execInSandboxAsync(
 ```rust
 // Parser populates request.script_code = "echo hello" from the wire-format `process`
 // block (same path as one-shot). The dispatcher then calls:
-backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecConsumer::Executor)
+backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecStdio::Relayed)
 // returns Ok(ExecHandle { stdout, stderr, stdin, waiter, terminator })
 ```
 

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -1207,26 +1207,19 @@ pub trait StatefulSandboxBackend {
 
     /// Required. Must execute the workload and return a handle.
     ///
-    /// `stdio` is the caller's intent and is authoritative. This is
-    /// deliberately not `StdioMode`: that enum's `Inherit` means the OS hands
-    /// the child the executor's own handles, which no state-aware backend can
-    /// do, since the workload runs inside an isolation session, a VM, or
-    /// behind an SDK callback. What matters here is who is on the other end,
-    /// because that fixes the topology of the returned streams.
+    /// `stdio` is authoritative and fixes the topology of the returned streams.
     ///
-    /// `Piped` (the library / FFI streaming path) means the caller drives
-    /// the streams itself, so an implementation must surface separate raw pipe
+    /// `Piped` means the caller drives the streams itself, so an
+    /// implementation must surface separate raw pipe
     /// handles, allocate no pseudo-console, and not touch the host console.
-    /// `Relayed` (the relay path) means the handle is relayed to **the calling
+    /// `Relayed` means the handle is relayed to **the calling
     /// process's** own stdio, where a pseudo-console is legitimate and stderr may
     /// therefore arrive merged into stdout, leaving `ExecHandle::stderr` null. A
     /// backend that probes the host to decide how to wire stdio must confine that
     /// probe to the `Relayed` case, where the probing process is the relay
     /// target.
     ///
-    /// The variant names describe the caller each was written for, not the
-    /// rule. What separates them is who consumes the streams; "in-process" does
-    /// not imply `Piped`.
+    /// Topology, not caller identity: "in-process" does not imply `Piped`.
     ///
     /// A backend that cannot serve `Piped` at all — because it relays the
     /// workload's output to the *host process's* own stdio rather than
@@ -1338,7 +1331,7 @@ pub struct ExecHandle {
     /// Stderr pipe handle from the running process. The relay path writes it to
     /// the calling process's own stderr.
     pub stderr: PipeHandle,
-    /// Stdin pipe handle. Not consumed by the executor relay, which forwards
+    /// Stdin pipe handle. Not consumed by the relay, which forwards
     /// no input; the streaming path hands it to an in-process caller.
     pub stdin: PipeHandle,
     /// Function to wait for exit; returns how the exec finished.
@@ -1359,7 +1352,8 @@ pub struct ExecHandle {
 /// Deliberately not "the backend killed it": a workload that overruns its
 /// deadline and then exits on its own has still missed it, and how far the
 /// termination reaches is the backend's to state. Only `ExecStdio::Piped`
-/// can observe `TimedOut`; the executor relay has no field to carry it.
+/// can observe `TimedOut`; a backend serving `ExecStdio::Relayed` reports
+/// `Exited`.
 pub enum ExecOutcome {
     Exited(i32),
     TimedOut,

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -939,7 +939,7 @@ const r = await execInSandboxAsync(
 // Parser populates request.script_code = "echo hello", request.script_timeout =
 // 5000 from the wire-format `process` block (same path as one-shot). The
 // dispatcher then calls:
-backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecConsumer::Executor)
+backend.exec("iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0", &request, /* config */ None, ExecStdio::Relayed)
 // returns Ok(ExecHandle { ... pipe handles + waiter ... })
 ```
 
@@ -1207,41 +1207,41 @@ pub trait StatefulSandboxBackend {
 
     /// Required. Must execute the workload and return a handle.
     ///
-    /// `consumer` is the caller's intent and is authoritative. This is
+    /// `stdio` is the caller's intent and is authoritative. This is
     /// deliberately not `StdioMode`: that enum's `Inherit` means the OS hands
     /// the child the executor's own handles, which no state-aware backend can
     /// do, since the workload runs inside an isolation session, a VM, or
     /// behind an SDK callback. What matters here is who is on the other end,
     /// because that fixes the topology of the returned streams.
     ///
-    /// `Library` (the library / FFI streaming path) means the caller drives
+    /// `Piped` (the library / FFI streaming path) means the caller drives
     /// the streams itself, so an implementation must surface separate raw pipe
     /// handles, allocate no pseudo-console, and not touch the host console.
-    /// `Executor` (the relay path) means the handle is relayed to **the calling
+    /// `Relayed` (the relay path) means the handle is relayed to **the calling
     /// process's** own stdio, where a pseudo-console is legitimate and stderr may
     /// therefore arrive merged into stdout, leaving `ExecHandle::stderr` null. A
     /// backend that probes the host to decide how to wire stdio must confine that
-    /// probe to the `Executor` case, where the probing process is the relay
+    /// probe to the `Relayed` case, where the probing process is the relay
     /// target.
     ///
     /// The variant names describe the caller each was written for, not the
     /// rule. What separates them is who consumes the streams; "in-process" does
-    /// not imply `Library`.
+    /// not imply `Piped`.
     ///
-    /// A backend that cannot serve `Library` at all — because it relays the
+    /// A backend that cannot serve `Piped` at all — because it relays the
     /// workload's output to the *host process's* own stdio rather than
     /// returning streams — must refuse **before running anything**. The
     /// workload is arbitrary and may not be idempotent, so a refusal issued
     /// after the fact reports "unsupported" for something that has already
     /// taken effect and whose output has already gone somewhere the caller
-    /// never asked for. `wxc_common::state_aware_backend::unsupported_library_exec`
+    /// never asked for. `wxc_common::state_aware_backend::unsupported_piped_exec`
     /// is the shared refusal.
     fn exec(
         &mut self,
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError>;
 
     /// Optional. Default returns success with no metadata.
@@ -1358,7 +1358,7 @@ pub struct ExecHandle {
 /// no longer running — whereas `Err` means the exit could not be determined.
 /// Deliberately not "the backend killed it": a workload that overruns its
 /// deadline and then exits on its own has still missed it, and how far the
-/// termination reaches is the backend's to state. Only `ExecConsumer::Library`
+/// termination reaches is the backend's to state. Only `ExecStdio::Piped`
 /// can observe `TimedOut`; the executor relay has no field to carry it.
 pub enum ExecOutcome {
     Exited(i32),
@@ -1512,7 +1512,7 @@ fn dispatch_state_aware<B: StatefulSandboxBackend>(
             validate_exec_common(request)?;
             backend.validate_exec(sandbox_id, request, config.as_ref())?;
             if dry_run { return Ok(DispatchOutcome::Envelope(empty_envelope())); }
-            let handle = backend.exec(sandbox_id, request, config, ExecConsumer::Executor)?;
+            let handle = backend.exec(sandbox_id, request, config, ExecStdio::Relayed)?;
             // relay_exec_to_stdio streams the script's pipes to the executor's
             // stdout/stderr live, awaits exit, and returns the script's exit code.
             let exit_code = relay_exec_to_stdio(handle)?;

--- a/src/backends/isolation_session/common/src/manager.rs
+++ b/src/backends/isolation_session/common/src/manager.rs
@@ -356,7 +356,7 @@ impl IsolationSessionManager {
     /// return it **without waiting**.
     ///
     /// Split out of [`Self::create_process`] so the caller chooses how the
-    /// streams are consumed: the executor path bridges them with its own relay
+    /// streams are consumed: the relayed path bridges them with its own relay
     /// threads and blocks (see `create_process`), while an in-process SDK
     /// caller takes the raw handles and drives them itself.
     pub(super) fn start_process(
@@ -658,7 +658,7 @@ impl StartedProcess {
     /// Block until the process exits and yield its exit code, escalating
     /// through the graceful-shutdown ladder if it outlives `timeout_ms`.
     ///
-    /// The *instruction sequence* is the one the executor path runs inline, but
+    /// The *instruction sequence* is the one the relayed path runs inline, but
     /// the ladder's first two tiers are **inert for a consumer that holds
     /// duplicates of the pipe handles**:
     ///
@@ -666,7 +666,7 @@ impl StartedProcess {
     ///   only when *every* write end is closed, so tier 1 alone does not
     ///   produce EOF.
     /// - Tier 2 (`SendCtrlClose`) is ConPTY-only and returns `E_NOTIMPL`
-    ///   otherwise, and a library consumer never allocates one.
+    ///   otherwise, and a piped exec never allocates one.
     ///
     /// The ladder therefore degrades to the full 5s + 3s stall followed by
     /// tier 3's hard terminate.
@@ -947,7 +947,7 @@ impl Drop for RelayScope<'_> {
 /// it goes out of scope.
 ///
 /// Close-on-drop is **opt-in per consumer** rather than a property of
-/// [`StartedProcess`] itself, because the two consumers need opposite things:
+/// [`StartedProcess`] itself, because the two topologies need opposite things:
 ///
 /// - The streaming consumer has no other teardown point — it hands the handles
 ///   to an in-process caller and never returns to this crate — so without this

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -240,7 +240,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
 
     /// Executes the workload inside the running isolation session.
     ///
-    /// **The two consumers get different shapes, deliberately** — see
+    /// **The two topologies get different shapes, deliberately** — see
     /// [`ExecStdio`]. Under `Relayed` this keeps the backend's own relay:
     /// `create_process` blocks, bridging the guest's pipes to the calling
     /// process's stdio
@@ -265,7 +265,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
     /// termination — on a host running the OS-side service, which CI and most
     /// dev machines do not have, so those tests skip elsewhere.
     ///
-    /// Pinned host-independently: the consumer split itself
+    /// Pinned host-independently: the topology split itself
     /// (`wants_interactive_console`), and — in `wxc_common` — that
     /// `ExecSandboxProcess::wait` drains streams the caller did not take, which
     /// is the deadlock this branch would otherwise arm.
@@ -382,11 +382,11 @@ mod tests {
     // silently swallow every per-phase config (the field would still
     // deserialize from the containment slot via models.rs's serde
     // rename — only the experimental block would go missing).
-    // ====== Consumer-conditional stdio ======
+    // ====== Stdio topology ======
 
-    /// A library caller must never get a ConPTY — **including on a host whose
+    /// A piped exec must never get a ConPTY — **including on a host whose
     /// stdout is a terminal**, which is the only case that can distinguish a
-    /// correct implementation from one that ignores the consumer.
+    /// correct implementation from one that always follows the host.
     ///
     /// Allocating one here would be doubly wrong: a pseudo-console merges
     /// stderr into stdout, so the caller would silently lose the separate
@@ -400,16 +400,16 @@ mod tests {
                 probed = true;
                 true
             }),
-            "a terminal host must not leak a console into the library path"
+            "a terminal host must not leak a console into the piped path"
         );
         assert!(
             !probed,
-            "the library path must not even evaluate the host probe -- passing the \
+            "the piped path must not even evaluate the host probe -- passing the \
              probe's value rather than a closure would run it eagerly"
         );
     }
 
-    /// The executor path is the only one allowed to act on the probe, and it
+    /// The relayed path is the only one allowed to act on the probe, and it
     /// must actually follow it rather than hardcoding either answer.
     ///
     /// Both host answers are asserted, so hardcoding `true` *or* `false` fails.

--- a/src/backends/isolation_session/common/src/state_aware.rs
+++ b/src/backends/isolation_session/common/src/state_aware.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use wxc_common::models::{ExecutionRequest, IsolationSessionProvisionConfig};
 use wxc_common::mxc_error::MxcError;
 use wxc_common::state_aware_backend::{
-    DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult, StartResult,
+    DeprovisionResult, ExecHandle, ExecOutcome, ExecStdio, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
 use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
@@ -59,23 +59,20 @@ fn extract_agent_user_name(sandbox_id: &str) -> Result<String, MxcError> {
 ///
 /// `host_is_terminal` is a **closure**, not a value, and that is load-bearing:
 /// Rust evaluates arguments eagerly, so passing the probe's result would run the
-/// probe on the `Library` path too — contradicting the contract this function
-/// exists to enforce. Taking a closure makes "never probes under `Library`" a
+/// probe on the `Piped` path too — contradicting the contract this function
+/// exists to enforce. Taking a closure makes "never probes under `Piped`" a
 /// property of the code rather than a claim in a comment, and one a test can
 /// actually observe.
 ///
-/// The rule itself: only [`ExecConsumer::Executor`] may consult the host. Under
-/// `Library` an embedded host's stdout says nothing about the sandbox, and
+/// The rule itself: only [`ExecStdio::Relayed`] may consult the host. Under
+/// `Piped` an embedded host's stdout says nothing about the sandbox, and
 /// allocating a pseudo-console would both merge stderr into stdout — destroying
 /// the separate streams the caller asked for — and touch console state the
 /// caller owns.
-fn wants_interactive_console(
-    consumer: ExecConsumer,
-    host_is_terminal: impl FnOnce() -> bool,
-) -> bool {
-    match consumer {
-        ExecConsumer::Executor => host_is_terminal(),
-        ExecConsumer::Library => false,
+fn wants_interactive_console(stdio: ExecStdio, host_is_terminal: impl FnOnce() -> bool) -> bool {
+    match stdio {
+        ExecStdio::Relayed => host_is_terminal(),
+        ExecStdio::Piped => false,
     }
 }
 
@@ -244,7 +241,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
     /// Executes the workload inside the running isolation session.
     ///
     /// **The two consumers get different shapes, deliberately** — see
-    /// [`ExecConsumer`]. Under `Executor` this keeps the backend's own relay:
+    /// [`ExecStdio`]. Under `Relayed` this keeps the backend's own relay:
     /// `create_process` blocks, bridging the guest's pipes to the calling
     /// process's stdio
     /// through internal threads that also manage the ConPTY, the raw-VT console
@@ -255,7 +252,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
     /// handles plus a waiter yielding the already-captured exit code, and the
     /// dispatcher's relay stays a call-through.
     ///
-    /// Under `Library` the caller drives the streams, so this starts the process
+    /// Under `Piped` the caller drives the streams, so this starts the process
     /// without waiting and hands back its real pipe handles, a waiter that
     /// blocks on exit, and a terminator that actually kills. It performs **no**
     /// console probe: an embedded host's stdout says nothing about the sandbox,
@@ -263,7 +260,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
     ///
     /// # Coverage
     ///
-    /// The `Library` branch is exercised end-to-end by `mxc-sdk`'s
+    /// The `Piped` branch is exercised end-to-end by `mxc-sdk`'s
     /// `tests/isolation_session.rs` — streaming, exit-code propagation and
     /// termination — on a host running the OS-side service, which CI and most
     /// dev machines do not have, so those tests skip elsewhere.
@@ -277,17 +274,17 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError> {
         let agent_user_name = extract_agent_user_name(sandbox_id)?;
         let manager =
             IsolationSessionManager::new(&agent_user_name).map_err(map_lifecycle_error)?;
 
-        match consumer {
-            ExecConsumer::Executor => {
+        match stdio {
+            ExecStdio::Relayed => {
                 let options = build_process_options(
                     request,
-                    wants_interactive_console(consumer, || std::io::stdout().is_terminal()),
+                    wants_interactive_console(stdio, || std::io::stdout().is_terminal()),
                 );
 
                 let exit_code = manager
@@ -304,7 +301,7 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
                     stdin: null,
                     stdin_closer: None,
                     // `Exited`, never `TimedOut`: a backend serving
-                    // `ExecConsumer::Executor` reports an exit code, and the
+                    // `ExecStdio::Relayed` reports an exit code, and the
                     // relay rejects anything else.
                     waiter: Box::new(move || Ok(ExecOutcome::Exited(exit_code))),
                     // Nothing to terminate: `create_process` returned only once
@@ -312,10 +309,10 @@ impl StatefulSandboxBackend for IsolationSessionRunner {
                     terminator: Box::new(|| Ok(())),
                 })
             }
-            ExecConsumer::Library => {
+            ExecStdio::Piped => {
                 let options = build_process_options(
                     request,
-                    wants_interactive_console(consumer, || std::io::stdout().is_terminal()),
+                    wants_interactive_console(stdio, || std::io::stdout().is_terminal()),
                 );
                 // The caller's deadline, enforced by our own wait below. The
                 // service timer is armed with a margin so it cannot fire first
@@ -396,10 +393,10 @@ mod tests {
     /// stream it asked for, and setting it up touches console state the caller
     /// owns.
     #[test]
-    fn a_library_caller_never_gets_an_interactive_console() {
+    fn a_piped_exec_never_gets_an_interactive_console() {
         let mut probed = false;
         assert!(
-            !wants_interactive_console(ExecConsumer::Library, || {
+            !wants_interactive_console(ExecStdio::Piped, || {
                 probed = true;
                 true
             }),
@@ -417,13 +414,13 @@ mod tests {
     ///
     /// Both host answers are asserted, so hardcoding `true` *or* `false` fails.
     #[test]
-    fn the_executor_path_follows_the_host() {
+    fn a_relayed_exec_follows_the_host() {
         assert!(
-            wants_interactive_console(ExecConsumer::Executor, || true),
+            wants_interactive_console(ExecStdio::Relayed, || true),
             "a terminal host must still get an interactive console"
         );
         assert!(
-            !wants_interactive_console(ExecConsumer::Executor, || false),
+            !wants_interactive_console(ExecStdio::Relayed, || false),
             "a piped host must not get one"
         );
     }

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -762,7 +762,7 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
         _config: Option<()>,
         stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError> {
-        // Before any work: this backend relays to the executor's stdio, so it
+        // Before any work: this backend relays to the calling process's stdio, so it
         // cannot return exec streams to the caller, and running the workload first
         // would make the refusal a lie about what has already happened.
         if stdio == ExecStdio::Piped {
@@ -1063,7 +1063,7 @@ mod tests {
     /// something that already took effect.
     ///
     /// `extract_token` would reject this id, and there is no live daemon behind
-    /// it either — so any error other than the refusal means the consumer check
+    /// it either — so any error other than the refusal means the check
     /// came too late.
     #[test]
     fn a_piped_exec_is_refused_before_the_workload_runs() {

--- a/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
+++ b/src/backends/windows_sandbox/lifecycle/src/state_aware.rs
@@ -18,7 +18,7 @@ use wxc_common::mxc_error::MxcError;
 use wxc_common::process_util::resolve_sibling_binary;
 use wxc_common::script_runner::get_timeout_milliseconds;
 use wxc_common::state_aware_backend::{
-    DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult, StartResult,
+    DeprovisionResult, ExecHandle, ExecOutcome, ExecStdio, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
 use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
@@ -760,13 +760,13 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError> {
         // Before any work: this backend relays to the executor's stdio, so it
         // cannot return exec streams to the caller, and running the workload first
         // would make the refusal a lie about what has already happened.
-        if consumer == ExecConsumer::Library {
-            return Err(wxc_common::state_aware_backend::unsupported_library_exec(
+        if stdio == ExecStdio::Piped {
+            return Err(wxc_common::state_aware_backend::unsupported_piped_exec(
                 "Windows Sandbox",
             ));
         }
@@ -810,7 +810,7 @@ impl StatefulSandboxBackend for WindowsSandboxRunner {
             stdin_closer: None,
             // `Exited`, not `TimedOut`: this backend runs the workload to
             // completion inside `exec` and reports what the guest returned, so
-            // there is no live process left to have timed out. A `Library` path
+            // there is no live process left to have timed out. A `Piped` path
             // that could distinguish the two does not exist here yet.
             waiter: Box::new(move || Ok(ExecOutcome::Exited(exit_code))),
             // Nothing to terminate: the workload is already gone.
@@ -1055,7 +1055,7 @@ mod tests {
     use wxc_common::models::{ContainerPolicy, NetworkEgressPolicy, NetworkPolicy};
     use wxc_common::mxc_error::MxcErrorCode;
 
-    /// A `Library` exec is refused before the backend looks for the daemon.
+    /// A `Piped` exec is refused before the backend looks for the daemon.
     ///
     /// This backend relays the workload's output to *this process's* stdio, so
     /// it cannot return exec streams to the caller. The refusal has to precede any
@@ -1066,14 +1066,14 @@ mod tests {
     /// it either — so any error other than the refusal means the consumer check
     /// came too late.
     #[test]
-    fn a_library_exec_is_refused_before_the_workload_runs() {
+    fn a_piped_exec_is_refused_before_the_workload_runs() {
         let mut runner = WindowsSandboxRunner::new();
         let err = runner
             .exec(
                 "not-a-valid-sandbox-id",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Library,
+                ExecStdio::Piped,
             )
             .expect_err("a streams-consuming caller must be refused");
         assert!(
@@ -1343,7 +1343,7 @@ mod tests {
                 "wsb:abcd1234",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Executor,
+                ExecStdio::Relayed,
             )
             .unwrap_err();
         // With no daemon holding the sandbox, exec reports NotStarted rather
@@ -1359,7 +1359,7 @@ mod tests {
                 "iso:abc",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Executor,
+                ExecStdio::Relayed,
             )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::MalformedId);
@@ -1576,7 +1576,7 @@ mod tests {
                 "wsb:cccc3333",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Executor,
+                ExecStdio::Relayed,
             )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::NotStarted);

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -19,7 +19,7 @@ use wxc_common::logger::{Logger, Mode};
 use wxc_common::models::{ContainerPolicy, ExecutionRequest, NetworkPolicy};
 use wxc_common::mxc_error::MxcError;
 use wxc_common::state_aware_backend::{
-    null_pipe_handle, DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult,
+    null_pipe_handle, DeprovisionResult, ExecHandle, ExecOutcome, ExecStdio, ProvisionResult,
     StartResult, StatefulSandboxBackend, StopResult,
 };
 use wxc_common::validator::{validate_state_aware_network_policy_support, NetworkPolicySupport};
@@ -139,13 +139,13 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         sandbox_id: &str,
         request: &ExecutionRequest,
         _config: Option<()>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError> {
         // Before any work: this backend relays to the executor's stdio, so it
         // cannot return exec streams to the caller, and running the workload first
         // would make the refusal a lie about what has already happened.
-        if consumer == ExecConsumer::Library {
-            return Err(wxc_common::state_aware_backend::unsupported_library_exec(
+        if stdio == ExecStdio::Piped {
+            return Err(wxc_common::state_aware_backend::unsupported_piped_exec(
                 "WSLc",
             ));
         }
@@ -218,7 +218,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
             // already run the workload to completion by the time it returns, so
             // `exit_code` is whatever the container reported — including for a
             // workload the daemon timed out. Reporting a timeout as such needs
-            // the `Library` path this backend does not have yet.
+            // the `Piped` path this backend does not have yet.
             waiter: Box::new(move || Ok(ExecOutcome::Exited(exit_code))),
             // Nothing to terminate: the workload is already gone. `Ok(())` is
             // the truthful answer here, not a placeholder.
@@ -437,7 +437,7 @@ mod tests {
     use super::*;
     use wxc_common::models::{ContainerPolicy, NetworkEgressPolicy};
 
-    /// A `Library` exec is refused before the backend touches the daemon.
+    /// A `Piped` exec is refused before the backend touches the daemon.
     ///
     /// This backend writes the workload's output to *this process's* stdout and
     /// stderr, so it cannot return exec streams to the caller. The refusal has to come
@@ -449,14 +449,14 @@ mod tests {
     /// to connect to. Any error other than the refusal means the guard ran too
     /// late — the code reached the daemon before checking who was asking.
     #[test]
-    fn a_library_exec_is_refused_before_the_workload_runs() {
+    fn a_piped_exec_is_refused_before_the_workload_runs() {
         let mut runner = WslcStateAwareRunner::new();
         let err = runner
             .exec(
                 "wslc:0123456789abcdef0123456789abcdef",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Library,
+                ExecStdio::Piped,
             )
             .expect_err("a streams-consuming caller must be refused");
         assert!(

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -141,7 +141,7 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         _config: Option<()>,
         stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError> {
-        // Before any work: this backend relays to the executor's stdio, so it
+        // Before any work: this backend relays to the calling process's stdio, so it
         // cannot return exec streams to the caller, and running the workload first
         // would make the refusal a lie about what has already happened.
         if stdio == ExecStdio::Piped {

--- a/src/core/mxc-sdk/tests/state_aware.rs
+++ b/src/core/mxc-sdk/tests/state_aware.rs
@@ -10,8 +10,8 @@
 //! needs the OS-side IsoSessionOps service, so the real lifecycle paths are
 //! exercised by the executor E2E suites instead.
 //!
-//! Those suites drive the `ExecConsumer::Executor` path. The
-//! `ExecConsumer::Library` path [`exec_sandbox`] uses is covered end-to-end by
+//! Those suites drive the `ExecStdio::Relayed` path. The
+//! `ExecStdio::Piped` path [`exec_sandbox`] uses is covered end-to-end by
 //! `tests/isolation_session.rs`, which is gated on a host running the OS-side
 //! service. So the assertions here deliberately stop at the facade's contract:
 //! parse, reject one-shot, reject non-dry-run exec, surface unsupported_phase

--- a/src/core/wxc_common/src/exec_stream.rs
+++ b/src/core/wxc_common/src/exec_stream.rs
@@ -599,7 +599,7 @@ fn wrap_read(handle: PipeHandle) -> Option<Box<dyn Read + Send>> {
 /// Wrap a readable pipe as a **cancellable** reader plus its closer, so a
 /// discard of it can be ended on demand rather than abandoned.
 ///
-/// Separate from [`wrap_read`] because the executor's relay does not need a
+/// Separate from [`wrap_read`] because the relay does not need a
 /// closer — it has its own mute-and-abandon path — and only the streaming
 /// adapter stores one.
 #[cfg(target_os = "windows")]
@@ -714,7 +714,7 @@ pub(crate) fn wrap_read_checked(
 
 /// Cancellable counterpart of [`wrap_read_checked`], for the streaming adapter.
 ///
-/// Module-private: unlike [`wrap_read_checked`], which the executor's relay also
+/// Module-private: unlike [`wrap_read_checked`], which the relay also
 /// calls, this one has a single caller in this file.
 fn wrap_cancellable_read_checked(
     handle: PipeHandle,
@@ -871,7 +871,7 @@ mod tests {
         };
 
         let err = match ExecSandboxProcess::from_exec_handle(handle) {
-            Ok(_) => panic!("a backend exposing no streams cannot serve a library caller"),
+            Ok(_) => panic!("a backend exposing no streams cannot serve a piped exec"),
             Err(err) => err,
         };
         assert!(

--- a/src/core/wxc_common/src/exec_stream.rs
+++ b/src/core/wxc_common/src/exec_stream.rs
@@ -24,13 +24,13 @@
 //! its `waiter`/`terminator`, which may also reference them) are untouched — so
 //! there is no double-close even for a backend that keeps and closes its own
 //! pipe ends. IsolationSession is exactly that case under
-//! [`ExecConsumer::Library`]: it is the only state-aware backend that returns
+//! [`ExecStdio::Piped`]: it is the only state-aware backend that returns
 //! real pipe handles, and it closes its own ends when its process object drops.
-//! Under [`ExecConsumer::Executor`] it relays internally and returns null
-//! handles, as do Windows Sandbox and WSLc — which under [`ExecConsumer::Library`]
+//! Under [`ExecStdio::Relayed`] it relays internally and returns null
+//! handles, as do Windows Sandbox and WSLc — which under [`ExecStdio::Piped`]
 //! return no handle at all, refusing it up front. A handle with *all three*
 //! streams null is refused here rather than wrapped: it means the backend has
-//! not implemented the `Library` contract, and a stream-less `SandboxProcess`
+//! not implemented the `Piped` contract, and a stream-less `SandboxProcess`
 //! would hide that.
 //!
 //! Each readable duplicate is wrapped as a **cancellable** reader, so a read on
@@ -41,8 +41,8 @@
 //! [`stdout_closer`](SandboxProcess::stdout_closer).
 //!
 //! [`try_clone_to_owned`]: std::os::windows::io::BorrowedHandle::try_clone_to_owned
-//! [`ExecConsumer::Library`]: crate::state_aware_backend::ExecConsumer::Library
-//! [`ExecConsumer::Executor`]: crate::state_aware_backend::ExecConsumer::Executor
+//! [`ExecStdio::Piped`]: crate::state_aware_backend::ExecStdio::Piped
+//! [`ExecStdio::Relayed`]: crate::state_aware_backend::ExecStdio::Relayed
 
 use std::io::{Read, Write};
 use std::sync::{Arc, Mutex};
@@ -154,22 +154,22 @@ impl ExecSandboxProcess {
         } = handle;
 
         // A handle with nothing on any stream is a backend that has not
-        // implemented the `Library` contract — it relayed internally and ran the
-        // workload to completion, which is the `Executor` shape. Wrapping it
+        // implemented the `Piped` contract — it relayed internally and ran the
+        // workload to completion, which is the `Relayed` shape. Wrapping it
         // would hand the caller a `SandboxProcess` whose `take_stdout` is `None`
         // and whose `wait` returns an exit code the backend already had, while
         // the sandbox's output went wherever the backend chose — for the
         // internally-relaying backends, the *host application's* own stdout.
         //
         // This is a **backstop, not the guard that matters**. The backends that
-        // cannot serve `Library` refuse it up front instead (see
-        // `unsupported_library_exec`), so reaching this branch means a backend
-        // returned an all-null handle for a `Library` exec anyway — hence the
+        // cannot serve `Piped` refuse it up front instead (see
+        // `unsupported_piped_exec`), so reaching this branch means a backend
+        // returned an all-null handle for a `Piped` exec anyway — hence the
         // distinct wording, so the two are told apart in a log.
         //
         // **The process is not assumed to have finished.** The comment above
         // describes the shape this usually means, not a guarantee: the
-        // IsolationSession `Library` path starts a process and passes through
+        // IsolationSession `Piped` path starts a process and passes through
         // whatever handles the service gave it, so an all-zero set can name a
         // process that is very much alive. Reaping is therefore conditional on
         // the kill being accepted, exactly as on every other teardown path — a
@@ -847,7 +847,7 @@ mod tests {
     /// This test previously asserted the opposite — that the all-null shape
     /// yielded a stream-less process carrying the waiter's exit code. That was
     /// the contract when no backend surfaced real pipes; it is now the signature
-    /// of a backend that has not implemented the `Library` path, and handing the
+    /// of a backend that has not implemented the `Piped` path, and handing the
     /// caller a `SandboxProcess` with no streams hides that behind an object
     /// that looks live. The exec is reaped on the way out, so refusing does not
     /// orphan it.
@@ -1216,7 +1216,7 @@ mod tests {
     ///
     /// The regression this pins: the backstop reaped unconditionally on the
     /// assumption that an all-null handle always means a finished process. It
-    /// does not — the IsolationSession `Library` path starts a process and
+    /// does not — the IsolationSession `Piped` path starts a process and
     /// passes through whatever handles the service returned, so an all-zero set
     /// can name a live one. With a refused kill and no deadline, reaping it
     /// hangs `from_exec_handle`, which the caller cannot interrupt because it

--- a/src/core/wxc_common/src/state_aware_backend.rs
+++ b/src/core/wxc_common/src/state_aware_backend.rs
@@ -72,18 +72,7 @@ pub struct DeprovisionResult<M> {
     pub metadata: Option<M>,
 }
 
-/// Who will consume an exec's streams — the state-aware counterpart to
-/// [`StdioMode`](crate::sandbox_process::StdioMode).
-///
-/// This is deliberately **not** `StdioMode`. That enum offers `Inherit`,
-/// meaning the OS hands the child the executor's own stdin/stdout/stderr. No
-/// state-aware backend can do that: the workload runs inside an isolation
-/// session, inside a VM, or behind an SDK callback, so its streams always have
-/// to be materialised on this side of the boundary and copied across. For this
-/// contract `Inherit` is not merely ambiguous, it is unimplementable.
-///
-/// What a state-aware backend needs to know is who is on the other end, because
-/// that decides the **topology** of the streams it returns:
+/// How an exec's streams are wired.
 ///
 /// * [`Relayed`](Self::Relayed) — the calling process relays onto its own
 ///   stdio. The backend may allocate a pseudo-console inside the sandbox when
@@ -100,9 +89,8 @@ pub struct DeprovisionResult<M> {
 ///   backend must return separate raw stdout and stderr pipes, allocate no
 ///   pseudo-console, and leave the host's console untouched.
 ///
-/// These distinguish who consumes the streams, not whether the caller is
-/// in-process: a console application hosting an interactive sandboxed shell is
-/// in-process and wants `Relayed`.
+/// Topology, not caller identity: a console application hosting an interactive
+/// sandboxed shell is in-process and wants `Relayed`.
 ///
 /// The value is **authoritative**. A backend that probes the host to shape stdio
 /// may consult that probe only under `Relayed`, where the probing process is
@@ -141,15 +129,10 @@ pub fn unsupported_piped_exec(backend: &str) -> MxcError {
 /// apart from "I could not find out what happened", which are different problems
 /// with different responses.
 ///
-/// # Which consumers can see `TimedOut`
+/// # Which topologies can observe `TimedOut`
 ///
-/// Only [`ExecStdio::Piped`]. The executor path has nowhere to put it:
-/// `ScriptResponse` carries an `exit_code` and no timeout field, so `wxc-exec`
-/// reports a timed-out workload as the exit code its killed process produced.
-/// A backend serving `ExecStdio::Relayed` therefore keeps returning
-/// [`Exited`](Self::Exited) exactly as before — giving the CLI a timeout channel
-/// is a change to its output contract, and belongs with that work rather than
-/// here.
+/// Only [`ExecStdio::Piped`]. A backend serving [`ExecStdio::Relayed`] reports
+/// [`Exited`](Self::Exited); the dispatcher rejects anything else.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExecOutcome {
     /// The process exited with this code.
@@ -177,16 +160,16 @@ pub enum ExecOutcome {
 }
 
 /// Streaming exec handle. The dispatcher relays `stdout` / `stderr` to the
-/// executor's own streams, awaits exit via `waiter`, and calls `terminator` to
-/// tear the exec down.
+/// calling process's own streams, awaits exit via `waiter`, and calls
+/// `terminator` to tear the exec down.
 ///
 /// # Handle ownership
 ///
 /// Ownership of `stdout` and `stderr` stays with the underlying process object:
 /// consumers duplicate them and never close the originals.
 ///
-/// `stdin` is **not consumed by the executor relay**, which forwards no input.
-/// The streaming path hands it to an in-process caller, which duplicates it
+/// `stdin` is **not consumed by the relay**, which forwards no input. Under
+/// [`ExecStdio::Piped`] it goes to the caller, which duplicates it
 /// rather than taking it. A pipe reaches EOF only once *every* write handle is
 /// closed, so dropping that duplicate is not enough — `stdin_closer` closes the
 /// backend's own end. A backend that exposes `stdin` must supply one.
@@ -282,9 +265,7 @@ pub trait StatefulSandboxBackend {
 
     /// Required. Executes the workload and returns a streaming handle.
     ///
-    /// `stdio` carries the **caller's** intent and is authoritative — see
-    /// [`ExecStdio`] for the full contract, including why this is not
-    /// [`StdioMode`](crate::sandbox_process::StdioMode) and what each variant
+    /// `stdio` is authoritative — see [`ExecStdio`] for what each variant
     /// implies for the topology of the returned streams.
     ///
     /// # Honored by one backend so far

--- a/src/core/wxc_common/src/state_aware_backend.rs
+++ b/src/core/wxc_common/src/state_aware_backend.rs
@@ -85,7 +85,7 @@ pub struct DeprovisionResult<M> {
 /// What a state-aware backend needs to know is who is on the other end, because
 /// that decides the **topology** of the streams it returns:
 ///
-/// * [`Executor`](Self::Executor) — the calling process relays onto its own
+/// * [`Relayed`](Self::Relayed) — the calling process relays onto its own
 ///   stdio. The backend may allocate a pseudo-console inside the sandbox when
 ///   that process is on a TTY; a pseudo-console has a single output stream, so
 ///   stderr is then merged into stdout and [`ExecHandle::stderr`] is null, which
@@ -96,27 +96,27 @@ pub struct DeprovisionResult<M> {
 ///   reading stdin would block forever. Return a null [`ExecHandle::stdin`]. A
 ///   backend that relays internally, as IsolationSession does through its
 ///   pseudo-console, forwards this process's stdin itself.
-/// * [`Library`](Self::Library) — the caller drives the streams itself. The
+/// * [`Piped`](Self::Piped) — the caller drives the streams itself. The
 ///   backend must return separate raw stdout and stderr pipes, allocate no
 ///   pseudo-console, and leave the host's console untouched.
 ///
 /// These distinguish who consumes the streams, not whether the caller is
 /// in-process: a console application hosting an interactive sandboxed shell is
-/// in-process and wants `Executor`.
+/// in-process and wants `Relayed`.
 ///
 /// The value is **authoritative**. A backend that probes the host to shape stdio
-/// may consult that probe only under `Executor`, where the probing process is
+/// may consult that probe only under `Relayed`, where the probing process is
 /// the relay target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ExecConsumer {
+pub enum ExecStdio {
     /// The calling process relays the streams to its own stdio.
-    Executor,
+    Relayed,
     /// The caller drives the returned streams itself.
-    Library,
+    Piped,
 }
 
 /// The error a backend returns when it is asked to serve
-/// [`ExecConsumer::Library`] and cannot.
+/// [`ExecStdio::Piped`] and cannot.
 ///
 /// Must be raised **before running anything**: the workload is arbitrary and may
 /// not be idempotent, so a later refusal has already caused the side effects the
@@ -124,7 +124,7 @@ pub enum ExecConsumer {
 ///
 /// Shared so the refusal reads identically whichever backend raises it, and so
 /// the check cannot drift into a per-backend spelling.
-pub fn unsupported_library_exec(backend: &str) -> MxcError {
+pub fn unsupported_piped_exec(backend: &str) -> MxcError {
     MxcError::backend_error(format!(
         "the {backend} backend cannot return exec streams to the caller: it relays the sandbox's \
          output to this process's own stdout and stderr rather than handing back pipes. Run the \
@@ -143,10 +143,10 @@ pub fn unsupported_library_exec(backend: &str) -> MxcError {
 ///
 /// # Which consumers can see `TimedOut`
 ///
-/// Only [`ExecConsumer::Library`]. The executor path has nowhere to put it:
+/// Only [`ExecStdio::Piped`]. The executor path has nowhere to put it:
 /// `ScriptResponse` carries an `exit_code` and no timeout field, so `wxc-exec`
 /// reports a timed-out workload as the exit code its killed process produced.
-/// A backend serving `ExecConsumer::Executor` therefore keeps returning
+/// A backend serving `ExecStdio::Relayed` therefore keeps returning
 /// [`Exited`](Self::Exited) exactly as before — giving the CLI a timeout channel
 /// is a change to its output contract, and belongs with that work rather than
 /// here.
@@ -282,8 +282,8 @@ pub trait StatefulSandboxBackend {
 
     /// Required. Executes the workload and returns a streaming handle.
     ///
-    /// `consumer` carries the **caller's** intent and is authoritative — see
-    /// [`ExecConsumer`] for the full contract, including why this is not
+    /// `stdio` carries the **caller's** intent and is authoritative — see
+    /// [`ExecStdio`] for the full contract, including why this is not
     /// [`StdioMode`](crate::sandbox_process::StdioMode) and what each variant
     /// implies for the topology of the returned streams.
     ///
@@ -293,24 +293,24 @@ pub trait StatefulSandboxBackend {
     /// through the streaming entry points. It is not yet a description of every
     /// backend's behaviour:
     ///
-    /// - **IsolationSession** honors both variants. Under `Library` it starts
+    /// - **IsolationSession** honors both variants. Under `Piped` it starts
     ///   the process without waiting, hands back its real pipe handles, a waiter
     ///   that blocks on exit and a terminator that kills, and does not touch the
-    ///   host console. Under `Executor` it relays internally and returns null
+    ///   host console. Under `Relayed` it relays internally and returns null
     ///   handles.
-    /// - **Windows Sandbox** and **WSLc** honor `Executor` only. They relay
-    ///   internally and return null handles; a `Library` request is refused
+    /// - **Windows Sandbox** and **WSLc** honor `Relayed` only. They relay
+    ///   internally and return null handles; a `Piped` request is refused
     ///   without running the workload.
     ///
     /// Reaching any of this from an in-process caller additionally requires the
     /// experimental opt-in, which the state-aware entry points expose as an
     /// `experimental` parameter.
     ///
-    /// # Backends that cannot serve `Library`
+    /// # Backends that cannot serve `Piped`
     ///
     /// A backend that relays the workload's output to the *host process's* own
-    /// stdio, rather than returning streams, must refuse [`ExecConsumer::Library`]
-    /// **before running anything** — see [`unsupported_library_exec`], which is
+    /// stdio, rather than returning streams, must refuse [`ExecStdio::Piped`]
+    /// **before running anything** — see [`unsupported_piped_exec`], which is
     /// the shared refusal. Returning a handle with no streams instead is a
     /// contract violation: by then the workload has run, so the refusal the
     /// caller eventually receives describes side effects that have already
@@ -320,7 +320,7 @@ pub trait StatefulSandboxBackend {
         sandbox_id: &str,
         request: &ExecutionRequest,
         config: Option<Self::ExecConfig>,
-        consumer: ExecConsumer,
+        stdio: ExecStdio,
     ) -> Result<ExecHandle, MxcError>;
 
     /// Optional. Default returns success with no metadata.
@@ -421,7 +421,7 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
-            _consumer: ExecConsumer,
+            _stdio: ExecStdio,
         ) -> Result<ExecHandle, MxcError> {
             Err(MxcError::backend_error("StubBackend::exec not implemented"))
         }
@@ -507,7 +507,7 @@ mod tests {
                 "stub:abcd1234",
                 &ExecutionRequest::default(),
                 None,
-                ExecConsumer::Executor,
+                ExecStdio::Relayed,
             )
             .unwrap_err();
         assert_eq!(err.code, MxcErrorCode::BackendError);

--- a/src/core/wxc_common/src/state_aware_dispatch.rs
+++ b/src/core/wxc_common/src/state_aware_dispatch.rs
@@ -28,7 +28,7 @@ use crate::id::parse_sandbox_id_prefix;
 use crate::models::ContainmentBackend;
 use crate::mxc_error::{MxcError, ResponseEnvelope};
 use crate::state_aware_backend::{
-    DeprovisionResult, ExecConsumer, ExecHandle, ExecOutcome, ProvisionResult, StartResult,
+    DeprovisionResult, ExecHandle, ExecOutcome, ExecStdio, ProvisionResult, StartResult,
     StatefulSandboxBackend, StopResult,
 };
 use crate::state_aware_request::{ParsedStateAwareRequest, Phase};
@@ -94,7 +94,7 @@ pub fn dispatch_state_aware_exec<B: StatefulSandboxBackend>(
     backend.validate_exec(&sandbox_id, &request, config.as_ref())?;
     // The caller drives the returned streams itself, so the backend must
     // surface real pipes and leave this process's console alone.
-    backend.exec(&sandbox_id, &request, config, ExecConsumer::Library)
+    backend.exec(&sandbox_id, &request, config, ExecStdio::Piped)
 }
 
 /// Per-backend phase router. The `run_state_aware` arm for a participating
@@ -140,7 +140,7 @@ pub fn dispatch_state_aware<B: StatefulSandboxBackend>(
             if dry_run {
                 return Ok(DispatchOutcome::Envelope(empty_result_envelope()));
             }
-            let handle = backend.exec(&sandbox_id, &request, config, ExecConsumer::Executor)?;
+            let handle = backend.exec(&sandbox_id, &request, config, ExecStdio::Relayed)?;
             let exit_code = relay_exec_to_stdio(handle)?;
             Ok(DispatchOutcome::ExecCompleted { exit_code })
         }
@@ -216,7 +216,7 @@ fn backend_from_prefix(prefix: &str) -> Result<ContainmentBackend, MxcError> {
 ///   documents both hazards and solves them with
 ///   `create_relay_thread_with_stop`; the generic path will need an equivalent.
 ///
-///   Until that exists, a backend under [`ExecConsumer::Executor`] **must not
+///   Until that exists, a backend under [`ExecStdio::Relayed`] **must not
 ///   give the child a stdin pipe whose write end it keeps**. Nothing here writes
 ///   to that pipe and nothing can close it, so a workload that reads stdin
 ///   blocks forever -- and it does so while this function is inside `waiter()`,
@@ -329,13 +329,13 @@ fn relay_prepared_streams(
     // Drain what the child wrote before it exited. Bounded -- see `drain_pumps`.
     drain_pumps(pumps);
 
-    // A backend serving `ExecConsumer::Executor` reports `Exited`, so a timeout
+    // A backend serving `ExecStdio::Relayed` reports `Exited`, so a timeout
     // here is a contract violation.
     match outcome {
         Ok(ExecOutcome::Exited(code)) => Ok(code),
         Ok(ExecOutcome::TimedOut) => Err(MxcError::backend_error(
             "backend reported a timeout to the executor relay, which has no way \
-             to represent one; a backend serving ExecConsumer::Executor must \
+             to represent one; a backend serving ExecStdio::Relayed must \
              report ExecOutcome::Exited",
         )),
         Err(error) => Err(error),
@@ -601,11 +601,11 @@ mod tests {
         validate_exec_calls: Cell<u32>,
         validate_stop_calls: Cell<u32>,
         validate_deprovision_calls: Cell<u32>,
-        /// The [`ExecConsumer`] the dispatcher passed to the most recent
+        /// The [`ExecStdio`] the dispatcher passed to the most recent
         /// `exec`. Recorded so the caller-intent split can be asserted --
         /// swapping the two would otherwise compile and silently change
         /// behaviour on both paths.
-        last_exec_consumer: Cell<Option<ExecConsumer>>,
+        last_exec_stdio: Cell<Option<ExecStdio>>,
         provision_error: Option<MxcError>,
         validate_provision_error: Option<MxcError>,
     }
@@ -623,7 +623,7 @@ mod tests {
                 validate_exec_calls: Cell::new(0),
                 validate_stop_calls: Cell::new(0),
                 validate_deprovision_calls: Cell::new(0),
-                last_exec_consumer: Cell::new(None),
+                last_exec_stdio: Cell::new(None),
                 provision_error: None,
                 validate_provision_error: None,
             }
@@ -671,10 +671,10 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
-            consumer: ExecConsumer,
+            stdio: ExecStdio,
         ) -> Result<ExecHandle, MxcError> {
             self.exec_calls.set(self.exec_calls.get() + 1);
-            self.last_exec_consumer.set(Some(consumer));
+            self.last_exec_stdio.set(Some(stdio));
             Err(MxcError::backend_error("stub exec not wired"))
         }
         fn stop(
@@ -789,7 +789,7 @@ mod tests {
             _sandbox_id: &str,
             _request: &ExecutionRequest,
             _config: Option<()>,
-            _consumer: ExecConsumer,
+            _stdio: ExecStdio,
         ) -> Result<ExecHandle, MxcError> {
             Err(MxcError::backend_error("typed stub exec not wired"))
         }
@@ -1174,13 +1174,13 @@ mod tests {
     /// The executor path relays the handle to its own stdio, so the backend is
     /// told a human is on the other end and a pseudo-console is legitimate.
     #[test]
-    fn executor_dispatch_passes_executor_consumer_to_exec() {
+    fn dispatch_state_aware_asks_for_relayed_stdio() {
         let mut b = StubBackend::new();
         let _ = dispatch_state_aware(&mut b, parsed_runnable_exec("stubd:abc"), false);
         assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
         assert_eq!(
-            b.last_exec_consumer.get(),
-            Some(ExecConsumer::Executor),
+            b.last_exec_stdio.get(),
+            Some(ExecStdio::Relayed),
             "the executor path must not ask a backend for caller-owned pipes"
         );
     }
@@ -1188,13 +1188,13 @@ mod tests {
     /// The streaming path hands the caller the streams, so the backend must be
     /// told to surface separate raw pipes and leave the host console alone.
     #[test]
-    fn streaming_dispatch_passes_library_consumer_to_exec() {
+    fn dispatch_state_aware_exec_asks_for_piped_stdio() {
         let mut b = StubBackend::new();
         let _ = dispatch_state_aware_exec(&mut b, parsed_runnable_exec("stubd:abc"));
         assert_eq!(b.exec_calls.get(), 1, "exec should have been reached");
         assert_eq!(
-            b.last_exec_consumer.get(),
-            Some(ExecConsumer::Library),
+            b.last_exec_stdio.get(),
+            Some(ExecStdio::Piped),
             "the streaming path must never let a backend touch the caller's console"
         );
     }
@@ -1238,7 +1238,7 @@ mod tests {
     /// contract, and the relay says so rather than inventing an exit code.
     ///
     /// `ExecOutcome::TimedOut` is unreachable here by construction — a backend
-    /// serving `ExecConsumer::Executor` has run the workload to completion
+    /// serving `ExecStdio::Relayed` has run the workload to completion
     /// before returning, and `ScriptResponse` has no timeout field to carry one
     /// anyway. The regression this pins is the tempting alternative: mapping it
     /// to some sentinel code, which the CLI would then report as the workload's
@@ -1256,7 +1256,7 @@ mod tests {
         let err =
             relay_exec_to_stdio(handle).expect_err("the executor relay cannot represent a timeout");
         assert!(
-            err.message.contains("ExecConsumer::Executor"),
+            err.message.contains("ExecStdio::Relayed"),
             "the refusal should name the contract it is enforcing: {}",
             err.message
         );

--- a/src/core/wxc_common/src/state_aware_dispatch.rs
+++ b/src/core/wxc_common/src/state_aware_dispatch.rs
@@ -67,8 +67,8 @@ pub fn run_state_aware(
 
 /// Streaming counterpart of the exec phase of [`dispatch_state_aware`]: run the
 /// exec phase up to (and including) [`StatefulSandboxBackend::exec`] and return
-/// the resulting [`ExecHandle`] to the caller **without** relaying it to the
-/// executor's stdio.
+/// the resulting [`ExecHandle`] to the caller **without** relaying it to
+/// this process's stdio.
 ///
 /// This is what lets the library / FFI streaming path drive an exec live —
 /// wrapping the returned handle in a [`SandboxProcess`](crate::sandbox_process::SandboxProcess)
@@ -196,7 +196,7 @@ fn backend_from_prefix(prefix: &str) -> Result<ContainmentBackend, MxcError> {
     }
 }
 
-/// Streams the running process's pipes to executor stdio and waits for exit.
+/// Streams the running process's pipes to this process's stdio and waits for exit.
 ///
 /// Relay threads start **before** the waiter runs: a child that fills its
 /// stdout pipe buffer would otherwise block forever, since nothing would be
@@ -334,7 +334,7 @@ fn relay_prepared_streams(
     match outcome {
         Ok(ExecOutcome::Exited(code)) => Ok(code),
         Ok(ExecOutcome::TimedOut) => Err(MxcError::backend_error(
-            "backend reported a timeout to the executor relay, which has no way \
+            "backend reported a timeout to the relay, which has no way \
              to represent one; a backend serving ExecStdio::Relayed must \
              report ExecOutcome::Exited",
         )),
@@ -602,9 +602,8 @@ mod tests {
         validate_stop_calls: Cell<u32>,
         validate_deprovision_calls: Cell<u32>,
         /// The [`ExecStdio`] the dispatcher passed to the most recent
-        /// `exec`. Recorded so the caller-intent split can be asserted --
-        /// swapping the two would otherwise compile and silently change
-        /// behaviour on both paths.
+        /// `exec`. Swapping the two variants would compile and silently
+        /// change behaviour on both paths.
         last_exec_stdio: Cell<Option<ExecStdio>>,
         provision_error: Option<MxcError>,
         validate_provision_error: Option<MxcError>,
@@ -1164,15 +1163,16 @@ mod tests {
         assert_eq!(err.code, MxcErrorCode::MalformedId);
     }
 
-    // ===== caller-intent split =============================================
+    // ===== stdio topology per entry point ===================================
     //
-    // Which mode each entry point sends is the whole point of the parameter,
-    // and getting it backwards would compile: the executor would lose its
-    // interactive console, and an embedded caller would have its own console
-    // written to by a sandbox. Both directions are pinned.
+    // Which topology each entry point sends is the whole point of the parameter,
+    // and getting it backwards would compile: a relayed exec would lose its
+    // console, and a piped caller would have its own console written to by a
+    // sandbox. Both directions are pinned.
 
-    /// The executor path relays the handle to its own stdio, so the backend is
-    /// told a human is on the other end and a pseudo-console is legitimate.
+    /// The relayed path relays the handle to this process's stdio, so the backend
+    /// may probe this process's terminal state to decide whether to allocate a
+    /// pseudo-console.
     #[test]
     fn dispatch_state_aware_asks_for_relayed_stdio() {
         let mut b = StubBackend::new();
@@ -1181,7 +1181,7 @@ mod tests {
         assert_eq!(
             b.last_exec_stdio.get(),
             Some(ExecStdio::Relayed),
-            "the executor path must not ask a backend for caller-owned pipes"
+            "the relayed path must not ask a backend for caller-owned pipes"
         );
     }
 
@@ -1234,13 +1234,10 @@ mod tests {
         assert_eq!(relay_exec_to_stdio(handle).unwrap(), 42);
     }
 
-    /// A backend that reports a timeout to the executor relay has broken the
+    /// A backend that reports a timeout to the relay has broken the
     /// contract, and the relay says so rather than inventing an exit code.
     ///
-    /// `ExecOutcome::TimedOut` is unreachable here by construction — a backend
-    /// serving `ExecStdio::Relayed` has run the workload to completion
-    /// before returning, and `ScriptResponse` has no timeout field to carry one
-    /// anyway. The regression this pins is the tempting alternative: mapping it
+    /// The regression this pins is the tempting alternative: mapping it
     /// to some sentinel code, which the CLI would then report as the workload's
     /// own exit status.
     #[test]
@@ -1253,8 +1250,7 @@ mod tests {
             waiter: Box::new(|| Ok(ExecOutcome::TimedOut)),
             terminator: Box::new(|| Ok(())),
         };
-        let err =
-            relay_exec_to_stdio(handle).expect_err("the executor relay cannot represent a timeout");
+        let err = relay_exec_to_stdio(handle).expect_err("the relay cannot represent a timeout");
         assert!(
             err.message.contains("ExecStdio::Relayed"),
             "the refusal should name the contract it is enforcing: {}",


### PR DESCRIPTION
## 📖 Description

`ExecConsumer::{Executor, Library}` named the caller a state-aware backend was expected to have. What a backend needs to know is the stdio topology, so the type, its variants and its parameter now say that:

| Was | Now |
|---|---|
| `ExecConsumer` | `ExecStdio` |
| `ExecConsumer::Executor` | `ExecStdio::Relayed` |
| `ExecConsumer::Library` | `ExecStdio::Piped` |
| parameter `consumer` | `stdio` |
| `unsupported_library_exec` | `unsupported_piped_exec` |

Six test names carrying the old vocabulary are renamed with it, and prose that named the old variants now names the topology.

Two doc justifications are deleted rather than reworded:

- `ExecStdio`'s "this is deliberately not `StdioMode`" paragraph argued that no state-aware backend can implement `Inherit`, because such a backend's streams must be materialised on this side of the boundary and copied. WSLc's `SandboxBackend` impl does exactly that copying and implements `Inherit`, so the argument does not hold. The type now documents what it selects.
- `ExecOutcome`'s `TimedOut` block justified the restriction with the CLI's `ScriptResponse` shape. That is narrower than the rule it defended, since the dispatcher refuses a `TimedOut` from any relayed caller. It now states the rule.

Two test comments lose claims the topology does not make: that a relayed exec proves a human is on the other end, and that a relayed backend has necessarily finished the workload before returning.

One user-visible diagnostic changes wording deliberately: the timeout refusal in `state_aware_dispatch` said "the executor relay", which names the retired variant, and now says "the relay". Its `MxcError` code is unchanged and no caller branches on the message.

"Executor" is left where it means the `wxc-exec` binary, and "library consumer" where it means an SDK consumer; neither is stranded by the rename.

No behaviour change: every changed code line is an identifier substitution, a rustfmt reflow from the new spelling, a test rename, or an assertion string.

## 🔗 References

Resolves #1094

## 🔍 Validation

Local CI-equivalent checks, all green: formatting, clippy, build and test with `isolation_session` both on and off, the arm64 cross-build, the versioning and codegen gates, the C# SDK build and tests, and the Node SDK unit, pack and integration suites.

Isolation-session end-to-end suites on a Windows test VM: 247 passed, 0 failed, 2 skipped, with no leaked agent accounts.

Interactive terminal scenarios run manually at the VM console: all passed.

`cargo doc --no-deps` compared against the merge base introduces no new diagnostics.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)

## 📋 Issue Type

- [x] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1095)