### PR TITLE
Migrate development requests to version-specific parsers

### DIFF
--- a/.github/workflows/hyperlight-e2e.yml
+++ b/.github/workflows/hyperlight-e2e.yml
@@ -87,7 +87,7 @@ jobs:
         shell: pwsh
         run: |
           $binDir = Join-Path $env:GITHUB_WORKSPACE "src\target\x86_64-pc-windows-msvc\debug"
-          $json = '{"process":{"commandLine":"print(\"snapshot warm\")"},"containment":"hyperlight"}'
+          $json = '{"version":"0.9.0-alpha","process":{"commandLine":"print(\"snapshot warm\")"},"containment":"hyperlight"}'
           $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($json))
           & "$binDir\wxc-exec.exe" --experimental --config-base64 $b64 2>&1
           if ($LASTEXITCODE -ne 0) {

--- a/docs/isolation-session/oneshot.md
+++ b/docs/isolation-session/oneshot.md
@@ -121,7 +121,7 @@ invocations, without changing the manager's interface. See
 
 ```json
 {
-    "version": "0.6.0-alpha",
+    "version": "0.9.0-alpha",
     "containerId": "MyIsolationSessionRun",
     "containment": "isolation_session",
     "process": {
@@ -387,7 +387,7 @@ wxc-exec.exe --experimental hello.json
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "Hello",
   "containment": "isolation_session",
   "process": {

--- a/docs/isolation-session/state-aware-typescript.md
+++ b/docs/isolation-session/state-aware-typescript.md
@@ -45,7 +45,7 @@ contract (including fields not yet exposed via the SDK).
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `version` | string | SDK `SUPPORTED_VERSION` | Schema-version override. |
+| `version` | `0.9.0-alpha` | `0.9.0-alpha` | Optional explicit declaration of the registered state-aware contract; other values are rejected by the SDK. |
 | `network` | `{ defaultPolicy: 'allow'; allowLocalNetwork: true }` | — (**required**) | Unrestricted-network acknowledgment. The container runs on a network MXC cannot filter or deny (outbound open; a process inside can listen on a port reachable from outside via localhost), so the caller must explicitly acknowledge it. This exact value is the only one accepted; any other network policy (or omission) is rejected at provision, and `network` is not accepted on the post-provision phases (the posture is fixed at provision). |
 | `appId` | string | absent | Optional identifier for the calling application, associating the provisioned agent user with its owning app. **A packaged application must supply its Package Family Name in the form `PFN:<packageFamilyName>`** (for example `PFN:Contoso.App_8wekyb3d8bbwe`). An unpackaged application may pass any string. Carried inside the `sandboxId` so later lifecycle phases can recover it without the caller re-supplying it. Validated structurally only (no control characters, at most 256 characters); rejections surface as `MxcError` with `code: 'policy_validation'`. Whitespace and case are preserved exactly, and an explicitly supplied empty string is a **distinct** value from omitting the field. Provision-phase only — it is fixed for the sandbox's lifetime, and the `IsolationSessionStartConfig` type rejects it at compile time. |
 
@@ -68,7 +68,7 @@ in the SDK parses past the `iso:` prefix.
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `version` | string | SDK `SUPPORTED_VERSION` | Schema-version override. |
+| `version` | `0.9.0-alpha` | `0.9.0-alpha` | Optional explicit declaration of the registered state-aware contract; other values are rejected by the SDK. |
 
 **Metadata:** none.
 
@@ -78,7 +78,7 @@ in the SDK parses past the `iso:` prefix.
 
 | Field | Type | Description |
 |---|---|---|
-| `version` | string | Schema-version override. |
+| `version` | `0.9.0-alpha` | Optional explicit declaration of the registered state-aware contract; other values are rejected by the SDK. |
 | `process` | `ProcessConfig` (required) | Cross-cutting process info — `commandLine`, `cwd`, `env`, `timeout`. |
 
 **Metadata:** n/a — exec returns an exit code and streamed stdio, not a structured result.

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,7 +4,7 @@
 MXC uses a JSON configuration file. The current stable schema is at
 [`schemas/stable/mxc-config.schema.0.8.0-alpha.json`](../schemas/stable/mxc-config.schema.0.8.0-alpha.json).
 For development, the dev schema at
-[`schemas/dev/mxc-config.schema.0.9.0-dev.json`](../schemas/dev/mxc-config.schema.0.9.0-dev.json)
+[`schemas/dev/mxc-config.schema.0.9.0-alpha.json`](../schemas/dev/mxc-config.schema.0.9.0-alpha.json)
 includes experimental features and may change without notice.
 
 Editors that support JSON Schema will provide autocomplete and validation when
@@ -16,7 +16,7 @@ production configs and the dev schema when working on experimental features:
 "$schema": "./schemas/stable/mxc-config.schema.0.8.0-alpha.json"
 
 // Development (experimental features)
-"$schema": "./schemas/dev/mxc-config.schema.0.9.0-dev.json"
+"$schema": "./schemas/dev/mxc-config.schema.0.9.0-alpha.json"
 ```
 
 ### Schema 0.8 networking
@@ -374,21 +374,21 @@ a config that also carries an unrelated backend's section is **rejected** with a
 
 ### State-aware lifecycle envelope
 
-The dev schema additionally documents a multi-phase envelope shape for the
+The exact development schema documents a multi-phase envelope shape for the
 state-aware lifecycle (`provision` / `start` / `exec` / `stop` /
 `deprovision`). Where the one-shot config above is a self-contained
 `ExecutionRequest` to run once, a state-aware envelope identifies which
 phase is being driven against an existing provisioned sandbox.
 
-The envelope follows the same supported version range as one-shot requests:
-`>=0.6, <=0.9`. The example uses `0.6.0-alpha`, which is accepted throughout
-that range. The state-aware field shape is documented by the current dev
-schema:
+State-aware envelopes currently require the exact `0.9.0-alpha` development
+contract. The published `0.6.0-alpha`, `0.7.0-alpha`, and `0.8.0-alpha`
+contracts contain only one-shot request roots. The state-aware field shape is
+documented by the exact development schema:
 
 ```json
 {
-    "$schema": "./schemas/dev/mxc-config.schema.0.9.0-dev.json",
-    "version": "0.6.0-alpha",
+    "$schema": "./schemas/dev/mxc-config.schema.0.9.0-alpha.json",
+    "version": "0.9.0-alpha",
     "phase": "exec",                       // One of: provision | start | exec | stop | deprovision
     "sandboxId": "wsb:abcd1234",           // Required for non-provision phases.
                                            // Prefix routes to the backend (wsb: -> windows_sandbox,

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api-overview.md
@@ -304,7 +304,7 @@ const { sandboxId } = await provisionSandbox(
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containment": "isolation_session",
   "phase": "provision",
   "network": { "defaultPolicy": "allow", "allowLocalNetwork": true }
@@ -348,7 +348,7 @@ const r = await execInSandboxAsync(
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "exec",
   "sandboxId": "iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0",
   "process": { "commandLine": "echo hello" }

--- a/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
+++ b/docs/state-aware-lifecycle/mxc-state-aware-sandbox-api.md
@@ -254,6 +254,8 @@ directly on the per-(backend, phase) Configs introduced below.
 ### 6.1 Type definitions
 
 ```typescript
+import type { StateAwareSchemaVersion } from '@microsoft/mxc-sdk';
+
 type SandboxId<C extends StateAwareContainmentBackend> =
   string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
 
@@ -277,7 +279,7 @@ type StateAwareContainmentBackend = Extract<ContainmentBackend, 'isolation_sessi
 // example in §7.4 and the config-typing example in §10.2.
 
 interface IsolationSessionProvisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   // IsolationSession cannot filter or deny the container network, so provision
   // requires the canonical unrestricted-network acknowledgment — the only accepted
   // value. filesystem policy is rejected by this backend (§10.3).
@@ -285,20 +287,20 @@ interface IsolationSessionProvisionConfig {
 }
 
 interface IsolationSessionStartConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 interface IsolationSessionExecConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   process: ProcessConfig;
 }
 
 interface IsolationSessionStopConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 interface IsolationSessionDeprovisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 interface IsolationSessionProvisionMetadata {
@@ -312,25 +314,25 @@ interface IsolationSessionProvisionMetadata {
 // provision and is immutable thereafter (see §10.3).
 
 interface WindowsSandboxProvisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   filesystem?: FilesystemConfig;
 }
 
 interface WindowsSandboxStartConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 interface WindowsSandboxExecConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   process: ProcessConfig;
 }
 
 interface WindowsSandboxStopConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 interface WindowsSandboxDeprovisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
 }
 
 // WindowsSandbox returns no metadata for any phase.
@@ -433,11 +435,12 @@ Phases with no backend-specific or cross-cutting fields declare a Config carryin
 change: extend `StateAwareContainmentBackend`, define five new `*Config` interfaces, and
 add an arm to `ConfigsForBackend`.
 
-Each Config carries an optional `version?: string`. When omitted, the SDK fills in its
-own `SUPPORTED_VERSION`; an explicit value is range-validated against the SDK's
-`MIN_VERSION` and `SUPPORTED_VERSION` (same convention as today's
-`validatePolicyVersion`). The override exists so consumers can target a specific wire
-version when debugging or testing version negotiation.
+Each Config carries an optional `version?: StateAwareSchemaVersion`, using the
+existing SDK type for the exact state-aware contract, currently `0.9.0-alpha`.
+When omitted, the SDK supplies `STATE_AWARE_VERSION` (`0.9.0-alpha`); an explicit
+value must name that same registered state-aware contract. Other spellings are
+rejected, not range-validated or negotiated. The emitted JSON envelope always
+contains the required `version` declaration.
 
 ### 6.2 Method signatures
 
@@ -601,7 +604,7 @@ single call — `phase` fully discriminates which interpretation applies.
 ```typescript
 interface OneShotRequest {
   phase?: never;                                  // discriminator: absent
-  version?: string;
+  version: string;
   containment: ContainmentType | ContainmentBackend;
   containerId?: string;
   process: ProcessConfig;
@@ -616,7 +619,7 @@ interface OneShotRequest {
 
 interface ProvisionStateAwareRequest {
   phase: 'provision';                             // discriminator
-  version?: string;
+  version: StateAwareSchemaVersion;
   containment: StateAwareContainmentBackend;
   filesystem?: FilesystemConfig;                  // backend declares per-phase honor
   network?: NetworkConfig;                        // backend declares per-phase honor
@@ -626,7 +629,7 @@ interface ProvisionStateAwareRequest {
 
 interface NonProvisionStateAwareRequest {
   phase: 'start' | 'exec' | 'stop' | 'deprovision';  // discriminator
-  version?: string;
+  version: StateAwareSchemaVersion;
   sandboxId: SandboxId<StateAwareContainmentBackend>;  // backend resolved from prefix
   process?: ProcessConfig;                            // exec only
   filesystem?: FilesystemConfig;                      // backend declares per-phase honor
@@ -648,7 +651,7 @@ Top-level fields shared by both branches:
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `version` | string | No | Schema version (semver). |
+| `version` | string | Yes | Exact registered schema version; state-aware requests declare `0.9.0-alpha`. The SDK fills this field when the consumer Config omits it. |
 | `experimental` | object | No | Backend-specific config block. Shape depends on `phase` (§7.2). |
 
 Backend-routing fields:
@@ -850,7 +853,7 @@ const { sandboxId } = await provisionSandbox(
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containment": "isolation_session",
   "phase": "provision",
   "network": { "defaultPolicy": "allow", "allowLocalNetwork": true }
@@ -893,7 +896,7 @@ await startSandbox(
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "start",
   "sandboxId": "iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0"
 }
@@ -928,7 +931,7 @@ const r = await execInSandboxAsync(
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "exec",
   "sandboxId": "iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0",
   "process": { "commandLine": "echo hello", "timeout": 5000 }
@@ -959,7 +962,7 @@ await stopSandbox(sandboxId, {}, { experimental: true });
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "stop",
   "sandboxId": "iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0"
 }
@@ -982,7 +985,7 @@ await deprovisionSandbox(sandboxId, {}, { experimental: true });
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "deprovision",
   "sandboxId": "iso:eyJ2ZXJzaW9uIjoxLCJhZ2VudFVzZXJOYW1lIjoiX2lzb19hYmNfMTIzIn0"
 }
@@ -1661,7 +1664,7 @@ with serde renames to camelCase and represent the wire-shape sub-portion that li
 under `experimental.<BACKEND_KEY>.<phase>` — backend-specific fields only. The
 TypeScript type exported from the SDK package is the consumer-facing per-(backend,
 phase) Config from §6.1; it is a strict superset of the wire shape, adding
-`version?` (for explicit version overrides) and the cross-cutting `filesystem` /
+`version?` (for an optional exact schema declaration) and the cross-cutting `filesystem` /
 `network` / `ui` fields in phases where the backend's policy honor matrix marks them
 as `applied` (§10.3).
 
@@ -1675,7 +1678,7 @@ pub struct IsolationSessionProvisionConfig {
 
 ```typescript
 interface IsolationSessionProvisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   appId?: string;
   network: { defaultPolicy: 'allow'; allowLocalNetwork: true };
 }
@@ -1807,12 +1810,12 @@ carrying only `version?`. Example shape (mirroring §6.1):
 
 ```typescript
 interface MyBackendProvisionConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   // cross-cutting fields for phases where MyBackend's matrix marks `applied`
 }
 
 interface MyBackendStartConfig {
-  version?: string;
+  version?: StateAwareSchemaVersion;
   // backend-specific start fields
 }
 
@@ -1986,7 +1989,7 @@ calls (and the executor stops gating them behind `--experimental`). For example,
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "provision",
   "containment": "isolation_session",
   "network": { "defaultPolicy": "allow", "allowLocalNetwork": true },
@@ -1998,11 +2001,15 @@ calls (and the executor stops gating them behind `--experimental`). For example,
 }
 ```
 
-to this shape after the backend's state-aware path graduates:
+to a shape like the following after the backend's state-aware path graduates.
+This is a hypothetical, non-runnable example: `<future-graduated-version>` is
+a placeholder for a future registered contract that defines this placement,
+not an existing published version. The policy vocabulary must also match that
+future contract.
 
 ```json
 {
-  "version": "0.7.0-alpha",
+  "version": "<future-graduated-version>",
   "phase": "provision",
   "containment": "isolation_session",
   "network": { "defaultPolicy": "allow", "allowLocalNetwork": true },

--- a/docs/version-specific-parser-migration-inventory.md
+++ b/docs/version-specific-parser-migration-inventory.md
@@ -1,0 +1,181 @@
+# Version-specific parser migration inventory
+
+Generated from commit `2d4b094b32feedbf00afd55d875a8fa9e3a0bb6f`
+on 2026-09-03. The inventory covers every JSON document named by the
+differential harness's `expected_corpus_divergences` table before migration.
+The post-migration corpus baseline was refreshed at commit
+`6cc6830aa01bcf45f24f1c88e108d420fedacf98` on 2026-09-11 after rebasing
+over newer configuration fixtures, primarily the Seatbelt validation corpus
+from #1125. The rebase added 73 JSON documents and removed one, producing 67
+additional equivalent accepts and five additional shared rejections without
+changing the seven classified exact-stricter results.
+
+## Summary
+
+| Classification | Documents | Migration |
+| --- | ---: | --- |
+| Missing version | 55 | Declare `0.9.0-alpha` |
+| Development containment under published version | 45 | Declare `0.9.0-alpha` |
+| Experimental content under published version | 2 | Declare `0.9.0-alpha` |
+| State-aware request under published version | 21 | Declare `0.9.0-alpha` |
+| Published comment rejected first | 2 | Declare `0.9.0-alpha` |
+| **Total** | **125** | |
+
+All migrated documents target the mutable exact development contract because every document is state-aware, uses a development-only containment or experimental field, or is the telemetry example whose closed shape is defined on the development line. Existing `$schema` references are updated when present; no new schema reference is added.
+
+Three versionless files under `tests/policy` are intentionally absent from this inventory: `request-directional-network.json`, `request-process-container.json`, and `request-wslc.json` are policy-builder inputs rather than complete request documents, and both parsers already reject them in the nine-document shared-rejection set.
+
+## Residual parser differences after migration
+
+Version migration removes 118 of the 125 recorded divergences. Seven remain
+because the rolling and exact parsers intentionally enforce different
+boundaries:
+
+- `isolation_session_configid_ignored.json` and
+  `isolation_session_one_shot_stray_config_ignored.json` exercise the rolling
+  parser's historical parse-and-ignore behavior for a one-shot experimental
+  IsolationSession object. The closed 0.9 contract rejects that object.
+- Four IsolationSession provision rejection fixtures carry filesystem, UI, or
+  a non-canonical network posture. The rolling parser defers those policies to
+  backend validation; the request-specific 0.9 root rejects them structurally
+  or through its exact marker value.
+- `wslc_state_aware_exec_rejected_filesystem.json` exercises immutable
+  post-provision policy validation. The rolling parser defers the filesystem
+  policy to normalization/backend validation; the 0.9 exec root excludes it.
+
+Rewriting these documents to make both parsers accept would remove the invalid
+policy each fixture exists to test. This inventory therefore records the seven
+exact-stricter results explicitly rather than weakening the exact contract or
+changing backend-test intent. The post-migration corpus result is 333
+equivalent accepts, 14 shared rejections, seven classified exact-stricter
+rejections, no exact-looser acceptance, and no accepted-model mismatch.
+
+## Documents
+
+| Path | Request kind | Classification | Current version | Target version | Existing schema reference | Owner |
+| --- | --- | --- | --- | --- | --- | --- |
+| `tests/configs/basic_windows_sandbox.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/experimental_hello_lxc.json` | one-shot | PublishedExperimental | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/experimental_hello_processcontainer.json` | one-shot | PublishedExperimental | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_exit_code.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_fs.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_hello.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_networking.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_networking_blocked.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_pandas.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/hyperlight_timeout.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_concurrent_A.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_concurrent_B.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_concurrent_C.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_concurrent_D.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_configid_ignored.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_exit42.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_hello.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_lifecycle_rejected.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_network_rejected.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_network_rejected_hosts.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_network_rejected_no_local.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_stray_config_ignored.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_one_shot_ui_rejected.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_powershell_interactive.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_deprovision.json` | state-aware deprovision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_basic.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_cwd.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_env_absent.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_env_initial.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_env_modified.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_exit_0.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_exit_1.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_exit_2.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_read_marker.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_read_persist.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_setx_initial.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_setx_modified.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_exec_write_marker.json` | state-aware exec | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_appid.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_appid_control.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_appid_empty.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_appid_too_long.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_rejected_denied.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_rejected_network.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_rejected_ui.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_provision_with_filesystem.json` | state-aware provision | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_start.json` | state-aware start | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_state_aware_stop.json` | state-aware stop | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_stderr.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_stdout_stderr_interleaved.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_streaming_smoke.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/isolation_session_timeout.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_error.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_error_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_exit_code.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_exit_code_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_hello.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_hello_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_large_output.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_large_output_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_multiline.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_multiline_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_network.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_network_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_stdlib.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_stdlib_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_timeout.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/microvm_timeout_linux.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_custom_timeout.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_echo.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_exit_code.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_powershell.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_powershell_env.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_stderr.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/windows_sandbox_timeout.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_custom_registry.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_custom_registry_ghcr.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_custom_registry_quay.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_denied_dotdot_alias.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_denied_masking.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_destroy_on_exit_false_rejected.json` | one-shot | PublishedComment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_destroy_on_exit_true.json` | one-shot | PublishedComment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_env_vars.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_exit_code.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_filesystem.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_filesystem_object.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_large_output.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_most_specific_denied_parent.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_network_isolated.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_network_proxy.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_port_mapping_multiple.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_port_mapping_tcp.json` | one-shot | PublishedDevelopmentContainment | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_python_hello.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_python_stdlib.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_readonly_mount.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_deprovision.json` | state-aware deprovision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_basic.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_drip.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_env.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_exit_0.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_exit_1.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_exit_7.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_proxy.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_read_marker.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_rejected_filesystem.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_exec_write_marker.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision_bridged.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision_rejected_denied.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision_rejected_hosts.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision_rejected_proxy.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_provision_with_filesystem.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_start.json` | state-aware start | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_state_aware_stop.json` | state-aware stop | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_stderr.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_tar_import_docker_save.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_tar_import_rootfs.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/configs/wslc_timeout.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | backend/config test |
+| `tests/examples/09_windows_sandbox_hello_world.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | example |
+| `tests/examples/10_windows_sandbox_network_isolated.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | example |
+| `tests/examples/28_telemetry_enabled.json` | one-shot | MissingVersion | `(missing)` | `0.9.0-alpha` | `../../schemas/dev/mxc-config.schema.0.9.0-alpha.json` | example |
+| `tests/examples/wslc_hello_world.json` | one-shot | PublishedDevelopmentContainment | `0.6.0-alpha` | `0.9.0-alpha` | (none) | example |
+| `tests/policy/state-aware-wslc-exec.json` | state-aware exec | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | SDK/FFI policy fixture |
+| `tests/policy/state-aware-wslc-provision.json` | state-aware provision | PublishedStateAware | `0.8.0-alpha` | `0.9.0-alpha` | (none) | SDK/FFI policy fixture |

--- a/docs/windows-sandbox/windows-sandbox.md
+++ b/docs/windows-sandbox/windows-sandbox.md
@@ -97,7 +97,7 @@ There is no idle watchdog. A started state-aware sandbox remains active until
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "powershell -NoProfile -Command \"Write-Output 'hello'\"",
@@ -110,7 +110,7 @@ There is no idle watchdog. A started state-aware sandbox remains active until
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "provision",
   "containment": "windows_sandbox",
   "filesystem": {

--- a/docs/wsl/wsl-container-getting-started.md
+++ b/docs/wsl/wsl-container-getting-started.md
@@ -146,7 +146,7 @@ fields before spawning:
 import { createConfigFromPolicy, spawnSandboxFromConfig } from '@microsoft/mxc-sdk';
 
 const policy = {
-  version: '0.6.0-alpha',
+  version: '0.9.0-alpha',
   network: { allowOutbound: true },
 };
 
@@ -184,7 +184,7 @@ use mxc_sdk::{
 };
 
 let policy = SandboxPolicy {
-    version: "0.7.0-alpha".to_string(),
+    version: "0.9.0-alpha".to_string(),
     filesystem: None,
     network: None,
     ui: None,
@@ -332,7 +332,7 @@ address the container can reach:
 
 ```json
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containment": "wslc",
   "process": { "commandLine": "curl -fsSL https://example.com && echo OK" },
   "network": {

--- a/schemas/schema-version.json
+++ b/schemas/schema-version.json
@@ -2,8 +2,8 @@
   "$comment": "Canonical source of truth for MXC CONFIG SCHEMA versions. Separate from the PRODUCT version (src/Cargo.toml [workspace.package] and sdk/package.json), which tracks the binaries/npm package and is checked independently by check-version-sync.js. Fields: min = lowest schema version the parser/SDK accept; maxSupported = highest version they accept (the in-development 0.9 line; equals Rust CURRENT_SCHEMA_VERSION, the SUPPORTED_VERSION upper bound, and the SDK SUPPORTED_VERSION) \u2014 note this is NOT a released stable schema, it is the dev line; stableLatest = highest released immutable stable schema file; stateAware = shared state-aware default used by IsolationSession and Windows Sandbox; stateAwareWslc = WSLC's independently promoted state-aware default; devSchemaFile = filename suffix of the in-progress dev schema. Every matching constant in the Rust parser, the SDKs, and the schema filenames must agree with these values; check-schema-versions.js enforces it in CI. When you bump a schema version, change it HERE and run `node scripts/versioning/check-schema-versions.js` to find every place that must follow.",
   "min": "0.6.0-alpha",
   "maxSupported": "0.9.0-alpha",
-  "stateAware": "0.6.0-alpha",
-  "stateAwareWslc": "0.8.0-alpha",
+  "stateAware": "0.9.0-alpha",
+  "stateAwareWslc": "0.9.0-alpha",
   "stableLatest": "0.8.0-alpha",
   "devSchemaFile": "0.9.0-dev"
 }

--- a/scripts/versioning/check-schema-versions.js
+++ b/scripts/versioning/check-schema-versions.js
@@ -84,7 +84,7 @@ if (!supMatch) {
   }
 }
 
-// -- SDK (sdk/node/src/sandbox.ts, sdk/node/src/state-aware-helper.ts) --
+// -- SDK (sandbox.ts, state-aware-types.ts, state-aware-helper.ts) --
 const sandboxTs = read("sdk", "node", "src", "sandbox.ts");
 expectConst(
   "sandbox.ts",
@@ -100,9 +100,9 @@ expectConst(
   /const MIN_VERSION\s*=\s*'([^']+)'/,
   min
 );
-const stateAwareTs = read("sdk", "node", "src", "state-aware-helper.ts");
+const stateAwareTs = read("sdk", "node", "src", "state-aware-types.ts");
 expectConst(
-  "state-aware-helper.ts",
+  "state-aware-types.ts",
   stateAwareTs,
   "STATE_AWARE_VERSION",
   /const STATE_AWARE_VERSION\s*=\s*'([^']+)'/,
@@ -110,19 +110,11 @@ expectConst(
 );
 expectConst(
   "state-aware-helper.ts",
-  stateAwareTs,
+  read("sdk", "node", "src", "state-aware-helper.ts"),
   "WSLC_STATE_AWARE_VERSION",
   /const WSLC_STATE_AWARE_VERSION\s*=\s*'([^']+)'/,
   stateAwareWslc
 );
-expectConst(
-  "state-aware-helper.ts",
-  stateAwareTs,
-  "TELEMETRY_STATE_AWARE_VERSION",
-  /const TELEMETRY_STATE_AWARE_VERSION\s*=\s*'([^']+)'/,
-  maxSupported
-);
-
 // -- C# SDK (sdk/dotnet/Microsoft.Mxc.Sdk/SchemaVersions.cs) --
 const schemaVersionsCs = read(
   "sdk",

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
@@ -297,7 +297,7 @@ public class MxcLifecycleTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("0.6.0-alpha", root.GetProperty("version").GetString());
+        Assert.Equal("0.9.0-alpha", root.GetProperty("version").GetString());
         Assert.Equal("provision", root.GetProperty("phase").GetString());
         Assert.Equal("isolation_session", root.GetProperty("containment").GetString());
 
@@ -392,7 +392,7 @@ public class MxcLifecycleTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("0.6.0-alpha", root.GetProperty("version").GetString());
+        Assert.Equal("0.9.0-alpha", root.GetProperty("version").GetString());
         Assert.Equal("windows_sandbox", root.GetProperty("containment").GetString());
         Assert.Equal(
             @"C:\input",
@@ -401,7 +401,7 @@ public class MxcLifecycleTests
     }
 
     [Fact]
-    public void BuildProvisionEnvelope_WslcUsesV08AndNestsImageOptions()
+    public void BuildProvisionEnvelope_WslcUsesV09AndNestsImageOptions()
     {
         var json = MxcLifecycle
             .BuildProvisionEnvelope(
@@ -419,7 +419,7 @@ public class MxcLifecycleTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("0.8.0-alpha", root.GetProperty("version").GetString());
+        Assert.Equal("0.9.0-alpha", root.GetProperty("version").GetString());
         Assert.Equal("wslc", root.GetProperty("containment").GetString());
         Assert.Equal(
             "allow",
@@ -496,20 +496,19 @@ public class MxcLifecycleTests
     }
 
     [Fact]
-    public void BuildExecEnvelope_PreservesOlderVersionForNativeValidation()
+    public void BuildExecEnvelope_RejectsUnregisteredVersionWithInheritedEnvironment()
     {
-        var envelope = MxcLifecycle.BuildExecEnvelope(
-            new SandboxId("wslc:0123456789abcdef0123456789abcdef"),
-            "echo hi",
-            new WslcExecOptions
-            {
-                Version = "0.8.0-alpha",
-                InheritDefaultEnvironment = true,
-            });
+        var ex = Assert.Throws<ArgumentException>(
+            () => MxcLifecycle.BuildExecEnvelope(
+                new SandboxId("wslc:0123456789abcdef0123456789abcdef"),
+                "echo hi",
+                new WslcExecOptions
+                {
+                    Version = "0.8.0-alpha",
+                    InheritDefaultEnvironment = true,
+                }));
 
-        Assert.Equal("0.8.0-alpha", envelope["version"]!.GetValue<string>());
-        Assert.True(
-            envelope["process"]!["inheritDefaultEnv"]!.GetValue<bool>());
+        Assert.Contains("require schema version '0.9.0-alpha'", ex.Message);
     }
 
     [Fact]
@@ -533,7 +532,7 @@ public class MxcLifecycleTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("0.6.0-alpha", root.GetProperty("version").GetString());
+        Assert.Equal("0.9.0-alpha", root.GetProperty("version").GetString());
         Assert.Equal("start", root.GetProperty("phase").GetString());
         Assert.Equal("iso:abc", root.GetProperty("sandboxId").GetString());
         Assert.False(root.TryGetProperty("experimental", out _));
@@ -541,7 +540,7 @@ public class MxcLifecycleTests
     }
 
     [Fact]
-    public void IdPhases_InferBackendVersionAndHonorOverrides()
+    public void IdPhases_InferBackendVersionAndAcceptRegisteredExplicitVersion()
     {
         var wslcStart = MxcLifecycle.BuildStartEnvelope(
             new SandboxId("wslc:0123456789abcdef0123456789abcdef"));
@@ -550,9 +549,20 @@ public class MxcLifecycleTests
             new SandboxId("iso:abc"),
             new StateAwarePhaseOptions { Version = "0.9.0-alpha" });
 
-        Assert.Equal("0.8.0-alpha", wslcStart["version"]!.GetValue<string>());
-        Assert.Equal("0.6.0-alpha", wsbStop["version"]!.GetValue<string>());
+        Assert.Equal("0.9.0-alpha", wslcStart["version"]!.GetValue<string>());
+        Assert.Equal("0.9.0-alpha", wsbStop["version"]!.GetValue<string>());
         Assert.Equal("0.9.0-alpha", overridden["version"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void IdPhases_RejectUnregisteredVersionOverrides()
+    {
+        var options = new StateAwarePhaseOptions { Version = "0.8.0-alpha" };
+
+        var ex = Assert.Throws<ArgumentException>(
+            () => MxcLifecycle.BuildStopEnvelope(new SandboxId("iso:abc"), options));
+
+        Assert.Contains("require schema version '0.9.0-alpha'", ex.Message);
     }
 
     [Fact]
@@ -677,7 +687,7 @@ public class MxcLifecycleTests
     }
 
     [Fact]
-    public void BuildStartEnvelope_LeavesExplicitTelemetryVersionForNativeValidation()
+    public void BuildStartEnvelope_RejectsUnregisteredVersionWhenTelemetryIsPresent()
     {
         var options = new StateAwarePhaseOptions
         {
@@ -685,9 +695,10 @@ public class MxcLifecycleTests
             Telemetry = new TelemetrySettings { Enabled = false },
         };
 
-        var root = MxcLifecycle.BuildStartEnvelope(new SandboxId("iso:abc"), options);
-        Assert.Equal(SchemaVersions.LatestStable, root["version"]?.GetValue<string>());
-        Assert.False(root["telemetry"]?["enabled"]?.GetValue<bool>());
+        var ex = Assert.Throws<ArgumentException>(
+            () => MxcLifecycle.BuildStartEnvelope(new SandboxId("iso:abc"), options));
+
+        Assert.Contains("require schema version '0.9.0-alpha'", ex.Message);
     }
 
     [Fact]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -115,7 +115,7 @@ public class MxcSandboxTests
             "echo network");
 
         var wslc = new SandboxRequest(
-            new SandboxPolicy { Version = "0.8.0-alpha" },
+            new SandboxPolicy { Version = "0.9.0-alpha" },
             "printf parity")
         {
             Containment = new WslcContainment

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
@@ -101,7 +101,7 @@ public static class MxcLifecycle
         var backend = ContainmentKey(containment);
         var envelope = NewEnvelope(
             "provision",
-            options?.Version ?? DefaultVersion(containment));
+            ResolveVersion(containment, options?.Version));
         envelope["containment"] = backend;
 
         switch (options)
@@ -452,7 +452,7 @@ public static class MxcLifecycle
         var containment = ContainmentForId(id);
         var envelope = NewEnvelope(
             phase,
-            version ?? DefaultVersion(containment));
+            ResolveVersion(containment, version));
         envelope["sandboxId"] = id.Value;
         return envelope;
     }
@@ -495,6 +495,23 @@ public static class MxcLifecycle
         containment == StateAwareContainment.Wslc
             ? WslcStateAwareVersion
             : StateAwareVersion;
+
+    private static string ResolveVersion(
+        StateAwareContainment containment,
+        string? requestedVersion)
+    {
+        var expectedVersion = DefaultVersion(containment);
+        if (requestedVersion is not null
+            && !string.Equals(requestedVersion, expectedVersion, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"State-aware {containment} requests require schema version "
+                    + $"'{expectedVersion}', got '{requestedVersion}'.",
+                nameof(requestedVersion));
+        }
+
+        return expectedVersion;
+    }
 
     private static void ValidateProvisionOptions(
         StateAwareContainment containment,

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SchemaVersions.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SchemaVersions.cs
@@ -21,8 +21,8 @@ public static class SchemaVersions
     public const string LatestStable = "0.8.0-alpha";
 
     /// <summary>Default state-aware version for IsolationSession and Windows Sandbox.</summary>
-    public const string StateAware = "0.6.0-alpha";
+    public const string StateAware = "0.9.0-alpha";
 
     /// <summary>Default state-aware version for WSLC.</summary>
-    public const string WslcStateAware = "0.8.0-alpha";
+    public const string WslcStateAware = "0.9.0-alpha";
 }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/StateAwareTypes.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/StateAwareTypes.cs
@@ -69,7 +69,10 @@ public sealed class StateAwareFilesystemPolicy
 /// <summary>Base class for backend-specific provision options.</summary>
 public abstract class StateAwareProvisionOptions
 {
-    /// <summary>Overrides the backend's default state-aware schema version.</summary>
+    /// <summary>
+    /// Optional explicit state-aware schema version. It must equal the
+    /// registered version for the selected backend.
+    /// </summary>
     public string? Version { get; set; }
 
     /// <summary>
@@ -164,7 +167,10 @@ public sealed class ProvisionSandboxOptions : StateAwareProvisionOptions
 /// <summary>Options shared by start, stop, and deprovision phases.</summary>
 public class StateAwarePhaseOptions
 {
-    /// <summary>Overrides the schema version inferred from the sandbox id.</summary>
+    /// <summary>
+    /// Optional explicit state-aware schema version. It must equal the
+    /// registered version inferred from the sandbox id.
+    /// </summary>
     public string? Version { get; set; }
 
     /// <summary>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -258,7 +258,7 @@ resource, storage, GPU, and host-to-container TCP port settings:
 var request = new SandboxRequest(
     new SandboxPolicy
     {
-        Version = "0.8.0-alpha",
+        Version = "0.9.0-alpha",
         Network = new NetworkPolicy { AllowOutbound = true },
     },
     "python3 -c 'print(42)'")
@@ -701,12 +701,11 @@ var wslc = new WslcProvisionOptions
 };
 ```
 
-IsolationSession and Windows Sandbox default to schema `0.6.0-alpha`; WSLC
-defaults to `0.8.0-alpha`. Set `Version` on provision or phase options to
-override the inferred version. State-aware exec options expose working
-directory, `KEY=VALUE` environment entries, `InheritDefaultEnvironment`, and
-timeout. When `InheritDefaultEnvironment` is supplied without an explicit
-version, the SDK selects `0.9.0-alpha`; an explicitly older version is rejected.
+All state-aware backends use the exact development schema `0.9.0-alpha`.
+`Version` may be omitted or explicitly set to that registered value; the SDK
+rejects other values rather than emitting an envelope for an unregistered
+state-aware contract. State-aware exec options expose working directory,
+`KEY=VALUE` environment entries, `InheritDefaultEnvironment`, and timeout.
 WSLC also accepts a proxy-only per-exec override:
 
 ```csharp

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -60,11 +60,11 @@ child.on('close', (code) => console.log('exit:', code));
 | `0.6.0-alpha` | Stable (minimum supported) | [`schemas/stable/mxc-config.schema.0.6.0-alpha.json`](https://github.com/microsoft/mxc/blob/main/schemas/stable/mxc-config.schema.0.6.0-alpha.json) |
 | `0.7.0-alpha` | Stable | [`schemas/stable/mxc-config.schema.0.7.0-alpha.json`](https://github.com/microsoft/mxc/blob/main/schemas/stable/mxc-config.schema.0.7.0-alpha.json) |
 | `0.8.0-alpha` | Stable (current) | [`schemas/stable/mxc-config.schema.0.8.0-alpha.json`](https://github.com/microsoft/mxc/blob/main/schemas/stable/mxc-config.schema.0.8.0-alpha.json) |
-| `0.9.0-alpha` | Dev (experimental backends, the `experimental.*` block, state-aware sandbox lifecycle) | [`schemas/dev/mxc-config.schema.0.9.0-dev.json`](https://github.com/microsoft/mxc/blob/main/schemas/dev/mxc-config.schema.0.9.0-dev.json) |
+| `0.9.0-alpha` | Dev (experimental backends, the `experimental.*` block, state-aware sandbox lifecycle) | [`schemas/dev/mxc-config.schema.0.9.0-alpha.json`](https://github.com/microsoft/mxc/blob/main/schemas/dev/mxc-config.schema.0.9.0-alpha.json) |
 
 Pick `0.8.0-alpha` for new code on any supported platform.
 
-> **Stable schemas document only the non-experimental surface.** Experimental backends (`windows_sandbox`, `wslc`, `microvm`, `hyperlight`, `isolation_session`), the `experimental.*` block, and state-aware lifecycle live in `0.9.0-dev`. The parser still accepts them when paired with `--experimental` regardless of which schema your config validates against — schema choice affects editor validation, not runtime behavior.
+> **Stable schemas document only the non-experimental surface.** Experimental backends (`windows_sandbox`, `wslc`, `microvm`, `hyperlight`, `isolation_session`), the `experimental.*` block, and state-aware lifecycle are defined by the registered exact `0.9.0-alpha` development contract. State-aware SDK calls stamp and require that exact version. During Phase 8, production executor requests still run through the rolling `wxc_common::wire` parser, so some rolling-parser compatibility behavior remains until exact dispatch becomes authoritative; `--experimental` is still required to activate experimental backends.
 
 > **Network host allow/block lists are not implemented on Windows.** `network.allowedHosts` / `network.blockedHosts` have no enforcement on this platform — use `network.defaultPolicy` (`allow` / `block`) or `network.proxy` to constrain network access.
 
@@ -339,7 +339,7 @@ await deprovisionSandbox(sandboxId, undefined, opts);
 
 `windows_sandbox` follows the same shape (substitute the containment string and provide `filesystem.readwritePaths` / `readonlyPaths` at provision if needed). See [`docs/windows-sandbox/windows-sandbox.md`](https://github.com/microsoft/mxc/blob/main/docs/windows-sandbox/windows-sandbox.md) for the per-phase config matrix.
 
-`wslc` follows the same shape and needs no provision config at all (it defaults to an `alpine:latest` container with no network). Provide `filesystem.readwritePaths` / `readonlyPaths` (mounted for the sandbox's lifetime), `network.defaultPolicy: 'allow'` (a bridged container; the default `'block'` gives no network), and/or a backend-specific `image` / `imageTarPath` at provision; inject a cooperative `network.proxy: { url }` per-exec. WSLc state-aware requests normally default to schema `0.8.0-alpha`; requests that include `telemetry` or `process.inheritDefaultEnv` default to `0.9.0-alpha`. An explicitly older version is rejected for either field. See [`docs/wsl/wslc-state-aware.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wslc-state-aware.md) for the per-phase config matrix.
+`wslc` follows the same shape and needs no provision config at all (it defaults to an `alpine:latest` container with no network). Provide `filesystem.readwritePaths` / `readonlyPaths` (mounted for the sandbox's lifetime), `network.defaultPolicy: 'allow'` (a bridged container; the default `'block'` gives no network), and/or a backend-specific `image` / `imageTarPath` at provision; inject a cooperative `network.proxy: { url }` per-exec. All state-aware requests default to the exact development schema `0.9.0-alpha`. See [`docs/wsl/wslc-state-aware.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wslc-state-aware.md) for the per-phase config matrix.
 
 **Handling failures.** Every lifecycle call rejects with a typed `MxcError`. Branch on `code` first:
 

--- a/sdk/node/src/index.ts
+++ b/sdk/node/src/index.ts
@@ -101,7 +101,9 @@ export {
 // Export state-aware lifecycle types
 export {
   Phase,
+  STATE_AWARE_VERSION,
   StateAwareContainmentBackend,
+  StateAwareSchemaVersion,
   SandboxId,
   IsolationSessionProvisionConfig,
   IsolationSessionStartConfig,

--- a/sdk/node/src/state-aware-helper.ts
+++ b/sdk/node/src/state-aware-helper.ts
@@ -6,18 +6,19 @@ import { resolveBinaryAndCommonArgs } from './helper.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { mxcErrorFromCode, mxcErrorFromEnvelope, WireError } from './errors.js';
 import { diagLog } from './diagnostic.js';
-import { Phase, StateAwareContainmentBackend } from './state-aware-types.js';
+import {
+  Phase,
+  STATE_AWARE_VERSION,
+  StateAwareContainmentBackend,
+} from './state-aware-types.js';
 import { TelemetryConfig } from './types.js';
 
-export const STATE_AWARE_VERSION = '0.6.0-alpha';
+export { STATE_AWARE_VERSION };
 
-// WSLc's state-aware surface shipped at a later schema version than the
-// `STATE_AWARE_VERSION` default above (the shared default for IsolationSession
-// and Windows Sandbox). WSLc is intentionally NOT gate-locked to it: the
-// backends were promoted independently, so WSLc carries its own later default.
-// See `DEFAULT_STATE_AWARE_VERSION`.
-export const WSLC_STATE_AWARE_VERSION = '0.8.0-alpha';
-export const TELEMETRY_STATE_AWARE_VERSION = '0.9.0-alpha';
+// Keep the WSLC constant separate because it is part of the public SDK surface
+// and remains independently versioned, even though every state-aware backend
+// currently uses the exact 0.9 development contract.
+export const WSLC_STATE_AWARE_VERSION = '0.9.0-alpha';
 
 // Wire-format cross-cutting fields that live at the envelope's top level.
 // Anything else on a per-(backend, phase) Config is backend-specific and is
@@ -107,18 +108,16 @@ export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string,
   // Anything left becomes experimental.<backend>.<phase>.
   const backendSpecific: Record<string, unknown> = { ...(config ?? {}) };
   const defaultVersion = DEFAULT_STATE_AWARE_VERSION[backendKey] ?? STATE_AWARE_VERSION;
-  const suppliedVersion =
-    typeof backendSpecific.version === 'string' ? backendSpecific.version : undefined;
   const telemetry = backendSpecific.telemetry as TelemetryConfig | undefined;
-  const hasTelemetry = telemetry !== undefined;
-  const process = backendSpecific.process;
-  const hasInheritDefaultEnv =
-    typeof process === 'object' &&
-    process !== null &&
-    Object.prototype.hasOwnProperty.call(process, 'inheritDefaultEnv') &&
-    (process as Record<string, unknown>).inheritDefaultEnv !== undefined;
-  const requires09 = hasTelemetry || hasInheritDefaultEnv;
-  const version = suppliedVersion || (requires09 ? TELEMETRY_STATE_AWARE_VERSION : defaultVersion);
+  const requestedVersion = backendSpecific.version;
+  if (requestedVersion !== undefined && requestedVersion !== defaultVersion) {
+    throw mxcErrorFromCode(
+      'malformed_request',
+      `State-aware ${backendKey} requests require schema version '${defaultVersion}', ` +
+      `got '${String(requestedVersion)}'.`,
+    );
+  }
+  const version = defaultVersion;
   delete backendSpecific.version;
 
   const envelope: Record<string, unknown> = { version, phase };

--- a/sdk/node/src/state-aware-types.ts
+++ b/sdk/node/src/state-aware-types.ts
@@ -33,12 +33,15 @@ export type StateAwareContainmentBackend = Extract<
 export type SandboxId<C extends StateAwareContainmentBackend> =
   string & { readonly __mxcBrand: 'SandboxId'; readonly __mxcBackend: C };
 
+/** The exact contract currently registered for state-aware requests. */
+export const STATE_AWARE_VERSION = '0.9.0-alpha' as const;
+
+/** Exact contract versions accepted by state-aware config types. */
+export type StateAwareSchemaVersion = typeof STATE_AWARE_VERSION;
+
 interface StateAwareConfig {
-  /**
-   * Schema version. When omitted, the SDK selects `0.9.0-alpha` if telemetry
-   * is present; otherwise it selects the backend default.
-   */
-  version?: string;
+  /** Schema version. Omit to use the current state-aware contract. */
+  version?: StateAwareSchemaVersion;
   /** Optional telemetry request for this phase. */
   telemetry?: TelemetryConfig;
 }
@@ -196,7 +199,7 @@ export type WslcDeprovisionConfig = StateAwareConfig;
  * The five per-phase Config slots every state-aware backend must declare.
  * `object` (not `Record<string, unknown>`) is the slot base: interfaces have
  * no implicit index signature, so a `Record<string, unknown>` base would
- * spuriously reject `{ version?: string }`-shaped configs.
+ * spuriously reject configs carrying an optional schema version.
  */
 type StateAwarePhaseConfigs = Record<Phase, object>;
 

--- a/sdk/node/tests/integration/common.test.ts
+++ b/sdk/node/tests/integration/common.test.ts
@@ -21,7 +21,12 @@ describe('Platform support', () => {
 
 const platformSupport = sdk.getPlatformSupport();
 
-for (const schemaVersion of supportedVersions) {
+// The exact 0.6 contract predates Seatbelt, which is the native macOS backend.
+const platformVersions = os.platform() === 'darwin'
+  ? supportedVersions.filter((version) => version.compare('0.7.0-alpha') >= 0)
+  : supportedVersions;
+
+for (const schemaVersion of platformVersions) {
   const skipReason = !platformSupport.isSupported
     ? `Platform not supported: ${platformSupport.reason}`
     : undefined;

--- a/sdk/node/tests/integration/macos-seatbelt.test.ts
+++ b/sdk/node/tests/integration/macos-seatbelt.test.ts
@@ -17,8 +17,8 @@ import {
 
 const seatbeltSpawnOptions = { ...debugSpawnOptions, experimental: true };
 
-// Seatbelt requires at least schema 0.5.0; the corpus floor is now 0.6.0-alpha.
-const schemaVersion = '0.6.0-alpha';
+// Seatbelt first appears in the exact 0.7 contract.
+const schemaVersion = '0.7.0-alpha';
 
 // Clipboard tests require a running pasteboard service. Probe once at
 // module load and skip clipboard tests when the service is unavailable

--- a/sdk/node/tests/integration/microvm-filesystem.test.ts
+++ b/sdk/node/tests/integration/microvm-filesystem.test.ts
@@ -95,7 +95,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
   it('should run a simple Python script and capture output', async () => {
     const config = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       containment: 'microvm' as const,
       process: {
         commandLine: "print('Hello from MicroVM SDK E2E!')",
@@ -111,7 +111,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
   it('should propagate non-zero exit codes', async () => {
     const config = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       containment: 'microvm' as const,
       process: {
         commandLine: "import sys; sys.exit(42)",
@@ -125,7 +125,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
   it('should run multiline scripts with imports', async () => {
     const config = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       containment: 'microvm' as const,
       process: {
         commandLine: [
@@ -154,7 +154,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
       // Use the host path directly in the script — the staging layer rewrites
       // it to the guest mount path before the script reaches the VM.
       const config = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         containment: 'microvm' as const,
         process: {
           commandLine: [
@@ -183,7 +183,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
   it('should reject denied_paths with an error', async () => {
     const config = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       containment: 'microvm' as const,
       process: {
         commandLine: "print('should not run')",
@@ -208,7 +208,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
     try {
       const config = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         containment: 'microvm' as const,
         process: {
           commandLine: [
@@ -242,7 +242,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
 
     try {
       const config = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         containment: 'microvm' as const,
         process: {
           commandLine: [
@@ -278,7 +278,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
     try {
       const rwDirPy = pyEscape(rwDir);
       const config = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         containment: 'microvm' as const,
         process: {
           // Generate a minimal valid PPTX using only stdlib (zipfile + xml).
@@ -334,7 +334,7 @@ describe('MicroVM SDK E2E — spawnSandboxFromConfig with containment: microvm',
     try {
       const rwDirPy = pyEscape(rwDir);
       const config = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         containment: 'microvm' as const,
         process: {
           commandLine: [

--- a/sdk/node/tests/integration/wslc-e2e.test.ts
+++ b/sdk/node/tests/integration/wslc-e2e.test.ts
@@ -56,7 +56,7 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
 
     try {
       const policy = {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         network: { allowOutbound: true },
         filesystem: { readwritePaths: [mountDir] },
       };
@@ -107,7 +107,7 @@ describe('WSLC SDK E2E — createConfigFromPolicy → customize → spawn', {
     const CONTAINER_PORT = 8080;
 
     const policy = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       network: { allowOutbound: true },
       filesystem: {},
     };
@@ -209,7 +209,7 @@ srv.handle_request()
     // SDK type narrows `protocol` to `'tcp'`, so a cast is required here to
     // exercise the parser path that rejects an out-of-type value at runtime.
     const policy = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       network: { allowOutbound: true },
       filesystem: {},
     };

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -306,6 +306,7 @@ describe('buildSandboxPayload', () => {
 
   describe('Containment override', () => {
     let originalPlatform: PropertyDescriptor | undefined;
+    const developmentPolicy: SandboxPolicy = { version: '0.9.0-alpha' };
 
     const mockWindows = () => {
       originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
@@ -321,7 +322,7 @@ describe('buildSandboxPayload', () => {
     it('should return minimal config for microvm without filesystem', () => {
       mockWindows();
       try {
-        const payload = buildSandboxPayload('print(42)', defaultPolicy, undefined, undefined, 'microvm');
+        const payload = buildSandboxPayload('print(42)', developmentPolicy, undefined, undefined, 'microvm');
         assert.strictEqual(payload.containment, 'microvm');
         assert.strictEqual(payload.filesystem, undefined);
         assert.strictEqual(payload.processContainer, undefined);
@@ -334,7 +335,7 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
-          version: '0.6.0-alpha',
+          version: '0.9.0-alpha',
           filesystem: { readwritePaths: ['/tmp'] },
         };
         const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
@@ -352,7 +353,7 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
-          version: '0.6.0-alpha',
+          version: '0.9.0-alpha',
           filesystem: { readwritePaths: ['/tmp'], clearPolicyOnExit: false },
         };
         const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
@@ -366,7 +367,7 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
-          version: '0.6.0-alpha',
+          version: '0.9.0-alpha',
           network: { allowOutbound: true },
         };
         const payload = buildSandboxPayload('echo hi', policy);
@@ -381,7 +382,7 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
-          version: '0.6.0-alpha',
+          version: '0.9.0-alpha',
           network: { allowOutbound: true },
         };
         assert.throws(
@@ -392,7 +393,7 @@ describe('buildSandboxPayload', () => {
           () => buildSandboxPayload(
             'print(42)',
             {
-              version: '0.8.0-alpha',
+              version: '0.9.0-alpha',
               runtimeConfig: { networkProxy: 'http://127.0.0.1:8080' },
             },
             undefined,
@@ -411,7 +412,7 @@ describe('buildSandboxPayload', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' });
       try {
         assert.throws(
-          () => buildSandboxPayload('print(42)', defaultPolicy, undefined, undefined, 'microvm'),
+          () => buildSandboxPayload('print(42)', developmentPolicy, undefined, undefined, 'microvm'),
           { message: /only supported on Windows/ },
         );
       } finally {
@@ -423,7 +424,7 @@ describe('buildSandboxPayload', () => {
       mockWindows();
       try {
         const policy: SandboxPolicy = {
-          version: '0.6.0-alpha',
+          version: '0.9.0-alpha',
           filesystem: { clearPolicyOnExit: false },
         };
         const payload = buildSandboxPayload('print(42)', policy, undefined, undefined, 'microvm');
@@ -437,7 +438,7 @@ describe('buildSandboxPayload', () => {
     it('should set process commandLine and containerId for microvm', () => {
       mockWindows();
       try {
-        const payload = buildSandboxPayload('print(42)', defaultPolicy, undefined, 'my-container', 'microvm');
+        const payload = buildSandboxPayload('print(42)', developmentPolicy, undefined, 'my-container', 'microvm');
         assert.strictEqual(payload.process!.commandLine, 'print(42)');
         assert.strictEqual(payload.containerId, 'my-container');
       } finally {
@@ -449,26 +450,26 @@ describe('buildSandboxPayload', () => {
 
   describe('WSLC', () => {
     it('should set containment to wslc when containment option is passed', () => {
-      const payload = buildSandboxPayload('echo hello', { version: '0.6.0-alpha' }, undefined, undefined, 'wslc');
+      const payload = buildSandboxPayload('echo hello', { version: '0.9.0-alpha' }, undefined, undefined, 'wslc');
       assert.strictEqual(payload.containment, 'wslc');
       assert.strictEqual(payload.process!.commandLine, 'echo hello');
     });
 
     it('should populate experimental.wslc with default image', () => {
-      const payload = buildSandboxPayload('echo hello', { version: '0.6.0-alpha' }, undefined, undefined, 'wslc');
+      const payload = buildSandboxPayload('echo hello', { version: '0.9.0-alpha' }, undefined, undefined, 'wslc');
       assert.ok(payload.experimental?.wslc);
       assert.strictEqual(payload.experimental!.wslc!.image, 'alpine:latest');
     });
 
     it('should not set processContainer or lxc config', () => {
-      const payload = buildSandboxPayload('echo hello', { version: '0.6.0-alpha' }, undefined, undefined, 'wslc');
+      const payload = buildSandboxPayload('echo hello', { version: '0.9.0-alpha' }, undefined, undefined, 'wslc');
       assert.strictEqual(payload.processContainer, undefined);
       assert.strictEqual(payload.lxc, undefined);
     });
 
-    it('should set default-deny network', () => {
-      const payload = buildSandboxPayload('echo hello', { version: '0.6.0-alpha' }, undefined, undefined, 'wslc');
-      assert.strictEqual(payload.network!.defaultPolicy, 'block');
+    it('should rely on the 0.9 implicit default-deny network', () => {
+      const payload = buildSandboxPayload('echo hello', { version: '0.9.0-alpha' }, undefined, undefined, 'wslc');
+      assert.strictEqual(payload.network, undefined);
     });
   });
 });
@@ -1172,7 +1173,7 @@ describe('createConfigFromPolicy', () => {
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
-          version: '0.6.0-alpha',
+          version: '0.7.0-alpha',
           network: { allowedHosts: ['api.github.com'] },
         });
         // Abstract 'process' on macOS resolves to 'seatbelt' in the wire format
@@ -1189,7 +1190,7 @@ describe('createConfigFromPolicy', () => {
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
-          version: '0.6.0-alpha',
+          version: '0.7.0-alpha',
           network: { blockedHosts: ['evil.com'] },
         });
         assert.strictEqual(config.containment, 'seatbelt');
@@ -1208,7 +1209,7 @@ describe('createConfigFromPolicy', () => {
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
-          version: '0.6.0-alpha',
+          version: '0.7.0-alpha',
           network: { allowOutbound: true, allowLocalNetwork: true },
         });
         assert.strictEqual(config.containment, 'seatbelt');
@@ -1222,7 +1223,7 @@ describe('createConfigFromPolicy', () => {
       mockDarwin();
       try {
         const config = createConfigFromPolicy({
-          version: '0.6.0-alpha',
+          version: '0.7.0-alpha',
           network: { allowOutbound: true },
         });
         assert.strictEqual(config.network!.allowLocalNetwork, undefined);
@@ -1517,7 +1518,7 @@ describe('createConfigFromPolicy', () => {
 
   describe('WSLC', () => {
     it('should set containment to wslc and populate experimental.wslc', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       assert.strictEqual(config.containment, 'wslc');
       assert.ok(config.experimental?.wslc);
       assert.strictEqual(config.experimental!.wslc!.image, 'alpine:latest');
@@ -1526,7 +1527,7 @@ describe('createConfigFromPolicy', () => {
     it('should forward schema 0.8 ProcessContainer peer policy for native rejection', () => {
       const config = createConfigFromPolicy(
         {
-          version: '0.8.0-alpha',
+          version: '0.9.0-alpha',
           processContainer: {
             network: {
               allowedProxyPeer: 'Contoso.Proxy_1234567890abc',
@@ -1541,14 +1542,14 @@ describe('createConfigFromPolicy', () => {
       });
     });
 
-    it('should set default-deny network when no network policy is specified', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
-      assert.strictEqual(config.network!.defaultPolicy, 'block');
+    it('should rely on the 0.9 implicit default-deny network when no policy is specified', () => {
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
+      assert.strictEqual(config.network, undefined);
     });
 
     it('should map allowOutbound to network allow policy', () => {
       const config = createConfigFromPolicy({
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         network: { allowOutbound: true },
       }, 'wslc');
       assert.strictEqual(config.network!.defaultPolicy, 'allow');
@@ -1556,7 +1557,7 @@ describe('createConfigFromPolicy', () => {
 
     it('should not set enforcementMode for wslc', () => {
       const config = createConfigFromPolicy({
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         network: { allowOutbound: true },
       }, 'wslc');
       assert.strictEqual(config.network!.enforcementMode, undefined);
@@ -1564,7 +1565,7 @@ describe('createConfigFromPolicy', () => {
 
     it('should allow allowedHosts without allowOutbound (block + allowlist)', () => {
       const config = createConfigFromPolicy({
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         network: { allowedHosts: ['example.com'] },
       }, 'wslc');
       assert.strictEqual(config.network!.defaultPolicy, 'block');
@@ -1572,18 +1573,18 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should not set processContainer config for wslc', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       assert.strictEqual(config.processContainer, undefined);
     });
 
     it('should not set lxc config for wslc', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       assert.strictEqual(config.lxc, undefined);
     });
 
     it('should map filesystem paths correctly', () => {
       const config = createConfigFromPolicy({
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         filesystem: {
           readwritePaths: ['C:\\workspace'],
           readonlyPaths: ['C:\\data'],
@@ -1597,19 +1598,19 @@ describe('createConfigFromPolicy', () => {
 
     it('should map timeoutMs to process.timeout', () => {
       const config = createConfigFromPolicy({
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         timeoutMs: 30000,
       }, 'wslc');
       assert.strictEqual(config.process!.timeout, 30000);
     });
 
     it('should set containerId', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc', 'my-container');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc', 'my-container');
       assert.strictEqual(config.containerId, 'my-container');
     });
 
     it('should throw from spawnSandbox when experimental backend is used via config', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
       assert.throws(
         () => spawnSandboxFromConfig(config),
@@ -1618,7 +1619,7 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should throw from spawnSandboxFromConfig when experimental is not set', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
       assert.throws(
         () => spawnSandboxFromConfig(config),
@@ -1739,7 +1740,7 @@ describe('createConfigFromPolicy', () => {
   });
 });
 
-describe('Schema 0.6.0 vocabulary', () => {
+describe('Development containment vocabulary', () => {
   it('should accept isolation_session as a SandboxingMethod', () => {
     const m: SandboxingMethod = 'isolation_session';
     assert.strictEqual(m, 'isolation_session');
@@ -1747,7 +1748,7 @@ describe('Schema 0.6.0 vocabulary', () => {
 
   it('should accept isolation_session as a ContainerConfig.containment value', () => {
     const c: ContainerConfig = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       containment: 'isolation_session',
     };
     assert.strictEqual(c.containment, 'isolation_session');
@@ -1761,8 +1762,14 @@ describe('resolveExecutableAndArgs (containment validation)', { skip: platformSk
   const fakeExe = process.execPath;
 
   function makeConfig(containment: string): ContainerConfig {
+    const version =
+      ['microvm', 'vm', 'wslc', 'isolation_session', 'windows_sandbox'].includes(containment)
+        ? '0.9.0-alpha'
+        : ['seatbelt', 'macos_sandbox'].includes(containment)
+          ? '0.7.0-alpha'
+          : '0.6.0-alpha';
     return {
-      version: '0.6.0-alpha',
+      version,
       containment: containment as ContainerConfig['containment'],
       process: { commandLine: 'echo hi' },
     };

--- a/sdk/node/tests/unit/state-aware-types.test.ts
+++ b/sdk/node/tests/unit/state-aware-types.test.ts
@@ -13,7 +13,9 @@ import {
   ProvisionResult,
   SandboxId,
   StartMetadataFor,
+  STATE_AWARE_VERSION,
   StateAwareContainmentBackend,
+  StateAwareSchemaVersion,
   StopConfigFor,
   WindowsSandboxProvisionConfig,
   WindowsSandboxStartConfig,
@@ -47,6 +49,13 @@ describe('SandboxId<C> brand', () => {
   });
 });
 
+describe('StateAwareSchemaVersion', () => {
+  it('is derived from the canonical runtime constant', () => {
+    const version: StateAwareSchemaVersion = STATE_AWARE_VERSION;
+    assert.strictEqual(version, '0.9.0-alpha');
+  });
+});
+
 describe('IsolationSessionProvisionConfig', () => {
   // The one accepted network value: the unrestricted-network acknowledgment.
   const network: { defaultPolicy: 'allow'; allowLocalNetwork: true } = {
@@ -55,12 +64,16 @@ describe('IsolationSessionProvisionConfig', () => {
   };
 
   it('requires the canonical network acknowledgment', () => {
-    const ok: IsolationSessionProvisionConfig = { version: '0.6.0-alpha', network };
+    const ok: IsolationSessionProvisionConfig = { version: '0.9.0-alpha', network };
     assert.strictEqual(ok.network.defaultPolicy, 'allow');
     assert.strictEqual(ok.network.allowLocalNetwork, true);
 
+    // @ts-expect-error — no state-aware contract is registered for 0.8.
+    const oldVersion: IsolationSessionProvisionConfig = { version: '0.8.0-alpha', network };
+    assert.ok(oldVersion);
+
     // @ts-expect-error — network is required; provision must acknowledge the unrestricted network.
-    const missing: IsolationSessionProvisionConfig = { version: '0.6.0-alpha' };
+    const missing: IsolationSessionProvisionConfig = { version: '0.9.0-alpha' };
     assert.ok(missing);
   });
 
@@ -213,7 +226,7 @@ describe('IsolationSessionExecConfig', () => {
 
 describe('IsolationSessionStopConfig and IsolationSessionDeprovisionConfig', () => {
   it('only carry version', () => {
-    const stopCfg: StopConfigFor<'isolation_session'> = { version: '0.6.0-alpha' };
+    const stopCfg: StopConfigFor<'isolation_session'> = { version: '0.9.0-alpha' };
     const deprovCfg: DeprovisionConfigFor<'isolation_session'> = {};
 
     const wrongStop: StopConfigFor<'isolation_session'> = {
@@ -229,7 +242,7 @@ describe('IsolationSessionStopConfig and IsolationSessionDeprovisionConfig', () 
 describe('ConfigsForBackend', () => {
   it('selects the IsolationSession bundle for the isolation_session backend', () => {
     const bundle: ConfigsForBackend<'isolation_session'> = {
-      provision: { version: '0.6.0-alpha', network: { defaultPolicy: 'allow', allowLocalNetwork: true } },
+      provision: { version: '0.9.0-alpha', network: { defaultPolicy: 'allow', allowLocalNetwork: true } },
       start: {},
       exec: { process: { commandLine: 'echo' } },
       stop: {},
@@ -240,7 +253,7 @@ describe('ConfigsForBackend', () => {
 
   it('selects the WindowsSandbox bundle for the windows_sandbox backend', () => {
     const bundle: ConfigsForBackend<'windows_sandbox'> = {
-      provision: { version: '0.6.0-alpha', filesystem: { readwritePaths: ['C:\\workspace'] } },
+      provision: { version: '0.9.0-alpha', filesystem: { readwritePaths: ['C:\\workspace'] } },
       start: {},
       exec: { process: { commandLine: 'echo' } },
       stop: {},
@@ -253,7 +266,7 @@ describe('ConfigsForBackend', () => {
 describe('WindowsSandboxProvisionConfig', () => {
   it('accepts version and filesystem (incl. deniedPaths)', () => {
     const cfg: WindowsSandboxProvisionConfig = {
-      version: '0.6.0-alpha',
+      version: '0.9.0-alpha',
       filesystem: {
         readwritePaths: ['C:\\workspace'],
         readonlyPaths: ['C:\\inputs'],
@@ -287,8 +300,8 @@ describe('WindowsSandboxProvisionConfig', () => {
 
 describe('WindowsSandboxStartConfig', () => {
   it('carries only version (no configurationId, no backend-specific fields)', () => {
-    const ok: WindowsSandboxStartConfig = { version: '0.6.0-alpha' };
-    assert.strictEqual(ok.version, '0.6.0-alpha');
+    const ok: WindowsSandboxStartConfig = { version: '0.9.0-alpha' };
+    assert.strictEqual(ok.version, '0.9.0-alpha');
 
     const withConfigurationId: WindowsSandboxStartConfig = {
       // @ts-expect-error — windows_sandbox start has no configurationId.
@@ -373,7 +386,7 @@ describe('ProvisionResult<C>', () => {
 describe('WslcProvisionConfig', () => {
   it('accepts version, filesystem, network, and the backend-specific image knobs', () => {
     const cfg: WslcProvisionConfig = {
-      version: '0.8.0-alpha',
+      version: '0.9.0-alpha',
       filesystem: { readwritePaths: ['C:\\ws\\rw'], readonlyPaths: ['C:\\ws\\ro'] },
       network: { defaultPolicy: 'allow' },
       image: 'alpine:latest',
@@ -408,10 +421,10 @@ describe('WslcProvisionConfig', () => {
 
 describe('WslcStartConfig / WslcStopConfig / WslcDeprovisionConfig', () => {
   it('carry only version', () => {
-    const start: WslcStartConfig = { version: '0.8.0-alpha' };
+    const start: WslcStartConfig = { version: '0.9.0-alpha' };
     const stop: WslcStopConfig = {};
     const deprov: WslcDeprovisionConfig = {};
-    assert.strictEqual(start.version, '0.8.0-alpha');
+    assert.strictEqual(start.version, '0.9.0-alpha');
     assert.ok(stop);
     assert.ok(deprov);
 

--- a/sdk/node/tests/unit/state-aware.test.ts
+++ b/sdk/node/tests/unit/state-aware.test.ts
@@ -33,15 +33,21 @@ describe('buildStateAwareEnvelope', () => {
     assert.equal(env.experimental, undefined);
   });
 
-  it('leaves explicit telemetry schema validation to the native parser', () => {
-    const env = buildStateAwareEnvelope({
-      phase: 'start',
-      backendKey: 'windows_sandbox',
-      sandboxId: 'wsb:01234567',
-      config: { version: '0.8.0-alpha', telemetry: { enabled: true } },
-    });
-    assert.equal(env.version, '0.8.0-alpha');
-    assert.deepEqual(env.telemetry, { enabled: true });
+  it('rejects an explicitly older schema version when telemetry is present', () => {
+    assert.throws(
+      () => buildStateAwareEnvelope({
+        phase: 'start',
+        backendKey: 'windows_sandbox',
+        sandboxId: 'wsb:01234567',
+        config: { version: '0.8.0-alpha', telemetry: { enabled: true } },
+      }),
+      (error: unknown) =>
+        error instanceof MxcError &&
+        error.code === 'malformed_request' &&
+        error.message.includes(
+          "State-aware windows_sandbox requests require schema version '0.9.0-alpha'",
+        ),
+    );
   });
 
   it('selects schema 0.9 when exec inherits the backend environment', () => {
@@ -57,42 +63,33 @@ describe('buildStateAwareEnvelope', () => {
       },
     });
     assert.equal(env.version, '0.9.0-alpha');
-  });
-
-  it('does not select schema 0.9 when environment inheritance is undefined', () => {
-    const env = buildStateAwareEnvelope({
-      phase: 'exec',
-      backendKey: 'wslc',
-      sandboxId: 'wslc:abc',
-      config: {
-        version: '0.8.0-alpha',
-        process: {
-          commandLine: 'echo hi',
-          inheritDefaultEnv: undefined,
-        },
-      },
-    });
-    assert.equal(env.version, '0.8.0-alpha');
-  });
-
-  it('preserves an older inherited-environment version for native validation', () => {
-    const env = buildStateAwareEnvelope({
-      phase: 'exec',
-      backendKey: 'wslc',
-      sandboxId: 'wslc:abc',
-      config: {
-        version: '0.8.0-alpha',
-        process: {
-          commandLine: 'echo hi',
-          inheritDefaultEnv: true,
-        },
-      },
-    });
-    assert.equal(env.version, '0.8.0-alpha');
     assert.deepEqual(env.process, {
       commandLine: 'echo hi',
       inheritDefaultEnv: true,
     });
+  });
+
+  it('rejects an explicitly older schema version when the environment is inherited', () => {
+    assert.throws(
+      () => buildStateAwareEnvelope({
+        phase: 'exec',
+        backendKey: 'wslc',
+        sandboxId: 'wslc:abc',
+        config: {
+          version: '0.8.0-alpha',
+          process: {
+            commandLine: 'echo hi',
+            inheritDefaultEnv: true,
+          },
+        },
+      }),
+      (error: unknown) =>
+        error instanceof MxcError &&
+        error.code === 'malformed_request' &&
+        error.message.includes(
+          "State-aware wslc requests require schema version '0.9.0-alpha'",
+        ),
+    );
   });
 
   it('produces a provision envelope with cross-cutting fields lifted to top-level', () => {
@@ -101,7 +98,7 @@ describe('buildStateAwareEnvelope', () => {
       backendKey: 'isolation_session',
       containment: 'isolation_session',
       config: {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         filesystem: { readwritePaths: ['C:\\workspace'] },
         network: { defaultPolicy: 'block' },
         ui: { disable: true, clipboard: 'none', injection: false },
@@ -153,14 +150,18 @@ describe('buildStateAwareEnvelope', () => {
     }
   });
 
-  it('uses caller-supplied version when provided', () => {
-    const env = buildStateAwareEnvelope({
-      phase: 'provision',
-      backendKey: 'isolation_session',
-      containment: 'isolation_session',
-      config: { version: '0.6.5-alpha' },
-    });
-    assert.strictEqual(env.version, '0.6.5-alpha');
+  it('rejects an untyped caller-supplied version with malformed_request', () => {
+    assert.throws(
+      () => buildStateAwareEnvelope({
+        phase: 'provision',
+        backendKey: 'isolation_session',
+        containment: 'isolation_session',
+        config: { version: '0.6.5-alpha' },
+      }),
+      (err: unknown) => err instanceof MxcError &&
+        err.code === 'malformed_request' &&
+        /require schema version '0\.9\.0-alpha'/.test(err.message),
+    );
   });
 
   it('nests provision appId under experimental.isolation_session.provision', () => {
@@ -560,7 +561,7 @@ describe('windows_sandbox state-aware lifecycle', () => {
       backendKey: 'windows_sandbox',
       containment: 'windows_sandbox',
       config: {
-        version: '0.6.0-alpha',
+        version: '0.9.0-alpha',
         filesystem: {
           readwritePaths: ['C:\\workspace'],
           readonlyPaths: ['C:\\inputs'],
@@ -635,24 +636,28 @@ describe('windows_sandbox state-aware lifecycle', () => {
 });
 
 describe('wslc state-aware lifecycle', () => {
-  it('defaults the version to 0.8.0-alpha (not the isolation_session default)', () => {
+  it('defaults the version to the shared 0.9.0-alpha development contract', () => {
     const env = buildStateAwareEnvelope({
       phase: 'provision',
       backendKey: 'wslc',
       containment: 'wslc',
       config: { image: 'alpine:latest' },
     });
-    assert.strictEqual(env.version, '0.8.0-alpha');
+    assert.strictEqual(env.version, '0.9.0-alpha');
   });
 
-  it('still honors a caller-supplied version over the wslc default', () => {
-    const env = buildStateAwareEnvelope({
-      phase: 'provision',
-      backendKey: 'wslc',
-      containment: 'wslc',
-      config: { version: '0.8.1-alpha', image: 'alpine:latest' },
-    });
-    assert.strictEqual(env.version, '0.8.1-alpha');
+  it('rejects a caller-supplied version without a registered wslc state-aware contract', () => {
+    assert.throws(
+      () => buildStateAwareEnvelope({
+        phase: 'provision',
+        backendKey: 'wslc',
+        containment: 'wslc',
+        config: { version: '0.8.1-alpha', image: 'alpine:latest' },
+      }),
+      (err: unknown) => err instanceof MxcError &&
+        err.code === 'malformed_request' &&
+        /require schema version '0\.9\.0-alpha'/.test(err.message),
+    );
   });
 
   it('lifts filesystem + network and nests image under experimental.wslc.provision', () => {
@@ -716,7 +721,7 @@ describe('wslc state-aware lifecycle', () => {
       assert.strictEqual(result.sandboxId, 'wslc:0123abcd');
       assert.strictEqual(fake.captured.envelope?.phase, 'provision');
       assert.strictEqual(fake.captured.envelope?.containment, 'wslc');
-      assert.strictEqual(fake.captured.envelope?.version, '0.8.0-alpha');
+      assert.strictEqual(fake.captured.envelope?.version, '0.9.0-alpha');
     });
 
     it('startSandbox infers wslc from the wslc: prefix', async () => {

--- a/src/core/mxc-sdk/README.md
+++ b/src/core/mxc-sdk/README.md
@@ -351,7 +351,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 // Provision. IsolationSession accepts only the canonical unrestricted-network
 // acknowledgment; an absent policy defaults to `block`, which it refuses.
 let provisioned = run_state_aware_json(
-    r#"{"phase":"provision","containment":"isolation_session",
+    r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#,
     false, // dry_run
     true,  // experimental
@@ -360,14 +360,14 @@ let provisioned = run_state_aware_json(
 
 // Start. The exec phase runs against a started session.
 run_state_aware_json(
-    r#"{"phase":"start","sandboxId":"..."}"#,
+    r#"{"version":"0.9.0-alpha","phase":"start","sandboxId":"..."}"#,
     false, // dry_run
     true,  // experimental
 )?;
 
 // Exec phase, attached: an interactive shell on this console.
 let outcome = exec_attached(
-    r#"{"phase":"exec","sandboxId":"...","process":{"commandLine":"powershell.exe"}}"#,
+    r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"...","process":{"commandLine":"powershell.exe"}}"#,
     true, // experimental
 )?;
 let _ = outcome;

--- a/src/core/mxc-sdk/examples/isolation_session_console.rs
+++ b/src/core/mxc-sdk/examples/isolation_session_console.rs
@@ -35,9 +35,10 @@ impl Drop for Teardown {
     fn drop(&mut self) {
         let id = &self.0;
         eprintln!("\n[driver] tearing down…");
-        let stop = format!(r#"{{"phase":"stop","sandboxId":"{id}"}}"#);
+        let stop = format!(r#"{{"version":"0.9.0-alpha","phase":"stop","sandboxId":"{id}"}}"#);
         let _ = mxc_sdk::run_state_aware_json(&stop, false, true);
-        let deprovision = format!(r#"{{"phase":"deprovision","sandboxId":"{id}"}}"#);
+        let deprovision =
+            format!(r#"{{"version":"0.9.0-alpha","phase":"deprovision","sandboxId":"{id}"}}"#);
         match mxc_sdk::run_state_aware_json(&deprovision, false, true) {
             Ok(_) => eprintln!("[driver] deprovisioned."),
             Err(e) => eprintln!("[driver] WARNING: deprovision failed, account may leak: {e:?}"),
@@ -115,7 +116,7 @@ fn run() -> i32 {
         return 2;
     }
 
-    let provision = r#"{"phase":"provision","containment":"isolation_session",
+    let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
     let response = mxc_sdk::run_state_aware_json(provision, false, true).expect("provision");
     // The sandbox id is opaque by contract — carried verbatim, never parsed.
@@ -128,7 +129,8 @@ fn run() -> i32 {
     let _teardown = Teardown(sandbox_id.clone());
     eprintln!("[driver] provisioned.");
 
-    let start = format!(r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#);
+    let start =
+        format!(r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#);
     mxc_sdk::run_state_aware_json(&start, false, true).expect("start");
     eprintln!("[driver] started. Scenario: {label}");
     if let Some(g) = guidance {
@@ -138,7 +140,7 @@ fn run() -> i32 {
 
     let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
     let exec = format!(
-        r#"{{"phase":"exec","sandboxId":"{sandbox_id}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{sandbox_id}",
             "process":{{"commandLine":"{escaped}","timeout":3600000}}}}"#
     );
 

--- a/src/core/mxc-sdk/examples/sta_probe.rs
+++ b/src/core/mxc-sdk/examples/sta_probe.rs
@@ -50,12 +50,13 @@ fn teardown(id: &str, who: &str) {
     let worker = std::thread::spawn(move || {
         println!("    [{who}] tearing down {id}");
         let _ = std::io::stdout().flush();
-        let stop = format!(r#"{{"phase":"stop","sandboxId":"{id}"}}"#);
+        let stop = format!(r#"{{"version":"0.9.0-alpha","phase":"stop","sandboxId":"{id}"}}"#);
         match mxc_sdk::run_state_aware_json(&stop, false, true) {
             Ok(_) => println!("    [{who}] stopped"),
             Err(e) => println!("    [{who}] stop failed: {e:?}"),
         }
-        let deprovision = format!(r#"{{"phase":"deprovision","sandboxId":"{id}"}}"#);
+        let deprovision =
+            format!(r#"{{"version":"0.9.0-alpha","phase":"deprovision","sandboxId":"{id}"}}"#);
         match mxc_sdk::run_state_aware_json(&deprovision, false, true) {
             Ok(_) => println!("    [{who}] deprovisioned"),
             Err(e) => println!("    [{who}] WARNING: deprovision failed, account may leak: {e:?}"),
@@ -147,7 +148,7 @@ fn main() {
         }
 
         checkpoint("provision — the first async join");
-        let provision = r#"{"phase":"provision","containment":"isolation_session",
+        let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
             "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
         let response = match mxc_sdk::run_state_aware_json(provision, false, true) {
             Ok(r) => r,
@@ -175,7 +176,7 @@ fn main() {
 
         checkpoint("start — a second async join, on a live session");
         if let Err(e) = mxc_sdk::run_state_aware_json(
-            &format!(r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#),
+            &format!(r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#),
             false,
             true,
         ) {
@@ -189,7 +190,7 @@ fn main() {
         // initialising COM themselves.
         checkpoint("exec — worker threads call WinRT with no apartment of their own");
         let exec = format!(
-            r#"{{"phase":"exec","sandboxId":"{sandbox_id}",
+            r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{sandbox_id}",
                 "process":{{"commandLine":"cmd.exe /c echo sta-probe-marker","timeout":30000}}}}"#
         );
         let mut exec_ok = false;
@@ -262,7 +263,7 @@ fn measure_handle_outliving_its_thread() {
     let (tx, rx) = std::sync::mpsc::channel();
     let (exec_tx, exec_rx) = std::sync::mpsc::channel();
     let worker = std::thread::spawn(move || {
-        let provision = r#"{"phase":"provision","containment":"isolation_session",
+        let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
             "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
         let response = match mxc_sdk::run_state_aware_json(provision, false, true) {
             Ok(r) => r,
@@ -285,7 +286,8 @@ fn measure_handle_outliving_its_thread() {
         // Sent before anything else can fail, so main owns cleanup from here.
         let _ = tx.send(Ok(sandbox_id.clone()));
 
-        let start = format!(r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#);
+        let start =
+            format!(r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#);
         if let Err(e) = mxc_sdk::run_state_aware_json(&start, false, true) {
             let _ = exec_tx.send(Err(format!("start failed: {e:?}")));
             return;
@@ -295,7 +297,7 @@ fn measure_handle_outliving_its_thread() {
         // thread exits, so the handle under test is live, but short enough to
         // end on its own so no kill races the read path.
         let exec = format!(
-            r#"{{"phase":"exec","sandboxId":"{sandbox_id}",
+            r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{sandbox_id}",
                 "process":{{"commandLine":"cmd.exe /c echo marker-before && ping -n 4 127.0.0.1","timeout":120000}}}}"#
         );
         match mxc_sdk::exec_sandbox(&exec, true) {

--- a/src/core/mxc-sdk/tests/isolation_session.rs
+++ b/src/core/mxc-sdk/tests/isolation_session.rs
@@ -26,7 +26,7 @@ fn iso_policy_with_deadline(timeout_ms: Option<u32>) -> SandboxPolicy {
     network.allow_local_network = true;
 
     SandboxPolicy {
-        version: "0.7.0-alpha".to_string(),
+        version: "0.9.0-alpha".to_string(),
         filesystem: None,
         network: Some(network),
         ui: None,
@@ -89,7 +89,7 @@ macro_rules! skip_unless_supported {
 fn a_single_threaded_apartment_is_refused_before_the_service_is_reached() {
     enter_sta();
 
-    let provision = r#"{"phase":"provision","containment":"isolation_session",
+    let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
     let err = mxc_sdk::run_state_aware_json(provision, false, true)
         .expect_err("a single-threaded apartment must be refused");
@@ -675,9 +675,10 @@ impl Drop for Teardown {
         if id.is_empty() {
             return;
         }
-        let stop = format!(r#"{{"phase":"stop","sandboxId":"{id}"}}"#);
+        let stop = format!(r#"{{"version":"0.9.0-alpha","phase":"stop","sandboxId":"{id}"}}"#);
         let _ = mxc_sdk::run_state_aware_json(&stop, false, true);
-        let deprovision = format!(r#"{{"phase":"deprovision","sandboxId":"{id}"}}"#);
+        let deprovision =
+            format!(r#"{{"version":"0.9.0-alpha","phase":"deprovision","sandboxId":"{id}"}}"#);
         if let Err(e) = mxc_sdk::run_state_aware_json(&deprovision, false, true) {
             eprintln!("WARNING: deprovision of {id} failed, the agent account may leak: {e:?}");
         }
@@ -688,7 +689,7 @@ impl Drop for Teardown {
 fn state_aware_lifecycle_runs_end_to_end() {
     skip_unless_supported!();
 
-    let provision = r#"{"phase":"provision","containment":"isolation_session",
+    let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
     let response = mxc_sdk::run_state_aware_json(provision, false, true)
         .expect("provision must succeed on a supported host");
@@ -709,7 +710,8 @@ fn state_aware_lifecycle_runs_end_to_end() {
     );
     let _teardown = Teardown(sandbox_id.clone());
 
-    let start = format!(r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#);
+    let start =
+        format!(r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#);
     mxc_sdk::run_state_aware_json(&start, false, true).expect("start must succeed");
 
     let captured = exec_capture_stdout(&sandbox_id, "cmd.exe /c echo state-aware-marker");
@@ -730,7 +732,7 @@ struct Started {
 }
 
 fn provision_and_start() -> Started {
-    let provision = r#"{"phase":"provision","containment":"isolation_session",
+    let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
     let response =
         mxc_sdk::run_state_aware_json(provision, false, true).expect("provision must succeed");
@@ -754,7 +756,8 @@ fn provision_and_start() -> Started {
         })
         .to_string();
 
-    let start = format!(r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#);
+    let start =
+        format!(r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#);
     mxc_sdk::run_state_aware_json(&start, false, true).expect("start must succeed");
     Started {
         sandbox_id,
@@ -850,10 +853,13 @@ fn the_workspace_is_shared_with_the_agent_and_removed_on_deprovision() {
         "the workspace was written by an unexpected account, got: {produced:?}"
     );
 
-    let stop = format!(r#"{{"phase":"stop","sandboxId":"{}"}}"#, started.sandbox_id);
+    let stop = format!(
+        r#"{{"version":"0.9.0-alpha","phase":"stop","sandboxId":"{}"}}"#,
+        started.sandbox_id
+    );
     mxc_sdk::run_state_aware_json(&stop, false, true).expect("stop must succeed");
     let deprovision = format!(
-        r#"{{"phase":"deprovision","sandboxId":"{}"}}"#,
+        r#"{{"version":"0.9.0-alpha","phase":"deprovision","sandboxId":"{}"}}"#,
         started.sandbox_id
     );
     mxc_sdk::run_state_aware_json(&deprovision, false, true).expect("deprovision must succeed");
@@ -869,7 +875,7 @@ fn the_workspace_is_shared_with_the_agent_and_removed_on_deprovision() {
 fn exec_attached_rejects_a_non_exec_phase() {
     // `provision` is a real phase, so this exercises the guard rather than the
     // parser's unknown-phase rejection.
-    let provision = r#"{"phase":"provision","containment":"isolation_session",
+    let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
         "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
     let err = mxc_sdk::exec_attached(provision, true)
         .expect_err("an attached exec must reject a non-exec phase");
@@ -887,7 +893,7 @@ fn state_aware_exec_propagates_a_non_zero_exit_code() {
     let started = provision_and_start();
 
     let exec = format!(
-        r#"{{"phase":"exec","sandboxId":"{}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{}",
             "process":{{"commandLine":"cmd.exe /c exit 42","timeout":30000}}}}"#,
         started.sandbox_id
     );
@@ -909,7 +915,7 @@ fn state_aware_exec_can_be_killed() {
     // Long enough that a prompt `wait` proves the kill worked rather than
     // racing a process that was about to exit.
     let exec = format!(
-        r#"{{"phase":"exec","sandboxId":"{}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{}",
             "process":{{"commandLine":"cmd.exe /c ping -n 300 127.0.0.1","timeout":600000}}}}"#,
         started.sandbox_id
     );
@@ -948,7 +954,7 @@ fn a_workload_reading_stdin_to_eof_terminates_when_the_writer_drops() {
     // `more` reads stdin to EOF and exits. Without EOF it runs until the
     // deadline, so the timeout below is the failure signal, not the pass.
     let exec = format!(
-        r#"{{"phase":"exec","sandboxId":"{}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{}",
             "process":{{"commandLine":"cmd.exe /c more","timeout":60000}}}}"#,
         started.sandbox_id
     );
@@ -988,7 +994,7 @@ fn a_backgrounded_descendant_does_not_hold_the_exec_open() {
     // The foreground command exits at once; the spawned child outlives it by
     // ~30s while holding the inherited stdout/stderr write ends.
     let exec = format!(
-        r#"{{"phase":"exec","sandboxId":"{}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{}",
             "process":{{"commandLine":"cmd.exe /c start /b ping -n 31 127.0.0.1 > nul & echo done","timeout":120000}}}}"#,
         started.sandbox_id
     );

--- a/src/core/mxc-sdk/tests/state_aware.rs
+++ b/src/core/mxc-sdk/tests/state_aware.rs
@@ -32,7 +32,7 @@ fn run_state_aware_json_rejects_one_shot_config() {
 fn run_state_aware_json_rejects_non_dry_run_exec() {
     // A non-dry-run exec streams; it must be routed through exec_sandbox, not
     // the envelope entry point.
-    let json = r#"{"phase":"exec","sandboxId":"isolationsession:abc","process":{"commandLine":"echo hi"}}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"isolationsession:abc","process":{"commandLine":"echo hi"}}"#;
     let err =
         run_state_aware_json(json, false, false).expect_err("non-dry-run exec must be rejected");
     assert_eq!(err.code, ErrorCode::MalformedRequest);
@@ -48,7 +48,7 @@ fn run_state_aware_json_malformed_json_is_malformed_request() {
 
 #[test]
 fn exec_sandbox_rejects_non_exec_phase() {
-    let json = r#"{"phase":"provision","containment":"isolation_session"}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session"}"#;
     // `Sandbox` is not `Debug`, so match rather than `expect_err`.
     match exec_sandbox(json, false) {
         Ok(_) => panic!("a provision request is not an exec"),
@@ -75,7 +75,7 @@ fn exec_sandbox_rejects_one_shot_config() {
 // covered by the host-gated executor E2E suites.)
 #[test]
 fn unregistered_backend_prefix_is_unsupported_containment() {
-    let json = r#"{"phase":"start","sandboxId":"nosuchbackend:abc123"}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"start","sandboxId":"nosuchbackend:abc123"}"#;
     let err = run_state_aware_json(json, false, false)
         .expect_err("an unregistered sandbox-id prefix has no backend");
     assert_eq!(err.code, ErrorCode::UnsupportedContainment);
@@ -86,7 +86,7 @@ fn unregistered_backend_prefix_is_unsupported_containment() {
 /// before backend dispatch on every platform.
 #[test]
 fn experimental_backend_is_refused_without_the_optin() {
-    let json = r#"{"phase":"provision","containment":"windows_sandbox"}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#;
     let err = run_state_aware_json(json, true, false)
         .expect_err("an experimental backend without the opt-in must be refused");
     assert_eq!(err.code, ErrorCode::BackendUnavailable);
@@ -107,7 +107,7 @@ fn experimental_backend_is_refused_without_the_optin() {
 /// this fails. A dry run keeps it side-effect-free.
 #[test]
 fn the_optin_admits_an_experimental_backend() {
-    let json = r#"{"phase":"provision","containment":"windows_sandbox"}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#;
     if let Err(err) = run_state_aware_json(json, true, true) {
         assert_ne!(
             err.code,
@@ -123,7 +123,7 @@ fn the_optin_admits_an_experimental_backend() {
 /// offers no hint either.
 #[test]
 fn the_refusal_carries_no_api_call_detail() {
-    let json = r#"{"phase":"provision","containment":"windows_sandbox"}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#;
     let err = run_state_aware_json(json, true, false).expect_err("must be refused");
     assert_eq!(err.operation, None);
     assert_eq!(err.native_code, None);
@@ -142,7 +142,7 @@ fn the_refusal_carries_no_api_call_detail() {
 /// `backend_unavailable`, which is the very code the gate returns.)
 #[test]
 fn exec_honours_the_optin_on_its_own_path() {
-    let json = r#"{"phase":"exec","sandboxId":"wsb:0a1b2c3d","process":{"commandLine":"echo hi"}}"#;
+    let json = r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"wsb:0a1b2c3d","process":{"commandLine":"echo hi"}}"#;
 
     match exec_sandbox(json, false) {
         Ok(_) => panic!("without the opt-in the gate must refuse"),

--- a/src/core/mxc_engine/src/state_aware.rs
+++ b/src/core/mxc_engine/src/state_aware.rs
@@ -742,7 +742,7 @@ mod tests {
         // The gate and phase checks pass, so the refusal can only come from the
         // single-flight claim. The exec goes no further: `wsb:` resolves to a
         // backend needing a live host, and the claim is taken before that.
-        let json = r#"{"phase":"exec","sandboxId":"wsb:0123abcd",
+        let json = r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"wsb:0123abcd",
             "process":{"commandLine":"cmd.exe /c echo hi"}}"#;
 
         let held = claim_attached_exec().expect("the claim must be available");
@@ -760,7 +760,7 @@ mod tests {
 
     #[test]
     fn attached_exec_requires_a_terminal() {
-        let json = r#"{"phase":"exec","sandboxId":"wsb:0123abcd",
+        let json = r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"wsb:0123abcd",
             "process":{"commandLine":"cmd.exe /c echo hi"}}"#;
 
         let err = exec_state_aware_attached_with(json, true, || false)
@@ -777,7 +777,7 @@ mod tests {
     fn attached_exec_checks_the_phase_before_the_terminal() {
         // A non-exec phase must be reported as such even from a non-terminal
         // host, so the caller learns the actionable problem first.
-        let provision = r#"{"phase":"provision","containment":"isolation_session",
+        let provision = r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
             "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#;
 
         let err = exec_state_aware_attached_with(provision, true, || false)
@@ -957,8 +957,12 @@ mod tests {
 
         // Provision without containment — the dispatcher rejects it as
         // `MalformedRequest` before ever reaching a backend.
-        let error =
-            super::run_state_aware_json(r#"{"phase":"provision"}"#, false, false).unwrap_err();
+        let error = super::run_state_aware_json(
+            r#"{"version":"0.9.0-alpha","phase":"provision"}"#,
+            false,
+            false,
+        )
+        .unwrap_err();
         assert_eq!(error.code, ErrorCode::MalformedRequest);
         assert_eq!(
             telemetry::classify_mxc_error(&MxcError::malformed_request(error.message)),
@@ -969,7 +973,7 @@ mod tests {
         // `BackendUnavailable` → `InitError`; the shared classifier keeps
         // streaming and state-aware attribution in lockstep.
         let error = super::run_state_aware_json(
-            r#"{"phase":"provision","containment":"windows_sandbox"}"#,
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#,
             false,
             false,
         )
@@ -998,7 +1002,7 @@ mod tests {
         use crate::error::ErrorCode;
         for _ in 0..3 {
             let error = super::run_state_aware_json(
-                r#"{"phase":"provision","containment":"windows_sandbox"}"#,
+                r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#,
                 false,
                 false,
             )

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -2458,6 +2458,7 @@ mod tests {
     fn state_aware_exec_cli_command_overrides_policy_command_line() {
         let argv = &["wxc-exec", "policy.json", "--", "echo", "hi"];
         let policy = r#"{
+            "version": "0.9.0-alpha",
             "phase": "exec",
             "sandboxId": "iso:abcd1234",
             "process": {
@@ -2480,6 +2481,7 @@ mod tests {
     fn state_aware_exec_cli_command_fills_absent_policy_command_line_without_override_log() {
         let argv = &["wxc-exec", "policy.json", "--", "echo", "hi"];
         let policy = r#"{
+            "version": "0.9.0-alpha",
             "phase": "exec",
             "sandboxId": "iso:abcd1234"
         }"#;
@@ -2499,6 +2501,7 @@ mod tests {
     fn state_aware_non_exec_cli_command_error_routes_to_envelope() {
         let argv = &["wxc-exec", "policy.json", "--", "echo", "hi"];
         let policy = r#"{
+            "version": "0.9.0-alpha",
             "phase": "start",
             "sandboxId": "iso:abcd1234"
         }"#;
@@ -2525,6 +2528,7 @@ mod tests {
             "hidden\0payload",
         ];
         let policy = r#"{
+            "version": "0.9.0-alpha",
             "phase": "exec",
             "sandboxId": "iso:abcd1234"
         }"#;

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -2473,6 +2473,25 @@ mod tests {
         PublishedDevelopmentContainment,
         PublishedExperimental,
         PublishedStateAware,
+        DevelopmentContractTightening,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct ExpectedCorpusDivergence {
+        kind: CorpusDivergenceKind,
+        route: ErrorRoute,
+        category: ErrorCategory,
+        path: Option<&'static str>,
+        message_fragment: &'static str,
+    }
+
+    impl ExpectedCorpusDivergence {
+        fn matches(self, actual: &DiagnosticSnapshot) -> bool {
+            actual.route == self.route
+                && actual.category == self.category
+                && actual.path.as_deref() == self.path
+                && actual.message.contains(self.message_fragment)
+        }
     }
 
     impl CorpusDivergenceKind {
@@ -2493,512 +2512,85 @@ mod tests {
                 Self::PublishedStateAware => {
                     "Published 0.6-0.8 contracts are one-shot only; state-aware roots exist in the development contract."
                 }
+                Self::DevelopmentContractTightening => {
+                    "The migrated 0.9 contract intentionally rejects a parse-and-ignore one-shot extension or a phase/backend policy that the rolling parser defers to backend validation."
+                }
             }
         }
     }
 
     fn expected_corpus_divergences(
-    ) -> std::collections::BTreeMap<&'static str, CorpusDivergenceKind> {
+    ) -> std::collections::BTreeMap<&'static str, ExpectedCorpusDivergence> {
         let entries = [
             (
-                "tests/configs/basic_windows_sandbox.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/experimental_hello_lxc.json",
-                CorpusDivergenceKind::PublishedExperimental,
-            ),
-            (
-                "tests/configs/experimental_hello_processcontainer.json",
-                CorpusDivergenceKind::PublishedExperimental,
-            ),
-            (
-                "tests/configs/hyperlight_exit_code.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_fs.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_hello.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_networking.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_networking_blocked.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_pandas.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/hyperlight_timeout.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_concurrent_A.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_concurrent_B.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_concurrent_C.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_concurrent_D.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
                 "tests/configs/isolation_session_configid_ignored.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_exit42.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_hello.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_one_shot_lifecycle_rejected.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_one_shot_network_rejected.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_one_shot_network_rejected_hosts.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_one_shot_network_rejected_no_local.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::OneShot,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("experimental.isolation_session"),
+                    message_fragment: "unknown field `isolation_session`",
+                },
             ),
             (
                 "tests/configs/isolation_session_one_shot_stray_config_ignored.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_one_shot_ui_rejected.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_powershell_interactive.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_deprovision.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_basic.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_cwd.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_env_absent.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_env_initial.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_env_modified.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_exit_0.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_exit_1.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_exit_2.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_read_marker.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_read_persist.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_setx_initial.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_setx_modified.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_exec_write_marker.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_provision.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_provision_appid.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_provision_appid_control.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_provision_appid_empty.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_provision_appid_too_long.json",
-                CorpusDivergenceKind::MissingVersion,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::OneShot,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("experimental.isolation_session"),
+                    message_fragment: "unknown field `isolation_session`",
+                },
             ),
             (
                 "tests/configs/isolation_session_state_aware_provision_rejected_denied.json",
-                CorpusDivergenceKind::MissingVersion,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::StateAware,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("filesystem"),
+                    message_fragment: "unknown field `filesystem`",
+                },
             ),
             (
                 "tests/configs/isolation_session_state_aware_provision_rejected_network.json",
-                CorpusDivergenceKind::MissingVersion,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::StateAware,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("network.defaultPolicy"),
+                    message_fragment: "unknown variant `block`, expected `allow`",
+                },
             ),
             (
                 "tests/configs/isolation_session_state_aware_provision_rejected_ui.json",
-                CorpusDivergenceKind::MissingVersion,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::StateAware,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("ui"),
+                    message_fragment: "unknown field `ui`",
+                },
             ),
             (
                 "tests/configs/isolation_session_state_aware_provision_with_filesystem.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_start.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_state_aware_stop.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/isolation_session_stderr.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_stdout_stderr_interleaved.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_streaming_smoke.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/isolation_session_timeout.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/microvm_error.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_error_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_exit_code.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_exit_code_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_hello.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_hello_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_large_output.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_large_output_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_multiline.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_multiline_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_network.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_network_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_stdlib.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_stdlib_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_timeout.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/microvm_timeout_linux.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_custom_timeout.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/windows_sandbox_echo.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_exit_code.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_powershell.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_powershell_env.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_stderr.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/windows_sandbox_timeout.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/configs/wslc_custom_registry.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_custom_registry_ghcr.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_custom_registry_quay.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_denied_dotdot_alias.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_denied_masking.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_destroy_on_exit_false_rejected.json",
-                CorpusDivergenceKind::PublishedComment,
-            ),
-            (
-                "tests/configs/wslc_destroy_on_exit_true.json",
-                CorpusDivergenceKind::PublishedComment,
-            ),
-            (
-                "tests/configs/wslc_env_vars.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_exit_code.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_filesystem.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_filesystem_object.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_large_output.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_most_specific_denied_parent.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_network_isolated.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_network_proxy.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_port_mapping_multiple.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_port_mapping_tcp.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_python_hello.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_python_stdlib.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_readonly_mount.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_state_aware_deprovision.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_basic.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_drip.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_env.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_exit_0.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_exit_1.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_exit_7.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_proxy.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_read_marker.json",
-                CorpusDivergenceKind::PublishedStateAware,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::StateAware,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("filesystem"),
+                    message_fragment: "unknown field `filesystem`",
+                },
             ),
             (
                 "tests/configs/wslc_state_aware_exec_rejected_filesystem.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_exec_write_marker.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision_bridged.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision_rejected_denied.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision_rejected_hosts.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision_rejected_proxy.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_provision_with_filesystem.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_start.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_state_aware_stop.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/configs/wslc_stderr.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_tar_import_docker_save.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_tar_import_rootfs.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/configs/wslc_timeout.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/examples/09_windows_sandbox_hello_world.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/examples/10_windows_sandbox_network_isolated.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/examples/28_telemetry_enabled.json",
-                CorpusDivergenceKind::MissingVersion,
-            ),
-            (
-                "tests/examples/wslc_hello_world.json",
-                CorpusDivergenceKind::PublishedDevelopmentContainment,
-            ),
-            (
-                "tests/policy/state-aware-wslc-exec.json",
-                CorpusDivergenceKind::PublishedStateAware,
-            ),
-            (
-                "tests/policy/state-aware-wslc-provision.json",
-                CorpusDivergenceKind::PublishedStateAware,
+                ExpectedCorpusDivergence {
+                    kind: CorpusDivergenceKind::DevelopmentContractTightening,
+                    route: ErrorRoute::StateAware,
+                    category: ErrorCategory::TypedStructure,
+                    path: Some("filesystem"),
+                    message_fragment: "unknown field `filesystem`",
+                },
             ),
         ];
         let divergences: std::collections::BTreeMap<_, _> = entries.into_iter().collect();
@@ -3262,6 +2854,27 @@ mod tests {
         }
 
         let version = object.get("version")?.as_str()?;
+        if version == "0.9.0-alpha" {
+            let is_closed_one_shot_extension = exact.route == ErrorRoute::OneShot
+                && exact.category == ErrorCategory::TypedStructure
+                && exact.message.contains("unknown field `isolation_session`");
+            let is_state_aware_policy_tightening = exact.route == ErrorRoute::StateAware
+                && matches!(
+                    exact.category,
+                    ErrorCategory::TypedStructure | ErrorCategory::Semantic
+                )
+                && (object.contains_key("filesystem")
+                    || object.contains_key("ui")
+                    || object
+                        .get("network")
+                        .and_then(serde_json::Value::as_object)
+                        .and_then(|network| network.get("defaultPolicy"))
+                        .and_then(serde_json::Value::as_str)
+                        == Some("block"));
+            return (is_closed_one_shot_extension || is_state_aware_policy_tightening)
+                .then_some(CorpusDivergenceKind::DevelopmentContractTightening);
+        }
+
         if !matches!(version, "0.6.0-alpha" | "0.7.0-alpha" | "0.8.0-alpha")
             || exact.route != ErrorRoute::OneShot
             || exact.category != ErrorCategory::TypedStructure
@@ -4358,12 +3971,15 @@ mod tests {
 
         let expected = expected_corpus_divergences();
         let expected_diagnostics = expected_corpus_diagnostic_divergences();
-        let expected_counts = corpus_divergence_counts(expected.values().copied());
+        let expected_counts =
+            corpus_divergence_counts(expected.values().map(|expected| expected.kind));
         let mut observed = std::collections::BTreeMap::new();
         let mut observed_diagnostics = std::collections::BTreeSet::new();
         let mut seen_files = std::collections::BTreeSet::new();
         let mut classified = Vec::new();
         let mut blockers = Vec::new();
+        let mut equivalent_accepts = 0;
+        let mut shared_rejections = 0;
 
         for path in &files {
             let relative = path
@@ -4383,9 +3999,11 @@ mod tests {
             let (rolling, exact) = parse_both(&json);
             match (&rolling, &exact) {
                 (ParserSnapshot::Accepted(rolling), ParserSnapshot::Accepted(exact)) => {
-                    if let Some(kind) = expected.get(relative.as_str()) {
+                    equivalent_accepts += 1;
+                    if let Some(expected) = expected.get(relative.as_str()) {
                         blockers.push(format!(
-                            "{relative}: expected {kind:?} exact-stricter divergence, but both parsers accepted"
+                            "{relative}: expected {:?} exact-stricter divergence, but both parsers accepted",
+                            expected.kind
                         ));
                     }
                     if rolling != exact {
@@ -4398,9 +4016,11 @@ mod tests {
                     ParserSnapshot::Rejected(rolling_diagnostic),
                     ParserSnapshot::Rejected(exact_diagnostic),
                 ) => {
-                    if let Some(kind) = expected.get(relative.as_str()) {
+                    shared_rejections += 1;
+                    if let Some(expected) = expected.get(relative.as_str()) {
                         blockers.push(format!(
-                            "{relative}: expected {kind:?} exact-stricter divergence, but both parsers rejected"
+                            "{relative}: expected {:?} exact-stricter divergence, but both parsers rejected",
+                            expected.kind
                         ));
                     }
                     match expected_diagnostics.get(relative.as_str()) {
@@ -4446,11 +4066,14 @@ mod tests {
                             kind.reason()
                         ));
                         match expected.get(relative.as_str()) {
-                            Some(expected_kind) if *expected_kind == kind => {
-                                observed.insert(relative.clone(), kind);
+                            Some(expected)
+                                if expected.kind == kind
+                                    && expected.matches(exact_diagnostic) =>
+                            {
+                                observed.insert(relative.clone(), expected.kind);
                             }
-                            Some(expected_kind) => blockers.push(format!(
-                                "{relative}: expected {expected_kind:?}, observed {kind:?}\nexact={exact_diagnostic:?}"
+                            Some(expected) => blockers.push(format!(
+                                "{relative}: expected {expected:?}, observed kind={kind:?}\nexact={exact_diagnostic:?}"
                             )),
                             None => blockers.push(format!(
                                 "{relative}: newly divergent corpus file requires explicit classification as {kind:?}\nexact={exact_diagnostic:?}"
@@ -4470,10 +4093,11 @@ mod tests {
             }
         }
 
-        for (relative, kind) in &expected {
+        for (relative, expected) in &expected {
             if !seen_files.contains(*relative) {
                 blockers.push(format!(
-                    "{relative}: expected {kind:?} divergence fixture is missing from the corpus"
+                    "{relative}: expected {:?} divergence fixture is missing from the corpus",
+                    expected.kind
                 ));
             }
         }
@@ -4501,6 +4125,11 @@ mod tests {
         assert_eq!(
             observed_counts, expected_counts,
             "explicit divergence inventory and observed category totals differ"
+        );
+        assert_eq!(
+            (files.len(), equivalent_accepts, shared_rejections),
+            (354, 333, 14),
+            "the Phase 8 corpus inventory changed; regenerate the migration report and explain the delta"
         );
     }
 

--- a/src/ffi/mxc_ffi/examples/attached_console_ffi.rs
+++ b/src/ffi/mxc_ffi/examples/attached_console_ffi.rs
@@ -76,9 +76,10 @@ impl Drop for Teardown {
         eprintln!("\n[driver] tearing down…");
         // Best-effort: a failed stop must not prevent the deprovision that
         // releases the account.
-        let stop = format!(r#"{{"phase":"stop","sandboxId":"{id}"}}"#);
+        let stop = format!(r#"{{"version":"0.9.0-alpha","phase":"stop","sandboxId":"{id}"}}"#);
         let _ = std::panic::catch_unwind(move || phase(&stop));
-        let deprovision = format!(r#"{{"phase":"deprovision","sandboxId":"{id}"}}"#);
+        let deprovision =
+            format!(r#"{{"version":"0.9.0-alpha","phase":"deprovision","sandboxId":"{id}"}}"#);
         match std::panic::catch_unwind(move || phase(&deprovision)) {
             Ok(_) => eprintln!("[driver] deprovisioned."),
             Err(_) => eprintln!("[driver] WARNING: deprovision failed, account may leak"),
@@ -94,7 +95,7 @@ fn run() -> i32 {
         .unwrap_or_else(|| "powershell.exe -NoLogo".into());
 
     let provisioned = phase(
-        r#"{"phase":"provision","containment":"isolation_session",
+        r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
             "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#,
     );
     // The sandbox id is opaque by contract — carried verbatim, never parsed.
@@ -113,14 +114,14 @@ fn run() -> i32 {
     eprintln!("[driver] provisioned.");
 
     phase(&format!(
-        r#"{{"phase":"start","sandboxId":"{sandbox_id}"}}"#
+        r#"{{"version":"0.9.0-alpha","phase":"start","sandboxId":"{sandbox_id}"}}"#
     ));
     eprintln!("[driver] started. Running: {command}");
     eprintln!("[driver] everything below runs inside the isolation session.\n");
 
     let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
     let exec = CString::new(format!(
-        r#"{{"phase":"exec","sandboxId":"{sandbox_id}",
+        r#"{{"version":"0.9.0-alpha","phase":"exec","sandboxId":"{sandbox_id}",
             "process":{{"commandLine":"{escaped}","timeout":3600000}}}}"#
     ))
     .expect("request holds no interior NUL");

--- a/src/ffi/mxc_ffi/src/state_aware.rs
+++ b/src/ffi/mxc_ffi/src/state_aware.rs
@@ -477,7 +477,7 @@ mod tests {
     #[test]
     fn non_dry_run_exec_is_rejected() {
         let mut out = call(
-            r#"{"phase":"exec","sandboxId":"isolationsession:abc","process":{"commandLine":"echo hi"}}"#,
+            r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"isolationsession:abc","process":{"commandLine":"echo hi"}}"#,
             false,
         );
         assert_eq!(out.status, crate::MXC_STATUS_MALFORMED_REQUEST);
@@ -493,7 +493,7 @@ mod tests {
         // (A real isolation_session provision is avoided: on a capable host it
         // would actually provision a sandbox. See the mxc-sdk state_aware test.)
         let mut out = call(
-            r#"{"phase":"start","sandboxId":"nosuchbackend:abc123"}"#,
+            r#"{"version":"0.9.0-alpha","phase":"start","sandboxId":"nosuchbackend:abc123"}"#,
             false,
         );
         assert_eq!(out.status, crate::MXC_STATUS_UNSUPPORTED_CONTAINMENT);
@@ -514,7 +514,10 @@ mod tests {
 
     #[test]
     fn null_out_reports_null_argument() {
-        let j = CString::new(r#"{"phase":"provision","containment":"isolation_session"}"#).unwrap();
+        let j = CString::new(
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session"}"#,
+        )
+        .unwrap();
         // SAFETY: valid string, deliberately-null out.
         let status = unsafe { mxc_state_aware(j.as_ptr(), 0, 0, ptr::null_mut()) };
         assert_eq!(status, MXC_STATUS_NULL_ARGUMENT);
@@ -522,7 +525,8 @@ mod tests {
 
     #[test]
     fn exec_null_out_handle_is_null_argument() {
-        let j = CString::new(r#"{"phase":"exec","sandboxId":"x:y"}"#).unwrap();
+        let j =
+            CString::new(r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"x:y"}"#).unwrap();
         // SAFETY: valid string, deliberately-null out_handle.
         let status =
             unsafe { mxc_state_aware_exec(j.as_ptr(), 0, ptr::null_mut(), ptr::null_mut()) };
@@ -531,7 +535,10 @@ mod tests {
 
     #[test]
     fn exec_non_exec_phase_reports_error_and_null_handle() {
-        let j = CString::new(r#"{"phase":"provision","containment":"isolation_session"}"#).unwrap();
+        let j = CString::new(
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session"}"#,
+        )
+        .unwrap();
         let mut handle: *mut MxcSandbox = ptr::null_mut();
         let mut err = MxcErrorDetail::none();
         // SAFETY: valid string and out pointers.
@@ -549,7 +556,7 @@ mod tests {
     #[test]
     fn experimental_backend_is_refused_without_the_optin() {
         let mut out = call_opt(
-            r#"{"phase":"provision","containment":"windows_sandbox"}"#,
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#,
             true,
             false,
         );
@@ -569,7 +576,7 @@ mod tests {
     #[test]
     fn the_optin_admits_an_experimental_backend() {
         let mut out = call_opt(
-            r#"{"phase":"provision","containment":"windows_sandbox"}"#,
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"windows_sandbox"}"#,
             true,
             true,
         );
@@ -587,7 +594,7 @@ mod tests {
     #[test]
     fn exec_honours_the_optin_on_its_own_path() {
         let j = CString::new(
-            r#"{"phase":"exec","sandboxId":"wsb:0a1b2c3d","process":{"commandLine":"echo hi"}}"#,
+            r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"wsb:0a1b2c3d","process":{"commandLine":"echo hi"}}"#,
         )
         .unwrap();
 
@@ -643,7 +650,7 @@ mod tests {
     #[test]
     fn attached_rejects_a_null_outcome_before_running_anything() {
         let j = CString::new(
-            r#"{"phase":"exec","sandboxId":"isolationsession:x",
+            r#"{"version":"0.9.0-alpha","phase":"exec","sandboxId":"isolationsession:x",
             "process":{"commandLine":"cmd.exe /c echo hi"}}"#,
         )
         .unwrap();
@@ -662,7 +669,7 @@ mod tests {
         // this is independent of the test binary's stdio. The message assertion
         // discriminates it from the other refusals, which share this status.
         let (status, outcome, mut err) = attached(
-            r#"{"phase":"provision","containment":"isolation_session",
+            r#"{"version":"0.9.0-alpha","phase":"provision","containment":"isolation_session",
                 "network":{"defaultPolicy":"allow","allowLocalNetwork":true}}"#,
             true,
         );

--- a/src/testing/wxc_e2e_tests/tests/e2e_isolation_session_policy.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_isolation_session_policy.rs
@@ -138,6 +138,7 @@ fn state_aware_provision_refuses_ui_policy_with_policy_validation() {
     }
 
     let request = json!({
+        "version": "0.9.0-alpha",
         "phase": "provision",
         "containment": "isolation_session",
         "network": { "defaultPolicy": "allow", "allowLocalNetwork": true },
@@ -170,6 +171,7 @@ fn state_aware_provision_accepts_canonical_request_shape() {
     // anything, so this is safe on a host with the OS-side service and on one
     // without it alike.
     let request = json!({
+        "version": "0.9.0-alpha",
         "phase": "provision",
         "containment": "isolation_session",
         "network": { "defaultPolicy": "allow", "allowLocalNetwork": true }

--- a/src/testing/wxc_e2e_tests/tests/e2e_state_aware.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_state_aware.rs
@@ -55,6 +55,7 @@ fn state_aware_unknown_containment_emits_error_envelope_on_stdout() {
     // a state-aware request — exercises the parser-level rejection branch of
     // the wire-format error contract.
     let request = json!({
+        "version": "0.9.0-alpha",
         "containment": "totally_made_up",
         "phase": "provision"
     });
@@ -84,6 +85,7 @@ fn state_aware_recognized_but_non_state_aware_backend_emits_unsupported_phase() 
     // `backend_unavailable` instead, so a non-experimental GA backend is used
     // here to exercise the fallback.
     let request = json!({
+        "version": "0.9.0-alpha",
         "containment": "processcontainer",
         "phase": "provision"
     });

--- a/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_windows.rs
@@ -207,6 +207,7 @@ fn microvm_network_blocked() {
 
     // Negative case: host is on the blocklist -> guest egress denied (EACCES).
     let blocked = serde_json::json!({
+        "version": "0.9.0-alpha",
         "process": { "commandLine": source, "timeout": 30000 },
         "containment": "microvm",
         "network": { "blockedHosts": [host_ip.to_string()] }
@@ -233,6 +234,7 @@ fn microvm_network_blocked() {
     // closed target yields a connection error other than EACCES (typically
     // ECONNREFUSED / errno 111), never the filter's EACCES.
     let allowed = serde_json::json!({
+        "version": "0.9.0-alpha",
         "process": { "commandLine": source, "timeout": 30000 },
         "containment": "microvm",
         "network": { "defaultPolicy": "allow" }
@@ -292,6 +294,7 @@ fn processcontainer_capture_denials_output_file() {
     let _ = std::fs::remove_file(&output_path);
 
     let config = serde_json::json!({
+        "version": "0.9.0-alpha",
         "process": { "commandLine": "cmd.exe /c echo capture-denials-e2e", "timeout": 30000 },
         "containment": "processcontainer",
         "processContainer": {
@@ -407,6 +410,7 @@ fn processcontainer_capture_denials_timeout_retention() {
     let _ = std::fs::remove_file(&output_path);
 
     let config = serde_json::json!({
+        "version": "0.9.0-alpha",
         "process": {
             "commandLine": "cmd.exe /d /c \"for /L %i in (1,1,100000000) do @rem\"",
             "timeout": 1000
@@ -1055,6 +1059,7 @@ fn hyperlight_suite() {
         );
 
         let config = serde_json::json!({
+            "version": "0.9.0-alpha",
             "process": { "commandLine": script, "timeout": 30000 },
             "containment": "hyperlight",
             "filesystem": { "readwritePaths": [mount_dir.to_string_lossy()] }
@@ -1119,6 +1124,7 @@ fn hyperlight_suite() {
         );
 
         let config = serde_json::json!({
+            "version": "0.9.0-alpha",
             "process": { "commandLine": script, "timeout": 30000 },
             "containment": "hyperlight",
             "filesystem": {

--- a/tests/configs/basic_windows_sandbox.json
+++ b/tests/configs/basic_windows_sandbox.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-WindowsSandbox-Hello-World",
   "containment": "windows_sandbox",
   "process": {

--- a/tests/configs/experimental_hello_lxc.json
+++ b/tests/configs/experimental_hello_lxc.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-Experimental-Hello-LXC",
   "containment": "lxc",
   "process": {

--- a/tests/configs/experimental_hello_processcontainer.json
+++ b/tests/configs/experimental_hello_processcontainer.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-Experimental-Hello",
   "containment": "processcontainer",
   "process": {

--- a/tests/configs/hyperlight_exit_code.json
+++ b/tests/configs/hyperlight_exit_code.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import sys; sys.exit(42)",
         "timeout": 30000

--- a/tests/configs/hyperlight_fs.json
+++ b/tests/configs/hyperlight_fs.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "_comment": "End-to-end filesystem test. readwritePaths are exposed to the guest under /host/<basename>. Before running, create /tmp/hyperlight-fs-demo/ and drop a file in it (or let the script create one). After the run, /tmp/hyperlight-fs-demo/written.txt will exist with guest-written content.",
 
     "process": {

--- a/tests/configs/hyperlight_hello.json
+++ b/tests/configs/hyperlight_hello.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import sys\nprint(f'Hello from Hyperlight! Python {sys.version.split()[0]} on {sys.platform}')",
         "timeout": 30000

--- a/tests/configs/hyperlight_networking.json
+++ b/tests/configs/hyperlight_networking.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import urllib.request; r = urllib.request.urlopen('http://example.com/'); print(r.status)",
         "timeout": 30000

--- a/tests/configs/hyperlight_networking_blocked.json
+++ b/tests/configs/hyperlight_networking_blocked.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import urllib.request\ntry:\n    urllib.request.urlopen('http://httpbin.org/', timeout=5)\n    print('FAIL: request should have been blocked')\nexcept Exception as e:\n    print('BLOCKED:', type(e).__name__)",
         "timeout": 30000

--- a/tests/configs/hyperlight_pandas.json
+++ b/tests/configs/hyperlight_pandas.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import pandas as pd, numpy as np\ndf = pd.DataFrame({'x': np.arange(5), 'y': np.arange(5) ** 2})\nprint(df.sum().to_dict())",
         "timeout": 30000

--- a/tests/configs/hyperlight_timeout.json
+++ b/tests/configs/hyperlight_timeout.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import time; time.sleep(120); print('should not reach here')",
         "timeout": 1000

--- a/tests/configs/isolation_session_concurrent_A.json
+++ b/tests/configs/isolation_session_concurrent_A.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-concurrent-A",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_concurrent_B.json
+++ b/tests/configs/isolation_session_concurrent_B.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-concurrent-B",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_concurrent_C.json
+++ b/tests/configs/isolation_session_concurrent_C.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-concurrent-C",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_concurrent_D.json
+++ b/tests/configs/isolation_session_concurrent_D.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-concurrent-D",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_configid_ignored.json
+++ b/tests/configs/isolation_session_configid_ignored.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-hello",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_exit42.json
+++ b/tests/configs/isolation_session_exit42.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-exit42",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_hello.json
+++ b/tests/configs/isolation_session_hello.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-hello",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_lifecycle_rejected.json
+++ b/tests/configs/isolation_session_one_shot_lifecycle_rejected.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-lifecycle-rejected",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_network_rejected.json
+++ b/tests/configs/isolation_session_one_shot_network_rejected.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-network-rejected",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_network_rejected_hosts.json
+++ b/tests/configs/isolation_session_one_shot_network_rejected_hosts.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-network-rejected-hosts",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_network_rejected_no_local.json
+++ b/tests/configs/isolation_session_one_shot_network_rejected_no_local.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-network-rejected-no-local",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_stray_config_ignored.json
+++ b/tests/configs/isolation_session_one_shot_stray_config_ignored.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-stray-config-ignored",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_one_shot_ui_rejected.json
+++ b/tests/configs/isolation_session_one_shot_ui_rejected.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-one-shot-ui-rejected",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_powershell_interactive.json
+++ b/tests/configs/isolation_session_powershell_interactive.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-powershell-interactive",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_state_aware_deprovision.json
+++ b/tests/configs/isolation_session_state_aware_deprovision.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "deprovision",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/isolation_session_state_aware_exec_basic.json
+++ b/tests/configs/isolation_session_state_aware_exec_basic.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_cwd.json
+++ b/tests/configs/isolation_session_state_aware_exec_cwd.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_env_absent.json
+++ b/tests/configs/isolation_session_state_aware_exec_env_absent.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_env_initial.json
+++ b/tests/configs/isolation_session_state_aware_exec_env_initial.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_env_modified.json
+++ b/tests/configs/isolation_session_state_aware_exec_env_modified.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_exit_0.json
+++ b/tests/configs/isolation_session_state_aware_exec_exit_0.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_exit_1.json
+++ b/tests/configs/isolation_session_state_aware_exec_exit_1.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_exit_2.json
+++ b/tests/configs/isolation_session_state_aware_exec_exit_2.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_read_marker.json
+++ b/tests/configs/isolation_session_state_aware_exec_read_marker.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_read_persist.json
+++ b/tests/configs/isolation_session_state_aware_exec_read_persist.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_setx_initial.json
+++ b/tests/configs/isolation_session_state_aware_exec_setx_initial.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_setx_modified.json
+++ b/tests/configs/isolation_session_state_aware_exec_setx_modified.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_exec_write_marker.json
+++ b/tests/configs/isolation_session_state_aware_exec_write_marker.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/isolation_session_state_aware_provision.json
+++ b/tests/configs/isolation_session_state_aware_provision.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_appid.json
+++ b/tests/configs/isolation_session_state_aware_provision_appid.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_appid_control.json
+++ b/tests/configs/isolation_session_state_aware_provision_appid_control.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "phase": "provision",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_state_aware_provision_appid_empty.json
+++ b/tests/configs/isolation_session_state_aware_provision_appid_empty.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_appid_too_long.json
+++ b/tests/configs/isolation_session_state_aware_provision_appid_too_long.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_rejected_denied.json
+++ b/tests/configs/isolation_session_state_aware_provision_rejected_denied.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "filesystem": {

--- a/tests/configs/isolation_session_state_aware_provision_rejected_network.json
+++ b/tests/configs/isolation_session_state_aware_provision_rejected_network.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_rejected_ui.json
+++ b/tests/configs/isolation_session_state_aware_provision_rejected_ui.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "network": {

--- a/tests/configs/isolation_session_state_aware_provision_with_filesystem.json
+++ b/tests/configs/isolation_session_state_aware_provision_with_filesystem.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "isolation_session",
     "filesystem": {

--- a/tests/configs/isolation_session_state_aware_start.json
+++ b/tests/configs/isolation_session_state_aware_start.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "start",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/isolation_session_state_aware_stop.json
+++ b/tests/configs/isolation_session_state_aware_stop.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "phase": "stop",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/isolation_session_stderr.json
+++ b/tests/configs/isolation_session_stderr.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-stderr",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_stdout_stderr_interleaved.json
+++ b/tests/configs/isolation_session_stdout_stderr_interleaved.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-interleaved",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_streaming_smoke.json
+++ b/tests/configs/isolation_session_streaming_smoke.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-streaming-smoke",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/isolation_session_timeout.json
+++ b/tests/configs/isolation_session_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "isolation-session-timeout",
   "containment": "isolation_session",
   "network": {

--- a/tests/configs/microvm_error.json
+++ b/tests/configs/microvm_error.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "raise ValueError('intentional test error')",
         "timeout": 30000

--- a/tests/configs/microvm_error_linux.json
+++ b/tests/configs/microvm_error_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "raise ValueError('intentional test error')",
         "timeout": 30000

--- a/tests/configs/microvm_exit_code.json
+++ b/tests/configs/microvm_exit_code.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import sys; sys.exit(42)",
         "timeout": 30000

--- a/tests/configs/microvm_exit_code_linux.json
+++ b/tests/configs/microvm_exit_code_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import sys; sys.exit(42)",
         "timeout": 30000

--- a/tests/configs/microvm_hello.json
+++ b/tests/configs/microvm_hello.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "x = 42\ny = 58\nprint('Hello from MicroVM! sum=%d' % (x + y))",
         "timeout": 30000

--- a/tests/configs/microvm_hello_linux.json
+++ b/tests/configs/microvm_hello_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "x = 42\ny = 58\nprint('Hello from NanVix/KVM on Linux! sum=%d' % (x + y))",
         "timeout": 30000

--- a/tests/configs/microvm_large_output.json
+++ b/tests/configs/microvm_large_output.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "for i in range(1000):\n    print(f'line {i}: ' + 'x' * 80)",
         "timeout": 30000

--- a/tests/configs/microvm_large_output_linux.json
+++ b/tests/configs/microvm_large_output_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "for i in range(1000):\n    print(f'line {i}: ' + 'x' * 80)",
         "timeout": 30000

--- a/tests/configs/microvm_multiline.json
+++ b/tests/configs/microvm_multiline.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "def fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\n\nfor i in range(10):\n    print(f'fib({i}) = {fib(i)}')",
         "timeout": 30000

--- a/tests/configs/microvm_multiline_linux.json
+++ b/tests/configs/microvm_multiline_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "def fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\n\nfor i in range(10):\n    print(f'fib({i}) = {fib(i)}')",
         "timeout": 30000

--- a/tests/configs/microvm_network.json
+++ b/tests/configs/microvm_network.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import _socket\nsrv = _socket.socket(2, 1, 0)\nsrv.bind(('127.0.0.1', 8080))\nsrv.listen(1)\ncli = _socket.socket(2, 1, 0)\ncli.connect(('127.0.0.1', 8080))\nfd, addr = srv._accept()\nconn = _socket.socket(2, 1, 0, fd)\ncli.send(b'ping')\nassert conn.recv(64) == b'ping'\nconn.send(b'pong')\nassert cli.recv(64) == b'pong'\nprint('NET_OK loopback roundtrip', flush=True)",
         "timeout": 30000

--- a/tests/configs/microvm_network_linux.json
+++ b/tests/configs/microvm_network_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import _socket\nsrv = _socket.socket(2, 1, 0)\nsrv.bind(('127.0.0.1', 8080))\nsrv.listen(1)\ncli = _socket.socket(2, 1, 0)\ncli.connect(('127.0.0.1', 8080))\nfd, addr = srv._accept()\nconn = _socket.socket(2, 1, 0, fd)\ncli.send(b'ping')\nassert conn.recv(64) == b'ping'\nconn.send(b'pong')\nassert cli.recv(64) == b'pong'\nprint('NET_OK loopback roundtrip', flush=True)",
         "timeout": 30000

--- a/tests/configs/microvm_stdlib.json
+++ b/tests/configs/microvm_stdlib.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import json, math, hashlib\ndata = {'pi': math.pi, 'e': math.e, 'hash': hashlib.sha256(b'nanvix').hexdigest()[:16]}\nprint(json.dumps(data))",
         "timeout": 30000

--- a/tests/configs/microvm_stdlib_linux.json
+++ b/tests/configs/microvm_stdlib_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "process": {
         "commandLine": "import json, math, hashlib\ndata = {'pi': math.pi, 'e': math.e, 'hash': hashlib.sha256(b'nanvix').hexdigest()[:16]}\nprint(json.dumps(data))",
         "timeout": 30000

--- a/tests/configs/microvm_timeout.json
+++ b/tests/configs/microvm_timeout.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "_comment": "Timeout test. Note: MicroVM adds a 60s boot grace to the 5s script timeout, so actual wall time is ~65s.",
     "process": {
         "commandLine": "import time; time.sleep(120); print('should not reach here')",

--- a/tests/configs/microvm_timeout_linux.json
+++ b/tests/configs/microvm_timeout_linux.json
@@ -1,4 +1,5 @@
 {
+    "version": "0.9.0-alpha",
     "_comment": "Timeout test. NanVix adds a 60s boot grace to the 5s script timeout, so actual wall time is ~65s.",
     "process": {
         "commandLine": "import time; time.sleep(120); print('should not reach here')",

--- a/tests/configs/windows_sandbox_custom_timeout.json
+++ b/tests/configs/windows_sandbox_custom_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-WindowsSandbox-Timeout",
   "containment": "windows_sandbox",
   "process": {

--- a/tests/configs/windows_sandbox_echo.json
+++ b/tests/configs/windows_sandbox_echo.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "echo Hello from sandbox!",

--- a/tests/configs/windows_sandbox_exit_code.json
+++ b/tests/configs/windows_sandbox_exit_code.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "exit /b 42",

--- a/tests/configs/windows_sandbox_powershell.json
+++ b/tests/configs/windows_sandbox_powershell.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "powershell -NoProfile -Command \"Write-Output 'PowerShell works'; $PSVersionTable.PSVersion.ToString()\"",

--- a/tests/configs/windows_sandbox_powershell_env.json
+++ b/tests/configs/windows_sandbox_powershell_env.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "powershell -NoProfile -Command \"Write-Output ('ComputerName=' + $env:COMPUTERNAME); Write-Output ('User=' + $env:USERNAME); Write-Output ('ProcessCount=' + (Get-Process | Measure-Object).Count)\"",

--- a/tests/configs/windows_sandbox_stderr.json
+++ b/tests/configs/windows_sandbox_stderr.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "echo stdout-message && echo stderr-message 1>&2",

--- a/tests/configs/windows_sandbox_timeout.json
+++ b/tests/configs/windows_sandbox_timeout.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.9.0-alpha",
   "containment": "windows_sandbox",
   "process": {
     "commandLine": "ping -n 30 127.0.0.1",

--- a/tests/configs/wslc_custom_registry.json
+++ b/tests/configs/wslc_custom_registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-custom-registry",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_custom_registry_ghcr.json
+++ b/tests/configs/wslc_custom_registry_ghcr.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-ghcr-registry",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_custom_registry_quay.json
+++ b/tests/configs/wslc_custom_registry_quay.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-quay-registry",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_denied_dotdot_alias.json
+++ b/tests/configs/wslc_denied_dotdot_alias.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-denied-dotdot-alias",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_denied_masking.json
+++ b/tests/configs/wslc_denied_masking.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-denied-masking",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_destroy_on_exit_false_rejected.json
+++ b/tests/configs/wslc_destroy_on_exit_false_rejected.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Rejection fixture: the one-shot WSLc surface refuses lifecycle.destroyOnExit=false. The container is scoped to a session this process owns, and terminating that session reaps the container regardless of the AutoRemove flag, so `false` cannot be honored. Expects a rejection before any container is created -- the payload must never run.",
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-destroy-on-exit-false-rejected",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_destroy_on_exit_true.json
+++ b/tests/configs/wslc_destroy_on_exit_true.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Smoke test: asserts the config parses and the payload runs. WSLC's session teardown reaps session-scoped containers regardless of the AutoRemove flag, so `true` has no externally observable effect -- it is accepted because that teardown is exactly what it asks for. See wslc_destroy_on_exit_false_rejected.json for the refused counterpart.",
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-destroy-on-exit-true",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_env_vars.json
+++ b/tests/configs/wslc_env_vars.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-env-vars",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_exit_code.json
+++ b/tests/configs/wslc_exit_code.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-exit-code",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_filesystem.json
+++ b/tests/configs/wslc_filesystem.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-filesystem-test",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_filesystem_object.json
+++ b/tests/configs/wslc_filesystem_object.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-object-validation",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_large_output.json
+++ b/tests/configs/wslc_large_output.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-large-output",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_most_specific_denied_parent.json
+++ b/tests/configs/wslc_most_specific_denied_parent.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-most-specific-denied-parent",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_network_isolated.json
+++ b/tests/configs/wslc_network_isolated.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-network-isolated",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_network_proxy.json
+++ b/tests/configs/wslc_network_proxy.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-network-proxy",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_port_mapping_multiple.json
+++ b/tests/configs/wslc_port_mapping_multiple.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-port-mapping-multiple",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_port_mapping_tcp.json
+++ b/tests/configs/wslc_port_mapping_tcp.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-port-mapping-tcp",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_python_hello.json
+++ b/tests/configs/wslc_python_hello.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-python-hello",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_python_stdlib.json
+++ b/tests/configs/wslc_python_stdlib.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-python-stdlib",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_readonly_mount.json
+++ b/tests/configs/wslc_readonly_mount.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-readonly-mount",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_state_aware_deprovision.json
+++ b/tests/configs/wslc_state_aware_deprovision.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "deprovision",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/wslc_state_aware_exec_basic.json
+++ b/tests/configs/wslc_state_aware_exec_basic.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_drip.json
+++ b/tests/configs/wslc_state_aware_exec_drip.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_env.json
+++ b/tests/configs/wslc_state_aware_exec_env.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_exit_0.json
+++ b/tests/configs/wslc_state_aware_exec_exit_0.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_exit_1.json
+++ b/tests/configs/wslc_state_aware_exec_exit_1.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_exit_7.json
+++ b/tests/configs/wslc_state_aware_exec_exit_7.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_proxy.json
+++ b/tests/configs/wslc_state_aware_exec_proxy.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "network": {

--- a/tests/configs/wslc_state_aware_exec_read_marker.json
+++ b/tests/configs/wslc_state_aware_exec_read_marker.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_exec_rejected_filesystem.json
+++ b/tests/configs/wslc_state_aware_exec_rejected_filesystem.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "filesystem": {

--- a/tests/configs/wslc_state_aware_exec_write_marker.json
+++ b/tests/configs/wslc_state_aware_exec_write_marker.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "exec",
     "sandboxId": "{{SANDBOX_ID}}",
     "process": {

--- a/tests/configs/wslc_state_aware_provision.json
+++ b/tests/configs/wslc_state_aware_provision.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "network": {

--- a/tests/configs/wslc_state_aware_provision_bridged.json
+++ b/tests/configs/wslc_state_aware_provision_bridged.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "network": {

--- a/tests/configs/wslc_state_aware_provision_rejected_denied.json
+++ b/tests/configs/wslc_state_aware_provision_rejected_denied.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "filesystem": {

--- a/tests/configs/wslc_state_aware_provision_rejected_hosts.json
+++ b/tests/configs/wslc_state_aware_provision_rejected_hosts.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "network": {

--- a/tests/configs/wslc_state_aware_provision_rejected_proxy.json
+++ b/tests/configs/wslc_state_aware_provision_rejected_proxy.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "network": {

--- a/tests/configs/wslc_state_aware_provision_with_filesystem.json
+++ b/tests/configs/wslc_state_aware_provision_with_filesystem.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "provision",
     "containment": "wslc",
     "filesystem": {

--- a/tests/configs/wslc_state_aware_start.json
+++ b/tests/configs/wslc_state_aware_start.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "start",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/wslc_state_aware_stop.json
+++ b/tests/configs/wslc_state_aware_stop.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0-alpha",
+    "version": "0.9.0-alpha",
     "phase": "stop",
     "sandboxId": "{{SANDBOX_ID}}"
 }

--- a/tests/configs/wslc_stderr.json
+++ b/tests/configs/wslc_stderr.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-stderr",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_tar_import_docker_save.json
+++ b/tests/configs/wslc_tar_import_docker_save.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-tar-import-docker-save",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_tar_import_rootfs.json
+++ b/tests/configs/wslc_tar_import_rootfs.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-tar-import",
   "containment": "wslc",
   "process": {

--- a/tests/configs/wslc_timeout.json
+++ b/tests/configs/wslc_timeout.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-timeout-test",
   "containment": "wslc",
   "process": {

--- a/tests/examples/09_windows_sandbox_hello_world.json
+++ b/tests/examples/09_windows_sandbox_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-WindowsSandbox-Hello-World",
   "containment": "windows_sandbox",
   "process": {

--- a/tests/examples/10_windows_sandbox_network_isolated.json
+++ b/tests/examples/10_windows_sandbox_network_isolated.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "CLI-WindowsSandbox-Network-Isolated",
   "containment": "windows_sandbox",
   "process": {

--- a/tests/examples/28_telemetry_enabled.json
+++ b/tests/examples/28_telemetry_enabled.json
@@ -1,5 +1,6 @@
 {
-    "$schema": "../../schemas/dev/mxc-config.schema.0.9.0-dev.json",
+    "version": "0.9.0-alpha",
+    "$schema": "../../schemas/dev/mxc-config.schema.0.9.0-alpha.json",
     "containment": "processcontainer",
     "process": {
         "commandLine": "cmd.exe /c echo Hello from telemetry-enabled sandbox"

--- a/tests/examples/wslc_hello_world.json
+++ b/tests/examples/wslc_hello_world.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0-alpha",
+  "version": "0.9.0-alpha",
   "containerId": "wslc-hello-world",
   "containment": "wslc",
   "process": {

--- a/tests/playground/src/renderer/app.ts
+++ b/tests/playground/src/renderer/app.ts
@@ -1221,6 +1221,7 @@ function buildRawBackendConfig(
   var scenarioPolicy: any = scenario ? scenario.policy : {};
   var timeoutMs = timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0;
   var config: any = {
+    version: '0.9.0-alpha',
     containment: containment,
     process: {
       commandLine: script,

--- a/tests/policy/request-wslc.json
+++ b/tests/policy/request-wslc.json
@@ -1,6 +1,6 @@
 {
   "policy": {
-    "version": "0.8.0-alpha"
+    "version": "0.9.0-alpha"
   },
   "command": "printf parity",
   "containment": {

--- a/tests/policy/state-aware-wslc-exec.json
+++ b/tests/policy/state-aware-wslc-exec.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "exec",
   "sandboxId": "wslc:0123456789abcdef0123456789abcdef",
   "process": {

--- a/tests/policy/state-aware-wslc-provision.json
+++ b/tests/policy/state-aware-wslc-provision.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.8.0-alpha",
+  "version": "0.9.0-alpha",
   "phase": "provision",
   "containment": "wslc",
   "filesystem": {

--- a/tests/scripts/run_isolation_session_resize_smoke.ps1
+++ b/tests/scripts/run_isolation_session_resize_smoke.ps1
@@ -210,7 +210,7 @@ $encodedLoop = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($loop
 # the container's network). timeout=0 lets the loop run until Ctrl-C.
 
 $config = [ordered]@{
-    version     = '0.6.0-alpha'
+    version     = '0.9.0-alpha'
     containerId = 'isolation-session-resize-smoke'
     containment = 'isolation_session'
     network     = [ordered]@{

--- a/tests/scripts/run_isolation_session_state_aware_tests.ps1
+++ b/tests/scripts/run_isolation_session_state_aware_tests.ps1
@@ -199,6 +199,10 @@ function Invoke-StateAware {
             $json = $json -replace '\{\{SANDBOX_ID\}\}', $SandboxId
         }
     } elseif ($Request) {
+        if (-not $Request.ContainsKey('version')) {
+            $Request = $Request.Clone()
+            $Request['version'] = '0.9.0-alpha'
+        }
         $json = $Request | ConvertTo-Json -Compress -Depth 12
     } else {
         throw "Invoke-StateAware requires either -Request or -ConfigFile"

--- a/tests/scripts/run_windows_sandbox_state_aware_tests.ps1
+++ b/tests/scripts/run_windows_sandbox_state_aware_tests.ps1
@@ -131,6 +131,10 @@ function Invoke-StateAware {
         [int]$TimeoutSec = 120
     )
 
+    if (-not $Request.ContainsKey('version')) {
+        $Request = $Request.Clone()
+        $Request['version'] = '0.9.0-alpha'
+    }
     $json = $Request | ConvertTo-Json -Compress -Depth 12
     $b64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($json))
 

--- a/tests/scripts/run_wslc_state_aware_tests.ps1
+++ b/tests/scripts/run_wslc_state_aware_tests.ps1
@@ -152,6 +152,10 @@ function Invoke-StateAware {
             $json = $json -replace '\{\{SANDBOX_ID\}\}', $SandboxId
         }
     } elseif ($Request) {
+        if (-not $Request.ContainsKey('version')) {
+            $Request = $Request.Clone()
+            $Request['version'] = '0.9.0-alpha'
+        }
         $json = $Request | ConvertTo-Json -Compress -Depth 12
     } else {
         throw "Invoke-StateAware requires either -Request or -ConfigFile"
@@ -222,6 +226,10 @@ function Invoke-StateAwareStreaming {
             $json = $json -replace '\{\{SANDBOX_ID\}\}', $SandboxId
         }
     } elseif ($Request) {
+        if (-not $Request.ContainsKey('version')) {
+            $Request = $Request.Clone()
+            $Request['version'] = '0.9.0-alpha'
+        }
         $json = $Request | ConvertTo-Json -Compress -Depth 12
     } else {
         throw "Invoke-StateAwareStreaming requires either -Request or -ConfigFile"


### PR DESCRIPTION
This PR changes development and state-aware request producers to target the
exact 0.9.0-alpha contract and makes their compatibility status executable.

Details

* Migrates 125 corpus documents and SDK request producers to 0.9.0-alpha.
* Classifies seven intentional contract tightenings whose fixtures exercise
  rolling-only compatibility behavior.
* Records the migrated corpus in a checked-in inventory for future audits.
* Aligns development documentation and examples with the exact 0.9.0-alpha
  schema and documents the state-aware version boundary.

Tests

* `cargo fmt --all -- --check`
* `cargo check --workspace --all-targets`
* `cargo clippy --workspace --all-targets -- -D warnings`
* `cargo test --workspace`
* Node SDK build and unit tests; C# SDK tests (118 passed, 24 skipped).
* Config validation, schema/version synchronization, and codegen drift gates.

  
###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1099)