### PR TITLE
docs: add missing entries to Documentation index in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,11 @@ Privacy information can be found at https://privacy.microsoft.com and in the Mic
 | [docs/telemetry/telemetry.md](docs/telemetry/telemetry.md) | TraceLogging telemetry architecture |
 | [docs/telemetry/telemetry-consent-design.md](docs/telemetry/telemetry-consent-design.md) | Telemetry consent contract |
 | [docs/telemetry/telemetry-administrative-policy.md](docs/telemetry/telemetry-administrative-policy.md) | Administrative telemetry controls |
+| [docs/authoring-a-new-feature.md](docs/authoring-a-new-feature.md) | Step-by-step guide for adding a new feature (schema, Rust, tests) |
+| [docs/fuzzing.md](docs/fuzzing.md) | Fuzzing with `cargo-fuzz` |
+| [docs/ci-validation-infrastructure.md](docs/ci-validation-infrastructure.md) | E2E validation test infrastructure |
+| [docs/playground-limitations.md](docs/playground-limitations.md) | Playground known limitations and compatibility |
+| [docs/pull-requests.md](docs/pull-requests.md) | How PR builds are validated |
 
 ## Contributing
 


### PR DESCRIPTION
Five guides under `docs/` exist in the repo but are not listed in the README Documentation table, so they are hard to discover:

| Missing doc | Content |
|---|---|
| `docs/authoring-a-new-feature.md` | Step-by-step guide for adding a new feature — notably, this is referenced by [CONTRIBUTING.md](https://github.com/microsoft/mxc/blob/main/CONTRIBUTING.md) (Experimental features section), but the index it points readers to for docs doesn't list it |
| `docs/fuzzing.md` | Fuzzing with `cargo-fuzz` |
| `docs/ci-validation-infrastructure.md` | How E2E validation suites run across real OSes |
| `docs/playground-limitations.md` | Playground known limitations and compatibility |
| `docs/pull-requests.md` | How PR builds are validated |

This PR appends all five to the Documentation table. Docs-only change, no code touched.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1103)