### PR TITLE
Enforce ProcessContainer ingress with PSEC 1.1

### DIFF
--- a/docs/process-container/networking.md
+++ b/docs/process-container/networking.md
@@ -106,9 +106,9 @@ non-AppContainer proxy lacks an accepted peer identity and requires `hostLoopbac
 development/testing compatibility deployment, not the shared policy's strict host-loopback-closure guarantee. It
 authorizes both host-loopback directions, although WFP still restricts client-container egress to the configured proxy
 endpoint. Host-loopback clients can reach listeners in the MXC client container.
-On the PSEC path, MXC maps `hostLoopback: "allow"` to the `networkLoopback` capability and the reserved
-`MXC-Loopback` peer identity passed to `CreateProcessSecurityEnvironment`. Caller-supplied `allowedProxyPeer` values
-cannot use that reserved identity.
+When the OS advertises PSEC ingress support, MXC passes `ingress.default` and `ingress.hostLoopback` through the
+PSEC 1.1 ingress table. On older PSEC hosts, MXC retains the PSEC 1.0 `networkLoopback` capability and reserved
+`MXC-Loopback` peer lowering.
 
 #### Identity-scoped proxy
 

--- a/src/backends/appcontainer/common/src/base_container_helpers.rs
+++ b/src/backends/appcontainer/common/src/base_container_helpers.rs
@@ -6,10 +6,10 @@
 use process_security_environment_spec::process_security_environment_layout::{
     finish_process_security_environment_buffer, DestinationRuleT as PsecDestinationRuleT,
     EndpointPolicyT as PsecEndpointPolicy, EndpointRuleT as PsecEndpointRuleT,
-    FilterAction as PsecFilterAction, IpProtocol as PsecIpProtocol, IpSubnetT as PsecIpSubnetT,
-    NetworkPolicyT as PsecNetworkPolicy, PortRuleT as PsecPortRuleT,
-    ProcessSecurityEnvironmentT as PsecProcessSecurityEnvironment, ProxyInfoT as PsecProxyInfo,
-    SchemaVersionT,
+    FilterAction as PsecFilterAction, IngressPolicyT as PsecIngressPolicy,
+    IpProtocol as PsecIpProtocol, IpSubnetT as PsecIpSubnetT, NetworkPolicyT as PsecNetworkPolicy,
+    PortRuleT as PsecPortRuleT, ProcessSecurityEnvironmentT as PsecProcessSecurityEnvironment,
+    ProxyInfoT as PsecProxyInfo, SchemaVersionT,
 };
 use sandbox_spec::base_container_layout::{
     endpoint_policyT, finish_sandbox_spec_buffer, proxy_infoT, FilterAction as SboxFilterAction,
@@ -43,8 +43,16 @@ pub(super) fn has_conflicting_proxy_identity(policy: &ContainerPolicy) -> bool {
 }
 
 pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
+    build_psec_spec_with_ingress(request, false)
+}
+
+pub(super) fn build_psec_spec_with_ingress(
+    request: &ExecutionRequest,
+    ingress_supported: bool,
+) -> Vec<u8> {
     let mut builder = flatbuffers::FlatBufferBuilder::with_capacity(1024);
-    let capabilities = effective_capabilities(&request.policy, true);
+    let use_ingress = ingress_supported && request.policy.network_ingress.is_some();
+    let capabilities = effective_capabilities(&request.policy, !use_ingress);
     let ui_restrictions = crate::job_object::to_job_object_uilimit_mask(
         &wxc_common::ui_policy::resolve_ui_restrictions(
             &request.policy.ui,
@@ -53,14 +61,20 @@ pub(super) fn build_psec_spec(request: &ExecutionRequest) -> Vec<u8> {
     ) as u64;
 
     let mut spec = PsecProcessSecurityEnvironment::default();
-    spec.version = SchemaVersionT { major: 1, minor: 0 };
+    spec.version = SchemaVersionT {
+        major: 1,
+        minor: u16::from(use_ingress),
+    };
     spec.capabilities = (!capabilities.is_empty()).then(|| capabilities.join(","));
     spec.disallow_win32k_system_calls = request.policy.ui.disable;
     spec.ui_restrictions = ui_restrictions;
     spec.fs_read_write = non_empty_paths(&request.policy.readwrite_paths);
     spec.fs_read_only = non_empty_paths(&request.policy.readonly_paths);
     spec.fs_deny = non_empty_paths(&request.policy.denied_paths);
-    spec.network_policy = Some(Box::new(build_psec_network_policy(&request.policy)));
+    spec.network_policy = Some(Box::new(build_psec_network_policy(
+        &request.policy,
+        use_ingress,
+    )));
     let spec = spec.pack(&mut builder);
     finish_process_security_environment_buffer(&mut builder, spec);
     builder.finished_data().to_vec()
@@ -133,7 +147,7 @@ fn build_legacy_sbox_network_policy(policy: &ContainerPolicy) -> SboxNetworkPoli
     network
 }
 
-fn build_psec_network_policy(policy: &ContainerPolicy) -> PsecNetworkPolicy {
+fn build_psec_network_policy(policy: &ContainerPolicy, use_ingress: bool) -> PsecNetworkPolicy {
     let mut network = PsecNetworkPolicy::default();
     if policy.network_proxy.is_enabled() {
         // Proxy and direct egress are mutually exclusive PSEC policy forms.
@@ -158,8 +172,27 @@ fn build_psec_network_policy(policy: &ContainerPolicy) -> PsecNetworkPolicy {
         }
         network.egress = Some(Box::new(egress));
     }
-    network.allowed_appcontainer_peer = allowed_appcontainer_peer(policy);
+    network.allowed_appcontainer_peer = if use_ingress {
+        policy.allowed_proxy_peer.clone()
+    } else {
+        allowed_appcontainer_peer(policy)
+    };
+    if use_ingress {
+        network.ingress = policy.network_ingress.as_ref().map(|policy| {
+            let mut ingress = PsecIngressPolicy::default();
+            ingress.default_action = psec_filter_action(policy.default);
+            ingress.host_loopback = psec_filter_action(policy.host_loopback);
+            Box::new(ingress)
+        });
+    }
     network
+}
+
+fn psec_filter_action(action: NetworkAction) -> PsecFilterAction {
+    match action {
+        NetworkAction::Allow => PsecFilterAction::allow,
+        NetworkAction::Deny => PsecFilterAction::deny,
+    }
 }
 
 fn effective_egress_default(policy: &ContainerPolicy) -> NetworkAction {

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -3,7 +3,7 @@
 
 //! `BaseContainerRunner` — executes scripts through the Windows BaseContainer APIs.
 //!
-//! The runner prefers the PSEC 1.0 / `CreateProcessSecurityEnvironment`
+//! The runner prefers the PSEC / `CreateProcessSecurityEnvironment`
 //! two-phase contract whenever its runtime probe succeeds and attaches the
 //! resulting environment to `CreateProcessW`. It temporarily falls back to the
 //! legacy `SandboxSpec` / one-shot `Experimental_CreateProcessInSandbox`
@@ -39,7 +39,8 @@ use windows::Win32::System::Threading::{
 use windows_core::{PCWSTR, PWSTR};
 
 use crate::base_container_helpers::{
-    build_psec_spec, build_sbox_spec, has_conflicting_proxy_identity, requires_psec_networking,
+    build_psec_spec, build_psec_spec_with_ingress, build_sbox_spec, has_conflicting_proxy_identity,
+    requires_psec_networking,
 };
 use crate::capture_output::{
     combine_capture_and_cleanup_results, combine_process_and_teardown_results,
@@ -1182,12 +1183,17 @@ impl BaseContainerRunner {
             let _ = writeln!(logger, "{EMOJI_SECTION} SECTION: captureDenials");
         }
 
-        let process_security_environment_spec =
-            use_process_security_environment.then(|| build_psec_spec(&request));
+        let psec_ingress_supported = use_process_security_environment
+            && SecurityEnvironmentApi::load()
+                .and_then(|api| api.support())
+                .is_ok_and(|support| support.supports_network_ingress());
+        let process_security_environment_spec = use_process_security_environment
+            .then(|| build_psec_spec_with_ingress(&request, psec_ingress_supported));
         if let Some(psec_spec) = process_security_environment_spec.as_ref() {
             let _ = writeln!(
                 logger,
-                "process security environment spec built (PSEC 1.0, {} bytes)",
+                "process security environment spec built (PSEC 1.{}, {} bytes)",
+                u8::from(psec_ingress_supported && request.policy.network_ingress.is_some()),
                 psec_spec.len()
             );
         }
@@ -4077,6 +4083,47 @@ mod tests {
             network.allowed_appcontainer_peer(),
             Some(LOOPBACK_NETWORK_PEER)
         );
+    }
+
+    #[test]
+    fn psec_1_1_encodes_ingress_without_legacy_loopback_fields() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
+            default: NetworkAction::Deny,
+            host_loopback: NetworkAction::Allow,
+        });
+
+        let bytes = build_psec_spec_with_ingress(&request, true);
+        let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
+        let network = spec.network_policy().expect("network policy");
+        let ingress = network.ingress().expect("ingress policy");
+        let version = spec.version();
+
+        assert_eq!((version.major(), version.minor()), (1, 1));
+        assert!(spec.capabilities().is_none());
+        assert!(network.allowed_appcontainer_peer().is_none());
+        assert_eq!(ingress.default_action(), psec_layout::FilterAction::deny);
+        assert_eq!(ingress.host_loopback(), psec_layout::FilterAction::allow);
+    }
+
+    #[test]
+    fn psec_1_1_maps_ingress_fields_independently() {
+        let mut request = ExecutionRequest::default();
+        request.policy.network_ingress = Some(wxc_common::models::NetworkIngressPolicy {
+            default: NetworkAction::Allow,
+            host_loopback: NetworkAction::Deny,
+        });
+
+        let bytes = build_psec_spec_with_ingress(&request, true);
+        let spec = psec_layout::root_as_process_security_environment(&bytes).unwrap();
+        let ingress = spec
+            .network_policy()
+            .expect("network policy")
+            .ingress()
+            .expect("ingress policy");
+
+        assert_eq!(ingress.default_action(), psec_layout::FilterAction::allow);
+        assert_eq!(ingress.host_loopback(), psec_layout::FilterAction::deny);
     }
 
     #[test]

--- a/src/backends/learning_mode/windows/src/lib.rs
+++ b/src/backends/learning_mode/windows/src/lib.rs
@@ -74,7 +74,8 @@ pub use process_lifetime::{
 pub use secenv::{
     is_security_environment_api_available, probe_security_environment_exports,
     ProcessSecurityEnvironment, SecurityEnvironmentApi, SecurityEnvironmentExportReport,
-    SecurityEnvironmentStartupInfo, PROCESS_SECURITY_ENVIRONMENT_FLAG_NONE,
+    SecurityEnvironmentStartupInfo, SecurityEnvironmentSupport,
+    PROCESS_SECURITY_ENVIRONMENT_FLAG_NONE,
 };
 
 /// Errors surfaced while loading or invoking the Learning Mode trace API.

--- a/src/backends/learning_mode/windows/src/secenv.rs
+++ b/src/backends/learning_mode/windows/src/secenv.rs
@@ -54,6 +54,28 @@ const PROCESSMODEL_DLL: &str = "processmodel.dll";
 const SECURITY_ENVIRONMENT_API_SET_NAME: &str = "api-win-appmodel-processmodel~securityenvironment";
 const SECURITY_ENVIRONMENT_API_SET: &core::ffi::CStr =
     c"api-win-appmodel-processmodel~securityenvironment";
+const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
+const PSE_SUPPORT_NETWORK_INGRESS: u64 = 0x0000_0000_0000_0008;
+
+/// Capabilities reported by `QueryProcessSecurityEnvironmentSupport`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SecurityEnvironmentSupport {
+    flags: u64,
+}
+
+impl SecurityEnvironmentSupport {
+    /// Whether PSEC supports native filesystem deny paths.
+    #[must_use]
+    pub fn supports_deny_paths(self) -> bool {
+        self.flags & PSE_SUPPORT_FS_DENY != 0
+    }
+
+    /// Whether PSEC supports the 1.1 ingress policy table.
+    #[must_use]
+    pub fn supports_network_ingress(self) -> bool {
+        self.flags & PSE_SUPPORT_NETWORK_INGRESS != 0
+    }
+}
 
 /// No special behaviour when creating the security environment
 /// (`PROCESS_SECURITY_ENVIRONMENT_FLAGS` value `0`).
@@ -317,7 +339,7 @@ const CLOSE_NAMES: &[&core::ffi::CStr] = &[c"CloseProcessSecurityEnvironment"];
 /// `cacheable` records whether this surface was produced by the memoizing
 /// [`SecurityEnvironmentApi::load`] (the real, process-wide singleton) as opposed
 /// to a test fake. Only cacheable surfaces are allowed to populate the process-wide
-/// [`supports_deny_paths`](Self::supports_deny_paths) cache, so injected fakes can
+/// [`support`](Self::support) cache, so injected fakes can
 /// never poison it for the real API or for each other.
 #[derive(Clone, Copy)]
 pub struct SecurityEnvironmentApi {
@@ -352,7 +374,7 @@ impl SecurityEnvironmentApi {
     /// same work and return the same answer. The cached error is cloned (see
     /// [`LearningModeError`]), preserving the original diagnostic on every call. The
     /// cached surface is marked cacheable so its
-    /// [`supports_deny_paths`](Self::supports_deny_paths) result is memoized too.
+    /// [`support`](Self::support) result is memoized too.
     ///
     /// # Errors
     /// - [`LearningModeError::ApiSetUnavailable`] if the security-environment
@@ -408,7 +430,7 @@ impl SecurityEnvironmentApi {
 
     /// Construct an API surface directly from raw export pointers, bypassing the
     /// DLL load. Test-only: lets sibling modules inject fakes. The surface is marked
-    /// non-cacheable so its [`supports_deny_paths`](Self::supports_deny_paths) result
+    /// non-cacheable so its [`support`](Self::support) result
     /// never populates the process-wide cache.
     #[cfg(test)]
     pub(crate) fn from_raw_parts(
@@ -425,7 +447,7 @@ impl SecurityEnvironmentApi {
     }
 
     /// Like [`from_raw_parts`](Self::from_raw_parts) but marked cacheable, so the
-    /// memoization of [`supports_deny_paths`](Self::supports_deny_paths) can be
+    /// memoization of [`support`](Self::support) can be
     /// exercised host-independently. Test-only.
     #[cfg(test)]
     pub(crate) fn from_raw_parts_cacheable(
@@ -441,26 +463,28 @@ impl SecurityEnvironmentApi {
         }
     }
 
-    /// Whether the official V2 API supports native deny paths.
+    /// Returns the capabilities supported by the official PSEC API.
     ///
     /// The answer is a fixed host capability, so for the real (cacheable) API the
     /// result — including a typed error — is memoized once per process. Non-cacheable
     /// test fakes always query directly and never touch the process-wide cache.
-    pub fn supports_deny_paths(&self) -> Result<bool, LearningModeError> {
+    pub fn support(&self) -> Result<SecurityEnvironmentSupport, LearningModeError> {
         if self.cacheable {
-            static CACHE: OnceLock<Result<bool, LearningModeError>> = OnceLock::new();
-            CACHE
-                .get_or_init(|| self.query_deny_paths_support())
-                .clone()
+            static CACHE: OnceLock<Result<SecurityEnvironmentSupport, LearningModeError>> =
+                OnceLock::new();
+            CACHE.get_or_init(|| self.query_support()).clone()
         } else {
-            self.query_deny_paths_support()
+            self.query_support()
         }
     }
 
-    /// Query `QueryProcessSecurityEnvironmentSupport` for the native-deny-path bit,
-    /// without consulting or populating the process-wide cache.
-    fn query_deny_paths_support(&self) -> Result<bool, LearningModeError> {
-        const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
+    /// Whether the official V2 API supports native deny paths.
+    pub fn supports_deny_paths(&self) -> Result<bool, LearningModeError> {
+        self.support()
+            .map(SecurityEnvironmentSupport::supports_deny_paths)
+    }
+
+    fn query_support(&self) -> Result<SecurityEnvironmentSupport, LearningModeError> {
         let mut support_flags = 0u64;
         // SAFETY: `query_support` matches the official V2 declaration and
         // `support_flags` is a valid out-pointer.
@@ -471,7 +495,9 @@ impl SecurityEnvironmentApi {
                 code: result.0,
             });
         }
-        Ok(support_flags & PSE_SUPPORT_FS_DENY != 0)
+        Ok(SecurityEnvironmentSupport {
+            flags: support_flags,
+        })
     }
 
     /// Create a process security environment from a PSEC FlatBuffer
@@ -626,9 +652,6 @@ mod tests {
     static QUERY_RESULT: AtomicI32 = AtomicI32::new(S_OK.0);
     static QUERY_FLAGS: AtomicU64 = AtomicU64::new(0);
 
-    /// Native-deny-path support bit reported by `QueryProcessSecurityEnvironmentSupport`.
-    const PSE_SUPPORT_FS_DENY: u64 = 0x0000_0000_0000_0001;
-
     unsafe extern "system" fn fake_close(_: HANDLE) {
         CLOSE_CALLS.fetch_add(1, Ordering::SeqCst);
     }
@@ -770,23 +793,22 @@ mod tests {
     }
 
     #[test]
-    fn supports_deny_paths_reports_flag_state() {
+    fn support_flags_are_reported_independently() {
         let _guard = QUERY_LOCK.lock().unwrap();
         let api = fake_uncached_api();
 
         reset_query_fakes();
         QUERY_FLAGS.store(PSE_SUPPORT_FS_DENY, Ordering::SeqCst);
-        assert!(api.supports_deny_paths().unwrap());
+        let support = api.support().unwrap();
+        assert!(support.supports_deny_paths());
+        assert!(!support.supports_network_ingress());
         assert_eq!(QUERY_CALLS.load(Ordering::SeqCst), 1);
 
         reset_query_fakes();
-        QUERY_FLAGS.store(0, Ordering::SeqCst);
-        assert!(!api.supports_deny_paths().unwrap());
-
-        reset_query_fakes();
-        // Unrelated support bits must not be mistaken for deny-path support.
-        QUERY_FLAGS.store(0xFFFF_FFFF_FFFF_FFFE, Ordering::SeqCst);
-        assert!(!api.supports_deny_paths().unwrap());
+        QUERY_FLAGS.store(PSE_SUPPORT_NETWORK_INGRESS, Ordering::SeqCst);
+        let support = api.support().unwrap();
+        assert!(!support.supports_deny_paths());
+        assert!(support.supports_network_ingress());
     }
 
     #[test]
@@ -796,7 +818,7 @@ mod tests {
         QUERY_RESULT.store(E_FAIL.0, Ordering::SeqCst);
         let api = fake_uncached_api();
 
-        let error = api.supports_deny_paths().unwrap_err();
+        let error = api.support().unwrap_err();
         assert!(matches!(
             error,
             LearningModeError::HResultCall {


### PR DESCRIPTION
## 📖 Description

Pass `network.ingress.default` and `network.ingress.hostLoopback` through the OS PSEC 1.1 ingress table when `PSE_SUPPORT_NETWORK_INGRESS` is advertised. Older hosts retain the existing PSEC 1.0 capability/peer lowering.

This intentionally leaves PSEC usability probing and a public MXC capability-probing API out of scope for a separate change.

## 🔗 References


## 🔍 Validation

- `cargo test -p learning_mode_windows secenv::tests`
- `cargo test -p appcontainer_common`
- `cargo clippy -p learning_mode_windows -p appcontainer_common --all-targets -- -D warnings`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [x] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [x] Feature
- [ ] Task
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1119)