### PR TITLE
Add default environment behavior across SDKs

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -84,7 +84,7 @@ cannot mix both formats in one request.
 
 ```json
 {
-    "version": "0.6.0-alpha",              // Schema version (semver). Minimum supported: "0.6.0-alpha"; current stable: "0.8.0-alpha".
+    "version": "0.9.0-alpha",              // Schema version (semver). Minimum supported: "0.6.0-alpha"; current stable: "0.8.0-alpha".
     "containerId": "my-container",         // Externally assigned container ID
     "containment": "processcontainer",     // Backend (see table below)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -100,7 +100,7 @@ cannot mix both formats in one request.
                                            //  than inheriting the launcher's — see
                                            //  "Working Directory" below)
         "env": ["MY_VAR=value"],           // Omitted: backend default; supplied: used verbatim
-        "inheritDefaultEnv": true,         // Layer env on the backend default (default false)
+        "inheritDefaultEnv": true,         // Layer env on the backend default (0.9.0-alpha+)
         "timeout": 30000                   // Timeout in ms (0 = no timeout)
     },
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -99,7 +99,8 @@ cannot mix both formats in one request.
                                            //  backend substitutes a granted directory rather
                                            //  than inheriting the launcher's — see
                                            //  "Working Directory" below)
-        "env": ["MY_VAR=value"],           // Environment variables as KEY=VALUE
+        "env": ["MY_VAR=value"],           // Omitted: backend default; supplied: used verbatim
+        "inheritDefaultEnv": true,         // Layer env on the backend default (default false)
         "timeout": 30000                   // Timeout in ms (0 = no timeout)
     },
 

--- a/schemas/dev/mxc-config.schema.0.9.0-alpha.json
+++ b/schemas/dev/mxc-config.schema.0.9.0-alpha.json
@@ -1092,11 +1092,15 @@
           "type": "string"
         },
         "env": {
-          "description": "Optional environment entries encoded as `KEY=VALUE` strings.",
+          "description": "Optional environment entries encoded as `KEY=VALUE` strings.\n\nOmitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inherit_default_env` is set.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "inheritDefaultEnv": {
+          "description": "Layer `env` on top of the backend's default environment rather than replacing it.",
+          "type": "boolean"
         },
         "timeout": {
           "description": "Optional execution timeout in milliseconds.",

--- a/schemas/dev/mxc-config.schema.0.9.0-alpha.json
+++ b/schemas/dev/mxc-config.schema.0.9.0-alpha.json
@@ -1092,7 +1092,7 @@
           "type": "string"
         },
         "env": {
-          "description": "Optional environment entries encoded as `KEY=VALUE` strings.\n\nOmitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inherit_default_env` is set.",
+          "description": "Optional environment entries encoded as `KEY=VALUE` strings.\n\nOmitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inheritDefaultEnv` is set.",
           "items": {
             "type": "string"
           },

--- a/schemas/dev/mxc-config.schema.0.9.0-dev.json
+++ b/schemas/dev/mxc-config.schema.0.9.0-dev.json
@@ -750,12 +750,19 @@
           ]
         },
         "env": {
-          "description": "Environment variables as `\"KEY=VALUE\"` strings.",
+          "description": "Environment variables as `\"KEY=VALUE\"` strings.\n\nOmit the field to give the child the backend's default environment (on Windows, the user's profile block). Supply it — including as an empty array — and it is used verbatim; MXC adds nothing to it unless `inheritDefaultEnv` is set.",
           "items": {
             "type": "string"
           },
           "type": [
             "array",
+            "null"
+          ]
+        },
+        "inheritDefaultEnv": {
+          "description": "Start from the backend's default environment and layer `env` on top of it, rather than replacing it (default false).\n\nThis exists because the default environment is not something a caller can assemble: on Windows it is the user's profile block, which only the OS can produce. Entries in `env` override same-named defaults. Has no effect on backends whose default environment is empty, and none when `env` is omitted (that already yields the default).",
+          "type": [
+            "boolean",
             "null"
           ]
         },

--- a/scripts/check-dotnet-api-parity.js
+++ b/scripts/check-dotnet-api-parity.js
@@ -197,8 +197,19 @@ function managedJsonFields(source, className) {
     /public\s+(?:required\s+)?[\w<>,?.\[\]\s]+\s+(\w+)\s*\{/y
   )
     .filter(
-      ({ attributes }) =>
-        !/\[\s*JsonIgnore(?:Attribute)?(?:\s*\]|\s*\()/.test(attributes)
+      ({ attributes }) => {
+        const ignored = /\[\s*JsonIgnore(?:Attribute)?\s*(?:\(\s*([^)]*)\s*\))?\s*\]/.exec(
+          attributes
+        );
+        if (!ignored) return true;
+
+        const arguments = ignored[1]?.trim();
+        return (
+          arguments !== undefined &&
+          arguments !== "" &&
+          !/\bCondition\s*=\s*JsonIgnoreCondition\.Always\b/.test(arguments)
+        );
+      }
     )
     .map(({ attributes, name }) => {
       const renamed = /JsonPropertyName\("([^"]+)"\)/.exec(attributes);

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
@@ -469,6 +469,7 @@ public class MxcLifecycleTests
                 {
                     WorkingDirectory = "/work",
                     Environment = new List<string> { "A=1", "B=two" },
+                    InheritDefaultEnvironment = true,
                     TimeoutMs = 1234,
                     Network = new WslcExecNetworkPolicy
                     {
@@ -484,6 +485,7 @@ public class MxcLifecycleTests
         Assert.Equal("/work", process.GetProperty("cwd").GetString());
         Assert.Equal("A=1", process.GetProperty("env")[0].GetString());
         Assert.Equal("B=two", process.GetProperty("env")[1].GetString());
+        Assert.True(process.GetProperty("inheritDefaultEnv").GetBoolean());
         Assert.Equal(1234, process.GetProperty("timeout").GetInt32());
         var network = root.GetProperty("network");
         Assert.Equal(

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
@@ -496,23 +496,20 @@ public class MxcLifecycleTests
     }
 
     [Fact]
-    public void BuildExecEnvelope_RejectsInheritedEnvironmentWithOlderVersion()
+    public void BuildExecEnvelope_PreservesOlderVersionForNativeValidation()
     {
-        var exception = Assert.Throws<MxcException>(
-            () => MxcLifecycle.BuildExecEnvelope(
-                new SandboxId("wslc:0123456789abcdef0123456789abcdef"),
-                "echo hi",
-                new WslcExecOptions
-                {
-                    Version = "0.8.0-alpha",
-                    InheritDefaultEnvironment = true,
-                }));
+        var envelope = MxcLifecycle.BuildExecEnvelope(
+            new SandboxId("wslc:0123456789abcdef0123456789abcdef"),
+            "echo hi",
+            new WslcExecOptions
+            {
+                Version = "0.8.0-alpha",
+                InheritDefaultEnvironment = true,
+            });
 
-        Assert.Equal(ErrorCode.MalformedRequest, exception.Code);
-        Assert.Contains(
-            "process.inheritDefaultEnv requires schema version 0.9.0-alpha",
-            exception.Message,
-            StringComparison.Ordinal);
+        Assert.Equal("0.8.0-alpha", envelope["version"]!.GetValue<string>());
+        Assert.True(
+            envelope["process"]!["inheritDefaultEnv"]!.GetValue<bool>());
     }
 
     [Fact]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleTests.cs
@@ -480,7 +480,7 @@ public class MxcLifecycleTests
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        Assert.Equal("0.8.0-alpha", root.GetProperty("version").GetString());
+        Assert.Equal("0.9.0-alpha", root.GetProperty("version").GetString());
         var process = root.GetProperty("process");
         Assert.Equal("/work", process.GetProperty("cwd").GetString());
         Assert.Equal("A=1", process.GetProperty("env")[0].GetString());
@@ -493,6 +493,26 @@ public class MxcLifecycleTests
             network.GetProperty("proxy").GetProperty("url").GetString());
         Assert.False(network.TryGetProperty("defaultPolicy", out _));
         Assert.False(network.TryGetProperty("allowLocalNetwork", out _));
+    }
+
+    [Fact]
+    public void BuildExecEnvelope_RejectsInheritedEnvironmentWithOlderVersion()
+    {
+        var exception = Assert.Throws<MxcException>(
+            () => MxcLifecycle.BuildExecEnvelope(
+                new SandboxId("wslc:0123456789abcdef0123456789abcdef"),
+                "echo hi",
+                new WslcExecOptions
+                {
+                    Version = "0.8.0-alpha",
+                    InheritDefaultEnvironment = true,
+                }));
+
+        Assert.Equal(ErrorCode.MalformedRequest, exception.Code);
+        Assert.Contains(
+            "process.inheritDefaultEnv requires schema version 0.9.0-alpha",
+            exception.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -489,6 +489,7 @@ public class MxcSandboxTests
             "echo hi");
         using var omittedDoc = JsonDocument.Parse(MxcSandbox.SerializeRequest(omitted));
         Assert.False(omittedDoc.RootElement.TryGetProperty("environment", out _));
+        Assert.False(omittedDoc.RootElement.TryGetProperty("inheritDefaultEnv", out _));
 
         var explicitlyEmpty = new SandboxRequest(
             new SandboxPolicy { Version = "0.8.0-alpha" },

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -463,7 +463,7 @@ public class MxcSandboxTests
             WorkingDirectory = @"C:\work",
             Experimental = true,
             InheritDefaultEnvironment = true,
-            Environment =
+            Environment = new()
             {
                 ["GREETING"] = "hello",
             },
@@ -479,6 +479,28 @@ public class MxcSandboxTests
         Assert.Equal("hello", root.GetProperty("environment").GetProperty("GREETING").GetString());
         Assert.True(root.GetProperty("inheritDefaultEnv").GetBoolean());
         Assert.True(root.GetProperty("experimental").GetBoolean());
+    }
+
+    [Fact]
+    public void SandboxRequest_DistinguishesOmittedAndExplicitlyEmptyEnvironment()
+    {
+        var omitted = new SandboxRequest(
+            new SandboxPolicy { Version = "0.8.0-alpha" },
+            "echo hi");
+        using var omittedDoc = JsonDocument.Parse(MxcSandbox.SerializeRequest(omitted));
+        Assert.False(omittedDoc.RootElement.TryGetProperty("environment", out _));
+
+        var explicitlyEmpty = new SandboxRequest(
+            new SandboxPolicy { Version = "0.8.0-alpha" },
+            "echo hi")
+        {
+            Environment = new(),
+        };
+        using var explicitlyEmptyDoc =
+            JsonDocument.Parse(MxcSandbox.SerializeRequest(explicitlyEmpty));
+        var environment = explicitlyEmptyDoc.RootElement.GetProperty("environment");
+        Assert.Equal(JsonValueKind.Object, environment.ValueKind);
+        Assert.Empty(environment.EnumerateObject());
     }
 
     [Fact]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -462,6 +462,7 @@ public class MxcSandboxTests
             ContainerName = "test-container",
             WorkingDirectory = @"C:\work",
             Experimental = true,
+            InheritDefaultEnvironment = true,
             Environment =
             {
                 ["GREETING"] = "hello",
@@ -476,6 +477,7 @@ public class MxcSandboxTests
         Assert.Equal("test-container", root.GetProperty("containerName").GetString());
         Assert.Equal(@"C:\work", root.GetProperty("workingDirectory").GetString());
         Assert.Equal("hello", root.GetProperty("environment").GetProperty("GREETING").GetString());
+        Assert.True(root.GetProperty("inheritDefaultEnv").GetBoolean());
         Assert.True(root.GetProperty("experimental").GetBoolean());
     }
 

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
@@ -271,6 +271,10 @@ public static class MxcLifecycle
         {
             process["env"] = SerializeToNode(env);
         }
+        if (options?.InheritDefaultEnvironment is { } inheritDefaultEnv)
+        {
+            process["inheritDefaultEnv"] = inheritDefaultEnv;
+        }
         if (options?.TimeoutMs is { } timeout)
         {
             process["timeout"] = timeout;

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
@@ -264,16 +264,9 @@ public static class MxcLifecycle
         ArgumentNullException.ThrowIfNull(command);
         ValidateExecOptions(id, options);
         var version = options?.Version;
-        if (options?.InheritDefaultEnvironment is not null)
+        if (options?.InheritDefaultEnvironment is not null && version is null)
         {
-            if (version is null)
-            {
-                version = InheritDefaultEnvironmentVersion;
-            }
-            else
-            {
-                ValidateInheritDefaultEnvironmentVersion(version);
-            }
+            version = InheritDefaultEnvironmentVersion;
         }
         var envelope = BuildIdEnvelope("exec", id, version);
         var process = new JsonObject { ["commandLine"] = command };
@@ -413,24 +406,6 @@ public static class MxcLifecycle
         containment == StateAwareContainment.Wslc
             ? WslcStateAwareVersion
             : StateAwareVersion;
-
-    private static void ValidateInheritDefaultEnvironmentVersion(string version)
-    {
-        var coreVersion = version.Split('-', 2)[0].Split('.');
-        if (coreVersion.Length < 2
-            || !uint.TryParse(coreVersion[0], out var major)
-            || !uint.TryParse(coreVersion[1], out var minor))
-        {
-            return;
-        }
-        if (major == 0 && minor < 9)
-        {
-            throw new MxcException(
-                ErrorCode.MalformedRequest,
-                $"process.inheritDefaultEnv requires schema version "
-                    + $"{InheritDefaultEnvironmentVersion} or later; got {version}");
-        }
-    }
 
     private static void ValidateProvisionOptions(
         StateAwareContainment containment,

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcLifecycle.cs
@@ -29,6 +29,8 @@ public static class MxcLifecycle
     /// <summary>Default state-aware schema for WSLC.</summary>
     public const string WslcStateAwareVersion = SchemaVersions.WslcStateAware;
 
+    private const string InheritDefaultEnvironmentVersion = "0.9.0-alpha";
+
     /// <summary>IsolationSession containment wire key.</summary>
     public const string IsolationSessionContainment = "isolation_session";
 
@@ -261,7 +263,19 @@ public static class MxcLifecycle
     {
         ArgumentNullException.ThrowIfNull(command);
         ValidateExecOptions(id, options);
-        var envelope = BuildIdEnvelope("exec", id, options?.Version);
+        var version = options?.Version;
+        if (options?.InheritDefaultEnvironment is not null)
+        {
+            if (version is null)
+            {
+                version = InheritDefaultEnvironmentVersion;
+            }
+            else
+            {
+                ValidateInheritDefaultEnvironmentVersion(version);
+            }
+        }
+        var envelope = BuildIdEnvelope("exec", id, version);
         var process = new JsonObject { ["commandLine"] = command };
         if (options?.WorkingDirectory is { } cwd)
         {
@@ -399,6 +413,24 @@ public static class MxcLifecycle
         containment == StateAwareContainment.Wslc
             ? WslcStateAwareVersion
             : StateAwareVersion;
+
+    private static void ValidateInheritDefaultEnvironmentVersion(string version)
+    {
+        var coreVersion = version.Split('-', 2)[0].Split('.');
+        if (coreVersion.Length < 2
+            || !uint.TryParse(coreVersion[0], out var major)
+            || !uint.TryParse(coreVersion[1], out var minor))
+        {
+            return;
+        }
+        if (major == 0 && minor < 9)
+        {
+            throw new MxcException(
+                ErrorCode.MalformedRequest,
+                $"process.inheritDefaultEnv requires schema version "
+                    + $"{InheritDefaultEnvironmentVersion} or later; got {version}");
+        }
+    }
 
     private static void ValidateProvisionOptions(
         StateAwareContainment containment,

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
@@ -279,7 +279,9 @@ public static class MxcSandbox
             Containment = containment,
             ContainerName = request.ContainerName,
             WorkingDirectory = request.WorkingDirectory,
-            Environment = new Dictionary<string, string>(request.Environment),
+            Environment = request.Environment is null
+                ? null
+                : new Dictionary<string, string>(request.Environment),
             InheritDefaultEnvironment = request.InheritDefaultEnvironment,
             Experimental = request.Experimental,
         };

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandbox.cs
@@ -280,6 +280,7 @@ public static class MxcSandbox
             ContainerName = request.ContainerName,
             WorkingDirectory = request.WorkingDirectory,
             Environment = new Dictionary<string, string>(request.Environment),
+            InheritDefaultEnvironment = request.InheritDefaultEnvironment,
             Experimental = request.Experimental,
         };
     }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
@@ -41,18 +41,19 @@ public sealed class SandboxRequest
     public string? WorkingDirectory { get; set; }
 
     /// <summary>
-    /// Environment variables supplied to the sandboxed process.
+    /// Optional environment variables supplied to the sandboxed process.
     /// </summary>
     /// <remarks>
-    /// When non-empty, this is the child's environment and is used verbatim —
-    /// nothing is merged into it, so an environment missing what the platform
-    /// requires fails the launch. Set <see cref="InheritDefaultEnvironment"/>
-    /// to layer these on top of the default environment instead. Leaving the
-    /// dictionary empty gives the child the backend's default environment (on
-    /// Windows, the user's profile block).
+    /// When non-null, this is the child's environment and is used verbatim —
+    /// including when the dictionary is empty. Nothing is merged into it, so
+    /// an environment missing what the platform requires fails the launch.
+    /// Set <see cref="InheritDefaultEnvironment"/> to layer these entries on
+    /// top of the default environment instead. Leave this property null to
+    /// give the child the backend's default environment (on Windows, the
+    /// user's profile block).
     /// </remarks>
     [JsonPropertyName("environment")]
-    public Dictionary<string, string> Environment { get; set; } = new();
+    public Dictionary<string, string>? Environment { get; set; }
 
     /// <summary>
     /// Start from the backend's default environment and layer
@@ -63,7 +64,7 @@ public sealed class SandboxRequest
     /// default is the user's profile block, which only the OS can produce, so
     /// it cannot be assembled by a caller. This is a different set from the
     /// calling process's own variables, which you can still add explicitly.
-    /// Has no effect when <see cref="Environment"/> is empty.
+    /// Has no effect when <see cref="Environment"/> is null.
     /// </remarks>
     [JsonPropertyName("inheritDefaultEnv")]
     public bool InheritDefaultEnvironment { get; set; }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
@@ -67,6 +67,7 @@ public sealed class SandboxRequest
     /// Has no effect when <see cref="Environment"/> is null.
     /// </remarks>
     [JsonPropertyName("inheritDefaultEnv")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool InheritDefaultEnvironment { get; set; }
 
     /// <summary>Opt in to experimental containment backends and features.</summary>

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
@@ -40,9 +40,33 @@ public sealed class SandboxRequest
     [JsonPropertyName("workingDirectory")]
     public string? WorkingDirectory { get; set; }
 
-    /// <summary>Environment variables supplied to the sandboxed process.</summary>
+    /// <summary>
+    /// Environment variables supplied to the sandboxed process.
+    /// </summary>
+    /// <remarks>
+    /// When non-empty, this is the child's environment and is used verbatim —
+    /// nothing is merged into it, so an environment missing what the platform
+    /// requires fails the launch. Set <see cref="InheritDefaultEnvironment"/>
+    /// to layer these on top of the default environment instead. Leaving the
+    /// dictionary empty gives the child the backend's default environment (on
+    /// Windows, the user's profile block).
+    /// </remarks>
     [JsonPropertyName("environment")]
     public Dictionary<string, string> Environment { get; set; } = new();
+
+    /// <summary>
+    /// Start from the backend's default environment and layer
+    /// <see cref="Environment"/> on top of it, rather than replacing it.
+    /// </summary>
+    /// <remarks>
+    /// Use this for "the usual environment, plus these": on Windows the
+    /// default is the user's profile block, which only the OS can produce, so
+    /// it cannot be assembled by a caller. This is a different set from the
+    /// calling process's own variables, which you can still add explicitly.
+    /// Has no effect when <see cref="Environment"/> is empty.
+    /// </remarks>
+    [JsonPropertyName("inheritDefaultEnv")]
+    public bool InheritDefaultEnvironment { get; set; }
 
     /// <summary>Opt in to experimental containment backends and features.</summary>
     [JsonPropertyName("experimental")]

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/StateAwareTypes.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/StateAwareTypes.cs
@@ -169,7 +169,18 @@ public class StateAwareExecOptions : StateAwarePhaseOptions
     public string? WorkingDirectory { get; set; }
 
     /// <summary>Environment variables encoded as <c>KEY=VALUE</c> strings.</summary>
+    /// <remarks>
+    /// <see langword="null"/> gives the child the backend's default
+    /// environment. A supplied list — including an empty one — is used
+    /// verbatim unless <see cref="InheritDefaultEnvironment"/> is set.
+    /// </remarks>
     public List<string>? Environment { get; set; }
+
+    /// <summary>
+    /// Layer <see cref="Environment"/> on top of the backend's default
+    /// environment rather than replacing it.
+    /// </summary>
+    public bool? InheritDefaultEnvironment { get; set; }
 
     /// <summary>Wall-clock timeout in milliseconds. Zero means no timeout.</summary>
     public uint? TimeoutMs { get; set; }

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -160,6 +160,7 @@ var request = new SandboxRequest(
 {
     ContainerName = "example",
     WorkingDirectory = @"C:\work",
+    InheritDefaultEnvironment = true,
     Environment =
     {
         ["GREETING"] = "hello",
@@ -168,6 +169,11 @@ var request = new SandboxRequest(
 
 RunResult result = await MxcSandbox.RunAsync(request);
 ```
+
+By default, a non-empty `Environment` dictionary replaces the child's
+environment. Set `InheritDefaultEnvironment` to layer those entries on the
+backend default instead; on Windows process containers, that default is the
+user profile environment block.
 
 `MxcSandbox.Run(request)` and `MxcSandbox.Spawn(request)` pass this complete
 request through the co-versioned native FFI contract. The existing
@@ -632,8 +638,8 @@ var wslc = new WslcProvisionOptions
 IsolationSession and Windows Sandbox default to schema `0.6.0-alpha`; WSLC
 defaults to `0.8.0-alpha`. Set `Version` on provision or phase options to
 override the inferred version. State-aware exec options expose working
-directory, `KEY=VALUE` environment entries, and timeout. WSLC also accepts a
-proxy-only per-exec override:
+directory, `KEY=VALUE` environment entries, `InheritDefaultEnvironment`, and
+timeout. WSLC also accepts a proxy-only per-exec override:
 
 ```csharp
 var options = new WslcExecOptions

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -174,7 +174,8 @@ By default, a non-null `Environment` dictionary replaces the child's
 environment, including when the dictionary is explicitly empty. Leave it null
 to use the backend default. Set `InheritDefaultEnvironment` to layer a non-null
 dictionary on the backend default instead; on Windows process containers, that
-default is the user profile environment block.
+default is the user profile environment block. Environment inheritance requires
+schema version `0.9.0-alpha` or later.
 
 `MxcSandbox.Run(request)` and `MxcSandbox.Spawn(request)` pass this complete
 request through the co-versioned native FFI contract. The existing
@@ -640,7 +641,9 @@ IsolationSession and Windows Sandbox default to schema `0.6.0-alpha`; WSLC
 defaults to `0.8.0-alpha`. Set `Version` on provision or phase options to
 override the inferred version. State-aware exec options expose working
 directory, `KEY=VALUE` environment entries, `InheritDefaultEnvironment`, and
-timeout. WSLC also accepts a proxy-only per-exec override:
+timeout. When `InheritDefaultEnvironment` is supplied without an explicit
+version, the SDK selects `0.9.0-alpha`; an explicitly older version is rejected.
+WSLC also accepts a proxy-only per-exec override:
 
 ```csharp
 var options = new WslcExecOptions

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -161,7 +161,7 @@ var request = new SandboxRequest(
     ContainerName = "example",
     WorkingDirectory = @"C:\work",
     InheritDefaultEnvironment = true,
-    Environment =
+    Environment = new()
     {
         ["GREETING"] = "hello",
     },
@@ -170,10 +170,11 @@ var request = new SandboxRequest(
 RunResult result = await MxcSandbox.RunAsync(request);
 ```
 
-By default, a non-empty `Environment` dictionary replaces the child's
-environment. Set `InheritDefaultEnvironment` to layer those entries on the
-backend default instead; on Windows process containers, that default is the
-user profile environment block.
+By default, a non-null `Environment` dictionary replaces the child's
+environment, including when the dictionary is explicitly empty. Leave it null
+to use the backend default. Set `InheritDefaultEnvironment` to layer a non-null
+dictionary on the backend default instead; on Windows process containers, that
+default is the user profile environment block.
 
 `MxcSandbox.Run(request)` and `MxcSandbox.Spawn(request)` pass this complete
 request through the co-versioned native FFI contract. The existing

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -174,8 +174,7 @@ By default, a non-null `Environment` dictionary replaces the child's
 environment, including when the dictionary is explicitly empty. Leave it null
 to use the backend default. Set `InheritDefaultEnvironment` to layer a non-null
 dictionary on the backend default instead; on Windows process containers, that
-default is the user profile environment block. Environment inheritance requires
-schema version `0.9.0-alpha` or later.
+default is the user profile environment block.
 
 `MxcSandbox.Run(request)` and `MxcSandbox.Spawn(request)` pass this complete
 request through the co-versioned native FFI contract. The existing

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -209,7 +209,7 @@ const tools = getAvailableToolsPolicy(process.env);
 const temp  = getTemporaryFilesPolicy();
 
 const pty = spawnSandbox('python script.py', {
-  version: '0.6.0-alpha',
+  version: '0.9.0-alpha',
   filesystem: {
     readonlyPaths:  tools.readonlyPaths,
     readwritePaths: temp.readwritePaths,

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -215,10 +215,19 @@ const pty = spawnSandbox('python script.py', {
     readwritePaths: temp.readwritePaths,
   },
   timeoutMs: 30_000,
+}, {
+  inheritDefaultEnv: true,
+}, undefined, undefined, {
+  APP_MODE: 'development',
 });
 pty.onData((d) => process.stdout.write(d));
 pty.onExit(({ exitCode }) => console.log('exit:', exitCode));
 ```
+
+An explicitly supplied environment is used verbatim by default. Set
+`inheritDefaultEnv: true` to layer those entries on the backend default instead;
+on Windows process containers, that default is the user profile environment
+block. The SDK never implicitly copies `process.env` into the child.
 
 ### 3. `spawnSandboxAsync(script, policy, ...)` — promise-style
 

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -227,7 +227,8 @@ pty.onExit(({ exitCode }) => console.log('exit:', exitCode));
 An explicitly supplied environment is used verbatim by default. Set
 `inheritDefaultEnv: true` to layer those entries on the backend default instead;
 on Windows process containers, that default is the user profile environment
-block. The SDK never implicitly copies `process.env` into the child.
+block. This option requires schema version `0.9.0-alpha` or later. The SDK never
+implicitly copies `process.env` into the child.
 
 ### 3. `spawnSandboxAsync(script, policy, ...)` — promise-style
 
@@ -338,7 +339,7 @@ await deprovisionSandbox(sandboxId, undefined, opts);
 
 `windows_sandbox` follows the same shape (substitute the containment string and provide `filesystem.readwritePaths` / `readonlyPaths` at provision if needed). See [`docs/windows-sandbox/windows-sandbox.md`](https://github.com/microsoft/mxc/blob/main/docs/windows-sandbox/windows-sandbox.md) for the per-phase config matrix.
 
-`wslc` follows the same shape and needs no provision config at all (it defaults to an `alpine:latest` container with no network). Provide `filesystem.readwritePaths` / `readonlyPaths` (mounted for the sandbox's lifetime), `network.defaultPolicy: 'allow'` (a bridged container; the default `'block'` gives no network), and/or a backend-specific `image` / `imageTarPath` at provision; inject a cooperative `network.proxy: { url }` per-exec. WSLc state-aware requests normally default to schema `0.8.0-alpha`; requests that include `telemetry` default to `0.9.0-alpha`. See [`docs/wsl/wslc-state-aware.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wslc-state-aware.md) for the per-phase config matrix.
+`wslc` follows the same shape and needs no provision config at all (it defaults to an `alpine:latest` container with no network). Provide `filesystem.readwritePaths` / `readonlyPaths` (mounted for the sandbox's lifetime), `network.defaultPolicy: 'allow'` (a bridged container; the default `'block'` gives no network), and/or a backend-specific `image` / `imageTarPath` at provision; inject a cooperative `network.proxy: { url }` per-exec. WSLc state-aware requests normally default to schema `0.8.0-alpha`; requests that include `telemetry` or `process.inheritDefaultEnv` default to `0.9.0-alpha`. An explicitly older version is rejected for either field. See [`docs/wsl/wslc-state-aware.md`](https://github.com/microsoft/mxc/blob/main/docs/wsl/wslc-state-aware.md) for the per-phase config matrix.
 
 **Handling failures.** Every lifecycle call rejects with a typed `MxcError`. Branch on `code` first:
 

--- a/sdk/node/src/generated/v0_9_0_alpha/wire.ts
+++ b/sdk/node/src/generated/v0_9_0_alpha/wire.ts
@@ -579,8 +579,14 @@ export interface Process {
   cwd?: string;
   /**
    * Optional environment entries encoded as `KEY=VALUE` strings.
+   * 
+   * Omitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inherit_default_env` is set.
    */
   env?: string[];
+  /**
+   * Layer `env` on top of the backend's default environment rather than replacing it.
+   */
+  inheritDefaultEnv?: boolean;
   /**
    * Optional execution timeout in milliseconds.
    */

--- a/sdk/node/src/generated/v0_9_0_alpha/wire.ts
+++ b/sdk/node/src/generated/v0_9_0_alpha/wire.ts
@@ -580,7 +580,7 @@ export interface Process {
   /**
    * Optional environment entries encoded as `KEY=VALUE` strings.
    * 
-   * Omitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inherit_default_env` is set.
+   * Omitted gives the backend's default environment; supplied (including as an empty array) is used verbatim unless `inheritDefaultEnv` is set.
    */
   env?: string[];
   /**

--- a/sdk/node/src/generated/wire.ts
+++ b/sdk/node/src/generated/wire.ts
@@ -359,8 +359,16 @@ export interface Process {
   cwd?: string | null;
   /**
    * Environment variables as `"KEY=VALUE"` strings.
+   * 
+   * Omit the field to give the child the backend's default environment (on Windows, the user's profile block). Supply it — including as an empty array — and it is used verbatim; MXC adds nothing to it unless `inheritDefaultEnv` is set.
    */
   env?: string[] | null;
+  /**
+   * Start from the backend's default environment and layer `env` on top of it, rather than replacing it (default false).
+   * 
+   * This exists because the default environment is not something a caller can assemble: on Windows it is the user's profile block, which only the OS can produce. Entries in `env` override same-named defaults. Has no effect on backends whose default environment is empty, and none when `env` is omitted (that already yields the default).
+   */
+  inheritDefaultEnv?: boolean | null;
   /**
    * Wall-clock timeout in milliseconds.
    */

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -13,6 +13,7 @@ import { MxcError, mxcErrorFromEnvelope } from './errors.js';
 
 const SUPPORTED_VERSION = '0.9.0-alpha';
 const MIN_VERSION = '0.6.0-alpha';
+const INHERIT_DEFAULT_ENV_VERSION = '0.9.0-alpha';
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -595,10 +596,28 @@ function applyInheritDefaultEnv(config: ContainerConfig, options: SandboxSpawnOp
   if (options.inheritDefaultEnv === undefined) {
     return;
   }
+  if (!options.inheritDefaultEnv) {
+    if (config.process) {
+      delete config.process.inheritDefaultEnv;
+    }
+    return;
+  }
   if (!config.process) {
     config.process = { commandLine: '' };
   }
-  config.process.inheritDefaultEnv = options.inheritDefaultEnv;
+  config.process.inheritDefaultEnv = true;
+}
+
+function validateInheritDefaultEnvVersion(config: ContainerConfig): void {
+  if (config.process?.inheritDefaultEnv === undefined) {
+    return;
+  }
+  const parsed = semverParse(config.version);
+  if (!parsed || (parsed.major === 0 && parsed.minor < 9)) {
+    throw new Error(
+      `process.inheritDefaultEnv requires policy version ${INHERIT_DEFAULT_ENV_VERSION} or later`,
+    );
+  }
 }
 
 /**
@@ -616,6 +635,7 @@ function spawnWithConfig(
     injectEnvIntoConfig(config, env);
   }
   applyInheritDefaultEnv(config, options);
+  validateInheritDefaultEnvVersion(config);
 
   const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
 

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -482,6 +482,36 @@ export interface SandboxSpawnOptions {
   allowTestingFeatures?: boolean;
 
   /**
+   * Start from the backend's default environment and layer the supplied
+   * environment variables on top of it, rather than replacing it
+   * (default false).
+   *
+   * Without this, an environment you supply is used verbatim — which on the
+   * Windows process container means a sparse environment is missing the
+   * variables Windows requires to be present, and the launch fails. Use this
+   * to express "the usual environment, plus these": the default is the user's
+   * profile block, which only the OS can produce.
+   *
+   * This is a different, smaller set than the calling process's `process.env`,
+   * which you can still pass explicitly as the `env` argument if you want your
+   * own variables handed to the child.
+   *
+   * Maps to `process.inheritDefaultEnv` in the JSON config.
+   */
+  inheritDefaultEnv?: boolean;
+
+  /**
+   * State-aware lifecycle only: the correlation vector (MS-CV) returned by
+   * {@link provisionSandbox} as `correlationVector`. Relay it verbatim on every
+   * later phase (`start` / `exec` / `stop` / `deprovision`) so all phases of one
+   * lifecycle share a telemetry base prefix. The client relays it unchanged; the
+   * executor derives each phase's own vector from it (spinning a mutable base or
+   * reseeding a missing/malformed value). Ignored by one-shot spawns and by
+   * `provision` (which seeds its own).
+   */
+  correlationVector?: string;
+
+  /**
    * Explicit path to the wxc-exec (or lxc-exec) binary.
    * When set, the SDK uses this path directly instead of searching.
    * Useful for packaged apps (e.g., Electron) where the binary
@@ -556,6 +586,22 @@ function injectEnvIntoConfig(
 }
 
 /**
+ * Apply {@link SandboxSpawnOptions.inheritDefaultEnv} to the config, so the
+ * environment is layered on the backend's default rather than replacing it.
+ * Only ever sets the flag: an option left unset must not clobber a value the
+ * caller already put in the config.
+ */
+function applyInheritDefaultEnv(config: ContainerConfig, options: SandboxSpawnOptions): void {
+  if (!options.inheritDefaultEnv) {
+    return;
+  }
+  if (!config.process) {
+    config.process = { commandLine: '' };
+  }
+  config.process.inheritDefaultEnv = true;
+}
+
+/**
  * Internal helper: resolves the executor binary path and spawns a PTY process.
  */
 function spawnWithConfig(
@@ -569,6 +615,7 @@ function spawnWithConfig(
   if (env) {
     injectEnvIntoConfig(config, env);
   }
+  applyInheritDefaultEnv(config, options);
 
   const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
 
@@ -685,6 +732,7 @@ export function spawnSandboxFromConfig(
     if (env) {
       injectEnvIntoConfig(config, env);
     }
+    applyInheritDefaultEnv(config, options);
 
     const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
     try {

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -588,17 +588,17 @@ function injectEnvIntoConfig(
 /**
  * Apply {@link SandboxSpawnOptions.inheritDefaultEnv} to the config, so the
  * environment is layered on the backend's default rather than replacing it.
- * Only ever sets the flag: an option left unset must not clobber a value the
- * caller already put in the config.
+ * An option left unset does not clobber a value the caller already put in the
+ * config; an explicit boolean overrides it.
  */
 function applyInheritDefaultEnv(config: ContainerConfig, options: SandboxSpawnOptions): void {
-  if (!options.inheritDefaultEnv) {
+  if (options.inheritDefaultEnv === undefined) {
     return;
   }
   if (!config.process) {
     config.process = { commandLine: '' };
   }
-  config.process.inheritDefaultEnv = true;
+  config.process.inheritDefaultEnv = options.inheritDefaultEnv;
 }
 
 /**

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -753,6 +753,7 @@ export function spawnSandboxFromConfig(
       injectEnvIntoConfig(config, env);
     }
     applyInheritDefaultEnv(config, options);
+    validateInheritDefaultEnvVersion(config);
 
     const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
     try {

--- a/sdk/node/src/sandbox.ts
+++ b/sdk/node/src/sandbox.ts
@@ -13,7 +13,6 @@ import { MxcError, mxcErrorFromEnvelope } from './errors.js';
 
 const SUPPORTED_VERSION = '0.9.0-alpha';
 const MIN_VERSION = '0.6.0-alpha';
-const INHERIT_DEFAULT_ENV_VERSION = '0.9.0-alpha';
 
 /**
  * Generates a random 8-character alphanumeric string for the app container name.
@@ -502,17 +501,6 @@ export interface SandboxSpawnOptions {
   inheritDefaultEnv?: boolean;
 
   /**
-   * State-aware lifecycle only: the correlation vector (MS-CV) returned by
-   * {@link provisionSandbox} as `correlationVector`. Relay it verbatim on every
-   * later phase (`start` / `exec` / `stop` / `deprovision`) so all phases of one
-   * lifecycle share a telemetry base prefix. The client relays it unchanged; the
-   * executor derives each phase's own vector from it (spinning a mutable base or
-   * reseeding a missing/malformed value). Ignored by one-shot spawns and by
-   * `provision` (which seeds its own).
-   */
-  correlationVector?: string;
-
-  /**
    * Explicit path to the wxc-exec (or lxc-exec) binary.
    * When set, the SDK uses this path directly instead of searching.
    * Useful for packaged apps (e.g., Electron) where the binary
@@ -608,18 +596,6 @@ function applyInheritDefaultEnv(config: ContainerConfig, options: SandboxSpawnOp
   config.process.inheritDefaultEnv = true;
 }
 
-function validateInheritDefaultEnvVersion(config: ContainerConfig): void {
-  if (config.process?.inheritDefaultEnv === undefined) {
-    return;
-  }
-  const parsed = semverParse(config.version);
-  if (!parsed || (parsed.major === 0 && parsed.minor < 9)) {
-    throw new Error(
-      `process.inheritDefaultEnv requires policy version ${INHERIT_DEFAULT_ENV_VERSION} or later`,
-    );
-  }
-}
-
 /**
  * Internal helper: resolves the executor binary path and spawns a PTY process.
  */
@@ -635,7 +611,6 @@ function spawnWithConfig(
     injectEnvIntoConfig(config, env);
   }
   applyInheritDefaultEnv(config, options);
-  validateInheritDefaultEnvVersion(config);
 
   const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
 
@@ -753,7 +728,6 @@ export function spawnSandboxFromConfig(
       injectEnvIntoConfig(config, env);
     }
     applyInheritDefaultEnv(config, options);
-    validateInheritDefaultEnvVersion(config);
 
     const { executablePath, args, logger, startTime } = prepareSpawn(config, options);
     try {

--- a/sdk/node/src/state-aware-helper.ts
+++ b/sdk/node/src/state-aware-helper.ts
@@ -18,6 +18,7 @@ export const STATE_AWARE_VERSION = '0.6.0-alpha';
 // See `DEFAULT_STATE_AWARE_VERSION`.
 export const WSLC_STATE_AWARE_VERSION = '0.8.0-alpha';
 export const TELEMETRY_STATE_AWARE_VERSION = '0.9.0-alpha';
+export const INHERIT_DEFAULT_ENV_STATE_AWARE_VERSION = '0.9.0-alpha';
 
 // Wire-format cross-cutting fields that live at the envelope's top level.
 // Anything else on a per-(backend, phase) Config is backend-specific and is
@@ -101,15 +102,25 @@ export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string,
   // Anything left becomes experimental.<backend>.<phase>.
   const backendSpecific: Record<string, unknown> = { ...(config ?? {}) };
   const defaultVersion = DEFAULT_STATE_AWARE_VERSION[backendKey] ?? STATE_AWARE_VERSION;
-  const suppliedVersion = typeof backendSpecific.version === 'string' && backendSpecific.version;
+  const suppliedVersion =
+    typeof backendSpecific.version === 'string' ? backendSpecific.version : undefined;
   const hasTelemetry = backendSpecific.telemetry !== undefined;
-  const version = suppliedVersion || (hasTelemetry ? TELEMETRY_STATE_AWARE_VERSION : defaultVersion);
-  if (hasTelemetry && suppliedVersion) {
+  const process = backendSpecific.process;
+  const hasInheritDefaultEnv =
+    typeof process === 'object' &&
+    process !== null &&
+    Object.prototype.hasOwnProperty.call(process, 'inheritDefaultEnv');
+  const requires09 = hasTelemetry || hasInheritDefaultEnv;
+  const version = suppliedVersion || (requires09 ? TELEMETRY_STATE_AWARE_VERSION : defaultVersion);
+  if (requires09 && suppliedVersion) {
     const parsed = semverParse(suppliedVersion);
     if (parsed && parsed.major === 0 && parsed.minor < 9) {
+      const feature = hasTelemetry
+        ? 'telemetry'
+        : 'process.inheritDefaultEnv';
       throw mxcErrorFromCode(
         'malformed_request',
-        `telemetry requires schema version ${TELEMETRY_STATE_AWARE_VERSION} or later; got ${suppliedVersion}`,
+        `${feature} requires schema version ${TELEMETRY_STATE_AWARE_VERSION} or later; got ${suppliedVersion}`,
       );
     }
   }

--- a/sdk/node/src/state-aware-helper.ts
+++ b/sdk/node/src/state-aware-helper.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { spawn } from 'child_process';
-import { parse as semverParse } from 'semver';
 import { resolveBinaryAndCommonArgs } from './helper.js';
 import { SandboxSpawnOptions } from './sandbox.js';
 import { mxcErrorFromCode, mxcErrorFromEnvelope, WireError } from './errors.js';
@@ -18,7 +17,6 @@ export const STATE_AWARE_VERSION = '0.6.0-alpha';
 // See `DEFAULT_STATE_AWARE_VERSION`.
 export const WSLC_STATE_AWARE_VERSION = '0.8.0-alpha';
 export const TELEMETRY_STATE_AWARE_VERSION = '0.9.0-alpha';
-export const INHERIT_DEFAULT_ENV_STATE_AWARE_VERSION = '0.9.0-alpha';
 
 // Wire-format cross-cutting fields that live at the envelope's top level.
 // Anything else on a per-(backend, phase) Config is backend-specific and is
@@ -113,18 +111,6 @@ export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string,
     (process as Record<string, unknown>).inheritDefaultEnv !== undefined;
   const requires09 = hasTelemetry || hasInheritDefaultEnv;
   const version = suppliedVersion || (requires09 ? TELEMETRY_STATE_AWARE_VERSION : defaultVersion);
-  if (requires09 && suppliedVersion) {
-    const parsed = semverParse(suppliedVersion);
-    if (parsed && parsed.major === 0 && parsed.minor < 9) {
-      const feature = hasTelemetry
-        ? 'telemetry'
-        : 'process.inheritDefaultEnv';
-      throw mxcErrorFromCode(
-        'malformed_request',
-        `${feature} requires schema version ${TELEMETRY_STATE_AWARE_VERSION} or later; got ${suppliedVersion}`,
-      );
-    }
-  }
   delete backendSpecific.version;
 
   const envelope: Record<string, unknown> = { version, phase };

--- a/sdk/node/src/state-aware-helper.ts
+++ b/sdk/node/src/state-aware-helper.ts
@@ -109,7 +109,8 @@ export function buildStateAwareEnvelope(args: BuildEnvelopeArgs): Record<string,
   const hasInheritDefaultEnv =
     typeof process === 'object' &&
     process !== null &&
-    Object.prototype.hasOwnProperty.call(process, 'inheritDefaultEnv');
+    Object.prototype.hasOwnProperty.call(process, 'inheritDefaultEnv') &&
+    (process as Record<string, unknown>).inheritDefaultEnv !== undefined;
   const requires09 = hasTelemetry || hasInheritDefaultEnv;
   const version = suppliedVersion || (requires09 ? TELEMETRY_STATE_AWARE_VERSION : defaultVersion);
   if (requires09 && suppliedVersion) {

--- a/sdk/node/src/types.ts
+++ b/sdk/node/src/types.ts
@@ -15,8 +15,27 @@ export interface ProcessConfig {
   commandLine: string;
   /** Working directory for the process */
   cwd?: string;
-  /** Environment variables as KEY=VALUE strings */
+  /**
+   * Environment variables as KEY=VALUE strings.
+   *
+   * Omit this field to give the child the backend's default environment (on
+   * Windows, the user's profile block). Supply it -- including as an empty
+   * array -- and it is used **verbatim**: MXC adds nothing to it, so an
+   * environment missing what the platform requires will fail the launch.
+   * Set {@link ProcessConfig.inheritDefaultEnv} to layer these on the
+   * default environment instead of replacing it.
+   */
   env?: string[];
+  /**
+   * Start from the backend's default environment and layer {@link
+   * ProcessConfig.env} on top of it, rather than replacing it (default false).
+   *
+   * Use this when you want "the usual environment, plus these": on Windows the
+   * default is the user's profile block, which only the OS can produce, so it
+   * cannot be assembled by a caller. Note this is a different set from the
+   * calling process's `process.env`, which you can still pass explicitly.
+   */
+  inheritDefaultEnv?: boolean;
   /** Execution timeout in milliseconds (default: 0 = no timeout) */
   timeout?: number;
 }

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1624,6 +1624,19 @@ describe('createConfigFromPolicy', () => {
         { message: /experimental mode/ },
       );
     });
+
+    it('should apply inheritDefaultEnv without replacing the supplied environment', () => {
+      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      config.process!.commandLine = 'echo hello';
+      config.process!.env = ['GREETING=hello'];
+
+      assert.throws(
+        () => spawnSandboxFromConfig(config, { inheritDefaultEnv: true }),
+        { message: /experimental mode/ },
+      );
+      assert.deepStrictEqual(config.process!.env, ['GREETING=hello']);
+      assert.strictEqual(config.process!.inheritDefaultEnv, true);
+    });
   });
 
   describe('Bubblewrap', () => {

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1637,6 +1637,18 @@ describe('createConfigFromPolicy', () => {
       assert.deepStrictEqual(config.process!.env, ['GREETING=hello']);
       assert.strictEqual(config.process!.inheritDefaultEnv, true);
     });
+
+    it('should allow explicit false to disable inheritDefaultEnv in a supplied config', () => {
+      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      config.process!.commandLine = 'echo hello';
+      config.process!.inheritDefaultEnv = true;
+
+      assert.throws(
+        () => spawnSandboxFromConfig(config, { inheritDefaultEnv: false }),
+        { message: /experimental mode/ },
+      );
+      assert.strictEqual(config.process!.inheritDefaultEnv, false);
+    });
   });
 
   describe('Bubblewrap', () => {

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1648,6 +1648,19 @@ describe('createConfigFromPolicy', () => {
       );
     });
 
+    it('should reject inheritDefaultEnv before schema version 0.9 without a PTY', () => {
+      const config = createConfigFromPolicy({ version: '0.8.0-alpha' }, 'wslc');
+      config.process!.commandLine = 'echo hello';
+
+      assert.throws(
+        () => spawnSandboxFromConfig(config, {
+          usePty: false,
+          inheritDefaultEnv: true,
+        }),
+        { message: /process\.inheritDefaultEnv requires policy version 0\.9\.0-alpha/ },
+      );
+    });
+
     it('should allow explicit false to disable inheritDefaultEnv in a supplied config', () => {
       const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1626,7 +1626,7 @@ describe('createConfigFromPolicy', () => {
     });
 
     it('should apply inheritDefaultEnv without replacing the supplied environment', () => {
-      const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
+      const config = createConfigFromPolicy({ version: '0.9.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
       config.process!.env = ['GREETING=hello'];
 
@@ -1638,6 +1638,16 @@ describe('createConfigFromPolicy', () => {
       assert.strictEqual(config.process!.inheritDefaultEnv, true);
     });
 
+    it('should reject inheritDefaultEnv before schema version 0.9', () => {
+      const config = createConfigFromPolicy({ version: '0.8.0-alpha' }, 'wslc');
+      config.process!.commandLine = 'echo hello';
+
+      assert.throws(
+        () => spawnSandboxFromConfig(config, { inheritDefaultEnv: true }),
+        { message: /process\.inheritDefaultEnv requires policy version 0\.9\.0-alpha/ },
+      );
+    });
+
     it('should allow explicit false to disable inheritDefaultEnv in a supplied config', () => {
       const config = createConfigFromPolicy({ version: '0.6.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
@@ -1647,7 +1657,7 @@ describe('createConfigFromPolicy', () => {
         () => spawnSandboxFromConfig(config, { inheritDefaultEnv: false }),
         { message: /experimental mode/ },
       );
-      assert.strictEqual(config.process!.inheritDefaultEnv, false);
+      assert.strictEqual(config.process!.inheritDefaultEnv, undefined);
     });
   });
 

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1638,17 +1638,19 @@ describe('createConfigFromPolicy', () => {
       assert.strictEqual(config.process!.inheritDefaultEnv, true);
     });
 
-    it('should reject inheritDefaultEnv before schema version 0.9', () => {
+    it('should leave inheritDefaultEnv version validation to the native engine', () => {
       const config = createConfigFromPolicy({ version: '0.8.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
 
       assert.throws(
         () => spawnSandboxFromConfig(config, { inheritDefaultEnv: true }),
-        { message: /process\.inheritDefaultEnv requires policy version 0\.9\.0-alpha/ },
+        { message: /experimental mode/ },
       );
+      assert.equal(config.version, '0.8.0-alpha');
+      assert.strictEqual(config.process!.inheritDefaultEnv, true);
     });
 
-    it('should reject inheritDefaultEnv before schema version 0.9 without a PTY', () => {
+    it('should leave non-PTY inheritDefaultEnv version validation to the native engine', () => {
       const config = createConfigFromPolicy({ version: '0.8.0-alpha' }, 'wslc');
       config.process!.commandLine = 'echo hello';
 
@@ -1657,8 +1659,10 @@ describe('createConfigFromPolicy', () => {
           usePty: false,
           inheritDefaultEnv: true,
         }),
-        { message: /process\.inheritDefaultEnv requires policy version 0\.9\.0-alpha/ },
+        { message: /experimental mode/ },
       );
+      assert.equal(config.version, '0.8.0-alpha');
+      assert.strictEqual(config.process!.inheritDefaultEnv, true);
     });
 
     it('should allow explicit false to disable inheritDefaultEnv in a supplied config', () => {

--- a/sdk/node/tests/unit/state-aware.test.ts
+++ b/sdk/node/tests/unit/state-aware.test.ts
@@ -48,6 +48,44 @@ describe('buildStateAwareEnvelope', () => {
     );
   });
 
+  it('selects schema 0.9 when exec inherits the backend environment', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'exec',
+      backendKey: 'wslc',
+      sandboxId: 'wslc:abc',
+      config: {
+        process: {
+          commandLine: 'echo hi',
+          inheritDefaultEnv: true,
+        },
+      },
+    });
+    assert.equal(env.version, '0.9.0-alpha');
+  });
+
+  it('rejects inherited environments with an explicitly older schema version', () => {
+    assert.throws(
+      () => buildStateAwareEnvelope({
+        phase: 'exec',
+        backendKey: 'wslc',
+        sandboxId: 'wslc:abc',
+        config: {
+          version: '0.8.0-alpha',
+          process: {
+            commandLine: 'echo hi',
+            inheritDefaultEnv: true,
+          },
+        },
+      }),
+      (error: unknown) =>
+        error instanceof MxcError &&
+        error.code === 'malformed_request' &&
+        error.message.includes(
+          'process.inheritDefaultEnv requires schema version 0.9.0-alpha',
+        ),
+    );
+  });
+
   it('produces a provision envelope with cross-cutting fields lifted to top-level', () => {
     const env = buildStateAwareEnvelope({
       phase: 'provision',

--- a/sdk/node/tests/unit/state-aware.test.ts
+++ b/sdk/node/tests/unit/state-aware.test.ts
@@ -33,19 +33,15 @@ describe('buildStateAwareEnvelope', () => {
     assert.equal(env.experimental, undefined);
   });
 
-  it('rejects telemetry with an explicitly older schema version', () => {
-    assert.throws(
-      () => buildStateAwareEnvelope({
-        phase: 'start',
-        backendKey: 'windows_sandbox',
-        sandboxId: 'wsb:01234567',
-        config: { version: '0.8.0-alpha', telemetry: { enabled: true } },
-      }),
-      (error: unknown) =>
-        error instanceof MxcError &&
-        error.code === 'malformed_request' &&
-        error.message.includes('telemetry requires schema version 0.9.0-alpha'),
-    );
+  it('preserves an older telemetry version for native validation', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'start',
+      backendKey: 'windows_sandbox',
+      sandboxId: 'wsb:01234567',
+      config: { version: '0.8.0-alpha', telemetry: { enabled: true } },
+    });
+    assert.equal(env.version, '0.8.0-alpha');
+    assert.deepEqual(env.telemetry, { enabled: true });
   });
 
   it('selects schema 0.9 when exec inherits the backend environment', () => {
@@ -79,27 +75,24 @@ describe('buildStateAwareEnvelope', () => {
     assert.equal(env.version, '0.8.0-alpha');
   });
 
-  it('rejects inherited environments with an explicitly older schema version', () => {
-    assert.throws(
-      () => buildStateAwareEnvelope({
-        phase: 'exec',
-        backendKey: 'wslc',
-        sandboxId: 'wslc:abc',
-        config: {
-          version: '0.8.0-alpha',
-          process: {
-            commandLine: 'echo hi',
-            inheritDefaultEnv: true,
-          },
+  it('preserves an older inherited-environment version for native validation', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'exec',
+      backendKey: 'wslc',
+      sandboxId: 'wslc:abc',
+      config: {
+        version: '0.8.0-alpha',
+        process: {
+          commandLine: 'echo hi',
+          inheritDefaultEnv: true,
         },
-      }),
-      (error: unknown) =>
-        error instanceof MxcError &&
-        error.code === 'malformed_request' &&
-        error.message.includes(
-          'process.inheritDefaultEnv requires schema version 0.9.0-alpha',
-        ),
-    );
+      },
+    });
+    assert.equal(env.version, '0.8.0-alpha');
+    assert.deepEqual(env.process, {
+      commandLine: 'echo hi',
+      inheritDefaultEnv: true,
+    });
   });
 
   it('produces a provision envelope with cross-cutting fields lifted to top-level', () => {

--- a/sdk/node/tests/unit/state-aware.test.ts
+++ b/sdk/node/tests/unit/state-aware.test.ts
@@ -63,6 +63,22 @@ describe('buildStateAwareEnvelope', () => {
     assert.equal(env.version, '0.9.0-alpha');
   });
 
+  it('does not select schema 0.9 when environment inheritance is undefined', () => {
+    const env = buildStateAwareEnvelope({
+      phase: 'exec',
+      backendKey: 'wslc',
+      sandboxId: 'wslc:abc',
+      config: {
+        version: '0.8.0-alpha',
+        process: {
+          commandLine: 'echo hi',
+          inheritDefaultEnv: undefined,
+        },
+      },
+    });
+    assert.equal(env.version, '0.8.0-alpha');
+  });
+
   it('rejects inherited environments with an explicitly older schema version', () => {
     assert.throws(
       () => buildStateAwareEnvelope({

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -202,6 +202,57 @@ pub(crate) fn build_explicit_entries(
     entries
 }
 
+/// Environment variables the OS itself requires to be present in a child's
+/// environment block when creating an AppContainer or process-security-environment
+/// process.
+///
+/// The OS looks these names up while preparing the container's profile and system
+/// paths. Only presence matters — the values are never validated — but if either
+/// name is absent, process creation fails with `ERROR_ENVVAR_NOT_FOUND` (203)
+/// before the workload ever starts.
+const REQUIRED_CHILD_ENV_VARS: [&str; 2] = ["SYSTEMROOT", "LOCALAPPDATA"];
+
+/// Ensure `entries` carries the variables the OS requires to launch a contained
+/// process, appending any that a caller-supplied environment omitted.
+///
+/// Missing values are sourced from the current user's profile block
+/// (`CreateEnvironmentBlock` with `bInherit = FALSE`) and never from the parent
+/// process's environment, so an explicit environment keeps its isolation
+/// guarantee: the child still sees only what the caller asked for, plus the
+/// handful of names without which it could not be created at all.
+///
+/// Does nothing when every required name is already present, which is the common
+/// case for a caller that passes a full environment.
+pub(crate) fn ensure_required_env_entries(
+    entries: &mut Vec<(String, String)>,
+) -> Result<(), WxcError> {
+    let missing: Vec<&str> = REQUIRED_CHILD_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|required| {
+            !entries
+                .iter()
+                .any(|(key, _)| key.eq_ignore_ascii_case(required))
+        })
+        .collect();
+
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let defaults = create_default_env_entries()?;
+    for required in missing {
+        if let Some((key, value)) = defaults
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(required))
+        {
+            entries.push((key.clone(), value.clone()));
+        }
+    }
+
+    Ok(())
+}
+
 /// Strip any pre-existing proxy env vars from `entries`, then inject the
 /// configured proxy as `HTTP_PROXY` / `HTTPS_PROXY`.
 pub(crate) fn inject_proxy_vars(
@@ -1039,11 +1090,13 @@ impl AppContainerScriptRunner {
         // Environment block for the sandboxed child.
         // SECURITY: Never pass NULL (which would inherit the parent process's
         // full environment). Always build an explicit block:
-        //   1. If explicit env vars were provided, use only those (+ proxy injection).
+        //   1. If explicit env vars were provided, use only those (+ proxy injection),
+        //      topped up with the names the OS requires to create the container.
         //   2. Otherwise, call CreateEnvironmentBlock(bInherit=FALSE) for a clean
         //      default user environment and merge proxy vars if needed.
         let env_block: Vec<u16> = if !request.env.is_empty() {
-            let entries = build_explicit_entries(&request.env, self.proxy_address.as_ref());
+            let mut entries = build_explicit_entries(&request.env, self.proxy_address.as_ref());
+            ensure_required_env_entries(&mut entries)?;
             encode_env_block(&entries)
         } else {
             // Get clean default user env without inheriting process env vars.
@@ -2449,6 +2502,46 @@ mod tests {
         let block = super::encode_env_block(&entries);
         let parsed = super::parse_environment_block(block.as_ptr());
         assert_eq!(parsed, entries);
+    }
+
+    #[test]
+    fn ensure_required_env_entries_adds_missing_names() {
+        let mut entries = vec![("MYVAR".to_string(), "hello".to_string())];
+        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
+
+        assert!(entries.iter().any(|(k, _)| k.eq_ignore_ascii_case("MYVAR")));
+        for required in super::REQUIRED_CHILD_ENV_VARS {
+            assert!(
+                entries
+                    .iter()
+                    .any(|(k, _)| k.eq_ignore_ascii_case(required)),
+                "{required} should have been injected"
+            );
+        }
+    }
+
+    #[test]
+    fn ensure_required_env_entries_preserves_caller_values() {
+        let mut entries = vec![
+            ("SystemRoot".to_string(), "C:\\Custom".to_string()),
+            ("localappdata".to_string(), "C:\\Other".to_string()),
+        ];
+        super::ensure_required_env_entries(&mut entries).expect("no lookup needed");
+
+        // Already present (in any case), so nothing is added or overwritten.
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].1, "C:\\Custom");
+        assert_eq!(entries[1].1, "C:\\Other");
+    }
+
+    #[test]
+    fn ensure_required_env_entries_is_idempotent() {
+        let mut entries = vec![("MYVAR".to_string(), "hello".to_string())];
+        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
+        let after_first = entries.len();
+        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
+
+        assert_eq!(entries.len(), after_first);
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 
 use windows::Win32::Foundation::{
     CloseHandle, GetLastError, LocalFree, SetHandleInformation, ERROR_ACCESS_DISABLED_BY_POLICY,
-    ERROR_ALREADY_EXISTS, HANDLE, HANDLE_FLAG_INHERIT, HLOCAL, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    ERROR_ALREADY_EXISTS, ERROR_ENVVAR_NOT_FOUND, HANDLE, HANDLE_FLAG_INHERIT, HLOCAL,
+    WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::Security::Authorization::ConvertSidToStringSidW;
 use windows::Win32::Security::Isolation::{
@@ -37,7 +38,7 @@ use crate::guarded_capture::{
     GuardedCaptureSession, GuardedStop,
 };
 use crate::job_object::UiJobObject;
-use crate::launch_diagnostics::diagnose_create_process_failure;
+use crate::launch_diagnostics::{diagnose_create_process_failure, diagnose_missing_required_env};
 use crate::network_policy_helpers::{add_default_network_capabilities, allows_network_egress};
 use crate::process_mitigation;
 use wxc_common::audit::{
@@ -81,6 +82,7 @@ fn create_process_failure(
     command_line: &str,
     readonly_paths: &[String],
     working_directory: &str,
+    supplied_env: Option<&[String]>,
 ) -> WxcError {
     let message = if err.code() == ERROR_ACCESS_DISABLED_BY_POLICY.to_hresult() {
         diagnose_create_process_failure(
@@ -89,6 +91,11 @@ fn create_process_failure(
             readonly_paths,
         )
         .message
+    } else if let Some(diag) = (err.code() == ERROR_ENVVAR_NOT_FOUND.to_hresult())
+        .then(|| diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, supplied_env))
+        .flatten()
+    {
+        diag.message
     } else {
         format!("CreateProcessW failed: {err}")
     };
@@ -180,6 +187,41 @@ fn parse_environment_block(block: *const u16) -> Vec<(String, String)> {
     entries
 }
 
+/// Build the child's entries by layering caller-supplied `KEY=VALUE` strings on
+/// top of the clean default user environment (`process.inheritDefaultEnv`).
+///
+/// The default block comes from `CreateEnvironmentBlock(bInherit=FALSE)`, so it
+/// is the *user's profile* environment and never the `wxc-exec` process's own.
+/// A caller entry replaces a same-named default (case-insensitively, as Windows
+/// environment names are case-insensitive) rather than duplicating it, since a
+/// block with two entries for one name has no well-defined winner.
+pub(crate) fn build_inherited_entries(
+    env_vars: &[String],
+    proxy_address: Option<&wxc_common::models::ProxyAddress>,
+) -> Result<Vec<(String, String)>, WxcError> {
+    let mut entries = create_default_env_entries()?;
+
+    for (key, value) in env_vars.iter().filter_map(|entry| {
+        entry
+            .split_once('=')
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+    }) {
+        match entries
+            .iter_mut()
+            .find(|(existing, _)| existing.eq_ignore_ascii_case(&key))
+        {
+            Some(slot) => *slot = (key, value),
+            None => entries.push((key, value)),
+        }
+    }
+
+    if let Some(addr) = proxy_address {
+        inject_proxy_vars(&mut entries, addr);
+    }
+
+    Ok(entries)
+}
+
 /// Parse explicit `KEY=VALUE` strings into entry pairs, optionally injecting
 /// proxy env vars (stripping any pre-existing proxy vars first).
 pub(crate) fn build_explicit_entries(
@@ -200,57 +242,6 @@ pub(crate) fn build_explicit_entries(
     }
 
     entries
-}
-
-/// Environment variables the OS itself requires to be present in a child's
-/// environment block when creating an AppContainer or process-security-environment
-/// process.
-///
-/// The OS looks these names up while preparing the container's profile and system
-/// paths. Only presence matters — the values are never validated — but if either
-/// name is absent, process creation fails with `ERROR_ENVVAR_NOT_FOUND` (203)
-/// before the workload ever starts.
-const REQUIRED_CHILD_ENV_VARS: [&str; 2] = ["SYSTEMROOT", "LOCALAPPDATA"];
-
-/// Ensure `entries` carries the variables the OS requires to launch a contained
-/// process, appending any that a caller-supplied environment omitted.
-///
-/// Missing values are sourced from the current user's profile block
-/// (`CreateEnvironmentBlock` with `bInherit = FALSE`) and never from the parent
-/// process's environment, so an explicit environment keeps its isolation
-/// guarantee: the child still sees only what the caller asked for, plus the
-/// handful of names without which it could not be created at all.
-///
-/// Does nothing when every required name is already present, which is the common
-/// case for a caller that passes a full environment.
-pub(crate) fn ensure_required_env_entries(
-    entries: &mut Vec<(String, String)>,
-) -> Result<(), WxcError> {
-    let missing: Vec<&str> = REQUIRED_CHILD_ENV_VARS
-        .iter()
-        .copied()
-        .filter(|required| {
-            !entries
-                .iter()
-                .any(|(key, _)| key.eq_ignore_ascii_case(required))
-        })
-        .collect();
-
-    if missing.is_empty() {
-        return Ok(());
-    }
-
-    let defaults = create_default_env_entries()?;
-    for required in missing {
-        if let Some((key, value)) = defaults
-            .iter()
-            .find(|(key, _)| key.eq_ignore_ascii_case(required))
-        {
-            entries.push((key.clone(), value.clone()));
-        }
-    }
-
-    Ok(())
 }
 
 /// Strip any pre-existing proxy env vars from `entries`, then inject the
@@ -1090,21 +1081,29 @@ impl AppContainerScriptRunner {
         // Environment block for the sandboxed child.
         // SECURITY: Never pass NULL (which would inherit the parent process's
         // full environment). Always build an explicit block:
-        //   1. If explicit env vars were provided, use only those (+ proxy injection),
-        //      topped up with the names the OS requires to create the container.
-        //   2. Otherwise, call CreateEnvironmentBlock(bInherit=FALSE) for a clean
-        //      default user environment and merge proxy vars if needed.
-        let env_block: Vec<u16> = if !request.env.is_empty() {
-            let mut entries = build_explicit_entries(&request.env, self.proxy_address.as_ref());
-            ensure_required_env_entries(&mut entries)?;
-            encode_env_block(&entries)
-        } else {
-            // Get clean default user env without inheriting process env vars.
-            let mut entries = create_default_env_entries()?;
-            if let Some(addr) = self.proxy_address.as_ref() {
-                inject_proxy_vars(&mut entries, addr);
+        //   1. If the caller supplied an environment, use exactly that (+ proxy
+        //      injection), including when it is empty. MXC does not add to a
+        //      caller-supplied environment unless `inheritDefaultEnv` asked it
+        //      to layer the environment on the default block.
+        //   2. If the caller supplied none, call CreateEnvironmentBlock(bInherit=FALSE)
+        //      for a clean default user environment and merge proxy vars if needed.
+        let env_block: Vec<u16> = match request.env.as_deref() {
+            Some(supplied) if request.inherit_default_env => {
+                let entries = build_inherited_entries(supplied, self.proxy_address.as_ref())?;
+                encode_env_block(&entries)
             }
-            encode_env_block(&entries)
+            Some(supplied) => {
+                let entries = build_explicit_entries(supplied, self.proxy_address.as_ref());
+                encode_env_block(&entries)
+            }
+            None => {
+                // Get clean default user env without inheriting process env vars.
+                let mut entries = create_default_env_entries()?;
+                if let Some(addr) = self.proxy_address.as_ref() {
+                    inject_proxy_vars(&mut entries, addr);
+                }
+                encode_env_block(&entries)
+            }
         };
 
         let env_ptr = env_block.as_ptr() as *const core::ffi::c_void;
@@ -1155,6 +1154,7 @@ impl AppContainerScriptRunner {
                 &request.script_code,
                 &request.policy.readonly_paths,
                 &working_directory.describe(),
+                request.env.as_deref(),
             )
         })?;
 
@@ -2505,46 +2505,6 @@ mod tests {
     }
 
     #[test]
-    fn ensure_required_env_entries_adds_missing_names() {
-        let mut entries = vec![("MYVAR".to_string(), "hello".to_string())];
-        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
-
-        assert!(entries.iter().any(|(k, _)| k.eq_ignore_ascii_case("MYVAR")));
-        for required in super::REQUIRED_CHILD_ENV_VARS {
-            assert!(
-                entries
-                    .iter()
-                    .any(|(k, _)| k.eq_ignore_ascii_case(required)),
-                "{required} should have been injected"
-            );
-        }
-    }
-
-    #[test]
-    fn ensure_required_env_entries_preserves_caller_values() {
-        let mut entries = vec![
-            ("SystemRoot".to_string(), "C:\\Custom".to_string()),
-            ("localappdata".to_string(), "C:\\Other".to_string()),
-        ];
-        super::ensure_required_env_entries(&mut entries).expect("no lookup needed");
-
-        // Already present (in any case), so nothing is added or overwritten.
-        assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].1, "C:\\Custom");
-        assert_eq!(entries[1].1, "C:\\Other");
-    }
-
-    #[test]
-    fn ensure_required_env_entries_is_idempotent() {
-        let mut entries = vec![("MYVAR".to_string(), "hello".to_string())];
-        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
-        let after_first = entries.len();
-        super::ensure_required_env_entries(&mut entries).expect("profile block is readable");
-
-        assert_eq!(entries.len(), after_first);
-    }
-
-    #[test]
     fn build_explicit_entries_no_proxy() {
         let env = vec!["FOO=bar".to_string(), "BAZ=qux".to_string()];
         let entries = super::build_explicit_entries(&env, None);
@@ -2641,6 +2601,7 @@ mod tests {
             r#""C:\Program Files\PowerShell\7\pwsh.exe" -NoProfile"#,
             &[],
             r"C:\work",
+            None,
         );
         let message = mapped.to_string();
 
@@ -2654,7 +2615,7 @@ mod tests {
     #[test]
     fn appcontainer_other_win32_error_preserves_create_process_message() {
         let err = windows_core::Error::from_hresult(ERROR_CALL_NOT_IMPLEMENTED.to_hresult());
-        let mapped = create_process_failure(&err, "cmd.exe", &[], r"C:\work");
+        let mapped = create_process_failure(&err, "cmd.exe", &[], r"C:\work", None);
         let message = mapped.to_string();
 
         assert!(message.contains("CreateProcessW failed"));

--- a/src/backends/appcontainer/common/src/appcontainer_runner.rs
+++ b/src/backends/appcontainer/common/src/appcontainer_runner.rs
@@ -119,6 +119,9 @@ pub(crate) fn encode_env_block(entries: &[(String, String)]) -> Vec<u16> {
         }
         block.push(0);
     }
+    if block.is_empty() {
+        block.push(0);
+    }
     block.push(0);
     block
 }
@@ -1154,7 +1157,11 @@ impl AppContainerScriptRunner {
                 &request.script_code,
                 &request.policy.readonly_paths,
                 &working_directory.describe(),
-                request.env.as_deref(),
+                if request.inherit_default_env {
+                    None
+                } else {
+                    request.env.as_deref()
+                },
             )
         })?;
 
@@ -2491,6 +2498,11 @@ mod tests {
         let parsed = super::parse_environment_block(block.as_ptr());
         assert_eq!(parsed[0].0, "alpha");
         assert_eq!(parsed[1].0, "Zebra");
+    }
+
+    #[test]
+    fn encode_env_block_empty_input_is_double_null_terminated() {
+        assert_eq!(super::encode_env_block(&[]), vec![0u16, 0u16]);
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -1768,14 +1768,18 @@ impl BaseContainerRunner {
             //
             // Diagnose the launch failure (FailurePhase::LaunchFailed).
             //
-            let diag =
-                diagnose_missing_required_env(err.0, request.env.as_deref()).unwrap_or_else(|| {
-                    diagnose_create_process_failure(
-                        err.0,
-                        &request.script_code,
-                        &request.policy.readonly_paths,
-                    )
-                });
+            let diagnostic_env = if request.inherit_default_env {
+                None
+            } else {
+                request.env.as_deref()
+            };
+            let diag = diagnose_missing_required_env(err.0, diagnostic_env).unwrap_or_else(|| {
+                diagnose_create_process_failure(
+                    err.0,
+                    &request.script_code,
+                    &request.policy.readonly_paths,
+                )
+            });
 
             let mut extended_error = format!(
                 "{launch_api_name} failed: {err:?} (working directory: {})",
@@ -3951,10 +3955,10 @@ mod tests {
                 .expect("an explicitly empty env must still produce a block");
             assert_eq!(
                 environment.len(),
-                1,
-                "an empty block is just the terminator"
+                2,
+                "an empty block still requires two terminators"
             );
-            assert_eq!(environment, vec![0u16]);
+            assert_eq!(environment, vec![0u16, 0u16]);
         }
     }
 

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -106,7 +106,13 @@ fn build_child_env_block(
         }
         entries
     } else {
-        crate::appcontainer_runner::build_explicit_entries(&request.env, proxy_address)
+        // A caller-supplied environment replaces the block wholesale, so top it up
+        // with the names the OS requires to create the container. Without this a
+        // sparse `process.env` fails with ERROR_ENVVAR_NOT_FOUND (203).
+        let mut entries =
+            crate::appcontainer_runner::build_explicit_entries(&request.env, proxy_address);
+        crate::appcontainer_runner::ensure_required_env_entries(&mut entries)?;
+        entries
     };
     Ok(Some(crate::appcontainer_runner::encode_env_block(&entries)))
 }

--- a/src/backends/appcontainer/common/src/base_container_runner.rs
+++ b/src/backends/appcontainer/common/src/base_container_runner.rs
@@ -52,8 +52,8 @@ use crate::guarded_capture::{
 };
 use crate::job_object::UiJobObject;
 use crate::launch_diagnostics::{
-    diagnose_create_process_failure, diagnose_environment_not_supported, diagnose_process_exit,
-    is_environment_not_supported,
+    diagnose_create_process_failure, diagnose_environment_not_supported,
+    diagnose_missing_required_env, diagnose_process_exit, is_environment_not_supported,
 };
 use crate::proxy_coordinator::ProxyCoordinator;
 use crate::sandbox_tracking::{self, TrackingEntry};
@@ -86,6 +86,23 @@ use windows::Win32::System::Threading::{
     ResumeThread, CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT,
 };
 
+/// Build the environment block handed to the contained child.
+///
+/// Honors the three states of [`ExecutionRequest::env`]:
+///
+/// * `None` — no environment supplied. The child gets a clean default user
+///   profile block (never the `wxc-exec` process's own variables). When the
+///   legacy one-shot SBOX API is in play and no proxy has to be injected, we
+///   return `Ok(None)` so the API supplies that default itself.
+/// * `Some(entries)` — the caller's environment, used **verbatim**. MXC adds
+///   nothing to it, including when `entries` is empty: an explicitly empty
+///   environment produces an empty block, not the default one. Proxy variables
+///   are still injected, because the proxy is enforced policy rather than
+///   inherited environment.
+///
+/// When `inherit_default_env` is set, `entries` is layered on top of the
+/// default block instead of replacing it, which is the supported way to ask for
+/// "the user's profile block plus these".
 fn build_child_env_block(
     request: &ExecutionRequest,
     use_process_security_environment: bool,
@@ -96,23 +113,23 @@ fn build_child_env_block(
         None
     };
 
-    let entries = if request.env.is_empty() {
-        if !use_process_security_environment && proxy_address.is_none() {
-            return Ok(None);
+    let entries = match request.env.as_deref() {
+        None => {
+            if !use_process_security_environment && proxy_address.is_none() {
+                return Ok(None);
+            }
+            let mut entries = crate::appcontainer_runner::create_default_env_entries()?;
+            if let Some(address) = proxy_address {
+                crate::appcontainer_runner::inject_proxy_vars(&mut entries, address);
+            }
+            entries
         }
-        let mut entries = crate::appcontainer_runner::create_default_env_entries()?;
-        if let Some(address) = proxy_address {
-            crate::appcontainer_runner::inject_proxy_vars(&mut entries, address);
+        Some(supplied) if request.inherit_default_env => {
+            crate::appcontainer_runner::build_inherited_entries(supplied, proxy_address)?
         }
-        entries
-    } else {
-        // A caller-supplied environment replaces the block wholesale, so top it up
-        // with the names the OS requires to create the container. Without this a
-        // sparse `process.env` fails with ERROR_ENVVAR_NOT_FOUND (203).
-        let mut entries =
-            crate::appcontainer_runner::build_explicit_entries(&request.env, proxy_address);
-        crate::appcontainer_runner::ensure_required_env_entries(&mut entries)?;
-        entries
+        Some(supplied) => {
+            crate::appcontainer_runner::build_explicit_entries(supplied, proxy_address)
+        }
     };
     Ok(Some(crate::appcontainer_runner::encode_env_block(&entries)))
 }
@@ -1751,11 +1768,14 @@ impl BaseContainerRunner {
             //
             // Diagnose the launch failure (FailurePhase::LaunchFailed).
             //
-            let diag = diagnose_create_process_failure(
-                err.0,
-                &request.script_code,
-                &request.policy.readonly_paths,
-            );
+            let diag =
+                diagnose_missing_required_env(err.0, request.env.as_deref()).unwrap_or_else(|| {
+                    diagnose_create_process_failure(
+                        err.0,
+                        &request.script_code,
+                        &request.policy.readonly_paths,
+                    )
+                });
 
             let mut extended_error = format!(
                 "{launch_api_name} failed: {err:?} (working directory: {})",
@@ -3871,7 +3891,7 @@ mod tests {
             address: Some(ProxyAddress::new("127.0.0.1".to_string(), 8080)),
             builtin_test_server: false,
         };
-        request.env = vec!["PATH=C:\\Windows".to_string()];
+        request.env = Some(vec!["PATH=C:\\Windows".to_string()]);
 
         assert!(!BaseContainerRunner::legacy_sbox_compatible_with_request(
             &request,
@@ -3885,6 +3905,107 @@ mod tests {
         assert!(rendered.contains("PATH=C:\\Windows"));
         assert!(rendered.contains("HTTP_PROXY=http://127.0.0.1:8080"));
         assert!(rendered.contains("HTTPS_PROXY=http://127.0.0.1:8080"));
+    }
+
+    #[test]
+    fn absent_env_yields_the_default_user_environment() {
+        // No caller environment: the child must get a populated default block,
+        // not an empty one.
+        let request = ExecutionRequest::default();
+        assert!(request.env.is_none());
+
+        let environment = build_child_env_block(&request, true)
+            .expect("environment")
+            .expect("PSEC always needs an explicit block");
+        let rendered = String::from_utf16_lossy(&environment);
+        assert!(
+            rendered.len() > 2,
+            "default block should carry the user profile variables"
+        );
+    }
+
+    #[test]
+    fn absent_env_defers_to_the_sbox_api_default() {
+        // The legacy one-shot API supplies its own default when handed NULL,
+        // and there is no proxy to inject, so we pass NULL rather than
+        // building a block ourselves.
+        let request = ExecutionRequest::default();
+        assert!(build_child_env_block(&request, false)
+            .expect("environment")
+            .is_none());
+    }
+
+    #[test]
+    fn explicitly_empty_env_yields_an_empty_block_not_the_default() {
+        // `"env": []` is a request for an empty environment. It must not be
+        // silently upgraded to the default profile block, and it must not
+        // become NULL (which the SBOX API reads as "give me the default").
+        let request = ExecutionRequest {
+            env: Some(Vec::new()),
+            ..Default::default()
+        };
+
+        for psec in [true, false] {
+            let environment = build_child_env_block(&request, psec)
+                .expect("environment")
+                .expect("an explicitly empty env must still produce a block");
+            assert_eq!(
+                environment.len(),
+                1,
+                "an empty block is just the terminator"
+            );
+            assert_eq!(environment, vec![0u16]);
+        }
+    }
+
+    #[test]
+    fn supplied_env_is_used_verbatim() {
+        // MXC adds nothing to a caller-supplied environment -- notably not the
+        // variables Windows requires to be present. A caller that replaces the
+        // block owns its contents; a missing requirement surfaces as an
+        // actionable launch error instead.
+        let request = ExecutionRequest {
+            env: Some(vec!["MYVAR=hello".to_string()]),
+            ..Default::default()
+        };
+
+        let environment = build_child_env_block(&request, true)
+            .expect("environment")
+            .expect("explicit block");
+        let rendered = String::from_utf16_lossy(&environment);
+
+        assert!(rendered.contains("MYVAR=hello"));
+        assert!(!rendered.to_ascii_uppercase().contains("SYSTEMROOT"));
+        assert!(!rendered.to_ascii_uppercase().contains("LOCALAPPDATA"));
+    }
+
+    #[test]
+    fn inherit_default_env_layers_the_caller_entries_on_the_default_block() {
+        // `inheritDefaultEnv` is how a caller asks for "the profile block plus
+        // these": the defaults must survive, and a caller entry must replace
+        // the same-named default rather than being appended alongside it.
+        let request = ExecutionRequest {
+            env: Some(vec![
+                "MYVAR=hello".to_string(),
+                "systemroot=C:\\Override".to_string(),
+            ]),
+            inherit_default_env: true,
+            ..Default::default()
+        };
+
+        let environment = build_child_env_block(&request, true)
+            .expect("environment")
+            .expect("explicit block");
+        let rendered = String::from_utf16_lossy(&environment);
+
+        assert!(rendered.contains("MYVAR=hello"));
+        assert!(rendered.to_ascii_uppercase().contains("LOCALAPPDATA"));
+        assert!(rendered.contains("systemroot=C:\\Override"));
+        assert_eq!(
+            rendered.to_ascii_uppercase().matches("SYSTEMROOT=").count(),
+            1,
+            "a caller entry must replace the default, not duplicate it"
+        );
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -90,9 +90,11 @@ pub fn diagnose_missing_required_env(
              the variable(s) Windows requires to be present: {}. \
              MXC started from your `process.env` ({described}) and does not inject these \
              required Windows variables. \
-             Add the missing variable(s) to `process.env` — any value will do, the check is \
-             presence-only — or omit `process.env` entirely to get the default user \
-             environment (ERROR_ENVVAR_NOT_FOUND, 203).",
+             Set `process.inheritDefaultEnv` to true to layer `process.env` on the default \
+             user environment. Alternatively, add the missing variable(s) to `process.env` \
+             — any value will do, the check is presence-only — or omit `process.env` \
+             entirely to use the default user environment \
+             (ERROR_ENVVAR_NOT_FOUND, 203).",
             missing.join(", ")
         ),
     })
@@ -416,6 +418,9 @@ mod tests {
         assert!(diag.message.contains("started from your `process.env`"));
         assert!(diag.message.contains("does not inject"));
         assert!(diag.message.contains("1 variable(s)"));
+        assert!(diag
+            .message
+            .contains("Set `process.inheritDefaultEnv` to true"));
     }
 
     #[test]

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -88,7 +88,8 @@ pub fn diagnose_missing_required_env(
         message: format!(
             "The sandboxed process could not be created because its environment is missing \
              the variable(s) Windows requires to be present: {}. \
-             MXC used your `process.env` verbatim ({described}), so nothing was added to it. \
+             MXC started from your `process.env` ({described}) and does not inject these \
+             required Windows variables. \
              Add the missing variable(s) to `process.env` — any value will do, the check is \
              presence-only — or omit `process.env` entirely to get the default user \
              environment (ERROR_ENVVAR_NOT_FOUND, 203).",
@@ -412,7 +413,8 @@ mod tests {
         assert_eq!(diag.kind, "missing_required_env");
         assert!(diag.message.contains("SYSTEMROOT"));
         assert!(diag.message.contains("LOCALAPPDATA"));
-        assert!(diag.message.contains("verbatim"));
+        assert!(diag.message.contains("started from your `process.env`"));
+        assert!(diag.message.contains("does not inject"));
         assert!(diag.message.contains("1 variable(s)"));
     }
 

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -28,6 +28,75 @@ pub struct LaunchDiagnostic {
 
 // -- Public API --------------------------------------------------------------
 
+/// Environment variable names Windows requires to be *present* in the child's
+/// environment block when creating a contained (AppContainer / PSEC) process.
+///
+/// Determined empirically against `CreateProcessW` with
+/// `PROC_THREAD_ATTRIBUTE_SECURITY_ENVIRONMENT`: with either name absent the
+/// call fails `ERROR_ENVVAR_NOT_FOUND` (203) before the workload ever starts.
+/// The check is presence-only and case-insensitive — an empty or nonsense value
+/// satisfies it — which is the fingerprint of a name lookup rather than path
+/// resolution.
+///
+/// MXC does not inject these into a caller-supplied environment: `process.env`
+/// is honored verbatim, so a caller that replaces the block wholesale owns the
+/// contents. This list exists to turn the resulting bare 203 into a message
+/// that names what is missing.
+pub const REQUIRED_CHILD_ENV_VARS: [&str; 2] = ["SYSTEMROOT", "LOCALAPPDATA"];
+
+/// Diagnose `ERROR_ENVVAR_NOT_FOUND` from a contained-process launch.
+///
+/// `supplied_env` is the caller's `process.env` — `None` when they supplied
+/// none, in which case MXC built the block itself and a missing variable is not
+/// the caller's doing, so no diagnostic is produced.
+///
+/// Returns `None` unless the error is 203 *and* a caller-supplied block is
+/// missing at least one of [`REQUIRED_CHILD_ENV_VARS`]; the generic
+/// [`diagnose_create_process_failure`] handles every other case.
+pub fn diagnose_missing_required_env(
+    win32_error: u32,
+    supplied_env: Option<&[String]>,
+) -> Option<LaunchDiagnostic> {
+    if win32_error != ERROR_ENVVAR_NOT_FOUND.0 {
+        return None;
+    }
+    let supplied = supplied_env?;
+
+    let missing: Vec<&str> = REQUIRED_CHILD_ENV_VARS
+        .iter()
+        .copied()
+        .filter(|required| {
+            !supplied.iter().any(|entry| {
+                entry
+                    .split_once('=')
+                    .is_some_and(|(key, _)| key.eq_ignore_ascii_case(required))
+            })
+        })
+        .collect();
+    if missing.is_empty() {
+        return None;
+    }
+
+    let described = if supplied.is_empty() {
+        "an empty environment".to_string()
+    } else {
+        format!("an environment of {} variable(s)", supplied.len())
+    };
+
+    Some(LaunchDiagnostic {
+        kind: "missing_required_env",
+        message: format!(
+            "The sandboxed process could not be created because its environment is missing \
+             the variable(s) Windows requires to be present: {}. \
+             MXC used your `process.env` verbatim ({described}), so nothing was added to it. \
+             Add the missing variable(s) to `process.env` — any value will do, the check is \
+             presence-only — or omit `process.env` entirely to get the default user \
+             environment (ERROR_ENVVAR_NOT_FOUND, 203).",
+            missing.join(", ")
+        ),
+    })
+}
+
 /// Diagnose a failed `CreateProcess` / `Experimental_CreateProcessInSandbox`
 /// call. Inspects the Win32 error code and the command line to identify known
 /// failure conditions.
@@ -119,8 +188,8 @@ const REQUIRED_VELOCITY_KEYS: &[(u32, &str)] = &[
 // flow through `u32`, which matches the existing public surface of
 // this module (`diagnose_create_process_failure` takes `u32`).
 use windows::Win32::Foundation::{
-    ERROR_ACCESS_DISABLED_BY_POLICY, ERROR_CALL_NOT_IMPLEMENTED, ERROR_NOT_SUPPORTED, E_NOTIMPL,
-    STATUS_DLL_INIT_FAILED,
+    ERROR_ACCESS_DISABLED_BY_POLICY, ERROR_CALL_NOT_IMPLEMENTED, ERROR_ENVVAR_NOT_FOUND,
+    ERROR_NOT_SUPPORTED, E_NOTIMPL, STATUS_DLL_INIT_FAILED,
 };
 
 // -- Internal heuristics -----------------------------------------------------
@@ -327,6 +396,66 @@ fn drive_root(exe_path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- diagnose_missing_required_env tests --
+
+    fn env(entries: &[&str]) -> Vec<String> {
+        entries.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn missing_required_env_names_the_absent_variables() {
+        let supplied = env(&["PATH=C:\\Windows"]);
+        let diag = diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, Some(&supplied))
+            .expect("203 with a sparse caller env must produce a diagnostic");
+
+        assert_eq!(diag.kind, "missing_required_env");
+        assert!(diag.message.contains("SYSTEMROOT"));
+        assert!(diag.message.contains("LOCALAPPDATA"));
+        assert!(diag.message.contains("verbatim"));
+        assert!(diag.message.contains("1 variable(s)"));
+    }
+
+    #[test]
+    fn missing_required_env_reports_only_what_is_absent() {
+        let supplied = env(&["SystemRoot=C:\\Windows"]);
+        let diag =
+            diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, Some(&supplied)).unwrap();
+
+        // Presence is case-insensitive, so SystemRoot satisfies SYSTEMROOT.
+        assert!(!diag.message.contains("SYSTEMROOT"));
+        assert!(diag.message.contains("LOCALAPPDATA"));
+    }
+
+    #[test]
+    fn missing_required_env_describes_an_explicitly_empty_environment() {
+        let diag = diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, Some(&[])).unwrap();
+        assert!(diag.message.contains("an empty environment"));
+    }
+
+    #[test]
+    fn missing_required_env_ignores_other_error_codes() {
+        let supplied = env(&["PATH=C:\\Windows"]);
+        assert!(diagnose_missing_required_env(5, Some(&supplied)).is_none());
+    }
+
+    #[test]
+    fn missing_required_env_ignores_a_caller_supplied_complete_environment() {
+        // 203 with both names present is not the sparse-env failure; let the
+        // generic diagnostic describe it rather than emitting a wrong cause.
+        let supplied = env(&[
+            "SYSTEMROOT=C:\\Windows",
+            "LOCALAPPDATA=C:\\Users\\u\\AppData\\Local",
+        ]);
+        assert!(diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, Some(&supplied)).is_none());
+    }
+
+    #[test]
+    fn missing_required_env_ignores_a_block_mxc_built_itself() {
+        // `None` means the caller supplied no environment, so MXC built the
+        // block; a 203 there is not something the caller can fix in config.
+        assert!(diagnose_missing_required_env(ERROR_ENVVAR_NOT_FOUND.0, None).is_none());
+    }
 
     // -- diagnose_create_process_failure tests --
 

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -150,7 +150,9 @@ fn check_exe_heuristics(
             message: "PowerShell exited with STATUS_DLL_INIT_FAILED (0xC0000142). \
                       This typically means the sandbox is blocking Win32k system calls \
                       (UI subsystem access), which PowerShell requires to initialize. \
-                      Enable UI access in your sandbox policy (set `ui.allowWindows: true`)."
+                      Enable UI access in your sandbox policy: set `ui.disable: false` \
+                      in the JSON config, or `ui.allowWindows: true` if you are using \
+                      the SDK's SandboxPolicy."
                 .to_string(),
         });
     }

--- a/src/backends/appcontainer/common/src/launch_diagnostics.rs
+++ b/src/backends/appcontainer/common/src/launch_diagnostics.rs
@@ -216,12 +216,12 @@ fn check_exe_heuristics(
         });
     }
 
-    if exit_code == Some(STATUS_DLL_INIT_FAILED.0 as u32) && is_powershell(exe_path) {
+    if exit_code == Some(STATUS_DLL_INIT_FAILED.0 as u32) {
         return Some(LaunchDiagnostic {
             kind: "dll_init_failed_ui_required",
-            message: "PowerShell exited with STATUS_DLL_INIT_FAILED (0xC0000142). \
-                      This typically means the sandbox is blocking Win32k system calls \
-                      (UI subsystem access), which PowerShell requires to initialize. \
+            message: "The target executable exited with STATUS_DLL_INIT_FAILED (0xC0000142). \
+                      This often means the sandbox is blocking Win32k system calls \
+                      (UI subsystem access), which is often required to initialize. \
                       Enable UI access in your sandbox policy: set `ui.disable: false` \
                       in the JSON config, or `ui.allowWindows: true` if you are using \
                       the SDK's SandboxPolicy."
@@ -359,15 +359,6 @@ pub fn extract_exe_from_command_line(command_line: &str) -> &str {
 fn is_packaged_app(exe_path: &Path) -> bool {
     let normalized = exe_path.to_string_lossy().to_lowercase();
     normalized.contains("\\windowsapps\\") || normalized.contains("/windowsapps/")
-}
-
-fn is_powershell(exe_path: &Path) -> bool {
-    let filename = exe_path
-        .file_name()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_lowercase();
-    filename == "pwsh.exe" || filename == "powershell.exe"
 }
 
 fn missing_root_readonly(exe_path: &Path, readonly_paths: &[String]) -> bool {
@@ -538,17 +529,6 @@ mod tests {
         );
         assert!(diag.is_some());
         assert_eq!(diag.unwrap().kind, "dll_init_failed_ui_required");
-    }
-
-    #[test]
-    fn dll_init_failed_non_powershell_does_not_trigger() {
-        let diag = diagnose_process_exit(
-            r"C:\tools\myapp.exe",
-            &["C:\\".to_string()],
-            &[],
-            STATUS_DLL_INIT_FAILED.0 as u32,
-        );
-        assert!(diag.is_none());
     }
 
     #[test]

--- a/src/backends/bubblewrap/common/src/bwrap_command.rs
+++ b/src/backends/bubblewrap/common/src/bwrap_command.rs
@@ -700,7 +700,7 @@ pub(crate) fn build_args_classified_with_mode(
     // Clear the inherited environment, then set only the vars from the
     // request so the sandbox has a minimal, predictable environment.
     args.push("--clearenv".into());
-    for env_str in &request.env {
+    for env_str in request.env_entries() {
         if let Some((key, value)) = env_str.split_once('=') {
             // When the proxy is active, drop any caller-supplied proxy env
             // entries so they cannot override the values we set below.
@@ -1913,7 +1913,7 @@ mod tests {
     #[test]
     fn environment_variables_are_set() {
         let mut r = base_request();
-        r.env = vec!["FOO=bar".into(), "PATH=/usr/bin".into()];
+        r.env = Some(vec!["FOO=bar".into(), "PATH=/usr/bin".into()]);
         let args = build_args(&r, None);
         assert!(args.contains(&"--clearenv".to_string()));
         let foo_pos = args.iter().position(|a| a == "FOO").unwrap();
@@ -2072,7 +2072,7 @@ mod tests {
     #[test]
     fn proxy_active_strips_caller_supplied_proxy_env() {
         let mut r = base_request();
-        r.env = vec![
+        r.env = Some(vec![
             "FOO=bar".into(),
             "HTTP_PROXY=http://attacker.example:9999".into(),
             "https_proxy=http://attacker.example:9999".into(),
@@ -2081,7 +2081,7 @@ mod tests {
             "ftp_proxy=http://attacker.example:9999".into(),
             "NO_PROXY=*".into(),
             "PATH=/usr/bin".into(),
-        ];
+        ]);
         let addr = ProxyAddress::new("127.0.0.1".into(), 9000);
         let args = build_args(&r, Some(&addr));
 
@@ -2125,7 +2125,7 @@ mod tests {
         // strip env vars whose keys happen to match PROXY_ENV_KEYS -- those
         // are just regular env vars set by the caller for some other reason.
         let mut r = base_request();
-        r.env = vec!["HTTP_PROXY=http://caller.example:8080".into()];
+        r.env = Some(vec!["HTTP_PROXY=http://caller.example:8080".into()]);
         let args = build_args(&r, None);
 
         let pos = args.iter().position(|a| a == "HTTP_PROXY").unwrap();

--- a/src/backends/isolation_session/common/src/process_options.rs
+++ b/src/backends/isolation_session/common/src/process_options.rs
@@ -60,7 +60,7 @@ pub(super) fn build_process_options(
     interactive: bool,
 ) -> ProcessOptions {
     let env_vars: Vec<(String, String)> = request
-        .env
+        .env_entries()
         .iter()
         .filter_map(|entry| {
             let mut parts = entry.splitn(2, '=');
@@ -325,7 +325,10 @@ mod tests {
     fn options_parses_env_vars() {
         let request = ExecutionRequest {
             script_code: "echo hi".to_string(),
-            env: vec!["FOO=bar".to_string(), "PATH=C:\\bin;C:\\tools".to_string()],
+            env: Some(vec![
+                "FOO=bar".to_string(),
+                "PATH=C:\\bin;C:\\tools".to_string(),
+            ]),
             ..Default::default()
         };
         let opts = build_process_options(&request, false);
@@ -341,11 +344,11 @@ mod tests {
     fn options_skips_malformed_env_vars() {
         let request = ExecutionRequest {
             script_code: "echo hi".to_string(),
-            env: vec![
+            env: Some(vec![
                 "GOOD=value".to_string(),
                 "=no_name".to_string(),
                 "ALSO_GOOD=".to_string(),
-            ],
+            ]),
             ..Default::default()
         };
         let opts = build_process_options(&request, false);

--- a/src/backends/lxc/common/src/lxc_runner.rs
+++ b/src/backends/lxc/common/src/lxc_runner.rs
@@ -467,7 +467,7 @@ impl LxcScriptRunner {
             Some(Duration::from_millis(u64::from(request.script_timeout)))
         };
         let _ = writeln!(logger, "Executing script inside container...");
-        let mut exec_env = request.env.clone();
+        let mut exec_env = request.env_entries().to_vec();
         // Scrub every inherited proxy variable and, when the policy carries a
         // proxy, point HTTP(S)_PROXY at it.
         wxc_common::proxy_env::apply_proxy_env(&mut exec_env, &request.policy.network_proxy);

--- a/src/backends/seatbelt/common/src/seatbelt_runner.rs
+++ b/src/backends/seatbelt/common/src/seatbelt_runner.rs
@@ -1038,7 +1038,7 @@ mod tests {
             "ALL_PROXY=http://attacker.example:9999".into(),
             "NO_PROXY=localhost".into(),
             "KEEP=me".into(),
-        ];
+        ]);
         let addr = ProxyAddress::new("127.0.0.1".into(), 7777);
         let pairs = resolve_environment(&request, Some(&addr));
         // Legitimate non-proxy var is preserved.

--- a/src/backends/seatbelt/common/src/seatbelt_runner.rs
+++ b/src/backends/seatbelt/common/src/seatbelt_runner.rs
@@ -1000,7 +1000,7 @@ mod tests {
     #[test]
     fn resolve_environment_without_proxy_passes_through() {
         let mut request = base_request();
-        request.env = vec!["FOO=bar".into(), "BAZ=qux".into()];
+        request.env = Some(vec!["FOO=bar".into(), "BAZ=qux".into()]);
         let pairs = resolve_environment(&request, None);
         assert_eq!(env_value(&pairs, "FOO"), Some("bar"));
         assert_eq!(env_value(&pairs, "BAZ"), Some("qux"));
@@ -1032,7 +1032,7 @@ mod tests {
     #[test]
     fn resolve_environment_strips_caller_proxy_when_active() {
         let mut request = base_request();
-        request.env = vec![
+        request.env = Some(vec![
             "HTTP_PROXY=http://attacker.example:9999".into(),
             "https_proxy=http://attacker.example:9999".into(),
             "ALL_PROXY=http://attacker.example:9999".into(),
@@ -1066,7 +1066,7 @@ mod tests {
         // With no proxy active the builder must not touch caller-supplied
         // vars whose keys happen to match PROXY_ENV_KEYS.
         let mut request = base_request();
-        request.env = vec!["HTTP_PROXY=http://caller.example:8080".into()];
+        request.env = Some(vec!["HTTP_PROXY=http://caller.example:8080".into()]);
         let pairs = resolve_environment(&request, None);
         assert_eq!(
             env_value(&pairs, "HTTP_PROXY"),

--- a/src/backends/seatbelt/common/src/seatbelt_runner.rs
+++ b/src/backends/seatbelt/common/src/seatbelt_runner.rs
@@ -758,7 +758,7 @@ fn resolve_environment(
     proxy_address: Option<&ProxyAddress>,
 ) -> Vec<(String, String)> {
     let mut pairs = Vec::new();
-    for kv in &request.env {
+    for kv in request.env_entries() {
         if let Some((key, value)) = kv.split_once('=') {
             if proxy_address.is_some() && PROXY_ENV_KEYS.contains(&key) {
                 continue;

--- a/src/backends/wslc/common/src/state_aware.rs
+++ b/src/backends/wslc/common/src/state_aware.rs
@@ -157,10 +157,10 @@ impl StatefulSandboxBackend for WslcStateAwareRunner {
         // `None` here means the proxy is disabled, not malformed.
         let env = match exec_proxy_url(request) {
             Some(proxy_url) => split_env(&wxc_common::proxy_env::apply_cooperative_proxy_env(
-                &request.env,
+                request.env_entries(),
                 proxy_url,
             )),
-            None => split_env(&request.env),
+            None => split_env(request.env_entries()),
         };
 
         let client = connect_daemon()?;

--- a/src/backends/wslc/common/src/wsl_container_runner.rs
+++ b/src/backends/wslc/common/src/wsl_container_runner.rs
@@ -1475,9 +1475,9 @@ impl WSLContainerRunner {
                 "[WSLC] Cooperative network proxy configured: {}",
                 wxc_common::proxy_env::redact_proxy_url(&proxy_url)
             );
-            wxc_common::proxy_env::apply_cooperative_proxy_env(&request.env, &proxy_url)
+            wxc_common::proxy_env::apply_cooperative_proxy_env(request.env_entries(), &proxy_url)
         } else {
-            request.env.clone()
+            request.env_entries().to_vec()
         };
 
         // Env buffers must outlive WslcCreateContainer: the SDK stores the

--- a/src/core/mxc_config_contract/src/dev/stable.rs
+++ b/src/core/mxc_config_contract/src/dev/stable.rs
@@ -40,7 +40,7 @@ pub struct Process {
     /// Optional environment entries encoded as `KEY=VALUE` strings.
     ///
     /// Omitted gives the backend's default environment; supplied (including as
-    /// an empty array) is used verbatim unless `inherit_default_env` is set.
+    /// an empty array) is used verbatim unless `inheritDefaultEnv` is set.
     #[serde(default)]
     pub env: OptionalField<Vec<String>>,
     /// Layer `env` on top of the backend's default environment rather than

--- a/src/core/mxc_config_contract/src/dev/stable.rs
+++ b/src/core/mxc_config_contract/src/dev/stable.rs
@@ -38,8 +38,15 @@ pub struct Process {
     #[serde(default)]
     pub cwd: OptionalField<String>,
     /// Optional environment entries encoded as `KEY=VALUE` strings.
+    ///
+    /// Omitted gives the backend's default environment; supplied (including as
+    /// an empty array) is used verbatim unless `inherit_default_env` is set.
     #[serde(default)]
     pub env: OptionalField<Vec<String>>,
+    /// Layer `env` on top of the backend's default environment rather than
+    /// replacing it.
+    #[serde(default)]
+    pub inherit_default_env: OptionalField<bool>,
     /// Optional execution timeout in milliseconds.
     #[serde(default)]
     pub timeout: OptionalField<u32>,

--- a/src/core/mxc_engine/src/policy.rs
+++ b/src/core/mxc_engine/src/policy.rs
@@ -245,11 +245,11 @@ fn env_or_process(env: Option<&[(String, String)]>) -> Cow<'_, [(String, String)
     }
 }
 
-fn environment_keys_equal(left: &str, right: &str) -> bool {
+fn environment_keys_equal(existing_key: &str, override_key: &str) -> bool {
     if cfg!(target_os = "windows") {
-        left.eq_ignore_ascii_case(right)
+        existing_key.eq_ignore_ascii_case(override_key)
     } else {
-        left == right
+        existing_key == override_key
     }
 }
 

--- a/src/core/mxc_engine/src/policy.rs
+++ b/src/core/mxc_engine/src/policy.rs
@@ -245,6 +245,28 @@ fn env_or_process(env: Option<&[(String, String)]>) -> Cow<'_, [(String, String)
     }
 }
 
+fn environment_keys_equal(left: &str, right: &str) -> bool {
+    if cfg!(target_os = "windows") {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
+}
+
+fn apply_environment_overrides<K, V>(
+    entries: &mut Vec<(String, String)>,
+    overrides: impl IntoIterator<Item = (K, V)>,
+) where
+    K: Into<String>,
+    V: Into<String>,
+{
+    for (key, value) in overrides {
+        let key = key.into();
+        entries.retain(|(existing, _)| !environment_keys_equal(existing, &key));
+        entries.push((key, value.into()));
+    }
+}
+
 /// PowerShell-specific policy: when `pwsh.exe` is found on `path_dirs`
 /// (Windows only), grant the system-drive root (`C:\`) read-only — `pwsh.exe`
 /// enumerates the drive root on startup — plus the PSReadLine history directory
@@ -732,12 +754,7 @@ impl SandboxRequest {
         V: Into<String>,
     {
         let mut entries: Vec<(String, String)> = std::env::vars().collect();
-        entries.extend(
-            extra
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect::<Vec<_>>(),
-        );
+        apply_environment_overrides(&mut entries, extra);
         self.set_env(entries)
     }
 
@@ -1388,6 +1405,32 @@ mod tests {
 
         assert!(request.inner.inherit_default_env);
         assert_eq!(env_of(&request), Some(vec!["EXTRA=1".to_string()]));
+    }
+
+    #[test]
+    fn environment_overrides_replace_exact_duplicate_names() {
+        let mut entries = vec![
+            ("PATH".to_string(), "old".to_string()),
+            ("KEEP".to_string(), "value".to_string()),
+        ];
+        super::apply_environment_overrides(&mut entries, [("PATH", "new")]);
+
+        assert_eq!(
+            entries,
+            vec![
+                ("KEEP".to_string(), "value".to_string()),
+                ("PATH".to_string(), "new".to_string()),
+            ]
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn environment_overrides_replace_windows_names_case_insensitively() {
+        let mut entries = vec![("Path".to_string(), "old".to_string())];
+        super::apply_environment_overrides(&mut entries, [("PATH", "new")]);
+
+        assert_eq!(entries, vec![("PATH".to_string(), "new".to_string())]);
     }
 
     #[test]

--- a/src/core/mxc_engine/src/policy.rs
+++ b/src/core/mxc_engine/src/policy.rs
@@ -663,6 +663,7 @@ impl SandboxRequest {
         K: Into<String>,
         V: Into<String>,
     {
+        self.inner.inherit_default_env = false;
         self.inner.env = Some(
             env.into_iter()
                 .map(|(k, v)| {
@@ -688,6 +689,7 @@ impl SandboxRequest {
     /// environment, whereas this asks for the backend's default one.
     pub fn clear_env(&mut self) -> &mut Self {
         self.inner.env = None;
+        self.inner.inherit_default_env = false;
         self
     }
 
@@ -1355,14 +1357,21 @@ mod tests {
         assert_eq!(env_of(&request), Some(vec!["ONLY=me".to_string()]));
         assert!(!request.inner.inherit_default_env);
 
+        request.inherit_default_env([("EXTRA", "1")]);
+        request.set_env([("REPLACEMENT", "2")]);
+        assert_eq!(env_of(&request), Some(vec!["REPLACEMENT=2".to_string()]));
+        assert!(!request.inner.inherit_default_env);
+
         // An empty iterator is a request for an empty environment, which is
         // distinct from never having set one.
         request.set_env(Vec::<(String, String)>::new());
         assert_eq!(env_of(&request), Some(Vec::<String>::new()));
 
         // clear_env goes back to the backend default.
+        request.inherit_default_env([("EXTRA", "1")]);
         request.clear_env();
         assert_eq!(env_of(&request), None::<Vec<String>>);
+        assert!(!request.inner.inherit_default_env);
     }
 
     #[test]

--- a/src/core/mxc_engine/src/policy.rs
+++ b/src/core/mxc_engine/src/policy.rs
@@ -647,19 +647,96 @@ impl SandboxRequest {
     /// the same way), so behavior is identical across the SDK and this crate.
     /// Iteration order is preserved, so on a duplicate key the later entry wins,
     /// matching the SDK.
+    ///
+    /// The environment you set is used **verbatim**: MXC does not merge the
+    /// calling process's variables or the user's profile block into it. On the
+    /// Windows process container that includes the variables Windows requires
+    /// to be present, so a sparse environment fails the launch with a
+    /// diagnostic naming them — see [`Self::inherit_default_env`] and
+    /// [`Self::inherit_process_env`] for the supported ways to start from a
+    /// complete environment.
+    ///
+    /// Calling this with an empty iterator requests an *empty* environment,
+    /// which is distinct from never calling it at all (see [`Self::clear_env`]).
     pub fn set_env<K, V>(&mut self, env: impl IntoIterator<Item = (K, V)>) -> &mut Self
     where
         K: Into<String>,
         V: Into<String>,
     {
-        self.inner.env = env
-            .into_iter()
-            .map(|(k, v)| {
-                let (k, v): (String, String) = (k.into(), v.into());
-                format!("{k}={v}")
-            })
-            .collect();
+        self.inner.env = Some(
+            env.into_iter()
+                .map(|(k, v)| {
+                    let (k, v): (String, String) = (k.into(), v.into());
+                    format!("{k}={v}")
+                })
+                .collect(),
+        );
         self
+    }
+
+    /// The child's environment as `KEY=VALUE` entries, or `None` when none has
+    /// been set (in which case the backend supplies its default — on Windows,
+    /// the user's profile block).
+    pub fn env(&self) -> Option<&[String]> {
+        self.inner.env.as_deref()
+    }
+
+    /// Drop any environment set on this request, returning it to the backend
+    /// default.
+    ///
+    /// This is *not* the same as `set_env([])`: that asks for an empty
+    /// environment, whereas this asks for the backend's default one.
+    pub fn clear_env(&mut self) -> &mut Self {
+        self.inner.env = None;
+        self
+    }
+
+    /// Start from the backend's default environment and append `extra` on top,
+    /// so the child gets a complete environment plus your additions.
+    ///
+    /// This is the supported way to express "the usual environment, plus these"
+    /// on the Windows process container: the default block is the user's
+    /// profile block, obtainable only from the OS, so it cannot be assembled by
+    /// a caller. Entries in `extra` override same-named defaults.
+    ///
+    /// On backends whose default environment is empty (LXC, Bubblewrap,
+    /// Seatbelt, WSLc) this is equivalent to [`Self::set_env`].
+    pub fn inherit_default_env<K, V>(
+        &mut self,
+        extra: impl IntoIterator<Item = (K, V)>,
+    ) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.set_env(extra);
+        self.inner.inherit_default_env = true;
+        self
+    }
+
+    /// Start from the *calling process's* environment and append `extra` on top.
+    ///
+    /// Note this is a different, generally larger and leakier set than
+    /// [`Self::inherit_default_env`]: it is whatever your process happens to be
+    /// running with, so anything you inherited — including secrets in the
+    /// ambient environment — is handed to the sandboxed child. Prefer
+    /// `inherit_default_env` unless you specifically need your own variables.
+    pub fn inherit_process_env<K, V>(
+        &mut self,
+        extra: impl IntoIterator<Item = (K, V)>,
+    ) -> &mut Self
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut entries: Vec<(String, String)> = std::env::vars().collect();
+        entries.extend(
+            extra
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect::<Vec<_>>(),
+        );
+        self.set_env(entries)
     }
 
     /// The Seatbelt (macOS) extra Mach service names the sandbox profile lets the
@@ -1248,7 +1325,60 @@ mod tests {
         };
         let mut request = build_request(&policy, None).expect("build_request should succeed");
         request.set_env([("FIRST", "1"), ("SECOND", "2")]);
-        assert_eq!(request.inner.env, vec!["FIRST=1", "SECOND=2"]);
+        assert_eq!(
+            env_of(&request),
+            Some(vec!["FIRST=1".to_string(), "SECOND=2".to_string()])
+        );
+    }
+
+    /// The request's environment as an owned value, so tests can compare it
+    /// against a literal without borrowing a temporary.
+    fn env_of(request: &super::SandboxRequest) -> Option<Vec<String>> {
+        request.env().map(<[String]>::to_vec)
+    }
+
+    #[test]
+    fn set_env_replaces_rather_than_merging() {
+        let policy = SandboxPolicy {
+            version: "0.7.0-alpha".to_string(),
+            filesystem: None,
+            network: None,
+            ui: None,
+            timeout_ms: None,
+        };
+        let mut request = build_request(&policy, None).expect("build_request should succeed");
+
+        // No environment set yet: the backend supplies its default.
+        assert_eq!(env_of(&request), None::<Vec<String>>);
+
+        request.set_env([("ONLY", "me")]);
+        assert_eq!(env_of(&request), Some(vec!["ONLY=me".to_string()]));
+        assert!(!request.inner.inherit_default_env);
+
+        // An empty iterator is a request for an empty environment, which is
+        // distinct from never having set one.
+        request.set_env(Vec::<(String, String)>::new());
+        assert_eq!(env_of(&request), Some(Vec::<String>::new()));
+
+        // clear_env goes back to the backend default.
+        request.clear_env();
+        assert_eq!(env_of(&request), None::<Vec<String>>);
+    }
+
+    #[test]
+    fn inherit_default_env_flags_the_request_and_keeps_the_extras() {
+        let policy = SandboxPolicy {
+            version: "0.7.0-alpha".to_string(),
+            filesystem: None,
+            network: None,
+            ui: None,
+            timeout_ms: None,
+        };
+        let mut request = build_request(&policy, None).expect("build_request should succeed");
+        request.inherit_default_env([("EXTRA", "1")]);
+
+        assert!(request.inner.inherit_default_env);
+        assert_eq!(env_of(&request), Some(vec!["EXTRA=1".to_string()]));
     }
 
     #[test]

--- a/src/core/mxc_engine/src/policy.rs
+++ b/src/core/mxc_engine/src/policy.rs
@@ -1390,7 +1390,8 @@ mod tests {
             ui: None,
             timeout_ms: None,
         };
-        let mut request = build_request(&policy, None).expect("build_request should succeed");
+        let mut request =
+            build_request(&policy, TEST_COMMAND, None).expect("build_request should succeed");
 
         // No environment set yet: the backend supplies its default.
         assert_eq!(env_of(&request), None::<Vec<String>>);
@@ -1425,7 +1426,8 @@ mod tests {
             ui: None,
             timeout_ms: None,
         };
-        let mut request = build_request(&policy, None).expect("build_request should succeed");
+        let mut request =
+            build_request(&policy, TEST_COMMAND, None).expect("build_request should succeed");
         request.inherit_default_env([("EXTRA", "1")]);
 
         assert!(request.inner.inherit_default_env);

--- a/src/core/wxc_common/src/config_contract_adapters/dev/common.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/dev/common.rs
@@ -17,12 +17,14 @@ pub(super) fn convert_process(value: contract::Process) -> wire::Process {
         command_line,
         cwd,
         env,
+        inherit_default_env,
         timeout,
     } = value;
     wire::Process {
         command_line: Some(command_line.into_inner()),
         cwd: cwd.into_option(),
         env: env.into_option(),
+        inherit_default_env: inherit_default_env.into_option(),
         timeout: timeout.into_option(),
     }
 }

--- a/src/core/wxc_common/src/config_contract_adapters/v0_6.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/v0_6.rs
@@ -31,6 +31,8 @@ fn convert_process(value: contract::Process) -> wire::Process {
         command_line: Some(command_line.into_inner()),
         cwd: cwd.into_option(),
         env: env.into_option(),
+        // The field postdates this released schema, so it is never set here.
+        inherit_default_env: None,
         timeout: timeout.into_option(),
     }
 }

--- a/src/core/wxc_common/src/config_contract_adapters/v0_7.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/v0_7.rs
@@ -32,6 +32,8 @@ fn convert_process(value: contract::Process) -> wire::Process {
         command_line: Some(command_line.into_inner()),
         cwd: cwd.into_option(),
         env: env.into_option(),
+        // The field postdates this released schema, so it is never set here.
+        inherit_default_env: None,
         timeout: timeout.into_option(),
     }
 }

--- a/src/core/wxc_common/src/config_contract_adapters/v0_8.rs
+++ b/src/core/wxc_common/src/config_contract_adapters/v0_8.rs
@@ -32,6 +32,8 @@ fn convert_process(value: contract::Process) -> wire::Process {
         command_line: Some(command_line.into_inner()),
         cwd: cwd.into_option(),
         env: env.into_option(),
+        // The field postdates this released schema, so it is never set here.
+        inherit_default_env: None,
         timeout: timeout.into_option(),
     }
 }

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -391,7 +391,8 @@ fn parse_mxc_request_json(
 
 fn validate_versioned_fields(config: &serde_json::Value) -> Result<(), WxcError> {
     validate_directional_network_field_versions(config)?;
-    validate_telemetry_field_version(config)
+    validate_telemetry_field_version(config)?;
+    validate_inherit_default_env_field_version(config)
 }
 
 fn validate_directional_network_field_versions(config: &serde_json::Value) -> Result<(), WxcError> {
@@ -442,6 +443,35 @@ fn validate_telemetry_field_version(config: &serde_json::Value) -> Result<(), Wx
         ));
     }
     Ok(())
+}
+
+fn validate_inherit_default_env_field_version(config: &serde_json::Value) -> Result<(), WxcError> {
+    let Some(config) = config.as_object() else {
+        return Ok(());
+    };
+    let has_inherit_default_env = config
+        .get("process")
+        .and_then(serde_json::Value::as_object)
+        .is_some_and(|process| process.contains_key("inheritDefaultEnv"));
+    if !has_inherit_default_env {
+        return Ok(());
+    }
+
+    if let Some(version) = config.get("version").and_then(serde_json::Value::as_str) {
+        let Ok(version) = semver::Version::parse(version) else {
+            // The ordinary schema-version validator owns malformed-version
+            // diagnostics so this feature gate does not mask the more useful error.
+            return Ok(());
+        };
+        if version.major > 0 || version.minor >= 9 {
+            return Ok(());
+        }
+    }
+
+    Err(WxcError::ConfigParse(
+        "'process.inheritDefaultEnv' requires config schema version 0.9.0-alpha or later"
+            .to_string(),
+    ))
 }
 
 fn log_one_shot_error<T>(logger: &mut Logger, result: &Result<T, WxcError>) {
@@ -6784,6 +6814,65 @@ mod tests {
             load_request_from_value(serde_json::from_str(json).unwrap(), &mut logger, false)
                 .unwrap_err();
         assert!(error.to_string().contains(expected), "got {error:?}");
+    }
+
+    #[test]
+    fn inherit_default_env_rejects_pre_09_and_absent_versions() {
+        let expected = "'process.inheritDefaultEnv' requires config schema version 0.9.0-alpha";
+        for version in [Some("0.6.0-alpha"), Some("0.8.0-alpha"), None] {
+            let version = version
+                .map(|value| format!(r#""version":"{value}","#))
+                .unwrap_or_default();
+            let json = format!(
+                r#"{{{version}"process":{{"commandLine":"echo hi","inheritDefaultEnv":true}}}}"#
+            );
+
+            let mut logger = test_logger();
+            let error = load_request_from_json(&json, &mut logger).unwrap_err();
+            assert!(error.to_string().contains(expected), "got {error:?}");
+        }
+
+        let state_aware = r#"{
+            "version": "0.8.0-alpha",
+            "phase": "exec",
+            "sandboxId": "wslc:0123456789abcdef0123456789abcdef",
+            "process": {
+                "commandLine": "echo hi",
+                "inheritDefaultEnv": true
+            }
+        }"#;
+        let mut logger = test_logger();
+        let error = load_mxc_request_from_json(state_aware, &mut logger).unwrap_err();
+        assert!(error.message().contains(expected), "got {error:?}");
+    }
+
+    #[test]
+    fn inherit_default_env_accepts_09_for_one_shot_and_state_aware() {
+        let one_shot = r#"{
+            "version": "0.9.0-alpha",
+            "process": {
+                "commandLine": "echo hi",
+                "env": ["EXTRA=1"],
+                "inheritDefaultEnv": true
+            }
+        }"#;
+        let mut logger = test_logger();
+        let request = load_request_from_json(one_shot, &mut logger).unwrap();
+        assert!(request.inherit_default_env);
+
+        let state_aware = r#"{
+            "version": "0.9.0-alpha",
+            "phase": "exec",
+            "sandboxId": "iso:abc",
+            "process": {
+                "commandLine": "echo hi",
+                "env": ["EXTRA=1"],
+                "inheritDefaultEnv": true
+            }
+        }"#;
+        let mut logger = test_logger();
+        load_mxc_request_from_json(state_aware, &mut logger)
+            .expect("0.9 state-aware inheritance should parse");
     }
 
     #[test]

--- a/src/core/wxc_common/src/config_parser.rs
+++ b/src/core/wxc_common/src/config_parser.rs
@@ -924,44 +924,46 @@ fn convert_wire_config(
     // non-exec state-aware phases (require_process == false) or when the driver
     // signalled a CLI command-line override (allow_missing_command).
     let command_required = require_process && !allow_missing_command;
-    let (script_code, working_directory, script_timeout, env) = match cfg.process {
-        Some(process) => {
-            let script_code = match process.command_line {
-                Some(s) if !s.is_empty() => s,
-                Some(_) if command_required => {
-                    return Err(WxcError::ConfigParse(
-                        "process.commandLine cannot be empty".to_string(),
-                    ));
-                }
-                None if command_required => {
-                    return Err(WxcError::ConfigParse(
-                        "Missing required field: process.commandLine".to_string(),
-                    ));
-                }
-                _ => String::new(),
-            };
+    let (script_code, working_directory, script_timeout, env, inherit_default_env) =
+        match cfg.process {
+            Some(process) => {
+                let script_code = match process.command_line {
+                    Some(s) if !s.is_empty() => s,
+                    Some(_) if command_required => {
+                        return Err(WxcError::ConfigParse(
+                            "process.commandLine cannot be empty".to_string(),
+                        ));
+                    }
+                    None if command_required => {
+                        return Err(WxcError::ConfigParse(
+                            "Missing required field: process.commandLine".to_string(),
+                        ));
+                    }
+                    _ => String::new(),
+                };
 
-            // Null bytes can hide malicious payloads from audit logs.
-            if script_code.contains('\0') {
+                // Null bytes can hide malicious payloads from audit logs.
+                if script_code.contains('\0') {
+                    return Err(WxcError::ConfigParse(
+                        "process.commandLine must not contain null bytes".to_string(),
+                    ));
+                }
+
+                (
+                    script_code,
+                    process.cwd.unwrap_or_default(),
+                    process.timeout.unwrap_or(0),
+                    process.env,
+                    process.inherit_default_env.unwrap_or(false),
+                )
+            }
+            None if command_required => {
                 return Err(WxcError::ConfigParse(
-                    "process.commandLine must not contain null bytes".to_string(),
+                    "'process' section is required".into(),
                 ));
             }
-
-            (
-                script_code,
-                process.cwd.unwrap_or_default(),
-                process.timeout.unwrap_or(0),
-                process.env.unwrap_or_default(),
-            )
-        }
-        None if command_required => {
-            return Err(WxcError::ConfigParse(
-                "'process' section is required".into(),
-            ));
-        }
-        None => (String::new(), String::new(), 0, Vec::new()),
-    };
+            None => (String::new(), String::new(), 0, None, false),
+        };
 
     // Containment backend selection. The wire enum has already constrained the
     // value to a known variant (invalid strings fail at deserialize); abstract
@@ -1522,6 +1524,7 @@ fn convert_wire_config(
         schema_version,
         container_id,
         env,
+        inherit_default_env,
         script_code,
         working_directory,
         script_timeout,
@@ -4847,7 +4850,10 @@ mod tests {
         let mut logger = test_logger();
 
         let req = load_request(&encoded, &mut logger, true).unwrap();
-        assert_eq!(req.env, vec!["FOO=bar", "BAZ=qux"]);
+        assert_eq!(
+            req.env,
+            Some(vec!["FOO=bar".to_string(), "BAZ=qux".to_string()])
+        );
     }
 
     #[test]

--- a/src/core/wxc_common/src/diagnostic.rs
+++ b/src/core/wxc_common/src/diagnostic.rs
@@ -164,18 +164,21 @@ pub fn redacted_request_json(request: &ExecutionRequest) -> String {
     // Build a redacted copy for serialization.
     let mut redacted = request.clone();
 
-    // Redact env values: keep keys, replace values.
-    redacted.env = redacted
-        .env
-        .iter()
-        .map(|entry| {
-            if let Some(pos) = entry.find('=') {
-                format!("{}=<redacted>", &entry[..pos])
-            } else {
-                entry.clone()
-            }
-        })
-        .collect();
+    // Redact env values: keep keys, replace values. `None` (no environment
+    // supplied) is preserved as `None` so the dump distinguishes it from an
+    // explicitly empty environment.
+    redacted.env = redacted.env.map(|entries| {
+        entries
+            .iter()
+            .map(|entry| {
+                if let Some(pos) = entry.find('=') {
+                    format!("{}=<redacted>", &entry[..pos])
+                } else {
+                    entry.clone()
+                }
+            })
+            .collect()
+    });
 
     // Truncate script_code.
     if redacted.script_code.len() > SCRIPT_CODE_TRUNCATE_LEN {
@@ -400,10 +403,10 @@ mod tests {
     #[test]
     fn redacted_request_hides_env_values() {
         let request = ExecutionRequest {
-            env: vec![
+            env: Some(vec![
                 "PATH=C:\\Windows".to_string(),
                 "SECRET_TOKEN=abc123".to_string(),
-            ],
+            ]),
             ..Default::default()
         };
         let json = redacted_request_json(&request);

--- a/src/core/wxc_common/src/models.rs
+++ b/src/core/wxc_common/src/models.rs
@@ -971,8 +971,32 @@ pub struct ExecutionRequest {
     pub schema_version: String,
     /// Externally assigned container identifier.
     pub container_id: String,
-    /// Environment variables as "KEY=VALUE" strings (from process.env).
-    pub env: Vec<String>,
+    /// Environment variables as "KEY=VALUE" strings (from `process.env`).
+    ///
+    /// Three states, deliberately distinct:
+    ///
+    /// * `None` — the caller supplied no environment. Backends provide a
+    ///   default: on Windows, the user's profile block.
+    /// * `Some(vec![])` — the caller asked for an *empty* environment. This is
+    ///   not the same as `None`, and on the Windows process container it is
+    ///   expected to fail at process creation, because the OS requires certain
+    ///   names to be present (see `REQUIRED_CHILD_ENV_VARS`).
+    /// * `Some(entries)` — the caller's environment, used verbatim. MXC does
+    ///   not add to it; callers that want the profile block or the calling
+    ///   process's variables must merge them in themselves.
+    ///
+    /// The distinction is currently honored only by the Windows process
+    /// container. The LXC, Bubblewrap, Seatbelt, and WSLc backends treat `None`
+    /// and `Some(vec![])` alike, as they did before the field became optional.
+    pub env: Option<Vec<String>>,
+
+    /// Layer [`ExecutionRequest::env`] on top of the backend's default
+    /// environment instead of replacing it (from `process.inheritDefaultEnv`).
+    ///
+    /// Only meaningful when `env` is `Some`: with `None` the child already gets
+    /// the default. Only the Windows process container has a non-empty default
+    /// (the user's profile block), so elsewhere this is inert.
+    pub inherit_default_env: bool,
     pub script_code: String,
     pub working_directory: String,
     pub script_timeout: u32,
@@ -1023,6 +1047,22 @@ pub struct ResolvedWorkingDirectory<'a> {
 }
 
 impl ExecutionRequest {
+    /// The caller's environment entries, with "not supplied" and "supplied but
+    /// empty" flattened to the same empty slice.
+    ///
+    /// For backends that build the child's environment additively from a
+    /// cleared base — LXC, Bubblewrap, Seatbelt, WSLc — the two cases are
+    /// already indistinguishable in the result, so they use this and keep the
+    /// behavior they had before [`ExecutionRequest::env`] became optional.
+    ///
+    /// The Windows process container must *not* use this: there, `None` means
+    /// "give the child the user's profile block" and `Some(vec![])` means "give
+    /// the child nothing", which are very different outcomes. It matches on
+    /// [`ExecutionRequest::env`] directly.
+    pub fn env_entries(&self) -> &[String] {
+        self.env.as_deref().unwrap_or(&[])
+    }
+
     /// Resolve the working directory for the sandboxed child: an explicit
     /// `working_directory`, else the first filesystem-policy grant that is an
     /// existing directory (`readwrite` paths before `readonly` ones), else

--- a/src/core/wxc_common/src/policy_identity.rs
+++ b/src/core/wxc_common/src/policy_identity.rs
@@ -154,6 +154,9 @@ fn policy_projection(request: &ExecutionRequest) -> Value {
         script_code: _excluded_command_line,
         // Environment variables are the classic secret carrier.
         env: _excluded_environment,
+        // Whether the default environment is merged is process launch
+        // behavior, not an enforcement decision.
+        inherit_default_env: _excluded_environment_mode,
         // Invocation modes, not policy.
         dry_run: _excluded_dry_run,
         testing_features_enabled: _excluded_testing_features,
@@ -600,12 +603,13 @@ mod tests {
 
         // Environment variables and the command line routinely carry secrets.
         let mut with_secrets = request();
-        with_secrets.env.push("API_KEY=hunter2".to_string());
+        with_secrets.env = Some(vec!["API_KEY=hunter2".to_string()]);
+        with_secrets.inherit_default_env = true;
         with_secrets.script_code = "curl -H 'Authorization: Bearer hunter2'".to_string();
         assert_eq!(
             baseline,
             policy_hash(&with_secrets),
-            "env and command line are excluded from the policy identity"
+            "env, environment mode, and command line are excluded from the policy identity"
         );
     }
 

--- a/src/core/wxc_common/src/wire.rs
+++ b/src/core/wxc_common/src/wire.rs
@@ -170,7 +170,21 @@ pub struct Process {
     /// working directory outright. See `docs/schema.md` ("Working Directory").
     pub cwd: Option<String>,
     /// Environment variables as `"KEY=VALUE"` strings.
+    ///
+    /// Omit the field to give the child the backend's default environment (on
+    /// Windows, the user's profile block). Supply it — including as an empty
+    /// array — and it is used verbatim; MXC adds nothing to it unless
+    /// `inheritDefaultEnv` is set.
     pub env: Option<Vec<String>>,
+    /// Start from the backend's default environment and layer `env` on top of
+    /// it, rather than replacing it (default false).
+    ///
+    /// This exists because the default environment is not something a caller
+    /// can assemble: on Windows it is the user's profile block, which only the
+    /// OS can produce. Entries in `env` override same-named defaults. Has no
+    /// effect on backends whose default environment is empty, and none when
+    /// `env` is omitted (that already yields the default).
+    pub inherit_default_env: Option<bool>,
     /// Wall-clock timeout in milliseconds.
     pub timeout: Option<u32>,
 }

--- a/src/ffi/mxc_ffi/src/request.rs
+++ b/src/ffi/mxc_ffi/src/request.rs
@@ -29,6 +29,8 @@ struct RequestSpec {
     #[serde(default)]
     environment: BTreeMap<String, String>,
     #[serde(default)]
+    inherit_default_env: bool,
+    #[serde(default)]
     experimental: bool,
 }
 
@@ -241,7 +243,18 @@ pub(crate) fn build_request_from_json(request_json: &str) -> Result<SandboxReque
     if let Some(working_directory) = spec.working_directory {
         request.set_working_directory(working_directory);
     }
-    request.set_env(spec.environment);
+    // An empty map means "the caller set no environment", not "give the child
+    // an empty one": the managed binding's `Environment` is a non-nullable
+    // dictionary that defaults to empty, so an empty map cannot be a
+    // deliberate request for an empty environment and must keep yielding the
+    // backend default.
+    if !spec.environment.is_empty() {
+        if spec.inherit_default_env {
+            request.inherit_default_env(spec.environment);
+        } else {
+            request.set_env(spec.environment);
+        }
+    }
     request.set_experimental(spec.experimental);
     Ok(request)
 }

--- a/src/ffi/mxc_ffi/src/request.rs
+++ b/src/ffi/mxc_ffi/src/request.rs
@@ -27,7 +27,7 @@ struct RequestSpec {
     #[serde(default)]
     working_directory: Option<String>,
     #[serde(default)]
-    environment: BTreeMap<String, String>,
+    environment: Option<BTreeMap<String, String>>,
     #[serde(default)]
     inherit_default_env: bool,
     #[serde(default)]
@@ -243,16 +243,11 @@ pub(crate) fn build_request_from_json(request_json: &str) -> Result<SandboxReque
     if let Some(working_directory) = spec.working_directory {
         request.set_working_directory(working_directory);
     }
-    // An empty map means "the caller set no environment", not "give the child
-    // an empty one": the managed binding's `Environment` is a non-nullable
-    // dictionary that defaults to empty, so an empty map cannot be a
-    // deliberate request for an empty environment and must keep yielding the
-    // backend default.
-    if !spec.environment.is_empty() {
+    if let Some(environment) = spec.environment {
         if spec.inherit_default_env {
-            request.inherit_default_env(spec.environment);
+            request.inherit_default_env(environment);
         } else {
-            request.set_env(spec.environment);
+            request.set_env(environment);
         }
     }
     request.set_experimental(spec.experimental);
@@ -278,7 +273,11 @@ mod tests {
             serde_json::from_str(process_container).expect("process-container golden parses");
         assert_eq!(process_spec.command, "echo parity");
         assert_eq!(
-            process_spec.environment.get("PARITY").map(String::as_str),
+            process_spec
+                .environment
+                .as_ref()
+                .and_then(|environment| environment.get("PARITY"))
+                .map(String::as_str),
             Some("true")
         );
         assert_eq!(process_spec.policy.timeout_ms, Some(30_000));
@@ -400,6 +399,28 @@ mod tests {
             _ => panic!("WSLC golden selected the wrong containment"),
         }
         build_request_from_json(wslc).expect("WSLC golden builds a public SDK request");
+    }
+
+    #[test]
+    fn environment_presence_distinguishes_default_from_explicitly_empty() {
+        let omitted = build_request_from_json(
+            r#"{
+                "policy": { "version": "0.8.0-alpha" },
+                "command": "echo hi"
+            }"#,
+        )
+        .expect("omitted environment builds");
+        assert!(omitted.env().is_none());
+
+        let explicitly_empty = build_request_from_json(
+            r#"{
+                "policy": { "version": "0.8.0-alpha" },
+                "command": "echo hi",
+                "environment": {}
+            }"#,
+        )
+        .expect("explicitly empty environment builds");
+        assert_eq!(explicitly_empty.env(), Some([].as_slice()));
     }
 
     #[test]

--- a/tests/policy/request-directional-network.json
+++ b/tests/policy/request-directional-network.json
@@ -37,5 +37,6 @@
     "type": "process"
   },
   "environment": {},
+  "inheritDefaultEnv": false,
   "experimental": false
 }

--- a/tests/policy/request-directional-network.json
+++ b/tests/policy/request-directional-network.json
@@ -36,6 +36,5 @@
   "containment": {
     "type": "process"
   },
-  "inheritDefaultEnv": false,
   "experimental": false
 }

--- a/tests/policy/request-directional-network.json
+++ b/tests/policy/request-directional-network.json
@@ -36,7 +36,6 @@
   "containment": {
     "type": "process"
   },
-  "environment": {},
   "inheritDefaultEnv": false,
   "experimental": false
 }

--- a/tests/policy/request-process-container.json
+++ b/tests/policy/request-process-container.json
@@ -56,5 +56,6 @@
   "environment": {
     "PARITY": "true"
   },
+  "inheritDefaultEnv": false,
   "experimental": false
 }

--- a/tests/policy/request-process-container.json
+++ b/tests/policy/request-process-container.json
@@ -56,6 +56,5 @@
   "environment": {
     "PARITY": "true"
   },
-  "inheritDefaultEnv": false,
   "experimental": false
 }

--- a/tests/policy/request-wslc.json
+++ b/tests/policy/request-wslc.json
@@ -19,7 +19,6 @@
     ]
   },
   "containerName": "golden-wslc",
-  "environment": {},
   "inheritDefaultEnv": false,
   "experimental": true
 }

--- a/tests/policy/request-wslc.json
+++ b/tests/policy/request-wslc.json
@@ -20,5 +20,6 @@
   },
   "containerName": "golden-wslc",
   "environment": {},
+  "inheritDefaultEnv": false,
   "experimental": true
 }

--- a/tests/policy/request-wslc.json
+++ b/tests/policy/request-wslc.json
@@ -19,6 +19,5 @@
     ]
   },
   "containerName": "golden-wslc",
-  "inheritDefaultEnv": false,
   "experimental": true
 }


### PR DESCRIPTION
## 📖 Description
Fixes Windows ProcessContainer launches that use a caller-supplied environment without the variables required by Windows initialization.

This change preserves the distinction between:

- An omitted environment, which uses the backend’s default environment.
- An explicitly empty environment, which remains empty.
- A supplied environment, which is used verbatim.
- A supplied environment with `inheritDefaultEnv`, which is layered over the backend default.

The new `process.inheritDefaultEnv` option is exposed consistently through the Rust, Node.js, .NET, and FFI request surfaces. This option now builds the effective environment from the user profile block when inheritance is requested, while other backends retain their existing behavior.

The change also improves launch diagnostics for incomplete environment blocks, updates generated schemas and wire types, and documents the new behavior.

## 🔗 References
Resolves #483

## 🔍 Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --exclude wxc_e2e_tests`
- Built `wxc` with the `microvm` feature and ran the Windows E2E suite:
  - 6 passed
  - 14 host-dependent tests ignored
- Node.js SDK:
  - `npm run build`
  - `npm test`
- .NET SDK:
  - 118 passed
  - 24 backend-dependent tests skipped
- Schema-version consistency check
- SDK wire-type codegen check
- Development contract codegen check
- Package version consistency check

## ✅ Checklist
<!-- Place an "x" between the brackets to check an item. e.g: [x] -->

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type
- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1120)