### PR TITLE
Add version flags to wxc-exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ MXC uses a JSON configuration to define execution parameters. See the [schema do
 
 ### Native Binary
 
+On Windows, `wxc-exec.exe --version` (or `-V`) prints the executor version and
+exits successfully without requiring a configuration file or starting a sandbox.
+
 ```bash
 # File path
 wxc-exec.exe config.json

--- a/src/core/wxc/src/main.rs
+++ b/src/core/wxc/src/main.rs
@@ -25,7 +25,7 @@ use wxc_common::state_aware_request::{MxcRequest, ParsedStateAwareRequest, Phase
 use wxc_common::telemetry;
 
 #[derive(Parser)]
-#[command(name = "wxc-exec", about = "Windows Container Executor")]
+#[command(name = "wxc-exec", version, about = "Windows Container Executor")]
 struct Cli {
     /// Path to config JSON file (positional)
     #[arg(value_name = "CONFIG_PATH")]
@@ -1745,6 +1745,24 @@ mod tests {
         Cli::try_parse_from(argv)
             .unwrap()
             .normalize_named_config_command()
+    }
+
+    #[test]
+    fn cli_version_flags_work_without_config() {
+        for flag in ["--version", "-V"] {
+            let error = match Cli::try_parse_from(["wxc-exec", flag]) {
+                Err(error) => error,
+                Ok(_) => panic!("{flag} should display the version and exit"),
+            };
+
+            assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+            assert_eq!(error.exit_code(), 0);
+            assert!(!error.use_stderr());
+            assert_eq!(
+                error.to_string(),
+                format!("wxc-exec {}\n", env!("CARGO_PKG_VERSION"))
+            );
+        }
     }
 
     fn encoded_policy(json: &str) -> String {


### PR DESCRIPTION
This PR adds `--version` and `-V` to `wxc-exec`, allowing tools to query the Cargo package version without a configuration file or starting a sandbox.

Resolves #1118.

### Details

* Enable Clap's built-in version flags and reuse the existing version exit handling.
* Add a regression test for version output, exit code, and stdout routing.
* Document usage in the README.

### Tests

Validated locally on Windows x64 with Rust 1.93.1, MSVC 14.44, and Windows SDK 10.0.26100.0:

* Formatting and whitespace checks passed.
* All 14 CLI unit tests passed, including version flags and command argument forwarding.
* Native debug build passed. Both `--version` and `-V` printed `wxc-exec 0.8.0` to stdout, with exit code 0 and empty stderr, without a config file.
* Full sandbox E2E tests were not run.
