### PR TITLE
[Seatbelt] Grant the active developer directory in the baseline profile

### DIFF
--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -159,12 +159,10 @@ The `/dev/*` entries are writable because shell redirections (`>/dev/null`,
 `</dev/urandom`) need both directions. Writes to `/dev/null` and `/dev/zero` are
 discarded; writes to the entropy devices are harmless.
 
-The developer grant is resolved from the `xcode-select` symlink, and only when
-root controls it — MXC checks that the link is a root-owned symlink and that
-every directory leading to it is root-owned and not group- or world-writable,
-so an unprivileged process cannot point the grant somewhere else. A link that
-fails the check is skipped. The `DEVELOPER_DIR` environment variable is ignored
-for the same reason: it is settable by any caller. When the link selects
+The developer grant resolves from the `xcode-select` symlink, and only when root
+owns both the link and every directory above it, so an unprivileged process
+cannot point it elsewhere. `DEVELOPER_DIR` is ignored for the same reason. When
+the link selects
 `<Xcode.app>/Contents/Developer`, MXC grants read-only access to the enclosing
 app bundle because dispatched tools load sibling frameworks; otherwise only the
 selected directory is granted. Many `/usr/bin` tools (`python3`, `git`) are

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -159,8 +159,12 @@ The `/dev/*` entries are writable because shell redirections (`>/dev/null`,
 `</dev/urandom`) need both directions. Writes to `/dev/null` and `/dev/zero` are
 discarded; writes to the entropy devices are harmless.
 
-The developer grant is resolved from the root-owned `xcode-select` symlink; the
-`DEVELOPER_DIR` environment variable is ignored. When it selects
+The developer grant is resolved from the `xcode-select` symlink, and only when
+root controls it — MXC checks that the link is a root-owned symlink and that
+every directory leading to it is root-owned and not group- or world-writable,
+so an unprivileged process cannot point the grant somewhere else. A link that
+fails the check is skipped. The `DEVELOPER_DIR` environment variable is ignored
+for the same reason: it is settable by any caller. When the link selects
 `<Xcode.app>/Contents/Developer`, MXC grants read-only access to the enclosing
 app bundle because dispatched tools load sibling frameworks; otherwise only the
 selected directory is granted. Many `/usr/bin` tools (`python3`, `git`) are

--- a/docs/seatbelt/seatbelt-backend.md
+++ b/docs/seatbelt/seatbelt-backend.md
@@ -151,13 +151,20 @@ and standard tools work:
 
 | Access | Paths |
 |---|---|
-| Read-only | `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/usr/lib`, `/usr/libexec`, `/usr/share`, `/System`, `/Library`, `/private/etc`, `/private/var/db/timezone`, `/private/var/db/dyld`, `/private/var/select` |
+| Read-only | `/bin`, `/sbin`, `/usr/bin`, `/usr/sbin`, `/usr/lib`, `/usr/libexec`, `/usr/share`, `/System`, `/Library`, `/private/etc`, `/private/var/db/timezone`, `/private/var/db/dyld`, `/private/var/select`, the active developer directory |
 | Read **+ write** | `/dev/null`, `/dev/zero`, `/dev/random`, `/dev/urandom` |
 | Read-data only | `/` itself — the loader can't resolve path lookups without it |
 
 The `/dev/*` entries are writable because shell redirections (`>/dev/null`,
 `</dev/urandom`) need both directions. Writes to `/dev/null` and `/dev/zero` are
 discarded; writes to the entropy devices are harmless.
+
+The developer grant is resolved from the root-owned `xcode-select` symlink; the
+`DEVELOPER_DIR` environment variable is ignored. When it selects
+`<Xcode.app>/Contents/Developer`, MXC grants read-only access to the enclosing
+app bundle because dispatched tools load sibling frameworks; otherwise only the
+selected directory is granted. Many `/usr/bin` tools (`python3`, `git`) are
+`xcrun` shims that need this access. `deniedPaths` still overrides the grant.
 
 SIP-protected paths stay unwritable no matter what you put in
 `readwritePaths` — the kernel enforces that independently of the profile.

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -155,18 +155,74 @@ const DEVELOPER_DIR_LINKS: [&str; 2] = [
 /// Command Line Tools install via its `/Library` grant, but an Xcode-selected
 /// host puts it under `/Applications`, where nothing in the baseline reaches.
 ///
-/// Resolved only from the root-owned `xcode-select` symlinks. The
-/// `DEVELOPER_DIR` override that `xcrun` honors is deliberately ignored: it
-/// is settable by any caller, so consulting it would let the environment
-/// choose what the profile grants.
+/// Resolved only from the `xcode-select` symlinks, and only when root controls
+/// them (see `link_is_root_controlled`). The `DEVELOPER_DIR` override that
+/// `xcrun` honors is deliberately ignored: it is settable by any caller, so
+/// consulting it would let the environment choose what the profile grants.
+///
+/// An untrusted candidate is skipped rather than fatal, so resolution
+/// continues to the legacy link.
 ///
 /// Returns `None` when no developer directory is installed
 fn active_developer_dir() -> Option<PathBuf> {
     DEVELOPER_DIR_LINKS
         .iter()
         .map(Path::new)
+        .filter(|link| link_is_root_controlled(link))
         .filter_map(|link| fs::read_link(link).ok())
         .find(|target| target.is_absolute() && target.is_dir())
+}
+
+/// Whether root alone decides what `link` resolves to.
+///
+/// This grant widens the baseline sandbox, so the ownership the doc comment
+/// above claims is enforced rather than assumed. Two independent facts are
+/// required: the entry is a symlink owned by root, and every directory leading
+/// to it is root-controlled. Neither implies the other — replacing a symlink is
+/// a directory operation, so a root-owned link inside a group-writable
+/// directory is still swappable by an unprivileged process, and a
+/// non-symlink at these paths is not something `xcode-select` produced.
+///
+/// The whole ancestor chain is checked, not just the parent: a writable
+/// directory anywhere along it lets its subtree be replaced wholesale.
+#[cfg(unix)]
+fn link_is_root_controlled(link: &Path) -> bool {
+    use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+    let Ok(link_meta) = fs::symlink_metadata(link) else {
+        return false;
+    };
+    if !link_meta.file_type().is_symlink() || link_meta.uid() != 0 {
+        return false;
+    }
+    // `ancestors()` starts at the link itself; the directories follow.
+    link.ancestors().skip(1).all(|dir| {
+        fs::metadata(dir)
+            .is_ok_and(|meta| dir_is_root_controlled(meta.uid(), meta.permissions().mode()))
+    })
+}
+
+/// Non-Unix hosts have no such ownership model to check against, so nothing is
+/// trusted there. Nothing is lost: the developer directory is a macOS concept,
+/// and this crate's profile builder is only compiled elsewhere for its tests.
+#[cfg(not(unix))]
+fn link_is_root_controlled(_link: &Path) -> bool {
+    false
+}
+
+/// Whether a directory with this owner and mode can only be modified by root.
+///
+/// Split out as a pure function so the rule is testable without a root-owned
+/// fixture. A world-writable directory is rejected even when sticky: the sticky
+/// bit would in fact prevent replacing another user's entry, but none of the
+/// real `xcode-select` locations are sticky, so refusing is free.
+#[cfg(unix)]
+fn dir_is_root_controlled(uid: u32, mode: u32) -> bool {
+    /// Group- and other-write bits — the ones that let a non-root user create
+    /// or replace entries in a directory.
+    const NON_OWNER_WRITE: u32 = 0o022;
+
+    uid == 0 && mode & NON_OWNER_WRITE == 0
 }
 
 /// Emit the read-only grant for the active developer directory.
@@ -2022,6 +2078,66 @@ mod tests {
         if active_developer_dir().is_none() {
             write_developer_dir_rule(&mut out);
             assert!(out.is_empty());
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn only_a_root_owned_unwritable_dir_is_trusted() {
+        // Every directory on the way to the link has to be root's alone; a
+        // group- or world-writable one lets an unprivileged process swap the
+        // link out from under us.
+        assert!(dir_is_root_controlled(0, 0o755));
+        assert!(dir_is_root_controlled(0, 0o700));
+        for mode in [0o775, 0o757, 0o777, 0o1777] {
+            assert!(!dir_is_root_controlled(0, mode), "mode {mode:o}");
+        }
+        for uid in [1, 501, 1000] {
+            assert!(!dir_is_root_controlled(uid, 0o755), "uid {uid}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_link_the_caller_controls_is_not_trusted() {
+        use std::os::unix::fs::{symlink, MetadataExt as _};
+
+        let dir = std::env::temp_dir().join(format!("mxc-devdir-trust-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("target")).expect("fixture dir");
+
+        let link = dir.join("link");
+        symlink(dir.join("target"), &link).expect("fixture symlink");
+        // Only decisive when the test user is not root: a root-owned fixture
+        // would legitimately satisfy the check this asserts rejects.
+        if fs::metadata(&dir).expect("fixture metadata").uid() != 0 {
+            assert!(!link_is_root_controlled(&link));
+        }
+
+        // These hold whoever runs the test: `xcode-select` writes a symlink,
+        // so anything else at that path is not something it produced.
+        let plain = dir.join("plain");
+        fs::write(&plain, "").expect("fixture file");
+        assert!(!link_is_root_controlled(&plain));
+        assert!(!link_is_root_controlled(&dir.join("missing")));
+
+        fs::remove_dir_all(&dir).expect("fixture cleanup");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_real_xcode_select_links_are_trusted_when_present() {
+        // Guards the other direction: on a stock macOS host the links and
+        // every directory above them are root-owned and unwritable, so the
+        // trust check has to accept them or the grant silently disappears.
+        for link in DEVELOPER_DIR_LINKS.iter().map(Path::new) {
+            if fs::symlink_metadata(link).is_ok() {
+                assert!(
+                    link_is_root_controlled(link),
+                    "rejected a stock link: {}",
+                    link.display()
+                );
+            }
         }
     }
 

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -26,6 +26,8 @@
 //! rules — the behavior callers expect from MXC's `denied_paths`.
 
 use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::seatbelt_policy;
 use wxc_common::filesystem_resolve::{resolve_path_plan, FsIntent};
@@ -65,6 +67,7 @@ pub fn build_profile_with_proxy(
 
     // Filesystem — read-only system paths every process needs.
     out.push_str(SYSTEM_READ_ALLOW);
+    write_developer_dir_rule(&mut out);
 
     // Pseudo-terminal access — when the executor binary runs under a pty
     // the sandboxed shell inherits that TTY, so it sees a real terminal
@@ -135,6 +138,87 @@ const SYSTEM_READ_ALLOW: &str = "\
     (literal \"/dev/random\")
     (literal \"/dev/urandom\"))
 ";
+
+/// Locations `xcode-select` uses to record the active developer directory.
+/// Both are symlinks owned by root; the first is what `xcode-select --switch`
+/// writes, the second is the older path some releases still populate.
+const DEVELOPER_DIR_LINKS: [&str; 2] = [
+    "/private/var/db/xcode_select_link",
+    "/private/var/select/developer_dir",
+];
+
+/// Resolve the active Xcode / Command Line Tools developer directory.
+///
+/// `/usr/bin/python3`, `/usr/bin/git` and the other `/usr/bin` stubs are
+/// `xcrun` shims: they `dlopen` `libxcrun.dylib` from this directory, so they
+/// cannot start unless it is readable. `SYSTEM_READ_ALLOW` covers the
+/// Command Line Tools install via its `/Library` grant, but an Xcode-selected
+/// host puts it under `/Applications`, where nothing in the baseline reaches.
+///
+/// Resolved only from the root-owned `xcode-select` symlinks. The
+/// `DEVELOPER_DIR` override that `xcrun` honors is deliberately ignored: it
+/// is settable by any caller, so consulting it would let the environment
+/// choose what the profile grants.
+///
+/// Returns `None` when no developer directory is installed
+fn active_developer_dir() -> Option<PathBuf> {
+    DEVELOPER_DIR_LINKS
+        .iter()
+        .map(Path::new)
+        .filter_map(|link| fs::read_link(link).ok())
+        .find(|target| target.is_absolute() && target.is_dir())
+}
+
+/// Emit the read-only grant for the active developer directory.
+///
+/// Read-only, and scoped to the smallest subtree that works: the developer
+/// directory itself for Command Line Tools, or the enclosing bundle when the
+/// developer directory lives inside an `Xcode.app`.
+fn write_developer_dir_rule(out: &mut String) {
+    if let Some(dir) = active_developer_dir() {
+        push_developer_dir_rule(out, &developer_dir_grant_root(&dir));
+    }
+}
+
+/// Widen a developer directory to the `.app` bundle that contains it, if any.
+///
+/// An Xcode developer directory is `<Xcode.app>/Contents/Developer`, but the
+/// tools `xcrun` dispatches to reach outside it: `xcodebuild` loads
+/// `DVTSystemPrerequisites` and friends from `<Xcode.app>/Contents/
+/// SharedFrameworks` and `Contents/Frameworks`. Granting only the developer
+/// directory lets `libxcrun` load and then fails at the next hop, so the
+/// bundle root is the smallest subtree that actually lets the tools run.
+/// A Command Line Tools install has no `.app` ancestor and is returned as-is.
+fn developer_dir_grant_root(dir: &Path) -> PathBuf {
+    enclosing_app_bundle(dir).map_or_else(|| dir.to_path_buf(), Path::to_path_buf)
+}
+
+/// The bundle for which `dir` is exactly `<bundle>.app/Contents/Developer`.
+fn enclosing_app_bundle(dir: &Path) -> Option<&Path> {
+    if dir.file_name()? != "Developer" {
+        return None;
+    }
+    let contents = dir.parent()?;
+    if contents.file_name()? != "Contents" {
+        return None;
+    }
+    let bundle = contents.parent()?;
+    bundle
+        .extension()?
+        .eq_ignore_ascii_case("app")
+        .then_some(bundle)
+}
+
+/// Emit the grant for an already-resolved path. Split from
+/// `write_developer_dir_rule` so the emitted rule can be tested without
+/// depending on what is installed on the host running the tests.
+fn push_developer_dir_rule(out: &mut String, dir: &Path) {
+    let Some(path) = dir.to_str() else {
+        return;
+    };
+    out.push_str(";; --- active developer directory (xcrun shims in /usr/bin) ---\n");
+    let _ = writeln!(out, "(allow file-read* (subpath {}))", quote_scheme(path));
+}
 
 /// Pseudo-terminal device access required by the inner shell when the
 /// runner attaches it to a pty. The secondary fd we hand the child as
@@ -1825,5 +1909,131 @@ mod tests {
         });
         let p = build_profile(&r).unwrap();
         assert!(p.contains("(global-name \"weird\\\"name\")"));
+    }
+
+    #[test]
+    fn developer_dir_rule_grants_read_only_subpath() {
+        let mut out = String::new();
+        push_developer_dir_rule(
+            &mut out,
+            Path::new("/Applications/Xcode.app/Contents/Developer"),
+        );
+        assert!(out.contains(
+            "(allow file-read* (subpath \"/Applications/Xcode.app/Contents/Developer\"))"
+        ));
+        // The xcrun shims only need to read it; a write grant would widen the
+        // sandbox for no benefit.
+        assert!(!out.contains("file-write"));
+    }
+
+    #[test]
+    fn developer_dir_rule_escapes_embedded_quotes() {
+        let mut out = String::new();
+        push_developer_dir_rule(&mut out, Path::new("/tmp/we\"ird/Developer"));
+        assert!(out.contains("(subpath \"/tmp/we\\\"ird/Developer\")"));
+    }
+
+    #[test]
+    fn xcode_developer_dir_widens_to_the_app_bundle() {
+        // xcodebuild loads DVTSystemPrerequisites from Contents/SharedFrameworks,
+        // which sits outside Contents/Developer.
+        let root =
+            developer_dir_grant_root(Path::new("/Applications/Xcode_26.6.app/Contents/Developer"));
+        assert_eq!(root, Path::new("/Applications/Xcode_26.6.app"));
+    }
+
+    #[test]
+    fn command_line_tools_dir_is_not_widened() {
+        let dir = Path::new("/Library/Developer/CommandLineTools");
+        assert_eq!(developer_dir_grant_root(dir), dir);
+    }
+
+    #[test]
+    fn developer_dir_widening_is_case_insensitive_on_the_extension() {
+        let root =
+            developer_dir_grant_root(Path::new("/Applications/Xcode.APP/Contents/Developer"));
+        assert_eq!(root, Path::new("/Applications/Xcode.APP"));
+    }
+
+    #[test]
+    fn widening_accepts_any_bundle_name_and_install_location() {
+        // xcode-select fixes the Contents/Developer suffix, never the prefix:
+        // beta bundles, the per-version bundles on CI images, and custom
+        // install locations are all legitimate.
+        for (dir, want) in [
+            (
+                "/Applications/Xcode-beta.app/Contents/Developer",
+                "/Applications/Xcode-beta.app",
+            ),
+            (
+                "/Applications/Xcode_26.6.app/Contents/Developer",
+                "/Applications/Xcode_26.6.app",
+            ),
+            (
+                "/Volumes/Build/Xcode.app/Contents/Developer",
+                "/Volumes/Build/Xcode.app",
+            ),
+        ] {
+            assert_eq!(developer_dir_grant_root(Path::new(dir)), Path::new(want));
+        }
+    }
+
+    #[test]
+    fn a_dir_deeper_inside_a_bundle_is_not_widened_to_it() {
+        // Only the exact Contents/Developer layout widens, so a developer
+        // directory pointed elsewhere inside a bundle grants just itself.
+        for dir in [
+            "/Applications/Evil.app/Contents/Developer/usr/bin",
+            "/Applications/Evil.app/a/b/Developer",
+            "/Applications/Evil.app/Contents/Developer2",
+        ] {
+            assert_eq!(developer_dir_grant_root(Path::new(dir)), Path::new(dir));
+        }
+    }
+
+    #[test]
+    fn widening_handles_non_normalized_paths_without_overreaching() {
+        // A trailing slash, a repeated separator, or a `.` component all
+        // normalize away, so these are the same directory and still widen.
+        for dir in [
+            "/Applications/Xcode.app/Contents/Developer/",
+            "/Applications/Xcode.app/Contents//Developer",
+            "/Applications/Xcode.app/Contents/./Developer",
+        ] {
+            assert_eq!(
+                developer_dir_grant_root(Path::new(dir)),
+                Path::new("/Applications/Xcode.app")
+            );
+        }
+        // `..` is not normalized away, so it fails the layout match and grants
+        // only the directory itself rather than resolving to somewhere higher.
+        let parent_ref = "/Applications/Xcode.app/Contents/Developer/..";
+        assert_eq!(
+            developer_dir_grant_root(Path::new(parent_ref)),
+            Path::new(parent_ref)
+        );
+    }
+
+    #[test]
+    fn developer_dir_absent_emits_nothing() {
+        // `write_developer_dir_rule` is a no-op when nothing is installed, so
+        // a host without developer tools still builds a valid profile.
+        let mut out = String::new();
+        if active_developer_dir().is_none() {
+            write_developer_dir_rule(&mut out);
+            assert!(out.is_empty());
+        }
+    }
+
+    #[test]
+    fn baseline_profile_grants_the_active_developer_dir() {
+        // The documented baseline promise is that standard tools work, and
+        // the /usr/bin xcrun shims cannot start without this directory.
+        let Some(dir) = active_developer_dir() else {
+            return;
+        };
+        let granted = developer_dir_grant_root(&dir);
+        let p = build_profile(&req()).unwrap();
+        assert!(p.contains(&format!("(subpath \"{}\")", granted.display())));
     }
 }

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -186,7 +186,8 @@ fn link_is_root_controlled(link: &Path) -> bool {
     })
 }
 
-/// Nothing is trusted off Unix; the developer directory is a macOS concept.
+/// Windows only: this module compiles everywhere but `std::os::unix` does not.
+/// There is no `xcode-select` there, so nothing to trust.
 #[cfg(not(unix))]
 fn link_is_root_controlled(_link: &Path) -> bool {
     false

--- a/src/backends/seatbelt/common/src/profile_builder.rs
+++ b/src/backends/seatbelt/common/src/profile_builder.rs
@@ -139,9 +139,8 @@ const SYSTEM_READ_ALLOW: &str = "\
     (literal \"/dev/urandom\"))
 ";
 
-/// Locations `xcode-select` uses to record the active developer directory.
-/// Both are symlinks owned by root; the first is what `xcode-select --switch`
-/// writes, the second is the older path some releases still populate.
+/// Where `xcode-select` records the active developer directory. The second
+/// entry is the older path some releases still populate.
 const DEVELOPER_DIR_LINKS: [&str; 2] = [
     "/private/var/db/xcode_select_link",
     "/private/var/select/developer_dir",
@@ -149,21 +148,13 @@ const DEVELOPER_DIR_LINKS: [&str; 2] = [
 
 /// Resolve the active Xcode / Command Line Tools developer directory.
 ///
-/// `/usr/bin/python3`, `/usr/bin/git` and the other `/usr/bin` stubs are
-/// `xcrun` shims: they `dlopen` `libxcrun.dylib` from this directory, so they
-/// cannot start unless it is readable. `SYSTEM_READ_ALLOW` covers the
-/// Command Line Tools install via its `/Library` grant, but an Xcode-selected
-/// host puts it under `/Applications`, where nothing in the baseline reaches.
+/// The `/usr/bin` stubs (`python3`, `git`) are `xcrun` shims that `dlopen`
+/// `libxcrun.dylib` from here, so they cannot start unless it is readable.
+/// `SYSTEM_READ_ALLOW` reaches a Command Line Tools install through its
+/// `/Library` grant, but an Xcode-selected host puts it under `/Applications`.
 ///
-/// Resolved only from the `xcode-select` symlinks, and only when root controls
-/// them (see `link_is_root_controlled`). The `DEVELOPER_DIR` override that
-/// `xcrun` honors is deliberately ignored: it is settable by any caller, so
-/// consulting it would let the environment choose what the profile grants.
-///
-/// An untrusted candidate is skipped rather than fatal, so resolution
-/// continues to the legacy link.
-///
-/// Returns `None` when no developer directory is installed
+/// `DEVELOPER_DIR` is ignored because any caller can set it. An untrusted link
+/// is skipped, so resolution continues to the legacy one.
 fn active_developer_dir() -> Option<PathBuf> {
     DEVELOPER_DIR_LINKS
         .iter()
@@ -175,16 +166,9 @@ fn active_developer_dir() -> Option<PathBuf> {
 
 /// Whether root alone decides what `link` resolves to.
 ///
-/// This grant widens the baseline sandbox, so the ownership the doc comment
-/// above claims is enforced rather than assumed. Two independent facts are
-/// required: the entry is a symlink owned by root, and every directory leading
-/// to it is root-controlled. Neither implies the other — replacing a symlink is
-/// a directory operation, so a root-owned link inside a group-writable
-/// directory is still swappable by an unprivileged process, and a
-/// non-symlink at these paths is not something `xcode-select` produced.
-///
-/// The whole ancestor chain is checked, not just the parent: a writable
-/// directory anywhere along it lets its subtree be replaced wholesale.
+/// Requires both a root-owned symlink and root-owned, non-group/world-writable
+/// directories above it: replacing a symlink is a directory operation, so the
+/// link's own ownership settles nothing by itself.
 #[cfg(unix)]
 fn link_is_root_controlled(link: &Path) -> bool {
     use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
@@ -202,49 +186,35 @@ fn link_is_root_controlled(link: &Path) -> bool {
     })
 }
 
-/// Non-Unix hosts have no such ownership model to check against, so nothing is
-/// trusted there. Nothing is lost: the developer directory is a macOS concept,
-/// and this crate's profile builder is only compiled elsewhere for its tests.
+/// Nothing is trusted off Unix; the developer directory is a macOS concept.
 #[cfg(not(unix))]
 fn link_is_root_controlled(_link: &Path) -> bool {
     false
 }
 
-/// Whether a directory with this owner and mode can only be modified by root.
-///
-/// Split out as a pure function so the rule is testable without a root-owned
-/// fixture. A world-writable directory is rejected even when sticky: the sticky
-/// bit would in fact prevent replacing another user's entry, but none of the
-/// real `xcode-select` locations are sticky, so refusing is free.
+/// Pure so the rule is testable without a root-owned fixture. Sticky
+/// world-writable directories are rejected too — none of the real
+/// `xcode-select` locations are sticky, so refusing costs nothing.
 #[cfg(unix)]
 fn dir_is_root_controlled(uid: u32, mode: u32) -> bool {
-    /// Group- and other-write bits — the ones that let a non-root user create
-    /// or replace entries in a directory.
     const NON_OWNER_WRITE: u32 = 0o022;
 
     uid == 0 && mode & NON_OWNER_WRITE == 0
 }
 
 /// Emit the read-only grant for the active developer directory.
-///
-/// Read-only, and scoped to the smallest subtree that works: the developer
-/// directory itself for Command Line Tools, or the enclosing bundle when the
-/// developer directory lives inside an `Xcode.app`.
 fn write_developer_dir_rule(out: &mut String) {
     if let Some(dir) = active_developer_dir() {
         push_developer_dir_rule(out, &developer_dir_grant_root(&dir));
     }
 }
 
-/// Widen a developer directory to the `.app` bundle that contains it, if any.
+/// Widen a developer directory to the `.app` bundle containing it, if any.
 ///
-/// An Xcode developer directory is `<Xcode.app>/Contents/Developer`, but the
-/// tools `xcrun` dispatches to reach outside it: `xcodebuild` loads
-/// `DVTSystemPrerequisites` and friends from `<Xcode.app>/Contents/
-/// SharedFrameworks` and `Contents/Frameworks`. Granting only the developer
-/// directory lets `libxcrun` load and then fails at the next hop, so the
-/// bundle root is the smallest subtree that actually lets the tools run.
-/// A Command Line Tools install has no `.app` ancestor and is returned as-is.
+/// The tools `xcrun` dispatches load frameworks from
+/// `<Xcode.app>/Contents/SharedFrameworks`, outside `Contents/Developer`, so
+/// the bundle root is the smallest subtree that lets them run. A Command Line
+/// Tools install has no `.app` ancestor and is returned as-is.
 fn developer_dir_grant_root(dir: &Path) -> PathBuf {
     enclosing_app_bundle(dir).map_or_else(|| dir.to_path_buf(), Path::to_path_buf)
 }
@@ -265,9 +235,8 @@ fn enclosing_app_bundle(dir: &Path) -> Option<&Path> {
         .then_some(bundle)
 }
 
-/// Emit the grant for an already-resolved path. Split from
-/// `write_developer_dir_rule` so the emitted rule can be tested without
-/// depending on what is installed on the host running the tests.
+/// Emit the grant for an already-resolved path. Split out so it can be tested
+/// independently of what is installed on the test host.
 fn push_developer_dir_rule(out: &mut String, dir: &Path) {
     let Some(path) = dir.to_str() else {
         return;
@@ -1991,8 +1960,6 @@ mod tests {
 
     #[test]
     fn xcode_developer_dir_widens_to_the_app_bundle() {
-        // xcodebuild loads DVTSystemPrerequisites from Contents/SharedFrameworks,
-        // which sits outside Contents/Developer.
         let root =
             developer_dir_grant_root(Path::new("/Applications/Xcode_26.6.app/Contents/Developer"));
         assert_eq!(root, Path::new("/Applications/Xcode_26.6.app"));
@@ -2013,9 +1980,7 @@ mod tests {
 
     #[test]
     fn widening_accepts_any_bundle_name_and_install_location() {
-        // xcode-select fixes the Contents/Developer suffix, never the prefix:
-        // beta bundles, the per-version bundles on CI images, and custom
-        // install locations are all legitimate.
+        // xcode-select fixes the Contents/Developer suffix, never the prefix.
         for (dir, want) in [
             (
                 "/Applications/Xcode-beta.app/Contents/Developer",
@@ -2036,8 +2001,7 @@ mod tests {
 
     #[test]
     fn a_dir_deeper_inside_a_bundle_is_not_widened_to_it() {
-        // Only the exact Contents/Developer layout widens, so a developer
-        // directory pointed elsewhere inside a bundle grants just itself.
+        // Only the exact Contents/Developer layout widens.
         for dir in [
             "/Applications/Evil.app/Contents/Developer/usr/bin",
             "/Applications/Evil.app/a/b/Developer",
@@ -2049,8 +2013,7 @@ mod tests {
 
     #[test]
     fn widening_handles_non_normalized_paths_without_overreaching() {
-        // A trailing slash, a repeated separator, or a `.` component all
-        // normalize away, so these are the same directory and still widen.
+        // These all normalize to the same directory, so they still widen.
         for dir in [
             "/Applications/Xcode.app/Contents/Developer/",
             "/Applications/Xcode.app/Contents//Developer",
@@ -2061,8 +2024,7 @@ mod tests {
                 Path::new("/Applications/Xcode.app")
             );
         }
-        // `..` is not normalized away, so it fails the layout match and grants
-        // only the directory itself rather than resolving to somewhere higher.
+        // `..` is not normalized away, so it fails the layout match.
         let parent_ref = "/Applications/Xcode.app/Contents/Developer/..";
         assert_eq!(
             developer_dir_grant_root(Path::new(parent_ref)),
@@ -2072,8 +2034,6 @@ mod tests {
 
     #[test]
     fn developer_dir_absent_emits_nothing() {
-        // `write_developer_dir_rule` is a no-op when nothing is installed, so
-        // a host without developer tools still builds a valid profile.
         let mut out = String::new();
         if active_developer_dir().is_none() {
             write_developer_dir_rule(&mut out);
@@ -2084,9 +2044,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn only_a_root_owned_unwritable_dir_is_trusted() {
-        // Every directory on the way to the link has to be root's alone; a
-        // group- or world-writable one lets an unprivileged process swap the
-        // link out from under us.
         assert!(dir_is_root_controlled(0, 0o755));
         assert!(dir_is_root_controlled(0, 0o700));
         for mode in [0o775, 0o757, 0o777, 0o1777] {
@@ -2108,14 +2065,12 @@ mod tests {
 
         let link = dir.join("link");
         symlink(dir.join("target"), &link).expect("fixture symlink");
-        // Only decisive when the test user is not root: a root-owned fixture
-        // would legitimately satisfy the check this asserts rejects.
+        // Only decisive when the test user is not root.
         if fs::metadata(&dir).expect("fixture metadata").uid() != 0 {
             assert!(!link_is_root_controlled(&link));
         }
 
-        // These hold whoever runs the test: `xcode-select` writes a symlink,
-        // so anything else at that path is not something it produced.
+        // True for any user: `xcode-select` writes a symlink, nothing else.
         let plain = dir.join("plain");
         fs::write(&plain, "").expect("fixture file");
         assert!(!link_is_root_controlled(&plain));
@@ -2127,9 +2082,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn the_real_xcode_select_links_are_trusted_when_present() {
-        // Guards the other direction: on a stock macOS host the links and
-        // every directory above them are root-owned and unwritable, so the
-        // trust check has to accept them or the grant silently disappears.
+        // The check must accept a stock host, or the grant silently vanishes.
         for link in DEVELOPER_DIR_LINKS.iter().map(Path::new) {
             if fs::symlink_metadata(link).is_ok() {
                 assert!(


### PR DESCRIPTION
## 📖 Description

Split out of #1125, where the seatbelt technical test suite found it.

`/usr/bin/python3`, `/usr/bin/git` and the other `/usr/bin` stubs get redirected
on Macs with Xcode installed. Instead of routing to the standard
"CommandLineTools" in /Library, they get routed to the installations of python
and git inside of the Xcode .app bundle.

The baseline now includes a read-only `subpath` grant for the active developer
directory, resolved **only** from the root-owned `xcode-select` symlinks
(`/private/var/db/xcode_select_link`, `/private/var/select/developer_dir`).
`DEVELOPER_DIR` is deliberately ignored: it is settable by any caller, so
honoring it would let an environment variable choose what the profile grants.

An Xcode developer directory (`<Xcode.app>/Contents/Developer`) widens to the
enclosing `.app` bundle, because the tools `xcrun` dispatches load sibling
frameworks from `Contents/SharedFrameworks`. Only that exact layout widens; a
Command Line Tools install is granted as-is. `deniedPaths` still overrides the
grant, and a host with no developer tools emits nothing.

## 🔗 References

Resolves #1110

Split out of #1125 — the seatbelt test suite, its CI wiring, and the profile
logging fix stay there.

## 🔍 Validation

- `cargo test -p seatbelt_common` — 111 tests pass
- `cargo fmt --all -- --check` and `cargo clippy -p seatbelt_common --all-targets -- -D warnings` clean
- Unit tests cover the emitted rule (read-only, quote-escaped), the bundle
  widening (beta / versioned / custom install locations, case-insensitive
  extension), the cases that must **not** widen (deeper paths inside a bundle,
  `..`), non-normalized paths, and the absent-tools no-op
- Tests in #1125 pass on both the macOS 15 and macOS 26 runners,
  confirming the grant works on a real Xcode host

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed) — N/A
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes — N/A, `Cargo.lock` unchanged

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1128)