### PR TITLE
docs: explain Learning Mode denial capture

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -35,7 +35,7 @@ local diagnostic session.
 | Method | Setting | Description |
 |--------|---------|-------------|
 | CLI flag | `--log-file <path>` | Write diagnostics and structured audit records to a file. Independent of the console — needs no pipe and no token. |
-| Env var | `MXC_DIAG_CONSOLE=1` | Enable diagnostic pipe output and auto-inject `learningModeLogging` capability |
+| Env var | `MXC_DIAG_CONSOLE=1` | Enable diagnostic pipe output and auto-inject the deny-and-record `learningModeLogging` capability for live ETW observation |
 | Env var | `MXC_DIAG_PIPE_TOKEN=<token>` | **Required** for pipe output. Selects the per-session pipe and authenticates it; use the same token for the console and `wxc-exec` |
 
 ### The pipe token
@@ -63,6 +63,128 @@ it:
 If the console starts but never shows any events, an unset or malformed token on
 the `wxc-exec` side is the first thing to check — the two processes must agree on
 the token exactly, because it is part of the pipe *name*.
+
+## Learning Mode: live observation versus persisted capture
+
+`MXC_DIAG_CONSOLE=1` enables **live observation**, not the
+`processContainer.captureDenials` artifact pipeline:
+
+1. For a Windows ProcessContainer run, `wxc-exec` injects the reserved
+   `learningModeLogging` capability when no learning-mode capability is already
+   active. Windows continues to deny failed access checks and emits
+   Kernel-General learning-mode events for them.
+2. `mxc-diagnostic-console.exe` starts a real-time ETW session for the
+   Kernel-General and MXC OS-side providers. This ETW portion requires
+   elevation; pipe diagnostics continue to work without it.
+
+The console displays those events as they arrive. Its `--collect` option writes
+rendered `verbose.log` and `minified.log` files, but it does **not** retain the
+raw ETL, analyze denials, or create actionable and verbose denial JSON.
+
+Use one of the separate capture workflows when persistent artifacts are
+required:
+
+| Workflow | Entry point | Enforcement | Persistent outputs |
+|----------|-------------|-------------|--------------------|
+| Live diagnostic console | `MXC_DIAG_CONSOLE=1` | Failed checks stay denied | Optional rendered `verbose.log` and `minified.log`; no retained ETL or denial JSON |
+| Safe application capture | `captureDenials.mode: "block"` | Failed checks stay denied | Actionable JSON, verbose JSON sibling, and optional retained ETL |
+| Permissive policy authoring | `wxc-exec.exe --audit` | Ungranted checks are recorded **and allowed** | Stable audit copies of actionable JSON, verbose JSON, retained ETL, and policy-authoring files |
+
+### Safe deny-and-record capture
+
+For diagnostics that preserve production containment, configure a Windows
+ProcessContainer run with `captureDenials.mode: "block"`. Set `retainEtl` to
+keep the sealed ETL after analysis:
+
+```json
+{
+  "version": "0.8.0-alpha",
+  "containment": "processcontainer",
+  "process": {
+    "commandLine": "cmd.exe /c type C:\\data\\input.txt"
+  },
+  "processContainer": {
+    "captureDenials": {
+      "mode": "block",
+      "outputPath": "C:\\logs\\denials.json",
+      "retainEtl": true
+    }
+  }
+}
+```
+
+The `outputPath` must be absolute and its parent directory must already exist.
+Run the config normally:
+
+```powershell
+New-Item -ItemType Directory -Force C:\logs | Out-Null
+wxc-exec.exe --config capture-config.json
+```
+
+This workflow can run while the diagnostic console is active. The console
+shows the live events, while `captureDenials` independently owns trace
+finalization and the persistent artifacts.
+
+After a terminal wait, a successful capture produces:
+
+- `denials.<run-id>.json` — actionable, authorable policy denials;
+- `denials.<run-id>.verbose.json` — the deterministic diagnostic sibling; and
+- a sealed ETL when `retainEtl` is `true`.
+
+MXC inserts the run identifier even when `outputPath` names `denials.json`.
+`wxc-exec` prints a structured JSON pointer on stderr containing the actual
+`outputPath` and, when retained, `etlPath`. Derive the verbose JSON path from
+the actionable filename; it is intentionally not repeated in the pointer.
+Native and guarded-WPR capture use different managed ETL locations, so callers
+must use the reported `etlPath` rather than guessing it.
+
+Streaming SDK callers must complete the process with `wait` or
+`wait_with_output`. Abandoning the process without a terminal wait discards the
+internal trace. Retained ETL can contain sensitive paths and identifiers; the
+caller is responsible for deleting it when it is no longer needed.
+
+The checked-in
+[`tests/examples/29_capture_denials.json`](../tests/examples/29_capture_denials.json)
+is a minimal block-mode example. See
+[Learning-mode capabilities](learning-mode/capabilities.md#relationship-to-denial-capture)
+for the output schemas, bounds, host-selection behavior, and SDK metadata
+surfaces.
+
+### Permissive audit policy-authoring mode
+
+For developer policy authoring, `--audit` is the existing convenience command:
+
+```powershell
+wxc-exec.exe --audit --config policy.json
+```
+
+It wraps `captureDenials.mode: "allow"` with `retainEtl: true`, then relocates
+the results into a per-run directory:
+
+```text
+%LOCALAPPDATA%\Microsoft\MXC\PLM\logs\<timestamp>_pid<pid>\
+```
+
+If `%LOCALAPPDATA%` is unavailable, the equivalent directory is created under
+`%TEMP%`. A successful non-dry-run audit contains:
+
+- `denials.json` — actionable denials;
+- `denials.verbose.json` — bounded verbose diagnostics;
+- `trace.etl` — retained, process-scoped Learning Mode events; and
+- a source-config snapshot and `Adjusted_*.json` when source config is
+  available and analysis is not truncated.
+
+`--audit-verbose` prints learned-policy post-processing details. It does not
+control whether `denials.verbose.json` is created; every successful denial
+analysis writes the actionable and verbose JSON pair.
+
+> **Security warning:** `--audit` is ProcessContainer-only and uses permissive
+> Learning Mode. Ungranted access checks are allowed for the duration of the
+> run, so deny-by-default is not enforced. Do not use it to validate production
+> containment. It cannot be combined with an explicit
+> `processContainer.captureDenials` section. Native PSEC/V2 capture runs without
+> UAC; a compatible legacy tier may use the guarded-WPR fallback, whose
+> fixed-operation guardian prompts for elevation.
 
 ## What Gets Logged
 
@@ -138,6 +260,11 @@ containing:
 - `verbose.log` -- all ETW event properties (full detail)
 - `minified.log` -- reduced ETW event properties
 
+These are rendered console logs, not the
+`captureDenials` `denials.verbose.json` artifact or a retained `.etl` trace.
+See [Learning Mode: live observation versus persisted capture](#learning-mode-live-observation-versus-persisted-capture)
+when raw and analyzed capture artifacts are required.
+
 The console continues to display events normally while collecting. Press **Ctrl+C** to
 stop collection, at which point the tool:
 1. Flushes both log files
@@ -161,6 +288,11 @@ mxc-diagnostic-console.exe | Tee-Object -Encoding ascii -FilePath out.log
 The console captures ETW events from the MXC OS-side provider and Kernel-General
 learning-mode access check events. **Admin privileges required** for ETW; pipe
 messages work without elevation.
+
+This is a real-time subscription only. Use
+[`processContainer.captureDenials`](#safe-deny-and-record-capture) or
+[`--audit`](#permissive-audit-policy-authoring-mode) to retain a sealed ETL
+and produce denial-analysis files.
 
 ### Security
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -170,9 +170,10 @@ If `%LOCALAPPDATA%` is unavailable, the equivalent directory is created under
 
 - `denials.json` — actionable denials;
 - `denials.verbose.json` — bounded verbose diagnostics;
-- `trace.etl` — retained, process-scoped Learning Mode events; and
-- a source-config snapshot and `Adjusted_*.json` when source config is
-  available and analysis is not truncated.
+- `trace.etl` — retained, process-scoped Learning Mode events;
+- a source-config snapshot when source config is available; and
+- `Adjusted_*.json` when source config is available, analysis is not truncated,
+  and at least one denial can be merged into the policy.
 
 `--audit-verbose` prints learned-policy post-processing details. It does not
 control whether `denials.verbose.json` is created; every successful denial


### PR DESCRIPTION
## 📖 Description

Clarifies the relationship between the live MXC diagnostic console and persisted Learning Mode denial capture.

- Explains how `MXC_DIAG_CONSOLE=1` enables deny-and-record ETW observation without producing capture artifacts.
- Documents the safe `processContainer.captureDenials` block-mode workflow for actionable JSON, verbose JSON, and optional retained ETL.
- Documents `wxc-exec.exe --audit` as the permissive policy-authoring workflow and calls out its security implications and stable output files.
- Distinguishes console `--collect` logs from `captureDenials` artifacts and links to the detailed Learning Mode reference and checked-in example.

## 🔗 References

No related issue.

## 🔍 Validation

- Checked relative documentation links.
- Verified command names, configuration fields, artifact names, and behavior against the current CLI, schema model, diagnostic console, and audit implementation.
- Ran `git diff --check` with the repository's CRLF line endings accounted for.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [ ] Linked to an issue
- [x] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [ ] Bug fix
- [ ] Feature
- [x] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1131)