### PR TITLE
Simple (per-Issue) Regression test harness (ready for vm!)

### DIFF
--- a/src/backends/appcontainer/common/Cargo.toml
+++ b/src/backends/appcontainer/common/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license.workspace = true
 
 [features]
+# Enables the MXC_FORCE_TIER environment override for dedicated test executors.
+# Never enable this feature for production binaries.
+force-tier-testing = []
 # Compile-time gate for Tier 2 (AppContainer + BFS via bfscfg.exe).
 # OFF by default: production wxc-exec cannot resolve or spawn bfscfg.exe,
 # and `fallback_detector::detect` naturally falls through T2 to T3 because

--- a/src/backends/appcontainer/common/src/fallback_detector.rs
+++ b/src/backends/appcontainer/common/src/fallback_detector.rs
@@ -238,7 +238,8 @@ pub enum FallbackError {
 ///
 /// The algorithm matches the design doc:
 ///
-/// 1. If `MXC_FORCE_TIER` is set in a test build, honor it (test seam).
+/// 1. If `MXC_FORCE_TIER` is set in a unit test or a build with the
+///    `force-tier-testing` feature, honor it.
 /// 2. Try Tier 1 (BaseContainer) when `prefer_base_container` is true and the
 ///    backend is *usable*. See [`is_base_container_usable`], a capability check
 ///    (not just symbol presence) so a disabled build degrades to a lower tier
@@ -291,21 +292,13 @@ pub(crate) fn detect_with_base_container_capabilities(
     let has_fs_policy =
         !policy.readwrite_paths.is_empty() || !policy.readonly_paths.is_empty() || denied;
 
-    // Test-only injection seam. An invalid value is silently ignored and we
-    // proceed with the real probe chain — that lets tests assert
-    // pass-through behavior without any error plumbing.
+    // Test-executor injection seam. An invalid value is silently ignored and
+    // we proceed with the real probe chain.
     //
-    // Gate is `cfg(test)`, not `cfg(debug_assertions)`: production
-    // `wxc-exec.exe` builds (release *and* dev binaries) must not honor
-    // `MXC_FORCE_TIER` from the environment. `cfg(test)` ensures the
-    // seam is compiled in only when the crate is built as a test binary
-    // — which is exactly the case for unit tests under any profile,
-    // including CI's `cargo test --profile release` invocation. The
-    // dispatcher/fallback unit tests in this crate's `mod tests` thus
-    // actually exercise tier selection under release-profile CI runs
-    // (previously the seam was elided by `cfg(debug_assertions)` and
-    // the tests silently no-op'd).
-    #[cfg(test)]
+    // Normal debug and release builds do not compile this branch. Unit tests
+    // always get it; a runnable test executor gets it only through the explicit
+    // `force-tier-testing` Cargo feature.
+    #[cfg(any(test, feature = "force-tier-testing"))]
     if let Ok(forced) = std::env::var("MXC_FORCE_TIER") {
         if let Ok(tier) = forced.parse::<IsolationTier>() {
             return forced_decision(tier, policy, denied);
@@ -586,7 +579,7 @@ fn check_write_dac_path(path: &Path) -> Result<(), FallbackError> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "force-tier-testing"))]
 fn forced_decision(
     tier: IsolationTier,
     policy: &ContainerPolicy,

--- a/src/core/mxc_engine/Cargo.toml
+++ b/src/core/mxc_engine/Cargo.toml
@@ -58,6 +58,8 @@ isolation_session = [
     "dep:isolation_session_bindings",
     "dep:isolation_session_common",
 ]
+# Forwards the test-executor-only ProcessContainer tier override.
+force-tier-testing = ["appcontainer_common/force-tier-testing"]
 # Forwards appcontainer_common/tier2_bfs. OFF by default; see appcontainer_common/Cargo.toml.
 tier2_bfs = ["appcontainer_common/tier2_bfs"]
 

--- a/src/core/wxc/Cargo.toml
+++ b/src/core/wxc/Cargo.toml
@@ -42,5 +42,10 @@ microvm = ["dep:nanvix_binaries", "nanvix_binaries/microvm", "mxc_engine/microvm
 wslc = ["dep:wslc_common", "wslc_common/link-wslcsdk", "mxc_engine/wslc"]
 hyperlight = ["dep:hyperlight_common", "hyperlight_common/hyperlight", "mxc_engine/hyperlight"]
 isolation_session = ["mxc_engine/isolation_session"]
+# Builds a test executor that honors MXC_FORCE_TIER. Never enable in production.
+force-tier-testing = [
+    "appcontainer_common/force-tier-testing",
+    "mxc_engine/force-tier-testing",
+]
 # Forwards appcontainer_common/tier2_bfs. OFF by default; see appcontainer_common/Cargo.toml.
 tier2_bfs = ["appcontainer_common/tier2_bfs", "mxc_engine/tier2_bfs"]

--- a/src/testing/wxc_e2e_tests/tests/e2e_processcontainer_characterization.rs
+++ b/src/testing/wxc_e2e_tests/tests/e2e_processcontainer_characterization.rs
@@ -23,8 +23,9 @@
 //!
 //! Tier note: the ProcessContainer tier (BaseContainer vs AppContainer+DACL) is
 //! **not** independently selectable from a config — the dispatcher derives it
-//! purely from host capability, and the `MXC_FORCE_TIER` seam is `cfg(test)`-only
-//! so it has no effect on the production `wxc-exec.exe`. These tests therefore
+//! purely from host capability. A dedicated executor built with the
+//! `force-tier-testing` feature can override selection through `MXC_FORCE_TIER`;
+//! normal production executors do not honor it. Without that feature these tests
 //! exercise whichever tier the prepared lane resolves to; running them on both a
 //! BaseContainer-capable and a downlevel host covers both tiers. Because that is
 //! not enforceable in ordinary CI, the tier-independent guarantee — that neither

--- a/tests/regression_tests/README.md
+++ b/tests/regression_tests/README.md
@@ -1,0 +1,51 @@
+# ProcessContainer regression repros
+
+1. These are per-Issue test cases: each in a .ps1 file.
+1. VM-ready (needs no repo or PowerShell test framework)
+1. Copy this folder and `wxc-exec.exe` + `host_prep.exe` to a VM
+1. Run a case .ps1 directly or use `Run-RegressionTests.ps1`
+
+`TestCases.psd1` is a catalog of each test case, including expected tier support and prerequisites. `ExpectedTierSupport` lists the tiers on which the behavior should work, including tiers beyond the original issue report; it does not select or enforce the executor tier.
+
+## Run
+Individual
+```powershell
+.\test_cases\Invoke-Issue1102-DefaultPath.ps1
+```
+
+Full
+```powershell
+.\Run-RegressionTests.ps1
+```
+
+## Harness info
+- Harness warns about all missing manifest-listed dependencies and prints their installation commands.
+- Missing dependencies stop the run by default; pass `-InstallMissingDependencies` to install supported dependencies with `winget`, or `-RunWithMissingDependencies` to attempt the tests anyway.
+- `wxc-exec.exe` is searched for in current directory or `PATH`
+- Destructive cases include `DESTRUCTIVE` in the filename, are skipped by default, and refuse direct execution without `-AllowDestructive`.
+
+### Objective output
+Use `-PassThru` to emit unformatted result objects for the pipeline:
+
+```powershell
+.\Run-RegressionTests.ps1 -PassThru | Where-Object Status -eq "Failed"
+```
+
+## Force a ProcessContainer tier
+
+Build a test-only executor from `src`:
+
+```powershell
+cargo build -p wxc --features force-tier-testing
+```
+
+Set `MXC_FORCE_TIER` before running a case or the harness:
+
+```powershell
+$env:MXC_FORCE_TIER = "appcontainer-dacl"
+.\Run-RegressionTests.ps1 -WxcExec ..\src\target\debug\wxc-exec.exe
+```
+
+Accepted values are `base-container`, `appcontainer-bfs`, and `appcontainer-dacl`. The override is absent from normal builds; never ship an executor built with `force-tier-testing`.
+
+Issue #694 requires `appcontainer-dacl` and fails its precondition when another tier is selected.

--- a/tests/regression_tests/Run-RegressionTests.ps1
+++ b/tests/regression_tests/Run-RegressionTests.ps1
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[CmdletBinding()]
+param(
+    [string]$WxcExec,
+    [string]$SecondaryDriveWorkDirectory,
+    [string]$HostPrepExe,
+    [string]$DisposableVolumeRoot,
+    [switch]$IncludeDestructive,
+    [switch]$InstallMissingDependencies,
+    [switch]$RunWithMissingDependencies,
+    [switch]$PassThru
+)
+
+$ErrorActionPreference = "Continue"
+. (Join-Path $PSScriptRoot "inc\Run-RegressionTests.Lib.ps1")
+
+# Load the test catalog.
+$shell = (Get-Process -Id $PID).Path
+$manifest = Import-PowerShellDataFile (Join-Path $PSScriptRoot "TestCases.psd1")
+
+# Find and report missing dependencies.
+$missingDependencies = @(Get-MissingTestDependencies $manifest)
+if ($missingDependencies) {
+    Write-MissingDependencyWarning $missingDependencies -InstallRequested:$InstallMissingDependencies
+}
+
+# Install dependencies when requested.
+if ($missingDependencies -and $InstallMissingDependencies) {
+    foreach ($missingDependency in $missingDependencies) {
+        [void](Install-Dependency $missingDependency.Dependency)
+    }
+    $missingDependencies = @(Get-MissingTestDependencies $manifest)
+}
+
+# Stop before execution unless missing dependencies were explicitly allowed.
+if ($missingDependencies -and -not $RunWithMissingDependencies) {
+    Write-Error "Dependency preflight failed. Install the listed dependencies or pass -RunWithMissingDependencies to attempt the tests anyway."
+    exit 1
+}
+
+# Run every cataloged test in issue order.
+$results = foreach ($entry in $manifest.GetEnumerator() | Sort-Object { [int]$_.Key }) {
+    Invoke-RegressionTestCase -Issue $entry.Key -Metadata $entry.Value -RegressionRoot $PSScriptRoot -Shell $shell `
+        -WxcExec $WxcExec -SecondaryDriveWorkDirectory $SecondaryDriveWorkDirectory -HostPrepExe $HostPrepExe `
+        -DisposableVolumeRoot $DisposableVolumeRoot -IncludeDestructive:$IncludeDestructive `
+        -RunWithMissingDependencies:$RunWithMissingDependencies
+}
+
+# Emit pipeline objects or the colored console report.
+if ($PassThru) {
+    $results
+} else {
+    Write-RegressionTestResults $results
+}
+
+# Return failure when any test failed.
+$failed = $results.Where({ $_.Status -eq "Failed" }).Count
+if ($failed) { exit 1 }

--- a/tests/regression_tests/TestCases.psd1
+++ b/tests/regression_tests/TestCases.psd1
@@ -1,0 +1,123 @@
+@{
+    "473" = @{
+        FriendlyName = "Packaged App Launch"
+        Script = "test_cases\Invoke-Issue473-PackagedApp.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "MSIX packaged Notepad")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "483" = @{
+        FriendlyName = "Bun Runtime Launch"
+        Script = "test_cases\Invoke-Issue483-BunAndSparsePath.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "Bun")
+        Dependencies = @(
+            @{
+                Name = "Bun"
+                Executable = "bun.exe"
+                WingetId = "Oven-sh.Bun"
+                ArgumentName = "BunExe"
+            }
+        )
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "636" = @{
+        FriendlyName = "Edge Isolated Startup"
+        Script = "test_cases\Invoke-Issue636-EdgeStartup.ps1"
+        ExpectedTierSupport = @("appcontainer-dacl")
+        Prerequisites = @("wxc-exec", "Microsoft Edge", "interactive desktop")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "648" = @{
+        FriendlyName = "Host ACL Propagation"
+        Script = "test_cases\Invoke-Issue648-DESTRUCTIVE-HostPrepDescendantAcl.ps1"
+        ExpectedTierSupport = @("host-preparation")
+        Prerequisites = @("wxc-host-prep", "administrator", "disposable NTFS volume")
+        HarnessArguments = "HostPrep"
+        Destructive = $true
+    }
+    "694" = @{
+        FriendlyName = "DOS Path Resolution"
+        Script = "test_cases\Invoke-Issue694-GetFinalPathNameByHandle.ps1"
+        ExpectedTierSupport = @("appcontainer-dacl")
+        Prerequisites = @("force-tier-testing wxc-exec", "MXC_FORCE_TIER=appcontainer-dacl", "Go")
+        Dependencies = @(
+            @{
+                Name = "Go"
+                Executable = "go.exe"
+                WingetId = "GoLang.Go"
+                ArgumentName = "GoExe"
+            }
+        )
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "785" = @{
+        FriendlyName = "Capture Probe Agreement"
+        Script = "test_cases\Invoke-Issue785-ProbeCaptureDenials.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "captureDenials support")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "825" = @{
+        FriendlyName = "PowerShell Provider Location"
+        Script = "test_cases\Invoke-Issue825-PowerShellProviderLocation.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "secondary NTFS volume", "PowerShell")
+        HarnessArguments = "SecondaryDrive"
+        Destructive = $false
+    }
+    "902" = @{
+        FriendlyName = "Relative Working Directory"
+        Script = "test_cases\Invoke-Issue902-RelativeWorkingDirectory.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "1061" = @{
+        FriendlyName = "MSYS Object Namespace"
+        Script = "test_cases\Invoke-Issue1061-MsysBaseNamedObjects.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "Git Bash or MSYS2")
+        Dependencies = @(
+            @{
+                Name = "Git for Windows"
+                Executable = "bash.exe"
+                Paths = @("%ProgramFiles%\Git\bin\bash.exe")
+                WingetId = "Git.Git"
+                ArgumentName = "BashExe"
+            }
+        )
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "1102" = @{
+        FriendlyName = "Default PATH Inheritance"
+        Script = "test_cases\Invoke-Issue1102-DefaultPath.ps1"
+        ExpectedTierSupport = @("appcontainer-bfs", "appcontainer-dacl", "base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "1109" = @{
+        FriendlyName = "Volume Root Grant"
+        Script = "test_cases\Invoke-Issue1109-BaseContainerVolumeRoot.ps1"
+        ExpectedTierSupport = @("base-container-psec", "base-container-sbox")
+        Prerequisites = @("wxc-exec", "BaseContainer-capable host")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+    "1130" = @{
+        FriendlyName = "SBOX Environment Fallback"
+        Script = "test_cases\Invoke-Issue1130-SboxSparseEnvironment.ps1"
+        ExpectedTierSupport = @("base-container-sbox")
+        Prerequisites = @("wxc-exec", "SBOX-capable host")
+        HarnessArguments = "Default"
+        Destructive = $false
+    }
+}

--- a/tests/regression_tests/inc/Add-RegressionCommandLine.ps1
+++ b/tests/regression_tests/inc/Add-RegressionCommandLine.ps1
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Add-RegressionCommandLine {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ConfigJson,
+        [Parameter(Mandatory)]
+        [string]$CommandLine
+    )
+
+    $config = $ConfigJson | ConvertFrom-Json
+    if ($null -eq $config.process) {
+        throw "Regression configuration is missing the process object."
+    }
+
+    $config.process | Add-Member -NotePropertyName "commandLine" -NotePropertyValue $CommandLine
+    $config | ConvertTo-Json -Depth 10 -Compress
+}

--- a/tests/regression_tests/inc/Complete-RegressionTest.ps1
+++ b/tests/regression_tests/inc/Complete-RegressionTest.ps1
@@ -1,0 +1,22 @@
+function Complete-RegressionTest {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Passed,
+        [Parameter(Mandatory)]
+        [string]$SuccessMessage,
+        [Parameter(Mandatory)]
+        [string]$FailureMessage,
+        [int]$FailureExitCode = 1
+    )
+
+    if ($Passed) {
+        Write-Host "PASSED: $SuccessMessage" -ForegroundColor Green
+        exit 0
+    }
+
+    if ($FailureExitCode -eq 0) {
+        $FailureExitCode = 1
+    }
+    Write-Host "FAILED: $FailureMessage" -ForegroundColor Red
+    exit $FailureExitCode
+}

--- a/tests/regression_tests/inc/Resolve-RegressionExecutable.ps1
+++ b/tests/regression_tests/inc/Resolve-RegressionExecutable.ps1
@@ -1,0 +1,29 @@
+function Resolve-RegressionExecutable {
+    param(
+        [string]$Value,
+        [Parameter(Mandatory)]
+        [string]$Name
+    )
+
+    if ($Value) {
+        if (Test-Path -LiteralPath $Value -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $Value).Path
+        }
+        $command = Get-Command $Value -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($command) {
+            return $command.Source
+        }
+        throw "Executable '$Value' was not found."
+    }
+
+    $local = Join-Path (Get-Location) $Name
+    if (Test-Path -LiteralPath $local -PathType Leaf) {
+        return (Resolve-Path -LiteralPath $local).Path
+    }
+
+    $command = Get-Command $Name -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($command) {
+        return $command.Source
+    }
+    throw "Executable '$Name' was not found in the current directory or PATH."
+}

--- a/tests/regression_tests/inc/Run-RegressionTests.Lib.ps1
+++ b/tests/regression_tests/inc/Run-RegressionTests.Lib.ps1
@@ -1,0 +1,228 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+function Find-DependencyExecutable {
+    param([hashtable]$Dependency)
+
+    foreach ($path in @($Dependency.Paths)) {
+        $expandedPath = [Environment]::ExpandEnvironmentVariables($path)
+        if (Test-Path -LiteralPath $expandedPath -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $expandedPath).Path
+        }
+    }
+
+    if ($Dependency.Executable) {
+        $localPath = Join-Path (Get-Location) $Dependency.Executable
+        if (Test-Path -LiteralPath $localPath -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $localPath).Path
+        }
+
+        $command = Get-Command $Dependency.Executable -CommandType Application -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($command) {
+            return $command.Source
+        }
+    }
+
+    return $null
+}
+
+function Install-Dependency {
+    param([hashtable]$Dependency)
+
+    if (-not $Dependency.WingetId) {
+        return $false
+    }
+
+    $winget = Get-Command "winget.exe" -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if (-not $winget) {
+        return $false
+    }
+
+    Write-Host "Installing $($Dependency.Name) with winget..." -ForegroundColor Yellow
+    & $winget.Source install --id $Dependency.WingetId --exact --accept-source-agreements --accept-package-agreements | Out-Host
+    return $LASTEXITCODE -eq 0
+}
+
+function Get-TestDependencies {
+    param([hashtable]$Metadata)
+
+    if (-not $Metadata.ContainsKey("Dependencies")) {
+        return
+    }
+
+    $dependencyMetadata = $Metadata["Dependencies"]
+    if ($dependencyMetadata -is [System.Collections.IDictionary]) {
+        Write-Output -NoEnumerate $dependencyMetadata
+    } else {
+        $dependencyMetadata
+    }
+}
+
+function Get-MissingTestDependencies {
+    param([hashtable]$Manifest)
+
+    foreach ($entry in $Manifest.GetEnumerator() | Sort-Object { [int]$_.Key }) {
+        foreach ($dependency in @(Get-TestDependencies $entry.Value)) {
+            if (-not (Find-DependencyExecutable $dependency)) {
+                [pscustomobject]@{
+                    Issue = "#$($entry.Key)"
+                    Name = $dependency.Name
+                    InstallCommand = if ($dependency.WingetId) {
+                        "winget install --id $($dependency.WingetId) --exact"
+                    } else {
+                        "No automatic installer configured"
+                    }
+                    Dependency = $dependency
+                }
+            }
+        }
+    }
+}
+
+function Write-MissingDependencyWarning {
+    param(
+        [object[]]$MissingDependencies,
+        [switch]$InstallRequested
+    )
+
+    $warningLines = $MissingDependencies | ForEach-Object {
+        "$($_.Issue): $($_.Name) - $($_.InstallCommand)"
+    }
+    $installNote = if ($InstallRequested) {
+        "`nAutomatic installation was requested and will be attempted before tests start."
+    } else {
+        "`nUse -InstallMissingDependencies to install dependencies with configured winget packages."
+    }
+    Write-Warning ("Missing test dependencies:`n  " + ($warningLines -join "`n  ") + $installNote)
+}
+
+function New-RegressionTestResult {
+    param(
+        [string]$Issue,
+        [hashtable]$Metadata,
+        [ValidateSet("Passed", "Failed", "Skipped")]
+        [string]$Status,
+        [string]$Detail = "",
+        [AllowNull()]
+        [object]$ExitCode
+    )
+
+    [pscustomobject]@{
+        Issue = "#$Issue"
+        FriendlyName = $Metadata.FriendlyName
+        ExpectedTierSupport = $Metadata.ExpectedTierSupport -join ", "
+        Status = $Status
+        Detail = $Detail
+        ExitCode = $ExitCode
+    }
+}
+
+function Invoke-RegressionTestCase {
+    param(
+        [string]$Issue,
+        [hashtable]$Metadata,
+        [string]$RegressionRoot,
+        [string]$Shell,
+        [string]$WxcExec,
+        [string]$SecondaryDriveWorkDirectory,
+        [string]$HostPrepExe,
+        [string]$DisposableVolumeRoot,
+        [switch]$IncludeDestructive,
+        [switch]$RunWithMissingDependencies
+    )
+
+    if ($Metadata.Destructive -and -not $IncludeDestructive) {
+        return New-RegressionTestResult $Issue $Metadata "Skipped" "Destructive test; use -IncludeDestructive" $null
+    }
+
+    $test = Join-Path $RegressionRoot $Metadata.Script
+    if (-not (Test-Path -LiteralPath $test -PathType Leaf)) {
+        return New-RegressionTestResult $Issue $Metadata "Failed" "Script not found: $test" 1
+    }
+
+    $arguments = @("-NoProfile", "-File", $test)
+    foreach ($dependency in @(Get-TestDependencies $Metadata)) {
+        $dependencyPath = Find-DependencyExecutable $dependency
+        if (-not $dependencyPath) {
+            if ($RunWithMissingDependencies) {
+                continue
+            }
+            $installHint = if ($dependency.WingetId) {
+                " Install with: winget install --id $($dependency.WingetId) --exact"
+            } else {
+                ""
+            }
+            return New-RegressionTestResult $Issue $Metadata "Failed" "Missing dependency: $($dependency.Name).$installHint" 1
+        }
+
+        if ($dependency.ArgumentName) {
+            $arguments += @("-$($dependency.ArgumentName)", $dependencyPath)
+        }
+    }
+
+    if ($Metadata.HarnessArguments -eq "HostPrep") {
+        if (-not $DisposableVolumeRoot) {
+            return New-RegressionTestResult $Issue $Metadata "Failed" "-DisposableVolumeRoot is required" 1
+        }
+        $arguments += @("-DisposableVolumeRoot", $DisposableVolumeRoot, "-AllowDestructive", "-AcknowledgeDisposableVolume")
+        if ($HostPrepExe) {
+            $arguments += @("-HostPrepExe", $HostPrepExe)
+        }
+    } elseif ($Metadata.HarnessArguments -eq "SecondaryDrive") {
+        if (-not $SecondaryDriveWorkDirectory) {
+            $systemDrive = [IO.Path]::GetPathRoot($env:SystemRoot).TrimEnd("\")
+            $secondaryDrive = Get-PSDrive -PSProvider FileSystem |
+                Where-Object { $_.Root.TrimEnd("\") -ne $systemDrive } |
+                Select-Object -First 1
+            if (-not $secondaryDrive) {
+                return New-RegressionTestResult $Issue $Metadata "Failed" "No secondary filesystem drive exists" 1
+            }
+            $SecondaryDriveWorkDirectory = Join-Path $secondaryDrive.Root "mxc-regression-825"
+        }
+        $arguments += @("-WxcExec", $WxcExec, "-WorkDirectory", $SecondaryDriveWorkDirectory)
+    } elseif ($WxcExec) {
+        $arguments += @("-WxcExec", $WxcExec)
+    }
+
+    Write-Host "`n=== Issue #${Issue}: $($Metadata.ExpectedTierSupport -join ', ') ===" -ForegroundColor Cyan
+    & $Shell @arguments | Out-Host
+    $exitCode = $LASTEXITCODE
+    $status = if ($exitCode -eq 0) { "Passed" } else { "Failed" }
+    if ($exitCode -eq 0) {
+        Write-Host "PASS" -ForegroundColor Green
+    } else {
+        Write-Host "FAIL" -ForegroundColor Red
+    }
+    New-RegressionTestResult $Issue $Metadata $status "" $exitCode
+}
+
+function Write-RegressionTestResults {
+    param([object[]]$Results)
+
+    $issueWidth = [Math]::Max(5, ($Results.Issue | Measure-Object -Property Length -Maximum).Maximum)
+    $nameWidth = [Math]::Max(4, ($Results.FriendlyName | Measure-Object -Property Length -Maximum).Maximum)
+    $tiersWidth = [Math]::Max(21, ($Results.ExpectedTierSupport | Measure-Object -Property Length -Maximum).Maximum)
+    $statusWidth = 7
+
+    Write-Host ""
+    Write-Host (("{0,-$issueWidth}  {1,-$nameWidth}  {2,-$tiersWidth}  {3,-$statusWidth}  {4}" -f "Issue", "Name", "Expected Tier Support", "Status", "Detail"))
+    Write-Host (("-" * $issueWidth) + "  " + ("-" * $nameWidth) + "  " + ("-" * $tiersWidth) + "  " + ("-" * $statusWidth) + "  " + ("-" * 6))
+    foreach ($result in $Results) {
+        Write-Host (("{0,-$issueWidth}  {1,-$nameWidth}  {2,-$tiersWidth}  " -f $result.Issue, $result.FriendlyName, $result.ExpectedTierSupport)) -NoNewline
+        $statusColor = switch ($result.Status) {
+            "Passed" { "Green" }
+            "Failed" { "Red" }
+            "Skipped" { "Yellow" }
+            default { "White" }
+        }
+        Write-Host (("{0,-$statusWidth}" -f $result.Status)) -ForegroundColor $statusColor -NoNewline
+        Write-Host "  $($result.Detail)"
+    }
+
+    $passed = $Results.Where({ $_.Status -eq "Passed" }).Count
+    $failed = $Results.Where({ $_.Status -eq "Failed" }).Count
+    $skipped = $Results.Where({ $_.Status -eq "Skipped" }).Count
+    Write-Host "`nTotal: $($Results.Count), Passed: $passed, Failed: $failed, Skipped: $skipped"
+}

--- a/tests/regression_tests/test_cases/Invoke-Issue1061-MsysBaseNamedObjects.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue1061-MsysBaseNamedObjects.ps1
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$BashExe = "$env:ProgramFiles\Git\bin\bash.exe"
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+if (-not (Test-Path -LiteralPath $BashExe -PathType Leaf)) {
+    throw "Git Bash or MSYS2 bash was not found at '$BashExe'. Pass -BashExe explicitly."
+}
+
+$gitRoot = Split-Path -Parent (Split-Path -Parent $BashExe)
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($gitRoot | ConvertTo-Json -Compress),
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readonlyPaths": $((ConvertTo-Json -InputObject @($gitRoot, $env:SystemRoot) -Compress)),
+        "readwritePaths": []
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false
+    }
+}
+"@
+
+# Command
+$commandLine = "`"$BashExe`" --version"
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+Write-Host "Issue #1061: MSYS2/Cygwin access to \BaseNamedObjects" -ForegroundColor Cyan
+& $WxcExec --probe --config-base64 $base64
+
+# Run
+& $WxcExec --config-base64 $base64
+$exitCode = $LASTEXITCODE
+Write-Host "Expected bug: bash initialization fails, commonly with exit 0xC0000142." -ForegroundColor Yellow
+Complete-RegressionTest -Passed ($exitCode -eq 0) -SuccessMessage "Git Bash initialized successfully." -FailureMessage "Git Bash exited with code $exitCode." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue1102-DefaultPath.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue1102-DefaultPath.ps1
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-1102")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+$whereExe = Join-Path $env:SystemRoot "System32\where.exe"
+
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+function Invoke-PathCase([string]$Name, [string[]]$Environment) {
+    $environmentProperty = if ($null -eq $Environment) {
+        ""
+    } else {
+        ",`n        `"env`": $((ConvertTo-Json -InputObject $Environment -Compress))"
+    }
+
+    # Config
+    $configJson = @"
+{
+    "version": "0.9.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "timeout": 30000$environmentProperty
+    },
+    "filesystem": {
+        "readonlyPaths": $((ConvertTo-Json -InputObject @($env:SystemRoot) -Compress)),
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false
+    }
+}
+"@
+
+    # Command
+    $commandLine = "`"$whereExe`" cmd.exe"
+
+    $json = Add-RegressionCommandLine $configJson $commandLine
+    $base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+    Write-Host "`n$Name" -ForegroundColor Cyan
+
+    # Run
+    & $WxcExec --config-base64 $base64
+    [pscustomobject]@{ Case = $Name; ExitCode = $LASTEXITCODE }
+}
+
+$default = Invoke-PathCase "Default environment" $null
+$sparse = Invoke-PathCase "Unrelated explicit variable only" @("FOO=bar")
+$default
+$sparse
+Write-Host "Issue #1102 reproduces when the default case succeeds and FOO=bar loses PATH or required Windows variables." -ForegroundColor Yellow
+$reproduced = $default.ExitCode -eq 0 -and $sparse.ExitCode -ne 0
+Complete-RegressionTest -Passed $reproduced -SuccessMessage "The default environment succeeded and the sparse environment failed." -FailureMessage "The expected environment behavior was not observed."

--- a/tests/regression_tests/test_cases/Invoke-Issue1109-BaseContainerVolumeRoot.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue1109-BaseContainerVolumeRoot.ps1
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:USERPROFILE "Downloads\mxc-issue-1109")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+Set-Content -LiteralPath (Join-Path $WorkDirectory "sentinel.txt") -Value "host-sentinel"
+
+function Invoke-Case([string]$Name, [string[]]$ReadOnlyPaths) {
+    # Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "process",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress)),
+        "readonlyPaths": $((ConvertTo-Json -InputObject $ReadOnlyPaths -Compress)),
+        "deniedPaths": []
+    }
+}
+"@
+
+    # Command
+    $commandLine = "cmd.exe /D /S /C `"dir && type sentinel.txt && echo sandbox-write>from-sandbox-$Name.txt`""
+
+    $json = Add-RegressionCommandLine $configJson $commandLine
+    $base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+    Write-Host "`n$Name probe (must report base-container):" -ForegroundColor Cyan
+    & $WxcExec --probe --config-base64 $base64
+    Write-Host "$Name execution:" -ForegroundColor Cyan
+
+    # Run
+    & $WxcExec --config-base64 $base64
+    [pscustomobject]@{ Case = $Name; ExitCode = $LASTEXITCODE }
+}
+
+$withoutRoot = Invoke-Case "without-volume-root" @()
+$volumeRoot = [IO.Path]::GetPathRoot($WorkDirectory)
+$withRoot = Invoke-Case "with-volume-root" @($volumeRoot)
+
+$withoutRoot
+$withRoot
+Write-Host "Issue #1109 reproduces when the first case fails and the volume-root control succeeds." -ForegroundColor Yellow
+$reproduced = $withoutRoot.ExitCode -ne 0 -and $withRoot.ExitCode -eq 0
+Complete-RegressionTest -Passed $reproduced -SuccessMessage "The volume-root control changed the result as expected." -FailureMessage "The expected volume-root grant behavior was not observed."

--- a/tests/regression_tests/test_cases/Invoke-Issue1130-SboxSparseEnvironment.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue1130-SboxSparseEnvironment.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-1130")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "env": $((ConvertTo-Json -InputObject @("SystemRoot=$env:SystemRoot", "TEMP=$WorkDirectory", "TMP=$WorkDirectory") -Compress)),
+        "timeout": 5000
+    },
+    "filesystem": {
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "processContainer": {
+        "leastPrivilege": true,
+        "capabilities": []
+    },
+    "ui": {
+        "disable": false,
+        "clipboard": "none",
+        "injection": false
+    }
+}
+"@
+
+# Command
+$commandLine = "$env:SystemRoot\System32\cmd.exe /d /c echo COMMAND_EXECUTED"
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+# Run
+Write-Host "Issue #1130: sparse explicit environment on the legacy SBOX path" -ForegroundColor Cyan
+Write-Host "Expected bug: error 203 and no COMMAND_EXECUTED marker." -ForegroundColor Yellow
+& $WxcExec --config-base64 $base64
+
+$exitCode = $LASTEXITCODE
+Complete-RegressionTest -Passed ($exitCode -eq 0) -SuccessMessage "The sparse environment launched successfully." -FailureMessage "The sparse environment launch exited with code $exitCode." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue473-PackagedApp.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue473-PackagedApp.ps1
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$PackageName = "Microsoft.WindowsNotepad"
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+$package = Get-AppxPackage $PackageName | Select-Object -First 1
+if (-not $package) { throw "Package '$PackageName' is not installed for the current user." }
+
+$exe = Get-ChildItem -LiteralPath $package.InstallLocation -Recurse -Filter Notepad.exe -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+if (-not $exe) { throw "No Notepad.exe was found under '$($package.InstallLocation)'." }
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($package.InstallLocation | ConvertTo-Json -Compress),
+        "timeout": 10000
+    },
+    "filesystem": {
+        "readonlyPaths": $((ConvertTo-Json -InputObject @($package.InstallLocation) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false,
+        "clipboard": "none",
+        "injection": false
+    }
+}
+"@
+
+# Command
+$commandLine = "`"$exe`""
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+# Run
+Write-Host "Issue #473: direct launch of packaged app '$PackageName'." -ForegroundColor Cyan
+Write-Host "Expected current behavior: activation fails or exits immediately, often with a packaged_app diagnostic." -ForegroundColor Yellow
+& $WxcExec --config-base64 $base64
+
+$exitCode = $LASTEXITCODE
+Complete-RegressionTest -Passed ($exitCode -eq 0) -SuccessMessage "The packaged application launched successfully." -FailureMessage "The packaged application exited with code $exitCode." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue483-BunAndSparsePath.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue483-BunAndSparsePath.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$BunExe,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-483")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+$bun = Resolve-RegressionExecutable $BunExe "bun.exe"
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+function Invoke-BunCase {
+    # Config
+    $configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readonlyPaths": $((ConvertTo-Json -InputObject @((Split-Path -Parent $bun), $env:SystemRoot) -Compress)),
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false
+    }
+}
+"@
+
+    # Command
+    $commandLine = "`"$bun`" -e `"console.log('mxc smoke')`""
+
+    $json = Add-RegressionCommandLine $configJson $commandLine
+    $base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+    Write-Host "Issue #483: Bun initialization" -ForegroundColor Cyan
+
+    # Run
+    & $WxcExec --config-base64 $base64 | Out-Host
+    return $LASTEXITCODE
+}
+
+$bunExitCode = Invoke-BunCase
+Complete-RegressionTest -Passed ($bunExitCode -eq 0) -SuccessMessage "Bun initialized and completed successfully." -FailureMessage "Bun exited with code $bunExitCode; the reported failure code is 66." -FailureExitCode $bunExitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue636-EdgeStartup.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue636-EdgeStartup.ps1
@@ -1,0 +1,56 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$EdgeExe = "${env:ProgramFiles(x86)}\Microsoft\Edge\Application\msedge.exe"
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+if (-not (Test-Path -LiteralPath $EdgeExe -PathType Leaf)) {
+    throw "Edge was not found at '$EdgeExe'. Pass -EdgeExe explicitly."
+}
+$edgeRoot = Split-Path -Parent $EdgeExe
+$scratch = Join-Path $env:TEMP "mxc-issue-636-edge-profile"
+New-Item -ItemType Directory -Force -Path $scratch | Out-Null
+
+# Config
+$configJson = @"
+{
+    "version": "0.7.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($edgeRoot | ConvertTo-Json -Compress),
+        "timeout": 10000
+    },
+    "filesystem": {
+        "readonlyPaths": $((ConvertTo-Json -InputObject @($edgeRoot) -Compress)),
+        "readwritePaths": $((ConvertTo-Json -InputObject @($scratch) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false
+    }
+}
+"@
+
+# Command
+$commandLine = "`"$EdgeExe`" --user-data-dir=`"$scratch`" --no-first-run --new-window about:blank"
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+Write-Host "Issue #636: launching Edge with an isolated writable profile." -ForegroundColor Cyan
+
+# Run
+& $WxcExec --config-base64 $base64
+$exitCode = $LASTEXITCODE
+Complete-RegressionTest -Passed ($exitCode -eq 0) -SuccessMessage "The Edge configuration launched successfully." -FailureMessage "The Edge configuration exited with code $exitCode." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue648-DESTRUCTIVE-HostPrepDescendantAcl.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue648-DESTRUCTIVE-HostPrepDescendantAcl.ps1
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$HostPrepExe,
+    [Parameter(Mandatory)]
+    [ValidatePattern("^[A-Za-z]:\\$")]
+    [string]$DisposableVolumeRoot,
+    [switch]$AllowDestructive,
+    [switch]$AcknowledgeDisposableVolume
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+$HostPrepExe = Resolve-RegressionExecutable $HostPrepExe "wxc-host-prep.exe"
+if (-not $AllowDestructive) {
+    throw "Refusing to run this destructive test without -AllowDestructive."
+}
+if (-not $AcknowledgeDisposableVolume) {
+    throw "Refusing to run without -AcknowledgeDisposableVolume. Use only a dedicated disposable NTFS test volume."
+}
+if ($DisposableVolumeRoot -eq [IO.Path]::GetPathRoot($env:SystemRoot)) {
+    throw "Refusing to run this repro against the system volume."
+}
+
+function Get-AclSnapshot {
+    param([string]$Root)
+    Get-ChildItem -LiteralPath $Root -Force -Recurse | ForEach-Object {
+        try {
+            "$($_.FullName)`t$((Get-Acl -LiteralPath $_.FullName).Sddl)"
+        } catch {
+            "$($_.FullName)`t<ACL-READ-FAILED>"
+        }
+    } | Sort-Object
+}
+
+Write-Host "Issue #648: snapshotting descendant ACLs on disposable volume $DisposableVolumeRoot." -ForegroundColor Cyan
+$before = Get-AclSnapshot $DisposableVolumeRoot
+& $HostPrepExe prepare-system-drive --target $DisposableVolumeRoot
+$hostPrepExit = $LASTEXITCODE
+if ($hostPrepExit -ne 0) {
+    Complete-RegressionTest -Passed $false -SuccessMessage "Unused" -FailureMessage "Host preparation exited with code $hostPrepExit." -FailureExitCode $hostPrepExit
+}
+$after = Get-AclSnapshot $DisposableVolumeRoot
+$differences = Compare-Object $before $after
+$differences
+Write-Host "Issue reproduces when descendant ACL differences are listed." -ForegroundColor Yellow
+Write-Host "Do not use unprepare as cleanup for this repro; restore the disposable volume from its baseline." -ForegroundColor Yellow
+Complete-RegressionTest -Passed ([bool]$differences) -SuccessMessage "Descendant ACL differences reproduced." -FailureMessage "No descendant ACL differences were detected."

--- a/tests/regression_tests/test_cases/Invoke-Issue694-GetFinalPathNameByHandle.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue694-GetFinalPathNameByHandle.ps1
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-694"),
+    [string]$GoExe
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+$GoExe = Resolve-RegressionExecutable $GoExe "go.exe"
+
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+$sourceMaterial = Join-Path $PSScriptRoot "data\Issue694-GetFinalPathNameByHandle.go"
+$source = Join-Path $WorkDirectory "mytest.go"
+$probe = Join-Path $WorkDirectory "mytest.exe"
+$inputFile = Join-Path $WorkDirectory "config.json"
+
+Copy-Item -LiteralPath $sourceMaterial -Destination $source -Force
+& $GoExe build -o $probe $source
+if ($LASTEXITCODE -ne 0) { throw "Failed to build the issue author's Go probe." }
+Set-Content -LiteralPath $inputFile -Value "{}" -Encoding utf8
+
+# Config
+$configJson = @"
+{
+    "version": "0.6.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "processContainer": {
+        "leastPrivilege": false
+    }
+}
+"@
+
+# Command
+$commandLine = "`"$probe`""
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+Write-Host "Issue #694: GetFinalPathNameByHandle with VOLUME_NAME_DOS." -ForegroundColor Cyan
+Write-Host "Expected bug: VOLUME_NAME_DOS reports Access is denied while VOLUME_NAME_NT succeeds." -ForegroundColor Yellow
+$probeOutput = & $WxcExec --probe --config-base64 $base64
+$probeOutput | Out-Host
+$probeExitCode = $LASTEXITCODE
+if ($probeExitCode -ne 0) {
+    Complete-RegressionTest -Passed $false -SuccessMessage "Unused" -FailureMessage "Tier probe exited with code $probeExitCode." -FailureExitCode $probeExitCode
+}
+
+$selectedTier = ($probeOutput | ConvertFrom-Json).tier
+if ($selectedTier -ne "appcontainer-dacl") {
+    Complete-RegressionTest -Passed $false -SuccessMessage "Unused" -FailureMessage "Issue #694 requires appcontainer-dacl, but the selected tier was '$selectedTier'. Build with force-tier-testing and set MXC_FORCE_TIER=appcontainer-dacl."
+}
+
+# Run
+& $WxcExec --config-base64 $base64 2>&1 | Tee-Object -Variable runOutput | Out-Host
+$exitCode = $LASTEXITCODE
+$outputText = $runOutput | Out-String
+$dosSucceeded = $outputText -match "(?m)^VOLUME_NAME_DOS:"
+$ntSucceeded = $outputText -match "(?m)^VOLUME_NAME_NT:"
+$apiFailed = $outputText -match "(?m)^(CreateFile|VOLUME_NAME_(DOS|NT)) error:"
+$passed = $exitCode -eq 0 -and $dosSucceeded -and $ntSucceeded -and -not $apiFailed
+
+Complete-RegressionTest -Passed $passed -SuccessMessage "DOS and NT final-path resolution both succeeded." -FailureMessage "The final-path probe reported an API failure or omitted a success marker." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue785-ProbeCaptureDenials.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue785-ProbeCaptureDenials.ps1
@@ -1,0 +1,58 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-785")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+$isolatedWxc = Join-Path $WorkDirectory "wxc-exec.exe"
+Copy-Item -LiteralPath $WxcExec -Destination $isolatedWxc -Force
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "processcontainer",
+    "process": {
+        "timeout": 30000
+    },
+    "processContainer": {
+        "leastPrivilege": true,
+        "captureDenials": {
+            "mode": "block",
+            "outputPath": $((Join-Path $WorkDirectory "denials.json") | ConvertTo-Json -Compress)
+        }
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    }
+}
+"@
+
+# Command
+$commandLine = "cmd.exe /d /c echo capture"
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+Write-Host "Issue #785: probe/runtime disagreement with captureDenials and no sibling plm.exe." -ForegroundColor Cyan
+& $isolatedWxc --probe --config-base64 $base64
+$probeExit = $LASTEXITCODE
+
+# Run
+& $isolatedWxc --config-base64 $base64
+$runExit = $LASTEXITCODE
+
+[pscustomobject]@{ ProbeExitCode = $probeExit; RunExitCode = $runExit }
+Write-Host "Issue reproduces when probe succeeds but execution fails." -ForegroundColor Yellow
+$reproduced = $probeExit -eq 0 -and $runExit -ne 0
+Complete-RegressionTest -Passed $reproduced -SuccessMessage "The probe/runtime disagreement reproduced." -FailureMessage "The expected probe/runtime disagreement was not observed."

--- a/tests/regression_tests/test_cases/Invoke-Issue825-PowerShellProviderLocation.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue825-PowerShellProviderLocation.ps1
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [Parameter(Mandatory)]
+    [string]$WorkDirectory
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+$systemRoot = [IO.Path]::GetPathRoot($env:SystemRoot)
+$workRoot = [IO.Path]::GetPathRoot([IO.Path]::GetFullPath($WorkDirectory))
+if ($workRoot -eq $systemRoot) {
+    throw "Issue #825 requires a directory on a non-system NTFS volume."
+}
+New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "process",
+    "process": {
+        "cwd": $($WorkDirectory | ConvertTo-Json -Compress),
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress)),
+        "readonlyPaths": []
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    },
+    "ui": {
+        "disable": false
+    }
+}
+"@
+
+# Command
+$commandLine = "powershell.exe -NoProfile -NonInteractive -Command `"Write-Output ('ProcessCwd=' + [Environment]::CurrentDirectory); Write-Output ('PSLocation=' + (Get-Location).Path)`""
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+# Run
+Write-Host "Issue #825: compare ProcessCwd and PSLocation." -ForegroundColor Cyan
+Write-Host "Expected bug: ProcessCwd is '$WorkDirectory' while PSLocation is on the system drive." -ForegroundColor Yellow
+& $WxcExec --config-base64 $base64
+$exitCode = $LASTEXITCODE
+Complete-RegressionTest -Passed ($exitCode -eq 0) -SuccessMessage "The PowerShell location probe completed successfully." -FailureMessage "The PowerShell location probe exited with code $exitCode." -FailureExitCode $exitCode

--- a/tests/regression_tests/test_cases/Invoke-Issue902-RelativeWorkingDirectory.ps1
+++ b/tests/regression_tests/test_cases/Invoke-Issue902-RelativeWorkingDirectory.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+param(
+    [string]$WxcExec,
+    [string]$WorkDirectory = (Join-Path $env:TEMP "mxc-issue-902")
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Resolve-RegressionExecutable.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Complete-RegressionTest.ps1")
+. (Join-Path (Split-Path -Parent $PSScriptRoot) "inc\Add-RegressionCommandLine.ps1")
+
+$WxcExec = Resolve-RegressionExecutable $WxcExec "wxc-exec.exe"
+
+$subdirectory = Join-Path $WorkDirectory "sub"
+New-Item -ItemType Directory -Force -Path $subdirectory | Out-Null
+
+# Config
+$configJson = @"
+{
+    "version": "0.8.0-alpha",
+    "containment": "process",
+    "process": {
+        "cwd": "sub",
+        "timeout": 30000
+    },
+    "filesystem": {
+        "readwritePaths": $((ConvertTo-Json -InputObject @($WorkDirectory) -Compress))
+    },
+    "fallback": {
+        "allowDaclMutation": true
+    }
+}
+"@
+
+# Command
+$commandLine = "cmd.exe /D /C cd"
+
+$json = Add-RegressionCommandLine $configJson $commandLine
+$base64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($json))
+
+Push-Location $WorkDirectory
+try {
+    Write-Host "Issue #902: relative process.cwd is resolved against host state." -ForegroundColor Cyan
+    Write-Host "Expected bug: succeeds and prints '$subdirectory'. Healthy behavior rejects relative cwd." -ForegroundColor Yellow
+
+    # Run
+    & $WxcExec --config-base64 $base64
+    $exitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+Complete-RegressionTest -Passed ($exitCode -ne 0) -SuccessMessage "The relative working directory was rejected." -FailureMessage "The relative working directory was accepted."

--- a/tests/regression_tests/test_cases/data/Issue694-GetFinalPathNameByHandle.go
+++ b/tests/regression_tests/test_cases/data/Issue694-GetFinalPathNameByHandle.go
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Supporting probe from https://github.com/microsoft/mxc/issues/694.
+
+package main
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	volumeNameDOS = 0x0
+	volumeNameNT  = 0x2
+)
+
+func getFinalPath(proc *syscall.Proc, handle syscall.Handle, flags uintptr) (string, error) {
+	buf := make([]uint16, 1024)
+	ret, _, callErr := proc.Call(
+		uintptr(handle),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)),
+		flags,
+	)
+	if ret == 0 {
+		return "", callErr
+	}
+	if int(ret) > len(buf) {
+		// Buffer too small; grow and retry.
+		buf = make([]uint16, ret)
+		ret, _, callErr = proc.Call(
+			uintptr(handle),
+			uintptr(unsafe.Pointer(&buf[0])),
+			uintptr(len(buf)),
+			flags,
+		)
+		if ret == 0 {
+			return "", callErr
+		}
+	}
+	return syscall.UTF16ToString(buf[:ret]), nil
+}
+
+func main() {
+	// Open config.json in the current directory.
+	path, err := syscall.UTF16PtrFromString("config.json")
+	if err != nil {
+		fmt.Println("UTF16PtrFromString error:", err)
+		return
+	}
+
+	handle, err := syscall.CreateFile(
+		path,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		fmt.Println("CreateFile error:", err)
+		return
+	}
+	defer syscall.CloseHandle(handle)
+
+	// Resolve GetFinalPathNameByHandleW from kernel32 (no x/sys).
+	kernel32 := syscall.MustLoadDLL("kernel32.dll")
+	proc := kernel32.MustFindProc("GetFinalPathNameByHandleW")
+
+	// VOLUME_NAME_DOS (default): e.g. \\?\C:\...
+	if p, err := getFinalPath(proc, handle, volumeNameDOS); err != nil {
+		fmt.Println("VOLUME_NAME_DOS error:", err)
+	} else {
+		fmt.Println("VOLUME_NAME_DOS:", p)
+	}
+
+	// VOLUME_NAME_NT: e.g. \Device\HarddiskVolumeX\...
+	if p, err := getFinalPath(proc, handle, volumeNameNT); err != nil {
+		fmt.Println("VOLUME_NAME_NT error:", err)
+	} else {
+		fmt.Println("VOLUME_NAME_NT:", p)
+	}
+}


### PR DESCRIPTION
Regression tests
- Per-Issue self-contained regression tests
- Simple harness (Run-RegressionTests.ps1) to run them all
- Ready to copy to VM!

Added build config to allow building a 'test' wxc-exec.exe flavor that can force a specific backend Tier.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1141)