### PR TITLE
Fix legacy LXC SDK enforcement mode

### DIFF
--- a/sdk/node/src/helper.ts
+++ b/sdk/node/src/helper.ts
@@ -97,13 +97,14 @@ export function makeLogFilePath(dir: string): string {
  *      unprivileged enforcement path. The proxy applies the host policy
  *      for cooperating HTTP clients; raw-socket clients bypass it.
  *
- * Legacy LXC network blocks use `'firewall'` because capabilities are
- * Windows-only. Bubblewrap uses firewall only for host lists without a proxy.
+ * Legacy LXC network blocks with no explicit enforcement mode use `'firewall'`
+ * because capabilities are Windows-only. Bubblewrap uses firewall only for
+ * host lists without a proxy.
  *
  * If the caller explicitly passes `enforcementMode: 'capabilities'` we
  * warn: `'capabilities'` is a Windows/AppContainer concept (a token
- * capability mask) and has no Linux equivalent — the Linux runner will
- * not enforce anything and the field is silently dropped.
+ * capability mask) and has no Linux equivalent. The explicit value is left
+ * unchanged so native backend validation can report unsupported combinations.
  *
  * Shared between the explicit `'bubblewrap'` / `'lxc'` builders and the
  * abstract `'process'` branch on Linux (which resolves to Bubblewrap
@@ -129,11 +130,12 @@ export function applyLinuxNetworkPolicy(config: ContainerConfig): void {
       "for unprivileged Bubblewrap enforcement)."
     );
   }
-  // LXC cannot enforce Windows AppContainer capabilities, so legacy policies use firewall.
+  // LXC cannot enforce Windows AppContainer capabilities, so omitted legacy modes use firewall.
+  const isLegacyNetwork =
+    config.network.egress === undefined && config.network.ingress === undefined;
   if (
     config.containment === 'lxc' &&
-    config.network.egress === undefined &&
-    config.network.ingress === undefined &&
+    isLegacyNetwork &&
     config.network.enforcementMode === undefined
   ) {
     config.network.enforcementMode = 'firewall';

--- a/sdk/node/src/helper.ts
+++ b/sdk/node/src/helper.ts
@@ -130,7 +130,12 @@ export function applyLinuxNetworkPolicy(config: ContainerConfig): void {
     );
   }
   // LXC cannot enforce Windows AppContainer capabilities, so legacy policies use firewall.
-  if (config.containment === 'lxc' && config.network.enforcementMode === undefined) {
+  if (
+    config.containment === 'lxc' &&
+    config.network.egress === undefined &&
+    config.network.ingress === undefined &&
+    config.network.enforcementMode === undefined
+  ) {
     config.network.enforcementMode = 'firewall';
   }
   const hasProxy = !!config.network.proxy;

--- a/sdk/node/src/helper.ts
+++ b/sdk/node/src/helper.ts
@@ -97,10 +97,8 @@ export function makeLogFilePath(dir: string): string {
  *      unprivileged enforcement path. The proxy applies the host policy
  *      for cooperating HTTP clients; raw-socket clients bypass it.
  *
- * This helper auto-promotes `enforcementMode` to `'firewall'` when host
- * lists are present without a proxy — without it, the parser would leave
- * the mode unset and the runtime would silently ignore `allowedHosts` /
- * `blockedHosts`.
+ * Legacy LXC network blocks use `'firewall'` because capabilities are
+ * Windows-only. Bubblewrap uses firewall only for host lists without a proxy.
  *
  * If the caller explicitly passes `enforcementMode: 'capabilities'` we
  * warn: `'capabilities'` is a Windows/AppContainer concept (a token
@@ -130,6 +128,9 @@ export function applyLinuxNetworkPolicy(config: ContainerConfig): void {
       "default mode (auto-promotes to 'firewall' for LXC, or use network.proxy " +
       "for unprivileged Bubblewrap enforcement)."
     );
+  }
+  if (config.containment === 'lxc' && config.network.enforcementMode === undefined) {
+    config.network.enforcementMode = 'firewall';
   }
   const hasProxy = !!config.network.proxy;
   const hasHostRules =

--- a/sdk/node/src/helper.ts
+++ b/sdk/node/src/helper.ts
@@ -129,6 +129,7 @@ export function applyLinuxNetworkPolicy(config: ContainerConfig): void {
       "for unprivileged Bubblewrap enforcement)."
     );
   }
+  // LXC cannot enforce Windows AppContainer capabilities, so legacy policies use firewall.
   if (config.containment === 'lxc' && config.network.enforcementMode === undefined) {
     config.network.enforcementMode = 'firewall';
   }

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1713,7 +1713,7 @@ describe('createConfigFromPolicy', () => {
       assert.strictEqual(config.lxc!.distribution, 'alpine');
     });
 
-    it('should use firewall enforcement for legacy policies with or without network access', () => {
+    it('should use firewall enforcement for legacy LXC policies with or without network access', () => {
       for (const version of ['0.6.0-alpha', '0.7.0-alpha'] as const) {
         const noNetwork = createConfigFromPolicy({ version }, 'lxc');
         assert.strictEqual(noNetwork.network!.defaultPolicy, 'block');

--- a/sdk/node/tests/unit/sandbox.test.ts
+++ b/sdk/node/tests/unit/sandbox.test.ts
@@ -1713,6 +1713,26 @@ describe('createConfigFromPolicy', () => {
       assert.strictEqual(config.lxc!.distribution, 'alpine');
     });
 
+    it('should use firewall enforcement for legacy policies with or without network access', () => {
+      for (const version of ['0.6.0-alpha', '0.7.0-alpha'] as const) {
+        const noNetwork = createConfigFromPolicy({ version }, 'lxc');
+        assert.strictEqual(noNetwork.network!.defaultPolicy, 'block');
+        assert.strictEqual(noNetwork.network!.enforcementMode, 'firewall');
+
+        const outbound = createConfigFromPolicy({
+          version,
+          network: { allowOutbound: true },
+        }, 'lxc');
+        assert.strictEqual(outbound.network!.defaultPolicy, 'allow');
+        assert.strictEqual(outbound.network!.enforcementMode, 'firewall');
+      }
+    });
+
+    it('should not add a legacy enforcement mode to a schema 0.8 policy', () => {
+      const config = createConfigFromPolicy({ version: '0.8.0-alpha' }, 'lxc');
+      assert.strictEqual(config.network, undefined);
+    });
+
     it('should force enforcementMode=firewall when host filtering is requested', () => {
       // The LXC runner only invokes iptables when network_enforcement_mode is
       // Firewall|Both (see lxc_common::network_iptables). Without this stamp,


### PR DESCRIPTION
## 📖 Description

Pre-0.8 Node SDK policies always emit a legacy network block. For explicit LXC containment, an omitted `enforcementMode` inherits the Windows-only `capabilities` default, which LXC cannot enforce and now rejects.

Set generated legacy LXC network policies to `firewall` while preserving Bubblewrap and schema 0.8 directional behavior. Add regression coverage for legacy deny-all and outbound policies, plus the schema 0.8 omission case.

## 🔗 References

Resolves #1135

Related to #1041

## 🔍 Validation

- `npm run build` from `sdk/node`
- `npm test` from `sdk/node`

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Linked to an issue
- [ ] Updated documentation (if applicable)
- [ ] Updated [Copilot instructions](.github/copilot-instructions.md) (if build, architecture, or conventions changed)
- [ ] If this PR changes `Cargo.lock`, the `dependency-feed-check` check passes (see [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md))

## 📋 Issue Type

- [x] Bug fix
- [ ] Feature
- [ ] Task

---

GitHub Actions runs the PR validation build automatically. The ADO pipeline
(`MXC-PR-Build`) is the Azure version of the PR pipeline, kept in parity with the GitHub
Actions build; it runs on merge to `main`, and Microsoft reviewers with write access can trigger it
on a PR with `/azp run`. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md).

If the `dependency-feed-check` check fails on a new dependency, the crate must be added to
the feed before the PR can pass. See [docs/pull-requests.md](https://github.com/microsoft/mxc/blob/main/docs/pull-requests.md)
for the steps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1146)