### PR TITLE
Let a C# caller select isolation sessions on the one-shot surface

### DIFF
--- a/scripts/check-dotnet-api-parity.js
+++ b/scripts/check-dotnet-api-parity.js
@@ -262,9 +262,7 @@ const managedPolicy = read(
   "Microsoft.Mxc.Sdk",
   "SandboxPolicy.cs"
 );
-const rustOneShot = enumVariants(rustPolicy, "Containment", "rust").filter(
-  (variant) => variant !== "IsolationSession"
-);
+const rustOneShot = enumVariants(rustPolicy, "Containment", "rust");
 compare(
   "Rust SDK vs managed containment variants",
   managedDerivedTypes(managedRequest, "SandboxContainment").map((name) =>

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/IsolationSessionHost.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/IsolationSessionHost.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Mxc.Sdk;
+using Xunit;
+
+namespace Microsoft.Mxc.Sdk.Tests;
+
+/// <summary>
+/// The live-host gate the isolation-session suites share. A live run needs
+/// Windows, the OS-side service, and a native library built with the
+/// isolation_session feature.
+/// </summary>
+internal static class IsolationSessionHost
+{
+    // Evaluated once: this answer decides failure versus skip, so it has to be
+    // the same for every test that consults it.
+    private static readonly Lazy<bool> Available = new(() =>
+        MxcSandbox.GetAvailableBackends()
+            .Any(b => b.Backend == ContainmentBackend.IsolationSession));
+
+    // Without this, a run in which everything skipped is indistinguishable from
+    // one that passed. The same variable the Rust isolation-session suite honours.
+    private static bool SkipsAreFailures =>
+        Environment.GetEnvironmentVariable("MXC_ISO_TESTS_REQUIRED") is "1" or "true";
+
+    /// <summary>Skips the calling test when the backend is unavailable, or fails
+    /// it when skips have been declared failures.</summary>
+    internal static void Require()
+    {
+        Assert.False(
+            SkipsAreFailures && !Available.Value,
+            "MXC_ISO_TESTS_REQUIRED is set, but GetAvailableBackends() does not "
+                + "report the isolation-session backend. That needs both a build "
+                + "with MxcWithIsolationSession and a host running the OS-side "
+                + "service.");
+        Assert.SkipUnless(
+            Available.Value,
+            "GetAvailableBackends() does not report the isolation-session backend");
+    }
+}

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/IsolationSessionHost.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/IsolationSessionHost.cs
@@ -6,6 +6,12 @@ using Xunit;
 
 namespace Microsoft.Mxc.Sdk.Tests;
 
+// These suites share one OS-side service.
+[CollectionDefinition("MxcLiveHost", DisableParallelization = true)]
+public sealed class MxcLiveHostCollectionDefinition
+{
+}
+
 /// <summary>
 /// The live-host gate the isolation-session suites share. A live run needs
 /// Windows, the OS-side service, and a native library built with the

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
@@ -19,32 +19,6 @@ namespace Microsoft.Mxc.Sdk.Tests;
 /// </remarks>
 public class MxcLifecycleE2ETests
 {
-    // Evaluated once: this answer decides failure versus skip, so it has to be
-    // the same for every test in the class.
-    private static readonly Lazy<bool> HostRunsIsolationSession = new(() =>
-        MxcSandbox.GetAvailableBackends()
-            .Any(b => b.Backend == ContainmentBackend.IsolationSession));
-
-    // Without this, a run in which everything skipped is indistinguishable from
-    // one that passed. The same variable the Rust isolation-session suite honours.
-    private static bool SkipsAreFailures =>
-        Environment.GetEnvironmentVariable("MXC_ISO_TESTS_REQUIRED") is "1" or "true";
-
-    /// <summary>Skips the calling test when the backend is unavailable, or fails
-    /// it when skips have been declared failures.</summary>
-    private static void RequireIsolationSessionHost()
-    {
-        Assert.False(
-            SkipsAreFailures && !HostRunsIsolationSession.Value,
-            "MXC_ISO_TESTS_REQUIRED is set, but GetAvailableBackends() does not "
-                + "report the isolation-session backend. That needs both a build "
-                + "with MxcWithIsolationSession and a host running the OS-side "
-                + "service.");
-        Assert.SkipUnless(
-            HostRunsIsolationSession.Value,
-            "GetAvailableBackends() does not report the isolation-session backend");
-    }
-
     private const string Cmd = @"C:\Windows\System32\cmd.exe";
 
     /// <summary>
@@ -157,7 +131,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Exec_RunsAsTheAgentUserFromTheProvisionMetadata()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -177,7 +151,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Exec_PropagatesANonZeroExitCode()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -195,7 +169,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Exec_ReportsConfiguredTimeout()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -217,7 +191,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public void Deprovision_RetiresTheSandboxId()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -236,7 +210,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Lifecycle_RunsEndToEnd()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)
@@ -253,7 +227,7 @@ public class MxcLifecycleE2ETests
     [Fact]
     public async Task Workspace_IsSharedWithTheAgent_AndRemovedOnDeprovision()
     {
-        RequireIsolationSessionHost();
+        IsolationSessionHost.Require();
 
         var started = ProvisionAndStart();
         using (started.Teardown)

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcLifecycleE2ETests.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Mxc.Sdk.Tests;
 /// rather than only through the engine: the identity and workspace that
 /// provision reports, and the output and exit code an exec returns.
 /// </remarks>
+[Collection("MxcLiveHost")]
 public class MxcLifecycleE2ETests
 {
     private const string Cmd = @"C:\Windows\System32\cmd.exe";

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxIsolationSessionE2ETests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxIsolationSessionE2ETests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Security.Principal;
+using System.Text;
+using Microsoft.Mxc.Sdk;
+using Xunit;
+
+namespace Microsoft.Mxc.Sdk.Tests;
+
+/// <summary>
+/// Runs one-shot isolation sessions against a live host through this binding.
+/// </summary>
+/// <remarks>
+/// The engine's own suite covers the backend; these establish that the managed
+/// type, the request envelope, the C ABI and the native library agree, which is
+/// the part no Rust test can see.
+/// </remarks>
+[Collection("MxcLiveHost")]
+public class MxcSandboxIsolationSessionE2ETests
+{
+    // The backend wraps the command in `cmd.exe /c` itself, so these are bare
+    // shell commands. Adding another wrapper nests two shells and the outer one
+    // consumes the `&`, which silently changes what runs.
+    private static SandboxRequest Request(string command) =>
+        new(
+            new SandboxPolicy
+            {
+                // The backend cannot restrict the container's network, so it
+                // accepts only an explicit acknowledgment of that and refuses an
+                // absent policy, whose default is a deny it could not enforce.
+                Version = "0.9.0-alpha",
+                Network = new NetworkPolicy
+                {
+                    AllowOutbound = true,
+                    AllowLocalNetwork = true,
+                },
+            },
+            command)
+        {
+            Experimental = true,
+            Containment = new IsolationSessionContainment(),
+        };
+
+    [Fact]
+    public void Run_ReturnsTheWorkloadsOutputAndExitCode()
+    {
+        IsolationSessionHost.Require();
+
+        var result = MxcSandbox.Run(Request("echo mxc_iso_run_ok & exit /b 3"));
+
+        Assert.False(result.TimedOut);
+        Assert.Equal(3, result.ExitCode);
+        Assert.Contains("mxc_iso_run_ok", result.Stdout, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Run_ExecutesUnderADifferentAccount()
+    {
+        IsolationSessionHost.Require();
+
+        // `/fo csv /nh` prints `"machine\account","SID"`. The SID is compared
+        // because it is canonical, and no account is named in a failure message.
+        var result = MxcSandbox.Run(Request("whoami /user /fo csv /nh"));
+
+        Assert.Equal(0, result.ExitCode);
+        var sid = result.Stdout.Trim().Split(',').Last().Trim('"');
+
+        Assert.False(
+            string.IsNullOrWhiteSpace(sid),
+            "the workload reported no account SID");
+
+        if (OperatingSystem.IsWindows())
+        {
+            var caller = WindowsIdentity.GetCurrent().User?.Value;
+            Assert.False(
+                string.Equals(sid, caller, StringComparison.OrdinalIgnoreCase),
+                "the workload ran as the caller's own account, so it was not isolated");
+        }
+    }
+
+    [Fact]
+    public void Spawn_StreamsStandardOutput()
+    {
+        IsolationSessionHost.Require();
+
+        using var proc = MxcSandbox.Spawn(Request("echo mxc_iso_stream_ok"));
+
+        var stdout = proc.StandardOutput;
+        Assert.NotNull(stdout);
+        using var reader = new StreamReader(stdout!, Encoding.UTF8);
+        var text = reader.ReadToEnd();
+
+        var result = proc.Wait();
+        Assert.False(result.TimedOut);
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("mxc_iso_stream_ok", text, StringComparison.Ordinal);
+    }
+}

--- a/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk.Tests/MxcSandboxTests.cs
@@ -585,6 +585,53 @@ public class MxcSandboxTests
     }
 
     [Fact]
+    public void SandboxRequest_SerializesIsolationSessionContainment()
+    {
+        var request = new SandboxRequest(
+            new SandboxPolicy { Version = "0.9.0-alpha" },
+            @"cmd.exe /c echo hi")
+        {
+            Experimental = true,
+            Containment = new IsolationSessionContainment(),
+        };
+
+        using var doc = JsonDocument.Parse(MxcSandbox.SerializeRequest(request));
+        var containment = doc.RootElement.GetProperty("containment");
+
+        // The native side derives this spelling from a serde attribute while the
+        // managed side names it in an attribute of its own.
+        Assert.Equal("isolationSession", containment.GetProperty("type").GetString());
+
+        // The backend takes no configuration, so the discriminator is the whole
+        // object.
+        Assert.Single(containment.EnumerateObject());
+    }
+
+    [Fact]
+    public void SandboxRequest_IsolationSessionWithoutExperimental_IsRefused()
+    {
+        var request = new SandboxRequest(
+            new SandboxPolicy { Version = "0.9.0-alpha" },
+            @"cmd.exe /c echo hi")
+        {
+            Containment = new IsolationSessionContainment(),
+        };
+
+        var exception = Assert.Throws<MxcException>(() => MxcSandbox.Run(request));
+
+        // Both refusals name the backend. Which of the two fires depends on
+        // whether the native library was built with the backend.
+        Assert.Contains(
+            nameof(ContainmentBackend.IsolationSession),
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.True(
+            exception.Code is ErrorCode.MalformedRequest
+                or ErrorCode.UnsupportedContainment,
+            $"unexpected refusal: {exception.Code}: {exception.Message}");
+    }
+
+    [Fact]
     public void SandboxPolicy_SerializesDirectionalNetworking()
     {
         var policy = new SandboxPolicy

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/MxcSandboxProcess.cs
@@ -41,7 +41,7 @@ public interface ISandboxProcess : IDisposable
     /// <summary>A handle that can interrupt standard-error reads.</summary>
     ISandboxStreamCloser? StandardErrorCloser { get; }
 
-    /// <summary>Security warnings emitted while applying the policy.</summary>
+    /// <summary>Security warnings from this sandbox.</summary>
     IReadOnlyList<string> Warnings { get; }
 
     /// <summary>Structured feature output available after terminal completion.</summary>
@@ -72,11 +72,11 @@ public interface ISandboxProcess : IDisposable
 /// Stream the child's stdio with <see cref="StandardInput"/> /
 /// <see cref="StandardOutput"/> / <see cref="StandardError"/>, wait for it with
 /// <see cref="Wait"/> / <see cref="WaitAsync"/>, or kill it (and its whole tree)
-/// with <see cref="Kill"/>. <see cref="Warnings"/> reports policy relaxations
-/// immediately. Each standard stream is a separate object; different streams
-/// may be used concurrently on different threads, but a single stream must be
-/// driven from one thread at a time (its native reads/writes are serialized
-/// internally, since the underlying handle is not concurrency-safe).
+/// with <see cref="Kill"/>. Each standard stream is a separate object;
+/// different streams may be used concurrently on different threads, but a
+/// single stream must be driven from one thread at a time (its native
+/// reads/writes are serialized internally, since the underlying handle is not
+/// concurrency-safe).
 /// </para>
 /// <para>
 /// <b>Draining.</b> Like the underlying Rust <c>Sandbox</c>, <see cref="Wait"/>
@@ -114,7 +114,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
 
     private readonly object _controlLock = new();
     private readonly MxcSandboxHandle _handle;
-    private IReadOnlyList<string>? _warnings;
     private bool _disposed;
 
     // Tracks whether each readable standard stream is still available, has been
@@ -248,7 +247,8 @@ public sealed class MxcSandboxProcess : ISandboxProcess
         StandardErrorCloser;
 
     /// <summary>
-    /// Security warnings emitted while applying the sandbox policy.
+    /// Security warnings emitted while applying the sandbox policy, and
+    /// cleanup steps that failed after the workload exited.
     /// </summary>
     public IReadOnlyList<string> Warnings
     {
@@ -257,10 +257,6 @@ public sealed class MxcSandboxProcess : ISandboxProcess
             lock (_controlLock)
             {
                 ThrowIfDisposed();
-                if (_warnings is not null)
-                {
-                    return _warnings;
-                }
                 unsafe
                 {
                     byte* json = null;
@@ -273,15 +269,14 @@ public sealed class MxcSandboxProcess : ISandboxProcess
                     }
                     if (json is null)
                     {
-                        return _warnings = Array.Empty<string>();
+                        return Array.Empty<string>();
                     }
                     try
                     {
                         var text = Marshal.PtrToStringUTF8((IntPtr)json);
-                        _warnings = string.IsNullOrEmpty(text)
+                        return string.IsNullOrEmpty(text)
                             ? Array.Empty<string>()
                             : JsonSerializer.Deserialize<string[]>(text) ?? Array.Empty<string>();
-                        return _warnings;
                     }
                     finally
                     {

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/RunResult.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/RunResult.cs
@@ -28,10 +28,10 @@ public sealed class RunResult
     /// Security warnings raised during the run, empty when there were none.
     /// </summary>
     /// <remarks>
-    /// Raised when a policy relaxes containment — notably
+    /// A policy that relaxes containment raises one — notably
     /// <c>permissiveLearningMode</c>, which disables deny-by-default. These are
     /// never written to the host's stderr, so inspecting this is the only way to
-    /// learn that containment was relaxed.
+    /// see them.
     /// </remarks>
     public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
 }

--- a/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
+++ b/sdk/dotnet/Microsoft.Mxc.Sdk/SandboxRequest.cs
@@ -80,6 +80,7 @@ public sealed class SandboxRequest
 [JsonDerivedType(typeof(ProcessContainment), "process")]
 [JsonDerivedType(typeof(ProcessContainerContainment), "processContainer")]
 [JsonDerivedType(typeof(WslcContainment), "wslc")]
+[JsonDerivedType(typeof(IsolationSessionContainment), "isolationSession")]
 public abstract class SandboxContainment;
 
 /// <summary>
@@ -87,6 +88,13 @@ public abstract class SandboxContainment;
 /// Bubblewrap on Linux, and Seatbelt on macOS.
 /// </summary>
 public sealed class ProcessContainment : SandboxContainment;
+
+/// <summary>
+/// Experimental Windows IsolationSession backend, which runs the workload under
+/// an isolated agent user account.
+/// </summary>
+/// <remarks>Requires <see cref="SandboxRequest.Experimental"/>.</remarks>
+public sealed class IsolationSessionContainment : SandboxContainment;
 
 /// <summary>Explicit Windows ProcessContainer configuration.</summary>
 public sealed class ProcessContainerContainment : SandboxContainment

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -72,11 +72,11 @@ or the configured output directory.
 
 `RunResult.Warnings` carries security warnings raised during the run — notably
 when `permissiveLearningMode` disabled deny-by-default. MXC never writes these
-to the host's stderr, so inspecting `Warnings` is the only way to learn that
-containment was relaxed.
+to the host's stderr, so inspecting `Warnings` is the only way to see them.
 
-Streaming callers receive the same warnings immediately from
-`MxcSandboxProcess.Warnings`. They do not need to wait for the process to exit.
+Streaming callers read warnings from `MxcSandboxProcess.Warnings` without
+waiting for the process to exit. Cleanup failures are added during teardown,
+so read it again after `Wait`, `WaitAsync` or `Kill` to see them.
 
 ### Dependency injection and testing
 

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -129,8 +129,8 @@ foreach (AvailableBackend backend in MxcSandbox.GetAvailableBackends())
 `GetPlatformSupport()` reports whether this public SDK can launch a sandbox and
 the backends it can launch. `GetAvailableBackends()` is broader: it reports
 every backend the host can run, including lifecycle-only backends such as
-Windows Sandbox and IsolationSession. Its ProcessContainer `Tier` is the
-strongest tier the host can reach; policy can still select a weaker tier.
+Windows Sandbox. Its ProcessContainer `Tier` is the strongest tier the host can
+reach; policy can still select a weaker tier.
 `Capabilities` reports optional host features such as
 `BackendCapability.CaptureDenials`.
 
@@ -283,7 +283,42 @@ var request = new SandboxRequest(
 The image must already be cached unless `ImageTarPath` is supplied. The image
 store wins over the tar when both identify an already-cached image. WSLC is
 experimental, so `Experimental` is required; the native unit must also be built
-with WSLC support or execution returns `BackendUnavailable`.
+with WSLC support or execution returns `UnsupportedContainment`.
+
+#### Isolation session options
+
+`IsolationSessionContainment` selects the experimental IsolationSession backend,
+which runs the workload under an isolated agent user account. It carries no
+configuration of its own:
+
+```csharp
+var request = new SandboxRequest(
+    new SandboxPolicy
+    {
+        Version = "0.9.0-alpha",
+        Network = new NetworkPolicy
+        {
+            AllowOutbound = true,
+            AllowLocalNetwork = true,
+        },
+    },
+    "echo hello")
+{
+    Experimental = true,
+    Containment = new IsolationSessionContainment(),
+};
+```
+
+The network policy is not optional here. The backend cannot restrict the
+container's network, so it accepts only an explicit acknowledgment of that and
+refuses an absent policy, whose default is a deny it could not enforce. It also
+refuses filesystem paths and any `Ui`: supplying either is an error rather than
+a no-op, so the policy shown under Usage does not carry over to this backend.
+
+IsolationSession is experimental, so `Experimental` is required; the native unit
+must also be built with isolation-session support or execution returns
+`UnsupportedContainment`. It is refused from a single-threaded apartment, so a
+GUI caller must reach it from an MTA thread.
 
 ### Network proxy
 
@@ -584,7 +619,7 @@ exception messages and stack traces. See
   judged by whoever runs them; each states what to look for.
 - **`Microsoft.Mxc.Sdk.Tests`** — xUnit v3 tests. The streaming end-to-end tests
   need a capable host and skip, with a reason, unless `MXC_E2E_HOST_PREPPED=1`.
-  The isolation-session lifecycle tests skip unless `GetAvailableBackends()`
+  The isolation-session end-to-end tests skip unless `GetAvailableBackends()`
   reports that backend, which needs both a build with
   `-p:MxcWithIsolationSession=true` and a host running the OS-side service. Set
   `MXC_ISO_TESTS_REQUIRED=1` (or `true`) to turn those skips into failures.
@@ -611,9 +646,10 @@ other Windows RID for a multi-RID package.
 Exposes **run-to-completion** (`Run` / `RunAsync`), **streaming**
 (`Spawn` → `MxcSandboxProcess`), and the **state-aware lifecycle**
 (`MxcLifecycle`) over the backends the public Rust SDK supports (Windows
-ProcessContainer, Linux Bubblewrap, macOS Seatbelt for run/stream; the
-state-aware lifecycle supports IsolationSession, Windows Sandbox, and WSLC on
-Windows; all three are experimental).
+ProcessContainer, Linux Bubblewrap, macOS Seatbelt, and Windows
+IsolationSession and WSLC for run/stream; the state-aware lifecycle supports
+IsolationSession, Windows Sandbox, and WSLC on Windows; all three are
+experimental).
 
 `SchemaVersions` exposes the minimum and maximum accepted schema versions, the
 latest stable schema, and the backend-specific state-aware defaults. These

--- a/src/core/mxc-sdk/tests/isolation_session.rs
+++ b/src/core/mxc-sdk/tests/isolation_session.rs
@@ -628,8 +628,8 @@ fn one_shot_kill_stops_the_workload() {
         "the workload must be running before the kill, or this test cannot fail"
     );
 
-    // Bounded, because teardown has been seen to block on a platform call that
-    // never returns. The handle comes back so this test, not the worker, decides
+    // Bounded so a kill that never returns fails this test rather than hanging
+    // the suite. The handle comes back so this test, not the worker, decides
     // when it drops.
     let (killed_tx, killed_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {

--- a/src/ffi/mxc_ffi/src/lib.rs
+++ b/src/ffi/mxc_ffi/src/lib.rs
@@ -241,10 +241,10 @@ pub struct MxcRunResult {
     /// Security warnings raised during the run, as a JSON array of strings
     /// (UTF-8, NUL-terminated), or null when the run raised none.
     ///
-    /// The sandbox emits these when a policy relaxes containment — notably
+    /// A policy that relaxes containment raises one — notably
     /// `permissiveLearningMode`, which disables deny-by-default. They are not
     /// written to the host's stderr, so this field is the only way an FFI
-    /// caller learns that containment was relaxed.
+    /// caller sees them.
     pub warnings_json_utf8: *mut c_char,
 }
 

--- a/src/ffi/mxc_ffi/src/request.rs
+++ b/src/ffi/mxc_ffi/src/request.rs
@@ -156,6 +156,7 @@ enum RequestContainment {
         #[serde(default, rename = "portMappings")]
         port_mappings: Vec<WslcPortMappingSpec>,
     },
+    IsolationSession {},
 }
 
 #[derive(serde::Deserialize)]
@@ -271,6 +272,7 @@ impl RequestContainment {
                     .collect();
                 Containment::Wslc(wslc)
             }
+            Self::IsolationSession {} => Containment::IsolationSession,
         }
     }
 }
@@ -846,6 +848,39 @@ mod tests {
         assert!(config.gpu);
         assert_eq!(config.storage_path.as_deref(), Some(r"C:\wslc"));
         assert_eq!(config.port_mappings, [(8080, 80)]);
+    }
+
+    /// The discriminator is derived from the enum's `rename_all`, not written by
+    /// hand, and the managed binding spells it independently.
+    #[test]
+    fn isolation_session_selects_the_backend_from_its_wire_spelling() {
+        let containment: RequestContainment =
+            serde_json::from_str(r#"{ "type": "isolationSession" }"#)
+                .expect("request containment parses");
+
+        assert!(matches!(
+            containment.into_sdk(),
+            Containment::IsolationSession
+        ));
+    }
+
+    /// `deny_unknown_fields` does not reach an internally tagged unit variant,
+    /// so the empty-struct form is what closes this one.
+    #[test]
+    fn isolation_session_rejects_a_member_it_does_not_define() {
+        let error = build_request_from_json(
+            r#"{
+                "policy": { "version": "0.9.0-alpha" },
+                "command": "echo hi",
+                "containment": { "type": "isolationSession", "unexpected": true }
+            }"#,
+        )
+        .expect_err("an undefined member must not be discarded");
+
+        assert!(
+            error.message.contains("unexpected"),
+            "the error must name the member: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 📖 Description

The Rust SDK already serves the experimental Windows IsolationSession backend on its one-shot surface, but no managed type named it, so a C# caller could not reach it. This adds the containment variant to the C ABI and the matching derived type to the managed binding.

The wire spelling is derived from a serde attribute on the native side and written by hand in an attribute on the managed side, so each side has a test naming the literal it expects. The variant declares no members rather than being a bare unit, because `deny_unknown_fields` does not reach an internally tagged unit variant and the envelope would otherwise discard members it does not define.

One behaviour change comes with it. `MxcSandboxProcess.Warnings` answered from a snapshot taken on its first read, so a caller who read it before waiting never saw a warning raised during teardown — including the one reporting that an agent user could not be removed and an OS account may remain on the host. It now reads through on every call, matching the Rust SDK and the trait contract both layers implement.

Two gaps are deliberate, and tracked rather than closed here:

- **Nothing pins the read-through.** A live-host test that reads warnings before and after a *successful* teardown passes whether or not the snapshot is restored, so it would not discriminate. The only case that does needs an induced teardown failure, and no seam exists to induce one. The property is pinned one layer down, where a fake makes it reachable.
- **`isolationSession` has no shared request fixture** under `tests/policy`, unlike the other one-shot containments. Adding one also changes the differential corpus inventory, so it is a separate change.

## 🔗 References

Follows #1132, which added this backend to the Rust SDK's one-shot surface.

## 🔍 Validation

Windows host: `cargo fmt`, `cargo clippy -D warnings`, and `cargo test` with the `isolation_session` feature both **on and off**; the C# suite; the versioning, parity and codegen gates; and the SDK unit, pack and integration suites.

End-to-end coverage for the new selector ran against a host with the OS-side service, plus the manual interactive-terminal pass.

## ✅ Checklist

- [x] Signed the [Contributor License Agreement](https://cla.opensource.microsoft.com)
- [x] Updated documentation (if applicable)

## 📋 Issue Type
- [x] Feature
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/mxc/pull/1148)